### PR TITLE
httping: add libintl to buildInputs on Darwin

### DIFF
--- a/pkgs/tools/networking/httping/default.nix
+++ b/pkgs/tools/networking/httping/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gettext, ncurses, openssl
+{ stdenv, fetchurl, gettext, libintl, ncurses, openssl
 , fftw ? null }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1y7sbgkhgadmd93x1zafqc4yp26ssiv16ni5bbi9vmvvdl55m29y";
   };
 
-  buildInputs = [ fftw ncurses openssl ];
+  buildInputs = [ fftw libintl ncurses openssl ];
   nativeBuildInputs = [ gettext ];
 
   makeFlags = [
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.agpl3;
     maintainers = with maintainers; [ rickynils ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/httping/default.nix
+++ b/pkgs/tools/networking/httping/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "2.5";
 
   src = fetchurl {
-    url = "https://www.vanheusden.com/httping/${name}.tgz";
+    url = "https://vanheusden.com/httping/${name}.tgz";
     sha256 = "1y7sbgkhgadmd93x1zafqc4yp26ssiv16ni5bbi9vmvvdl55m29y";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.vanheusden.com/httping;
+    homepage = https://vanheusden.com/httping;
     description = "ping with HTTP requests";
     longDescription = ''
       Give httping an url, and it'll show you how long it takes to connect,


### PR DESCRIPTION
###### Motivation for this change

* make httping compile on macOS by adding `libintl` to its `buildInputs` (reference: https://github.com/NixOS/nixpkgs/issues/37056)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)

- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

