### PR TITLE
[18.03] net_snmp: fix CVE-2018-18065

### DIFF
--- a/pkgs/servers/monitoring/net-snmp/CVE-2018-18065.patch
+++ b/pkgs/servers/monitoring/net-snmp/CVE-2018-18065.patch
@@ -1,0 +1,30 @@
+commit 7ffb8e25a0db851953155de91f0170e9bf8c457d
+Author: Robert Story <rstory@freesnmp.com>
+Date:   Thu Oct 6 10:43:10 2016 -0400
+
+    CHANGES: BUG: 2743: snmpd crashes when receiving a GetNext PDU with multiple Varbinds
+    
+    skip out-of-range varbinds when calling next handler
+
+diff --git a/agent/helpers/table.c b/agent/helpers/table.c
+index 32a08033a..2666638b5 100644
+--- a/agent/helpers/table.c
++++ b/agent/helpers/table.c
+@@ -340,6 +340,8 @@ table_helper_handler(netsnmp_mib_handler *handler,
+             else if (reqinfo->mode == MODE_GET)
+                 table_helper_cleanup(reqinfo, request,
+                                      SNMP_NOSUCHOBJECT);
++            else
++                request->processed = 1; /* skip if next handler called */
+             continue;
+         }
+ 
+@@ -409,6 +411,8 @@ table_helper_handler(netsnmp_mib_handler *handler,
+                 else if (reqinfo->mode == MODE_GET)
+                     table_helper_cleanup(reqinfo, request,
+                                          SNMP_NOSUCHOBJECT);
++                else
++                    request->processed = 1; /* skip if next handler called */
+                 continue;
+             }
+             /*

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     (fetchAlpinePatch "fix-includes.patch" "0zpkbb6k366qpq4dax5wknwprhwnhighcp402mlm7950d39zfa3m")
     (fetchAlpinePatch "netsnmp-swinst-crash.patch" "0gh164wy6zfiwiszh58fsvr25k0ns14r3099664qykgpmickkqid")
     (fetchAlpinePatch "remove-U64-typedef.patch" "1msxyhcqkvhqa03dwb50288g7f6nbrcd9cs036m9xc8jdgjb8k8j")
+    ./CVE-2018-18065.patch
   ];
 
   preConfigure =


### PR DESCRIPTION
###### Motivation for this change

This addresses a remote DoS attack (CVE-2018-18065).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

