### PR TITLE
prooftree: cleaning

### DIFF
--- a/pkgs/applications/science/logic/prooftree/default.nix
+++ b/pkgs/applications/science/logic/prooftree/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, pkgconfig, ocaml, findlib, camlp5, ncurses, lablgtk ? null}:
+{ stdenv, fetchurl, pkgconfig, ncurses, ocamlPackages }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "prooftree-${version}";
   version = "0.13";
 
@@ -10,7 +10,8 @@ stdenv.mkDerivation (rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocaml findlib camlp5 ncurses lablgtk ];
+  buildInputs = [ ncurses ] ++ (with ocamlPackages; [
+    ocaml findlib camlp5 lablgtk ]);
 
   dontAddPrefix = true;
   configureFlags = [ "--prefix" "$(out)" ];
@@ -39,4 +40,4 @@ stdenv.mkDerivation (rec {
     maintainers = [ maintainers.jwiegley ];
     license = licenses.gpl3;
   };
-})
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21278,7 +21278,7 @@ with pkgs;
 
   libpoly = callPackage ../applications/science/logic/poly {};
 
-  prooftree = ocamlPackages.callPackage  ../applications/science/logic/prooftree { };
+  prooftree = callPackage  ../applications/science/logic/prooftree {};
 
   prover9 = callPackage ../applications/science/logic/prover9 { };
 


### PR DESCRIPTION
###### Motivation for this change

#48159

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jwiegley, maintainer.