### PR TITLE
pythonPackages.boto: 2.47.0 -> 2.49.0

### DIFF
--- a/pkgs/development/python-modules/boto/default.nix
+++ b/pkgs/development/python-modules/boto/default.nix
@@ -1,0 +1,38 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, nose
+, mock
+, requests
+, httpretty
+}:
+
+buildPythonPackage rec {
+  pname = "boto";
+  version = "2.49.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} tests/test.py default
+  '';
+
+  checkInputs = [ nose mock ];
+  propagatedBuildInputs = [ requests httpretty ];
+
+  meta = with pkgs.lib; {
+    homepage = https://github.com/boto/boto;
+    license = licenses.mit;
+    description = "Python interface to Amazon Web Services";
+    longDescription = ''
+      The boto module is an integrated interface to current and
+      future infrastructural services offered by Amazon Web
+      Services.  This includes S3, SQS, EC2, among others.
+    '';
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1331,36 +1331,7 @@ in {
 
   bokeh = callPackage ../development/python-modules/bokeh { };
 
-  boto = buildPythonPackage rec {
-    name = "boto-${version}";
-    version = "2.47.0";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/boto/boto/archive/${version}.tar.gz";
-      sha256 = "051gq8z9m2cir03jhc00qs36bnpla7zkqm9xqiqcqvdknmi2ndbq";
-    };
-
-    checkPhase = ''
-      ${python.interpreter} tests/test.py default
-    '';
-
-    buildInputs = [ self.nose self.mock ];
-    propagatedBuildInputs = [ self.requests self.httpretty ];
-
-    meta = {
-      homepage = https://github.com/boto/boto;
-
-      license = "bsd";
-
-      description = "Python interface to Amazon Web Services";
-
-      longDescription = ''
-        The boto module is an integrated interface to current and
-        future infrastructural services offered by Amazon Web
-        Services.  This includes S3, SQS, EC2, among others.
-      '';
-    };
-  };
+  boto = callPackage ../development/python-modules/boto { };
 
   boto3 = callPackage ../development/python-modules/boto3 { };
 


### PR DESCRIPTION
refactor move to python-modules

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

