### PR TITLE
nixos/security/misc: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -149,6 +149,7 @@
   ./security/duosec.nix
   ./security/hidepid.nix
   ./security/lock-kernel-modules.nix
+  ./security/misc.nix
   ./security/oath.nix
   ./security/pam.nix
   ./security/pam_usb.nix

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -12,6 +12,8 @@ with lib;
 
   security.lockKernelModules = mkDefault true;
 
+  security.allowUserNamespaces = mkDefault false;
+
   security.apparmor.enable = mkDefault true;
 
   boot.kernelParams = [
@@ -54,18 +56,6 @@ with lib;
 
   # ... or at least apply some hardening to it
   boot.kernel.sysctl."net.core.bpf_jit_harden" = mkDefault true;
-
-  # A recurring problem with user namespaces is that there are
-  # still code paths where the kernel's permission checking logic
-  # fails to account for namespacing, instead permitting a
-  # namespaced process to act outside the namespace with the
-  # same privileges as it would have inside it.  This is particularly
-  # bad in the common case of running as root within the namespace.
-  #
-  # Setting the number of allowed user namespaces to 0 effectively disables
-  # the feature at runtime.  Attempting to create a user namespace
-  # with unshare will then fail with "no space left on device".
-  boot.kernel.sysctl."user.max_user_namespaces" = mkDefault 0;
 
   # Raise ASLR entropy for 64bit & 32bit, respectively.
   #

--- a/nixos/modules/security/misc.nix
+++ b/nixos/modules/security/misc.nix
@@ -1,0 +1,39 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  meta = {
+    maintainers = [ maintainers.joachifm ];
+  };
+
+  options = {
+    security.allowUserNamespaces = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to allow creation of user namespaces.  A recurring problem
+        with user namespaces is the presence of code paths where the kernel's
+        permission checking logic fails to account for namespacing, instead
+        permitting a namespaced process to act outside the namespace with the
+        same privileges as it would have inside it.  This is particularly
+        damaging in the common case of running as root within the namespace.
+        When user namespace creation is disallowed, attempting to create
+        a user namespace fails with "no space left on device" (ENOSPC).
+      '';
+    };
+  };
+
+  config = mkIf (!config.security.allowUserNamespaces) {
+    # Setting the number of allowed user namespaces to 0 effectively disables
+    # the feature at runtime.  Note that root may raise the limit again
+    # at any time.
+    boot.kernel.sysctl."user.max_user_namespaces" = 0;
+
+    assertions = [
+      { assertion = config.nix.useSandbox -> config.security.allowUserNamespaces;
+        message = "`nix.useSandbox = true` conflicts with `!security.allowUserNamespaces`.";
+      }
+    ];
+  };
+}


### PR DESCRIPTION
A module for security options that are too small to warrant their own module.


###### Motivation for this change

The impetus for adding this module is to make it more convenient to override
the behavior of the hardened profile wrt user namespaces.
Without a dedicated option for user namespaces, the user needs to
1) know which sysctl knob controls userns
2) know how large a value the sysctl knob needs to allow e.g.,
   Nix sandbox builds to work
Because Nix sandbox support is a likely incompatibility for hardened profile
users, it makes sense to create a dedicated option.

Supercedes https://github.com/NixOS/nixpkgs/pull/48207, resolving the
immediate issue addressed by that PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

