### PR TITLE
[18.09] nixos/emby: use the dataDir option

### DIFF
--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -36,11 +36,18 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
-        test -d ${cfg.dataDir} || {
-          echo "Creating initial Emby data directory in ${cfg.dataDir}"
-          mkdir -p ${cfg.dataDir}
-          chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
-          }
+        if [ -d ${cfg.dataDir} ]
+        then
+            for plugin in ${cfg.dataDir}/plugins/*
+            do
+                echo "Correcting permissions of plugin: $plugin"
+                chmod u+w $plugin
+            done
+        else
+            echo "Creating initial Emby data directory in ${cfg.dataDir}"
+            mkdir -p ${cfg.dataDir}
+            chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
+        fi
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -55,7 +55,7 @@ in
         User = cfg.user;
         Group = cfg.group;
         PermissionsStartOnly = "true";
-        ExecStart = "${pkgs.emby}/bin/emby";
+        ExecStart = "${pkgs.emby}/bin/emby -programdata ${cfg.dataDir}";
         Restart = "on-failure";
       };
     };

--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -55,7 +55,7 @@ in
         User = cfg.user;
         Group = cfg.group;
         PermissionsStartOnly = "true";
-        ExecStart = "${pkgs.emby}/bin/MediaBrowser.Server.Mono";
+        ExecStart = "${pkgs.emby}/bin/emby";
         Restart = "on-failure";
       };
     };

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -1,22 +1,31 @@
-{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono54, ffmpeg, ... }:
+{ stdenv, fetchurl, unzip, sqlite, makeWrapper, mono54, ffmpeg }:
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.4.1.0";
+  version = "3.5.2.0";
 
+  # We are fetching a binary here, however, a source build is possible.
+  # See -> https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=emby-server-git#n43
+  # Though in my attempt it failed with this error repeatedly
+  # The type 'Attribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'.
+  # This may also need msbuild (instead of xbuild) which isn't in nixpkgs
+  # See -> https://github.com/NixOS/nixpkgs/issues/29817
   src = fetchurl {
-    url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "08jr6v8xhmiwbby0lfvpjrlma280inwh5qp6v4p93lzd07fjynh5";
+    url = "https://github.com/MediaBrowser/Emby.Releases/releases/download/${version}/embyserver-mono_${version}.zip";
+    sha256 = "12f9skvnr9qxnrvr3q014yggfwvkpjk0ynbgf0fwk56h4kal7fx8";
   };
 
-  buildInputs = with pkgs; [
+  buildInputs = [
     unzip
     makeWrapper
   ];
-  propagatedBuildInputs = with pkgs; [
+
+  propagatedBuildInputs = [
     mono54
     sqlite
   ];
+
+  preferLocalBuild = true;
 
   # Need to set sourceRoot as unpacker will complain about multiple directory output
   sourceRoot = ".";
@@ -27,18 +36,18 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -r * $out/bin
+    mkdir -p "$out/bin"
+    cp -r * "$out/bin"
 
     makeWrapper "${mono54}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
       --add-flags "$out/bin/MediaBrowser.Server.Mono.exe -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
-  meta = {
+  meta =  with stdenv.lib; {
     description = "MediaBrowser - Bring together your videos, music, photos, and live television";
     homepage = https://emby.media/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.fadenb ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fadenb ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -32,14 +32,14 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -dm 755 "$out/lib/emby-server"
-    cp -r * "$out/lib/emby-server"
+    install -dm 755 "$out/opt/emby-server"
+    cp -r * "$out/opt/emby-server"
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/emby \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         sqlite
       ]}" \
-      --add-flags "$out/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
+      --add-flags "$out/opt/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
   meta =  with stdenv.lib; {

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
     cp -r * "$out/usr/lib/emby-server"
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/emby \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
+        sqlite
+      ]}" \
       --add-flags "$out/usr/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -32,14 +32,14 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -dm 755 "$out/usr/lib/emby-server"
-    cp -r * "$out/usr/lib/emby-server"
+    install -dm 755 "$out/lib/emby-server"
+    cp -r * "$out/lib/emby-server"
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/emby \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         sqlite
       ]}" \
-      --add-flags "$out/usr/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
+      --add-flags "$out/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
   meta =  with stdenv.lib; {

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         sqlite
       ]}" \
-      --add-flags "$out/opt/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
+      --add-flags "$out/opt/emby-server/EmbyServer.dll -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
   meta =  with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
 In #48043 @joachifm suggest to add the pull request to the release. I added other commits to assure compatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

