### PR TITLE
ansible: Update to latest supported releases

### DIFF
--- a/pkgs/development/tools/ansible-lint/default.nix
+++ b/pkgs/development/tools/ansible-lint/default.nix
@@ -19,6 +19,10 @@ pythonPackages.buildPythonPackage rec {
     patchShebangs bin/ansible-lint
   '';
 
+   preBuild = ''
+     export HOME="$TMP"
+   '';
+
   checkPhase = ''
     nosetests test
   '';

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -62,6 +62,11 @@ in rec {
     sha256  = "10pakw9k9wd3cy1qk3ah2253ph7c7h3qzpal4k0s5lschzgy2fh0";
   };
 
-  ansible2 = ansible_2_6;
+  ansible_2_7 = generic {
+    version = "2.7.1";
+    sha256  = "0fg95x2nr3j4rwnlyd2n03h91xx9fssi34c32356vk3z6ir395g7";
+  };
+
+  ansible2 = ansible_2_7;
   ansible  = ansible2;
 }

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -58,8 +58,8 @@ in rec {
   };
 
   ansible_2_6 = generic {
-    version = "2.6.2";
-    sha256  = "1y5gd9h641p6pphwd7j99yyqglyj23rkmid7wgzk62611754qzkl";
+    version = "2.6.7";
+    sha256  = "10pakw9k9wd3cy1qk3ah2253ph7c7h3qzpal4k0s5lschzgy2fh0";
   };
 
   ansible2 = ansible_2_6;

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -53,8 +53,8 @@ in rec {
   };
 
   ansible_2_5 = generic {
-    version = "2.5.2";
-    sha256  = "1r9sq30xz3jrvx6yqssj5wmkml1f75rx1amd7g89f3ryngrq6m59";
+    version = "2.5.11";
+    sha256  = "07rhgkl3a2ba59rqh9pyz1p661gc389shlwa2sw1m6wwifg4lm24";
   };
 
   ansible_2_6 = generic {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8059,6 +8059,7 @@ with pkgs;
     ansible_2_4
     ansible_2_5
     ansible_2_6
+    ansible_2_7
     ansible2
     ansible;
 


### PR DESCRIPTION
###### Motivation for this change

Update to latest supported ansible releases, see https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#release-status

###### Things done

- ~~removed ansible 2.4~~
- updated to latest minor release for 2.5 + 2.6 
- added ansible 2.7


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I had to add the `preBuild` step for ansible-lint because some tests failed during `nix-shell -p nox --run "nox-review wip"`. I don't really understand why this was no issue before this change.

cc @jgeerds @joamaki 