### PR TITLE
dex: grab simple upstream patch so it reports the right version

### DIFF
--- a/pkgs/tools/X11/dex/default.nix
+++ b/pkgs/tools/X11/dex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3 }:
+{ stdenv, fetchFromGitHub, python3, fetchpatch }:
 
 stdenv.mkDerivation rec {
   program = "dex";
@@ -15,6 +15,13 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ python3 ];
   nativeBuildInputs = [ python3.pkgs.sphinx ];
   makeFlags = [ "PREFIX=$(out)" "VERSION=$(version)" ];
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/jceb/dex/commit/107358ddf5e1ca4fa56ef1a7ab161dc3b6adc45a.patch;
+      sha256 = "06dfkfzxp8199by0jc5wim8g8qw38j09dq9p6n9w4zaasla60pjq";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A program to generate and execute DesktopEntry files of the Application type";


### PR DESCRIPTION
'dex --version' shows incorrect value, which may be misleading.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---