### PR TITLE
nixos/virtualbox-demo: Reduce baseImageSize

### DIFF
--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -9,6 +9,7 @@ with lib;
       ../profiles/demo.nix
       ../profiles/clone-config.nix
     ];
+  virtualbox.baseImageSize = 10 * 1024; # 10G
 
   # FIXME: UUID detection is currently broken
   boot.loader.grub.fsIdentifier = "provided";


### PR DESCRIPTION
###### Motivation for this change

https://hydra.nixos.org/build/82516491

After #46649 `nixos.ova.x86_64-linux` has been unable to finish in time on Hydra. There may be a way to utilize the sparseness so that cptofs doesn't take forever, but this PR simply pushes a smaller diskSize to virtualbox-demo, allowing the build on Hydra to complete in decent time. Users of the infrastructure will still get the 100GB default when building their own images, as long as they don't rely on -demo itself.

cc @Enzime 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

