### PR TITLE
clisp: Mark as broken for aarch64

### DIFF
--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -96,7 +96,8 @@ stdenv.mkDerivation rec {
     description = "ANSI Common Lisp Implementation";
     homepage = http://clisp.cons.org;
     maintainers = with stdenv.lib.maintainers; [raskin tohl];
+    platforms = stdenv.lib.platforms.unix;
     # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
-    platforms = stdenv.lib.platforms.linux;
+    broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Has never built successfully on aarch64 and after looking into it for a bit I can't find the reason

[Hydra job](https://hydra.nixos.org/job/nixpkgs/trunk/clisp.aarch64-linux)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

