### PR TITLE
nixos/nftables: check ruleset syntax during build

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -110,10 +110,15 @@ in
       wantedBy = [ "multi-user.target" ];
       reloadIfChanged = true;
       serviceConfig = let
+        # Check whether the file is syntactically valid
+        checkedRulesetFile = pkgs.runCommand "nftables-rules-checked"
+          { src = cfg.rulesetFile; }
+          ''${pkgs.nftables}/bin/nft -c -f "$src" && cp $src $out'';
+
         rulesScript = pkgs.writeScript "nftables-rules" ''
           #! ${pkgs.nftables}/bin/nft -f
           flush ruleset
-          include "${cfg.rulesetFile}"
+          include "${checkedRulesetFile}"
         '';
         checkScript = pkgs.writeScript "nftables-check" ''
           #! ${pkgs.runtimeShell} -e


### PR DESCRIPTION
###### Motivation for this change
The nftables ruleset syntax should be verified during build to avoid misconfiguration.

~If the file is not syntactically valid, currently, the ruleset would be flushed without the new (incorrect) rules being applied, leaving the firewall in its default configuration (accept everything).~
Apparently, `nft` has become clever enough to not overwrite the old ruleset in case of a syntax error. However, the system configuration is still built and applied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There are now two files with similar names: `nftables-rules-checked` and `nftables-check`. In my opinion, the `nftables-check` file (which is actually the service start script) has a pretty bad name. This could be changed to something more meaningful to avoid confusion.