### PR TITLE
 deepin-wallpapers: init at 1.7.5; deepin-desktop-schemas: init at 3.2.18.7

### DIFF
--- a/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, python, deepin-gtk-theme,
+deepin-icon-theme, deepin-sound-theme, deepin-wallpapers, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-desktop-schemas";
+  version = "3.2.18.7";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1siv28wbfjydr3s9k9i5b9fin39yr8ys90f3wi7b8rfm3cr5yy6j";
+  };
+
+  nativeBuildInputs = [
+    python
+  ];
+
+  buildInputs = [
+    gnome3.dconf
+    deepin-gtk-theme
+    deepin-icon-theme
+    deepin-sound-theme
+    deepin-wallpapers
+  ];
+
+  postPatch = ''
+    # fix default background url
+    sed -i '/picture-uri/s|/usr/share/backgrounds/default_background.jpg|$out/share/backgrounds/deepin/default.png|' \
+      overrides/common/com.deepin.wrap.gnome.desktop.override
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "GSettings deepin desktop-wide schemas";
+    homepage = https://github.com/linuxdeepin/deepin-desktop-schemas;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/deepin-wallpapers/default.nix
+++ b/pkgs/desktops/deepin/deepin-wallpapers/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, dde-api }:
+
+stdenv.mkDerivation rec {
+  name = "deepin-wallpapers-${version}";
+  version = "1.7.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "deepin-wallpapers";
+    rev = version;
+    sha256 = "0mfjkh81ci0gjwmgycrh32by7v9b73nyvyjbqd29ccpb8bpyyakn";
+  };
+
+  nativeBuildInputs = [ dde-api.bin ];
+
+  postPatch = ''
+    sed -i -e "s:/usr/lib/deepin-api:${dde-api.bin}/lib/deepin-api:" Makefile
+    sed -i -e "s:/usr/share/wallpapers:$out/share/wallpapers:" Makefile
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/wallpapers/deepin
+    cp -a deepin/* deepin-community/* deepin-private/* $out/share/wallpapers/deepin
+    mkdir -p $out/var/cache
+    cp -a image-blur $out/var/cache
+    
+    # Suggested by upstream
+    mkdir -p $out/share/backgrounds/deepin
+    ln -s ../../wallpapers/deepin/Hummingbird_by_Shu_Le.jpg $out/share/backgrounds/deepin/desktop.jpg
+    ln -s $(echo -n $out/share/wallpapers/deepin/Hummingbird_by_Shu_Le.jpg | md5sum | cut -d " " -f 1).jpg \
+      $out/var/cache/image-blur/$(echo -n $out/share/backgrounds/deepin/desktop.jpg | md5sum | cut -d " " -f 1).jpg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Wallpapers for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/deepin-wallpapers;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -7,6 +7,7 @@ let
     dde-api = callPackage ./dde-api { };
     dde-calendar = callPackage ./dde-calendar { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
+    deepin-desktop-schemas = callPackage ./deepin-desktop-schemas { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -19,6 +19,7 @@ let
       inherit (pkgs.gnome3) libgee vte;
       wnck = pkgs.libwnck3;
     };
+    deepin-wallpapers = callPackage ./deepin-wallpapers { };
     dtkcore = callPackage ./dtkcore { };
     dtkwm = callPackage ./dtkwm { };
     dtkwidget = callPackage ./dtkwidget { };


### PR DESCRIPTION
###### Motivation for this change

- Add [deepin-wallpapers](https://github.com/linuxdeepin/deepin-wallpapers)
- Add [deepin-desktop-schemas](https://github.com/linuxdeepin/deepin-desktop-schemas), 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).