### PR TITLE
reattach-to-user-namespace: 2.6 -> 2.7

### DIFF
--- a/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
+++ b/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "reattach-to-user-namespace-${version}";
-  version = "2.6";
+  version = "2.7";
 
   src = fetchurl {
-    url = "https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/archive/v2.6.tar.gz";
-    sha256 = "1d8ynzkdlxyyky9f88f7z50g9lwdydkpb2n7gkw3jgl2ac569xc0";
+    url = "https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/archive/v${version}.tar.gz";
+    sha256 = "00mjyj8yicrpnlm46rlbkvxgl5381l8xawh7rmjk10p3zrm56jbv";
   };
 
   buildFlags = "ARCHES=x86_64";


### PR DESCRIPTION
###### Motivation for this change

Adds macOS Mojave (10.14) support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

