### PR TITLE
[18.03] Backport Signal-Desktop

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -55,11 +55,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.15.5";
+  version = "1.16.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1a63kyxbhdaz6izprg8wryvscmvfjii50xi1v5pxlf74x2pkxs8k";
+    sha256 = "0hw5h1m8fijhqybx0xijrkifn5wl50qibaxkn2mxqf4mjwlvaw9a";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -55,11 +55,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.15.4";
+  version = "1.15.5";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "02k64hnfzq8d5g805n4bjm2x8xazskp8fwbmcbl2s2rshdwil1jz";
+    sha256 = "1a63kyxbhdaz6izprg8wryvscmvfjii50xi1v5pxlf74x2pkxs8k";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.14.1";
+  version = "1.14.2";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1f54azqdfqa2yrzlp9b7pz7nswl5n3pgln38yxcvb3y5k6x0ljqp";
+    sha256 = "0szc7ynl26hqvvwk3sx02ym4abyz78akx0sp6cvif3bb4m8brz1c";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.14.3";
+  version = "1.14.4";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1z8z32d7ic28zg4mgk3cjmzb6kpism7xzym2ng25b0ndf72g1vfi";
+    sha256 = "0590r7748kv6g7zygq95v8qxf7vi2n5ypj6734x9yshrn8z6p8lr";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -2,7 +2,7 @@
 , gnome3, gtk3, atk, cairo, pango, gdk_pixbuf, glib, freetype, fontconfig
 , dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss, nspr, alsaLib
-, cups, expat, udev
+, cups, expat, udev, libnotify
 # Unfortunately this also overwrites the UI language (not just the spell
 # checking language!):
 , hunspellDicts, spellcheckerLanguage ? null # E.g. "de_DE"
@@ -35,6 +35,7 @@ let
     gnome3.gconf
     gtk3
     pango
+    libnotify
     libX11
     libXScrnSaver
     libXcomposite

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.14.2";
+  version = "1.14.3";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "0szc7ynl26hqvvwk3sx02ym4abyz78akx0sp6cvif3bb4m8brz1c";
+    sha256 = "1z8z32d7ic28zg4mgk3cjmzb6kpism7xzym2ng25b0ndf72g1vfi";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -55,11 +55,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.15.0";
+  version = "1.15.3";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1q73jx92h8zwk1dn103ymskz35q6kfiqc44886jr0p7mlpndqsa4";
+    sha256 = "009bcy90dvwiizya387fqrh3a8l0czgs4wnddxndy9gd477sn704";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -55,11 +55,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.16.1";
+  version = "1.16.2";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1qlibn6k5zbjw9bni2l20qx58jcpwrl99awdmgha1fzmpjkn6bl5";
+    sha256 = "1j1785sc8pmrhi8yhlv4brxn7zrd33skgkkvzfl60nqkh2nybh3y";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.14.4";
+  version = "1.15.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "0590r7748kv6g7zygq95v8qxf7vi2n5ypj6734x9yshrn8z6p8lr";
+    sha256 = "1q73jx92h8zwk1dn103ymskz35q6kfiqc44886jr0p7mlpndqsa4";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -55,11 +55,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.16.0";
+  version = "1.16.1";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "0hw5h1m8fijhqybx0xijrkifn5wl50qibaxkn2mxqf4mjwlvaw9a";
+    sha256 = "1qlibn6k5zbjw9bni2l20qx58jcpwrl99awdmgha1fzmpjkn6bl5";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -55,11 +55,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.15.3";
+  version = "1.15.4";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "009bcy90dvwiizya387fqrh3a8l0czgs4wnddxndy9gd477sn704";
+    sha256 = "02k64hnfzq8d5g805n4bjm2x8xazskp8fwbmcbl2s2rshdwil1jz";
   };
 
   phases = [ "unpackPhase" "installPhase" ];


### PR DESCRIPTION
###### Motivation for this change

Reason: Signal-Desktop displayed the following message: "This version of Signal Desktop has expired. Please upgrade to the latest version to continue messaging." (see #48436).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

