### PR TITLE
pythonPackages.gidgethub: init at 2.5.0

### DIFF
--- a/pkgs/development/python-modules/gidgethub/default.nix
+++ b/pkgs/development/python-modules/gidgethub/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools
+, pytestrunner
+, pytest
+, pytest-asyncio
+, twisted
+, treq
+, tornado
+, aiohttp
+, uritemplate
+}:
+
+buildPythonPackage rec {
+  pname = "gidgethub";
+  version = "2.5.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d37fdfd149bc0efa21d3899c737d9b5c7ff6348a9b3f03bf3aa0e9f8ca345483";
+  };
+
+  buildInputs = [ setuptools pytestrunner ];
+  checkInputs = [ pytest pytest-asyncio twisted treq tornado aiohttp ];
+  propagatedBuildInputs = [ uritemplate ];
+
+  # requires network (reqests github.com)
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "An async GitHub API library";
+    homepage = https://github.com/brettcannon/gidgethub;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -338,6 +338,8 @@ in {
 
   genanki = callPackage ../development/python-modules/genanki { };
 
+  gidgethub = callPackage ../development/python-modules/gidgethub { };
+
   globus-sdk = callPackage ../development/python-modules/globus-sdk { };
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };
@@ -559,7 +561,7 @@ in {
     slurm = pkgs.slurm;
   };
 
-  pystache = callPackage ../development/python-modules/pystache { }; 
+  pystache = callPackage ../development/python-modules/pystache { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 


### PR DESCRIPTION
###### Things done

pythonPackages.gidgethub: init at 2.5.0 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

