### PR TITLE
limesuite: 18.06.0->18.10.0

### DIFF
--- a/pkgs/applications/misc/limesuite/default.nix
+++ b/pkgs/applications/misc/limesuite/default.nix
@@ -4,7 +4,7 @@
 } :
 
 let
-  version = "18.06.0";
+  version = "18.10.0";
 
 in stdenv.mkDerivation {
   name = "limesuite-${version}";
@@ -13,8 +13,10 @@ in stdenv.mkDerivation {
     owner = "myriadrf";
     repo = "LimeSuite";
     rev = "v${version}";
-    sha256 = "0j6mxlvij2k6ib1d9jwzvilmqgm1h0q7wy9sf8a6bvidwlphvy25";
+    sha256 = "0nbyvcdwvfvln1wic9qwb7y221v3jv454gp5v6ms9112a41zj46h";
   };
+
+  enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake ];
 
@@ -36,10 +38,6 @@ in stdenv.mkDerivation {
 
     mkdir -p $out/share/limesuite
     cp bin/Release/lms7suite_mcu/* $out/share/limesuite
-
-    cp bin/dualRXTX $out/bin
-    cp bin/basicRX $out/bin
-    cp bin/singleRX $out/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update and do some cleanup.

###### Things done

* update
* remove example binaries from  output
* enable parallel building

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

