### PR TITLE
tikzit: init at 2.0

### DIFF
--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, qmake, qttools, qtbase, flex, bison }:
+
+stdenv.mkDerivation rec {
+  name = "tikzit-${version}";
+  version = "2.0-rc2";
+
+  src = fetchFromGitHub {
+    owner = "tikzit";
+    repo = "tikzit";
+    rev = "v${version}";
+    sha256 = "119cc8p82cf78rha711zxm4pzmazwgiv81w2qbwwwxd2mkhjwflx";
+  };
+
+  nativeBuildInputs = [ qmake qttools flex bison ];
+  buildInputs = [ qtbase ];
+
+  # The default installPhase tries to install under
+  # /nix/store/*-qtbase-*-dev/tests/tikzit. This is not what we want.
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tikzit $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a graphical editor for TikZ diagrams";
+    longDescription = ''
+      TikZiT is a simple GUI editor for graphs and string diagrams.
+      Its native file format is a subset of PGF/TikZ, which means TikZiT files
+      can be included directly in papers typeset using LaTeX.
+    '';
+    homepage = https://tikzit.github.io/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ maintainers.iblech ];
+  };
+}

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -2,29 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "tikzit-${version}";
-  version = "2.0-rc2";
+  version = "2.0-rc3";
 
   src = fetchFromGitHub {
     owner = "tikzit";
     repo = "tikzit";
-    rev = "v${version}";
-    sha256 = "119cc8p82cf78rha711zxm4pzmazwgiv81w2qbwwwxd2mkhjwflx";
+    rev = "24fbb3b7aca8dd5b957397a046d3cb71a00b324c";
+    sha256 = "03wycizv1d42zrb8irj2zqkqhdsvwkjcwxympqqcg11apicqv252";
   };
 
   nativeBuildInputs = [ qmake qttools flex bison ];
   buildInputs = [ qtbase ];
 
   preBuild = ''
-    sed -i '/DESTDIR/d' tikzit.pro
-    echo "DESTDIR = build" >> tikzit.pro
-    qmake
-  '';
-
-  # The default installPhase tries to install under
-  # /nix/store/*-qtbase-*-dev/tests/tikzit. This is not what we want.
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -r $srcdir/build/source/build/* $out/bin/
+    PREFIX=$out qmake
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake qttools flex bison ];
   buildInputs = [ qtbase ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "A graphical tool for rapidly creating graphs and diagrams using PGF/TikZ";
     longDescription = ''
@@ -22,8 +24,8 @@ stdenv.mkDerivation rec {
       can be included directly in papers typeset using LaTeX.
     '';
     homepage = https://tikzit.github.io/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
     maintainers = [ maintainers.iblech maintainers.mgttlinger ];
   };
 }

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -7,20 +7,9 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tikzit";
     repo = "tikzit";
-    rev = "fcc77f8b47882a77a9fced1e131fc6db092db749";
-    sha256 = "0xlk7k464s0f06bnkdj7jzdrhmxxsr0304zi7rgl6x5mgs022jk1";
+    rev = "d005c0ab40b98a5d91a85e288715d948d25c2274";
+    sha256 = "1qbh1y9fgh947h27gifl3lz391sajdimaqadrf52m42b855b8qx3";
   };
-
-  # TikZiT checks for updates by fetching a certain HTTP URL.
-  # The security impact of not fetching over HTTPS is minimal, since TikZiT
-  # uses the response only to display an information box, but it's probably
-  # still better to follow best practices and fetch over HTTPS.
-  #
-  # This fix is not yet contained in upstream because of difficulties with Qt
-  # and SSL on Ubuntu, see https://github.com/tikzit/tikzit/pull/34.
-  preBuild = ''
-    sed -ie 's+http://tikzit.github.io/+https://tikzit.github.io/+' src/tikzit.cpp
-  '';
 
   nativeBuildInputs = [ qmake qttools flex bison ];
   buildInputs = [ qtbase ];

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tikzit-${version}";
-  version = "2.0-rc3";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "tikzit";
     repo = "tikzit";
-    rev = "d005c0ab40b98a5d91a85e288715d948d25c2274";
-    sha256 = "1qbh1y9fgh947h27gifl3lz391sajdimaqadrf52m42b855b8qx3";
+    rev = "v${version}";
+    sha256 = "0fwxr9rc9vmw2jzpj084rygzyhp4xm3vm737668az600ln2scyad";
   };
 
   nativeBuildInputs = [ qmake qttools flex bison ];

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -11,6 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "0xlk7k464s0f06bnkdj7jzdrhmxxsr0304zi7rgl6x5mgs022jk1";
   };
 
+  # TikZiT checks for updates by fetching a certain HTTP URL.
+  # The security impact of not fetching over HTTPS is minimal, since TikZiT
+  # uses the response only to display an information box, but it's probably
+  # still better to follow best practices and fetch over HTTPS.
+  #
+  # This fix is not yet contained in upstream because of difficulties with Qt
+  # and SSL on Ubuntu, see https://github.com/tikzit/tikzit/pull/34.
+  preBuild = ''
+    sed -ie 's+http://tikzit.github.io/+https://tikzit.github.io/+' src/tikzit.cpp
+  '';
+
   nativeBuildInputs = [ qmake qttools flex bison ];
   buildInputs = [ qtbase ];
 

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -14,15 +14,21 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake qttools flex bison ];
   buildInputs = [ qtbase ];
 
+  preBuild = ''
+    sed -i '/DESTDIR/d' tikzit.pro
+    echo "DESTDIR = build" >> tikzit.pro
+    qmake
+  '';
+
   # The default installPhase tries to install under
   # /nix/store/*-qtbase-*-dev/tests/tikzit. This is not what we want.
   installPhase = ''
     mkdir -p $out/bin
-    cp tikzit $out/bin
+    cp -r $srcdir/build/source/build/* $out/bin/
   '';
 
   meta = with stdenv.lib; {
-    description = "a graphical editor for TikZ diagrams";
+    description = "A graphical tool for rapidly creating graphs and diagrams using PGF/TikZ";
     longDescription = ''
       TikZiT is a simple GUI editor for graphs and string diagrams.
       Its native file format is a subset of PGF/TikZ, which means TikZiT files
@@ -31,6 +37,6 @@ stdenv.mkDerivation rec {
     homepage = https://tikzit.github.io/;
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.all;
-    maintainers = [ maintainers.iblech ];
+    maintainers = [ maintainers.iblech maintainers.mgttlinger ];
   };
 }

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -7,16 +7,12 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tikzit";
     repo = "tikzit";
-    rev = "24fbb3b7aca8dd5b957397a046d3cb71a00b324c";
-    sha256 = "03wycizv1d42zrb8irj2zqkqhdsvwkjcwxympqqcg11apicqv252";
+    rev = "fcc77f8b47882a77a9fced1e131fc6db092db749";
+    sha256 = "0xlk7k464s0f06bnkdj7jzdrhmxxsr0304zi7rgl6x5mgs022jk1";
   };
 
   nativeBuildInputs = [ qmake qttools flex bison ];
   buildInputs = [ qtbase ];
-
-  preBuild = ''
-    PREFIX=$out qmake
-  '';
 
   meta = with stdenv.lib; {
     description = "A graphical tool for rapidly creating graphs and diagrams using PGF/TikZ";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5622,6 +5622,8 @@ with pkgs;
 
   tie = callPackage ../development/tools/misc/tie { };
 
+  tikzit = libsForQt5.callPackage ../tools/typesetting/tikzit { };
+
   tilix = callPackage ../applications/misc/tilix { };
 
   tinc_pre = callPackage ../tools/networking/tinc/pre.nix { };


### PR DESCRIPTION
###### Motivation for this change

[tikzit](https://tikzit.github.io/) is a graphical editor for TikZ diagrams (for inclusion in LaTeX files). This pull requests adds tikzit to our repository.

The current version of tikzit is 2.0-rc2. I suggest we wait for 2.0 to be released before including tikzit in nixpkgs, to reduce clutter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

