### PR TITLE
cfssl: allow building on all platforms

### DIFF
--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -29,5 +29,6 @@ buildGoPackage rec {
     description = "Cloudflare's PKI and TLS toolkit";
     license = licenses.bsd2;
     maintainers = with maintainers; [ mbrgm ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -27,7 +27,6 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = https://cfssl.org/;
     description = "Cloudflare's PKI and TLS toolkit";
-    platforms = platforms.linux;
     license = licenses.bsd2;
     maintainers = with maintainers; [ mbrgm ];
   };


### PR DESCRIPTION
###### Motivation for this change
CFSSL is a go package, and thus can be built on all platforms go supports, not just linux. I use this patch locally to use cfssl on OSX.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

