### PR TITLE
dia: fix on darwin

### DIFF
--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, autoconf, automake, libtool, gtk2, pkgconfig, perl,
 perlXMLParser, libxml2, gettext, python, libxml2Python, docbook5, docbook_xsl,
 libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui, hicolor-icon-theme,
-gtk-mac-integration }:
+gtk-mac-integration-gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "dia-${version}";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     [ gtk2 perlXMLParser libxml2 gettext python libxml2Python docbook5
       libxslt docbook_xsl libart_lgpl hicolor-icon-theme ]
       ++ stdenv.lib.optional withGNOME libgnomeui
-      ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration;
+      ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration-gtk2;
 
   nativeBuildInputs = [ autoconf automake libtool pkgconfig intltool perl ];
 


### PR DESCRIPTION
Fixes runtime error:
  GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

