### PR TITLE
matcha: 2018-09-14 -> 2018-10-12

### DIFF
--- a/pkgs/misc/themes/matcha/default.nix
+++ b/pkgs/misc/themes/matcha/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "matcha-${version}";
-  version = "2018-09-14";
+  version = "2018-10-12";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "matcha";
-    rev = "fe35259742b5ae007ab17d46d21acad5754477b9";
-    sha256 = "1qwb8l1xfx9ca2y9gcsckxikijz1ij28dirvpqvhbbyn1m8i9hwd";
+    rev = "c1c91db44d9e28cc71af019784a77175a60a7b9d";
+    sha256 = "0sr805ghgh8sr9nncs693b9p756nmi1l4d8mfywj6z219jhy77qv";
   };
 
   buildInputs = [ gdk_pixbuf librsvg ];


### PR DESCRIPTION
###### Motivation for this change

Update to version 2018-10-12.

_News_:
- Fixed xfce4 gtk3 issues
- Fixed nautilus 3.30 issues

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).