### PR TITLE
wpgtk: init at 5.7.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2686,6 +2686,11 @@
     github = "melsigl";
     name = "Melanie B. Sigl";
   };
+  melkor333 = {
+    email = "samuel@ton-kunst.ch";
+    github = "melkor333";
+    name = "Samuel Ruprecht";
+  };
   metabar = {
     email = "softs@metabarcoding.org";
     name = "Celine Mercier";

--- a/pkgs/tools/X11/wpgtk/default.nix
+++ b/pkgs/tools/X11/wpgtk/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, python36Packages, fetchFromGitHub, pywal, feh, libxslt, imagemagick,
+  gobjectIntrospection, gtk3, wrapGAppsHook, gnome3 }:
+
+python36Packages.buildPythonApplication rec {
+  pname = "wpgtk";
+  version = "5.7.4";
+
+  src = fetchFromGitHub {
+    owner = "deviantfero";
+    repo = "wpgtk";
+    rev = "${version}";
+    sha256 = "0c0kmc18lbr7nk3hh44hai9z06lfsgwxnjdv02hpjwrxg40zh726";
+  };
+
+  pythonPath = [
+    python36Packages.pygobject3
+    python36Packages.pillow
+    pywal
+    imagemagick
+  ];
+
+  buildInputs = [
+    wrapGAppsHook
+    gtk3
+    gobjectIntrospection
+    gnome3.adwaita-icon-theme
+    libxslt
+  ];
+
+  # The $HOME variable must be set to build the package. A "permission denied" error will occur otherwise
+  preBuild = ''
+      export HOME=$(pwd)
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Template based wallpaper/colorscheme generator and manager";
+    longDescription = ''
+     In short, wpgtk is a colorscheme/wallpaper manager with a template system attached which lets you create templates from any textfile and will replace keywords on it on the fly, allowing for great styling and theming possibilities.
+
+     wpgtk uses pywal as its colorscheme generator, but builds upon it with a UI and other features, such as the abilty to mix and edit the colorschemes generated and save them with their respective wallpapers, having light and dark themes, hackable and fast GTK+ theme made specifically for wpgtk and custom keywords and values to replace in templates.
+
+     INFO: To work properly, this tool needs "programs.dconf.enable = true" on nixos or dconf installed. A reboot may be required after installing dconf.
+     '';
+    homepage = https://github.com/deviantfero/wpgtk;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.melkor333 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6252,6 +6252,8 @@ with pkgs;
 
   wolf-shaper = callPackage ../applications/audio/wolf-shaper { };
 
+  wpgtk = callPackage ../tools/X11/wpgtk { };
+
   wring = nodePackages.wring;
 
   wrk = callPackage ../tools/networking/wrk { };


### PR DESCRIPTION
###### Motivation for this change

It needs `"programs.dconf.enabled = true"` in the NixOS configuration or `dconf` installed and running on other distributions. Since this can't be tested in the package, I added this information in the long description. I hope it is i.O. like that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) _**(excluding hidden wrappers)**_
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---