### PR TITLE
Remove .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,8 +1,0 @@
-;;; Directory Local Variables
-;;; For more information see (info "(emacs) Directory Variables")
-
-((nil
-  (bug-reference-bug-regexp . "\\(\\(?:[Ii]ssue \\|[Ff]ixe[ds] \\|[Rr]esolve[ds]? \\|[Cc]lose[ds]? \\|[Pp]\\(?:ull [Rr]equest\\|[Rr]\\) \\|(\\)#\\([0-9]+\\))?\\)")
-  (bug-reference-url-format . "https://github.com/NixOS/nixpkgs/issues/%s"))
- (nix-mode
-  (tab-width . 2)))


### PR DESCRIPTION
###### Motivation for this change

This file has been excruciatingly annoying to me. I don't personally want to save those dir-locals as trusted in my emacs config. So now every buffer I open prompts me "Do you really want to apply it?" This includes magit, which operates by opening buffers extremely frequently. Frankly, I think anyone who wants the behavior of this file should add it to their worktree themselves. I have to keep it deleted, which causes many git commands to fail because of unstaged changes, whereas *adding* the file to your worktree makes it untracked and git will basically never complain about it.