### PR TITLE
tor-browser-bundle-bin: 7.5.6 -> 8.0.2 [18.03 backport]

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -42,7 +42,7 @@
 # Wrapper runtime
 , coreutils
 , glibcLocales
-, hicolor-icon-theme
+, defaultIconTheme
 , shared-mime-info
 , gsettings-desktop-schemas
 
@@ -262,7 +262,7 @@ stdenv.mkDerivation rec {
     EOF
 
     WRAPPER_XDG_DATA_DIRS=${concatMapStringsSep ":" (x: "${x}/share") [
-      hicolor-icon-theme
+      defaultIconTheme
       shared-mime-info
     ]}
     WRAPPER_XDG_DATA_DIRS+=":"${concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -99,7 +99,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "8.0.1";
+  version = "8.0.2";
 
   lang = "en-US";
 
@@ -109,7 +109,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "05k914066pk11qxbwr77g6v20cfc8h9mh9yc3bpsfy35p8sypv8c";
+      sha256 = "1vajphnl53bhp0bnq8shljvnnq4k2wpvfrfclmxklp97lqvfl9vz";
     };
 
     "i686-linux" = fetchurl {
@@ -117,7 +117,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "1w2apsiimy6d5vpql37j5bmf8y8xhx4irryd5ad3vqqsr0x5wla7";
+      sha256 = "157yd8n53w79xx58xf5v983a50xq1s0c09cr7qfd5cxgs7zrwh34";
     };
   };
 in

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -14,7 +14,7 @@
 , freetype
 , gdk_pixbuf
 , glib
-, gtk2
+, gtk3
 , libxcb
 , libX11
 , libXext
@@ -67,7 +67,7 @@ let
     freetype
     gdk_pixbuf
     glib
-    gtk2
+    gtk3
     libxcb
     libX11
     libXext
@@ -98,7 +98,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "7.5.6";
+  version = "8.0";
 
   lang = "en-US";
 
@@ -108,7 +108,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "07z7lg5firyah0897pr04wqnbgf4mvsnk3gq2zgsg1rrwladxz5s";
+      sha256 = "139cizh33x3nzr0f4b2q3cchrv9l01n3c2v0v0mghq30hap55p79";
     };
 
     "i686-linux" = fetchurl {
@@ -116,7 +116,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "1s0k82ch7ypjyc5k5rb4skb9ylnp7b9ipvf8gb7pdhb8m4zjk461";
+      sha256 = "1vw5wh193vs5x3wizz34m2nyzlxpn24727hdxqpiqwlhwhj7y3nx";
     };
   };
 in
@@ -151,9 +151,13 @@ stdenv.mkDerivation rec {
     pushd "$TBB_IN_STORE"
 
     # Set ELF interpreter
-    for exe in firefox TorBrowser/Tor/tor ; do
+    for exe in firefox.real TorBrowser/Tor/tor ; do
+      echo "Setting ELF interpreter on $exe ..." >&2
       patchelf --set-interpreter "$interp" "$exe"
     done
+
+    # firefox is a wrapper that checks for a more recent libstdc++ & appends it to the ld path
+    mv firefox.real firefox
 
     # The final libPath.  Note, we could split this into firefoxLibPath
     # and torLibPath for accuracy, but this is more convenient ...
@@ -216,7 +220,7 @@ stdenv.mkDerivation rec {
 
     // Insist on using IPC for communicating with Tor
     //
-    // Defaults to creating $TBB_HOME/TorBrowser/Data/Tor/{socks,control}.socket
+    // Defaults to creating \$TBB_HOME/TorBrowser/Data/Tor/{socks,control}.socket
     lockPref("extensions.torlauncher.control_port_use_ipc", true);
     lockPref("extensions.torlauncher.socks_port_use_ipc", true);
 
@@ -241,10 +245,6 @@ stdenv.mkDerivation rec {
     FONTCONFIG_FILE=$TBB_IN_STORE/TorBrowser/Data/fontconfig/fonts.conf
     sed -i "$FONTCONFIG_FILE" \
         -e "s,<dir>fonts</dir>,<dir>$TBB_IN_STORE/fonts</dir>,"
-
-    # Move default extension overrides into distribution dir, to avoid
-    # having to synchronize between local state and store.
-    mv TorBrowser/Data/Browser/profile.default/preferences/extension-overrides.js defaults/pref/torbrowser.js
 
     # Preload extensions by moving into the runtime instead of storing under the
     # user's profile directory.
@@ -381,11 +381,7 @@ stdenv.mkDerivation rec {
     cp $desktopItem/share/applications"/"* $out/share/applications
     sed -i $out/share/applications/torbrowser.desktop \
         -e "s,Exec=.*,Exec=$out/bin/tor-browser," \
-        -e "s,Icon=.*,Icon=$out/share/pixmaps/torbrowser.png,"
-
-    # Install icons
-    mkdir -p $out/share/pixmaps
-    cp browser/icons/mozicon128.png $out/share/pixmaps/torbrowser.png
+        -e "s,Icon=.*,Icon=web-browser,"
 
     # Check installed apps
     echo "Checking bundled Tor ..."

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -44,6 +44,7 @@
 , glibcLocales
 , hicolor-icon-theme
 , shared-mime-info
+, gsettings-desktop-schemas
 
 # Whether to disable multiprocess support to work around crashing tabs
 # TODO: fix the underlying problem instead of this terrible work-around
@@ -264,6 +265,11 @@ stdenv.mkDerivation rec {
       hicolor-icon-theme
       shared-mime-info
     ]}
+    WRAPPER_XDG_DATA_DIRS+=":"${concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
+      glib
+      gsettings-desktop-schemas
+      gtk3
+    ]};
 
     # Generate wrapper
     mkdir -p $out/bin

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -99,7 +99,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "8.0";
+  version = "8.0.1";
 
   lang = "en-US";
 
@@ -109,7 +109,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "139cizh33x3nzr0f4b2q3cchrv9l01n3c2v0v0mghq30hap55p79";
+      sha256 = "05k914066pk11qxbwr77g6v20cfc8h9mh9yc3bpsfy35p8sypv8c";
     };
 
     "i686-linux" = fetchurl {
@@ -117,7 +117,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "1vw5wh193vs5x3wizz34m2nyzlxpn24727hdxqpiqwlhwhj7y3nx";
+      sha256 = "1w2apsiimy6d5vpql37j5bmf8y8xhx4irryd5ad3vqqsr0x5wla7";
     };
   };
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5070,7 +5070,9 @@ with pkgs;
     Also, consider using nix-built tor-browser-unwrapped package instead. Read its longDescription.
   '' */ tor-browser-bundle-bin;
 
-  tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin { };
+  tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin {
+    inherit (gnome3) defaultIconTheme;
+  };
 
   tor-browser-bundle = callPackage ../applications/networking/browsers/tor-browser-bundle {
     stdenv = stdenvNoCC;


### PR DESCRIPTION
###### Motivation for this change

For security-sensitive applications like this it is better to stick to supported versions, also this means we have to perform major version upgrades. cc @joachifm @andir 
The less-preferred alternative would be to mark it as insecure in 18.03 since there have been security fixes in 8.0.2


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

