### PR TITLE
lib/types: enhances separatedString's description.

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -194,7 +194,10 @@ rec {
     # separator between the values).
     separatedString = sep: mkOptionType rec {
       name = "separatedString";
-      description = "string";
+      description = if sep == ""
+        then "Concatenated string" # for types.string.
+        else "strings concatenated with ${builtins.toJSON sep}"
+      ;
       check = isString;
       merge = loc: defs: concatStringsSep sep (getValues defs);
       functor = (defaultFunctor name) // {


### PR DESCRIPTION
The previous description "string" is misleading in the full options
manual pages; they are actually concatenated strings, with a specific
character.

The string `""` has been documented to stay coherent with the previously
deprecated "types.string".


###### Motivation for this change

This is for [nixos-homepage/pull/246](https://github.com/NixOS/nixos-homepage/pull/246), where @ryantm [was curious about listing the type descriptions on the options page](https://logs.nix.samueldr.com/nixos/2018-10-11#1638655;). The particular type desired had to be fixed to be more useful (I think).

To be useful for nixos-homepage, it would need to be backported to 18.09.


###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- ✔️ Built the docs

---