### PR TITLE
pythonPackages.gsd: init at 1.5.2

### DIFF
--- a/pkgs/development/python-modules/gsd/default.nix
+++ b/pkgs/development/python-modules/gsd/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+}:
+
+buildPythonPackage rec {
+  version = "1.5.2";
+  pname = "gsd";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ce73a9bc7b79968a2b96cc2b0934e2cbe11700adbd02b4b492fea1e3d4d51f4";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  # tests not packaged with gsd
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/glotzer/gsd;
+    description = "General simulation data file format";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -310,6 +310,8 @@ in {
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };
 
+  gsd = callPackage ../development/python-modules/gsd { };
+
   gssapi = callPackage ../development/python-modules/gssapi { };
 
   h5py = callPackage ../development/python-modules/h5py {


### PR DESCRIPTION
###### Motivation for this change

###### Things 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

