### PR TITLE
tinc: 1.0.34 -> 1.0.35, 1.1pre16 -> 1.1pre17 (security update)

### DIFF
--- a/pkgs/tools/networking/tinc/default.nix
+++ b/pkgs/tools/networking/tinc/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, lzo, openssl, zlib}:
 
 stdenv.mkDerivation rec {
-  version = "1.0.34";
+  version = "1.0.35";
   name = "tinc-${version}";
 
   src = fetchurl {
     url = "https://www.tinc-vpn.org/packages/tinc-${version}.tar.gz";
-    sha256 = "1nngdp2x5kykrgh13q5wjry8m82vahqv53csvlb22ifxvrhrnfn0";
+    sha256 = "0pl92sdwrkiwgll78x0ww06hfljd07mkwm62g8x17qn3gha3pj0q";
   };
 
   buildInputs = [ lzo openssl zlib ];

--- a/pkgs/tools/networking/tinc/pre.nix
+++ b/pkgs/tools/networking/tinc/pre.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "tinc-${version}";
-  version = "1.1pre16";
+  version = "1.1pre17";
 
   src = fetchgit {
     rev = "refs/tags/release-${version}";
     url = "git://tinc-vpn.org/tinc";
-    sha256 = "03dsm1kxagq8srskzg649xyhbdqbbqxc84pdwrz7yakpa9m6225c";
+    sha256 = "12abmx9qglchgn94a1qwgzldf2kaz77p8705ylpggzyncxv6bw2q";
   };
 
   outputs = [ "out" "man" "info" ];


### PR DESCRIPTION
###### Motivation for this change

Critical security update (CVE-2018-16737, CVE-2018-16738, CVE-2018-16758).
Should be backported to `release-18.03` and `release-18.09` as well.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

