### PR TITLE
libaosd: init at 0.2.7-9-g177589f

### DIFF
--- a/pkgs/development/libraries/libaosd/default.nix
+++ b/pkgs/development/libraries/libaosd/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cairo, pango,
+  libX11, libXcomposite, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  version = "0.2.7-9-g177589f";
+  name = "libaosd-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "atheme-legacy";
+    repo   = "libaosd";
+    rev    = "${version}";
+    sha256 = "1cn7k0n74p6jp25kxwcyblhmbdvgw3mikvj0m2jh4c6xccfrgb9a";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkgconfig ];
+  buildInputs = [ cairo pango libX11 libXcomposite ];
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    longDescription = ''
+      libaosd is an advanced on screen display library.
+
+      It supports many modern features like anti-aliased text and
+      composited rendering via XComposite, as well as support for
+      rendering Cairo and Pango layouts.
+    '';
+    homepage = https://github.com/atheme-legacy/libaosd;
+    license = licenses.mit;
+    maintainers = with maintainers; [ unode ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10220,6 +10220,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreAudio CoreServices AudioUnit;
   };
 
+  libaosd = callPackage ../development/libraries/libaosd { };
+
   libabw = callPackage ../development/libraries/libabw { };
 
   libamqpcpp = callPackage ../development/libraries/libamqpcpp { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

