### PR TITLE
gotop: 1.2.9 -> 1.5.0

### DIFF
--- a/pkgs/tools/system/gotop/default.nix
+++ b/pkgs/tools/system/gotop/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "gotop-${version}";
-  version = "1.2.9";
+  version = "1.5.0";
 
   goPackagePath = "github.com/cjbassi/gotop";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     repo = "gotop";
     owner = "cjbassi";
     rev = version;
-    sha256 = "07s2f04yhc79vqr1gdh2v974kpn7flp4slnp99mavpa331lv9q8a";
+    sha256 = "19kj7mziwkfcf9kkwph05jh5vlkfqpyrpxdk5gdf2swg07w1ld35";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

