### PR TITLE
plex: use buildFHSUserEnv; update to 1.13.9.5439

### DIFF
--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -52,10 +52,10 @@ in
       };
       environment = {
         PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR=cfg.dataDir;
-        PLEX_MEDIA_SERVER_HOME="${cfg.package}/usr/lib/plexmediaserver";
+        #PLEX_MEDIA_SERVER_HOME="${cfg.package}/usr/lib/plexmediaserver";
         PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS="6";
         PLEX_MEDIA_SERVER_TMPDIR="/tmp";
-        LD_LIBRARY_PATH="/run/opengl-driver/lib:${cfg.package}/usr/lib/plexmediaserver";
+        LD_LIBRARY_PATH="/run/opengl-driver/lib:${cfg.package}/usr/lib/plexmediaserver/lib";
         LC_ALL="en_US.UTF-8";
         LANG="en_US.UTF-8";
       };

--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -1,142 +1,52 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
 let
   cfg = config.services.plex;
 in
+
 {
   options = {
     services.plex = {
       enable = mkEnableOption "Plex Media Server";
 
-      # FIXME: In order for this config option to work, symlinks in the Plex
-      # package in the Nix store have to be changed to point to this directory.
       dataDir = mkOption {
-        type = types.str;
         default = "/var/lib/plex";
         description = "The directory where Plex stores its data files.";
+        type = types.str;
       };
 
       openFirewall = mkOption {
-        type = types.bool;
         default = false;
-        description = ''
-          Open ports in the firewall for the media server
-        '';
-      };
-
-      user = mkOption {
-        type = types.str;
-        default = "plex";
-        description = "User account under which Plex runs.";
-      };
-
-      group = mkOption {
-        type = types.str;
-        default = "plex";
-        description = "Group under which Plex runs.";
-      };
-
-
-      managePlugins = mkOption {
+        description = "Open ports in the firewall for the media server.";
         type = types.bool;
-        default = true;
-        description = ''
-          If set to true, this option will cause all of the symlinks in Plex's
-          plugin directory to be removed and symlinks for paths specified in
-          <option>extraPlugins</option> to be added.
-        '';
-      };
-
-      extraPlugins = mkOption {
-        type = types.listOf types.path;
-        default = [];
-        description = ''
-          A list of paths to extra plugin bundles to install in Plex's plugin
-          directory. Every time the systemd unit for Plex starts up, all of the
-          symlinks in Plex's plugin directory will be cleared and this module
-          will symlink all of the paths specified here to that directory. If
-          this behavior is undesired, set <option>managePlugins</option> to
-          false.
-        '';
       };
 
       package = mkOption {
-        type = types.package;
         default = pkgs.plex;
         defaultText = "pkgs.plex";
         description = ''
           The Plex package to use. Plex subscribers may wish to use their own
           package here, pointing to subscriber-only server versions.
         '';
+        type = types.package;
       };
     };
   };
 
   config = mkIf cfg.enable {
-    # Most of this is just copied from the RPM package's systemd service file.
     systemd.services.plex = {
       description = "Plex Media Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      preStart = ''
-        test -d "${cfg.dataDir}/Plex Media Server" || {
-          echo "Creating initial Plex data directory in \"${cfg.dataDir}\"."
-          mkdir -p "${cfg.dataDir}/Plex Media Server"
-          chown -R ${cfg.user}:${cfg.group} "${cfg.dataDir}"
-        }
 
-        # Copy the database skeleton files to /var/lib/plex/.skeleton
-        # See the the Nix expression for Plex's package for more information on
-        # why this is done.
-        install --owner ${cfg.user} --group ${cfg.group} -d "${cfg.dataDir}/.skeleton"
-        for db in "com.plexapp.plugins.library.db"; do
-            if [ ! -e  "${cfg.dataDir}/.skeleton/$db" ]; then
-              cp "${cfg.package}/usr/lib/plexmediaserver/Resources/base_$db" "${cfg.dataDir}/.skeleton/$db"
-            fi
-            chmod u+w "${cfg.dataDir}/.skeleton/$db"
-            chown ${cfg.user}:${cfg.group} "${cfg.dataDir}/.skeleton/$db"
-        done
-
-        # If managePlugins is enabled, setup symlinks for plugins.
-        ${optionalString cfg.managePlugins ''
-          echo "Preparing plugin directory."
-          PLUGINDIR="${cfg.dataDir}/Plex Media Server/Plug-ins"
-          test -d "$PLUGINDIR" || {
-            mkdir -p "$PLUGINDIR";
-            chown ${cfg.user}:${cfg.group} "$PLUGINDIR";
-          }
-
-          echo "Removing old symlinks."
-          # First, remove all of the symlinks in the directory.
-          for f in `ls "$PLUGINDIR/"`; do
-            if [[ -L "$PLUGINDIR/$f" ]]; then
-              echo "Removing plugin symlink $PLUGINDIR/$f."
-              rm "$PLUGINDIR/$f"
-            fi
-          done
-
-          echo "Symlinking plugins."
-          for path in ${toString cfg.extraPlugins}; do
-            dest="$PLUGINDIR/$(basename $path)"
-            if [[ ! -d "$path" ]]; then
-              echo "Error symlinking plugin from $path: no such directory."
-            elif [[ -d "$dest" || -L "$dest" ]]; then
-              echo "Error symlinking plugin from $path to $dest: file or directory already exists."
-            else
-              echo "Symlinking plugin at $path..."
-              ln -s "$path" "$dest"
-            fi
-          done
-        ''}
-     '';
       serviceConfig = {
         Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
+        User = config.ids.uids.plex;
+        Group = config.ids.gids.plex;
         PermissionsStartOnly = "true";
-        ExecStart = "\"${cfg.package}/usr/lib/plexmediaserver/Plex Media Server\"";
+        ExecStart = "\"${cfg.package}/bin/plexmediaserver\"";
         KillSignal = "SIGQUIT";
         Restart = "on-failure";
       };
@@ -156,17 +66,13 @@ in
       allowedUDPPorts = [ 1900 5353 32410 32412 32413 32414 ];
     };
 
-    users.users = mkIf (cfg.user == "plex") {
-      plex = {
-        group = cfg.group;
-        uid = config.ids.uids.plex;
-      };
+    users.users.plex = {
+      group = "plex";
+      uid = config.ids.uids.plex;
     };
 
-    users.groups = mkIf (cfg.group == "plex") {
-      plex = {
-        gid = config.ids.gids.plex;
-      };
+    users.groups.plex = {
+      gid = config.ids.gids.plex;
     };
   };
 }

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -1,81 +1,51 @@
-{ stdenv, fetchurl, rpmextract, glibc
-, dataDir ? "/var/lib/plex" # Plex's data directory must be baked into the package due to symlinks.
-, enablePlexPass ? false
-}:
+{ stdenv, fetchurl, buildFHSUserEnv, runCommand, writeScript, rpmextract }:
 
 let
-  plexPass = throw "Plex pass has been removed at upstream's request; please unset nixpkgs.config.plex.pass";
-  plexpkg = if enablePlexPass then plexPass else {
-    version = "1.14.1.5488";
-    vsnHash = "cc260c476";
-    sha256 = "8ee806f35ccedcecd0cab028bbe1f7e2ac7de24292b715978d3165c4712f5c40";
-  };
-
-in stdenv.mkDerivation rec {
-  name = "plex-${version}";
-  version = plexpkg.version;
-  vsnHash = plexpkg.vsnHash;
-  sha256 = plexpkg.sha256;
+  name = "plexmediaserver-${version}";
+  version = "1.14.1.5488-cc260c476";
 
   src = fetchurl {
-    url = "https://downloads.plex.tv/plex-media-server/${version}-${vsnHash}/plexmediaserver-${version}-${vsnHash}.x86_64.rpm";
-    inherit sha256;
+    url = "https://downloads.plex.tv/plex-media-server/${version}/${name}.x86_64.rpm";
+    sha256 = "0h2w5xqw8r9iinbibdwj8bi7vb72yzhvna5hrb8frp6fbkrhds4f";
   };
 
-  buildInputs = [ rpmextract glibc ];
+  shellScript = content: writeScript "script" "#!${stdenv.shell}\n${content}";
 
-  phases = [ "unpackPhase" "installPhase" "fixupPhase" "distPhase" ];
-
-  unpackPhase = ''
-    rpmextract $src
+  app = runCommand name { outputs = [ "out" "db" ]; } ''
+    ${rpmextract}/bin/rpmextract ${src} && mv usr $out
+    f=$out/lib/plexmediaserver/Resources/com.plexapp.plugins.library.db
+    cat $f > $db
+    ln -fs /db $f
   '';
+in
 
-  installPhase = ''
-    install -d $out/usr/lib
-    cp -dr --no-preserve='ownership' usr/lib/plexmediaserver $out/usr/lib/
+buildFHSUserEnv {
+  name = "plexmediaserver";
 
-    # Now we need to patch up the executables and libraries to work on Nix.
-    # Side note: PLEASE don't put spaces in your binary names. This is stupid.
-    for bin in "Plex Media Server"              \
-               "Plex Commercial Skipper"        \
-               "Plex DLNA Server"               \
-               "Plex Media Scanner"             \
-               "Plex Relay"                     \
-               "Plex Script Host"               \
-               "Plex Transcoder"                \
-               "Plex Tuner Service"             ; do
-      patchelf --set-interpreter "${glibc.out}/lib/ld-linux-x86-64.so.2" "$out/usr/lib/plexmediaserver/$bin"
-      patchelf --set-rpath "$out/usr/lib/plexmediaserver" "$out/usr/lib/plexmediaserver/$bin"
-    done
+  runScript = shellScript ''
+    db=$HOME/com.plexapp.plugins.library.db
+    root=${app}/lib/plexmediaserver
 
-    find $out/usr/lib/plexmediaserver/Resources -type f -a -perm -0100 \
-        -print -exec patchelf --set-interpreter "${glibc.out}/lib/ld-linux-x86-64.so.2" '{}' \;
+    if test ! -f "$db"; then
+      cat ${app.db} > "$db"
+    fi
+    ln -s "$db" /db
 
-    # executables need libstdc++.so.6
-    ln -s "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}/libstdc++.so.6" "$out/usr/lib/plexmediaserver/libstdc++.so.6"
-
-    # Our next problem is the "Resources" directory in /usr/lib/plexmediaserver.
-    # This is ostensibly a skeleton directory, which contains files that Plex
-    # copies into its folder in /var. Unfortunately, there are some SQLite
-    # databases in the directory that are opened at startup. Since these
-    # database files are read-only, SQLite chokes and Plex fails to start. To
-    # solve this, we keep the resources directory in the Nix store, but we
-    # rename the database files and replace the originals with symlinks to
-    # /var/lib/plex. Then, in the systemd unit, the base database files are
-    # copied to /var/lib/plex before starting Plex.
-    RSC=$out/usr/lib/plexmediaserver/Resources
-    for db in "com.plexapp.plugins.library.db"; do
-        mv $RSC/$db $RSC/base_$db
-        ln -s "${dataDir}/.skeleton/$db" $RSC/$db
-    done
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$root exec "$root/Plex Media Server"
   '';
 
   meta = with stdenv.lib; {
     homepage = http://plex.tv/;
     license = licenses.unfree;
     platforms = platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ colemickens forkk thoughtpolice pjones lnl7 ];
-    description = "Media / DLNA server";
+    maintainers = with maintainers; [
+      colemickens
+      forkk
+      lnl7
+      pjones
+      thoughtpolice
+    ];
+    description = "Media library streaming server";
     longDescription = ''
       Plex is a media server which allows you to store your media and play it
       back across many different devices.

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -2,11 +2,11 @@
 
 let
   name = "plexmediaserver-${version}";
-  version = "1.14.1.5488-cc260c476";
+  version = "1.15.0.659-9311f93fd";
 
   src = fetchurl {
-    url = "https://downloads.plex.tv/plex-media-server/${version}/${name}.x86_64.rpm";
-    sha256 = "0h2w5xqw8r9iinbibdwj8bi7vb72yzhvna5hrb8frp6fbkrhds4f";
+    url = "https://downloads.plex.tv/plex-media-server-new/${version}/redhat/${name}.x86_64.rpm";
+    sha256 = "0mi4s4x6w7zib4dnglri8h2lllr1lcnzab302wzbrwsg5vy8fnwr";
   };
 
   shellScript = content: writeScript "script" "#!${stdenv.shell}\n${content}";
@@ -23,6 +23,7 @@ buildFHSUserEnv {
   name = "plexmediaserver";
 
   runScript = shellScript ''
+    set -x
     db=$HOME/com.plexapp.plugins.library.db
     root=${app}/lib/plexmediaserver
 
@@ -31,7 +32,7 @@ buildFHSUserEnv {
     fi
     ln -s "$db" /db
 
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$root exec "$root/Plex Media Server"
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$root/lib exec "$root/Plex Media Server"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4865,7 +4865,7 @@ in
 
   playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };
 
-  plex = callPackage ../servers/plex { enablePlexPass = config.plex.enablePlexPass or false; };
+  plex = callPackage ../servers/plex { };
 
   plexpy = callPackage ../servers/plexpy { python = python2; };
 


### PR DESCRIPTION
**NOTE**: Credit for this work and change all goes to @yegortimoshenko who actually did this module rewrite. I've just rebased it.

###### Motivation for this change

The original motivation is that Plex now downloads plugins at runtime and expects to be able to randomly execute such binaries.

* Replaces #38767  plex: use buildFHSUserEnv #38767 
* is rebased (albeit rebased and tested on `channels/nixos-unstable`)
* is tested with and without the module rewrite (note, I didn't test any sort of downgrade scenarios, only w/ and w/o the `buildFHSUserEnv` rewrite. according to discussion on #48505, this is sufficient)
* is updated with the latest (non-PlexPass) version of Plex

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

