### PR TITLE
rfc-bibtex: init at 2.2.1

### DIFF
--- a/pkgs/development/python-modules/rfc-bibtex/default.nix
+++ b/pkgs/development/python-modules/rfc-bibtex/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonApplication, fetchPypi, isPy3k }:
+
+buildPythonApplication rec {
+  pname = "rfc-bibtex";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p8xjgq4rig1jgqy5jqh34mbifxgxsyyxh8sizwz2wyixf8by8lq";
+  };
+
+  disabled = !isPy3k;
+
+  meta = with stdenv.lib; {
+    homepage = ttps://github.com/iluxonchik/rfc-bibtex/;
+    description = "Generate Bibtex entries for IETF RFCs and Internet-Drafts";
+    license = licenses.mit;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22033,6 +22033,8 @@ with pkgs;
 
   retrofe = callPackage ../misc/emulators/retrofe { };
 
+  rfc-bibtex = python3Packages.callPackage ../development/python-modules/rfc-bibtex { };
+
   rpl = callPackage ../tools/text/rpl {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
Generate bibtex entries from IETF rfc/drafts, for instance:
$ rfcbibtex RFC5246 draft-ietf-tls-tls13-21

@techreport{RFC5246,
  author = {T. Dierks and E. Rescorla},
  title = {{The Transport Layer Security (TLS) Protocol Version 1.2}},
  howpublished = {Internet Requests for Comments},
  type = {RFC},
  number = {5246},
  year = {2008},
  month = {August},
  issn = {2070-1721},
  publisher = {RFC Editor},
  institution = {RFC Editor},
  url = {http://www.rfc-editor.org/rfc/rfc5246.txt},
  note = {\url{http://www.rfc-editor.org/rfc/rfc5246.txt}},
}

@techreport{I-D.ietf-tls-tls13,
  author = {Eric Rescorla},
  title = {{The Transport Layer Security (TLS) Protocol Version 1.3}},
  howpublished = {Working Draft},
  type = {Internet-Draft},
  number = {draft-ietf-tls-tls13-21},
  year = {2017},
  month = {July},
  institution = {IETF Secretariat},
  url = {http://www.ietf.org/internet-drafts/draft-ietf-tls-tls13-21.txt},
  note = {\url{http://www.ietf.org/internet-drafts/draft-ietf-tls-tls13-21.txt}},
}

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

