### PR TITLE
Security Update: pythonPackages.moinmoin: 1.9.9 -> 1.9.10

### DIFF
--- a/pkgs/development/python-modules/moinmoin/default.nix
+++ b/pkgs/development/python-modules/moinmoin/default.nix
@@ -4,22 +4,17 @@
 
 buildPythonPackage rec {
   pname = "moinmoin";
-  version = "1.9.9";
+  version = "1.9.10";
 
-  # SyntaxError in setup.py
+  # Not yet supported, see http://moinmo.in/Python3
   disabled = isPy3k;
 
   src = fetchurl {
     url = "http://static.moinmo.in/files/moin-${version}.tar.gz";
-    sha256 = "197ga41qghykmir80ik17f9hjpmixslv3zjgj7bj9qvs1dvdg5s3";
+    sha256 = "0g05lnl1s8v61phi3z1g3b6lfj4g98grj9kw8nyjl246x0c489ja";
   };
 
   patches = [
-    # Recommended to install on their download page.
-    (fetchpatch {
-      url = "https://bitbucket.org/thomaswaldmann/moin-1.9/commits/561b7a9c2bd91b61d26cd8a5f39aa36bf5c6159e/raw";
-      sha256 = "1nscnl9nspnrwyf3n95ig0ihzndryinq9kkghliph6h55cncfc65";
-    })
     ./fix_tests.patch
   ];
 

--- a/pkgs/development/python-modules/moinmoin/fix_tests.patch
+++ b/pkgs/development/python-modules/moinmoin/fix_tests.patch
@@ -1,7 +1,8 @@
-diff -ru3 moin-1.9.9-old/MoinMoin/conftest.py moin-1.9.9-new/MoinMoin/conftest.py
---- moin-1.9.9-old/MoinMoin/conftest.py	2016-10-31 23:44:02.000000000 +0300
-+++ moin-1.9.9-new/MoinMoin/conftest.py	2018-02-18 12:13:19.551929093 +0300
-@@ -22,10 +22,11 @@
+diff --git a/MoinMoin/conftest.py b/MoinMoin/conftest.py
+index 8a84ad39..649d13d7 100644
+--- a/MoinMoin/conftest.py
++++ b/MoinMoin/conftest.py
+@@ -22,10 +22,11 @@ use a Config class to define the required configuration within the test class.
  
  import atexit
  import sys


### PR DESCRIPTION
contains fix for CVE-2017-5934: http://moinmo.in/SecurityFixes
Patch can be removed as it's integrated in 1.9.10:
https://github.com/moinwiki/moin-1.9/commit/672e54a1af0d65bd81019f78de2a3671e9c3607b

###### Motivation for this change
This minor release fixes a security-critical XSS attack vector and should be backported to stable.
This release also changes some behaviour by including better defaults, I see nothing in the [Changelog](https://github.com/moinwiki/moin-1.9/blob/1.9.10/docs/CHANGES#L13) that would be a breaking change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

