### PR TITLE
postgresql-jdbc: 42.2.2 -> 42.2.5

### DIFF
--- a/pkgs/servers/sql/postgresql/jdbc/default.nix
+++ b/pkgs/servers/sql/postgresql/jdbc/default.nix
@@ -2,25 +2,25 @@
 
 stdenv.mkDerivation rec {
   name = "postgresql-jdbc-${version}";
-  version = "42.2.2";
+  version = "42.2.5";
 
   src = fetchMavenArtifact {
     artifactId = "postgresql";
     groupId = "org.postgresql";
-    sha256 = "0w7sfi1gmzqhyhr4iq9znv8hff41xwwqcblkyd9ph0m34r0555hr";
+    sha256 = "1p0cbb7ka41xxipzjy81hmcndkqynav22xyipkg7qdqrqvw4dykz";
     inherit version;
   };
 
   phases = [ "installPhase" ];
 
   installPhase = ''
-    install -D $src/share/java/*_postgresql-${version}.jar $out/share/java/postgresql-jdbc.jar
+    install -m444 -D $src/share/java/*postgresql-${version}.jar $out/share/java/postgresql-jdbc.jar
   '';
 
   meta = with stdenv.lib; {
     homepage = https://jdbc.postgresql.org/;
     description = "JDBC driver for PostgreSQL allowing Java programs to connect to a PostgreSQL database";
-    license = licenses.bsd3;
+    license = licenses.bsd2;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump mostly for bug fixing but also one **CVE** fix :

> Security: added server hostname verification for non-default SSL factories in sslmode=verify-full (CVE-2018-10936)


Regarding the licensing :
https://github.com/pgjdbc/pgjdbc/pull/660
https://github.com/pgjdbc/pgjdbc/blob/master/LICENSE
https://jdbc.postgresql.org/about/license.html

And I removed the underscore in the `install` rule to avoid breaking the package with #26839

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

