### PR TITLE
subtitles-rs: init at 20180611

### DIFF
--- a/pkgs/applications/video/subtitles-rs/default.nix
+++ b/pkgs/applications/video/subtitles-rs/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper }:
+
+rustPlatform.buildRustPackage rec {
+  name = "subtitles-rs";
+  version = "20180611";
+
+  src = fetchFromGitHub {
+    owner = "emk";
+    repo = "subtitles-rs";
+    rev = "83d8a77a095f763e967372aaa00ba5728842eb34";
+    sha256 = "15gba9wdw2lprf00x7wvl7pwjg3sh50yvync0waf9b4945zw3b47";
+  };
+
+  cargoSha256 = "1851zf4pyi2mj4kq3w16abqi9izr6q9vznf4ap4mnfhaaplbc4x0";
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Tools and libraries for manipulating subtitles";
+    homepage = https://github.com/emk/subtitles-rs;
+    license = licenses.cc0;
+    maintainers = [ maintainers.teto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12391,6 +12391,8 @@ with pkgs;
 
   subtitleeditor = callPackage ../applications/video/subtitleeditor { };
 
+  subtitles-rs = callPackage ../applications/video/subtitles-rs { };
+
   suil = callPackage ../development/libraries/audio/suil { };
 
   suil-qt5 = suil.override {


### PR DESCRIPTION
Tooling to deal with video subtitles.

###### Motivation for this change

I have tested only the subtitles2srt binary.
If my memory is correct, I stole the derivation from @symphorien 's overlay.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

