### PR TITLE
go-junit-report: init at 2018-06-14 (385fac0ce9a)

### DIFF
--- a/pkgs/development/tools/go-junit-report/default.nix
+++ b/pkgs/development/tools/go-junit-report/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "go-junit-report-unstable-${version}";
+  version = "2018-06-14";
+  rev = "385fac0ced9acaae6dc5b39144194008ded00697";
+
+  goPackagePath = "github.com/jstemmer/go-junit-report";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "jstemmer";
+    repo = "go-junit-report";
+    sha256 = "109zs8wpdmc2ijc2khyqija8imay88ka6v50xvrpnnwnd3ywckxi";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Converts go test output to an xml report, suitable for applications that expect junit xml reports (e.g. Jenkins)";
+    homepage    = "https://${goPackagePath}";
+    maintainers = with maintainers; [ cryptix ];
+    license     = licenses.mit;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6918,6 +6918,8 @@ with pkgs;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 
+  go-junit-report = callPackage ../development/tools/go-junit-report { };
+
   gox = callPackage ../development/tools/gox { };
 
   gprolog = callPackage ../development/compilers/gprolog { };


### PR DESCRIPTION
###### Motivation for this change

tl;dr: pipe `go test` results into this and get enkins reports.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

