### PR TITLE
jameica: 2.8.1 -> 2.8.2

### DIFF
--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk, jre, xmlstarlet, gtk2, glib, xorg, Cocoa }:
+{ stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk, jre, gtk2, glib, xorg, Cocoa }:
 
 let
-  _version = "2.8.1";
-  _build = "449";
+  _version = "2.8.2";
+  _build = "450";
   version = "${_version}-${_build}";
   name = "jameica-${version}";
 
@@ -23,7 +23,7 @@ in
 stdenv.mkDerivation rec {
   inherit name version;
 
-  nativeBuildInputs = [ ant jdk makeWrapper xmlstarlet ];
+  nativeBuildInputs = [ ant jdk makeWrapper ];
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ gtk2 glib xorg.libXtst ]
                 ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
@@ -31,23 +31,13 @@ stdenv.mkDerivation rec {
     owner = "willuhn";
     repo = "jameica";
     rev = "V_${builtins.replaceStrings ["."] ["_"] _version}_BUILD_${_build}";
-    sha256 = "1w25lxjskn1yxllbv0vgvcc9f9xvgv9430dm4b59ia9baf98syd2";
+    sha256 = "197n35lvx51k6cbp3fhndvfb38sikl4mjqcd42fgvn2khy2sij68";
   };
 
   # there is also a build.gradle, but it only seems to be used to vendor 3rd party libraries
   # and is not able to build the application itself
   buildPhase = ''
-    (cd build; ant init compile jar)
-  '';
-
-  # jameica itself loads ./plugin.xml to determine it's version.
-  # Unfortunately, the version attribute there seems to be wrong,
-  # so it thinks it's older than it really is,
-  # and refuses to load plugins destined for its version.
-  # Set version manually to workaround that.
-  postPatch = ''
-    xml ed -u '/system/@version' -v '${version}' plugin.xml > plugin.xml.new
-    mv plugin.xml.new plugin.xml
+    (cd build; ant -Dsystem.version=${version} init compile jar)
   '';
 
   installPhase = ''
@@ -73,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://www.willuhn.de/products/jameica/;
-    description = "Free Runtime Environment for Java Applications.";
+    description = "Free Runtime Environment for Java Applications";
     longDescription = ''
       Runtime Environment for plugins like Hibiscus (HBCI Online Banking),
       SynTAX (accounting) and JVerein (club management).


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

