### PR TITLE
termbox: init at 1.1.2

### DIFF
--- a/pkgs/development/libraries/termbox/default.nix
+++ b/pkgs/development/libraries/termbox/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "termbox-${version}";
+  version = "1.1.2";
+  src = fetchFromGitHub {
+    owner = "nsf";
+    repo = "termbox";
+    rev = "v${version}";
+    sha256 = "08yqxzb8fny8806p7x8a6f3phhlbfqdd7dhkv25calswj7w1ssvs";
+  };
+  nativeBuildInputs = [ python3 ];
+  configurePhase = "python3 ./waf configure --prefix=$out";
+  buildPhase = "python3 ./waf build";
+  installPhase = "python3 ./waf install --destdir=$out";
+  meta = with stdenv.lib; {
+    description = "Library for writing text-based user interfaces";
+    license = licenses.mit;
+    homepage = "https://github.com/nsf/termbox#readme";
+    downloadPage = "https://github.com/nsf/termbox/releases";
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12283,6 +12283,8 @@ with pkgs;
 
   telepathy-qt = callPackage ../development/libraries/telepathy/qt { qtbase = qt4; };
 
+  termbox = callPackage ../development/libraries/termbox { };
+
   tevent = callPackage ../development/libraries/tevent {
     python = python2;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

