### PR TITLE
iio-sensor-proxy: 2.4 -> 2.5

### DIFF
--- a/pkgs/os-specific/linux/iio-sensor-proxy/default.nix
+++ b/pkgs/os-specific/linux/iio-sensor-proxy/default.nix
@@ -3,19 +3,23 @@
 
 stdenv.mkDerivation rec {
   name = "iio-sensor-proxy-${version}";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner  = "hadess";
     repo   = "iio-sensor-proxy";
     rev    = version;
-    sha256 = "1c8izq73c00gvv0jc6zby5hcircs4cb16a1d3ivp1i1iflknj46n";
+    sha256 = "06x1vvslsa44bgw8s5rr17q9i2ssbw0x04l75zsy3rql9r3y2jzg";
   };
 
   configurePhase = ''
+    runHook preConfigure
+
     ./autogen.sh --prefix=$out \
       --with-udevrulesdir=$out/lib/udev/rules.d \
       --with-systemdsystemunitdir=$out/lib/systemd/system
+
+    runHook postConfigure
   '';
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

