### PR TITLE
fetchgit: use buildPackages's git

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -171,7 +171,7 @@ with pkgs;
   fetchfossil = callPackage ../build-support/fetchfossil { };
 
   fetchgit = callPackage ../build-support/fetchgit {
-    git = gitMinimal;
+    git = buildPackages.gitMinimal;
   };
 
   fetchgitPrivate = callPackage ../build-support/fetchgit/private.nix { };


### PR DESCRIPTION
###### Motivation for this change

```fetchgit``` is to use ```buildPackages```'s ```git``` for the same reason why ```fetchurl``` uses ```buildPackages```'s ```curl```: to work smoothly in code blocks like
```
stdenv.mkDerivation {
   src = fetchgit { # <- here git of buildPlatform is expected to work
.............
   };
}
```
