### PR TITLE
sqlite-jdbc: 3.20.0 -> 3.25.2

### DIFF
--- a/pkgs/servers/sql/sqlite/jdbc/default.nix
+++ b/pkgs/servers/sql/sqlite/jdbc/default.nix
@@ -1,25 +1,28 @@
-{ lib, stdenv, fetchurl }:
+{ stdenv, fetchMavenArtifact }:
 
 stdenv.mkDerivation rec {
-  version = "3.20.0";
   pname = "sqlite-jdbc";
   name = "${pname}-${version}";
+  version = "3.25.2";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/xerial/${pname}/downloads/${name}.jar";
-    sha256 = "0wxfxnq2ghiwy2mwz3rljgmy1lciafhrw80lprvqz6iw8l51qfql";
+  src = fetchMavenArtifact {
+    groupId = "org.xerial";
+    artifactId = "sqlite-jdbc";
+    inherit version;
+    sha256 = "1xk5fi2wzq3jspvbdm5hvs78501i14jy3v7x6fjnh5fnpqdacpd4";
   };
 
   phases = [ "installPhase" ];
 
   installPhase = ''
-    install -D "${src}" "$out/share/java/${name}.jar"
+    install -m444 -D ${src}/share/java/*${name}.jar "$out/share/java/${name}.jar"
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     homepage = "https://github.com/xerial/sqlite-jdbc";
-    description = "SQLite JDBC Driver";
+    description = "Library for accessing and creating SQLite database files in Java";
     license = licenses.asl20;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ jraygauthier ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump + should now build on aarch64
cc @jraygauthier 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

