### PR TITLE
pythonPackages.azure-* refactor move to python-modules (no version change)

### DIFF
--- a/pkgs/development/python-modules/azure-common/default.nix
+++ b/pkgs/development/python-modules/azure-common/default.nix
@@ -1,0 +1,32 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-nspkg
+, isPyPy
+, python
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "azure-common";
+  disabled = isPyPy;
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "074rwwy8zzs7zw3nww5q2wg5lxgdc4rmypp2gfc9mwsz0gb70491";
+  };
+
+  propagatedBuildInputs = [ azure-nspkg ];
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-common/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-common/default.nix
@@ -1,0 +1,33 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-common
+, azure-mgmt-nspkg
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "0.20.0";
+  pname = "azure-mgmt-common";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1rmzpz3733wv31rsnqpdy4bbafvk5dhbqx7q0xf62dlz7p0i4f66";
+  };
+
+  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg requests ];
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-mgmt-common
+}:
+
+buildPythonPackage rec {
+  version = "0.20.0";
+  pname = "azure-mgmt-compute";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "12hr5vxdg2sk2fzr608a37f4i8nbchca7dgdmly2w5fc7x88jx2v";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/compute/computemanagement.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-network/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-network/default.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-mgmt-common
+, python
+}:
+
+buildPythonPackage rec {
+  version = "0.20.1";
+  pname = "azure-mgmt-network";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "10vj22h6nxpw0qpvib5x2g6qs5j8z31142icvh4qk8k40fcrs9hx";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/network/networkresourceprovider.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
@@ -1,0 +1,25 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-nspkg
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "azure-mgmt-nspkg";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1rq92fj3kvnqkk18596dybw0kvhgscvc6cd8hp1dhy3wrkqnhwmq";
+  };
+
+  propagatedBuildInputs = [ azure-nspkg ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -1,0 +1,38 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-mgmt-common
+}:
+
+
+buildPythonPackage rec {
+  version = "0.20.1";
+  pname = "azure-mgmt-resource";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0slh9qfm5nfacrdm3lid0sr8kwqzgxvrwf27laf9v38kylkfqvml";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/resource/resourcemanagement.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-mgmt-common
+}:
+
+buildPythonPackage rec {
+  version = "0.20.0";
+  pname = "azure-mgmt-storage";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "16iw7hqhq97vlzfwixarfnirc60l5mz951p57brpcwyylphl3yim";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/storage/storagemanagement.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-nspkg/default.nix
@@ -1,0 +1,22 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "azure-nspkg";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "293f286c15ea123761f30f5b1cb5adebe5f1e5009efade923c6dd1e017621bf7";
+  };
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
+++ b/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
@@ -1,0 +1,31 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-common
+, requests
+, python
+}:
+
+buildPythonPackage rec {
+  version = "0.20.1";
+  pname = "azure-servicemanagement-legacy";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "17dwrp99sx5x9cm4vldkaxhki9gbd6dlafa0lpr2n92xhh2838zs";
+  };
+
+  propagatedBuildInputs = [ azure-common requests ];
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure-storage/default.nix
+++ b/pkgs/development/python-modules/azure-storage/default.nix
@@ -1,0 +1,35 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-common
+, futures
+, dateutil
+, requests
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  version = "0.20.3";
+  pname = "azure-storage";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "06bmw6k2000kln5jwk5r9bgcalqbyvqirmdh9gq4s6nb4fv3c0jb";
+  };
+
+  propagatedBuildInputs = [ azure-common dateutil requests ]
+                            ++ pkgs.lib.optionals (!isPy3k) [ futures ];
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/development/python-modules/azure/default.nix
+++ b/pkgs/development/python-modules/azure/default.nix
@@ -1,0 +1,39 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, dateutil
+, futures
+, pyopenssl
+, requests
+, pythonOlder
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  version = "0.11.0";
+  pname = "azure";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "89c20b2efaaed3c6f56345d55c32a8d4e7d2a16c032d0acb92f8f490c508fe24";
+  };
+
+  propagatedBuildInputs = [ dateutil pyopenssl requests ]
+                            ++ pkgs.lib.optionals (!isPy3k) [ futures ];
+
+  # depends on futures for python 3 (not necissary)
+  patchPhase = if (!isPy3k) then "" else ''
+    sed -i -e "s/'futures'//" setup.py
+  '';
+
+  # tests are not packaged in pypi release
+  doCheck = false;
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -222,6 +222,8 @@ in {
 
   azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };
 
+  azure-mgmt-network = callPackage ../development/python-modules/azure-mgmt-network { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -776,31 +778,6 @@ in {
       url = mirror://pypi/a/azure-nspkg/azure-nspkg-1.0.0.zip;
       sha256 = "1xqvc8by1lbd7j9dxyly03jz3rgbmnsiqnqgydhkf4pa2mn2hgr9";
     };
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
-
-  azure-mgmt-network = buildPythonPackage rec {
-    version = "0.20.1";
-    name = "azure-mgmt-network-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-mgmt-network/azure-mgmt-network-0.20.1.zip;
-      sha256 = "10vj22h6nxpw0qpvib5x2g6qs5j8z31142icvh4qk8k40fcrs9hx";
-    };
-    preConfigure = ''
-      # Patch to make this package work on requests >= 2.11.x
-      # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-      sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/network/networkresourceprovider.py
-    '';
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
-    '';
-    propagatedBuildInputs = with self; [ azure-mgmt-common ];
     meta = {
       description = "Microsoft Azure SDK for Python";
       homepage = "https://azure.microsoft.com/en-us/develop/python/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -216,6 +216,8 @@ in {
 
   azure = callPackage ../development/python-modules/azure { };
 
+  azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
+
   azure-common = callPackage ../development/python-modules/azure-common { };
 
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
@@ -223,6 +225,8 @@ in {
   azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };
 
   azure-mgmt-network = callPackage ../development/python-modules/azure-mgmt-network { };
+
+  azure-mgmt-nspkg = callPackage ../development/python-modules/azure-mgmt-nspkg { };
 
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
@@ -769,38 +773,6 @@ in {
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};
 
   noise = callPackage ../development/python-modules/noise {};
-
-
-  azure-nspkg = buildPythonPackage rec {
-    version = "1.0.0";
-    name = "azure-nspkg-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-nspkg/azure-nspkg-1.0.0.zip;
-      sha256 = "1xqvc8by1lbd7j9dxyly03jz3rgbmnsiqnqgydhkf4pa2mn2hgr9";
-    };
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
-
-  azure-mgmt-nspkg = buildPythonPackage rec {
-    version = "1.0.0";
-    name = "azure-mgmt-nspkg-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-mgmt-nspkg/azure-mgmt-nspkg-1.0.0.zip;
-      sha256 = "1rq92fj3kvnqkk18596dybw0kvhgscvc6cd8hp1dhy3wrkqnhwmq";
-    };
-    propagatedBuildInputs = with self; [ azure-nspkg ];
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
 
   azure-mgmt-resource = buildPythonPackage rec {
     version = "0.20.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -228,6 +228,8 @@ in {
 
   azure-mgmt-nspkg = callPackage ../development/python-modules/azure-mgmt-nspkg { };
 
+  azure-mgmt-resource = callPackage ../development/python-modules/azure-mgmt-resource { };
+
   azure-mgmt-storage = callPackage ../development/python-modules/azure-mgmt-storage { };
 
   backports_csv = callPackage ../development/python-modules/backports_csv {};
@@ -775,56 +777,6 @@ in {
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};
 
   noise = callPackage ../development/python-modules/noise {};
-
-  azure-mgmt-resource = buildPythonPackage rec {
-    version = "0.20.1";
-    name = "azure-mgmt-resource-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-mgmt-resource/azure-mgmt-resource-0.20.1.zip;
-      sha256 = "0slh9qfm5nfacrdm3lid0sr8kwqzgxvrwf27laf9v38kylkfqvml";
-    };
-    preConfigure = ''
-      # Patch to make this package work on requests >= 2.11.x
-      # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-      sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/resource/resourcemanagement.py
-    '';
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
-    '';
-    propagatedBuildInputs = with self; [ azure-mgmt-common ];
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
-
-  azure-mgmt-storage = buildPythonPackage rec {
-    version = "0.20.0";
-    name = "azure-mgmt-storage-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-mgmt-storage/azure-mgmt-storage-0.20.0.zip;
-      sha256 = "16iw7hqhq97vlzfwixarfnirc60l5mz951p57brpcwyylphl3yim";
-    };
-    preConfigure = ''
-      # Patch to make this package work on requests >= 2.11.x
-      # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-      sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/storage/storagemanagement.py
-    '';
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
-    '';
-    propagatedBuildInputs = with self; [ azure-mgmt-common ];
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
 
   azure-storage = buildPythonPackage rec {
     version = "0.20.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -220,6 +220,8 @@ in {
 
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
 
+  azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -774,31 +776,6 @@ in {
       url = mirror://pypi/a/azure-nspkg/azure-nspkg-1.0.0.zip;
       sha256 = "1xqvc8by1lbd7j9dxyly03jz3rgbmnsiqnqgydhkf4pa2mn2hgr9";
     };
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
-
-  azure-mgmt-compute = buildPythonPackage rec {
-    version = "0.20.0";
-    name = "azure-mgmt-compute-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-mgmt-compute/azure-mgmt-compute-0.20.0.zip;
-      sha256 = "12hr5vxdg2sk2fzr608a37f4i8nbchca7dgdmly2w5fc7x88jx2v";
-    };
-    preConfigure = ''
-      # Patch to make this package work on requests >= 2.11.x
-      # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-      sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/compute/computemanagement.py
-    '';
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
-    '';
-    propagatedBuildInputs = with self; [ azure-mgmt-common ];
     meta = {
       description = "Microsoft Azure SDK for Python";
       homepage = "https://azure.microsoft.com/en-us/develop/python/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -214,6 +214,8 @@ in {
 
   ansiconv = callPackage ../development/python-modules/ansiconv { };
 
+  azure = callPackage ../development/python-modules/azure { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -760,25 +762,6 @@ in {
 
   noise = callPackage ../development/python-modules/noise {};
 
-  azure = buildPythonPackage rec {
-    version = "0.11.0";
-    name = "azure-${version}";
-    disabled = pythonOlder "2.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/a/azure/${name}.zip";
-      sha256 = "89c20b2efaaed3c6f56345d55c32a8d4e7d2a16c032d0acb92f8f490c508fe24";
-    };
-
-    propagatedBuildInputs = with self; [ dateutil futures pyopenssl requests ];
-
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
 
   azure-nspkg = buildPythonPackage rec {
     version = "1.0.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -216,6 +216,8 @@ in {
 
   azure = callPackage ../development/python-modules/azure { };
 
+  azure-common = callPackage ../development/python-modules/azure-common { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -770,26 +772,6 @@ in {
       url = mirror://pypi/a/azure-nspkg/azure-nspkg-1.0.0.zip;
       sha256 = "1xqvc8by1lbd7j9dxyly03jz3rgbmnsiqnqgydhkf4pa2mn2hgr9";
     };
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
-
-  azure-common = buildPythonPackage rec {
-    version = "1.0.0";
-    name = "azure-common-${version}";
-    disabled = isPyPy;
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-common/azure-common-1.0.0.zip;
-      sha256 = "074rwwy8zzs7zw3nww5q2wg5lxgdc4rmypp2gfc9mwsz0gb70491";
-    };
-    propagatedBuildInputs = with self; [ azure-nspkg ];
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-    '';
     meta = {
       description = "Microsoft Azure SDK for Python";
       homepage = "https://azure.microsoft.com/en-us/develop/python/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -232,6 +232,8 @@ in {
 
   azure-mgmt-storage = callPackage ../development/python-modules/azure-mgmt-storage { };
 
+  azure-storage = callPackage ../development/python-modules/azure-storage { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -777,25 +779,6 @@ in {
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};
 
   noise = callPackage ../development/python-modules/noise {};
-
-  azure-storage = buildPythonPackage rec {
-    version = "0.20.3";
-    name = "azure-storage-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-storage/azure-storage-0.20.3.zip;
-      sha256 = "06bmw6k2000kln5jwk5r9bgcalqbyvqirmdh9gq4s6nb4fv3c0jb";
-    };
-    propagatedBuildInputs = with self; [ azure-common futures dateutil requests ];
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-    '';
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
 
   azure-servicemanagement-legacy = buildPythonPackage rec {
     version = "0.20.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -218,6 +218,8 @@ in {
 
   azure-common = callPackage ../development/python-modules/azure-common { };
 
+  azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -772,26 +774,6 @@ in {
       url = mirror://pypi/a/azure-nspkg/azure-nspkg-1.0.0.zip;
       sha256 = "1xqvc8by1lbd7j9dxyly03jz3rgbmnsiqnqgydhkf4pa2mn2hgr9";
     };
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
-
-  azure-mgmt-common = buildPythonPackage rec {
-    version = "0.20.0";
-    name = "azure-mgmt-common-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-mgmt-common/azure-mgmt-common-0.20.0.zip;
-      sha256 = "1rmzpz3733wv31rsnqpdy4bbafvk5dhbqx7q0xf62dlz7p0i4f66";
-    };
-    propagatedBuildInputs = with self; [ azure-common azure-mgmt-nspkg requests ];
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
-    '';
     meta = {
       description = "Microsoft Azure SDK for Python";
       homepage = "https://azure.microsoft.com/en-us/develop/python/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -228,6 +228,8 @@ in {
 
   azure-mgmt-nspkg = callPackage ../development/python-modules/azure-mgmt-nspkg { };
 
+  azure-mgmt-storage = callPackage ../development/python-modules/azure-mgmt-storage { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -234,6 +234,8 @@ in {
 
   azure-storage = callPackage ../development/python-modules/azure-storage { };
 
+  azure-servicemanagement-legacy = callPackage ../development/python-modules/azure-servicemanagement-legacy { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
@@ -779,25 +781,6 @@ in {
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};
 
   noise = callPackage ../development/python-modules/noise {};
-
-  azure-servicemanagement-legacy = buildPythonPackage rec {
-    version = "0.20.1";
-    name = "azure-servicemanagement-legacy-${version}";
-    src = pkgs.fetchurl {
-      url = mirror://pypi/a/azure-servicemanagement-legacy/azure-servicemanagement-legacy-0.20.1.zip;
-      sha256 = "17dwrp99sx5x9cm4vldkaxhki9gbd6dlafa0lpr2n92xhh2838zs";
-    };
-    propagatedBuildInputs = with self; [ azure-common requests ];
-    postInstall = ''
-      echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
-    '';
-    meta = {
-      description = "Microsoft Azure SDK for Python";
-      homepage = "https://azure.microsoft.com/en-us/develop/python/";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ olcai ];
-    };
-  };
 
   backcall = callPackage ../development/python-modules/backcall { };
 


### PR DESCRIPTION
No versions or build instructions were changed only moved to python-modules (unless to add python 3 compatibility).

###### Things done

pythonPackages.azure: refactor move to python-modules 

pythonPackages.azure-common: refactor move to python-modules 

pythonPackages.azure-mgmt-common: refactor move to python-modules 

pythonPackages.azure-mgmt-compute: refactor move to python-modules 

pythonPackages.azure-mgmt-network: refactor move to python-modules 

pythonPackages.azure-nspkg: refactor move to python-modules 

pythonPackages.azure-mgmt-storage: refactor move to python-modules 

pythonPackages.azure-storage: refactor move to python-modules 

pythonPackages.azure-servicemanagement-lagacy: refactor move to python-modules

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

