### PR TITLE
Teleconsole

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2153,6 +2153,11 @@
     github = "kiloreux";
     name = "Kiloreux Emperex";
   };
+  kimburgess = {
+    email = "kim@acaprojects.com";
+    github = "kimburgess";
+    name = "Kim Burgess";
+  };
   kini = {
     email = "keshav.kini@gmail.com";
     github = "kini";

--- a/pkgs/tools/misc/teleconsole/default.nix
+++ b/pkgs/tools/misc/teleconsole/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "teleconsole-${version}";
+  version = "0.4.0";
+
+  goPackagePath = "github.com/gravitational/teleconsole";
+
+  src = fetchFromGitHub {
+    owner = "gravitational";
+    repo = "teleconsole";
+    rev = version;
+    sha256 = "01552422n0bj1iaaw6pvg9l1qr66r69sdsngxbcdjn1xh3mj74sm";
+  };
+
+  goDeps = ./deps.nix;
+
+  CGO_ENABLED = 1;
+  buildFlags = "-ldflags";
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.teleconsole.com/";
+    description = "Share your terminal session with people you trust";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    # Builds for Aarch64 not possible in the current release due to
+    # incompatibilities further up the dependency chain.
+    # See:
+    #  - https://github.com/gravitational/teleport/issues/679
+    #  - https://github.com/kr/pty/issues/27
+    broken = stdenv.isAarch64;
+    maintainers = [ maintainers.kimburgess ];
+  };
+}

--- a/pkgs/tools/misc/teleconsole/deps.nix
+++ b/pkgs/tools/misc/teleconsole/deps.nix
@@ -1,0 +1,13 @@
+[
+    # Teleport v2.0.0-alpha.4 required for build.
+    # See https://github.com/gravitational/teleconsole/blob/09591f227c2a8df4c68af8bc4adfadfc596f4ed2/Makefile#L8
+    {
+      goPackagePath = "github.com/gravitational/teleport";
+      fetch = {
+        type = "git";
+        url = "https://github.com/gravitational/teleport";
+        rev = "2cb40abd8ea8fb2915304ea4888b5b9f3e5bc223";
+        sha256 = "1xw3bfnjbj88x465snwwzn4bmpmzmsrq9r0pkj388qwvfrclgnfk";
+      };
+    }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5550,6 +5550,8 @@ with pkgs;
 
   teamviewer = libsForQt5.callPackage ../applications/networking/remote/teamviewer { };
 
+  teleconsole = callPackage ../tools/misc/teleconsole { };
+
   telegraf = callPackage ../servers/monitoring/telegraf { };
 
   teleport = callPackage ../servers/teleport {};


### PR DESCRIPTION
###### Motivation for this change

Adds support for [Teleconsole](https://www.teleconsole.com/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

