### PR TITLE
cryptodev-linux: update meta.homepage

### DIFF
--- a/pkgs/os-specific/linux/cryptodev/default.nix
+++ b/pkgs/os-specific/linux/cryptodev/default.nix
@@ -7,7 +7,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     urls = [
       "http://nwl.cc/pub/cryptodev-linux/${pname}.tar.gz"
-      "http://download.gna.org/cryptodev-linux/${pname}.tar.gz"
     ];
     sha256 = "0l3r8s71vkd0s2h01r7fhqnc3j8cqw4msibrdxvps9hfnd4hnk4z";
   };
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Device that allows access to Linux kernel cryptographic drivers";
-    homepage = http://home.gna.org/cryptodev-linux/;
+    homepage = http://cryptodev-linux.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
     broken = !stdenv.lib.versionOlder kernel.version "4.13";


### PR DESCRIPTION
###### Motivation for this change

New homepage and remove gna.org from `src` URLs since this forge has disappeared.
This is mostly cosmetic and the package is broken anyway for 4.14+

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

