### PR TITLE
haskellPackages.cryptonite: fix for aarch64 and re-enable tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -676,9 +676,6 @@ self: super: {
   # https://github.com/goldfirere/singletons/issues/122
   singletons = dontCheck super.singletons;
 
-  # https://github.com/fpco/stackage/issues/838
-  cryptonite = dontCheck super.cryptonite;
-
   # We cannot build this package w/o the C library from <http://www.phash.org/>.
   phash = markBroken super.phash;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -676,6 +676,14 @@ self: super: {
   # https://github.com/goldfirere/singletons/issues/122
   singletons = dontCheck super.singletons;
 
+  # Fix an aarch64 issue with cryptonite-0.25:
+  # https://github.com/haskell-crypto/cryptonite/issues/234
+  # This has been committed upstream, but there is, as of yet, no new release.
+  cryptonite = appendPatch super.cryptonite (pkgs.fetchpatch {
+    url = https://github.com/haskell-crypto/cryptonite/commit/4622e5fc8ece82f4cf31358e31cd02cf020e558e.patch;
+    sha256 = "1m2d47ni4jbrpvxry50imj91qahr3r7zkqm157clrzlmw6gzpgnq";
+  });
+
   # We cannot build this package w/o the C library from <http://www.phash.org/>.
   phash = markBroken super.phash;
 


### PR DESCRIPTION
###### Motivation for this change

`cryptonite` has been `dontCheck` for nearly 3 years:

https://github.com/NixOS/nixpkgs/commit/358db2a22c03570e14bde625b9067c6ac36e95e3

but the test failures that led to that nixpkgs commit were fixed upstream around the same time:

https://github.com/haskell-crypto/cryptonite/issues/28

The first patch in this series re-enables tests for `cryptonite`.

Meanwhile, `cryptonite-0.25` has a bug on `aarch64` that was not caught because the tests are disabled. It only manifested in test failures on that arch in `tls`. The fix for this issue has been committed upstream, but no release has been made since, so the second patch in this series cherry-picks the commit from `cryptonite` upstream for `aarch64`. The fix is guarded by a check for that architecture, so it does not impact other architectures.

As an aside, a package like `cryptonite` seems like a very dangerous one to leave `dontCheck` for so long. Probably there should be some way to revisit, from time to time, packages whose tests have been disabled. One idea would be to run an occasional Hydra build where `dontCheck` is a no-op.

/cc @srhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
