### PR TITLE
gitea: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -7,13 +7,21 @@ with stdenv.lib;
 
 buildGoPackage rec {
   name = "gitea-${version}";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "go-gitea";
     repo = "gitea";
     rev = "v${version}";
-    sha256 = "06h6v9py35mm0xk9l8xrq02vvr5vzl15gfbw9qqvpn8kiamkn53r";
+    sha256 = "168pbndlh7c148p8wzkd39kd7idiba9zw7v0alp9zqcqzzayaydj";
+    # Required to generate the same checksum on MacOS due to unicode encoding differences
+    # More information: https://github.com/NixOS/nixpkgs/pull/48128
+    extraPostFetch = ''
+      rm -rf $out/integrations
+      rm -rf $out/vendor/github.com/Unknown/cae/tz/testdata
+      rm -rf $out/vendor/github.com/Unknown/cae/zip/testdata
+      rm -rf $out/vendor/gopkg.in/macaron.v1/fixtures
+    '';
   };
 
   patches = [ ./static-root-path.patch ];


### PR DESCRIPTION
###### Motivation for this change
https://blog.gitea.io/2018/10/gitea-1.5.2-is-released/

“This is a smaller release, with only 12 merged PRs, but it contains several security related fixes and so we recommend upgrading whenever possible.”

Should therefore be safe to backport to 18.09, and required to get the security fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

