### PR TITLE
liblinear: 2.20 -> 2.21

### DIFF
--- a/pkgs/development/libraries/liblinear/default.nix
+++ b/pkgs/development/libraries/liblinear/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "liblinear-${version}";
-  version = "2.20";
+  version = "2.21";
 
   src = fetchurl {
     url = "https://www.csie.ntu.edu.tw/~cjlin/liblinear/liblinear-${version}.tar.gz";
-    sha256 = "13q48azqy9pd8jyhk0c2hzj5xav1snbdrj8pp38vwrv2wwhfz7rz";
+    sha256 = "0jp0z3s32czf748i6dnlabs1psqx1dcn9w96c56m24xq5l789chs";
   };
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Primary change:

*Since 2.20 we have continued to improve the conjugate gradient method in primal-based Newton solvers by applying a preconditioning technique. The convergence can be significantly improved on some problems.*

https://www.csie.ntu.edu.tw/~cjlin/liblinear/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

