### PR TITLE
Let folks try xi-editor (`xi-core`) and various front-ends.

### DIFF
--- a/pkgs/applications/editors/xi/default.nix
+++ b/pkgs/applications/editors/xi/default.nix
@@ -20,9 +20,9 @@ let
 
       cargoSha256 = "078cwlqdafa8mna2kmg9zbs4sd3g8dl07x9xqnmzswqgq8ds0fkk";
 
-      #postInstall = ''
-      #  make -C syntect-plugin install
-      #'';
+      postInstall = ''
+        make -C syntect-plugin install XI_PLUGIN_DIR=$out/share/xi/plugins
+      '';
 
       meta = with lib; {
         description = "A modern editor with a backend written in Rust";

--- a/pkgs/applications/editors/xi/default.nix
+++ b/pkgs/applications/editors/xi/default.nix
@@ -36,6 +36,7 @@ let
 
     gxi = callPackage ./gxi { };
     kod = callPackage ./kod { };
+    xi-gtk = callPackage ./xi-gtk { };
     xi-term = callPackage ./xi-term { };
   };
 in self

--- a/pkgs/applications/editors/xi/default.nix
+++ b/pkgs/applications/editors/xi/default.nix
@@ -20,6 +20,10 @@ let
 
       cargoSha256 = "078cwlqdafa8mna2kmg9zbs4sd3g8dl07x9xqnmzswqgq8ds0fkk";
 
+      #postInstall = ''
+      #  make -C syntect-plugin install
+      #'';
+
       meta = with lib; {
         description = "A modern editor with a backend written in Rust";
         homepage = https://github.com/xi-editor/xi-editor;

--- a/pkgs/applications/editors/xi/default.nix
+++ b/pkgs/applications/editors/xi/default.nix
@@ -22,7 +22,10 @@ let
 
       postInstall = ''
         make -C syntect-plugin install XI_PLUGIN_DIR=$out/share/xi/plugins
+        ln -vrs $out/share/xi/plugins/syntect $syntect
       '';
+
+      outputs = [ "out" "syntect" ];
 
       meta = with lib; {
         description = "A modern editor with a backend written in Rust";

--- a/pkgs/applications/editors/xi/default.nix
+++ b/pkgs/applications/editors/xi/default.nix
@@ -5,8 +5,8 @@ let
   xi-editor-src = fetchFromGitHub {
     owner = "xi-editor";
     repo = "xi-editor";
-    rev = "420d6e0653e6749bd5c58d2c32e9c88ff5b487a6";
-    sha256 = "1fjq2gp8iyig6flr46vpiikr3jfv4jqb400v98lkhz23g9z4v0vr";
+    rev = "392b778abcade4947fffe8a1507dfb522e578a5c";
+    sha256 = "040nag23fccfk7732vnbpsq1vvvlz82ffyxqj5zlyind430j3nqq";
   };
   callPackage = newScope self;
   self = {

--- a/pkgs/applications/editors/xi/default.nix
+++ b/pkgs/applications/editors/xi/default.nix
@@ -1,0 +1,37 @@
+{ lib, fetchFromGitHub, rustPlatform, newScope }:
+
+let
+  version = "2018-10-16";
+  xi-editor-src = fetchFromGitHub {
+    owner = "xi-editor";
+    repo = "xi-editor";
+    rev = "420d6e0653e6749bd5c58d2c32e9c88ff5b487a6";
+    sha256 = "1fjq2gp8iyig6flr46vpiikr3jfv4jqb400v98lkhz23g9z4v0vr";
+  };
+  callPackage = newScope self;
+  self = {
+    xi-core = rustPlatform.buildRustPackage {
+      name = "xi-core-${version}";
+      inherit version;
+
+      src = xi-editor-src;
+
+      sourceRoot = "source/rust";
+
+      cargoSha256 = "078cwlqdafa8mna2kmg9zbs4sd3g8dl07x9xqnmzswqgq8ds0fkk";
+
+      meta = with lib; {
+        description = "A modern editor with a backend written in Rust";
+        homepage = https://github.com/xi-editor/xi-editor;
+        license = licenses.asl20;
+        maintainers = with maintainers; [ dtzWill ];
+        platforms = platforms.all;
+      };
+    };
+    wrapXiFrontendHook = callPackage ./wrapper.nix { };
+
+    gxi = callPackage ./gxi { };
+    kod = callPackage ./kod { };
+    xi-term = callPackage ./xi-term { };
+  };
+in self

--- a/pkgs/applications/editors/xi/gxi/default.nix
+++ b/pkgs/applications/editors/xi/gxi/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, rustPlatform, cmake, pkgconfig, freetype, gtk3, wrapGAppsHook, wrapXiFrontendHook }:
+
+rustPlatform.buildRustPackage rec {
+  name = "gxi-unstable-${version}";
+  version = "2018-08-27";
+  
+  src = fetchFromGitHub {
+    owner = "bvinc";
+    repo = "gxi";
+    rev = "a35d2cf6c5f1ac71387caf6fc33f158454a89f25";
+    sha256 = "1yg9mglxssavmcyvi38mjsmzsgrls2ridnphvwrxgzgnw7293wav";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig freetype ];
+
+  buildInputs = [
+    gtk3
+    wrapGAppsHook
+    wrapXiFrontendHook
+  ];
+
+  cargoSha256 = "0v72s58g0v69gpja8n0sxzpc821849p6q53pmyasbrnjhyh51nxw";
+
+  postInstall = "wrapXiFrontend $out/bin/*";
+
+  meta = with stdenv.lib; {
+    description = "GTK frontend for the xi text editor, written in rust";
+    homepage = https://github.com/bvinc/gxi;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/xi/kod/default.nix
+++ b/pkgs/applications/editors/xi/kod/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoPackage, fetchFromGitHub, wrapXiFrontendHook }:
+
+buildGoPackage rec {
+  bname = "kod";
+  name = "kod-unstable-${version}";
+  version = "2018-10-16";
+  rev = "146fef39a44868c01ba4cb2b1a2ba18a90f1df06";
+
+  goPackagePath = "github.com/linde12/kod";
+
+  src = fetchFromGitHub {
+    owner = "linde12";
+    repo = "kod";
+    inherit rev;
+    sha256 = "0lavfivwlk1ga0xf237dxmdax06gs030a005xx1rdy1a3sy77bdg";
+  };
+
+  goDeps = ./deps.nix;
+
+  buildInputs = [ wrapXiFrontendHook ];
+
+  postInstall = "wrapXiFrontend $bin/bin/*";
+
+  meta = with lib; {
+    description = "terminal text editor written in Go, using xi-editor as backend";
+    homepage = https://github.com/linde12/kod;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/xi/kod/default.nix
+++ b/pkgs/applications/editors/xi/kod/default.nix
@@ -19,6 +19,8 @@ buildGoPackage rec {
 
   buildInputs = [ wrapXiFrontendHook ];
 
+  patches = [ ./tcell-bump.patch ];
+
   postInstall = "wrapXiFrontend $bin/bin/*";
 
   meta = with lib; {

--- a/pkgs/applications/editors/xi/kod/deps.nix
+++ b/pkgs/applications/editors/xi/kod/deps.nix
@@ -1,0 +1,48 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/gdamore/encoding";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gdamore/encoding";
+      rev =  "b23993cbb6353f0e6aa98d0ee318a34728f628b9";
+      sha256 = "0d7irqpx2fa9vkxgkhf04yiwazsm10fxh0yk86x5crflhph5fv8a";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gdamore/tcell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gdamore/tcell";
+      rev =  "061d51a604c546b48e92253cb65190d76cecf4c6";
+      sha256 = "0mwlncdhbz0fh4rly0sbrn30ms9vdvqv58dal3viv4alqfrij569";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lucasb-eyer/go-colorful";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lucasb-eyer/go-colorful";
+      rev =  "345fbb3dbcdb252d9985ee899a84963c0fa24c82";
+      sha256 = "0r3llqdc6vf6i76q7v8yrw7f9r39r7ij739w7agx0xfwvq7g3rmj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev =  "9e777a8366cce605130a531d2cd6363d07ad7317";
+      sha256 = "0vkrfrz3fzn5n6ix4k8s0cg0b448459sldq8bp4riavsxm932jzb";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+]

--- a/pkgs/applications/editors/xi/kod/deps.nix
+++ b/pkgs/applications/editors/xi/kod/deps.nix
@@ -14,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/gdamore/tcell";
-      rev =  "061d51a604c546b48e92253cb65190d76cecf4c6";
-      sha256 = "0mwlncdhbz0fh4rly0sbrn30ms9vdvqv58dal3viv4alqfrij569";
+      rev =  "de7e78efa4a71b3f36c7154989c529dbdf9ae623";
+      sha256 = "1ly3gqkziw01cb7h64k0wc4myzfcsr9hl7xznxd8k2yqzqvmhljz";
     };
   }
   {

--- a/pkgs/applications/editors/xi/kod/tcell-bump.patch
+++ b/pkgs/applications/editors/xi/kod/tcell-bump.patch
@@ -1,0 +1,27 @@
+From 6f2346527046bcfd9dfbf562255a879a6c643365 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 16 Oct 2018 17:01:43 -0500
+Subject: [PATCH] tcell: v1.0.0 -> v1.1.0
+
+---
+ Gopkg.lock | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Gopkg.lock b/Gopkg.lock
+index 1284da2..32d23e1 100644
+--- a/Gopkg.lock
++++ b/Gopkg.lock
+@@ -13,8 +13,8 @@
+     ".",
+     "terminfo"
+   ]
+-  revision = "061d51a604c546b48e92253cb65190d76cecf4c6"
+-  version = "v1.0.0"
++  revision = "de7e78efa4a71b3f36c7154989c529dbdf9ae623"
++  version = "v1.1.0"
+ 
+ [[projects]]
+   name = "github.com/lucasb-eyer/go-colorful"
+-- 
+2.19.1
+

--- a/pkgs/applications/editors/xi/wrapper.nix
+++ b/pkgs/applications/editors/xi/wrapper.nix
@@ -1,0 +1,13 @@
+{ lib, makeSetupHook, writeScript, makeWrapper, xi-core }:
+
+makeSetupHook {
+  name = "wrapXiFrontend-hook";
+  deps = [ makeWrapper ]; 
+} (writeScript "wrapXiFrontend" ''
+  wrapXiFrontend() {
+    for x in "$@"; do
+      wrapProgram "$x" \
+        --prefix PATH : ${lib.makeBinPath [ xi-core ]}
+    done
+  }
+'')

--- a/pkgs/applications/editors/xi/xi-gtk/default.nix
+++ b/pkgs/applications/editors/xi/xi-gtk/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, gtk3, json-glib, vala, wrapGAppsHook, wrapXiFrontendHook }:
+
+stdenv.mkDerivation rec {
+  name = "xi-gtk-${version}";
+  version = "2018-07-30";
+  
+  src = fetchFromGitHub {
+    owner = "eyelash";
+    repo = "xi-gtk";
+    rev = "50fff217df29e5da82aaaf196d92009757ffb571";
+    sha256 = "13r3i0z7j4jlv3n56nj76bx63zy9wh939j1rgjw1snw4q7v7s9x3";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+
+  buildInputs = [
+    gtk3 json-glib vala
+    wrapGAppsHook
+    wrapXiFrontendHook
+  ];
+
+  postInstall = "wrapXiFrontend $out/bin/*";
+
+  meta = with stdenv.lib; {
+    description = "A GTK+ front-end for the Xi editor";
+    homepage = https://github.com/eyelash/xi-gtk;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/xi/xi-term/default.nix
+++ b/pkgs/applications/editors/xi/xi-term/default.nix
@@ -1,0 +1,28 @@
+{ lib, rustPlatform, fetchFromGitHub, wrapXiFrontendHook }:
+
+rustPlatform.buildRustPackage rec {
+  name = "xi-term-${version}";
+  version = "2018-10-13";
+
+  src = fetchFromGitHub {
+    owner = "xi-frontend";
+    repo = "xi-term";
+    rev = "8a57bea757294a12df9d3ec81ae1319bd0e288cd";
+    sha256 = "0sn1jm6hx5dbxmpvgzkwcl6vxl826lk7vnbggxd64zbnhjyijdj8";
+  };
+
+  cargoSha256 = "1h49j2r5bh1rjqmss6ccivc2x0ndmamqqzhi6kd02vgrv8jnwxg1";
+
+  buildInputs = [ wrapXiFrontendHook ];
+
+  postInstall = "wrapXiFrontend $out/bin/*";
+
+  meta = with lib; {
+    description = "A terminal frontend for Xi";
+    homepage = https://github.com/xi-frontend/xi-term;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19700,6 +19700,7 @@ with pkgs;
     gxi
     kod
     xi-core
+    xi-gtk
     xi-term;
 
   xen = xenPackages.xen-vanilla;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19695,7 +19695,12 @@ with pkgs;
 
   xdotool = callPackage ../tools/X11/xdotool { };
 
-  xenPackages = recurseIntoAttrs (callPackage ../applications/virtualization/xen/packages.nix {});
+
+  inherit (callPackages ../applications/editors/xi { })
+    gxi
+    kod
+    xi-core
+    xi-term;
 
   xen = xenPackages.xen-vanilla;
   xen-slim = xenPackages.xen-slim;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19695,13 +19695,7 @@ with pkgs;
 
   xdotool = callPackage ../tools/X11/xdotool { };
 
-
-  inherit (callPackages ../applications/editors/xi { })
-    gxi
-    kod
-    xi-core
-    xi-gtk
-    xi-term;
+  xenPackages = recurseIntoAttrs (callPackage ../applications/virtualization/xen/packages.nix {});
 
   xen = xenPackages.xen-vanilla;
   xen-slim = xenPackages.xen-slim;
@@ -19717,6 +19711,14 @@ with pkgs;
   xkbset = callPackage ../tools/X11/xkbset { };
 
   xkbmon = callPackage ../applications/misc/xkbmon { };
+
+  inherit (callPackages ../applications/editors/xi { })
+    gxi
+    kod
+    xi-core
+    xi-gtk
+    xi-term;
+
 
   win-spice = callPackage ../applications/virtualization/driver/win-spice { };
   win-virtio = callPackage ../applications/virtualization/driver/win-virtio { };


### PR DESCRIPTION
They're all WIP (as in "upstream is still working towards a release") but
having them packaged makes it easier to get started and see what it's about.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---