### PR TITLE
qiskit: 0.5.7 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/ibmquantumexperience/default.nix
+++ b/pkgs/development/python-modules/ibmquantumexperience/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "IBMQuantumExperience";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f2a5662d7457c297af0751985979e64a88569beb07cfedad0ce1dfa5a7237842";
+    sha256 = "c5dbcc140344c7bdf545ad59db87f31a90ca35107c40d6cae1489bb997a47ba9";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/qasm2image/default.nix
+++ b/pkgs/development/python-modules/qasm2image/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "qasm2image";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
-    owner = "nelimeee";
+    owner = "nelimee";
     repo = "qasm2image";
-    rev = "57a640621bbbc74244f07e2e068a26411b0d9b24";
-    sha256 = "1ha5vfl4jfwcwbipsq07xlknkrvx79z5bwbzndybclyk9pa69dlz";
+    rev = "2c01756946ba9782973359dbd7bbf6651af6bee5";
+    sha256 = "1bnkzv7wrdvrq71dmsqanb3v2hcsxh5zaglfcxm2d9zzpmvb4a2n";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -13,19 +13,21 @@
 , requests
 , requests_ntlm
 , IBMQuantumExperience
+, jsonschema
+, psutil
 , cmake
 , llvmPackages 
 }:
 
 buildPythonPackage rec {
   pname = "qiskit";
-  version = "0.5.7";
+  version = "0.6.1";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a5a2c6c074f8479dc83d1d599dfebf2363402a182835b8fa5742804055148b17";
+    sha256 = "601e8db4db470593b94a32495c6e90e2db11a9382817a34584520573a7b8cc38";
   };
 
   buildInputs = [ cmake ]
@@ -43,6 +45,8 @@ buildPythonPackage rec {
     requests
     requests_ntlm
     IBMQuantumExperience
+    jsonschema
+    psutil
   ];
 
   # Pypi's tarball doesn't contain tests


### PR DESCRIPTION
###### Motivation for this change
update 3 packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

