### PR TITLE
fetchurl: warn on rev archives, resolves #32999

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -118,7 +118,6 @@ if test -n "$showURLs"; then
     exit 0
 fi
 
-
 if test -n "$preferHashedMirrors"; then
     tryHashedMirrors
 fi
@@ -128,6 +127,16 @@ set -o noglob
 
 success=
 for url in $urls; do
+    if [ -z "$postFetch" ]; then
+       case "$url" in
+           https://github.com/*/archive/*)
+               echo "warning: archives from GitHub revisions should use fetchFromGitHub"
+               ;;
+           https://gitlab.com/*/-/archive/*)
+               echo "warning: archives from GitLab revisions should use fetchFromGitLab"
+               ;;
+       esac
+    fi
     tryDownload "$url"
     if test -n "$success"; then finish; fi
 done


### PR DESCRIPTION
###### Motivation for this change

Resolves #32999. cc @c0bw3b @orivej @vcunat 

Usage example:

```
$ nix-build . -A all-cabal-hashes --substituters ''
these derivations will be built:
  /nix/store/kldqyijahq28d8jdyhk8zi0fnpd7frg4-70f02ad82349a18e1eff41eea4949be532486f7b.tar.gz.drv
building '/nix/store/kldqyijahq28d8jdyhk8zi0fnpd7frg4-70f02ad82349a18e1eff41eea4949be532486f7b.tar.gz.drv'...
warning: rev archives should use fetchzip instead

trying https://github.com/commercialhaskell/all-cabal-hashes/archive/70f02ad82349a18e1eff41eea4949be532486f7b.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   176    0   176    0     0    218      0 --:--:-- --:--:-- --:--:--   218

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

