### PR TITLE
pythonPackages.scikit-bio: init at 0.5.4

### DIFF
--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, requests
+, msgpack
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "0.12.5";
+  pname = "CacheControl";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cef77effdf51b43178f6a2d3b787e3734f98ade253fa3187f3bb7315aaa42ff7";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ requests msgpack ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ionrock/cachecontrol;
+    description = "Httplib2 caching for requests";
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/hdmedians/default.nix
+++ b/pkgs/development/python-modules/hdmedians/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, nose
+, cython
+, numpy
+}:
+
+buildPythonPackage rec {
+  version = "0.13";
+  pname = "hdmedians";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "230f80e064d905c49a1941af1b7e806e2f22b3c9a90ad5c21fd17d72636ea277";
+  };
+
+  buildInputs = [ cython ];
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ numpy ];
+
+  # cannot resolve path for packages in tests
+  doCheck = false;
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/daleroberts/hdmedians;
+    description = "High-dimensional medians";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/hdmedians/default.nix
+++ b/pkgs/development/python-modules/hdmedians/default.nix
@@ -15,8 +15,8 @@ buildPythonPackage rec {
     sha256 = "230f80e064d905c49a1941af1b7e806e2f22b3c9a90ad5c21fd17d72636ea277";
   };
 
-  buildInputs = [ cython ];
-  checkInputs = [ nose ];
+  # nose was specified in setup.py as a build dependency...
+  buildInputs = [ cython nose ];
   propagatedBuildInputs = [ numpy ];
 
   # cannot resolve path for packages in tests

--- a/pkgs/development/python-modules/lockfile/default.nix
+++ b/pkgs/development/python-modules/lockfile/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pbr
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "lockfile";
+  version = "0.12.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799";
+  };
+
+  buildInputs = [ pbr ];
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    homepage = https://launchpad.net/pylockfile;
+    description = "Platform-independent advisory file locking capability for Python applications";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/scikit-bio/default.nix
+++ b/pkgs/development/python-modules/scikit-bio/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, cython
+, lockfile
+, cachecontrol
+, decorator
+, ipython
+, matplotlib
+, natsort
+, numpy
+, pandas
+, scipy
+, hdmedians
+, scikitlearn
+, pytest
+, coverage
+, python
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  version = "0.5.4";
+  pname = "scikit-bio";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3243f1995ef24643c09ff4d9391a79528aadd8232e5aa5d66c38d7b2e0c92f24";
+  };
+
+  buildInputs = [ cython ];
+  checkInputs = [ coverage ];
+  propagatedBuildInputs = [ lockfile cachecontrol decorator ipython matplotlib natsort numpy pandas scipy hdmedians scikitlearn ];
+
+  # remove on when version > 0.5.4
+  postPatch = ''
+    sed -i "s/numpy >= 1.9.2, < 1.14.0/numpy/" setup.py
+    sed -i "s/pandas >= 0.19.2, < 0.23.0/pandas/" setup.py
+  '';
+
+  # cython package not included for tests
+  doCheck = false;
+
+  checkPhase = ''
+    ${python.interpreter} -m skbio.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://scikit-bio.org/;
+    description = "Data structures, algorithms and educational resources for bioinformatics";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11709,6 +11709,8 @@ in {
     inherit (pkgs) gfortran glibcLocales;
   };
 
+  scikit-bio = callPackage ../development/python-modules/scikit-bio { };
+
   scp = callPackage ../development/python-modules/scp {};
 
   scripttest = buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -264,6 +264,8 @@ in {
 
   bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
 
+  cachecontrol = callPackage ../development/python-modules/cachecontrol { };
+
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
   clustershell = callPackage ../development/python-modules/clustershell { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -364,6 +364,8 @@ in {
 
   histbook = callPackage ../development/python-modules/histbook { };
 
+  hdmedians = callPackage ../development/python-modules/hdmedians { };
+
   httpsig = callPackage ../development/python-modules/httpsig { };
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };
@@ -561,7 +563,7 @@ in {
     slurm = pkgs.slurm;
   };
 
-  pystache = callPackage ../development/python-modules/pystache { }; 
+  pystache = callPackage ../development/python-modules/pystache { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6606,29 +6606,7 @@ in {
 
   llvmlite = callPackage ../development/python-modules/llvmlite { llvm = pkgs.llvm_6; };
 
-  lockfile = buildPythonPackage rec {
-    pname = "lockfile";
-    version = "0.12.2";
-    name = "${pname}-${version}";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${name}.tar.gz";
-      sha256 = "6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799";
-    };
-
-    buildInputs = with self; [
-      pbr nose
-    ];
-
-    checkPhase = ''
-      nosetests
-    '';
-
-    meta = {
-      homepage = https://launchpad.net/pylockfile;
-      description = "Platform-independent advisory file locking capability for Python applications";
-      license = licenses.asl20;
-    };
-  };
+  lockfile = callPackage ../development/python-modules/lockfile { };
 
   logilab_common = callPackage ../development/python-modules/logilab/common.nix {};
 


### PR DESCRIPTION
###### Things done

pythonPackages.CacheControl: init at 0.12.5 

pythonPackages.hdmedians: init at 0.13 

pythonPackages.lockfile: init at 0.12.2 

pythonPackages.scikit-bio: init at 0.5.4 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

