### PR TITLE
tmux: 2.7 -> 2.8

### DIFF
--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -13,7 +13,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "tmux-${version}";
-  version = "2.7";
+  version = "2.8";
 
   outputs = [ "out" "man" ];
 
@@ -21,8 +21,12 @@ stdenv.mkDerivation rec {
     owner = "tmux";
     repo = "tmux";
     rev = version;
-    sha256 = "1yr4l8ckd67c3id4vrbpha91xxpdfpw0cpbr3v81lam0m7k4rgba";
+    sha256 = "0n8sjddy00xgh1rvvw968hh72pyslg1gahmzajfc4b3xax87drpi";
   };
+
+  postPatch = ''
+    sed -i 's/2.8-rc/2.8/' configure.ac
+  '';
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
 


### PR DESCRIPTION
tmux 2.8 has a broken version string (2.8-rc) which we patch in configure.ac

CHANGES FROM 2.7 to 2.8

* Make display-panes block the client until a pane is chosen or it
  times out.

* Clear history on RIS like most other terminals do.

* Add an "Any" key to run a command if a key is pressed that is not
  bound in the current key table.

* Expand formats in load-buffer and save-buffer.

* Add a rectangle_toggle format.

* Add set-hook -R to run a hook immediately.

* Add README.ja.

* Add pane focus hooks.

* Allow any punctuation as separator for s/x/y not only /.

* Improve resizing with the mouse (fix resizing the wrong pane in some
  layouts, and allow resizing multiple panes at the same time).

* Allow , and } to be escaped in formats as #, and #}.

* Add KRB5CCNAME to update-environment.

* Change meaning of -c to display-message so the client is used if it
  matches the session given to -t.

* Fixes to : form of SGR.

* Add x and X to choose-tree to kill sessions, windows or panes.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

