### PR TITLE
yojimbo: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3130,6 +3130,11 @@
     github = "pacien";
     name = "Pacien Tran-Girard";
   };
+  paddygord = {
+    email = "pgpatrickgordon@gmail.com";
+    github = "paddygord";
+    name = "Patrick Gordon";
+  };
   paholg = {
     email = "paho@paholg.com";
     github = "paholg";

--- a/pkgs/development/libraries/yojimbo/default.nix
+++ b/pkgs/development/libraries/yojimbo/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, premake5, doxygen, libsodium, mbedtls }:
+
+stdenv.mkDerivation rec {
+  name = "yojimbo";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "networkprotocol";
+    repo = "yojimbo";
+    rev = "e02219c102d9b440290539036992d77608eab3b0";
+    sha256 = "0jn25ddv73hwjals883a910m66kwj6glxxhnmn96bpzsvsaimnkr";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ premake5 doxygen ];
+  propagatedBuildInputs = [ libsodium mbedtls ];
+
+  buildPhase = ''
+    premake5 gmake
+    make all
+    premake5 docs
+  '';
+
+  installPhase = ''
+    install -Dm555 -t $out/lib bin/libyojimbo.a
+    install -Dm444 -t $out/include yojimbo.h
+    mkdir -p $out/share/doc/yojimbo
+    cp -r docs/html $out/share/doc/yojimbo
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A network library for client/server games with dedicated servers";
+    longDescription = ''
+      yojimbo is a network library for client/server games with dedicated servers.
+      It's designed around the networking requirements of competitive multiplayer games like first person shooters.
+      As such it provides a time critical networking layer on top of UDP, with a client/server architecture supporting up to 64 players per-dedicated server instance.
+    '';
+    homepage = https://github.com/networkprotocol/yojimbo;
+    license = licenses.bsd3;
+    platforms = platforms.x86_64;
+    maintainers = with maintainers; [ paddygord ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12700,6 +12700,8 @@ with pkgs;
 
   yajl = callPackage ../development/libraries/yajl { };
 
+  yojimbo = callPackage ../development/libraries/yojimbo { };
+
   yubioath-desktop = callPackage ../applications/misc/yubioath-desktop { };
 
   yubico-piv-tool = callPackage ../tools/misc/yubico-piv-tool { };


### PR DESCRIPTION
###### Motivation for this change
Upstream the derivation we use for development based on [Yojimbo](https://github.com/networkprotocol/yojimbo)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

