### PR TITLE
security-tool: --prefix instead of --set w/ DYLD_INSERT_LIBRARIES

### DIFF
--- a/pkgs/os-specific/darwin/security-tool/default.nix
+++ b/pkgs/os-specific/darwin/security-tool/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    wrapProgram $out/bin/security --set DYLD_INSERT_LIBRARIES /usr/lib/libsqlite3.dylib
+    wrapProgram $out/bin/security --prefix DYLD_INSERT_LIBRARIES : /usr/lib/libsqlite3.dylib
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Do not overwrite `DYLD_INSERT_LIBRARIES`, it might contain other libraries that securitytool depends on (e.g. if /nix/store has been bundled with macOS application). 

However, I'm not entirely sure if it should be there in the first place. It seems to be better to use pure SQLite instead. cc @matthewbauer @pikajude  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

