### PR TITLE
pythonPackages.django: update all supported versions

### DIFF
--- a/pkgs/development/python-modules/django/1_11.nix
+++ b/pkgs/development/python-modules/django/1_11.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "1.11.15";
+  version = "1.11.16";
 
   disabled = pythonOlder "2.7";
 
   src = fetchurl {
     url = "http://www.djangoproject.com/m/releases/1.11/${pname}-${version}.tar.gz";
-    sha256 = "0h2sl02x2mxr3rl3dy750pzm5kvmx77116fys8rrgw164kc3b0mi";
+    sha256 = "14apywfi8mfy50xh07cagp24kx9mlqfzfq4f60klz90ng328q9i9";
   };
 
   patches = stdenv.lib.optionals withGdal [

--- a/pkgs/development/python-modules/django/2_0.nix
+++ b/pkgs/development/python-modules/django/2_0.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "2.0.8";
+  version = "2.0.9";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12z3b9v0zl7w9bm5sl7dpkk5w35ypalizfmnaj9jac41k8vfmbk8";
+    sha256 = "0sgx548zp5xf8dajiamdskbrphssiyajhgbw8iza6b68mda4bnfn";
   };
 
   patches = stdenv.lib.optionals withGdal [

--- a/pkgs/development/python-modules/django/2_1.nix
+++ b/pkgs/development/python-modules/django/2_1.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "Django";
-  version = "2.1.1";
+  version = "2.1.2";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0b7p6d77xqs2hdq2k1amqgbr3050zn5i8asz5w2lxajqnvb1rk71";
+    sha256 = "0ibbs76pzy8zd47yviljrp1s66fmbf5b62fixayaznj7pdzavg7g";
   };
 
   patches = stdenv.lib.optionals withGdal [


### PR DESCRIPTION
###### Motivation for this change

There is a bunch of fixes across all the various django versions we support.

Once merges in master, I’ll backport them to `release-18.09`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

