### PR TITLE
wireguard: 0.0.20180925 -> 0.0.20181006

### DIFF
--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "wireguard-go-${version}";
-  version = "0.0.20180613";
+  version = "0.0.20181001";
 
   goPackagePath = "git.zx2c4.com/wireguard-go";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-    sha256 = "0pvg7s1kyn48az54lsnyn1ryhjk0flmpz5dx520rc94g6xn88fic";
+    sha256 = "0yh9f58xn8kcq3wgx2s8j19k2h1vbmg70fn5gvw9k98f5mzynls3";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "wireguard-tools-${version}";
-  version = "0.0.20180925";
+  version = "0.0.20181006";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "10k63ld0f5q5aykpcrg9m3xmrsf3qmlkvhiv18q73hnky2cjfx62";
+    sha256 = "0283slpyqb8d4cx9wyahqmqi4lwhzamc4i2710zid5y71vjgsgw3";
   };
 
   sourceRoot = "source/src/tools";


### PR DESCRIPTION
###### Motivation for this change

Bump WireGuard (including userspace Go implementation). cc @Mic92 @zx2c4 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

