### PR TITLE
pidgin-opensteamworks: 1.6.1 -> git-2018-08-02

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
@@ -2,22 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "pidgin-opensteamworks-${version}";
-  version = "1.6.1";
+  version = "unstable-2018-08-02";
 
   src = fetchFromGitHub {
     owner = "EionRobb";
     repo = "pidgin-opensteamworks";
-    rev = "${version}";
-    sha256 = "6ab27831e454ad3b440e4f06b52e0b3671a4f8417ba4da3ab6f56c56d82cc29b";
+    rev = "b16a636d177f4a8862abdfbdb2c0994712ea0cd3";
+    sha256 = "0qyxfrfzsm43f1gmbg350znwxld1fqr9a9yziqs322bx2vglzgfh";
   };
 
   preConfigure = "cd steam-mobile";
-  postInstall = ''
-    mkdir -p $out/lib/purple-2
-    mkdir -p $out/share/pixmaps/pidgin/protocols/
-    cp libsteam.so $out/lib/purple-2/
-    unzip releases/icons.zip -d $out/share/pixmaps/pidgin/protocols/
-  '';
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PLUGIN_DIR_PURPLE=/lib/purple-2"
+    "DATA_ROOT_DIR_PURPLE=/share"
+  ];
 
   buildInputs = [ pidgin unzip glib json-glib nss nspr libgnome-keyring ];
 


### PR DESCRIPTION
###### Motivation for this change
I've been somewhat hesitant to update this because there haven't been any actual releases after 1.6.1, but there have been a few relevant fixes and additions in the three years since then, so to git versions we go...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

