### PR TITLE
openxcom: 1.0.0.2018.01.28 -> 1.0.0.2018.10.08

### DIFF
--- a/pkgs/games/openxcom/default.nix
+++ b/pkgs/games/openxcom/default.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchFromGitHub, cmake, libGLU_combined, zlib, openssl, libyamlcpp, boost
 , SDL, SDL_image, SDL_mixer, SDL_gfx }:
 
-let version = "1.0.0.2018.01.28"; in
+let version = "1.0.0.2018.10.08"; in
 stdenv.mkDerivation {
   name = "openxcom-${version}";
   src = fetchFromGitHub {
     owner = "SupSuper";
     repo = "OpenXcom";
-    rev = "b148916268a6ce104c3b6b7eb4d9e0487cba5487";
-    sha256 = "1128ip3g4aw59f3f23mvlyhl8xckhwjjw9rd7wn7xv51hxdh191c";
+    rev = "13049d617fe762b91893faaf7c14ddefa49e2f1d";
+    sha256 = "0vpcfk3g1bnwwmrln14jkj2wvw2z8igxw2mdb7c3y66466wm93ig";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

Update to latest upstream version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

