### PR TITLE
use buildPackages in environment.extraSetup

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -140,7 +140,7 @@ in
           if [ -x $out/bin/glib-compile-schemas -a -w $out/share/glib-2.0/schemas ]; then
               $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas
           fi
-          
+
           ${config.environment.extraSetup}
         '';
     };

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -24,11 +24,11 @@ with lib;
 
     environment.extraSetup = ''
       if [ -w $out/share/mime ] && [ -d $out/share/mime/packages ]; then
-          XDG_DATA_DIRS=$out/share ${pkgs.shared-mime-info}/bin/update-mime-database -V $out/share/mime > /dev/null
+          XDG_DATA_DIRS=$out/share ${pkgs.buildPackages.shared-mime-info}/bin/update-mime-database -V $out/share/mime > /dev/null
       fi
 
       if [ -w $out/share/applications ]; then
-          ${pkgs.desktop-file-utils}/bin/update-desktop-database $out/share/applications
+          ${pkgs.buildPackages.desktop-file-utils}/bin/update-desktop-database $out/share/applications
       fi
     '';
   };

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -166,7 +166,7 @@ in
         if [ -w $out/share/info ]; then
           shopt -s nullglob
           for i in $out/share/info/*.info $out/share/info/*.info.gz; do
-              ${pkgs.texinfo}/bin/install-info $i $out/share/info/dir
+              ${pkgs.buildPackages.texinfo}/bin/install-info $i $out/share/info/dir
           done
         fi
       '';


### PR DESCRIPTION
###### Motivation for this change

use ```buildPackages``` in ```environment.extraSetup```, it is build time code
