### PR TITLE
dolphin-emu: fix metadata (GPLv2 -> GPLv2+, http -> https)

### DIFF
--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -37,9 +37,9 @@ stdenv.mkDerivation rec {
                   wxGTK30 soundtouch miniupnpc mbedtls curl lzo sfml ];
 
   meta = {
-    homepage = http://dolphin-emu.org/;
-    description = "Gamecube/Wii/Triforce emulator for x86_64 and ARM";
-    license = stdenv.lib.licenses.gpl2;
+    homepage = https://dolphin-emu.org/;
+    description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
+    license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ MP2E ];
     # x86_32 is an unsupported platform.
     # Enable generic build if you really want a JIT-less binary.

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -71,9 +71,9 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://dolphin-emu.org";
-    description = "Gamecube/Wii/Triforce emulator for x86_64 and ARM";
-    license = licenses.gpl2;
+    homepage = "https://dolphin-emu.org";
+    description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ MP2E ];
     branch = "master";
     # x86_32 is an unsupported platform.


### PR DESCRIPTION
###### Motivation for this change
Dolphin has been GPLv2+ since 2015. See https://dolphin-emu.org/blog/2015/05/25/relicensing-dolphin/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

