### PR TITLE
[ok] nmap: fix cross-build

### DIFF
--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -33,9 +33,21 @@ in stdenv.mkDerivation rec {
         --replace /usr/bin/libtool ar \
         --replace 'AR="libtool"' 'AR="ar"' \
         --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
+  '' + optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    sed -i -r 's@^RANLIB\s*=\s*ranlib@RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib@' liblinear/Makefile
+    sed -i -r 's@^RANLIB\s*=\s*ranlib@RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib@' liblinear/blas/Makefile
+    sed -i -r 's@^RANLIB\s*=\s*ranlib@RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib@' liblua/Makefile
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 liblinear/Makefile
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 liblinear/blas/Makefile
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 liblua/Makefile
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 libnetutil/Makefile.in
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 libpcre/Makefile.in
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 nbase/Makefile.in
+    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 nsock/src/Makefile.in
+    sed -i -r 's@^CC\s*=\s*gcc@CC=${stdenv.cc.targetPrefix}gcc@'                        liblua/Makefile
   '';
 
-  configureFlags = []
+  configureFlags = [ "--with-liblua=included" ]
     ++ optional (!pythonSupport) "--without-ndiff"
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -33,24 +33,18 @@ in stdenv.mkDerivation rec {
         --replace /usr/bin/libtool ar \
         --replace 'AR="libtool"' 'AR="ar"' \
         --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
-  '' + optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    sed -i -r 's@^RANLIB\s*=\s*ranlib@RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib@' liblinear/Makefile
-    sed -i -r 's@^RANLIB\s*=\s*ranlib@RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib@' liblinear/blas/Makefile
-    sed -i -r 's@^RANLIB\s*=\s*ranlib@RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib@' liblua/Makefile
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 liblinear/Makefile
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 liblinear/blas/Makefile
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 liblua/Makefile
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 libnetutil/Makefile.in
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 libpcre/Makefile.in
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 nbase/Makefile.in
-    sed -i -r 's@^AR\s*=\s*ar@AR=${stdenv.cc.bintools.targetPrefix}ar@'                 nsock/src/Makefile.in
-    sed -i -r 's@^CC\s*=\s*gcc@CC=${stdenv.cc.targetPrefix}gcc@'                        liblua/Makefile
   '';
 
   configureFlags = [ "--with-liblua=included" ]
     ++ optional (!pythonSupport) "--without-ndiff"
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;
+
+  makeFlags = optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "AR=${stdenv.cc.bintools.targetPrefix}ar"
+    "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
+    "CC=${stdenv.cc.targetPrefix}gcc"
+  ];
 
   postInstall = optionalString pythonSupport ''
       wrapProgram $out/bin/ndiff --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH"

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -40,6 +40,12 @@ in stdenv.mkDerivation rec {
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;
 
+  makeFlags = optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "AR=${stdenv.cc.bintools.targetPrefix}ar"
+    "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
+    "CC=${stdenv.cc.targetPrefix}gcc"
+  ];
+
   postInstall = optionalString pythonSupport ''
       wrapProgram $out/bin/ndiff --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH"
   '' + optionalString graphicalSupport ''

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -40,12 +40,6 @@ in stdenv.mkDerivation rec {
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;
 
-  makeFlags = optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    "AR=${stdenv.cc.bintools.targetPrefix}ar"
-    "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
-    "CC=${stdenv.cc.targetPrefix}gcc"
-  ];
-
   postInstall = optionalString pythonSupport ''
       wrapProgram $out/bin/ndiff --prefix PYTHONPATH : "$(toPythonPath $out)" --prefix PYTHONPATH : "$PYTHONPATH"
   '' + optionalString graphicalSupport ''

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libpcap, pkgconfig, openssl
+{ stdenv, fetchurl, libpcap, pkgconfig, openssl, lua
 , graphicalSupport ? false
 , libX11 ? null
 , gtk2 ? null
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
         --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
   '';
 
-  configureFlags = [ "--with-liblua=included" ]
+  configureFlags = [ "--with-liblua=${lua}" ]
     ++ optional (!pythonSupport) "--without-ndiff"
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libpcap, pkgconfig, openssl, lua
+{ stdenv, fetchurl, libpcap, pkgconfig, openssl, lua5_3
 , graphicalSupport ? false
 , libX11 ? null
 , gtk2 ? null
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
         --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
   '';
 
-  configureFlags = [ "--with-liblua=${lua}" ]
+  configureFlags = [ "--with-liblua=${lua5_3}" ]
     ++ optional (!pythonSupport) "--without-ndiff"
     ++ optional (!graphicalSupport) "--without-zenmap"
     ;


### PR DESCRIPTION
###### Motivation for this change

fix cross-build by adding target prefixes and hinting ```configure``` where to locate ```liblua``` files
