### PR TITLE
bepasty: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/xstatic-bootbox/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootbox/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-Bootbox";
-  version = "4.3.0.1";
+  version = "4.4.0.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "0wks1lsqngn3gvlhzrvaan1zj8w4wr58xi0pfqhrzckbghvvr0gj";
+    sha256 = "1g00q38g1k576lxjlwglv4w3fj4z0z8lxlwpc66wyhjglj4r4bwd";
   };
 
   # no tests implemented

--- a/pkgs/development/python-modules/xstatic-bootstrap/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootstrap/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-Bootstrap";
-  version = "3.3.5.1";
+  version = "3.3.7.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "0jzjq3d4vp2shd2n20f9y53jnnk1cvphkj1v0awgrf18qsy2bmin";
+    sha256 = "0cgihyjb9rg6r2ddpzbjm31y0901vyc8m9h3v0zrhxydx1w9x50c";
   };
 
   # no tests implemented

--- a/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-jQuery-File-Upload";
-  version = "9.7.0.1";
+  version = "9.22.0.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "0d5za18lhzhb54baxq8z73wazq801n3qfj5vgcz7ri3ngx7nb0cg";
+    sha256 = "0jy7xnww0177fv0asssxvv8l1032jcnbkvz39z16yd6k34v53fzf";
   };
 
   # no tests implemented

--- a/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-ui/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-jquery-ui";
-  version = "1.12.0.1";
+  version = "1.12.1.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "0w7mabv6qflpd47g33j3ggp5rv17mqk0xz3bsdswcj97wqpga2l2";
+    sha256 = "0449rkjcksq49yjyyszz9v11wa4nmvvfw0mynayah8248yxlifnn";
   };
 
   # no tests implemented

--- a/pkgs/development/python-modules/xstatic-jquery/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-jQuery";
-  version = "1.10.2.1";
+  version = "3.3.1.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "018kx4zijflcq8081xx6kmiqf748bsjdq7adij2k91bfp1mnlhc3";
+    sha256 = "0xlgs4rlabzfcp8p2zspwpsljycb0djyrk7qy4qh76i7zkfhwn8j";
   };
 
   # no tests implemented

--- a/pkgs/development/python-modules/xstatic-pygments/default.nix
+++ b/pkgs/development/python-modules/xstatic-pygments/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic-Pygments";
-  version = "1.6.0.1";
+  version = "2.2.0.1";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "0fjqgg433wfdnswn7fad1g6k2x6mf24wfnay2j82j0fwgkdxrr7m";
+    sha256 = "1rm073ag1hgwlazl52mng62wvnayz7ckr5ki341shvp9db1x2n51";
   };
 
   # no tests implemented

--- a/pkgs/development/python-modules/xstatic/default.nix
+++ b/pkgs/development/python-modules/xstatic/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "XStatic";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "09npcsyf1ccygjs0qc8kdsv4qqy8gm1m6iv63g9y1fgbcry3vj8f";
+    sha256 = "1a13i9b62qfmqz04gpa6kcwwy2x8fm9wcr1x6kjdxrmw6zz8vdw0";
   };
 
   # no tests implemented

--- a/pkgs/tools/misc/bepasty/default.nix
+++ b/pkgs/tools/misc/bepasty/default.nix
@@ -1,15 +1,15 @@
-{ python
+{ python3Packages
 , lib
 }:
 
-with python.pkgs;
+with python3Packages;
 
 #We need to use buildPythonPackage here to get the PYTHONPATH build correctly.
 #This is needed for services.bepasty
 #https://github.com/NixOS/nixpkgs/pull/38300
 buildPythonPackage rec {
   pname = "bepasty";
-  version = "0.4.0";
+  version = "0.5.0";
 
   propagatedBuildInputs = [
     flask
@@ -22,9 +22,12 @@ buildPythonPackage rec {
     xstatic-jquery-ui
     xstatic-pygments
   ];
+
+  buildInputs = [ setuptools_scm ];
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0bs79pgrjlnkmjfyj2hllbx3rw757va5w2g2aghi9cydmsl7gyi4";
+    sha256 = "1y3smw9620w2ia4zfsl2svb9j7mkfgc8z1bzjffyk1w5vryhwikh";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

update bepasty to latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

