### PR TITLE
pythonPackages.facebook-sdk: 0.3.0 -> 3.0.0 refactor move to python-modules

### DIFF
--- a/pkgs/development/python-modules/facebook-sdk/default.nix
+++ b/pkgs/development/python-modules/facebook-sdk/default.nix
@@ -1,0 +1,32 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, requests
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "facebook-sdk";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f3d450ec313b62d3716fadc4e5098183760e1d2a9e0434a94b74e59ea6ea3e4d";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # checks require network
+  doCheck = false;
+
+  checkPhase = ''
+    ${python.interpreter} test/test_facebook.py
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Client library that supports the Facebook Graph API and the official Facebook JavaScript SDK";
+    homepage = https://github.com/pythonforfacebook/facebook-sdk;
+    license = licenses.asl20 ;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2367,22 +2367,7 @@ in {
 
   ezdxf = callPackage ../development/python-modules/ezdxf {};
 
-  facebook-sdk = buildPythonPackage rec {
-    name = "facebook-sdk-0.4.0";
-
-    disabled = isPy3k;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/f/facebook-sdk/facebook-sdk-0.4.0.tar.gz";
-      sha256 = "5a96c54d06213039dff1fe1fabc51972e394666cd6d83ea70f7c2e67472d9b72";
-    };
-
-    meta = with pkgs.stdenv.lib; {
-      description = "Client library that supports the Facebook Graph API and the official Facebook JavaScript SDK";
-      homepage = https://github.com/pythonforfacebook/facebook-sdk;
-      license = licenses.asl20 ;
-    };
-  };
+  facebook-sdk = callPackage ../development/python-modules/facebook-sdk { };
 
   face_recognition = callPackage ../development/python-modules/face_recognition { };
 


### PR DESCRIPTION


###### Things done

pythonPackages.facebook-sdk: 0.3.0 -> 3.0.0 refactor move to python-modules

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

