### PR TITLE
vbam: unstable-2017-09-04 -> 2.1.0

### DIFF
--- a/pkgs/misc/emulators/vbam/default.nix
+++ b/pkgs/misc/emulators/vbam/default.nix
@@ -4,25 +4,23 @@
 , fetchFromGitHub
 , ffmpeg
 , gettext
-, gtk2-x11
 , libGLU_combined
 , openal
 , pkgconfig
 , SDL2
 , sfml
-, wxGTK
 , zip
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   name = "visualboyadvance-m-${version}";
-  version = "unstable-2017-09-04";
+  version = "2.1.0";
   src = fetchFromGitHub {
     owner = "visualboyadvance-m";
     repo = "visualboyadvance-m";
-    rev = "ceef480";
-    sha256 = "1lpmlj8mv6fwlfg9m58hzggx8ld6cnjvaqx5ka5sffxd9v95qq2l";
+    rev = "v${version}";
+    sha256 = "1dppfvy24rgg3h84gv33l1y7zznkv3zxn2hf98w85pca6k1y2afz";
   };
 
   buildInputs = [
@@ -30,13 +28,11 @@ stdenv.mkDerivation rec {
     cmake
     ffmpeg
     gettext
-    gtk2-x11
     libGLU_combined
     openal
     pkgconfig
     SDL2
     sfml
-    wxGTK
     zip
     zlib
   ];
@@ -44,8 +40,10 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE='Release'"
     "-DENABLE_FFMPEG='true'"
-    #"-DENABLE_LINK='true'" currently broken :/
+    "-DENABLE_LINK='true'"
     "-DSYSCONFDIR=etc"
+    "-DENABLE_WX='false'"
+    "-DENABLE_SDL='true'"
   ];
 
   meta = {


### PR DESCRIPTION
Link mode is now fixed again
gtk/wxWidgets support is broken because cmake can't find the deps. Building now with SDL2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

