### PR TITLE
dnscrypt-proxy2: 2.0.15 -> 2.0.17, add NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -498,6 +498,7 @@
   ./services/networking/dnscache.nix
   ./services/networking/dnschain.nix
   ./services/networking/dnscrypt-proxy.nix
+  ./services/networking/dnscrypt-proxy2.nix
   ./services/networking/dnscrypt-wrapper.nix
   ./services/networking/dnsdist.nix
   ./services/networking/dnsmasq.nix

--- a/nixos/modules/services/networking/dnscrypt-proxy2.nix
+++ b/nixos/modules/services/networking/dnscrypt-proxy2.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }: with lib;
+
+let
+  cfg = config.services.dnscrypt-proxy2;
+
+  json = pkgs.writeText "dnscrypt-proxy.json" (builtins.toJSON cfg.config);
+
+  toml = pkgs.runCommand "dnscrypt-proxy.toml" {} ''
+    ${pkgs.remarshal}/bin/json2toml < ${json} > $out
+  '';
+in
+
+{
+  options.services.dnscrypt-proxy2 = {
+    enable = mkEnableOption "dnscrypt-proxy";
+
+    config = mkOption {
+      description = ''
+        Attrset that is converted and passed as TOML config file.
+        For available params, see: https://git.io/fxBne
+      '';
+      example = literalExample ''
+        {
+          sources.public-resolvers = {
+            urls = [ "https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md" ];
+            cache_file = "public-resolvers.md";
+            minisign_key = "RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3";
+            refresh_delay = 72;
+          };
+        }
+      '';
+      type = types.attrs;
+    };
+
+    package = mkOption {
+      default = pkgs.dnscrypt-proxy2;
+      description = ''
+        dnscrypt-proxy2 package to use.
+      '';
+      type = types.package;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.nameservers = lib.mkDefault [ "127.0.0.1" ];
+
+    systemd.services.dnscrypt-proxy2 = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/dnscrypt-proxy -config ${toml}";
+      };
+    };
+  };
+}

--- a/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
@@ -1,24 +1,19 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchzip }:
 
 buildGoPackage rec {
-  name = "dnscrypt-proxy2-${version}";
-  version = "2.0.15";
+  name = "dnscrypt-proxy-${version}";
+  version = "2.0.17";
 
   goPackagePath = "github.com/jedisct1/dnscrypt-proxy";
 
-  src = fetchFromGitHub {
-    owner = "jedisct1";
-    repo = "dnscrypt-proxy";
-    rev = "${version}";
-    sha256 = "0iwvndk1h550zmwhwablb0smv9n2l51hqbmzj354mcgi6frnx819";
+  src = fetchzip {
+    url = "https://${goPackagePath}/archive/${version}.tar.gz";
+    sha256 = "12mg1jbla2hyq44wq9009sqb0mzwq16wi8shafabwk0zf9s2944d";
   };
 
   meta = with stdenv.lib; {
-    description = "A tool that provides secure DNS resolution";
-
+    description = "DNS over HTTPS and DNSCrypt proxy";
     license = licenses.isc;
-    homepage = https://dnscrypt.info/;
-    maintainers = with maintainers; [ waynr ];
-    platforms = with platforms; unix;
+    maintainers = with maintainers; [ waynr yegortimoshenko ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2168,9 +2168,7 @@ with pkgs;
 
   dnscrypt-proxy = callPackage ../tools/networking/dnscrypt-proxy/1.x { };
 
-  dnscrypt-proxy2 = callPackage ../tools/networking/dnscrypt-proxy/2.x {
-    buildGoPackage = buildGo110Package;
-  };
+  dnscrypt-proxy2 = callPackage ../tools/networking/dnscrypt-proxy/2.x { };
 
   dnscrypt-wrapper = callPackage ../tools/networking/dnscrypt-wrapper { };
 


### PR DESCRIPTION
###### Motivation for this change

Resolves https://github.com/NixOS/nixpkgs/issues/43298.

cc @joachifm @Shados 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

