### PR TITLE
deepin-metacity: init at 3.22.22

### DIFF
--- a/pkgs/desktops/deepin/deepin-metacity/default.nix
+++ b/pkgs/desktops/deepin/deepin-metacity/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, pkgconfig, intltool, libtool, gnome3, bamf,
+  json-glib, libcanberra-gtk3, libxkbcommon, libstartup_notification,
+  deepin-wallpapers, deepin-desktop-schemas }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-metacity";
+  version = "3.22.22";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0gr10dv8vphla6z7zqiyyg3n3ag4rrlz43c4kr7fd5xwx2bfvp3d";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libtool
+    gnome3.gnome-common
+    gnome3.glib.dev
+  ];
+
+  buildInputs = [
+    gnome3.dconf
+    gnome3.gtk
+    gnome3.libgtop
+    gnome3.zenity
+    bamf
+    json-glib
+    libcanberra-gtk3
+    libstartup_notification
+    libxkbcommon
+    deepin-wallpapers
+    deepin-desktop-schemas
+  ];
+
+  postPatch = ''
+    sed -i src/ui/deepin-background-cache.c \
+      -e 's;/usr/share/backgrounds/default_background.jpg;${deepin-wallpapers}/share/backgrounds/deepin/desktop.jpg;'
+  '';
+
+  NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
+
+  configureFlags = [ "--disable-themes-documentation" ];
+
+  preConfigure = ''
+    HOME=$TMP
+    NOCONFIGURE=1 ./autogen.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "2D window manager for Deepin";
+    homepage = https://github.com/linuxdeepin/deepin-metacity;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -13,6 +13,7 @@ let
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
     deepin-image-viewer = callPackage ./deepin-image-viewer { };
     deepin-menu = callPackage ./deepin-menu { };
+    deepin-metacity = callPackage ./deepin-metacity { };
     deepin-mutter = callPackage ./deepin-mutter { };
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
     deepin-sound-theme = callPackage ./deepin-sound-theme { };


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-metacity](https://github.com/linuxdeepin/deepin-metacity), a 2D window manager for Deepin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).