### PR TITLE
Sasview: unstable -> 4.2.0

### DIFF
--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -17,7 +17,7 @@ in
 
 python.pkgs.buildPythonApplication rec {
   pname = "sasview";
-  version = "unstable-2018-05-05";
+  version = "4.2.0";
 
   checkInputs = with python.pkgs; [
     pytest
@@ -60,8 +60,8 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "SasView";
     repo = "sasview";
-    rev = "de431924d0ddf73cfb952df88bd6661181947019";
-    sha256 = "01bk0i0g65yzyq16n1a61rgjna8rrc2i51x2ndf1z7khb1fl16vg";
+    rev = "v${version}";
+    sha256 = "0k3486h46k6406h0vla8h68fd78wh3dcaq5w6f12jh6g4cjxv9qa";
   };
 
   patches = [ ./pyparsing-fix.patch ./local_config.patch ];

--- a/pkgs/development/python-modules/sasmodels/default.nix
+++ b/pkgs/development/python-modules/sasmodels/default.nix
@@ -3,14 +3,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "sasmodels-unstable";
-  version = "2018-04-27";
+  pname = "sasmodels";
+  version = "0.98";
 
   src = fetchFromGitHub {
     owner = "SasView";
     repo = "sasmodels";
-    rev = "33969b656596e8b6cc8ce934cd1f8062f7b11cf2";
-    sha256 = "00rvhafg08qvx0k9mzn1ppdkc9i5yfn2gr3hidrf416srf8zgb85";
+    rev = "v${version}";
+    sha256 = "02y4lpjwaa73pr46ylk0pw0kbill4nfzqgnfv16v5m0z9smd76ir";
   };
 
   buildInputs = [ opencl-headers ];


### PR DESCRIPTION
###### Motivation for this change

Upgraded sasview from an old unstable commit to the recently released version 4.2.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

