### PR TITLE
hwloc: 1.11.1 -> 2.0.2

### DIFF
--- a/pkgs/development/libraries/hwloc/default.nix
+++ b/pkgs/development/libraries/hwloc/default.nix
@@ -7,15 +7,16 @@ assert x11Support -> libX11 != null && cairo != null;
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "hwloc-1.11.10";
+  name = "hwloc-2.0.2";
 
   src = fetchurl {
-    url = "http://www.open-mpi.org/software/hwloc/v1.11/downloads/${name}.tar.bz2";
-    sha256 = "1ryibcng40xcq22lsj85fn2vcvrksdx9rr3wwxpq8dw37lw0is1b";
+    url = "http://www.open-mpi.org/software/hwloc/v2.0/downloads/${name}.tar.bz2";
+    sha256 = "1phc863d5b2fvwpyyq4mlh4rkjdslh6h0h197zmyk3prwrq7si8l";
   };
 
   configureFlags = [
     "--localstatedir=/var"
+    "--enable-netloc"
   ];
 
   # XXX: libX11 is not directly needed, but needed as a propagated dep of Cairo.

--- a/pkgs/development/libraries/hwloc/default.nix
+++ b/pkgs/development/libraries/hwloc/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     # http://www.open-mpi.org/projects/hwloc/license.php
     license = licenses.bsd3;
     homepage = https://www.open-mpi.org/projects/hwloc/;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz markuskowa ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update `hwloc` and enable compilation of `netloc` (was a separate package previously in v1)

CC @fpletz 

###### Things done
* Update
* Enable `netloc`
* Add markuskowa as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

