### PR TITLE
libwacom: 0.29 -> 0.31

### DIFF
--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libwacom-${version}";
-  version = "0.29";
+  version = "0.31";
 
   src = fetchurl {
-    url = "mirror://sourceforge/linuxwacom/libwacom/${name}.tar.bz2";
-    sha256 = "1diklgcjhmvcxi9p1ifp6wcnyr6k7z9jhrlzfhzjqd6zipk01slw";
+    url = "https://github.com/linuxwacom/libwacom/releases/download/${name}/${name}.tar.bz2";
+    sha256 = "00xzkxhm0s9bvhbf27hscjbh17wa8lcgvxjqbmzm527f9cjqrm8q";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libwacom/default.nix
+++ b/pkgs/development/libraries/libwacom/default.nix
@@ -1,15 +1,17 @@
-{ fetchurl, stdenv, glib, pkgconfig, udev, libgudev }:
+{ stdenv, fetchFromGitHub, autoreconfHook, glib, pkgconfig, udev, libgudev }:
 
 stdenv.mkDerivation rec {
   name = "libwacom-${version}";
   version = "0.31";
 
-  src = fetchurl {
-    url = "https://github.com/linuxwacom/libwacom/releases/download/${name}/${name}.tar.bz2";
-    sha256 = "00xzkxhm0s9bvhbf27hscjbh17wa8lcgvxjqbmzm527f9cjqrm8q";
+  src = fetchFromGitHub {
+    owner = "linuxwacom";
+    repo = "libwacom";
+    rev = "libwacom-${version}";
+    sha256 = "0qjd4bn2abwzic34cm0sw3srx02spszbsvfdbzbpn2cb62b5gjmw";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ glib udev libgudev ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Upgrade libwacom. Also, changed the mirror from SourceForge to GitHub. (As requested in #48209)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
This uses `fetchurl` and takes the release package (`.tar.bz2`), as the release-commit differs slightly:
```
Only in release: aclocal.m4
Only in source: autogen.sh
Only in release: compile
Only in release: config.guess
Only in release: config.h.in
Only in release: config.sub
Only in release: configure
Only in release/data/layouts: Makefile.in
Only in release/data: Makefile.in
Only in release: depcomp
Only in release/doc: html
Only in release/doc: Makefile.in
Only in source: .gitignore
Only in release: install-sh
Only in release/libwacom: Makefile.in
Only in release: ltmain.sh
Only in release: Makefile.in
Only in release: missing
Only in release/test: Makefile.in
Only in release: test-driver
Only in source/tools: clean_svg.py
Only in release/tools: Makefile.in
Only in source: .travis.yml
```

I'm guessing most of these files could be generated by using the `autoreconfHook`. Is it better to take the release tarball or try using the source with `fetchGitHub`?