### PR TITLE
kdbg: init at 3.0.0

### DIFF
--- a/pkgs/development/tools/misc/kdbg/default.nix
+++ b/pkgs/development/tools/misc/kdbg/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, extra-cmake-modules, qt5,
+  ki18n, kconfig, kiconthemes, kxmlgui, kwindowsystem,
+}:
+
+stdenv.mkDerivation rec {
+  name = "kdbg-${version}";
+  version = "3.0.0";
+  src = fetchurl {
+    url = "mirror://sourceforge/kdbg/${version}/${name}.tar.gz";
+    sha256 = "0lxfal6jijdcrf0hc81gmapfmz0kq4569d5qzfm4p72rq9s4r5in";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ qt5.qtbase ki18n kconfig kiconthemes kxmlgui kwindowsystem ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.kdbg.org/;
+    description = ''
+      A graphical user interface to gdb, the GNU debugger. It provides an
+      intuitive interface for setting breakpoints, inspecting variables, and
+      stepping through code.
+    '';
+    license = licenses.gpl2;
+    maintainers = [ maintainers.catern ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3624,6 +3624,8 @@ with pkgs;
 
   lvmsync = callPackage ../tools/backup/lvmsync { };
 
+  kdbg = libsForQt5.callPackage ../development/tools/misc/kdbg { };
+
   kippo = callPackage ../servers/kippo { };
 
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

