### PR TITLE
weather-icons: init at 2.0.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3319,6 +3319,11 @@
     github = "pmyjavec";
     name = "Pauly Myjavec";
   };
+  pnelson = {
+    email = "me@pnelson.ca";
+    github = "pnelson";
+    name = "Philip Nelson";
+  };
   pneumaticat = {
     email = "kevin@potatofrom.space";
     github = "pneumaticat";

--- a/pkgs/data/fonts/weather-icons/default.nix
+++ b/pkgs/data/fonts/weather-icons/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "2.0.10";
+in fetchzip rec {
+  name = "weather-icons-${version}";
+
+  url = "https://github.com/erikflowers/weather-icons/archive/${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile weather-icons-${version}/_docs/font-source/weathericons-regular.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "10zny9987wybq55sm803hrjkp33dq1lgmnxc15kssr8yb81g6qrl";
+
+  meta = with stdenv.lib; {
+    description = "Weather Icons";
+    longDescription = ''
+      Weather Icons is the only icon font and CSS with 222 weather themed icons,
+      ready to be dropped right into Bootstrap, or any project that needs high
+      quality weather, maritime, and meteorological based icons!
+    '';
+    homepage = https://erikflowers.github.io/weather-icons/;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pnelson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15463,6 +15463,8 @@ with pkgs;
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };
 
+  weather-icons = callPackage ../data/fonts/weather-icons { };
+
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };
 
   wqy_microhei = callPackage ../data/fonts/wqy-microhei { };


### PR DESCRIPTION
###### Motivation for this change

Adds @erikflowers Weather Icons OTF font.

> Weather Icons is the only icon font and CSS with 222 weather themed icons, ready to be dropped right into Bootstrap, or any project that needs high quality weather, maritime, and meteorological based icons!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).