### PR TITLE
avrgcc: rename to avrgcc-unwrapped; add wrappers

### DIFF
--- a/pkgs/development/misc/avr/gcc/wrapper.nix
+++ b/pkgs/development/misc/avr/gcc/wrapper.nix
@@ -5,13 +5,12 @@ stdenv.mkDerivation rec {
   version = stdenv.lib.strings.getVersion avrgcc-unwrapped.name;
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ avrgcc-unwrapped avrlibc ];
-  builder = writeText "builder.sh" ''
-    source $stdenv/setup
-    mkdir -p $out/bin $out/lib
+  buildCommand = ''
+    mkdir -p $out/bin $out
     for exe in gcc g++; do
       makeWrapper "${avrgcc-unwrapped}/bin/avr-$exe" "$out/bin/avr-$exe" --add-flags "-B${avrlibc}/avr/lib -isystem ${avrlibc}/avr/include"
     done
-    ln -s ${avrgcc-unwrapped}/lib/* $out/lib
+    ln -s ${avrgcc-unwrapped}/lib $out/
   '';
   meta = with stdenv.lib; {
     description = "GNU Compiler Collection, version ${version} for AVR microcontrollers";

--- a/pkgs/development/misc/avr/gcc/wrapper.nix
+++ b/pkgs/development/misc/avr/gcc/wrapper.nix
@@ -1,0 +1,21 @@
+# Setup paths needed by avrgcc-unwrapped
+{ stdenv, writeText, makeWrapper, avrgcc-unwrapped, avrlibc }:
+stdenv.mkDerivation rec {
+  name = "avr-gcc-wrapper-${version}";
+  version = stdenv.lib.strings.getVersion avrgcc-unwrapped.name;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ avrgcc-unwrapped avrlibc ];
+  builder = writeText "builder.sh" ''
+    source $stdenv/setup
+    mkdir -p $out/bin $out/lib
+    for exe in gcc g++; do
+      makeWrapper "${avrgcc-unwrapped}/bin/avr-$exe" "$out/bin/avr-$exe" --add-flags "-B${avrlibc}/avr/lib -isystem ${avrlibc}/avr/include"
+    done
+    ln -s ${avrgcc-unwrapped}/lib/* $out/lib
+  '';
+  meta = with stdenv.lib; {
+    description = "GNU Compiler Collection, version ${version} for AVR microcontrollers";
+    license = licenses.gpl3Plus;
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/misc/avr/gcc/wrapper.nix
+++ b/pkgs/development/misc/avr/gcc/wrapper.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ avrgcc-unwrapped avrlibc ];
   buildCommand = ''
-    mkdir -p $out/bin $out
+    mkdir -p $out/bin
     for exe in gcc g++; do
       makeWrapper "${avrgcc-unwrapped}/bin/avr-$exe" "$out/bin/avr-$exe" --add-flags "-B${avrlibc}/avr/lib -isystem ${avrlibc}/avr/include"
     done

--- a/pkgs/development/misc/avr/libc/default.nix
+++ b/pkgs/development/misc/avr/libc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, avrgcc, avrbinutils, automake, autoconf }:
+{ stdenv, fetchurl, avrgcc-unwrapped, avrbinutils, automake, autoconf }:
 
 let
   version = "2.0.0";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "15svr2fx8j6prql2il2fc0ppwlv50rpmyckaxx38d3gxxv97zpdj";
   };
 
-  buildInputs = [ avrgcc avrbinutils automake autoconf ];
+  buildInputs = [ avrgcc-unwrapped avrbinutils automake autoconf ];
   configurePhase = ''
     unset LD
     unset AS

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7872,13 +7872,13 @@ with pkgs;
 
   avrgcclibc = throw "avrgcclibs are now separate packages, install avrbinutils, avrgcc and avrlibc";
 
-  avrbinutils      = callPackage ../development/misc/avr/binutils {};
+  avrbinutils = callPackage ../development/misc/avr/binutils {};
 
   avrgcc-unwrapped = callPackage ../development/misc/avr/gcc {};
 
-  avrgcc           = callPackage ../development/misc/avr/gcc/wrapper.nix {};
+  avrgcc = callPackage ../development/misc/avr/gcc/wrapper.nix {};
 
-  avrlibc          = callPackage ../development/misc/avr/libc {};
+  avrlibc = callPackage ../development/misc/avr/libc {};
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7872,11 +7872,13 @@ with pkgs;
 
   avrgcclibc = throw "avrgcclibs are now separate packages, install avrbinutils, avrgcc and avrlibc";
 
-  avrbinutils = callPackage ../development/misc/avr/binutils {};
+  avrbinutils      = callPackage ../development/misc/avr/binutils {};
 
-  avrgcc      = callPackage ../development/misc/avr/gcc {};
+  avrgcc-unwrapped = callPackage ../development/misc/avr/gcc {};
 
-  avrlibc     = callPackage ../development/misc/avr/libc {};
+  avrgcc           = callPackage ../development/misc/avr/gcc/wrapper.nix {};
+
+  avrlibc          = callPackage ../development/misc/avr/libc {};
 
   avr8burnomat = callPackage ../development/misc/avr8-burn-omat { };
 


### PR DESCRIPTION
The wrappers supply flags so that avr-gcc and avr-g++ can
find necessary headers and libraries.

Fixes #48205

###### Motivation for this change
As currently defined, it is not obvious how to use the `avgcc` compilers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

