### PR TITLE
nixos/roundcube: add roundcube module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -332,6 +332,7 @@
   ./services/mail/rspamd.nix
   ./services/mail/rss2email.nix
   ./services/mail/rmilter.nix
+  ./services/mail/roundcube.nix
   ./services/mail/nullmailer.nix
   ./services/misc/airsonic.nix
   ./services/misc/apache-kafka.nix

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -1,0 +1,89 @@
+{ lib, config, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.roundcube;
+in
+{
+  options.services.roundcube = {
+    enable = mkEnableOption "Roundcube";
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = 127.0.0.1;
+      description = "Listening address";
+    };
+
+    listenPort = mkOption {
+      type = types.int;
+      default = 80;
+      description = "Listening port";
+    };
+    
+    subDomain = mkOption {
+      type = types.str;
+      example = "webmail";
+      description = "Sub-domain to use which is the name of the nginx vhost";
+    };
+    
+    extraConfig = mkOption {
+      type = types.str;
+      default = ''
+        <?php
+
+        $config = array();
+        $config['db_dsnw'] = 'pgsql://roundcube:pass@localhost/roundcubemail';
+        $config['db_prefix'] = 'rc';
+        $config['default_host'] = 'tls://%h';
+        $config['smtp_server'] = 'tls://%h';
+        $config['smtp_user'] = '%u';
+        $config['smtp_pass'] = '%p';
+
+        $config['max_message_size'] = '25M';
+      '';
+      description = "Configuration for roundcube webmail instance";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."roundcube/config.inc.php".text = cfg.extraConfig;
+
+    services.nginx.virtualHosts = {
+      "${cfg.subDomain}" = {
+        listen = [ { addr = cfg.listenAddress; port = cfg.listenPort; } ];
+        locations."/" = {
+          root = pkgs.roundcube;
+          index = "index.php";
+          extraConfig = ''
+            location ~* \.php$ {
+              fastcgi_split_path_info ^(.+\.php)(/.+)$;
+              fastcgi_pass unix:/run/phpfpm/roundcube;
+              include ${pkgs.nginx}/conf/fastcgi_params;
+              include ${pkgs.nginx}/conf/fastcgi.conf;
+            }
+          '';
+        };
+      };
+    };
+
+    services.phpfpm.poolConfigs.${cfg.subDomain} = ''
+      listen = /run/phpfpm/roundcube
+      listen.owner = nginx
+      listen.group = nginx
+      listen.mode = 0660
+      user = nginx
+      pm = dynamic
+      pm.max_children = 75
+      pm.start_servers = 2
+      pm.min_spare_servers = 1
+      pm.max_spare_servers = 20
+      pm.max_requests = 500
+      php_admin_value[error_log] = 'stderr'
+      php_admin_flag[log_errors] = on
+      php_admin_value[post_max_size] = 25M
+      php_admin_value[upload_max_filesize] = 25M
+      catch_workers_output = yes
+   '';
+  };
+}

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -11,8 +11,8 @@ in
 
     listenAddress = mkOption {
       type = types.str;
-      default = 127.0.0.1;
-      description = "Listening address";
+      default = "[::]";
+      description = "Listening address. IPv6 addresses must be enclosed in square brackets";
     };
 
     listenPort = mkOption {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -178,6 +178,7 @@ in
   rabbitmq = handleTest ./rabbitmq.nix {};
   radicale = handleTest ./radicale.nix {};
   redmine = handleTest ./redmine.nix {};
+  roundcube = handleTest ./roundcube.nix {};
   rspamd = handleTest ./rspamd.nix {};
   rss2email = handleTest ./rss2email.nix {};
   rsyslogd = handleTest ./rsyslogd.nix {};

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -9,7 +9,6 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.roundcube = {
         enable = true;
         hostName = "roundcube";
-        nginx.enable = true;
         database.password = "notproduction";
       };
       services.nginx.virtualHosts.roundcube = {
@@ -23,6 +22,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     $roundcube->start;
     $roundcube->waitForUnit("postgresql.service");
     $roundcube->waitForUnit("phpfpm-roundcube.service");
+    $roundcube->waitForUnit("nginx.service");
     $roundcube->succeed("curl -sSfL http://roundcube/");
   '';
 })

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -1,0 +1,28 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "roundcube";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ globin ];
+  };
+
+  nodes = {
+    roundcube = { config, pkgs, ... }: {
+      services.roundcube = {
+        enable = true;
+        hostName = "roundcube";
+        nginx.enable = true;
+        database.password = "notproduction";
+      };
+      services.nginx.virtualHosts.roundcube = {
+        forceSSL = false;
+        enableACME = false;
+      };
+    };
+  };
+
+  testScript = ''
+    $roundcube->start;
+    $roundcube->waitForUnit("postgresql.service");
+    $roundcube->waitForUnit("phpfpm-roundcube.service");
+    $roundcube->succeed("curl -sSfL http://roundcube/");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
After failing me on my local repo, I suggest this module for roundcube, and I closed the #47655. I try to take in account @globin remarks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

