### PR TITLE
[wip] chromium{Beta,Dev}: fix build

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/patches/fix-freetype-70.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/fix-freetype-70.patch
@@ -1,0 +1,16 @@
+--- a/third_party/freetype/BUILD.gn
++++ b/third_party/freetype/BUILD.gn
+@@ -63,11 +63,13 @@ source_set("freetype_source") {
+     "src/src/base/ftbase.c",
+     "src/src/base/ftbbox.c",
+     "src/src/base/ftbitmap.c",
++    "src/src/base/ftfntfmt.c",
+     "src/src/base/ftdebug.c",
+     "src/src/base/ftfstype.c",
+     "src/src/base/ftgasp.c",
+     "src/src/base/ftglyph.c",
+     "src/src/base/ftinit.c",
++    "src/src/base/ftlcdfil.c",
+     "src/src/base/ftmm.c",
+     "src/src/base/ftstroke.c",
+     "src/src/base/fttype1.c",

--- a/pkgs/applications/networking/browsers/chromium/patches/nix_plugin_paths_70.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/nix_plugin_paths_70.patch
@@ -1,0 +1,61 @@
+diff --git a/chrome/common/chrome_paths.cc b/chrome/common/chrome_paths.cc
+index f4e119d..d9775bd 100644
+--- a/chrome/common/chrome_paths.cc
++++ b/chrome/common/chrome_paths.cc
+@@ -68,21 +68,14 @@ static base::LazyInstance<base::FilePath>
+     g_invalid_specified_user_data_dir = LAZY_INSTANCE_INITIALIZER;
+ 
+ // Gets the path for internal plugins.
+-bool GetInternalPluginsDirectory(base::FilePath* result) {
+-#if defined(OS_MACOSX)
+-  // If called from Chrome, get internal plugins from a subdirectory of the
+-  // framework.
+-  if (base::mac::AmIBundled()) {
+-    *result = chrome::GetFrameworkBundlePath();
+-    DCHECK(!result->empty());
+-    *result = result->Append("Internet Plug-Ins");
+-    return true;
+-  }
+-  // In tests, just look in the module directory (below).
+-#endif
+-
+-  // The rest of the world expects plugins in the module directory.
+-  return base::PathService::Get(base::DIR_MODULE, result);
++bool GetInternalPluginsDirectory(base::FilePath* result,
++                                 const std::string& ident) {
++  std::string full_env = std::string("NIX_CHROMIUM_PLUGIN_PATH_") + ident;
++  const char* value = getenv(full_env.c_str());
++  if (value == NULL)
++      return base::PathService::Get(base::DIR_MODULE, result);
++  else
++      *result = base::FilePath(value);
+ }
+ 
+ // Gets the path for bundled implementations of components. Note that these
+@@ -272,7 +265,7 @@ bool PathProvider(int key, base::FilePath* result) {
+       create_dir = true;
+       break;
+     case chrome::DIR_INTERNAL_PLUGINS:
+-      if (!GetInternalPluginsDirectory(&cur))
++      if (!GetInternalPluginsDirectory(&cur, "ALL"))
+         return false;
+       break;
+     case chrome::DIR_COMPONENTS:
+@@ -280,7 +273,7 @@ bool PathProvider(int key, base::FilePath* result) {
+         return false;
+       break;
+     case chrome::DIR_PEPPER_FLASH_PLUGIN:
+-      if (!GetInternalPluginsDirectory(&cur))
++      if (!GetInternalPluginsDirectory(&cur, "PEPPERFLASH"))
+         return false;
+       cur = cur.Append(kPepperFlashBaseDirectory);
+       break;
+@@ -358,7 +351,7 @@ bool PathProvider(int key, base::FilePath* result) {
+         cur = cur.DirName();
+       }
+ #else
+-      if (!GetInternalPluginsDirectory(&cur))
++      if (!GetInternalPluginsDirectory(&cur, "PNACL"))
+         return false;
+ #endif
+       cur = cur.Append(FILE_PATH_LITERAL("pnacl"));


### PR DESCRIPTION
###### Motivation for this change

Fix build
The patches for ```Chromium 69``` got rejected by ```Chromium 70```

This might need backport because ```18.09``` has no working Chromium on ```aarch64-linux```