### PR TITLE
gnutls: add SSL_CERT_FILE

### DIFF
--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -6,7 +6,7 @@
 # Version dependent args
 , version, src, patches ? [], postPatch ? "", nativeBuildInputs ? []
 , buildInputs ? []
-, ...}:
+, ... }:
 
 assert guileBindings -> guile != null;
 let
@@ -15,10 +15,12 @@ let
   doCheck = !stdenv.isFreeBSD && !stdenv.isDarwin && lib.versionAtLeast version "3.4"
       && stdenv.buildPlatform == stdenv.hostPlatform;
 in
+
 stdenv.mkDerivation {
   name = "gnutls-${version}";
+  inherit src version;
 
-  inherit src patches;
+  patches = patches ++ [ ./ssl-cert-file.patch ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
   outputInfo = "devdoc";

--- a/pkgs/development/libraries/gnutls/ssl-cert-file.patch
+++ b/pkgs/development/libraries/gnutls/ssl-cert-file.patch
@@ -1,0 +1,36 @@
+From 53091092876e668a4c43a4944d1b821015dea7a3 Mon Sep 17 00:00:00 2001
+From: Yegor Timoshenko <yegortimoshenko@riseup.net>
+Date: Wed, 17 Oct 2018 07:48:34 +0000
+Subject: [PATCH] Handle SSL_CERT_FILE environment variable
+
+---
+ lib/system/certs.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/lib/system/certs.c b/lib/system/certs.c
+index 53eb561d0..6adb960e3 100644
+--- a/lib/system/certs.c
++++ b/lib/system/certs.c
+@@ -137,6 +137,19 @@ add_system_trust(gnutls_x509_trust_list_t list,
+ 		r += ret;
+ #endif
+ 
++	char *env = secure_getenv("SSL_CERT_FILE");
++
++	if (env != NULL) {
++		ret =
++		    gnutls_x509_trust_list_add_trust_file(list,
++							  env,
++							  crl_file,
++							  GNUTLS_X509_FMT_PEM,
++							  tl_flags, tl_vflags);
++		if (ret > 0)
++			r += ret;
++	}
++
+ #ifdef DEFAULT_BLACKLIST_FILE
+ 	ret = gnutls_x509_trust_list_remove_trust_file(list, DEFAULT_BLACKLIST_FILE, GNUTLS_X509_FMT_PEM);
+ 	if (ret < 0) {
+-- 
+2.19.0
+


### PR DESCRIPTION
###### Motivation for this change

At the moment, GnuTLS programs from Nixpkgs will not always work on non-NixOS systems. This patch resolves the issue by providing pure `cacert` at configure time.

GnuTLS doesn't have an equivalent of `SSL_CERT_FILE`, it would be nice to patch that in.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

