### PR TITLE
deepin-wm: init at 1.9.32

### DIFF
--- a/pkgs/desktops/deepin/deepin-wm/default.nix
+++ b/pkgs/desktops/deepin/deepin-wm/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub, pkgconfig, intltool, libtool, vala, gnome3,
+  bamf, clutter-gtk, granite, libcanberra-gtk3, libwnck3,
+  deepin-mutter, deepin-wallpapers, deepin-desktop-schemas,
+  hicolor-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-wm";
+  version = "1.9.32";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "02vwbkfpxcwv01vqa70pg7dm0lhm1lwhdqhk057r147a9cjb3ssc";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libtool
+    gnome3.gnome-common
+    vala
+  ];
+
+  buildInputs = [
+    gnome3.gnome-desktop
+    gnome3.libgee
+    bamf
+    clutter-gtk
+    granite
+    libcanberra-gtk3
+    libwnck3
+    deepin-mutter
+    deepin-wallpapers
+    deepin-desktop-schemas
+    hicolor-icon-theme
+  ];
+
+  postPatch = ''
+    sed -i src/Background/BackgroundSource.vala \
+      -e 's;/usr/share/backgrounds/default_background.jpg;${deepin-wallpapers}/share/backgrounds/deepin/desktop.jpg;'
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Deepin Window Manager";
+    homepage = https://github.com/linuxdeepin/deepin-wm;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -21,6 +21,7 @@ let
       wnck = pkgs.libwnck3;
     };
     deepin-wallpapers = callPackage ./deepin-wallpapers { };
+    deepin-wm = callPackage ./deepin-wm { };
     dtkcore = callPackage ./dtkcore { };
     dtkwm = callPackage ./dtkwm { };
     dtkwidget = callPackage ./dtkwidget { };


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-wm](https://github.com/linuxdeepin/deepin-wm), the default window manager for Deepin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).