### PR TITLE
pythonPackages.python-ldap-test: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/python-ldap-test/default.nix
+++ b/pkgs/development/python-modules/python-ldap-test/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, py4j }:
+
+buildPythonPackage rec {
+  pname = "python-ldap-test";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qh9x3lncaldnw79fgpqbayichs8pbz8abr6pxb5qxbs7zrnyrwf";
+  };
+
+  propagatedBuildInputs = [ py4j ];
+
+  # Tests needs java to be present in path
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Tool for testing code speaking with LDAP server";
+    homepage = https://github.com/zoldar/python-ldap-test;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -563,6 +563,8 @@ in {
 
   python-lz4 = callPackage ../development/python-modules/python-lz4 { };
 
+  python-ldap-test = callPackage ../development/python-modules/python-ldap-test { };
+
   python-igraph = callPackage ../development/python-modules/python-igraph {
     pkgconfig = pkgs.pkgconfig;
     igraph = pkgs.igraph;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

