### PR TITLE
ghc: enable parallel building of GHC on aarch64.

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -88,8 +88,7 @@ stdenv.mkDerivation (rec {
     sha256 = "1z05vkpaj54xdypmaml50hgsdpw29dhbs2r7magx0cm199iw73mv";
   };
 
-  # https://ghc.haskell.org/trac/ghc/ticket/15449
-  enableParallelBuilding = !buildPlatform.isAarch64;
+  enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -90,8 +90,7 @@ stdenv.mkDerivation (rec {
     sha256 = "1mk046vb561j75saz05rghhbkps46ym5aci4264dwc2qk3dayixf";
   };
 
-  # https://ghc.haskell.org/trac/ghc/ticket/15449
-  enableParallelBuilding = !buildPlatform.isAarch64;
+  enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -86,8 +86,7 @@ stdenv.mkDerivation (rec {
     sha256 = "0dkh7idgrqr567fq94a0f5x3w0r4cm2ydn51nb5wfisw3rnw499c";
   };
 
-  # https://ghc.haskell.org/trac/ghc/ticket/15449
-  enableParallelBuilding = !buildPlatform.isAarch64;
+  enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
 


### PR DESCRIPTION
Note: this only affects GHC, not haskellPackages, which still suffers
from https://ghc.haskell.org/trac/ghc/ticket/15449.

###### Motivation for this change

@ElvishJerricco pointed out on #47901 that GHC's own build system (mostly) doesn't use `-j`. (This is not quite true as it does seem to use it for building some phases, but my test build made it through successfully, anyway, so perhaps these phases don't trigger the GHC bug mentioned above in the Trac issue.)

Therefore, we can re-enable parallel builds of GHC on `aarch64` and produce a working `ghc843` in just a few hours on the Packet.net hardware. This will allow Hydra to start compiling `haskellPackages` and we can deal with `aarch64` porting issues as they arise. In attempting to build my own Haskell packages with this compiler, many important packages (e.g., `lens`) build just fine, but `tls`'s tests are currently broken on this arch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

