### PR TITLE
nixos/gitlab: add custom hooks directory for gitlab-shell

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -53,6 +53,7 @@ let
     repos_path: "${cfg.statePath}/repositories"
     secret_file: "${cfg.statePath}/config/gitlab_shell_secret"
     log_file: "${cfg.statePath}/log/gitlab-shell.log"
+    custom_hooks_dir: "${cfg.statePath}/custom_hooks"
     redis:
       bin: ${pkgs.redis}/bin/redis-cli
       host: 127.0.0.1
@@ -562,6 +563,9 @@ in {
         mkdir -p ${cfg.statePath}/shell
         mkdir -p ${cfg.statePath}/db
         mkdir -p ${cfg.statePath}/uploads
+        mkdir -p ${cfg.statePath}/custom_hooks/pre-receive.d
+        mkdir -p ${cfg.statePath}/custom_hooks/post-receive.d
+        mkdir -p ${cfg.statePath}/custom_hooks/update.d
 
         rm -rf ${cfg.statePath}/config ${cfg.statePath}/shell/hooks
         mkdir -p ${cfg.statePath}/config


### PR DESCRIPTION
Add custom_hooks_dir to gitlab-shell yml config file.

###### Motivation for this change
Allow for use of global git hook scripts within gitlab.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

