### PR TITLE
release-notes/18-09: add licenses marked as unfree

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -477,6 +477,48 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
   <itemizedlist>
    <listitem>
     <para>
+     Some licenses that were incorrectly not marked as unfree now are. This is
+     the case for:
+     <itemizedlist>
+      <listitem>
+       <para>
+        cc-by-nc-sa-20: Creative Commons Attribution Non Commercial Share Alike
+        2.0
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        cc-by-nc-sa-25: Creative Commons Attribution Non Commercial Share Alike
+        2.5
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        cc-by-nc-sa-30: Creative Commons Attribution Non Commercial Share Alike
+        3.0
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        cc-by-nc-sa-40: Creative Commons Attribution Non Commercial Share Alike
+        4.0
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        cc-by-nd-30: Creative Commons Attribution-No Derivative Works v3.00
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        msrla: Microsoft Research License Agreement
+       </para>
+      </listitem>
+     </itemizedlist>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The deprecated <varname>services.cassandra</varname> module has seen a
      complete rewrite. (See above.)
     </para>


### PR DESCRIPTION
(cherry picked from commit 2a2c99673bca1d30d53c530787a10a7d1c5b1de6)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

