### PR TITLE
buildah: 1.1 -> 1.4

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -3,15 +3,15 @@
 , go-md2man }:
 
 let
-  version = "1.1";
+  version = "1.4";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    owner = "projectatomic";
+    owner = "containers";
     repo = "buildah";
-    sha256 = "0pc7bzcaafrz56glygzhnbilgaz4ca2kmklw8njfgamffbw4d54p";
+    sha256 = "0b9pfi22qcqyp0im8vp02ibrwd49ghgi64d5l98z01cj52n2j2dz";
   };
-  goPackagePath = "github.com/projectatomic/buildah";
+  goPackagePath = "github.com/containers/buildah";
 
 in buildGoPackage rec {
   name = "buildah-${version}";
@@ -45,7 +45,7 @@ in buildGoPackage rec {
 
   meta = {
     description = "A tool which facilitates building OCI images";
-    homepage = https://github.com/projectatomic/buildah;
+    homepage = https://github.com/containers/buildah;
     maintainers = with stdenv.lib.maintainers; [ Profpatsch ];
     license = stdenv.lib.licenses.asl20;
   };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump `buildah` to `1.4` and change the organization/import path now it moved to `containers` github organization.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

