### PR TITLE
xcpretty init

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -29,6 +29,7 @@
 , buildInputs ? []
 , postBuild ? ""
 , gemConfig ? null
+, passthru ? {}
 }@args:
 
 let

--- a/pkgs/development/tools/xcpretty/Gemfile
+++ b/pkgs/development/tools/xcpretty/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'xcpretty'

--- a/pkgs/development/tools/xcpretty/Gemfile.lock
+++ b/pkgs/development/tools/xcpretty/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rouge (2.0.7)
+    xcpretty (0.3.0)
+      rouge (~> 2.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  xcpretty
+
+BUNDLED WITH
+   1.16.4

--- a/pkgs/development/tools/xcpretty/default.nix
+++ b/pkgs/development/tools/xcpretty/default.nix
@@ -1,0 +1,27 @@
+{ lib, bundlerApp, bundler, bundix }:
+
+bundlerApp {
+  pname = "xcpretty";
+  gemdir = ./.;
+
+  exes = [ "xcpretty" ];
+
+  passthru = {
+    updateScript = ''
+      set -e
+      echo
+      cd ${toString ./.}
+      ${bundler}/bin/bundle lock --update
+      ${bundix}/bin/bundix
+    '';
+  };
+
+  meta = with lib; {
+    description     = "Flexible and fast xcodebuild formatter";
+    homepage        = https://github.com/supermarin/xcpretty;
+    license         = licenses.mit;
+    maintainers     = with maintainers; [
+      nicknovitski
+    ];
+  };
+}

--- a/pkgs/development/tools/xcpretty/gemset.nix
+++ b/pkgs/development/tools/xcpretty/gemset.nix
@@ -1,0 +1,19 @@
+{
+  rouge = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sfikq1q8xyqqx690iiz7ybhzx87am4w50w8f2nq36l3asw4x89d";
+      type = "gem";
+    };
+    version = "2.0.7";
+  };
+  xcpretty = {
+    dependencies = ["rouge"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xq47q2h5llj7b54rws4796904vnnjz7qqnacdv7wlp3gdbwrivm";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8994,6 +8994,8 @@ with pkgs;
     deps = [ xcbuild ];
   } ../development/tools/xcbuild/setup-hook.sh  ;
 
+  xcpretty = callPackage ../development/tools/xcpretty { };
+
   xmlindent = callPackage ../development/web/xmlindent {};
 
   xpwn = callPackage ../development/mobile/xpwn {};


### PR DESCRIPTION
Xcpretty is a command-line tool which fastlane invokes, but sometimes I use it directly.
~~I added the updateScript attribute to fastlane because it updates very frequently.~~


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---