### PR TITLE
nixos/nixos-install: Unset system

### DIFF
--- a/nixos/modules/installer/tools/nixos-install.sh
+++ b/nixos/modules/installer/tools/nixos-install.sh
@@ -13,6 +13,7 @@ extraBuildFlags=()
 
 mountPoint=/mnt
 channelPath=
+system=
 
 while [ "$#" -gt 0 ]; do
     i="$1"; shift 1


### PR DESCRIPTION
The system variable is used from the (possibly polluted) shell
environment.
This causes nixos-install to fail in a nix-shell because the system
shell variable is automatically set to the current system (e.g.
x86_64-linux).

###### Motivation for this change

I was unable to install NixOS from a nix shell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

