### PR TITLE
lib.version: change from "pre-" to "post-"

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -103,7 +103,7 @@ rec {
     let suffixFile = ../.version-suffix;
     in if pathExists suffixFile
     then lib.strings.fileContents suffixFile
-    else "pre-git";
+    else "post-git";
 
   # Attempt to get the revision nixpkgs is from
   revisionWithDefault = default:


### PR DESCRIPTION
###### Motivation for this change
Now that the release is out, I think the nixpkgs tree should identify
itself as 18.09post-git instad of 18.09pre-git.

This fixes snippets like this when building from git:

 lib.versionOlder lib.version "18.09"

Before:

  nix-repl> lib.versionOlder "18.09pre-git" "18.09"
  true

After:

  nix-repl> lib.versionOlder "18.09post-git" "18.09"
  false

(It also fixes the opposite test, lib.versionAtLeast.)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

