### PR TITLE
pythonPackages.cligj: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/cligj/default.nix
+++ b/pkgs/development/python-modules/cligj/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "cligj";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "mapbox";
     repo = "cligj";
     rev = version;
-    sha256 = "0fclxagxv23v75yiypb29a8sja23dakhvmx3blmxyhg2sci92sx8";
+    sha256 = "13vlibbn86dhh6iy8k831vsa249746jnk419wcr9vvr3pqxml6g2";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Bump cligj version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

