### PR TITLE
journaldriver: 1.0.0 -> 1.1.0

### DIFF
--- a/nixos/modules/services/logging/journaldriver.nix
+++ b/nixos/modules/services/logging/journaldriver.nix
@@ -7,7 +7,7 @@
 # to be set.
 #
 # For further information please consult the documentation in the
-# upstream repository at: https://github.com/aprilabank/journaldriver/
+# upstream repository at: https://github.com/tazjin/journaldriver/
 
 { config, lib, pkgs, ...}:
 

--- a/pkgs/tools/misc/journaldriver/default.nix
+++ b/pkgs/tools/misc/journaldriver/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   name        = "journaldriver-${version}";
-  version     = "1.0.0";
-  cargoSha256 = "04llhriwsrjqnkbjgd22nhci6zmhadclnd8r2bw5092gwdamf49k";
+  version     = "1.1.0";
+  cargoSha256 = "03rq96hzv97wh2gbzi8sz796bqgh6pbpvdn0zy6zgq2f2sgkavsl";
 
   src = fetchFromGitHub {
-    owner  = "aprilabank";
+    owner  = "tazjin";
     repo   = "journaldriver";
     rev    = "v${version}";
-    sha256 = "1163ghf7dxxchyawdaa7zdi8ly2pxmc005c2k549larbirjjbmgc";
+    sha256 = "0672iq6s9klb1p37hciyl7snbjgjw98kwrbfkypv07lplc5qcnrf";
   };
 
   buildInputs       = [ openssl systemd ];
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Log forwarder from journald to Stackdriver Logging";
-    homepage    = "https://github.com/aprilabank/journaldriver";
+    homepage    = "https://github.com/tazjin/journaldriver";
     license     = licenses.gpl3;
     maintainers = [ maintainers.tazjin ];
     platforms   = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

* new upstream release
* upstream repository has moved, URLs changed accordingly

The [new release](https://github.com/tazjin/journaldriver/releases/tag/v1.1.0) includes an important workaround/fix for [an issue](https://github.com/tazjin/journaldriver/issues/2) that could cause log-forwarding to fail after service restarts due to invalid journal cursors being persisted.

Journaldriver was included in 18.09 - is it possible to get this version bump backported for that fix?

---------

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
