### PR TITLE
screen: fix cross-compiling

### DIFF
--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation rec {
       stripLen = 1;
     });
 
+  postPatch = stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform)
+    # XXX: Awful hack to allow cross-compilation.
+    '' sed -i ./configure \
+           -e 's/^as_fn_error .. \("cannot run test program while cross compiling\)/$as_echo \1/g'
+    ''; # "
+
   buildInputs = [ ncurses ] ++ stdenv.lib.optional stdenv.isLinux pam
                             ++ stdenv.lib.optional stdenv.isDarwin utmp;
 


### PR DESCRIPTION
###### Motivation for this change

fix cross-compiling with awful hack taken from samba
https://github.com/NixOS/nixpkgs/blob/fce8f26af6ef8209c7d282938e9457438746841b/pkgs/servers/samba/3.x.nix

