### PR TITLE
eclipse: add Eclipse IDE for Java Developers 4.7 and 4.8

### DIFF
--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -229,27 +229,12 @@ rec {
   eclipse_sdk_37 = eclipse-sdk-37; # backward compatibility, added 2016-01-30
   
   ### Eclipse Java
+
+  eclipse-java = eclipse-java-49;
   
-  eclipse-java-47 = buildEclipse {
-    name = "eclipse-java-4.7.0";
-    description = "Eclipse IDE for Java Developers, Oxygen release";
-    src =
-      if stdenv.system == "x86_64-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/oxygen/3a/eclipse-java-oxygen-3a-linux-gtk-x86_64.tar.gz;
-          sha512 = "6333edb4556667d9606fc045032bafd8c54c21c056e03fd7e9fdb942d8da5cd183976ddbaff2383b5fe6d0da4f34a1caf5bfb9343f14e9069049c5b680895a21";
-        }
-      else if stdenv.system == "i686-linux" then
-        fetchurl {
-          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/oxygen/3a/eclipse-java-oxygen-3a-linux-gtk.tar.gz;
-          sha512 = "aec907057873671809dccad5d520fdcc3a5685a8607a57f413972bbd68f95614a2ea3787005b3d05162440690dab44a755fdcdd02b027a4d9d36b3f499e34a10";
-        }
-      else throw "Unsupported system: ${stdenv.system}";
-  };
-  
-  eclipse-java-48 = buildEclipse {
-    name = "eclipse-java-4.8.0";
-    description = "Eclipse IDE for Java Developers, Oxygen release";
+  eclipse-java-49 = buildEclipse {
+    name = "eclipse-java-4.9.0";
+    description = "Eclipse IDE for Java Developers";
     src =
       if stdenv.system == "x86_64-linux" then
         fetchurl {

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -227,6 +227,42 @@ rec {
     };
   };
   eclipse_sdk_37 = eclipse-sdk-37; # backward compatibility, added 2016-01-30
+  
+  ### Eclipse Java
+  
+  eclipse-java-47 = buildEclipse {
+    name = "eclipse-java-4.7.0";
+    description = "Eclipse IDE for Java Developers, Oxygen release";
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/oxygen/3a/eclipse-java-oxygen-3a-linux-gtk-x86_64.tar.gz;
+          sha512 = "6333edb4556667d9606fc045032bafd8c54c21c056e03fd7e9fdb942d8da5cd183976ddbaff2383b5fe6d0da4f34a1caf5bfb9343f14e9069049c5b680895a21";
+        }
+      else if stdenv.system == "i686-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/oxygen/3a/eclipse-java-oxygen-3a-linux-gtk.tar.gz;
+          sha512 = "aec907057873671809dccad5d520fdcc3a5685a8607a57f413972bbd68f95614a2ea3787005b3d05162440690dab44a755fdcdd02b027a4d9d36b3f499e34a10";
+        }
+      else throw "Unsupported system: ${stdenv.system}";
+  };
+  
+  eclipse-java-48 = buildEclipse {
+    name = "eclipse-java-4.8.0";
+    description = "Eclipse IDE for Java Developers, Oxygen release";
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/2018-09/R/eclipse-java-2018-09-linux-gtk-x86_64.tar.gz;
+          sha512 = "9dac5d040cdabf779de3996de87290e352130c7e860c1d0a98772f41da828ad45f90748b68e0a8a4f8d1ebbbbe5fdfe6401b7d871b93af34103d4a81a041c6a5";
+        }
+      else if stdenv.system == "i686-linux" then
+        fetchurl {
+          url = http://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/2018-09/R/eclipse-java-2018-09-linux-gtk.tar.gz;
+          sha512 = "24208e95b972e848d6b65ed8108d9e81584cf051397f2f43fb6269f5a625b8d7552ad77c7980a1a5653c87f06776e2926fd85607aae44e44657b4f6cc9b3e2e3";
+        }
+      else throw "Unsupported system: ${stdenv.system}";
+  };
 
   ### Environments
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

