### PR TITLE
pythonPackages.dopy: refactor move to python-modules

### DIFF
--- a/pkgs/development/python-modules/dopy/default.nix
+++ b/pkgs/development/python-modules/dopy/default.nix
@@ -1,0 +1,26 @@
+{ pkgs
+, buildPythonPackage
+, requests
+, six
+}:
+
+buildPythonPackage rec {
+  version = "2016-01-04";
+  pname = "dopy";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "Wiredcraft";
+    repo = "dopy";
+    rev = "cb443214166a4e91b17c925f40009ac883336dc3";
+    sha256 ="0ams289qcgna96aak96jbz6wybs6qb95h2gn8lb4lmx2p5sq4q56";
+  };
+
+  propagatedBuildInputs = [ requests six ];
+
+  meta = with pkgs.lib; {
+    description = "Digital Ocean API python wrapper";
+    homepage = "https://github.com/Wiredcraft/dopy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lihop ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2136,27 +2136,7 @@ in {
 
   dogpile_core = callPackage ../development/python-modules/dogpile.core { };
 
-  dopy = buildPythonPackage rec {
-    version = "2016-01-04";
-    name = "dopy-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "Wiredcraft";
-      repo = "dopy";
-      rev = "cb443214166a4e91b17c925f40009ac883336dc3";
-      sha256 ="0ams289qcgna96aak96jbz6wybs6qb95h2gn8lb4lmx2p5sq4q56";
-    };
-
-    propagatedBuildInputs = with self; [ requests six ];
-
-    meta = {
-      description = "Digital Ocean API python wrapper";
-      homepage = "https://github.com/Wiredcraft/dopy";
-      license = licenses.mit;
-      maintainers = with maintainers; [ lihop ];
-      platforms = platforms.all;
-    };
-  };
+  dopy = callPackage ../development/python-modules/dopy { };
 
   dpkt = callPackage ../development/python-modules/dpkt {};
 


### PR DESCRIPTION
###### Things done

pythonPackages.dopy: refactor move to python-modules

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

