### PR TITLE
pythonPackages.BoltzTraP2: init at 18.9.1

### DIFF
--- a/pkgs/development/python-modules/boltztrap2/default.nix
+++ b/pkgs/development/python-modules/boltztrap2/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, spglib
+, numpy
+, scipy
+, matplotlib
+, ase
+, netcdf4
+, pytest
+, pythonOlder
+, cython
+, cmake
+}:
+
+buildPythonPackage rec {
+  version = "18.9.1";
+  pname = "BoltzTraP2";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b828ad2b3b3a40956ef866e462e4c82faf83be79348af3945d4e7cede8a53913";
+  };
+
+  buildInputs = [ cython cmake ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ spglib numpy scipy matplotlib ase netcdf4 ];
+
+  # pypi release does no include files for tests
+  doCheck = false;
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.boltztrap.org/;
+    description = "Band-structure interpolator and transport coefficient calculator";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1137,6 +1137,8 @@ in {
     enablePython = true;
   });
 
+  boltztrap2 = callPackage ../development/python-modules/boltztrap2 { };
+
   bumps = callPackage ../development/python-modules/bumps {};
 
   cached-property = callPackage ../development/python-modules/cached-property { };


### PR DESCRIPTION
###### Things done

pythonPackages.BoltzTraP2: init at 18.9.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

