### PR TITLE
pythonPackages.pyvoro: init at 1.3.2

### DIFF
--- a/pkgs/development/python-modules/pyvoro/default.nix
+++ b/pkgs/development/python-modules/pyvoro/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "1.3.2";
+  pname = "pyvoro";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f31c047f6e4fc5f66eb0ab43afd046ba82ce247e18071141791364c4998716fc";
+  };
+
+  # No tests in package
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/joe-jordan/pyvoro;
+    description = "2D and 3D Voronoi tessellations: a python entry point for the voro++ library";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -540,6 +540,8 @@ in {
 
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });
 
+  pyvoro = callPackage ../development/python-modules/pyvoro { };
+
   relatorio = callPackage ../development/python-modules/relatorio { };
 
   pyzufall = callPackage ../development/python-modules/pyzufall { };


### PR DESCRIPTION
python wrapper to voro++

###### Motivation for this change

Needed to do voronoi analysis in python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

