### PR TITLE
sonic-pi: 3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -20,14 +20,14 @@ let
   };
 
 in stdenv.mkDerivation rec {
-  version = "3.0.1";
+  version = "3.1.0";
   name = "sonic-pi-${version}";
 
   src = fetchFromGitHub {
     owner = "samaaron";
     repo = "sonic-pi";
     rev = "v${version}";
-    sha256 = "1l1892hijp1dj2h799sfjr699q6xp660n0siibab5kv238521a81";
+    sha256 = "0gi4a73szaa8iz5q1gxgpsnyvhhghcfqm6bfwwxbix4m5csbfgh9";
   };
 
   buildInputs = [
@@ -58,21 +58,21 @@ in stdenv.mkDerivation rec {
     export SONIC_PI_HOME=$TMPDIR
     export AUBIO_LIB=${aubio}/lib/libaubio.so
 
-    pushd app/server/bin
+    pushd app/server/ruby/bin
       ./compile-extensions.rb
       ./i18n-tool.rb -t
     popd
 
     pushd app/gui/qt
       cp -f ruby_help.tmpl ruby_help.h
-      ../../server/bin/qt-doc.rb -o ruby_help.h
+      ../../server/ruby/bin/qt-doc.rb -o ruby_help.h
 
       substituteInPlace SonicPi.pro \
         --replace "LIBS += -lrt -lqt5scintilla2" \
                   "LIBS += -lrt -lqscintilla2 -lqwt"
 
       lrelease SonicPi.pro
-      qmake SonicPi.pro 
+      qmake SonicPi.pro
 
       make
     popd

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     description = "Programming language for real time audio synthesis";
     homepage = http://supercollider.sourceforge.net/;
     license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = [ "x686-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

There is a new version of sonic-pi available. The old version didn't work on my system, so I guess this change can be merged into the release branches as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

