### PR TITLE
go-sct: 20160529 -> 20180605

### DIFF
--- a/pkgs/tools/X11/go-sct/default.nix
+++ b/pkgs/tools/X11/go-sct/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, xorg, buildGoPackage, fetchgit }:
+{ stdenv, xorg, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "go-sct-${version}";
-  version = "20160529-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "1d6b5e05a0b63bfeac9df55003efec352e1bc19d";
+  version = "20180605-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "eb1e851f2d5017038d2b8e3653645c36d3a279f4";
 
   goPackagePath = "github.com/d4l3k/go-sct";
 
-  src = fetchgit {
+  src = fetchFromGitHub {
     inherit rev;
-    url = "https://github.com/d4l3k/go-sct";
-    sha256 = "1iqdagrq0j7sqxgsj31skgk73k2rbpbvj41v087af9103wf8h9z7";
+    owner = "d4l3k";
+    repo = "go-sct";
+    sha256 = "16z2ml9x424cnliazyxlw7pm7q64pppjam3dnmq2xab0wlbbm3nm";
   };
 
   goDeps = ./deps.nix;
@@ -20,7 +21,7 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     description = "Color temperature setting library and CLI that operates in a similar way to f.lux and Redshift";
     license = licenses.mit;
-    maintainers = with maintainers; [ cstrahan ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ rvolosatovs cstrahan ];
+    platforms = platforms.linux ++ platforms.windows;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

