### PR TITLE
rapid-photo-downloader: 0.9.10 -> 0.9.12

### DIFF
--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -6,11 +6,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "rapid-photo-downloader";
-  version = "0.9.10";
+  version = "0.9.12";
 
   src = fetchurl {
     url = "https://launchpad.net/rapid/pyqt/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "1i0lfj9gnfya49gxx59ls364z651fqagd4krnz9jhg9m0l48ljdf";
+    sha256 = "0nzahps7hs120xv2r55k293kialf83nx44x3jg85yh349rpqrii8";
   };
 
   # Disable version check and fix install tests

--- a/pkgs/development/python-modules/pymediainfo/default.nix
+++ b/pkgs/development/python-modules/pymediainfo/default.nix
@@ -22,6 +22,11 @@ buildPythonPackage rec {
                 'CDLL("${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}")' \
       --replace 'CDLL("libmediainfo.so.0")' \
                 'CDLL("${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}.0")'
+
+    # Fix test, remove after version 2.3.0
+    substituteInPlace tests/test_pymediainfo.py \
+      --replace 'codec, "AVC"'    'format, "AVC"' \
+      --replace 'codec, "AAC LC"' 'format, "AAC"'
   '';
 
   nativeBuildInputs = [ setuptools_scm ];


### PR DESCRIPTION
###### Motivation for this change

Update and fix dependency pymediainfo as mentioned in #36621.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @orivej
