### PR TITLE
pythonPackages.nest-asyncio: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/nest-asyncio/default.nix
+++ b/pkgs/development/python-modules/nest-asyncio/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  version = "0.9.1";
+  pname = "nest_asyncio";
+  disabled = !(pythonAtLeast "3.5");
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0844af67deda3243389d47cd8754b6775c5c828345e0277beca7bd008d273392";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/erdewit/nest_asyncio;
+    description = "Patch asyncio to allow nested event loops";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -352,6 +352,8 @@ in {
 
   mwoauth = callPackage ../development/python-modules/mwoauth { };
 
+  nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
+
   neuron = pkgs.neuron.override {
     inherit python;
   };


### PR DESCRIPTION
###### Motivation for this change

Very usefull package (necissary if using jupyterlab and asyncio). Allows for asyncronous processes to run async processes in python.

###### Things done

pythonPackages.nest-asyncio: init at 0.9.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

