### PR TITLE
debian vm tools: use snapshot.debian.org

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -990,7 +990,7 @@ rec {
       name = "debian-9.4-stretch-i386";
       fullName = "Debian 9.4 Stretch (i386)";
       packagesList = fetchurl {
-        url = https://web.archive.org/web/20180912163509/http://ftp.debian.org/debian/dists/stretch/main/binary-i386/Packages.xz;
+        url = http://snapshot.debian.org/archive/debian/20180912T154744Z/dists/stretch/main/binary-i386/Packages.xz;
         sha256 = "0flvn8zn7vk04p10ndf3aq0mdr8k2ic01g51aq4lsllkv8lmwzyh";
       };
       urlPrefix = mirror://debian;
@@ -1001,7 +1001,7 @@ rec {
       name = "debian-9.4-stretch-amd64";
       fullName = "Debian 9.4 Stretch (amd64)";
       packagesList = fetchurl {
-        url = https://web.archive.org/web/20180912163152/http://ftp.debian.org/debian/dists/stretch/main/binary-amd64/Packages.xz;
+        url = http://snapshot.debian.org/archive/debian/20180912T154744Z/dists/stretch/main/binary-amd64/Packages.xz;
         sha256 = "11vnn9bba2jabixvabfbw9zparl326c88xn99di7pbr5xsnl15jm";
       };
       urlPrefix = mirror://debian;


### PR DESCRIPTION

###### Motivation for this change
snapshot.debian.org actually keeps track of all of the updates as they
come in rather than doing arbitrary (?) snapshots. Conveniently enough, the hashes are the same

cc @andir who seems to be updating these


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

