### PR TITLE
nixos: initrd/luks: fix detection of devices by UUID

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -17,7 +17,7 @@ let
             return 0
         else
             local uuid=$(echo -n $target | sed -e 's,UUID=\(.*\),\1,g')
-            local dev=$(blkid --uuid $uuid)
+            blkid --uuid $uuid >/dev/null
             return $?
         fi
     }

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -7,19 +7,19 @@ let
 
   commonFunctions = ''
     die() {
-      echo "$@" >&2
-      exit 1
+        echo "$@" >&2
+        exit 1
     }
 
     dev_exist() {
-      local target="$1"
-      if [ -e $target ]; then
-        return 0
-      else
-        local uuid=$(echo -n $target | sed -e 's,UUID=\(.*\),\1,g')
-        local dev=$(blkid --uuid $uuid)
-        return $?
-      fi
+        local target="$1"
+        if [ -e $target ]; then
+            return 0
+        else
+            local uuid=$(echo -n $target | sed -e 's,UUID=\(.*\),\1,g')
+            local dev=$(blkid --uuid $uuid)
+            return $?
+        fi
     }
 
     wait_target() {
@@ -51,30 +51,30 @@ let
     }
 
     wait_yubikey() {
-      local secs="''${1:-10}"
+        local secs="''${1:-10}"
 
-      ykinfo -v 1>/dev/null 2>&1
-      if [ $? != 0 ]; then
-          echo -n "Waiting $secs seconds for Yubikey to appear..."
-          local success=false
-          for try in $(seq $secs); do
-              echo -n .
-              sleep 1
-              ykinfo -v 1>/dev/null 2>&1
-              if [ $? == 0 ]; then
-                  success=true
-                  break
-              fi
-          done
-          if [ $success == true ]; then
-              echo " - success";
-              return 0
-          else
-              echo " - failure";
-              return 1
-          fi
-      fi
-      return 0
+        ykinfo -v 1>/dev/null 2>&1
+        if [ $? != 0 ]; then
+            echo -n "Waiting $secs seconds for Yubikey to appear..."
+            local success=false
+            for try in $(seq $secs); do
+                echo -n .
+                sleep 1
+                ykinfo -v 1>/dev/null 2>&1
+                if [ $? == 0 ]; then
+                    success=true
+                    break
+                fi
+            done
+            if [ $success == true ]; then
+                echo " - success";
+                return 0
+            else
+                echo " - failure";
+                return 1
+            fi
+        fi
+        return 0
     }
   '';
 


### PR DESCRIPTION
###### Motivation for this change

#45998 has a small issue that causes the error shown in the first part of #47529. It assigns the output of `blkid` to a local variable and then tries to return its exit code. Since `local` is a command, it clobbers the value of `$?`, so the function always returns 0.

###### Things done

Since the local variable is never used, this PR removes it and redirects the output of `blkid` to `/dev/null`. I also fixed some inconsistent indentation in the surrounding functions.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

