### PR TITLE
libusb-compat: 0.1.5 -> 0.1.7 && change libusb source to GitHub

### DIFF
--- a/pkgs/development/libraries/libusb/default.nix
+++ b/pkgs/development/libraries/libusb/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, libusb1}:
+{stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1}:
 
 stdenv.mkDerivation rec {
   name = "libusb-compat-${version}";
@@ -7,12 +7,14 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ]; # get rid of propagating systemd closure
   outputBin = "dev";
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   propagatedBuildInputs = [ libusb1 ];
 
-  src = fetchurl {
-    url = "https://github.com/libusb/libusb-compat-0.1/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "1y2wjba4w9r53sfaacj6awyqhmi31n53j4wwx8g8qj82m8wcwy86";
+  src = fetchFromGitHub {
+    owner = "libusb";
+    repo = "libusb-compat-0.1";
+    rev = "v${version}";
+    sha256 = "1nybccgjs14b3phhaycq2jx1gym4nf6sghvnv9qdfmlqxacx0jz5";
   };
 
   patches = stdenv.lib.optional stdenv.hostPlatform.isMusl ./fix-headers.patch;

--- a/pkgs/development/libraries/libusb/default.nix
+++ b/pkgs/development/libraries/libusb/default.nix
@@ -1,7 +1,8 @@
 {stdenv, fetchurl, pkgconfig, libusb1}:
 
-stdenv.mkDerivation {
-  name = "libusb-compat-0.1.5";
+stdenv.mkDerivation rec {
+  name = "libusb-compat-${version}";
+  version = "0.1.7";
 
   outputs = [ "out" "dev" ]; # get rid of propagating systemd closure
   outputBin = "dev";
@@ -10,8 +11,8 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ libusb1 ];
 
   src = fetchurl {
-    url = mirror://sourceforge/libusb/libusb-compat-0.1.5.tar.bz2;
-    sha256 = "0nn5icrfm9lkhzw1xjvaks9bq3w6mjg86ggv3fn7kgi4nfvg8kj0";
+    url = "https://github.com/libusb/libusb-compat-0.1/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "1y2wjba4w9r53sfaacj6awyqhmi31n53j4wwx8g8qj82m8wcwy86";
   };
 
   patches = stdenv.lib.optional stdenv.hostPlatform.isMusl ./fix-headers.patch;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).