### PR TITLE
ocamlPackages.zmq: init at 20180726

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -158,6 +158,11 @@
     github = "alexanderkjeldaas";
     name = "Alexander Kjeldaas";
   };
+  akavel = {
+    email = "czapkofan@gmail.com";
+    github = "akavel";
+    name = "Mateusz Czapliński";
+  };
   akaWolf = {
     email = "akawolf0@gmail.com";
     github = "akaWolf";

--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, dune, czmq, stdint }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-zmq-${version}";
+  version = "20180726";
+  src = fetchFromGitHub {
+    owner = "issuu";
+    repo = "ocaml-zmq";
+    rev = "d312a8458d6b688f75470248f11875fbbfa5bb1a";
+    sha256 = "1f5l4bw78y4drabhyvmpj3z8k30bill33ca7bzhr02m55yf6gqpf";
+  };
+
+  patches = [
+    ./ocaml-zmq-issue43.patch
+  ];
+
+  buildInputs = [ ocaml findlib dune czmq ];
+
+  propagatedBuildInputs = [ stdint ];
+
+  buildPhase = "dune build -p zmq";
+
+  inherit (dune) installPhase;
+
+  meta = with stdenv.lib; {
+    description = "ZeroMQ bindings for OCaml";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ akavel ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/zmq/lwt.nix
+++ b/pkgs/development/ocaml-modules/zmq/lwt.nix
@@ -1,0 +1,12 @@
+{ stdenv, ocaml, findlib, dune, zmq, ocaml_lwt }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-zmq-lwt-${version}";
+  inherit (zmq) version src installPhase meta;
+
+  buildInputs = [ ocaml findlib dune ];
+
+  propagatedBuildInputs = [ zmq ocaml_lwt ];
+
+  buildPhase = "dune build -p zmq-lwt";
+}

--- a/pkgs/development/ocaml-modules/zmq/ocaml-zmq-issue43.patch
+++ b/pkgs/development/ocaml-modules/zmq/ocaml-zmq-issue43.patch
@@ -1,0 +1,11 @@
+--- source/zmq/src/caml_zmq_stubs.c	1970-01-01 01:00:01.000000000 +0100
++++ source/zmq/src/caml_zmq_stubs.c	1970-01-01 01:00:01.000000000 +0100
+@@ -35,7 +35,7 @@
+ #include "socket.h"
+ #include "msg.h"
+ 
+-#include <uint64.h>
++#include <ocaml_stdint/uint64.h>
+ 
+ /**
+  * Version

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -753,6 +753,10 @@ let
 
     zed = callPackage ../development/ocaml-modules/zed { };
 
+    zmq = callPackage ../development/ocaml-modules/zmq { };
+
+    zmq-lwt = callPackage ../development/ocaml-modules/zmq/lwt.nix { };
+
     ocsigen_deriving = callPackage ../development/ocaml-modules/ocsigen-deriving {
       oasis = ocaml_oasis;
     };


### PR DESCRIPTION
###### Motivation for this change

I plan to upstream an OCaml kernel for Jupyter Notebook later, and it has zmq as dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu 16.04 + Nix)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

