### PR TITLE
 cedille: init at v1.0.0

### DIFF
--- a/pkgs/applications/editors/emacs-modes/cedille/default.nix
+++ b/pkgs/applications/editors/emacs-modes/cedille/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, cedille, emacs }:
+
+stdenv.mkDerivation rec {
+  name    = "cedille-mode-${version}";
+  version = cedille.version;
+
+  src = cedille.src;
+
+  buildInputs = [ emacs ];
+
+  buildPhase = ":";
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install se-mode/*.el se-mode/*.elc $out/share/emacs/site-lisp
+    install cedille-mode/*.el cedille-mode/*.elc $out/share/emacs/site-lisp
+    install *.el *.elc $out/share/emacs/site-lisp
+    substituteInPlace $out/share/emacs/site-lisp/cedille-mode.el \
+      --replace /usr/bin/cedille ${cedille}/bin/cedille \
+
+  '';
+
+  meta = {
+    description = "Emacs major mode for Cedille";
+    homepage    = cedille.meta.homepage;
+    license     = cedille.meta.license ;
+    platforms   = cedille.meta.platforms;
+    maintainers = cedille.meta.maintainers;
+  };
+}

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, alex, happy, Agda, agdaIowaStdlib,
+  buildPlatform, buildPackages, ghcWithPackages }:
+stdenv.mkDerivation rec {
+  version = "1.0.0";
+  name = "cedille-${version}";
+  src = fetchFromGitHub {
+    owner = "cedille";
+    repo = "cedille";
+    rev = "v${version}";
+    sha256 = "08c2vgg8i6l3ws7hd5gsj89mki36lxm7x7s8hi1qa5gllq04a832";
+  };
+  buildInputs = [ alex happy Agda (ghcWithPackages (ps: [ps.ieee])) ];
+
+  LANG = "en_US.UTF-8";
+  LOCALE_ARCHIVE =
+    lib.optionalString (buildPlatform.libc == "glibc")
+      "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+
+  postPatch = ''
+    patchShebangs create-libraries.sh
+    cp -r ${agdaIowaStdlib.src} ial
+    chmod -R 755 ial
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv cedille $out/bin/cedille
+  '';
+
+  meta = {
+    description = "An interactive theorem-prover and dependently typed programming language, based on extrinsic (aka Curry-style) type theory.";
+    homepage = https://cedille.github.io/;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.mpickering ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/agda/agda-iowa-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/agda-iowa-stdlib/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, agda, fetchsvn }:
+{ stdenv, agda, fetchFromGitHub }:
 
 agda.mkDerivation (self: rec {
-  version = "18734";
+  version = "1.4.0";
   name = "agda-iowa-stdlib-${version}";
 
-  src = fetchsvn {
-    url = "https://svn.divms.uiowa.edu/repos/clc/projects/agda/lib";
-    rev = version;
-    sha256 = "0aqib88m5n6aqb5lmns9nl62x40yqhg6zpj0zjxibbn4s4qjw9ky";
+  src = fetchFromGitHub {
+    owner = "cedille";
+    repo  = "ial";
+    rev = "v${version}";
+    sha256 = "1gwxpybxwdj5ipbb3gapm7r5hfl3g6sj9kp13954pdmx8d5b0gma";
   };
 
   sourceDirectories = [ "./." ];
@@ -22,7 +23,5 @@ agda.mkDerivation (self: rec {
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
-
-    broken = true;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16236,6 +16236,8 @@ with pkgs;
 
     calfw = callPackage ../applications/editors/emacs-modes/calfw { };
 
+    cedille = callPackage ../applications/editors/emacs-modes/cedille { cedille = pkgs.cedille; };
+
     coffee = callPackage ../applications/editors/emacs-modes/coffee { };
 
     colorTheme = callPackage ../applications/editors/emacs-modes/color-theme { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1091,6 +1091,10 @@ with pkgs;
 
   cddl = callPackage ../development/tools/cddl { };
 
+  cedille = callPackage ../applications/science/logic/cedille
+                          { inherit (haskellPackages) alex happy Agda ghcWithPackages;
+                          };
+
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

