### PR TITLE
nixos-option: don't abort with shell failures if options are not existant

### DIFF
--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -314,13 +314,13 @@ else
   # echo 1>&2 "Warning: This value is not an option."
 
   result=$(evalCfg "")
-  if names=$(attrNames "$result" 2> /dev/null); then
+  if [ ! -z "$result" ]; then
+    names=$(attrNames "$result" 2> /dev/null)
     echo 1>&2 "This attribute set contains:"
     escapeQuotes () { eval echo "$1"; }
     nixMap escapeQuotes "$names"
   else
-    echo 1>&2 "An error occurred while looking for attribute names."
-    echo $result
+    echo 1>&2 "An error occurred while looking for attribute names. Are you sure that \`$option' exists?"
   fi
 fi
 

--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -320,7 +320,7 @@ else
     escapeQuotes () { eval echo "$1"; }
     nixMap escapeQuotes "$names"
   else
-    echo 1>&2 "An error occurred while looking for attribute names. Are you sure that \`$option' exists?"
+    echo 1>&2 "An error occurred while looking for attribute names. Are you sure that '$option' exists?"
   fi
 fi
 


### PR DESCRIPTION
###### Motivation for this change

`nixos-option` basically handles two cases: the given option is either a
valid option defined using `mkOption` or an attribute set which contains
a set of options.

If none of the above cases is valid, `$1` is invalid. Unfortunatley the
script interpreted invalid options as an attribute set which rendered
shell failures when trying to evaluate the arguments.

First of all, `if names=$(attrNames ...)` resulted in `<PRIMOP>` as
`attrNames` simply evaluated `builtins.attrNames $result` which results
in a non-applied function with `$result` being empty. Trying to map over
this string using `nixMap` while applying `escapeQuotes` causes the bash
error as `eval echo "<PRIMOP>"` is invalid syntax.

Explicitly checking if `$result' contains a value (do we have an
attribute set?) and otherwise returning a warning and asking if $option
exists fixes the problem.

Fixes #48060


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

