### PR TITLE
pythonPackages.av: 0.4.1 -> 0.5.3

### DIFF
--- a/pkgs/development/python-modules/av/default.nix
+++ b/pkgs/development/python-modules/av/default.nix
@@ -4,7 +4,7 @@
 , nose
 , pillow
 , numpy
-, ffmpeg_2
+, ffmpeg_4
 , git
 , libav
 , pkgconfig
@@ -12,16 +12,16 @@
 
 buildPythonPackage rec {
   pname = "av";
-  version = "0.4.1";
+  version = "0.5.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bf9a8d113392c6a445f424e16f9e64ac53d1db1548731e6326763d555647c24f";
+    sha256 = "0k5nbff8c2wxc8wnyn1qghndbd2rjck1y3552s63w41mccj1k1qr";
   };
 
-  buildInputs = [ nose pillow numpy ffmpeg_2 git libav pkgconfig ];
+  buildInputs = [ nose pillow numpy ffmpeg_4 git pkgconfig ];
 
-  # Because of https://github.com/mikeboers/PyAV/issues/152
+  # Tests require downloading files from internet
   doCheck = false;
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -744,9 +744,7 @@ in {
 
   autopep8 = callPackage ../development/python-modules/autopep8 { };
 
-  av = callPackage ../development/python-modules/av {
-    inherit (pkgs) ffmpeg_2 git libav pkgconfig;
-  };
+  av = callPackage ../development/python-modules/av { };
 
   avro = callPackage ../development/python-modules/avro {};
 


### PR DESCRIPTION
###### Things done
Update av to the latest version.

I switched to using a newer version of ffmpeg (it was previously using ffmpeg 2, which is no longer supported by this library). I also removed libav as a build input, because it does not seem to be necessary.

I've tested it with aiortc (out of nixpkgs tree) and it seems to work correctly.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

