### PR TITLE
pythonPackages.nvchecker: init at 1.1

### DIFF
--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pytest, setuptools, structlog, pytest-asyncio, pytest_xdist, flaky, tornado }:
+
+buildPythonPackage rec {
+  pname = "nvchecker";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nk9ff26s5r6v5v7w4l9110qi5kmhllvwk5kh20zyyhdvxv72m3i";
+  };
+
+  # tornado is not present in the tarball setup.py but is required by the executable
+  propagatedBuildInputs = [ setuptools structlog tornado ];
+  checkInputs = [ pytest pytest-asyncio pytest_xdist flaky ];
+
+  # Disable tests for now, because our version of pytest seems to be too new
+  # https://github.com/lilydjwg/nvchecker/commit/42a02efec84824a073601e1c2de30339d251e4c7
+  doCheck = false;
+
+  checkPhase = ''
+    py.test
+  '';
+
+  disabled = pythonOlder "3.5";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/lilydjwg/nvchecker;
+    description = "New version checker for software";
+    license = licenses.mit;
+    maintainers = with maintainers; [ marsam ];
+  };
+}

--- a/pkgs/development/python-modules/structlog/default.nix
+++ b/pkgs/development/python-modules/structlog/default.nix
@@ -6,6 +6,7 @@
 , pretend
 , freezegun
 , simplejson
+, six
 }:
 
 buildPythonPackage rec {
@@ -25,8 +26,8 @@ buildPythonPackage rec {
     })
   ];
 
-  checkInputs = [ pytest pretend freezegun ];
-  propagatedBuildInputs = [ simplejson ];
+  checkInputs = [ pytest pretend freezegun simplejson ];
+  propagatedBuildInputs = [ six ];
 
   checkPhase = ''
     rm tests/test_twisted.py*

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -418,6 +418,8 @@ in {
 
   ntlm-auth = callPackage ../development/python-modules/ntlm-auth { };
 
+  nvchecker = callPackage ../development/python-modules/nvchecker { };
+
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };
 
   ordered-set = callPackage ../development/python-modules/ordered-set { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

