### PR TITLE
alt-ergo: 1.30->2.2.0, ocplib-simplex: 0.3->0.4

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -500,6 +500,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Non-Profit Open Software License 3.0";
   };
 
+  ocamlpro_nc = {
+    fullName = " OCamlPro Non Commercial license version 1";
+    url = "https://alt-ergo.ocamlpro.com/http/alt-ergo-2.2.0/OCamlPro-Non-Commercial-License.pdf";
+    free = false;
+  };
+
   ofl = spdx {
     spdxId = "OFL-1.1";
     fullName = "SIL Open Font License 1.1";

--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "alt-ergo-${version}";
-  version = "1.30";
+  version = "2.2.0";
 
   src = fetchurl {
     url    = "https://alt-ergo.ocamlpro.com/download_manager.php?target=${name}.tar.gz";
     name   = "${name}.tar.gz";
-    sha256 = "025pacb4ax864fn5x8k78mw6hiig4jcazblj18gzxspg4f1l5n1g";
+    sha256 = "106zfgisq6qxr7dlk8z7gi68ly7qff4frn8wab2g8z2nkkwla92w";
   };
 
   buildInputs = with ocamlPackages;
-    [ ocaml findlib camlzip ocamlgraph zarith lablgtk ocplib-simplex ];
+    [ ocaml findlib camlzip ocamlgraph zarith lablgtk ocplib-simplex psmt2-frontend menhir num ];
 
   meta = {
     description = "High-performance theorem prover and SMT solver";
     homepage    = "https://alt-ergo.ocamlpro.com/";
-    license     = stdenv.lib.licenses.cecill-c; # LGPL-2 compatible
+    license     = stdenv.lib.licenses.ocamlpro_nc;
     platforms   = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };

--- a/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, ocaml, findlib }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, ocaml, findlib }:
 
 let
   pname = "ocplib-simplex";
-  version = "0.3";
+  version = "0.4";
 in
 
 stdenv.mkDerivation {
@@ -11,12 +11,14 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "OCamlPro-Iguernlala";
     repo = pname;
-    rev = version;
-    sha256 = "1fmz38w2cj9fny4adqqyil59dvndqkr59s7wk2gqs47r72b6sisa";
+    rev = "v${version}";
+    sha256 = "09niyidrjzrj8g1qwx4wgsdf5m6cwrnzg7zsgala36jliic4di60";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ ocaml findlib ];
+
+  installFlags = "LIBDIR=$(OCAMLFIND_DESTDIR)";
 
   createFindlibDestdir = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21164,9 +21164,7 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_05;
   };
 
-  alt-ergo = callPackage ../applications/science/logic/alt-ergo {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
-  };
+  alt-ergo = callPackage ../applications/science/logic/alt-ergo {};
 
   aspino = callPackage ../applications/science/logic/aspino {};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

