### PR TITLE
CONTRIBUTING.md: Clarify clarification on periods

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
   (Motivation for change. Additional information.)
   ```
 
-  For consistency, there should not be a period at the end of the commit message.
+  For consistency, there should not be a period at the end of the commit message's summary line (the first line of the commit message).
 
   Examples:
 


### PR DESCRIPTION
Commit 9428c28f7a37038b594c5ff36b1669b0f21afe41 added a note in `CONTRIBUTING.md` saying that, "For consistency, there should not be a period at the end of the commit message."

I believe it would be more correct (with respect to consistency) to say that there should not be a full stop/period at the end of the commit message's *summary line* (the first line of the commit message)
(indeed, the example commit message just above this note clearly does use full stops outside of its summary line), and this patch changes `CONTRIBUTING.md` accordingly.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

