### PR TITLE
scummvm: add several ScummVM supported games

### DIFF
--- a/pkgs/games/scummvm/games.nix
+++ b/pkgs/games/scummvm/games.nix
@@ -1,0 +1,125 @@
+{ stdenv, lib, fetchurl, makeDesktopItem, unzip, writeText
+, scummvm }:
+
+let
+  desktopItem = name: short: long: description: makeDesktopItem {
+    categories  = "Game;AdventureGame;";
+    comment     = description;
+    desktopName = long;
+    exec        = "@out@/bin/${short}";
+    genericName = description;
+    icon        = "scummvm";
+    name        = name;
+  };
+
+  run = name: short: code: writeText "${short}.sh" ''
+    #!${stdenv.shell} -eu
+
+    exec ${scummvm}/bin/scummvm \
+      --path=@out@/share/${name} \
+      --fullscreen \
+      ${code}
+  '';
+
+  generic = { plong, pshort, pcode, description, version, files, docs ? [ "readme.txt" ], ... } @attrs:
+    let
+      attrs' = builtins.removeAttrs attrs [ "plong" "pshort" "pcode" "description" "docs" "files" "version" ];
+      pname = lib.replaceStrings [ " " ":" ] [ "-" "" ] (lib.toLower plong);
+    in stdenv.mkDerivation ({
+      name = "${pname}-${version}";
+
+      nativeBuildInputs = [ unzip ];
+
+      dontBuild = true;
+      dontFixup = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/bin $out/share/{applications,${pname},doc/${pname}}
+
+        ${lib.concatStringsSep "\n" (map (f: "mv ${f} $out/share/doc/${pname}") docs)}
+        ${lib.concatStringsSep "\n" (map (f: "mv ${f} $out/share/${pname}") files)}
+
+        substitute ${run pname pshort pcode} $out/bin/${pshort} \
+          --subst-var out
+        substitute ${desktopItem pname pshort plong description}/share/applications/${pname}.desktop $out/share/applications/${pname}.desktop \
+          --subst-var out
+
+        chmod 0755 $out/bin/${pshort}
+
+        runHook postInstall
+      '';
+
+      meta = with stdenv.lib; {
+        homepage = https://www.scummvm.org;
+        license = licenses.free; # refer to the readme for exact wording
+        maintainers = with maintainers; [ peterhoeg ];
+        inherit description;
+        inherit (scummvm.meta) platforms;
+      };
+    } // attrs');
+
+in {
+  beneath-a-steel-sky = generic rec {
+    plong = "Beneath a Steel Sky";
+    pshort = "bass";
+    pcode = "sky";
+    description = "2D point-and-click science fiction thriller set in a bleak vision of the future";
+    version = "1.2";
+    src = fetchurl {
+      url = "mirror://sourceforge/scummvm/${pshort}-cd-${version}.zip";
+      sha256 = "14s5jz67kavm8l15gfm5xb7pbpn8azrv460mlxzzvdpa02a9n82k";
+    };
+    files = [ "sky.*" ];
+  };
+
+  drascula-the-vampire-strikes-back = generic rec {
+    plong = "Drascula: The Vampire Strikes Back";
+    pshort = "drascula";
+    pcode = "drascula";
+    description = "Spanish 2D classic point & click style adventure with tons of humor and an easy interface";
+    version = "1.0";
+    # srcs = {
+      src = fetchurl {
+        url = "mirror://sourceforge/scummvm/${pshort}-${version}.zip";
+        sha256 = "1pj29rpb754sn6a56f8brfv6f2m1p5qgaqik7d68pfi2bb5zccdp";
+      };
+      # audio = fetchurl {
+        # url = "mirror://sourceforge/scummvm/${pshort}-audio-flac-2.0.zip";
+        # sha256 = "1zmqhrby8f5sj1qy6xjdgkvk9wyhr3nw8ljrrl58fmxb83x1rryw";
+      # };
+    # };
+    sourceRoot = ".";
+    docs = [ "readme.txt" "drascula.doc" ];
+    files = [ "Packet.001" ];
+  };
+
+  flight-of-the-amazon-queen = generic rec {
+    plong = "Flight of the Amazon Queen";
+    pshort = "fotaq";
+    pcode = "queen";
+    description = "2D point-and-click adventure game set in the 1940s";
+    version = "1.1";
+    src = fetchurl {
+      url = "mirror://sourceforge/scummvm/FOTAQ_Talkie-${version}.zip";
+      sha256 = "1a6q71q1dl9vvw2qqsxk5h1sv0gaqy6236zr5905w2is01gdsp52";
+    };
+    sourceRoot = ".";
+    files = [ "*.1c" ];
+  };
+
+  lure-of-the-temptress = generic rec {
+    plong = "Lure of the Temptress";
+    pshort = "lott";
+    pcode = "lure";
+    description = "2D point-and-click adventure game with a fantasy theme";
+    version = "1.1";
+    src = fetchurl {
+      url = "mirror://sourceforge/scummvm/lure-${version}.zip";
+      sha256 = "0201i70qcs1m797kvxjx3ygkhg6kcl5yf49sihba2ga8l52q45zk";
+    };
+    docs = [ "README" "*.txt" "*.pdf" "*.PDF" ];
+    files = [ "*.vga" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20323,6 +20323,12 @@ with pkgs;
 
   scummvm = callPackage ../games/scummvm { };
 
+  inherit (callPackage ../games/scummvm/games.nix { })
+    beneath-a-steel-sky
+    drascula-the-vampire-strikes-back
+    flight-of-the-amazon-queen
+    lure-of-the-temptress;
+
   scorched3d = callPackage ../games/scorched3d { };
 
   scrolls = callPackage ../games/scrolls { };


### PR DESCRIPTION
###### Motivation for this change

 - Beneath a Steel Sky: v1.2
 - Drascula: The Vampire Strikes Back: v2.0
 - Flight of the Amazon Queen: v1.1
 - Lure of the Temptress: v1.1

We could also wrap scummvm instead of course.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

