### PR TITLE
cython: patch to fix w/3.7 from upstream

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -50,6 +50,13 @@ in buildPythonPackage rec {
 
   doCheck = !stdenv.isDarwin;
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/cython/cython/commit/eae37760bfbe19e7469aa41269480b84ce12b6cd.patch";
+      sha256 = "0irk53psrs05kzzlvbfv7s3q02x5lsnk5qrv0zd1ra3mw2sfyym6";
+    })
+  ];
+
   meta = {
     description = "An optimising static compiler for both the Python programming language and the extended Cython programming language";
     homepage = http://cython.org;


### PR DESCRIPTION
Upstream fix so tests pass w/python 3.7!

https://github.com/cython/cython/issues/2454


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---