### PR TITLE
gnome3.gdm: Always reset the environment for new sessions

### DIFF
--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -58,6 +58,10 @@ stdenv.mkDerivation rec {
     # Forwards certain environment variables to the gdm-x-session child process
     # to ensure that the above two patches actually work.
     ./gdm-session-worker_forward-vars.patch
+
+    # Set up the environment properly when launching sessions
+    # https://github.com/NixOS/nixpkgs/issues/48255
+    ./reset-environment.patch
   ];
 
   installFlags = [

--- a/pkgs/desktops/gnome-3/core/gdm/reset-environment.patch
+++ b/pkgs/desktops/gnome-3/core/gdm/reset-environment.patch
@@ -1,0 +1,20 @@
+--- a/daemon/gdm-wayland-session.c
++++ b/daemon/gdm-wayland-session.c
+@@ -285,6 +285,7 @@ spawn_session (State        *state,
+                                                     "WAYLAND_DISPLAY",
+                                                     "WAYLAND_SOCKET",
+                                                     "GNOME_SHELL_SESSION_MODE",
++                                                    "__NIXOS_SET_ENVIRONMENT_DONE",
+                                                     NULL };
+ 
+         g_debug ("Running wayland session");
+--- a/daemon/gdm-x-session.c
++++ b/daemon/gdm-x-session.c
+@@ -610,6 +610,7 @@ spawn_session (State        *state,
+                                                      "WAYLAND_DISPLAY",
+                                                      "WAYLAND_SOCKET",
+                                                      "GNOME_SHELL_SESSION_MODE",
++                                                     "__NIXOS_SET_ENVIRONMENT_DONE",
+                                                      NULL };
+ 
+         g_debug ("Running X session");


### PR DESCRIPTION
###### Motivation for this change

When GDM launches a new session it will inherit the user's systemd
environment (but only unset variables). If `__NIXOS_SET_ENVIRONMENT_DONE` is set
in the user's systemd environment it will prevent the environment to be set
properly or updated (eg. after having done a system rebuild).

Gnome sessions exports their environment to systemd at startup. If something
is keeping the user's systemd process alive (eg. ssh) launching a new gnome
session after logging out will result in a broken PATH. Specifically the PATH
will be inherited from GDM and never reset.

We patch GDM to never inherit `__NIXOS_SET_ENVIRONMENT_DONE` so new sessions
will always reset their base environment.

fixes https://github.com/NixOS/nixpkgs/issues/48255

For more info about the environment setup:
https://github.com/NixOS/nixpkgs/pull/45784

cc @jtojnar 

The issue is also present in 18.09 so this fix should be backported.

###### Things done

Tested in a VM that logging into a new gnome session works properly when ssh is active after logging out once.

---

