### PR TITLE
staruml: fix download URL

### DIFF
--- a/pkgs/tools/misc/staruml/default.nix
+++ b/pkgs/tools/misc/staruml/default.nix
@@ -14,10 +14,10 @@ stdenv.mkDerivation rec {
 
   src =
     if stdenv.hostPlatform.system == "i686-linux" then fetchurl {
-      url = "http://staruml.io/download/release/v${version}/StarUML-v${version}-32-bit.deb";
+      url = "https://s3.amazonaws.com/staruml-bucket/releases-v2/StarUML-v${version}-32-bit.deb";
       sha256 = "0vb3k9m3l6pmsid4shlk0xdjsriq3gxzm8q7l04didsppg0vvq1n";
     } else fetchurl {
-      url = "http://staruml.io/download/release/v${version}/StarUML-v${version}-64-bit.deb";
+      url = "https://s3.amazonaws.com/staruml-bucket/releases-v2/StarUML-v${version}-64-bit.deb";
       sha256 = "05gzrnlssjkhyh0wv019d4r7p40lxnsa1sghazll6f233yrqmxb0";
     };
 


### PR DESCRIPTION
###### Motivation for this change
The download URL `http://staruml.io/download/release/v${version}/StarUML-v${version}-64-bit.deb` for StarUML 2.8.1 does not work anymore.

###### Things done

I updated the URL to what can be found on [staruml.io](http://staruml.io/download) website in the download section.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

