### PR TITLE
profiles/hardened: Do not limit user namespaces if Nix's sandbox builds are enabled

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -1,7 +1,7 @@
 # A profile with most (vanilla) hardening options enabled by default,
 # potentially at the cost of features and performance.
 
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -65,7 +65,11 @@ with lib;
   # Setting the number of allowed user namespaces to 0 effectively disables
   # the feature at runtime.  Attempting to create a user namespace
   # with unshare will then fail with "no space left on device".
-  boot.kernel.sysctl."user.max_user_namespaces" = mkDefault 0;
+  #
+  # However, disabling user namespaces with the Nix Sandbox enabled results
+  # in Nix being unable to derive anything. Therefore, user namespaces are,
+  # by default, only disabled if the Nix Sandbox is disabled.
+  boot.kernel.sysctl."user.max_user_namespaces" = mkIf (! config.nix.useSandbox) (mkDefault 0);
 
   # Raise ASLR entropy for 64bit & 32bit, respectively.
   #


### PR DESCRIPTION
###### Motivation for this change
This is one of those small niche fixes I've been too lazy to commit for a while...

Nix apparently uses user namespaces when configured to build in a sandbox. This causes it to error out with an ENOSPC whenever you try to build after enabling the hardened profile, which cannot be circumvented in any other way than setting the user namespace count to a number high enough for the build to finish.

This commit gives priority to the `nix.useSandbox` setting: If it is enabled, it won't change the user namespace limit (so as to let it be whatever the kernel default is).

As I said, I've been sitting on this for a while, and I am unaware if this has been fixed some other way. I can't seem to find any issues, open or closed, related to this particular symptom.

An alternative fix I can think of is to have the nix-daemon (which AFAICS runs as root) or nixos-rebuild (which definitely does) to raise the limit itself before attempting a rebuild. This would require a way to tell how much does the number need to be raised (since setting it to 1 will let the first rebuild happen, but not the next one). I assume there is some way of getting the necessary info and implementing it, I've just not looked at it further.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

