### PR TITLE
skaffold: init at 0.16.0

### DIFF
--- a/pkgs/development/tools/skaffold/default.nix
+++ b/pkgs/development/tools/skaffold/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "skaffold-${version}";
+  version = "0.16.0";
+  # rev is the 0.16.0 commit, mainly for skaffold version command output
+  rev = "78e443973ee7475ee66d227431596351cf5e2caf";
+
+  goPackagePath = "github.com/GoogleContainerTools/skaffold";
+  subPackages = ["cmd/skaffold"];
+
+  buildFlagsArray = let t = "${goPackagePath}/pkg/skaffold"; in  ''
+    -ldflags=
+      -X ${t}/version.version=v${version}
+      -X ${t}/version.gitCommit=${rev}
+      -X ${t}/version.buildDate=unknown
+  '';
+
+  src = fetchFromGitHub {
+    owner = "GoogleContainerTools";
+    repo = "skaffold";
+    rev = "v${version}";
+    sha256 = "0vpjxyqppyj4zs02n8b0k0qd8zidrrcks60x6qd5a4bbqa0c1zld";
+  };
+
+  meta = {
+    description = "Easy and Repeatable Kubernetes Development";
+    homepage = https://github.com/GoogleContainerTools/skaffold;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ vdemeester ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12164,6 +12164,8 @@ with pkgs;
 
   shibboleth-sp = callPackage ../development/libraries/shibboleth-sp { };
 
+  skaffold = callPackage ../development/tools/skaffold { };
+
   skalibs = skawarePackages.skalibs;
 
   skawarePackages = recurseIntoAttrs {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Add [`skaffold`](https://github.com/GoogleContainerTools/skaffold) package to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

