### PR TITLE
linuxPackages.bpftrace: init at unstable-2018-10-27

### DIFF
--- a/pkgs/os-specific/linux/bpftrace/bcc-source.patch
+++ b/pkgs/os-specific/linux/bpftrace/bcc-source.patch
@@ -1,0 +1,32 @@
+From fc0a5bd2ddb5827c5288ee284c1f2d834d79e432 Mon Sep 17 00:00:00 2001
+From: Rodney Lorrimar <dev@rodney.id.au>
+Date: Tue, 16 Oct 2018 09:55:59 +1000
+Subject: [PATCH 1/3] Don't use ExternalProject for bcc sources
+
+---
+ CMakeLists.txt | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eae850a..b20fb33 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,6 +31,15 @@ if (OFFLINE_BUILDS)
+     UPDATE_DISCONNECTED 1
+     BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static
+     )
++elseif (NIX_BUILDS)
++  include(ExternalProject)
++  ExternalProject_Add(bcc
++    DOWNLOAD_COMMAND rmdir bcc && ln -sf $ENV{bccSrc} bcc
++    STEP_TARGETS build update
++    EXCLUDE_FROM_ALL 1
++    UPDATE_DISCONNECTED 1
++    BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static
++    )
+ else()
+   include(ExternalProject)
+   ExternalProject_Add(bcc
+-- 
+2.17.1
+

--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub
+, cmake, pkgconfig, flex, bison
+, llvmPackages, kernel, linuxHeaders, elfutils, libelf, bcc
+}:
+
+stdenv.mkDerivation rec {
+  name = "bpftrace-unstable-${version}";
+  version = "2018-10-27";
+
+  src = fetchFromGitHub {
+    owner = "iovisor";
+    repo = "bpftrace";
+    rev = "c07b54f61fd7b7b49e0a254e746d6f442c5d780d";
+    sha256 = "1mpcjfyay9akmpqxag2ndwpz1qsdx8ii07jh9fky4w40wi9cipyg";
+  };
+
+  # bpftrace requires an unreleased version of bcc, added to the cmake
+  # build as an ExternalProject.
+  # https://github.com/iovisor/bpftrace/issues/184
+  bccSrc = fetchFromGitHub {
+    owner = "iovisor";
+    repo = "bcc";
+    rev = "afd00154865f3b2da6781cf92cecebaca4853950";
+    sha256 = "0ad78smrnipr1f377i5rv6ksns7v2vq54g5badbj5ldqs4x0hygd";
+  };
+
+  buildInputs = [
+    llvmPackages.llvm llvmPackages.clang-unwrapped kernel
+    elfutils libelf bccSrc
+  ];
+
+  nativeBuildInputs = [ cmake pkgconfig flex bison ]
+    # libelf is incompatible with elfutils-libelf
+    ++ stdenv.lib.filter (x: x != libelf) kernel.moduleBuildDependencies;
+
+  patches = [
+    ./bcc-source.patch
+    # https://github.com/iovisor/bpftrace/issues/184
+    ./disable-gtests.patch
+  ];
+
+  configurePhase = ''
+    mkdir build
+    cd build
+    cmake ../                                   \
+      -DKERNEL_HEADERS_DIR=${linuxHeaders}      \
+      -DNIX_BUILDS:BOOL=ON                      \
+      -DCMAKE_INSTALL_PREFIX=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "High-level tracing language for Linux eBPF";
+    homepage = https://github.com/iovisor/bpftrace;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/os-specific/linux/bpftrace/disable-gtests.patch
+++ b/pkgs/os-specific/linux/bpftrace/disable-gtests.patch
@@ -1,0 +1,73 @@
+From 221eea24674fffb3b657b2bd0c923071b69d48a7 Mon Sep 17 00:00:00 2001
+From: Rodney Lorrimar <dev@rodney.id.au>
+Date: Tue, 16 Oct 2018 09:56:47 +1000
+Subject: [PATCH 2/3] Disable tests
+
+Would prefer to use gtest library in the normal way rather through
+ExternalProject.
+---
+ CMakeLists.txt       |  4 ++--
+ tests/CMakeLists.txt | 18 +++++++++++-------
+ 2 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b20fb33..7025d17 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,7 @@ add_compile_options("-Wno-format-security")
+ #add_compile_options("-Wstrict-overflow=5")
+ #add_compile_options("-Wdisabled-optimization")
+ 
+-enable_testing()
++# enable_testing()
+ 
+ if (OFFLINE_BUILDS)
+   include(ExternalProject)
+@@ -79,7 +79,7 @@ include_directories(${CLANG_INCLUDE_DIRS})
+ add_subdirectory(src/arch)
+ add_subdirectory(src/ast)
+ add_subdirectory(src)
+-add_subdirectory(tests)
++# add_subdirectory(tests)
+ add_subdirectory(resources)
+ add_subdirectory(tools)
+ add_subdirectory(man)
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index c283efa..6b5bff0 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -45,6 +45,8 @@ if (OFFLINE_BUILDS)
+     EXCLUDE_FROM_ALL 1
+     UPDATE_DISCONNECTED 1
+     )
++elseif (NIX_BUILDS)
++
+ else()
+   include(ExternalProject)
+   ExternalProject_Add(gtest-git
+@@ -54,13 +56,15 @@ else()
+     EXCLUDE_FROM_ALL 1
+     )
+ endif()
+-add_dependencies(bpftrace_test gtest-git-build)
+-ExternalProject_Get_Property(gtest-git source_dir binary_dir)
+-target_include_directories(bpftrace_test PUBLIC ${source_dir}/googletest/include)
+-target_include_directories(bpftrace_test PUBLIC ${source_dir}/googlemock/include)
+-target_link_libraries(bpftrace_test ${binary_dir}/googlemock/gtest/libgtest.a)
+-target_link_libraries(bpftrace_test ${binary_dir}/googlemock/gtest/libgtest_main.a)
+-target_link_libraries(bpftrace_test ${binary_dir}/googlemock/libgmock.a)
++
++find_library(LIBGTEST "gtest")
++if(LIBGTEST)
++    set(LIBRARY_DEPENDENCIES
++        ${LIBRARY_DEPENDENCIES}
++       ${LIBGTEST}
++    )
++endif()
++
+ target_link_libraries(bpftrace_test ${CMAKE_THREAD_LIBS_INIT})
+ 
+ add_test(NAME bpftrace_test COMMAND bpftrace_test)
+-- 
+2.17.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14210,6 +14210,8 @@ with pkgs;
       python = python3;
     };
 
+    bpftrace = callPackage ../os-specific/linux/bpftrace { };
+
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
     beegfs-module = callPackage ../os-specific/linux/beegfs/kernel-module.nix { };


### PR DESCRIPTION
###### Motivation for this change

Adds a nice new high-level Linux tracing tool: https://github.com/iovisor/bpftrace

There are no releases yet, so this is a git snapshot. The patches have upstream issues iovisor/bpftrace#183 and iovisor/bpftrace#184.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
