### PR TITLE
perlArchiveCpio -> perlPackages.ArchiveCpio

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -203,6 +203,7 @@ mapAliases ({
   owncloudclient = owncloud-client;  # added 2016-08
   p11_kit = p11-kit; # added 2018-02-25
   pass-otp = pass.withExtensions (ext: [ext.pass-otp]); # added 2018-05-04
+  perlArchiveCpio = perlPackages.ArchiveCpio; # added 2018-10-12
   pgp-tools = signing-party; # added 2017-03-26
   pidgin-with-plugins = pidgin; # added 2016-06
   pidginlatex = pidgin-latex; # added 2018-01-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12928,8 +12928,6 @@ with pkgs;
 
   ack = perlPackages.ack;
 
-  perlArchiveCpio = perlPackages.ArchiveCpio;
-
   perlcritic = perlPackages.PerlCritic;
 
   sqitchPg = callPackage ../development/tools/misc/sqitch {


### PR DESCRIPTION
###### Motivation for this change

```perlArchiveCpio = perlPackages.ArchiveCpio``` moved from ```all-packages.nix``` to ```aliases.nix```
