### PR TITLE
spectmorph: init at 0.4.1

### DIFF
--- a/pkgs/applications/audio/spectmorph/default.nix
+++ b/pkgs/applications/audio/spectmorph/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, libjack2, lv2, glib, qt5, libao, cairo, libsndfile, fftwFloat }:
+
+stdenv.mkDerivation rec {
+  name = "spectmorph-${version}";
+  version = "0.4.1";
+  src = fetchurl {
+    url = "http://spectmorph.org/files/releases/${name}.tar.bz2";
+    sha256 = "0z00yvv3jl8qsx6bz9msmg09mdnj5r5d4ws5bmnylwxk182whbrv";
+  };
+
+  buildInputs = [  libjack2 lv2 glib qt5.qtbase libao cairo libsndfile fftwFloat ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "Allows to analyze samples of musical instruments, and to combine them (morphing) to construct hybrid sounds";
+    homepage = http://spectmorph.org;
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ maintainers.magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17101,6 +17101,8 @@ with pkgs;
 
   singularity = callPackage ../applications/virtualization/singularity { };
 
+  spectmorph = callPackage ../applications/audio/spectmorph { };
+
   spectrwm = callPackage ../applications/window-managers/spectrwm { };
 
   spectral = qt5.callPackage ../applications/networking/instant-messengers/spectral { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

