### PR TITLE
pythonPackages.atomman: init at 1.2.3

### DIFF
--- a/pkgs/development/python-modules/atomman/default.nix
+++ b/pkgs/development/python-modules/atomman/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, xmltodict
+, datamodeldict
+, numpy
+, matplotlib
+, scipy
+, pandas
+, cython
+, numericalunits
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "1.2.3";
+  pname = "atomman";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9eb6acc5497263cfa89be8d0f383a9a69f0726b4ac6798c1b1d96f26705ec09c";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ xmltodict datamodeldict numpy matplotlib scipy pandas cython numericalunits ];
+
+  # tests not included with Pypi release
+  doCheck = false;
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/usnistgov/atomman/;
+    description = "Atomistic Manipulation Toolkit";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/datamodeldict/default.nix
+++ b/pkgs/development/python-modules/datamodeldict/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  version = "0.9.4";
+  pname = "DataModelDict";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "97d8e999e000cf69c48e57b1a72eb45a27d83576a38c6cd8550c230b018be7af";
+  };
+
+  propagatedBuildInputs = [ xmltodict ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/usnistgov/DataModelDict/;
+    description = "Class allowing for data models equivalently represented as Python dictionaries, JSON, and XML";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/numericalunits/default.nix
+++ b/pkgs/development/python-modules/numericalunits/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "1.16";
+  pname = "numericalunits";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "71ae8e236c7a223bccefffb670dca68be476dd63b7b9009641fc64099455da25";
+  };
+
+  # no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://pypi.python.org/pypi/numericalunits;
+    description = "A package that lets you define quantities with unit";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -212,6 +212,8 @@ in {
 
   aws-adfs = callPackage ../development/python-modules/aws-adfs { };
 
+  atomman = callPackage ../development/python-modules/atomman { };
+
   # packages defined elsewhere
 
   amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -284,6 +284,8 @@ in {
 
   btchip = callPackage ../development/python-modules/btchip { };
 
+  datamodeldict = callPackage ../development/python-modules/datamodeldict { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -428,6 +428,8 @@ in {
 
   nvchecker = callPackage ../development/python-modules/nvchecker { };
 
+  numericalunits = callPackage ../development/python-modules/numericalunits { };
+
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };
 
   ordered-set = callPackage ../development/python-modules/ordered-set { };


### PR DESCRIPTION
###### Motivation for this change

Material science python packages for molecular dynamics.

###### Things done


pythonPackages.numericalunits: init at 1.16 

pythonPackages.DataModelDict: init at 0.9.4 

pythonPackages.atomman: init at 1.2.3 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

