### PR TITLE
chromium 71+: add at-spi2-core dependency

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -14,7 +14,7 @@
 , glib, gtk2, gtk3, dbus-glib
 , libXScrnSaver, libXcursor, libXtst, libGLU_combined
 , protobuf, speechd, libXdamage, cups
-, ffmpeg, libxslt, libxml2
+, ffmpeg, libxslt, libxml2, at-spi2-core
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -129,7 +129,8 @@ let
     ] ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
-      ++ optional pulseSupport libpulseaudio;
+      ++ optional pulseSupport libpulseaudio
+      ++ optional (versionAtLeast version "71") at-spi2-core;
 
     patches = [
       # As major versions are added, you can trawl the gentoo and arch repos at


### PR DESCRIPTION
###### Motivation for this change

Chromium 71+ depends on ```at-spi2-core```

This alone does not fix the build.
There are few patches needed, but they are already upstream, so minor bump will likely fix the build