### PR TITLE
pythonPackages.escapism: 0.0.1 -> 1.0.0 move to python-modules

### DIFF
--- a/pkgs/development/python-modules/escapism/default.nix
+++ b/pkgs/development/python-modules/escapism/default.nix
@@ -1,0 +1,24 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "escapism";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5f1cc1fa04a95f5b85b3da194750f8a71846d493ea332f62e8798949f10c9b86";
+  };
+
+  # No tests distributed
+  doCheck = false;
+
+  meta = with pkgs.lib; {
+    description = "Simple, generic API for escaping strings";
+    homepage = "https://github.com/minrk/escapism";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bzizou ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2223,25 +2223,7 @@ in {
 
   enzyme = callPackage ../development/python-modules/enzyme {};
 
-  escapism = buildPythonPackage rec {
-    name = "escapism-${version}";
-    version = "0.0.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/e/escapism/${name}.tar.gz";
-      sha256 = "1yfyxwxb864xrmrrqgp85xgsh4yrrq5mmzvkdg19jwr7rm6sqx9p";
-    };
-
-    # No tests distributed
-    doCheck = false;
-
-    meta = {
-      description = "Simple, generic API for escaping strings";
-      homepage = "https://github.com/minrk/escapism";
-      license = licenses.mit;
-      maintainers = with maintainers; [ bzizou ];
-    };
-  };
+  escapism = callPackage ../development/python-modules/escapism { };
 
   etcd = buildPythonPackage rec {
     name = "etcd-${version}";


### PR DESCRIPTION
###### Things done

pythonPackages.escapism: 0.0.1 -> 1.0.0 move to python-modules

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

