### PR TITLE
accountsservice: 0.6.50 -> 0.6.54

### DIFF
--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -1,22 +1,26 @@
 { stdenv, fetchurl, pkgconfig, glib, intltool, makeWrapper, shadow
-, libtool, gobjectIntrospection, polkit, systemd, coreutils }:
+, gobjectIntrospection, polkit, systemd, coreutils, meson, dbus
+, ninja, python3 }:
 
 stdenv.mkDerivation rec {
   name = "accountsservice-${version}";
-  version = "0.6.50";
+  version = "0.6.54";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/accountsservice/accountsservice-${version}.tar.xz";
-    sha256 = "0jn7vg1z4vxnna0hl33hbcb4bb3zpilxc2vyclh24vx4vvsjhn83";
+    sha256 = "1b115n0a4yfa06kgxc69qfc1rc0w4frgs3id3029czkrhhn0ds96";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ pkgconfig makeWrapper meson ninja python3 ];
 
-  buildInputs = [ glib intltool libtool gobjectIntrospection polkit systemd ];
+  buildInputs = [ glib intltool gobjectIntrospection polkit systemd dbus ];
 
-  configureFlags = [ "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-                     "--localstatedir=/var" ];
+  mesonFlags = [ "-Dsystemdsystemunitdir=etc/systemd/system"
+                 "-Dlocalstatedir=/var" ];
   prePatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+
     substituteInPlace src/daemon.c --replace '"/usr/sbin/useradd"' '"${shadow}/bin/useradd"' \
                                    --replace '"/usr/sbin/userdel"' '"${shadow}/bin/userdel"'
     substituteInPlace src/user.c   --replace '"/usr/sbin/usermod"' '"${shadow}/bin/usermod"' \

--- a/pkgs/development/libraries/accountsservice/no-create-dirs.patch
+++ b/pkgs/development/libraries/accountsservice/no-create-dirs.patch
@@ -1,13 +1,15 @@
---- a/src/Makefile.in	2014-04-23 22:30:00.276005326 +0200
-+++ b/src/Makefile.in	2014-04-23 22:30:16.809409113 +0200
-@@ -881,8 +881,8 @@
- 	gdbus-codegen --generate-c-code accounts-user-generated --c-namespace Accounts --interface-prefix=org.freedesktop.Accounts. $(top_srcdir)/data/org.freedesktop.Accounts.User.xml
+diff --git a/meson_post_install.py b/meson_post_install.py
+index ba95055..17f7926 100644
+--- a/meson_post_install.py
++++ b/meson_post_install.py
+@@ -9,8 +9,8 @@ localstatedir = os.path.normpath(destdir + os.sep + sys.argv[1])
+ # FIXME: meson will not track the creation of these directories
+ #        https://github.com/mesonbuild/meson/blob/master/mesonbuild/scripts/uninstall.py#L39
+ dst_dirs = [
+-  os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'),
+-  os.path.join(localstatedir, 'lib', 'AccountsService', 'users'),
++  #os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'),
++  #os.path.join(localstatedir, 'lib', 'AccountsService', 'users'),
+ ]
  
- install-data-hook:
--	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/lib/AccountsService/users"
--	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/lib/AccountsService/icons"
-+#	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/lib/AccountsService/users"
-+#	$(MKDIR_P) "$(DESTDIR)$(localstatedir)/lib/AccountsService/icons"
- 
- # Tell versions [3.59,3.63) of GNU make to not export all variables.
- # Otherwise a system limit (for SysV at least) may be exceeded.
+ for dst_dir in dst_dirs:


### PR DESCRIPTION
###### Motivation for this change

Package update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

