### PR TITLE
qemu: enable smartcard support

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -10,6 +10,7 @@
 , sdlSupport ? !stdenv.isDarwin, SDL2
 , gtkSupport ? !stdenv.isDarwin && !xenSupport, gtk3, gettext, gnome3
 , vncSupport ? true, libjpeg, libpng
+, smartcardSupport ? true, libcacard
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
@@ -58,6 +59,7 @@ stdenv.mkDerivation rec {
     ++ optionals sdlSupport [ SDL2 ]
     ++ optionals gtkSupport [ gtk3 gettext gnome3.vte ]
     ++ optionals vncSupport [ libjpeg libpng ]
+    ++ optionals smartcardSupport [ libcacard ]
     ++ optionals spiceSupport [ spice-protocol spice ]
     ++ optionals usbredirSupport [ usbredir ]
     ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
@@ -108,6 +110,7 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin "--cpu=x86_64"
     ++ optional numaSupport "--enable-numa"
     ++ optional seccompSupport "--enable-seccomp"
+    ++ optional smartcardSupport "--enable-smartcard"
     ++ optional spiceSupport "--enable-spice"
     ++ optional usbredirSupport "--enable-usb-redir"
     ++ optional hostCpuOnly "--target-list=${hostCpuTargets}"

--- a/pkgs/development/libraries/libcacard/default.nix
+++ b/pkgs/development/libraries/libcacard/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, glib, nss }:
+
+stdenv.mkDerivation rec {
+  name = "libcacard-${version}";
+  version = "2.6.1";
+
+  src = fetchurl {
+    url = "https://www.spice-space.org/download/libcacard/${name}.tar.xz";
+    sha256 = "1w6y0kiakhg7dgyf8yqpm4jj6jiv17zhy9lp3d7z32q1pniccxk2";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ glib nss ];
+
+  meta = with stdenv.lib; {
+    description = "Smart card emulation library";
+    homepage = https://gitlab.freedesktop.org/spice/libcacard;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, pixman, celt, alsaLib
 , openssl, libXrandr, libXfixes, libXext, libXrender, libXinerama
 , libjpeg, zlib, spice-protocol, python, pyparsing, glib, cyrus_sasl
-, lz4 }:
+, libcacard, lz4 }:
 
 with stdenv.lib;
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pixman celt alsaLib openssl libjpeg zlib
                   libXrandr libXfixes libXrender libXext libXinerama
-                  python pyparsing glib cyrus_sasl lz4 ];
+                  python pyparsing glib cyrus_sasl libcacard lz4 ];
 
   nativeBuildInputs = [ pkgconfig spice-protocol ];
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-sasl"
-    "--disable-smartcard"
+    "--enable-smartcard"
     "--enable-client"
     "--enable-lz4"
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10279,6 +10279,8 @@ with pkgs;
     inherit (xorg) libX11 libXext;
   };
 
+  libcacard = callPackage ../development/libraries/libcacard { };
+
   libcanberra = callPackage ../development/libraries/libcanberra {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change

As of https://github.com/GNOME/gnome-boxes/commit/6bf871c4e220cb4c32f7d96c143618e6f5b680cb, GNOME Boxes only works with QEMU built with smartcard support.

For similar bug elsewhere, see: https://github.com/voidlinux/void-packages/issues/6336

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

