### PR TITLE
fmt: init at 5.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1882,6 +1882,11 @@
     github = "jdagilliland";
     name = "Jason Gilliland";
   };
+  jdehaas = {
+    email = "qqlq@nullptr.club";
+    github = "jeroendehaas";
+    name = "Jeroen de Haas";
+  };
   jefdaj = {
     email = "jefdaj@gmail.com";
     github = "jefdaj";

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, enableShared ? true }:
+
+stdenv.mkDerivation rec {
+  version = "5.2.1";
+  name = "fmt-${version}";
+  src = fetchFromGitHub {
+    owner = "fmtlib";
+    repo = "fmt";
+    rev = "${version}";
+    sha256 = "1cd8yq8va457iir1hlf17ksx11fx2hlb8i4jml8gj1875pizm0pk";
+  };
+  nativeBuildInputs = [ cmake ];
+  doCheck = true;
+  # preCheckHook ensures the test binaries can find libfmt.so.5
+  preCheck = if enableShared
+             then "export LD_LIBRARY_PATH=\"$PWD\""
+             else "";
+  cmakeFlags = [ "-DFMT_TEST=yes"
+                 "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}" ];
+  meta = with stdenv.lib; {
+    homepage = http://fmtlib.net/;
+    description = "Small, safe and fast formatting library";
+    longDescription = ''
+      fmt (formerly cppformat) is an open-source formatting library. It can be
+      used as a fast and safe alternative to printf and IOStreams.
+    '';
+    maintainers = [ maintainers.jdehaas ];
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9487,6 +9487,8 @@ with pkgs;
 
   flyway = callPackage ../development/tools/flyway { };
 
+  fmt = callPackage ../development/libraries/fmt/default.nix { };
+
   fplll = callPackage ../development/libraries/fplll {};
   fplll_20160331 = callPackage ../development/libraries/fplll/20160331.nix {};
 


### PR DESCRIPTION
This commit adds fmt, a C++ formatting library.

###### Motivation for this change
fmt is an actively developed C++ formatting library. This derivation provides a shared library by default, but can be overridden to produce a static version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

