### PR TITLE
jenkins: 2.138.1 -> 2.138.2

### DIFF
--- a/pkgs/development/tools/continuous-integration/jenkins/default.nix
+++ b/pkgs/development/tools/continuous-integration/jenkins/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "jenkins-${version}";
-  version = "2.138.1";
+  version = "2.138.2";
 
   src = fetchurl {
     url = "http://mirrors.jenkins.io/war-stable/${version}/jenkins.war";
-    sha256 = "09svkqii9lv1br0al6wjn1l0fsqf6s7fdrfc0awmfsg8fmjlpf7c";
+    sha256 = "10qyr8izngnhlr1b03a9vdnbmwprbqsjnd55hjdalmxy6dq5mvfq";
   };
 
   buildCommand = ''

--- a/pkgs/development/tools/continuous-integration/jenkins/update.sh
+++ b/pkgs/development/tools/continuous-integration/jenkins/update.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts jq
+
+set -eu -o pipefail
+
+core_json="$(curl --fail --location https://updates.jenkins.io/stable/update-center.actual.json | jq .core)"
+
+version="$(jq -r .version <<<$core_json)"
+sha256="$(jq -r .sha256 <<<$core_json)"
+hash="$(nix-hash --type sha256 --to-base32 "$sha256")"
+url="$(jq -r .url <<<$core_json)"
+
+update-source-version jenkins "$version" "$hash" "$url"


### PR DESCRIPTION
###### Motivation for this change

Multiple security vulnerabilities in Jenkins 2.145 and earlier, and LTS 2.138.1 and earlier

https://jenkins.io/security/advisory/2018-10-10/

###### Things done

I also added an update script for Jenkins. Let me know if this should be a separate PR.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

