### PR TITLE
Revert "Increase Virtualbox disk image size"

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -12,7 +12,7 @@ in {
     virtualbox = {
       baseImageSize = mkOption {
         type = types.int;
-        default = 100 * 1024;
+        default = 10 * 1024;
         description = ''
           The size of the VirtualBox base image in MiB.
         '';


### PR DESCRIPTION
Reverts NixOS/nixpkgs#46649
and unbreak the build of `nixos.ova.x86_64-linux` ( https://hydra.nixos.org/build/82516491 )