### PR TITLE
pythonPackages.atsim_potentials: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/atsim_potentials/default.nix
+++ b/pkgs/development/python-modules/atsim_potentials/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, future
+}:
+
+buildPythonPackage rec {
+  version = "0.2.1";
+  pname = "atsim.potentials";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2abdec2fb4e8198f4e0e41634ad86625d5356a4a3f1ba1f41568d0697df8f36f";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ future ];
+
+  # tests are not included with release
+  doCheck = false;
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/mjdr/atsim_potentials;
+    description = "Provides tools for working with pair and embedded atom method potential models including tabulation routines for DL_POLY and LAMMPS";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -740,6 +740,8 @@ in {
 
   attrs = callPackage ../development/python-modules/attrs { };
 
+  atsim_potentials = callPackage ../development/python-modules/atsim_potentials { };
+
   audioread = callPackage ../development/python-modules/audioread { };
 
   audiotools = callPackage ../development/python-modules/audiotools { };


### PR DESCRIPTION
###### Things done


pythonPackages.atsim_potentials: init at 0.2.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

