### PR TITLE
quickserve: init at 2018

### DIFF
--- a/pkgs/tools/networking/quickserve/default.nix
+++ b/pkgs/tools/networking/quickserve/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchzip, python3, python3Packages, writeScript }: let
+  threaded_servers = python3Packages.buildPythonPackage {
+    name = "threaded_servers";
+    src = fetchzip {
+      url = https://xyne.archlinux.ca/projects/python3-threaded_servers/src/python3-threaded_servers-2018.6.tar.xz;
+      sha256 = "1irliz90a1dk4lyl7mrfq8qnnrfad9czvbcw1spc13zyai66iyhf";
+    };
+
+    # stuff we don't care about pacserve
+    doCheck = false;
+  };
+  quickserve = writeScript "quickserve" ''
+    #!/bin/sh
+    ${python3.withPackages (_: [ threaded_servers ])}/bin/python -mThreadedServers.PeeredQuickserve "$@"
+  '';
+
+in stdenv.mkDerivation {
+  name = "quickserve";
+  version = "2018";
+
+  phases = [ "buildPhase" ];
+  buildPhase = ''
+    mkdir -p $out/bin
+    cp ${quickserve} $out/bin/quickserve
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple HTTP server for quickly sharing files.";
+    homepage = https://xyne.archlinux.ca/projects/quickserve/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ lassulus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4925,6 +4925,8 @@ with pkgs;
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  quickserve = callPackage ../tools/networking/quickserve { };
+
   quicktun = callPackage ../tools/networking/quicktun { };
 
   quilt = callPackage ../development/tools/quilt { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

