### PR TITLE
pythonPackages.tinycss: 0.3 -> 0.4 refactor move to python-modules

### DIFF
--- a/pkgs/development/python-modules/tinycss/default.nix
+++ b/pkgs/development/python-modules/tinycss/default.nix
@@ -1,0 +1,35 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, pytest
+, python
+, cssutils
+, isPyPy
+}:
+
+buildPythonPackage rec {
+  pname = "tinycss";
+  version = "0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12306fb50e5e9e7eaeef84b802ed877488ba80e35c672867f548c0924a76716e";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ cssutils ];
+
+  checkPhase = ''
+    py.test $out/${python.sitePackages}
+  '';
+
+  # Disable Cython tests for PyPy
+  TINYCSS_SKIP_SPEEDUPS_TESTS = pkgs.lib.optional isPyPy true;
+
+  meta = with pkgs.lib; {
+    description = "Complete yet simple CSS parser for Python";
+    license = licenses.bsd3;
+    homepage = https://pythonhosted.org/tinycss/;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1969,32 +1969,7 @@ in {
 
   pytest-sugar = callPackage ../development/python-modules/pytest-sugar { };
 
-  tinycss = buildPythonPackage rec {
-    name = "tinycss-${version}";
-    version = "0.3";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/t/tinycss/${name}.tar.gz";
-      sha256 = "1pichqra4wk86142hqgvy9s5x6c5k5zhy8l9qxr0620pqk8spbd4";
-    };
-
-    buildInputs = with self; [ pytest ];
-
-    propagatedBuildInputs = with self; [ cssutils ];
-
-    checkPhase = ''
-      py.test $out/${python.sitePackages}
-    '';
-
-    # Disable Cython tests for PyPy
-    TINYCSS_SKIP_SPEEDUPS_TESTS = optional isPyPy true;
-
-    meta = {
-      description = "Complete yet simple CSS parser for Python";
-      license = licenses.bsd3;
-      homepage = https://pythonhosted.org/tinycss/;
-    };
-  };
+  tinycss = callPackage ../development/python-modules/tinycss { };
 
   tinycss2 = callPackage ../development/python-modules/tinycss2 { };
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

