### PR TITLE
bazel-buildtools: upgrade to 2018-10-11

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -2,21 +2,21 @@
 
 buildGoPackage rec {
   name = "bazel-buildtools-unstable-${version}";
-  version = "2018-05-24";
+  version = "2018-10-11";
 
   goPackagePath = "github.com/bazelbuild/buildtools";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";
     repo = "buildtools";
-    rev = "588d90030bc8054b550967aa45a8a8d170deba0b";
-    sha256 = "18q1z138545kh4s5k0jcqwhpzc1w7il4x00l7yzv9wq8bg1vn1rv";
+    rev = "86b40b7fee59cc67d3371d20f10702fe8c6dd808";
+    sha256 = "10fzqbafwzv0bvx8aag78gh731k5j9nwlbcflhc5xm5zwhla9cyf";
   };
 
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
-    description = "This derivation contains developer tools for working with Google's bazel buildtool.";
+    description = "Tools for working with Google's bazel buildtool. Includes buildifier, buildozer, and unused_deps.";
     homepage = https://github.com/bazelbuild/buildtools;
     license = licenses.asl20;
     maintainers = with maintainers; [ uri-canva ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

