### PR TITLE
helm: build from source

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1195,6 +1195,11 @@
     github = "eduarrrd";
     name = "Eduard Bachmakov";
   };
+  edude03 = {
+    email = "michael@melenion.com";
+    github = "edude03";
+    name = "Michael Francis";
+  };
   edwtjo = {
     email = "ed@cflags.cc";
     github = "edwtjo";

--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -1,50 +1,48 @@
-{ stdenv, fetchurl, kubectl }:
-let
-  isLinux = stdenv.isLinux;
-  arch = if isLinux
-         then "linux-amd64"
-         else "darwin-amd64";
-  checksum = if isLinux
-             then "18bk4zqdxdrdcl34qay5mpzzywy9srmpz3mm91l0za6nhqapb902"
-             else "03xb73769awc6dpvz86nqm9fbgp3yrw30kf5lphf76klk2ii66sm";
-  pname = "helm";
-  version = "2.11.0";
-in
-stdenv.mkDerivation {
-  name = "${pname}-${version}";
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
-  src = fetchurl {
-    url = "https://kubernetes-helm.storage.googleapis.com/helm-v${version}-${arch}.tar.gz";
-    sha256 = checksum;
+buildGoPackage rec {
+  version = "2.11.0";
+  name = "helm-${version}";
+
+  src = fetchFromGitHub {
+    owner = "helm";
+    repo = "helm";
+    rev = "v${version}";
+    sha256 = "1z810a6mxyrrw4i908dip8aqsj95c0kmv6xpb1wwhskg1zmf85wk";
   };
 
-  preferLocalBuild = true;
+  goPackagePath = "k8s.io/helm";
+  subPackages = [ "cmd/helm" "cmd/tiller" "cmd/rudder" ];
 
-  buildInputs = [ ];
+  goDeps = ./deps.nix;
 
-  propagatedBuildInputs = [ kubectl ];
-
-  phases = [ "buildPhase" "installPhase" ];
-
-  buildPhase = ''
-    mkdir -p $out/bin
+  # Thsese are the original flags from the helm makefile
+  buildFlagsArray = ''
+    -ldflags=
+    -w
+    -s
   '';
 
-  installPhase = ''
-    tar -xvzf $src
-    cp ${arch}/helm $out/bin/${pname}
-    chmod +x $out/bin/${pname}
-    mkdir -p $out/share/bash-completion/completions
-    mkdir -p $out/share/zsh/site-functions
-    $out/bin/helm completion bash > $out/share/bash-completion/completions/helm
-    $out/bin/helm completion zsh > $out/share/zsh/site-functions/_helm
+  preBuild = ''
+    # This is a hack(?) to flatten the dependency tree the same way glide or dep would
+    # Otherwise you'll get errors like
+    # have DeepCopyObject() "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime".Object
+    # want DeepCopyObject() "k8s.io/apimachinery/pkg/runtime".Object
+    rm -rf $NIX_BUILD_TOP/go/src/k8s.io/kubernetes/vendor
+    rm -rf $NIX_BUILD_TOP/go/src/k8s.io/apiextensions-apiserver/vendor
+  '';
+
+  postInstall = ''
+    mkdir -p $bin/share/bash-completion/completions
+    mkdir -p $bin/share/zsh/site-functions
+    $bin/bin/helm completion bash > $bin/share/bash-completion/completions/helm
+    $bin/bin/helm completion zsh > $bin/share/zsh/site-functions/_helm
   '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/kubernetes/helm;
     description = "A package manager for kubernetes";
     license = licenses.asl20;
-    maintainers = [ maintainers.rlupton20 ];
-    platforms = [ "x86_64-linux" ] ++ platforms.darwin;
+    maintainers = [ maintainers.rlupton20 maintainers.edude03 ];
   };
 }

--- a/pkgs/applications/networking/cluster/helm/deps.nix
+++ b/pkgs/applications/networking/cluster/helm/deps.nix
@@ -1,0 +1,840 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "3b1ae45394a234c385be014e9a488f2bb6eef821";
+      sha256 = "0alb495ql6s02kb6lxcbnlkdcmhixyl8zv11sgrkhsk1bckzh119";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/go-ansiterm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-ansiterm";
+      rev =  "19f72df4d05d31cbe1c56bfc8045c96babff6c7e";
+      sha256 = "0663w5m5qlidpj17s5pqp6rhl0phw7vypf104n04dvdy5nd418ix";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/go-autorest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-autorest";
+      rev =  "1ff28809256a84bb6966640ff3d0371af82ccba4";
+      sha256 = "0sxvj2j1833bqwxvhq3wq3jgq73rnb81pnzvl0x3y1m0hzpaf2zv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev =  "b26d9c308763d68093482582cea63d69be07a0f0";
+      sha256 = "0k7v2i1d2d6si8gswn83qb84czhhia53v2wdy33yz9ppdidxk0ry";
+    };
+  }
+  {
+    goPackagePath  = "github.com/MakeNowJust/heredoc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/MakeNowJust/heredoc";
+      rev =  "bb23615498cded5e105af4ce27de75b089cbe851";
+      sha256 = "17m780i9afj3sbmcrgwgzarfly4x9376w56qblkqnzdkv6vps22i";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Masterminds/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/semver";
+      rev =  "517734cc7d6470c0d07130e40fd40bdeb9bcd3fd";
+      sha256 = "1625b5sxpmlz60jw67j1ljfcc09d4lhxg3z6gc4am8s2rrdgwij6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Masterminds/sprig";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/sprig";
+      rev =  "15f9564e7e9cf0da02a48e0d25f12a7b83559aa6";
+      sha256 = "1k5pfx9hxzb70kh73a009ikr3vqlq0jvzvbyvxz9x7a7yc4r5b14";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Masterminds/vcs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Masterminds/vcs";
+      rev =  "3084677c2c188840777bff30054f2b553729d329";
+      sha256 = "1062m73h0pp5d0574lf6px4jsjgywnsbkw50inxx3zal5r185ydm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/PuerkitoBio/purell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/purell";
+      rev =  "8a290539e2e8629dbc4e6bad948158f790ec31f4";
+      sha256 = "1qhsy1nm96b9kb63svkvkqmmw15xg6irwcysisxdgzk64adfwqv1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/PuerkitoBio/urlesc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/urlesc";
+      rev =  "5bd2802263f21d8788851d5305584c82a5c75d7e";
+      sha256 = "15y5r3asvm7196m3nza5xvdvlc2k11p6lfs6hi917hl7r9vgi6mp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/aokoli/goutils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aokoli/goutils";
+      rev =  "9c37978a95bd5c709a15883b6242714ea6709e64";
+      sha256 = "1c51qgk4pjc8c776h7589c3d14791h86f1yj3ykg4q7vlcf9xrnr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/asaskevich/govalidator";
+    fetch = {
+      type = "git";
+      url = "https://github.com/asaskevich/govalidator";
+      rev =  "7664702784775e51966f0885f5cd27435916517b";
+      sha256 = "1lmynw9vkgrxv7nh60wdywv0nx4gjlkiar433wydhpc2h3m5q968";
+    };
+  }
+  {
+    goPackagePath  = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev =  "3ac7bf7a47d159a033b107610db8a1b6575507a4";
+      sha256 = "1qc3l4r818xpvrhshh1sisc5lvl9479qspcfcdbivdyh0apah83r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/chai2010/gettext-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chai2010/gettext-go";
+      rev =  "bf70f2a70fb1b1f36d90d671a72795984eab0fcb";
+      sha256 = "0bwjwvjl7zqm7kxram1rzz0ri3h897kiin13ljy9hx3fzz1i9lml";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev =  "71acacd42f85e5e82f70a55327789582a5200a90";
+      sha256 = "0hmkrq4gdzb6mwllmh4p1y7vrz7hyr8xqagpk9nyr5dhygvnnq2v";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cyphar/filepath-securejoin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cyphar/filepath-securejoin";
+      rev =  "a261ee33d7a517f054effbf451841abaafe3e0fd";
+      sha256 = "0id32zjb92wm569m29nfrzz5mw9z1glr3klayr6j134pp4h1sgq4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "782f4967f2dc4564575ca782fe2d04090b5faca8";
+      sha256 = "1ypijjawqc0xgmgim42260ibcyclfgfizicz5cbvndw4plqfsswk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/distribution";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/distribution";
+      rev =  "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c";
+      sha256 = "1nqjaq1q6fs3c0avpb02sib0a906xfbk3m74hk2mqjdbyx9y8b4m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/docker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/docker";
+      rev =  "4f3616fb1c112e206b88cb7a9922bf49067a7756";
+      sha256 = "0zmsqm1lkwggfqgy2rw34g4g2jlvr6mvcsh65fmpdb30l65iaqzf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/go-connections";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-connections";
+      rev =  "3ede32e2033de7505e6500d6c868c2b9ed9f169d";
+      sha256 = "0v1pkr8apwmhyzbjfriwdrs1ihlk6pw7izm57r24mf9jdmg3fyb0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/go-units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-units";
+      rev =  "9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1";
+      sha256 = "1sqwvcszxqpv77xf2d8fxvryxphdwj9v8f93231wpnk9kpilhyii";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/spdystream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/spdystream";
+      rev =  "449fdfce4d962303d702fec724ef0ad181c92528";
+      sha256 = "1412cpiis971iq1kxrirzirhj2708ispjh0x0dh879b66x8507sl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/evanphx/json-patch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/evanphx/json-patch";
+      rev =  "94e38aa1586e8a6c8a75770bddf5ff84c48a106b";
+      sha256 = "1c9gzc3gb76lm5famc0345y90is1lyffn39bmdr0xk19462f8av5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/exponent-io/jsonpath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/exponent-io/jsonpath";
+      rev =  "d6023ce2651d8eafb5c75bb0c7167536102ec9f5";
+      sha256 = "1qkzaxsjs7yg1672sk67nr119j7jc4751yzgii0j3nbipjv321kc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/camelcase";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/camelcase";
+      rev =  "f6a740d52f961c60348ebb109adde9f4635d7540";
+      sha256 = "15vb86adns1izvbzjw0lmmzrwlarhbxw5qalhx10vzzdx73wh4ai";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev =  "73d445a93680fa1a78ae23a5839bad48f32ba1ee";
+      sha256 = "0pg53ky4sy3sp9j4n7vgf1p3gw4nbckwqfldcmmi9rf13kjh0mr7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/jsonpointer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/jsonpointer";
+      rev =  "46af16f9f7b149af66e5d1bd010e3574dc06de98";
+      sha256 = "0w0fphmdycjzbsm1vppdcjc9aqinkcdzcq3pxikdvdqh5p791gsc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/jsonreference";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/jsonreference";
+      rev =  "13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272";
+      sha256 = "1fh4xcl9ijww4bdq656sx981d57w2c9zx5148jsxlsg4bsvxmwis";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/spec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/spec";
+      rev =  "1de3e0542de65ad8d75452a595886fdd0befb363";
+      sha256 = "13i9y71fk9vr2abvpsk04k55il32ly3fjinvl1zlamh9mi2mdzf4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/swag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/swag";
+      rev =  "f3f9494671f93fcff853e3c6e9e948b3eb71e590";
+      sha256 = "13lqn4xqy9vma9aqsjb0fzfzi0q8l6dmg65sjxqdxf3q6gzkvmjy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gobwas/glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobwas/glob";
+      rev =  "5ccd90ef52e1e632236f7326478d4faa74f99438";
+      sha256 = "0jxk1x806zn5x86342s72dq2qy64ksb3zrvrlgir2avjhwb18n6z";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "c0656edd0d9eab7c66d1eb0c568f9039345796f7";
+      sha256 = "0b943dhx571lhgcs3rqzy0092mi2x5mwy2kl7g8rryhy3r5rzrz9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev =  "44145f04b68cf362d9c4df2182967c2275eaefed";
+      sha256 = "1k7sf6qmpgm0iw81gx2dwggf9di6lgw0n54mni7862hihwfrb5rq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/groupcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/groupcache";
+      rev =  "02826c3e79038b59d737d3b1c0a1d937f71a4433";
+      sha256 = "0w46bsllddfij66nrg8jbfjsr54birvfww8a2fj9fmgyig5syn2x";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9";
+      sha256 = "1ch3czyzq5abl6zm1l0dfsi09xj43ql9jcbmbhfhxz954pw03v3v";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev =  "7d79101e329e5a3adf994758c578dab82b90c017";
+      sha256 = "1c1hsy5s2pfawg3l9954jmqmy4yc2zp3f7i87m00km2yqgb8xpd0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev =  "44d81051d367757e1c7c6a5a86423ece9afcf63c";
+      sha256 = "0ivq2sl2fv8x0xxrcys27c42s8yq7irgl7lp6l0im9i7ky63nk0i";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev =  "064e2069ce9c359c118179501254f67d7d37ba24";
+      sha256 = "1b1ibx3rbiv7xwa9kz4b4zpp1fza5cjnn8v6749b4vrkjjmp3rqb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/googleapis/gnostic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gnostic";
+      rev =  "0c5108395e2debce0d731cf0287ddf7242066aba";
+      sha256 = "0jf3cp5clli88gpjf24r6wxbkvngnc1kf59d4cgjczsn2wasvsfc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gophercloud/gophercloud";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gophercloud/gophercloud";
+      rev =  "781450b3c4fcb4f5182bcc5133adb4b2e4a09d1d";
+      sha256 = "0xvapk94p1259k8arvwyvhwvcnzma9vdg12g750cgz2ghkzvfhff";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gosuri/uitable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gosuri/uitable";
+      rev =  "36ee7e946282a3fb1cfecd476ddc9b35d8847e42";
+      sha256 = "1ff68fv9g1df91fwbrcq83ar429gb4fi2vsd22zjmhvmbqx2zkil";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gregjones/httpcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gregjones/httpcache";
+      rev =  "787624de3eb7bd915c329cba748687a3b22666a6";
+      sha256 = "1zqlg9pkj7r6fqw7wv3ywvbz3bh0hvzifs2scgcraj812q5189w5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/grpc-ecosystem/go-grpc-prometheus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc-ecosystem/go-grpc-prometheus";
+      rev =  "0c1b191dbfe51efdabe3c14b9f6f3b96429e0722";
+      sha256 = "0d7vybd4yy9a9clk03578xdpyhifxsy3qv6iiglrrnblbmpgksjc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev =  "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4";
+      sha256 = "1z3h4aca31l3qs0inqr5l49vrlycpjm7vq1l9nh1mp0mb2ij0kmp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/huandu/xstrings";
+    fetch = {
+      type = "git";
+      url = "https://github.com/huandu/xstrings";
+      rev =  "3959339b333561bf62a38b424fd41517c2c90f40";
+      sha256 = "0f1jyd80grpr88gwhljx2x0xgsyzw07807n4z4axxxlybh5f0nh1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/imdario/mergo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/imdario/mergo";
+      rev =  "6633656539c1639d9d78127b7d47c622b5d7b6dc";
+      sha256 = "1fffbq1l17i0gynmvcxypl7d9h4v81g5vlimiph5bfgf4sp4db7g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev =  "f2b4162afba35581b6d4a50d3b8f34e33c144682";
+      sha256 = "0siqfghsm2lkdwinvg8x5gls3p76rq3cdm59c1r4x0b2mdfhnvcd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mailru/easyjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailru/easyjson";
+      rev =  "2f5df55504ebc322e4d52d34df6a1f5b503bf26d";
+      sha256 = "0d9m8kyhbawa452vnwn255xxnh6pkp3im0d2310rw1k14nh3yh1p";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev =  "d6bea18f789704b5f83375793155289da36a3c7f";
+      sha256 = "1hnigpn7rjbwd1ircxkyx9hvi0xmxr32b2jdy2jzw6b3jmcnz1fs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev =  "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a";
+      sha256 = "0ajg41h6402big484drvm72wvid1af2sffw0qkzbmpy04lq68ahj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/go-wordwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-wordwrap";
+      rev =  "ad45545899c7b13c020ea92b2072220eefad42b8";
+      sha256 = "0ny1ddngvwfj3njn7pmqnf3l903lw73ynddw15x8ymp7hidv27v9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev =  "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev =  "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd";
+      sha256 = "1721y3yr3dpx5dx5ashf063qczk2awy5zjir1jvp1h5hn7qz4i49";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/go-digest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/go-digest";
+      rev =  "a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb";
+      sha256 = "1paz3na2xkhi10p5bk7f7gbh5yykfgr9f9i2gcc13rb461yq6fmg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/image-spec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/image-spec";
+      rev =  "372ad780f63454fbbbbcc7cf80e5b90245c13e13";
+      sha256 = "0wajddbm49bfybkab9midilg18zvdvvsffwhkq7bpp7inj4jnsvs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/petar/GoLLRB";
+    fetch = {
+      type = "git";
+      url = "https://github.com/petar/GoLLRB";
+      rev =  "53be0d36a84c2a886ca057d34b6aa4468df9ccb4";
+      sha256 = "01xp3lcamqkvl91jg6ly202gdsgf64j39rkrcqxi6v4pbrcv7hz0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/peterbourgon/diskv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/peterbourgon/diskv";
+      rev =  "5f041e8faa004a95c88a202771f4cc3e991971e6";
+      sha256 = "1mxpa5aad08x30qcbffzk80g9540wvbca4blc1r2qyzl65b8929b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "d8ed2627bdf02c080bf22230dbb337003b7aba2d";
+      sha256 = "0w1jp4k4zbnrxh3jvh8fgbjgqpf2hg31pbj8fb32kh26px9ldpbs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev =  "c5b7fccd204277076155f10851dad72b76a49317";
+      sha256 = "1xqny3147g12n4j03kxm8s9mvdbs3ln6i56c655mybrn9jjy48kd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev =  "fa8ad6fec33561be4280a8f0514318c79d7f6cb6";
+      sha256 = "11a7v1fjzhhwsl128znjcf5v7v6129xjgkdpym2lial4lac1dhm9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev =  "13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207";
+      sha256 = "0i6mpcnsawi7f00rfmjfjq8llaplyzq4xrkrawlcgfd762p5hnp8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev =  "65c1f6f8f0fc1e2185eb9863a3bc751496404259";
+      sha256 = "0jfzmr8642hr04naim1maa3wklxvcxklykri2z7k4ayizc974lkq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev =  "300106c228d52c8941d4b3de6054a6062a86dda3";
+      sha256 = "1bcqwb9lk2sijn5q3kqp7sadhh0ysbxlj5bxjspk9yp5bp733cbh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/sanitized_anchor_name";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/sanitized_anchor_name";
+      rev =  "10ef21a441db47d8b13ebcc5fd2310f636973c77";
+      sha256 = "1cnbzcf47cn796rcjpph1s64qrabhkv5dn9sbynsy7m9zdwr5f01";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "89742aefa4b206dcf400792f3bd35b542998eb3b";
+      sha256 = "0hk7fabx59msg2y0iik6xvfp80s73ybrwlcshbm9ds91iqbkcxi6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "c439c4fa093711d42e1b01acb1235b52004753c1";
+      sha256 = "14v5vhb180yzaknxnm8j4n9jai58b0y2nzrqzpdq7bj9slsga1vd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "583c0c0531f06d5278b7d917446061adc344b5cd";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "e3a8ff8ce36581f87a15341206f205b1da467059";
+      sha256 = "179k26lcgafkbjylbhgj2f5pnh52bmv19rr1w95gca944blw8yga";
+    };
+  }
+  {
+    goPackagePath  = "github.com/technosophos/moniker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/technosophos/moniker";
+      rev =  "a5dbd03a2245d554160e3ae6bfdcf969fe58b431";
+      sha256 = "1z273gvbwr09lcxwd10wyvxmxjln93r952sr1w9hqxcgc1f8l3vl";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "49796115aa4b964c318aad4f3084fdb41e9aa067";
+      sha256 = "0pcq2drkzsw585xi6rda8imd7a139prrmvgmv8nz0zgzk6g4dy59";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "1c05540f6879653db88113bc4a2b70aec4bd491f";
+      sha256 = "0h8yqb0vcqgllgydrf9d3rzp83w8wlr8f0nm6r1rwf2qg30pq1pd";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "a6bd8cefa1811bd24b86f8902872e4e8225f74c4";
+      sha256 = "151in8qcf5y97ziavl6b03vgw4r87zqx5kg4vjhjszjbh60cfswp";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "43eea11bc92608addb41b8a406b0407495c106f6";
+      sha256 = "0k9wy278f5753d130p8asva2g573vi6wviwkxwwnpxni118knq1l";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "b19bf474d317b857955b12035d2c5acb57ce8b01";
+      sha256 = "0wc8csaafp0ps9jb2hdk8d6xpyw1axhk1np73h0z17x09zk3ylcr";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev =  "f51c12702a4d776e4c1fa9b0fabab841babae631";
+      sha256 = "07wc6g2fvafkr6djsscm0jpbpl4135khhb6kpyx1953hi5d1jvyy";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "12d5545dc1cfa6047a286d5e853841b6471f4c19";
+      sha256 = "1bv6cjakhi6j3s1bqb3n45qrmvf20qkhwxllvi94jag4i7hd91w8";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev =  "09f6ed296fc66555a25fe4ce95173148778dfa85";
+      sha256 = "06x5wr7vjsnvv35rpv7jaklilksqbzsbqk8bxababw8vr6avfwki";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev =  "5ffe3083946d5603a0578721101dc8165b1d5b5f";
+      sha256 = "1ij3sy49xfihwpcpiwd68mlfkrk375kdh6r6jlqka18zalxgpaan";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/inf.v0";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-inf/inf";
+      rev =  "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4";
+      sha256 = "0rf3vwyb8aqnac9x9d6ax7z5526c45a16yjm2pvkijr6qgqz8b82";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/square/go-jose.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/square/go-jose";
+      rev =  "f8f38de21b4dcd69d0413faf231983f5fd6634b1";
+      sha256 = "1bjrs3xq3m2ckfds0l4wqf81311ymm9agipmkllbvkadac156dsa";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "670d4cfef0544295bc27a114dbac37980d83185a";
+      sha256 = "182x97q4826cpzybkrl8icyx1n6l1z0kspmbz33fh901v10b6322";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/api";
+      rev =  "2d6f90ab1293a1fb871cf149423ebb72aa7423aa";
+      sha256 = "1cwrwdm104xd3608b1a5mw6a19w45532p647xdwnyn62rw2f08jx";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/apiextensions-apiserver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apiextensions-apiserver";
+      rev =  "898b0eda132e1aeac43a459785144ee4bf9b0a2e";
+      sha256 = "1zn4i4wfmk3y36n6mqcidgsp4aqzwy5w9749zjl2bfbwzpk81bcp";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/apimachinery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apimachinery";
+      rev =  "103fd098999dc9c0c88536f5c9ad2e5da39373ae";
+      sha256 = "04navnpm59d75dhlz07rmay7m2izrf4m0i9xklxzqg7mlk9g20jc";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/apiserver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apiserver";
+      rev =  "8b122ec9e3bbab91a262d17a39325e69349dc44d";
+      sha256 = "0qfxjypa10s16sll2a75kn2ddjddr2xsa5rsiaxar3gs5pqvq1h5";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/client-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/client-go";
+      rev =  "59698c7d9724b0f95f9dc9e7f7dfdcc3dfeceb82";
+      sha256 = "0f069d1msdb2x4yvwv0wa3hzanl97csg4hsp1pycxpnqck6qx6qh";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/kube-openapi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/kube-openapi";
+      rev =  "91cfa479c814065e420cee7ed227db0f63a5854e";
+      sha256 = "0l9yvc7gfa8i4snpv1d13vy03dplzp2jh47rqr3fhiihcz2wx4s7";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/kubernetes";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/kubernetes";
+      rev =  "2e809eed16445fff9dcbfc56e9936cf76ccbdadc";
+      sha256 = "13fzcbjfc5c35gy66nbn1ms63b8bj3g8z7wja0p8dd3yj9lcj68h";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/utils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/utils";
+      rev =  "258e2a2fa64568210fbd6267cf1d8fd87c3cb86e";
+      sha256 = "1mbw3q03sflrdgj6l7q3frqzb5f78n0m0gzjm228sy1wnm4c3760";
+    };
+  }
+  {
+    goPackagePath  = "vbom.ml/util";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fvbommel/util";
+      rev =  "db5cfe13f5cc80a4990d98e2e1b0707a4d1a5394";
+      sha256 = "1k9c3ihhkrcmhd26pwd62mp2ll7icr2q65i5pkymnfnhhv40p682";
+    };
+  }
+]


### PR DESCRIPTION
###### Motivation for this change
By building helm from source we can support more platforms. As well, this enables building of the `tiller` and `rudder` commands.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

