### PR TITLE
 prometheus-tor-exporter: init at 0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -986,6 +986,11 @@
     github = "deepfire";
     name = "Kosyrev Serge";
   };
+  delroth = {
+    email = "delroth@gmail.com";
+    github = "delroth";
+    name = "Pierre Bourdon";
+  };
   deltaevo = {
     email = "deltaduartedavid@gmail.com";
     github = "DeltaEvo";

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -30,6 +30,7 @@ let
     postfix   = import ./exporters/postfix.nix   { inherit config lib pkgs; };
     snmp      = import ./exporters/snmp.nix      { inherit config lib pkgs; };
     surfboard = import ./exporters/surfboard.nix { inherit config lib pkgs; };
+    tor       = import ./exporters/tor.nix       { inherit config lib pkgs; };
     unifi     = import ./exporters/unifi.nix     { inherit config lib pkgs; };
     varnish   = import ./exporters/varnish.nix   { inherit config lib pkgs; };
   };

--- a/nixos/modules/services/monitoring/prometheus/exporters/tor.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/tor.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.tor;
+in
+{
+  port = 9130;
+  extraOpts = {
+    torControlAddress = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        Tor control IP address or hostname.
+      '';
+    };
+
+    torControlPort = mkOption {
+      type = types.int;
+      default = 9051;
+      description = ''
+        Tor control port.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      DynamicUser = true;
+      ExecStart = ''
+        ${pkgs.prometheus-tor-exporter}/bin/prometheus-tor-exporter \
+          -b ${cfg.listenAddress} \
+          -p ${toString cfg.port} \
+          -a ${cfg.torControlAddress} \
+          -c ${toString cfg.torControlPort} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/tor-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/tor-exporter.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  name = "tor-exporter-${version}";
+  version = "0.3";
+
+  # Just a single .py file to use as the application's main entry point.
+  format = "other";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "atx";
+    repo = "prometheus-tor_exporter";
+    sha256 = "0d7pk8s8ya2pm8b4ijbfdniqcbd3vqy15dlhnmaf4wgb51pmm5yv";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ prometheus_client stem retrying ];
+
+  installPhase = ''
+    mkdir -p $out/share/
+    cp prometheus-tor-exporter.py $out/share/
+  '';
+
+  fixupPhase = ''
+    makeWrapper "${python3Packages.python.interpreter}" "$out/bin/prometheus-tor-exporter" \
+          --set PYTHONPATH "$PYTHONPATH" \
+          --add-flags "$out/share/prometheus-tor-exporter.py"
+  '';
+
+  meta = with lib; {
+    description = "Prometheus exporter that exposes metrics from a Tor daemon";
+    homepage = https://github.com/atx/prometheus-tor_exporter;
+    license = licenses.mit;
+    maintainers = with maintainers; [ delroth ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13530,6 +13530,7 @@ with pkgs;
   prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix {
     buildGoPackage = buildGo110Package;
   };
+  prometheus-tor-exporter = callPackage ../servers/monitoring/prometheus/tor-exporter.nix { };
   prometheus-statsd-exporter = callPackage ../servers/monitoring/prometheus/statsd-bridge.nix { };
   prometheus-surfboard-exporter = callPackage ../servers/monitoring/prometheus/surfboard-exporter.nix { };
   prometheus-unifi-exporter = callPackage ../servers/monitoring/prometheus/unifi-exporter { };


### PR DESCRIPTION
###### Motivation for this change
I want some monitoring for my Tor relay :) This is not a particularly widely used piece of software, but it seems to be still maintained upstream.

First time contributing and packaging things for Nix, please let me know if anything can be improved!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

