### PR TITLE
gnome3.gnome-contacts: fix compile failure due to clutter-gtk change

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   # /nix/store/*-cheese-3.28.0/include/cheese/cheese-widget.h:26:10: fatal error: clutter-gtk/clutter-gtk.h: No such file or directory
   #  #include <clutter-gtk/clutter-gtk.h>
   #           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-  NIX_CFLAGS_COMPILE = "-I${clutter-gtk}/include/clutter-gtk-1.0";
+  NIX_CFLAGS_COMPILE = "-I${stdenv.lib.getDev clutter-gtk}/include/clutter-gtk-1.0";
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

clutter-gtk moved to multiple outputs in 8abfa4084b5e9b81710e2a0a0d40c08a1531f4e8, and gnome-contacts requires a workaround that references clutter's headers directly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

