### PR TITLE
openvpn plugins: use absolute paths to configuration gui

### DIFF
--- a/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
@@ -28,6 +28,7 @@ in stdenv.mkDerivation rec {
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--localstatedir=/tmp"
+    "--enable-absolute-paths"
   ];
 
   passthru = {

--- a/pkgs/tools/networking/network-manager/iodine/default.nix
+++ b/pkgs/tools/networking/network-manager/iodine/default.nix
@@ -31,6 +31,7 @@ in stdenv.mkDerivation rec {
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--localstatedir=/" # needed for the management socket under /run/NetworkManager
+    "--enable-absolute-paths"
   ];
 
   passthru = {

--- a/pkgs/tools/networking/network-manager/l2tp/default.nix
+++ b/pkgs/tools/networking/network-manager/l2tp/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--localstatedir=/var"
     "--sysconfdir=$(out)/etc"
+    "--enable-absolute-paths"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/tools/networking/network-manager/openconnect/default.nix
+++ b/pkgs/tools/networking/network-manager/openconnect/default.nix
@@ -26,6 +26,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-gnome=${if withGnome then "yes" else "no"}"
+    "--enable-absolute-paths"
   ];
 
   passthru = {

--- a/pkgs/tools/networking/network-manager/openvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/openvpn/default.nix
@@ -28,6 +28,7 @@ in stdenv.mkDerivation rec {
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
     "--localstatedir=/" # needed for the management socket under /run/NetworkManager
+    "--enable-absolute-paths"
   ];
 
   passthru = {

--- a/pkgs/tools/networking/network-manager/vpnc/default.nix
+++ b/pkgs/tools/networking/network-manager/vpnc/default.nix
@@ -26,6 +26,7 @@ in stdenv.mkDerivation rec {
   configureFlags = [
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
+    "--enable-absolute-paths"
   ];
 
   passthru = {


### PR DESCRIPTION
(cherry picked from commit 5bfe8bfceac79e8b9de09a898afd23b10944c9fb)

###### Motivation for this change

NetworkManager plugins are broken. This has been fixed in master via https://github.com/NixOS/nixpkgs/pull/47212 but not backported to latest stable. 

The basic NetworkManager functionality is broken and this should be backported IMHO.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

