### PR TITLE
 adoptopenjdk-bin: init at 11

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -309,6 +309,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "GNU General Public License v2.0 only";
   };
 
+  gpl2Classpath = {
+    spdxId = "GPL-2.0-with-classpath-exception";
+    fullName = "GNU General Public License v2.0 only (with Classpath exception)";
+    url = https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception;
+  };
+
   gpl2ClasspathPlus = {
     fullName = "GNU General Public License v2.0 or later (with Classpath exception)";
     url = https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception;

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -1,0 +1,59 @@
+{ name
+, url
+, sha256
+}:
+
+{ swingSupport ? true # not used for now
+, stdenv
+, fetchurl
+}:
+
+let result = stdenv.mkDerivation rec {
+  inherit name;
+
+  src = fetchurl {
+    inherit url sha256;
+  };
+
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = 1;
+
+  installPhase = ''
+    cd ..
+
+    mv $sourceRoot $out
+
+    rm -rf $out/Home/demo
+
+    # Remove some broken manpages.
+    rm -rf $out/Home/man/ja*
+
+    # for backward compatibility
+    ln -s $out/Contents/Home $out/jre
+
+    ln -s $out/Contents/Home/* $out/
+
+    mkdir -p $out/nix-support
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  # FIXME: use multiple outputs or return actual JRE package
+  passthru.jre = result;
+
+  passthru.home = result;
+
+  # for backward compatibility
+  passthru.architecture = "";
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl2Classpath;
+    description = "AdoptOpenJDK, prebuilt OpenJDK binary";
+    platforms = [ "x86_64-darwin" ]; # some inherit jre.meta.platforms
+    maintainers = with stdenv.lib.maintainers; [ taku0 ];
+  };
+
+}; in result

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -1,0 +1,119 @@
+{ name
+, url
+, sha256
+}:
+
+{ swingSupport ? true
+, stdenv
+, fetchurl
+, file
+, xorg ? null
+, glib
+, libxml2
+, ffmpeg_2
+, libxslt
+, libGL
+, freetype
+, fontconfig
+, gtk2
+, pango
+, cairo
+, alsaLib
+, atk
+, gdk_pixbuf
+, zlib
+, elfutils
+}:
+
+assert swingSupport -> xorg != null;
+
+let
+  rSubPaths = [
+    "lib/jli"
+    "lib/server"
+    "lib/compressedrefs" # OpenJ9
+    "lib/j9vm" # OpenJ9
+    "lib"
+  ];
+
+  libraries = [
+    stdenv.cc.libc glib libxml2 ffmpeg_2 libxslt libGL
+    xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk_pixbuf
+    atk zlib elfutils
+  ] ++ (stdenv.lib.optionals swingSupport [
+    xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt
+    xorg.libXrender
+    stdenv.cc.cc
+  ]);
+in
+
+let result = stdenv.mkDerivation rec {
+  inherit name;
+
+  src = fetchurl {
+    inherit url sha256;
+  };
+
+  nativeBuildInputs = [ file ];
+
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = 1;
+
+  installPhase = ''
+    cd ..
+
+    # Set PaX markings
+    exes=$(file $sourceRoot/bin/* 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//')
+    for file in $exes; do
+      paxmark m "$file"
+      # On x86 for heap sizes over 700MB disable SEGMEXEC and PAGEEXEC as well.
+      ${stdenv.lib.optionalString stdenv.isi686 ''paxmark msp "$file"''}
+    done
+
+    mv $sourceRoot $out
+
+    rm -rf $out/demo
+
+    # Remove some broken manpages.
+    rm -rf $out/man/ja*
+
+    # for backward compatibility
+    ln -s $out $out/jre
+
+    mkdir -p $out/nix-support
+
+    # Set JAVA_HOME automatically.
+    cat <<EOF >> $out/nix-support/setup-hook
+    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    EOF
+  '';
+
+  postFixup = ''
+    rpath+="''${rpath:+:}${stdenv.lib.concatStringsSep ":" (map (a: "$out/${a}") rSubPaths)}"
+
+    # set all the dynamic linkers
+    find $out -type f -perm -0100 \
+        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "$rpath" {} \;
+
+    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
+  '';
+
+  rpath = stdenv.lib.strings.makeLibraryPath libraries;
+
+  # FIXME: use multiple outputs or return actual JRE package
+  passthru.jre = result;
+
+  passthru.home = result;
+
+  # for backward compatibility
+  passthru.architecture = "";
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl2Classpath;
+    description = "AdoptOpenJDK, prebuilt OpenJDK binary";
+    platforms = [ "x86_64-linux" ]; # some inherit jre.meta.platforms
+    maintainers = with stdenv.lib.maintainers; [ taku0 ];
+  };
+
+}; in result

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
@@ -1,0 +1,26 @@
+let
+  version = "11";
+  buildNumber = "28";
+  baseUrl = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}";
+  makePackage = { packageType, vmType, sha256 }: import ./jdk-darwin-base.nix {
+    name = if packageType == "jdk"
+      then
+        "adoptopenjdk-${vmType}-bin-${version}"
+      else
+        "adoptopenjdk-${packageType}-${vmType}-bin-${version}";
+    url = "${baseUrl}/OpenJDK${version}-${packageType}_x64_mac_${vmType}_${version}_${buildNumber}.tar.gz";
+    inherit sha256;
+  };
+in
+{
+  jdk-hotspot = makePackage {
+    packageType = "jdk";
+    vmType = "hotspot";
+    sha256 = "ca0ec49548c626904061b491cae0a29b9b4b00fb34d8973dc217e10ab21fb0f3";
+  };
+  jre-hotspot = makePackage {
+    packageType = "jre";
+    vmType = "hotspot";
+    sha256 = "ef4dbfe5aed6ab2278fcc14db6cc73abbaab56e95f6ebb023790a7ebc6d7f30c";
+  };
+}

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
@@ -1,0 +1,36 @@
+let
+  version = "11";
+  buildNumber = "28";
+  baseUrl = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}";
+  makePackage = { packageType, vmType, sha256 }: import ./jdk-linux-base.nix {
+    name = if packageType == "jdk"
+      then
+        "adoptopenjdk-${vmType}-bin-${version}"
+      else
+        "adoptopenjdk-${packageType}-${vmType}-bin-${version}";
+    url = "${baseUrl}/OpenJDK${version}-${packageType}_x64_linux_${vmType}_${version}_${buildNumber}.tar.gz";
+    inherit sha256;
+  };
+in
+{
+  jdk-hotspot = makePackage {
+    packageType = "jdk";
+    vmType = "hotspot";
+    sha256 = "e1e18fc9ce2917473da3e0acb5a771bc651f600c0195a3cb40ef6f22f21660af";
+  };
+  jre-hotspot = makePackage {
+    packageType = "jre";
+    vmType = "hotspot";
+    sha256 = "346448142d46c6e51d0fadcaadbcde31251d7678922ec3eb010fcb1b6e17804c";
+  };
+  jdk-openj9 = makePackage {
+    packageType = "jdk";
+    vmType = "openj9";
+    sha256 = "fd77f22eb74078bcf974415abd888296284d2ceb81dbaca6ff32f59416ebc57f";
+  };
+  jre-openj9 = makePackage {
+    packageType = "jre";
+    vmType = "openj9";
+    sha256 = "83a7c95e6b2150a739bdd5e8a6fe0315904fd13d8867c95db67c0318304a2c42";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6385,6 +6385,15 @@ with pkgs;
 
   abcl = callPackage ../development/compilers/abcl {};
 
+  adoptopenjdk-bin-11-packages = import ../development/compilers/adoptopenjdk-bin/jdk11-linux.nix;
+  adoptopenjdk-hotspot-bin-11 = callPackage adoptopenjdk-bin-11-packages.jdk-hotspot {};
+  adoptopenjdk-jre-hotspot-bin-11 = callPackage adoptopenjdk-bin-11-packages.jre-hotspot {};
+  adoptopenjdk-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages.jdk-openj9 {};
+  adoptopenjdk-jre-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages.jre-openj9 {};
+
+  adoptopenjdk-bin = adoptopenjdk-hotspot-bin-11;
+  adoptopenjdk-jre-bin = adoptopenjdk-jre-hotspot-bin-11;
+
   aldor = callPackage ../development/compilers/aldor { };
 
   aliceml = callPackage ../development/compilers/aliceml { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6385,11 +6385,19 @@ with pkgs;
 
   abcl = callPackage ../development/compilers/abcl {};
 
-  adoptopenjdk-bin-11-packages = import ../development/compilers/adoptopenjdk-bin/jdk11-linux.nix;
-  adoptopenjdk-hotspot-bin-11 = callPackage adoptopenjdk-bin-11-packages.jdk-hotspot {};
-  adoptopenjdk-jre-hotspot-bin-11 = callPackage adoptopenjdk-bin-11-packages.jre-hotspot {};
-  adoptopenjdk-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages.jdk-openj9 {};
-  adoptopenjdk-jre-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages.jre-openj9 {};
+  adoptopenjdk-bin-11-packages-linux = import ../development/compilers/adoptopenjdk-bin/jdk11-linux.nix;
+  adoptopenjdk-bin-11-packages-darwin = import ../development/compilers/adoptopenjdk-bin/jdk11-darwin.nix;
+
+  adoptopenjdk-hotspot-bin-11 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-11-packages-linux.jdk-hotspot {}
+    else callPackage adoptopenjdk-bin-11-packages-darwin.jdk-hotspot {};
+  adoptopenjdk-jre-hotspot-bin-11 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-11-packages-linux.jre-hotspot {}
+    else callPackage adoptopenjdk-bin-11-packages-darwin.jre-hotspot {};
+
+  # no OpenJ9 for Darwin
+  adoptopenjdk-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages-linux.jdk-openj9 {};
+  adoptopenjdk-jre-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {};
 
   adoptopenjdk-bin = adoptopenjdk-hotspot-bin-11;
   adoptopenjdk-jre-bin = adoptopenjdk-jre-hotspot-bin-11;


### PR DESCRIPTION
###### Motivation for this change

Oracle JDK 11 is not free of charge (except for development, testing, prototyping, or demonstration), and free users are guided to use OpenJDK 11. `openjdk11` package is in progress, but not building yet (https://github.com/NixOS/nixpkgs/pull/47375#issuecomment-428671180).

This PR add binary packages of AdoptOpenJDK, which includes combinations of JDK/JRE and Hotspot/OpenJ9 variants.

Only `x86_64-linux` is supported for now, though AdoptOpenJDK itself supports many platforms and architectures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

