### PR TITLE
generators: make toPretty handle floats correctly

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -143,6 +143,7 @@ rec {
   }@args: v: with builtins;
     let     isPath   = v: typeOf v == "path";
     in if   isInt      v then toString v
+    else if isFloat    v then "~${toString v}"
     else if isString   v then ''"${libStr.escape [''"''] v}"''
     else if true  ==   v then "true"
     else if false ==   v then "false"

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -369,6 +369,7 @@ runTests {
   testToPretty = {
     expr = mapAttrs (const (generators.toPretty {})) rec {
       int = 42;
+      float = 0.1337;
       bool = true;
       string = ''fno"rd'';
       path = /. + "/foo";
@@ -381,6 +382,7 @@ runTests {
     };
     expected = rec {
       int = "42";
+      float = "~0.133700";
       bool = "true";
       string = ''"fno\"rd"'';
       path = "/foo";


### PR DESCRIPTION
###### Motivation for this change

Tested via the `lib/tests/misc.nix` “test runner”.

Please consider backporting to 18.09 :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

