### PR TITLE
bootStage1: fix cross build

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -252,9 +252,8 @@ let
       echo checking syntax
       # check both with bash
       ${pkgs.buildPackages.bash}/bin/sh -n $target
-    '' + optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
       # and with ash shell, just in case
-      ${extraUtils}/bin/ash -n $target
+      ${pkgs.buildPackages.busybox}/bin/ash -n $target
     '';
 
     inherit udevRules extraUtils modulesClosure;

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -251,7 +251,8 @@ let
     postInstall = ''
       echo checking syntax
       # check both with bash
-      ${pkgs.bash}/bin/sh -n $target
+      ${pkgs.buildPackages.bash}/bin/sh -n $target
+    '' + optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
       # and with ash shell, just in case
       ${extraUtils}/bin/ash -n $target
     '';


### PR DESCRIPTION
###### Motivation for this change

use ```bash``` and ```busybox``` from ```buildPackages``` to check syntax at build time
