### PR TITLE
pythonPackages.filterpy: init at 1.4.5

### DIFF
--- a/pkgs/development/python-modules/filterpy/default.nix
+++ b/pkgs/development/python-modules/filterpy/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, matplotlib
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "1.4.5";
+  pname = "filterpy";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "4f2a4d39e4ea601b9ab42b2db08b5918a9538c168cff1c6895ae26646f3d73b1";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy scipy matplotlib ];
+
+  # single test fails (even on master branch of repository)
+  # project does not use CI
+  checkPhase = ''
+    pytest --ignore=filterpy/common/tests/test_discretization.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rlabbe/filterpy;
+    description = "Kalman filtering and optimal estimation library";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -302,6 +302,8 @@ in {
 
   fido2 = callPackage ../development/python-modules/fido2 {  };
 
+  filterpy = callPackage ../development/python-modules/filterpy { };
+
   fire = callPackage ../development/python-modules/fire { };
 
   fuse = callPackage ../development/python-modules/fuse-python { fuse = pkgs.fuse; };


### PR DESCRIPTION
###### Things done

pythonPackages.filterpy: init at 1.4.5 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

