### PR TITLE
deepin-desktop-base: init at 2018.7.23

### DIFF
--- a/pkgs/desktops/deepin/deepin-desktop-base/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-base/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, deepin-wallpapers }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-desktop-base";
+  version = "2018.7.23";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1n1bjkvhgq138jcg3zkwg55r41056x91mh191mirlpvpic574ydc";
+  };
+
+  buildInputs = [ deepin-wallpapers ];
+
+  postPatch = ''
+    sed -i Makefile -e "s:/usr:$out:" -e "s:/etc:$out/etc:"
+  '';
+
+  postInstall = ''
+    # Remove Deepin distro's lsb-release
+    rm $out/etc/lsb-release
+
+    # Don't override systemd timeouts
+    rm -r $out/etc/systemd
+
+    # Remove apt-specific templates
+    rm -r $out/share/python-apt
+
+    # Remove empty backgrounds directory
+    rm -r $out/share/backgrounds
+
+    # Make a symlink for deepin-version
+    ln -s ../lib/deepin/desktop-version $out/etc/deepin-version
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Base assets and definitions for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/deepin-desktop-base;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -7,6 +7,7 @@ let
     dde-api = callPackage ./dde-api { };
     dde-calendar = callPackage ./dde-calendar { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
+    deepin-desktop-base = callPackage ./deepin-desktop-base { };
     deepin-desktop-schemas = callPackage ./deepin-desktop-schemas { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-desktop-base](https://github.com/linuxdeepin/deepin-desktop-base) (base assets and definitions for Deepin Desktop Environment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).