### PR TITLE
nixos/nix: ignore nix.checkConfig when cross-compiling

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -62,11 +62,15 @@ let
         ''}
         $extraOptions
         END
-      '' + optionalString cfg.checkConfig ''
-        echo "Checking that Nix can read nix.conf..."
-        ln -s $out ./nix.conf
-        NIX_CONF_DIR=$PWD ${cfg.package}/bin/nix show-config >/dev/null
-      '');
+      '' + optionalString cfg.checkConfig (
+            if stdenv.hostPlatform != stdenv.buildPlatform ''
+              echo "Ignore nix.checkConfig when cross-compiling"
+            '' else ''
+              echo "Checking that Nix can read nix.conf..."
+              ln -s $out ./nix.conf
+              NIX_CONF_DIR=$PWD ${cfg.package}/bin/nix show-config >/dev/null
+            '')
+      );
 
 in
 

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -63,7 +63,7 @@ let
         $extraOptions
         END
       '' + optionalString cfg.checkConfig (
-            if stdenv.hostPlatform != stdenv.buildPlatform ''
+            if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then ''
               echo "Ignore nix.checkConfig when cross-compiling"
             '' else ''
               echo "Checking that Nix can read nix.conf..."


### PR DESCRIPTION
the check always fails because of architecture mismatch
