### PR TITLE
tikzit: init at 2.0-rc2

### DIFF
--- a/pkgs/applications/graphics/tikzit/default.nix
+++ b/pkgs/applications/graphics/tikzit/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, qmake, flex, bison }:
+
+stdenv.mkDerivation rec {
+  name = "tikzit-${version}";
+  version = "2.0-rc2";
+
+  src = fetchFromGitHub {
+    owner = "tikzit";
+    repo = "tikzit";
+    rev = "v${version}";
+    sha256 = "119cc8p82cf78rha711zxm4pzmazwgiv81w2qbwwwxd2mkhjwflx";
+  };
+
+  buildInputs = [ qmake flex bison ];
+
+  preBuild = ''
+    sed -i '/DESTDIR/d' tikzit.pro
+    echo "DESTDIR = build" >> tikzit.pro
+    qmake
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r $srcdir/build/source/build/* $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A graphical tool for rapidly creating graphs and diagrams using PGF/TikZ";
+    homepage = http://tikzit.github.io/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.mgttlinger ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5622,6 +5622,8 @@ with pkgs;
 
   tie = callPackage ../development/tools/misc/tie { };
 
+  tikzit = libsForQt5.callPackage ../applications/graphics/tikzit { };
+
   tilix = callPackage ../applications/misc/tilix { };
 
   tinc_pre = callPackage ../tools/networking/tinc/pre.nix { };


### PR DESCRIPTION
###### Motivation for this change

TikZit version 2 was officially announced yesterday and it was not already in nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

