### PR TITLE
prometheus-alertmanager: 0.15.1 -> 0.15.2

### DIFF
--- a/pkgs/servers/monitoring/prometheus/alertmanager.nix
+++ b/pkgs/servers/monitoring/prometheus/alertmanager.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "alertmanager-${version}";
-  version = "0.15.1";
+  version = "0.15.2";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/alertmanager";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "alertmanager";
-    sha256 = "110l8xy3bkgq137hvvz2v5cr464j02fy43lvgd3l8n5v8qmv81vy";
+    sha256 = "1r4j22jnxayicz9hn0pwm77cgzzywr5haq0hwz6sx5j2xwjmnwm7";
   };
 
   # Tests exist, but seem to clash with the firewall.


### PR DESCRIPTION
###### Motivation for this change

https://github.com/prometheus/alertmanager/releases/tag/v0.15.2

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

