### PR TITLE
py-solc: init at 3.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3190,6 +3190,11 @@
     github = "pawelpacana";
     name = "Paweł Pacana";
   };
+  paulperegud = {
+    email = "paulperegud@gmail.com";
+    github = "paulperegud";
+    name = "Paul Peregud";
+  };
   pbogdan = {
     email = "ppbogdan@gmail.com";
     github = "pbogdan";

--- a/pkgs/development/python-modules/py-solc/default.nix
+++ b/pkgs/development/python-modules/py-solc/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchPypi, buildPythonPackage, isPy3k, solc, semantic-version }:
+
+buildPythonPackage rec {
+  pname = "py-solc";
+  version = "3.2.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16lcxz9yhhv0w9dj4ayr611nf9dnpnb8mbrdrx42y1v1qvd5n2c2";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "setup_requires=['setuptools-markdown']," ""
+  '';
+
+  propagatedBuildInputs = [ solc semantic-version ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Python wrapper around the solc binary";
+    license = licenses.mit;
+    maintainers = [ maintainers.paulperegud ];
+  };
+}

--- a/pkgs/development/python-modules/py-solc/default.nix
+++ b/pkgs/development/python-modules/py-solc/default.nix
@@ -16,7 +16,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ solc semantic-version ];
 
-  doCheck = true;
+  # checks are disabled because test suite seem to be broken:
+  # see here: https://github.com/ethereum/py-solc/issues/60
+  doCheck = false;
 
   meta = with lib; {
     description = "Python wrapper around the solc binary";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -584,9 +584,11 @@ in {
 
   PyWebDAV = callPackage ../development/python-modules/pywebdav { };
 
+  pyvoro = callPackage ../development/python-modules/pyvoro { };
+
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });
 
-  pyvoro = callPackage ../development/python-modules/pyvoro { };
+  py-solc = callPackage ../development/python-modules/py-solc { };
 
   relatorio = callPackage ../development/python-modules/relatorio { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

