### PR TITLE
tribler: Fix startup

### DIFF
--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, makeWrapper, libtorrentRasterbar, imagemagick
+{ stdenv, fetchurl, pythonPackages, makeWrapper, imagemagick
 , enablePlayer ? true, vlc ? null, qt5 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   pythonPath = [
-    libtorrentRasterbar
+    pythonPackages.libtorrentRasterbar
     pythonPackages.apsw
     pythonPackages.twisted
     pythonPackages.netifaces


### PR DESCRIPTION
The python component of libtorrentRasterbar seems to now be in pythonPackages

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

