### PR TITLE
ttyplot: init at 1.0

### DIFF
--- a/pkgs/tools/misc/ttyplot/default.nix
+++ b/pkgs/tools/misc/ttyplot/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+stdenv.mkDerivation rec {
+  name = "ttyplot-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "tenox7";
+    repo = "ttyplot";
+    rev = version;
+    sha256 = "1i54hw7fad42gdlrlqg7s0vhsq01yxzdi2s0r3svwbb1sr7ynzn1";
+  };
+
+  buildInputs = [ ncurses ];
+
+  buildPhase = ''
+   ${stdenv.cc}/bin/cc ./ttyplot.c -lncurses -o ttyplot
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ttyplot $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a simple general purpose plotting utility for tty with data input from stdin.";
+    homepage = https://github.com/tenox7/ttyplot;
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ lassulus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5739,6 +5739,8 @@ with pkgs;
 
   tty-clock = callPackage ../tools/misc/tty-clock { };
 
+  ttyplot = callPackage ../tools/misc/ttyplot { };
+
   ttyrec = callPackage ../tools/misc/ttyrec { };
 
   ttylog = callPackage ../tools/misc/ttylog { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

