### PR TITLE
treewide: fix evaluation with `allowAliases = false`

### DIFF
--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -5,7 +5,7 @@
 , qtbase, qtmultimedia
 , libjson, libgpgerror
 , libX11, libxcb, libXau, libXdmcp, freetype, libbsd
-, pythonPackages, squashfsTools, desktop_file_utils
+, pythonPackages, squashfsTools, desktop-file-utils
 }:
 
 with stdenv.lib;
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  buildInputs = [ pythonPackages.binwalk squashfsTools desktop_file_utils ];
+  buildInputs = [ pythonPackages.binwalk squashfsTools desktop-file-utils ];
 
   # avoid usage of appimage's runner option --appimage-extract 
   unpackCmd = ''

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -540,7 +540,7 @@ self: super: builtins.intersectAttrs super {
           --prefix PATH : "${path}" \
           --set NIX_CC_WRAPPER_x86_64_unknown_linux_gnu_TARGET_HOST 1 \
           --set NIX_CFLAGS_COMPILE "-I${opencl-headers}/include" \
-          --set NIX_CFLAGS_LINK "-L${opencl-icd}/lib"
+          --set NIX_CFLAGS_LINK "-L${ocl-icd}/lib"
       '';
     });
 }


### PR DESCRIPTION
###### Motivation for this change

fix evaluation when using the configuration option `allowAliases = false`.