### PR TITLE
guile-cairo: 1.4.1 -> 1.10.0

### DIFF
--- a/pkgs/development/guile-modules/guile-cairo/default.nix
+++ b/pkgs/development/guile-modules/guile-cairo/default.nix
@@ -2,19 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "guile-cairo-${version}";
-  version = "1.4.1";
+  version = "1.10.0";
 
   src = fetchurl {
-    url = "http://download.gna.org/guile-cairo/${name}.tar.gz";
-    sha256 = "1f5nd9n46n6cwfl1byjml02q3y2hgn7nkx98km1czgwarxl7ws3x";
+    url = "mirror://savannah/guile-cairo/${name}.tar.gz";
+    sha256 = "0p6xrhf2k6n5dybn88050za7h90gnd7534n62l53vsca187pwgdf";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ guile cairo expat ];
-  checkInputs = [ guile-lib ];
+  enableParallelBuilding = true;
 
   doCheck = true;
+  checkInputs = [ guile-lib ];
 
   meta = with stdenv.lib; {
     description = "Cairo bindings for GNU Guile";
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
       maintained graphics library with all of the benefits of Scheme: memory
       management, exceptions, macros, and a dynamic programming environment.
     '';
-    homepage = "http://home.gna.org/guile-cairo/";
+    homepage = https://www.nongnu.org/guile-cairo/;
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7939,9 +7939,7 @@ with pkgs;
 
   jython = callPackage ../development/interpreters/jython {};
 
-  guile-cairo = callPackage ../development/guile-modules/guile-cairo {
-    guile = guile_2_0;
-  };
+  guile-cairo = callPackage ../development/guile-modules/guile-cairo { };
 
   guile-fibers = callPackage ../development/guile-modules/guile-fibers { };
 


### PR DESCRIPTION
###### Motivation for this change

Gna.org forge is closed but guile-cairo has a new home
\+ now builds with default Guile 2.2

/cc @vyp 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

