### PR TITLE
dde-polkit-agent: init at 0.2.1; dpa-ext-gnomekeyring: init at 0.1.0

### DIFF
--- a/pkgs/desktops/deepin/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/dde-polkit-agent/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, polkit-qt,
+dtkcore, dtkwidget, dde-qt-dbus-factory }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-polkit-agent";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1n3hys5hhhd99ycpx4im6ihy53vl9c28z7ls7smn117h3ca4c8wc";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    qttools
+  ];
+
+  buildInputs = [
+    dde-qt-dbus-factory
+    dtkcore
+    dtkwidget
+    polkit-qt
+  ];
+
+  postPatch = ''
+    patchShebangs .
+
+    sed -i dde-polkit-agent.pro polkit-dde-authentication-agent-1.desktop \
+      -e "s,/usr,$out,"
+
+    sed -i pluginmanager.cpp \
+      -e "s,/usr/lib/polkit-1-dde/plugins,/run/current-system/sw/lib/polkit-1-dde/plugins,"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PolicyKit agent for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/dde-polkit-agent;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -6,6 +6,7 @@ let
     dbus-factory = callPackage ./dbus-factory { };
     dde-api = callPackage ./dde-api { };
     dde-calendar = callPackage ./dde-calendar { };
+    dde-polkit-agent = callPackage ./dde-polkit-agent { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     deepin-desktop-schemas = callPackage ./deepin-desktop-schemas { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -24,6 +24,7 @@ let
     };
     deepin-wallpapers = callPackage ./deepin-wallpapers { };
     deepin-wm = callPackage ./deepin-wm { };
+    dpa-ext-gnomekeyring = callPackage ./dpa-ext-gnomekeyring { };
     dtkcore = callPackage ./dtkcore { };
     dtkwm = callPackage ./dtkwm { };
     dtkwidget = callPackage ./dtkwidget { };

--- a/pkgs/desktops/deepin/dpa-ext-gnomekeyring/default.nix
+++ b/pkgs/desktops/deepin/dpa-ext-gnomekeyring/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, gnome3, dde-polkit-agent }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dpa-ext-gnomekeyring";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "168j42nwyw7vcgwc0fha2pjpwwlgir70fq1hns4ia1dkdqa1nhzw";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    qttools
+  ];
+
+  buildInputs = [
+    dde-polkit-agent
+    gnome3.libgnome-keyring
+  ];
+
+  postPatch = ''
+    patchShebangs .
+
+    sed -i dpa-ext-gnomekeyring.pro gnomekeyringextention.cpp \
+      -e "s,/usr,$out,"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GNOME keyring extension for dde-polkit-agent";
+    homepage = https://github.com/linuxdeepin/dpa-ext-gnomekeyring;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

- Add [dde-polkit-agent](https://github.com/linuxdeepin/dde-polkit-agent) (PolicyKit agent for Deepin Desktop Environment)

- Add [dpa-ext-gnomekeyring](https://github.com/linuxdeepin/dpa-ext-gnomekeyring) (GNOME keyring extension for dde-polkit-agent)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).