### PR TITLE
gutenberg: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/applications/misc/gutenberg/default.nix
+++ b/pkgs/applications/misc/gutenberg/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   name = "gutenberg-${version}";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "Keats";
     repo = "gutenberg";
     rev = "v${version}";
-    sha256 = "0is7156aim2ad8xg2f5068crc4gfvm89x8gxa25vc25p0yr1bpla";
+    sha256 = "0kzxz26khk5rwb9mz0wi9r8y7r93w4n2dbq6v2qr07cy5h14pa6w";
   };
 
-  cargoSha256 = "146vlr85n9d06am5ki76fh1vb5r8a4lzx5b7dmgi292kc3dsn41z";
+  cargoSha256 = "0n4ji06chybmcvg5yz6cnhzqh162zhh5xpbz374a796dwp1132m8";
 
   nativeBuildInputs = [ cmake pkgconfig openssl ];
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices cf-private ];


### PR DESCRIPTION
###### Motivation for this change

Minor update, Changelog according to source:
0.4.2 (2018-09-03)

    Add assets to section indexes
    Allow users to add custom highlighting syntaxes
    Add Swift, MiniZinc syntaxes and update others
    Handle post summaries better: no more cutting references


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

