### PR TITLE
[RDY] apvlv: add .desktop file

### DIFF
--- a/pkgs/applications/misc/apvlv/default.nix
+++ b/pkgs/applications/misc/apvlv/default.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/doc/apvlv/
     cp ../Startup.pdf $out/share/doc/apvlv/Startup.pdf
     cp ../main_menubar.glade $out/share/doc/apvlv/main_menubar.glade
+  ''
+  + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    install -D ../apvlv.desktop $out/share/applications/apvlv.desktop
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

While waiting for zathura synctex fixes to be in nixos-unstable, I switched to apvlv but as there is no .desktop, I had no default pdf applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

