### PR TITLE
nixos/ssh: expose StreamLocalBindUnlink sshd config option

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -110,6 +110,15 @@ in
         '';
       };
 
+      streamLocalBindUnlink = mkOption {
+        type = types.enum ["yes" "no"];
+        default = "no";
+        description = ''
+          Whether to remove an existing Unix-domain socket before creating a
+          new one. Only relevant when port-forwarding to a UNIX domain socket.
+        '';
+      };
+
       permitRootLogin = mkOption {
         default = "prohibit-password";
         type = types.enum ["yes" "without-password" "prohibit-password" "forced-commands-only" "no"];
@@ -445,6 +454,8 @@ in
         '' else ''
           X11Forwarding no
         ''}
+
+        StreamLocalBindUnlink ${cfg.streamLocalBindUnlink}
 
         ${optionalString cfg.allowSFTP ''
           Subsystem sftp ${cfgc.package}/libexec/sftp-server ${concatStringsSep " " cfg.sftpFlags}


### PR DESCRIPTION
###### Motivation for this change

This option is needed on the server side for forwarding GnuPG agent connections over ssh to behave properly. With the option in question set, the directions given in https://wiki.gnupg.org/AgentForwarding work properly when connecting from a SSH client (with a hardware keystore accessible to the local agent) to a NixOS-based server (performing operations which requires those keys).

While this could otherwise be manually enabled by users using `config.services.openssh.extraConfig`, having high-utility functionality that depends on this flag being set to a non-default value argues in favor of exposing it directly.

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested via `nixos-rebuild build-vm`, and validating `ssh -T` within that guest.
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] *N/A* Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] *N/A* Tested execution of all binary files (usually in `./result/bin/`)
- [ ] *N/A* Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

