### PR TITLE
cdb: init at 0.75

### DIFF
--- a/pkgs/development/tools/database/cdb/default.nix
+++ b/pkgs/development/tools/database/cdb/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, lib, fetchurl, fetchFromGitHub, writeText }:
+
+let
+  version = "0.75";
+  sha256 = "1iajg55n47hqxcpdzmyq4g4aprx7bzxcp885i850h355k5vmf68r";
+  # Please don’t forget to update the docs:
+  # clone https://github.com/Profpatsch/cdb-docs
+  # and create a pull request with the result of running
+  # ./update <version>
+  # from the repository’s root folder.
+  docRepo = fetchFromGitHub {
+    owner = "Profpatsch";
+    repo = "cdb-docs";
+    rev = "359b6c55c9e170ebfc88f3f38face8ae2315eacb";
+    sha256 = "1y0ivviy58i0pmavhvrpznc4yjigjknff298gnw9rkg5wxm0gbbq";
+  };
+
+in stdenv.mkDerivation {
+  name = "cdb-${version}";
+
+  src = fetchurl {
+    url = "https://cr.yp.to/cdb/cdb-${version}.tar.gz";
+    inherit sha256;
+  };
+
+  outputs = [ "bin" "doc" "out" ];
+
+  postPatch = ''
+    # A little patch, borrowed from Archlinux AUR, borrowed from Gentoo Portage
+    sed -e 's/^extern int errno;$/#include <errno.h>/' -i error.h
+  '';
+
+  postInstall = ''
+    # don't use make setup, but move the binaries ourselves
+    mkdir -p $bin/bin
+    install -m 755 -t $bin/bin/ cdbdump cdbget cdbmake cdbmake-12 cdbmake-sv cdbstats cdbtest
+
+    # patch paths in scripts
+    function cdbmake-subst {
+      substituteInPlace $bin/bin/$1 \
+        --replace /usr/local/bin/cdbmake $bin/bin/cdbmake
+    }
+    cdbmake-subst cdbmake-12
+    cdbmake-subst cdbmake-sv
+
+    # docs
+    mkdir -p $doc/share/cdb
+    cp -r "${docRepo}/docs" $doc/share/cdb/html
+  '';
+
+  meta = {
+    homepage = "https://cr.yp.to/cdb";
+    license = lib.licenses.publicDomain;
+    maintainers = [ lib.maintainers.Profpatsch ];
+    platforms = [ lib.platforms.unix ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6390,6 +6390,8 @@ with pkgs;
     inherit (darwin) bootstrap_cmds;
   };
 
+  cdb = callPackage ../development/tools/database/cdb { };
+
   chez = callPackage ../development/compilers/chez {
     inherit (darwin) cctools;
   };


### PR DESCRIPTION
We check in the docs downloaded via wget, because upstream doesn’t
provide them.


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

