### PR TITLE
codimd: update patch and fix test

### DIFF
--- a/nixos/tests/codimd.nix
+++ b/nixos/tests/codimd.nix
@@ -40,8 +40,7 @@ import ./make-test.nix ({ pkgs, lib, ... }:
     subtest "CodiMD sqlite", sub {
       $codimdSqlite->waitForUnit("codimd.service");
       $codimdSqlite->waitForOpenPort(3000);
-      $codimdSqlite->sleep(10); # avoid 503 during startup
-      $codimdSqlite->succeed("curl -sSf http://localhost:3000/new");
+      $codimdSqlite->waitUntilSucceeds("curl -sSf http://localhost:3000/new");
     };
 
     subtest "CodiMD postgres", sub {
@@ -49,8 +48,7 @@ import ./make-test.nix ({ pkgs, lib, ... }:
       $codimdPostgres->waitForUnit("codimd.service");
       $codimdPostgres->waitForOpenPort(5432);
       $codimdPostgres->waitForOpenPort(3000);
-      $codimdPostgres->sleep(10); # avoid 503 during startup
-      $codimdPostgres->succeed("curl -sSf http://localhost:3000/new");
+      $codimdPostgres->waitUntilSucceeds("curl -sSf http://localhost:3000/new");
     };
   '';
 })

--- a/pkgs/servers/web-apps/codimd/default.nix
+++ b/pkgs/servers/web-apps/codimd/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch { # fixes for configurable paths
       url = "https://patch-diff.githubusercontent.com/raw/hackmdio/codimd/pull/940.patch";
-      sha256 = "0n9lfaxirngywx8m5f0nqzykqdjzc8f3cl10ir1g7s5kq4zc7hhn";
+      sha256 = "0w1cvnp3k1n8690gzlrfijisn182i0v8psjs3df394rfx2347xyp";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
I updated my PR, which was recently merged into master of CodiMD, so the checksum of the included patch changed.

Also [the test](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.codimd.x86_64-linux) still seems to be non-deterministic after #47179, because the first request right after startup results only sometimes in a 503. Now there is a `waitUntilSucceeds` for this request, because a consecutive request always works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

