### PR TITLE
theme-obsidian2: 2.6 -> 2.7

### DIFF
--- a/pkgs/misc/themes/obsidian2/default.nix
+++ b/pkgs/misc/themes/obsidian2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "theme-obsidian2-${version}";
-  version = "2.6";
+  version = "2.7";
 
   src = fetchFromGitHub {
     owner = "madmaxms";
     repo = "theme-obsidian-2";
     rev = "v${version}";
-    sha256 = "1bb629y11j79h0rxi36iszki6m6l59iwlcraygr472gf44a2xp11";
+    sha256 = "0my3q7xvi6m257x489wync0y5n8n1kig4xg5gfrb905avhxj5frs";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];


### PR DESCRIPTION
###### Motivation for this change

- Update to version [2.7](https://github.com/madmaxms/theme-obsidian-2/releases)
 
Changes:
- added support for the new nautilus pathbar in GNOME 3.30
- button details

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).