### PR TITLE
pythonPackages.pytest-* init 2 new pytest packages

### DIFF
--- a/pkgs/development/python-modules/pyannotate/default.nix
+++ b/pkgs/development/python-modules/pyannotate/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, six
+, mypy_extensions
+, typing
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "1.0.6";
+  pname = "pyannotate";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "dbdc2a26cbf45490a650e976ba45f99abe9ddbf0af5746307914e5ef419e325e";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ six mypy_extensions ]
+    ++ stdenv.lib.optionals (pythonOlder "3.5") [ typing ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dropbox/pyannotate;
+    description = "Auto-generate PEP-484 annotations";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-annotate/default.nix
+++ b/pkgs/development/python-modules/pytest-annotate/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pyannotate
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "1.0.2";
+  pname = "pytest-annotate";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03e4dece2d1aa91666034f1b2e8bb7a7b8c6be11baf3cf2929b26eea5c6e86f3";
+  };
+
+  propagatedBuildInputs = [ pyannotate pytest ];
+
+  # not testing for a testing module...
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kensho-technologies/pytest-annotate;
+    description = "Generate PyAnnotate annotations from your pytest tests";
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, ansible
+, pytest
+, mock
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  version = "2.0.1";
+  pname = "pytest-ansible";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "553f2bc9e64f8c871ad29b7d5c100f6e549fe85db26bd1ff5dda8b769bb38a3e";
+  };
+
+  patchPhase = ''
+    sed -i "s/'setuptools-markdown'//g" setup.py
+  '';
+
+  # requires pandoc < 2.0
+  # buildInputs = [ setuptools-markdown ];
+  checkInputs =  [ mock ];
+  propagatedBuildInputs = [ ansible pytest ];
+
+  # tests not included with release
+  doCheck = false;
+
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/jlaska/pytest-ansible;
+    description = "Plugin for py.test to simplify calling ansible modules from tests or fixtures";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1909,6 +1909,8 @@ in {
 
   pytest-annotate = callPackage ../development/python-modules/pytest-annotate { };
 
+  pytest-ansible = callPackage ../development/python-modules/pytest-ansible { };
+
   pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
 
   pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -412,6 +412,8 @@ in {
     inherit (pkgs) arrow-cpp cmake pkgconfig;
   };
 
+  pyannotate = callPackage ../development/python-modules/pyannotate { };
+
   pyatspi = callPackage ../development/python-modules/pyatspi { };
 
   pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1907,6 +1907,8 @@ in {
 
   pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
 
+  pytest-annotate = callPackage ../development/python-modules/pytest-annotate { };
+
   pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
 
   pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };


### PR DESCRIPTION
###### Things done


pythonPackages.pyannotate: init at 1.0.6 

pythonPackages.pytest-annotate: init at 1.0.2 

pythonPackages.pytest-ansible: init at 2.0.1 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

