### PR TITLE
libbsd: fix build w/musl by adding missing include

### DIFF
--- a/pkgs/development/libraries/libbsd/default.nix
+++ b/pkgs/development/libraries/libbsd/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
   # the configure scripts
   nativeBuildInputs = [ autoreconfHook ];
 
-  patches = stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
+  patches = stdenv.lib.optional stdenv.isDarwin ./darwin.patch
+    # Suitable for all but limited to musl to avoid rebuild
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./musl.patch;
 
   meta = with stdenv.lib; {
     description = "Common functions found on BSD systems";

--- a/pkgs/development/libraries/libbsd/musl.patch
+++ b/pkgs/development/libraries/libbsd/musl.patch
@@ -1,0 +1,14 @@
+Source: maxice8
+Upstream: no
+Reason: fixes compilation
+
+--- a/src/flopen.c
++++ b/src/flopen.c
+@@ -34,6 +34,7 @@
+ #include <errno.h>
+ #include <stdarg.h>
+ #include <unistd.h>
++#include <fcntl.h>
+ 
+ #include <libutil.h>
+ 


### PR DESCRIPTION
Patch from void, with prefix added.

cc #48344


Recent update broke build w/musl,
but happily fixing it is the easy patch in this PR.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---