### PR TITLE
firefox, nss: enable SSLKEYLOGFILE option

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames }:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, allowSSLKeylogFile ? false }:
 
 let
   nssPEM = fetchurl {
@@ -51,7 +51,8 @@ in stdenv.mkDerivation rec {
     "USE_SYSTEM_ZLIB=1"
     "NSS_USE_SYSTEM_SQLITE=1"
   ] ++ stdenv.lib.optional stdenv.is64bit "USE_64=1"
-    ++ stdenv.lib.optional stdenv.isDarwin "CCC=clang++";
+    ++ stdenv.lib.optional stdenv.isDarwin "CCC=clang++"
+    ++ stdenv.lib.optional allowSSLKeylogFile "NSS_ALLOW_SSLKEYLOGFILE=1";
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16667,6 +16667,16 @@ with pkgs;
                                             Kerberos AVFoundation MediaToolbox
                                             CoreLocation Foundation AddressBook;
       inherit (darwin) libobjc;
+
+      # See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format:
+      # > Note: starting with NSS 3.24 (used by Firefox 48 and 49 only), the
+      # > SSLKEYLOGFILE approach is disabled by default for optimized builds using
+      # > the Makefile (those using gyp via build.sh are not affected).
+      # > Distributors can re-enable it at compile time though (using the
+      # > NSS_ALLOW_SSLKEYLOGFILE=1 make variable) which is done for the official
+      # > Firefox binaries. (See bug 1188657.) Notably, Debian does not have this
+      # > option enabled, see Debian bug 842292.
+      nss = nss.override { allowSSLKeylogFile = true; };
     };
   });
 


### PR DESCRIPTION

###### Motivation for this change

See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format:

> Note: starting with NSS 3.24 (used by Firefox 48 and 49 only), the
> SSLKEYLOGFILE approach is disabled by default for optimized builds
> using the Makefile (those using gyp via build.sh are not affected).
> Distributors can re-enable it at compile time though (using the
> NSS_ALLOW_SSLKEYLOGFILE=1 make variable) which is done for the
> official Firefox binaries. (See bug 1188657.) Notably, Debian does not
> have this option enabled, see Debian bug 842292.

This patch fixes that, and allows other programs to also use this
options as they desire, with the `allowSSLKeylogFile` on the nss
package.

(NOTE: this option is NOT enabled by default on Firefox, the user
specifically has to set the SSLKEYLOGFILE environment variable!)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

