### PR TITLE
pythonPackages.vidstab: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/imutils/default.nix
+++ b/pkgs/development/python-modules/imutils/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, opencv3
+}:
+
+buildPythonPackage rec {
+  version = "0.5.1";
+  pname = "imutils";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "37d17adc9e71386c59b28f4ef5972ef6fe0023714fa1a652b8edc83f7ce0654c";
+  };
+
+  propagatedBuildInputs = [ opencv3 ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jrosebr1/imutils;
+    description = "A series of convenience functions to make basic image processing functions";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/progress/default.nix
+++ b/pkgs/development/python-modules/progress/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+}:
+
+buildPythonPackage rec {
+  version = "1.4";
+  pname = "progress";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5e2f9da88ed8236a76fffbee3ceefd259589cf42dfbc2cec2877102189fae58a";
+  };
+
+  # tests not packaged with pypi release
+  doCheck = false;
+
+  checkPhase = ''
+    ${python.interpreter} test_progress.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/verigak/progress/;
+    description = "Easy to use progress bars";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/vidstab/default.nix
+++ b/pkgs/development/python-modules/vidstab/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, pandas
+, imutils
+, progress
+, matplotlib
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "0.1.5";
+  pname = "vidstab";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b775652cc4f41812de04bc443ad522c1bdaef456a00c74857e9ebc5d2066e362";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy pandas imutils progress matplotlib ];
+
+  # tests not packaged with pypi
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/AdamSpannbauer/python_video_stab;
+    description = "Video Stabilization using OpenCV";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -328,6 +328,8 @@ in {
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };
 
+  imutils = callPackage ../development/python-modules/imutils { };
+
   intelhex = callPackage ../development/python-modules/intelhex { };
 
   jira = callPackage ../development/python-modules/jira { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -606,6 +606,8 @@ in {
 
   unifi = callPackage ../development/python-modules/unifi { };
 
+  vidstab = callPackage ../development/python-modules/vidstab { };
+
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };
 
   # packages defined here

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -392,6 +392,8 @@ in {
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  progress = callPackage ../development/python-modules/progress { };
+
   pymysql = callPackage ../development/python-modules/pymysql { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };


### PR DESCRIPTION
###### Motivation for this change

Adding package for image stabilization using opencv.

###### Things done

Added package along with two dependencies.

pythonPackages.progress: init at 1.4
pythonPackages.imutils: init at 0.5.1
pythonPackages.vidstab: init at 0.1.5

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

