### PR TITLE
sil-fonts: added charis, doulos, and andika

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1377,6 +1377,11 @@
     github = "expipiplus1";
     name = "Joe Hermaszewski";
   };
+  f--t = {
+    email = "git@f-t.me";
+    github = "f--t";
+    name = "f--t";
+  };
   f-breidenstein = {
     email = "mail@felixbreidenstein.de";
     github = "f-breidenstein";

--- a/pkgs/data/fonts/andika/default.nix
+++ b/pkgs/data/fonts/andika/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchzip}:
+
+let
+  version = "5.000";
+in
+  fetchzip rec {
+    name = "andika-${version}";
+
+    url = "https://software.sil.org/downloads/r/andika/Andika-${version}.zip";
+
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+
+    sha256 = "1jy9vpcprpd1k48p20wh6jhyn909ibia8lr5i747p41l0s8a7lqy";
+
+    meta = with stdenv.lib; {
+      homepage = https://software.sil.org/andika;
+      description = "A family designed especially for literacy use taking into account the needs of beginning readers";
+      longDescription = ''
+      Andika is a sans serif, Unicode-compliant font designed especially for literacy use, taking into account the needs of beginning readers. The focus is on clear, easy-to-perceive letterforms that will not be readily confused with one another.
+
+      A sans serif font is preferred by some literacy personnel for teaching people to read. Its forms are simpler and less cluttered than those of most serif fonts. For years, literacy workers have had to make do with fonts that were not really suitable for beginning readers and writers. In some cases, literacy specialists have had to tediously assemble letters from a variety of fonts in order to get all of the characters they need for their particular language project, resulting in confusing and unattractive publications. Andika addresses those issues.
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.f--t ];
+    };
+  }

--- a/pkgs/data/fonts/charis-sil/default.nix
+++ b/pkgs/data/fonts/charis-sil/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchzip}:
+
+let
+  version = "5.000";
+in
+  fetchzip rec {
+    name = "charis-sil-${version}";
+
+    url = "https://software.sil.org/downloads/r/charis/CharisSIL-${version}.zip";
+
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+
+    sha256 = "1a220s8n0flvcdkazqf5g10v6r55s2an308slvvarynpj6l7x27n";
+
+    meta = with stdenv.lib; {
+      homepage = https://software.sil.org/charis;
+      description = "A family of highly readable fonts for broad multilingual use";
+      longDescription = ''
+      This Charis SIL font is essentially the same design as the SIL Charis font first released by SIL in 1997. Charis is similar to Bitstream Charter, one of the first fonts designed specifically for laser printers. It is highly readable and holds up well in less-than-ideal reproduction environments. It also has a full set of styles – regular, italic, bold, bold italic. Charis is a serif, proportionally-spaced font optimized for readability in long printed documents.
+
+      The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.f--t ];
+    };
+  }

--- a/pkgs/data/fonts/doulos-sil/default.nix
+++ b/pkgs/data/fonts/doulos-sil/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchzip}:
+
+let
+  version = "5.000";
+in
+  fetchzip rec {
+    name = "doulos-sil-${version}";
+
+    url = "https://software.sil.org/downloads/r/doulos/DoulosSIL-${version}.zip";
+
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+
+    sha256 = "04a9cr7jbw7d8llcj8xsqp9rp8w6gcgbd9sdwvi02kz7jhqa0vad";
+
+    meta = with stdenv.lib; {
+      homepage = https://software.sil.org/doulos;
+      description = "A font that provides complete support for the International Phonetic Alphabet";
+      longDescription = ''
+      This Doulos SIL font is essentially the same design as the SIL Doulos font first released by SIL in 1992. The design has been changed from the original in that it has been scaled down to be a better match with contemporary digital fonts, such as Times New Roman®. This current release is a regular typeface, with no bold or italic version available or planned. It is intended for use alongside other Times-like fonts where a range of styles (italic, bold) are not needed. Therefore, just one font is included in the Doulos SIL release: Doulos SIL Regular.
+
+      The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
+      '';
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.f--t ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14946,6 +14946,8 @@ with pkgs;
 
   andagii = callPackage ../data/fonts/andagii { };
 
+  andika = callPackage ../data/fonts/andika { };
+
   android-udev-rules = callPackage ../os-specific/linux/android-udev-rules { };
 
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
@@ -14977,6 +14979,8 @@ with pkgs;
   capitaine-cursors = callPackage ../data/icons/capitaine-cursors { };
 
   carlito = callPackage ../data/fonts/carlito {};
+
+  charis-sil = callPackage ../data/fonts/charis-sil { };
 
   comfortaa = callPackage ../data/fonts/comfortaa {};
 
@@ -15035,6 +15039,8 @@ with pkgs;
     docbook_xsl_ns;
 
   documentation-highlighter = callPackage ../misc/documentation-highlighter { };
+
+  doulos-sil = callPackage ../data/fonts/doulos-sil { };
 
   cabin = callPackage ../data/fonts/cabin { };
 


### PR DESCRIPTION
###### Motivation for this change

added popular some popular Latin fonts from the SIL project.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

