### PR TITLE
chromiumCanary: init at 72.0.3598.0

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -15,6 +15,7 @@
 , libXScrnSaver, libXcursor, libXtst, libGLU_combined
 , protobuf, speechd, libXdamage, cups
 , ffmpeg, libxslt, libxml2, at-spi2-core
+, jdk
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -112,7 +113,7 @@ let
       ninja which python2Packages.python perl pkgconfig
       python2Packages.ply python2Packages.jinja2 nodejs
       gnutar
-    ];
+    ] ++ optional (versionAtLeast version "72") jdk;
 
     buildInputs = defaultDependencies ++ [
       nspr nss systemd

--- a/pkgs/applications/networking/browsers/chromium/update.nix
+++ b/pkgs/applications/networking/browsers/chromium/update.nix
@@ -207,7 +207,8 @@ in rec {
           inherit (oldChannel) sha256bin64;
         };
       in if isLatest channelName channel.version then keepOld else newUpstream;
-    in lib.mapAttrs genLatest channels.linux;
+    in (lib.mapAttrs genLatest channels.android) # Peek from "android" the channels not available for "linux" (currently it is only "canary").
+    // (lib.mapAttrs genLatest channels.linux);
 
     getLinuxFlash = channelName: channel: let
       inherit (channel) version;

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -5,6 +5,10 @@
     sha256bin64 = "13ghx5ysl8f2iphdvjh698q4jksh765ljjrd74m6x0ih6qm0ksaq";
     version = "71.0.3578.20";
   };
+  canary = {
+    sha256 = "0lb043nm4yrl0s0bc0y5jlg7wnd6vsgrqka32qpj0dy3h8l5sjv9";
+    version = "72.0.3598.0";
+  };
   dev = {
     sha256 = "1d7q8hbqbxy2izdvv4d9126ljiglsfc3w7wns3zbbbiyqa2rj00y";
     sha256bin64 = "0v6yahsvsgxcqg6k84lgr589rnx9af1r2axn7cggyn1a2lk63jck";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16009,6 +16009,8 @@ with pkgs;
 
   chromiumDev = lowPrio (chromium.override { channel = "dev"; });
 
+  chromiumCanary = lowPrio (chromium.override { channel = "canary"; });
+
   chuck = callPackage ../applications/audio/chuck {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon CoreAudio CoreMIDI CoreServices Kernel;
   };


### PR DESCRIPTION
###### Motivation for this change

Chromium has 4 channels: ```stable```, ```beta```, ```dev``` and ```canary```, of which only the first three are available for linux https://omahaproxy.appspot.com/viewer

```canary``` might also be interesting as it is a version ahead (72 currently, while ```beta``` is 70 and ```dev``` is 71) and it includes the latest fixes for ```GCC7``` and ```Aarch64```

---
