### PR TITLE
pythonPackages.fdint: init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/fdint/default.nix
+++ b/pkgs/development/python-modules/fdint/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, cython
+, numpy
+, python
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  version = "2.0.2";
+  pname = "fdint";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "30db139684d362652670e2cd3206b5dd7b3b93b86c3aff37f4b4fd4a3f98aead";
+  };
+
+  buildInputs = [ cython ];
+  propagatedBuildInputs = [ numpy ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  checkPhase = ''
+    ${python.interpreter} -m fdint.tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/scott-maddox/fdint;
+    description = "A free, open-source python package for quickly and precisely approximating Fermi-Dirac integrals";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -302,6 +302,8 @@ in {
 
   fire = callPackage ../development/python-modules/fire { };
 
+  fdint = callPackage ../development/python-modules/fdint { };
+
   fuse = callPackage ../development/python-modules/fuse-python { fuse = pkgs.fuse; };
 
   genanki = callPackage ../development/python-modules/genanki { };


### PR DESCRIPTION
###### Motivation for this change

Fermi dirac python integration. Adding optional dependency that can be used with pymatgen.

###### Things done

pythonPackages.fdint: init at 2.0.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

