### PR TITLE
szip: fix url (previous ftp is now private)

### DIFF
--- a/pkgs/development/libraries/szip/default.nix
+++ b/pkgs/development/libraries/szip/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   name = "szip-${version}";
   version = "2.1.1";
   src = fetchurl {
-    url = "ftp://ftp.hdfgroup.org/lib-external/szip/${version}/src/szip-${version}.tar.gz";
-    sha256 = "1a8415a7xifagb22aq9dmy7b2s5l0y6diany3b4qigylw6adlzc9";
+    url = "https://support.hdfgroup.org/ftp/lib-external/szip/${version}/src/szip-${version}.tar.gz";
+    sha256 = "04nlhkzzf1gihvrfbzc6rq4kc13p92ly39dzrb4y4jrd9y5rbvi1";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Fix the source url for the szip package. The previous ftp url has become private.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

