### PR TITLE
COPYING: move notice to README.md

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -18,12 +18,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-======================================================================
-
-Note: the license above does not apply to the packages built by the
-Nix Packages collection, merely to the package descriptions (i.e., Nix
-expressions, build scripts, etc.).  It also might not apply to patches
-included in Nixpkgs, which may be derivative works of the packages to
-which they apply.  The aforementioned artifacts are all covered by the
-licenses of the respective packages.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ Communication:
 
 * [Discourse Forum](https://discourse.nixos.org/)
 * [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)
+
+Note: MIT license does not apply to the packages built by Nixpkgs, merely to
+the package descriptions (Nix expressions, build scripts, and so on). It also
+might not apply to patches included in Nixpkgs, which may be derivative works
+of the packages to which they apply. The aforementioned artifacts are all
+covered by the licenses of the respective packages.


### PR DESCRIPTION
###### Motivation for this change

See: #43575

Move notice to README.md so that GitHub identifies the license and offers metadata for it, as proposed by @matthewbauer. Also, minor notice rewording.

cc @copumpkin @grahamc @pSub @samueldr 
