### PR TITLE
pythonPackages.python-packer: init at 0.1.2

### DIFF
--- a/pkgs/development/python-modules/python-packer/default.nix
+++ b/pkgs/development/python-modules/python-packer/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, sh }:
+
+buildPythonPackage rec {
+  pname = "python-packer";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fd363dae9bd2efd447739bbf7a4f29c1e4741596ae7b02d252fe525b2b4176e7";
+  };
+
+  propagatedBuildInputs = [ sh ];
+  
+  # Tests requires network connections
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "An interface for packer.io";
+    homepage = https://github.com/nir0s/python-packer;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -570,6 +570,8 @@ in {
 
   python3-openid = callPackage ../development/python-modules/python3-openid { };
 
+  python-packer = callPackage ../development/python-modules/python-packer { };
+
   python-periphery = callPackage ../development/python-modules/python-periphery { };
 
   python-prctl = callPackage ../development/python-modules/python-prctl { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

