### PR TITLE
wasm: add as temporary alias to proglodyte-wasm

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -318,6 +318,14 @@ mapAliases ({
   xlibs = xorg; # added 2015-09
   youtubeDL = youtube-dl;  # added 2014-10-26
 
+  # added 2018-10-16
+  # TODO(ekleog): remove after 19.03 branch-off
+  # TODO(ekleog): add ‘wasm’ alias to ‘ocamlPackages.wasm’ after 19.09
+  # branch-off
+  wasm = lib.warn
+    "‘wasm’ package has been renamed ‘proglodyte-wasm’, and will be dropped in the next release"
+    proglodyte-wasm;
+
   # added 2017-05-27
   wineMinimal = winePackages.minimal;
   wineFull = winePackages.full;


### PR DESCRIPTION
###### Motivation for this change

Completion of https://github.com/NixOS/nixpkgs/pull/44962, esp. https://github.com/NixOS/nixpkgs/pull/44962#issuecomment-429619042

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

