### PR TITLE
now-cli: init at 11.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -520,6 +520,11 @@
     github = "bgamari";
     name = "Ben Gamari";
   };
+  bhall = {
+    email = "brendan.j.hall@bath.edu";
+    github = "brendan-hall";
+    name = "Brendan Hall";
+  };
   bhipple = {
     email = "bhipple@protonmail.com";
     github = "bhipple";

--- a/pkgs/development/web/now-cli/default.nix
+++ b/pkgs/development/web/now-cli/default.nix
@@ -1,0 +1,87 @@
+{ stdenv, lib, fetchurl }:
+stdenv.mkDerivation rec {
+  name = "now-cli-${version}";
+  version = "11.4.6";
+
+  # TODO: switch to building from source, if possible
+  src = fetchurl {
+    url = "https://github.com/zeit/now-cli/releases/download/${version}/now-linux.gz";
+    sha256 = "1bl0yrzxdfy6sks674qlfch8mg3b0x1wj488v83glags8ibsg3cl";
+  };
+
+  sourceRoot = ".";
+  unpackCmd = ''
+    gunzip -c $curSrc > now-linux
+  '';
+
+  buildPhase = ":";
+
+  installPhase = ''
+    mkdir $out
+    mkdir $out/bin
+    cp now-linux $out/bin/now
+  '';
+
+    # now is a node program packaged using zeit/pkg.
+    # thus, it contains hardcoded offsets.
+    # patchelf shifts these locations when it expands headers.
+
+    # this could probably be generalised into allowing any program packaged
+    # with zeit/pkg to be run on nixos.
+
+  preFixup = let
+    libPath = lib.makeLibraryPath [stdenv.cc.cc];
+  in ''
+
+    orig_size=$(stat --printf=%s $out/bin/now)
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/now
+    patchelf --set-rpath ${libPath} $out/bin/now
+    chmod +x $out/bin/now
+
+    new_size=$(stat --printf=%s $out/bin/now)
+
+    ###### zeit-pkg fixing starts here.
+    # we're replacing plaintext js code that looks like
+    # PAYLOAD_POSITION = '1234                  ' | 0
+    # [...]
+    # PRELUDE_POSITION = '1234                  ' | 0
+    # ^-----20-chars-----^^------22-chars------^
+    # ^-- grep points here
+    #
+    # var_* are as described above
+    # shift_by seems to be safe so long as all patchelf adjustments occur 
+    # before any locations pointed to by hardcoded offsets
+
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+
+    function fix_offset {
+      # $1 = name of variable to adjust
+      location=$(grep -obUam1 "$1" $out/bin/now | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+
+      value=$(dd if=$out/bin/now iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+
+      echo -n $value | dd of=$out/bin/now bs=1 seek=$location conv=notrunc
+    }
+
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
+
+  '';
+  dontStrip = true;
+
+
+
+  meta = with stdenv.lib; {
+    homepage = https://zeit.co/now;
+    description = "The Command Line Interface for Now - Global Serverless Deployments";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bhall ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3759,6 +3759,8 @@ with pkgs;
 
   npm2nix = nodePackages.npm2nix;
 
+  now-cli = callPackage ../development/web/now-cli {};
+
   file-rename = callPackage ../tools/filesystems/file-rename { };
 
   kea = callPackage ../tools/networking/kea {


### PR DESCRIPTION
###### Motivation for this change
Adds Zeit's now-cli, per #36395 (sorry @giodamelio)
Uses the binary distribution, which presented some challenges as it's essentially an archive of a nodejs, and all the js files, with hardcoded offsets to said files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

