### PR TITLE
pythonPackages.fs: 0.5.4 -> 2.1.1 refactor move to python-modules

### DIFF
--- a/pkgs/development/python-modules/backports_os/default.nix
+++ b/pkgs/development/python-modules/backports_os/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, future
+, isPy3k
+, python
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  version = "0.1.1";
+  pname = "backports.os";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b472c4933094306ca08ec90b2a8cbb50c34f1fb2767775169a1c1650b7b74630";
+  };
+
+  buildInputs = [ setuptools_scm ];
+  checkInputs = [ hypothesis ];
+  propagatedBuildInputs = [ future ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pjdelport/backports.os;
+    description = "Backport of new features in Python's os module";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -1,0 +1,53 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, six
+, nose
+, appdirs
+, scandir
+, backports_os
+, typing
+, pytz
+, enum34
+, pyftpdlib
+, psutil
+, mock
+, pythonAtLeast
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "fs";
+  version = "2.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b20a4aeac9079b194f0160957d4265bb6c99ce68f1b12e980b0fb96f74aafb70";
+  };
+
+  buildInputs = [ pkgs.glibcLocales ];
+  checkInputs = [ nose pyftpdlib mock psutil ];
+  propagatedBuildInputs = [ six appdirs pytz ]
+    ++ pkgs.lib.optionals (!isPy3k) [ backports_os ]
+    ++ pkgs.lib.optionals (!pythonAtLeast "3.6") [ typing ]
+    ++ pkgs.lib.optionals (!pythonAtLeast "3.5") [ scandir ]
+    ++ pkgs.lib.optionals (!pythonAtLeast "3.5") [ enum34 ];
+
+  postPatch = ''
+    # required for installation
+    touch LICENSE
+    # tests modify home directory results in (4 tests failing) / 1600
+    rm tests/test_appfs.py tests/test_opener.py
+  '';
+
+  LC_ALL="en_US.utf-8";
+
+  meta = with pkgs.lib; {
+    description = "Filesystem abstraction";
+    homepage    = https://github.com/PyFilesystem/pyfilesystem2;
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
+  };
+
+}

--- a/pkgs/development/python-modules/pyftpdlib/default.nix
+++ b/pkgs/development/python-modules/pyftpdlib/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, mock
+, psutil
+, pyopenssl
+, pysendfile
+, python
+}:
+
+buildPythonPackage rec {
+  version = "1.5.4";
+  pname = "pyftpdlib";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e5fca613978743d41c3bfc68e25a811d646a3b8a9eee9eb07021daca89646a0f";
+  };
+
+  checkInputs = [ mock psutil ];
+  propagatedBuildInputs = [ pyopenssl pysendfile ];
+
+  checkPhase = ''
+    ${python.interpreter} pyftpdlib/test/runner.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/giampaolo/pyftpdlib/;
+    description = "Very fast asynchronous FTP server library";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5581,37 +5581,7 @@ in {
     };
   };
 
-  fs = buildPythonPackage rec {
-    name = "fs-0.5.4";
-
-    src = pkgs.fetchurl {
-      url    = "mirror://pypi/f/fs/${name}.tar.gz";
-      sha256 = "ba2cca8773435a7c86059d57cb4b8ea30fda40f8610941f7822d1ce3ffd36197";
-    };
-
-    LC_ALL = "en_US.UTF-8";
-    buildInputs = [ pkgs.glibcLocales ];
-    propagatedBuildInputs = [ self.six ];
-
-    checkPhase = ''
-      ${python.interpreter} -m unittest discover
-    '';
-
-    # Because 2to3 is used the tests in $out need to be run.
-    # Both when using unittest and pytest this resulted in many errors,
-    # some Python byte/str errors, and others specific to resources tested.
-    # Failing tests due to the latter is to be expected with this type of package.
-    # Tests are therefore disabled.
-    doCheck = false;
-
-    meta = {
-      description = "Filesystem abstraction";
-      homepage    = https://pypi.python.org/pypi/fs;
-      license     = licenses.bsd3;
-      maintainers = with maintainers; [ lovek323 ];
-      platforms   = platforms.unix;
-    };
-  };
+  fs = callPackage ../development/python-modules/fs { };
 
   fusepy = buildPythonPackage rec {
     name = "fusepy-2.0.4";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -995,6 +995,8 @@ in {
 
   backports_functools_lru_cache = callPackage ../development/python-modules/backports_functools_lru_cache { };
 
+  backports_os = callPackage ../development/python-modules/backports_os { };
+
   backports_shutil_get_terminal_size = callPackage ../development/python-modules/backports_shutil_get_terminal_size { };
 
   backports_ssl_match_hostname = if !(pythonOlder "3.5") then null else

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3857,6 +3857,8 @@ in {
 
   pydotplus = callPackage ../development/python-modules/pydotplus { };
 
+  pyftpdlib = callPackage ../development/python-modules/pyftpdlib { };
+
   pyfxa = callPackage ../development/python-modules/pyfxa { };
 
   pyhomematic = callPackage ../development/python-modules/pyhomematic { };


### PR DESCRIPTION
###### Motivation for this change

#48034 . 

###### Things done


pythonPackages.backports_os: init at 0.1.1 

pythonPackages.pyftpdlib: init at 1.5.4 

pythonPackages.fs: 0.5.4 -> 2.1.1 refactor move to python-modules 


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

