### PR TITLE
chromium/update.sh: don't use remote builders, lots of copying for work

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/update.sh
+++ b/pkgs/applications/networking/browsers/chromium/update.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 cd "$(dirname "$0")"
-sp="$(nix-build -Q --no-out-link update.nix -A update)"
+sp="$(nix-build --builders "" -Q --no-out-link update.nix -A update)"
 cat "$sp" > upstream-info.nix


### PR DESCRIPTION
When using a machine setup for distributed builds, current script will download
the huge sources and copy them to a remote builder to perform some minor calculation
(perhaps computing the hash, not sure).

Using remote builders for this is rather unlikely to 'pay off' even with a very fast link,
since the size of the data copied is so large compared to what it's used for.

This tweaks the script to avoid using remote builders.

Hopefully this sounds good to everyone, but especially the person(s) who normally update our chrome bits :).
If not, whatever works best for that person is probably the way to go.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---