### PR TITLE
pythonPackages.atom: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/atom/default.nix
+++ b/pkgs/development/python-modules/atom/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, future }:
+
+buildPythonPackage rec {
+  pname = "atom";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0awzja4k3f32y01gd068yyxvh35km62m4wka0vbg1yyy37ahgjmv";
+  };
+
+  propagatedBuildInputs = [ future ];
+
+  # Tests not released to pypi
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Memory efficient Python objects";
+    maintainers = [ maintainers.bhipple ];
+    homepage = https://github.com/nucleic/atom;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -190,7 +190,9 @@ in {
 
   astral = callPackage ../development/python-modules/astral { };
 
-  astropy = callPackage ../development/python-modules/astropy {  };
+  astropy = callPackage ../development/python-modules/astropy { };
+
+  atom = callPackage ../development/python-modules/atom { };
 
   augeas = callPackage ../development/python-modules/augeas {
     inherit (pkgs) augeas;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

