### PR TITLE
cholmod-extra: init at 1.2.0

### DIFF
--- a/pkgs/development/libraries/science/math/cholmod-extra/default.nix
+++ b/pkgs/development/libraries/science/math/cholmod-extra/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, gfortran, suitesparse, openblas }:
+let
+  suitesparse_ = suitesparse;
+in let
+  # SuiteSparse must use the same openblas
+  suitesparse = suitesparse_.override { inherit openblas; };
+in stdenv.mkDerivation rec {
+
+  name = "${pname}-${version}";
+  pname = "cholmod-extra";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "jluttine";
+    rev = version;
+    sha256 = "0hz1lfp0zaarvl0dv0zgp337hyd8np41kmdpz5rr3fc6yzw7vmkg";
+  };
+
+  buildInputs = [ suitesparse gfortran openblas ];
+
+  buildFlags = [
+    "BLAS=-lopenblas"
+  ];
+
+  installFlags = [
+    "INSTALL_LIB=$(out)/lib"
+    "INSTALL_INCLUDE=$(out)/include"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jluttine/cholmod-extra;
+    description = "A set of additional routines for SuiteSparse CHOLMOD Module";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ jluttine ];
+    platforms = with platforms; unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2352,6 +2352,8 @@ with pkgs;
 
   carp = callPackage ../development/compilers/carp { };
 
+  cholmod-extra = callPackage ../development/libraries/science/math/cholmod-extra { };
+
   emscriptenVersion = "1.37.36";
 
   emscripten = callPackage ../development/compilers/emscripten { };


### PR DESCRIPTION
###### Motivation for this change

Add cholmod-extra package. It's a small package adding one function to SuiteSparse CHOLMOD package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

