### PR TITLE
Set CMAKE_SYSTEM_* for cross compiling

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -46,6 +46,24 @@ rec {
       # Misc boolean options
       useAndroidPrebuilt = false;
       useiOSPrebuilt = false;
+
+      # Output from uname
+      uname = {
+        # uname -s
+        system = if final.isLinux then "Linux"
+                 else if final.isDarwin then "Darwin"
+                 else if final.isWindows then "Windows"
+                 else if final.isFreeBSD then "FreeBSD"
+                 else if final.isNetBSD then "NetBSD"
+                 else if final.isOpenBSD then "OpenBSD"
+                 else null;
+
+         # uname -p
+         processor = final.parsed.cpu.name;
+
+         # uname -r
+         release = null;
+      };
     } // mapAttrs (n: v: v final.parsed) inspect.predicates
       // args;
   in assert final.useAndroidPrebuilt -> final.isAndroid;

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -50,13 +50,14 @@ rec {
       # Output from uname
       uname = {
         # uname -s
-        system = if final.isLinux then "Linux"
-                 else if final.isDarwin then "Darwin"
-                 else if final.isWindows then "Windows"
-                 else if final.isFreeBSD then "FreeBSD"
-                 else if final.isNetBSD then "NetBSD"
-                 else if final.isOpenBSD then "OpenBSD"
-                 else null;
+        system = {
+          "linux" = "Linux";
+          "windows" = "Windows";
+          "darwin" = "Darwin";
+          "netbsd" = "NetBSD";
+          "freebsd" = "FreeBSD";
+          "openbsd" = "OpenBSD";
+        }.${final.parsed.kernel.name} or null;
 
          # uname -p
          processor = final.parsed.cpu.name;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -39,7 +39,7 @@ in rec {
   darwin  = filterDoubles predicates.isDarwin;
   freebsd = filterDoubles predicates.isFreeBSD;
   # Should be better, but MinGW is unclear.
-  gnu     = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; });
+  gnu     = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; });
   illumos = filterDoubles predicates.isSunOS;
   linux   = filterDoubles predicates.isLinux;
   netbsd  = filterDoubles predicates.isNetBSD;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -16,7 +16,7 @@ let
     "x86_64-cygwin" "x86_64-darwin" "x86_64-freebsd" "x86_64-linux"
     "x86_64-netbsd" "x86_64-openbsd" "x86_64-solaris"
 
-    "x86_64-mingw32" "i686-mingw32"
+    "x86_64-windows" "i686-windows"
   ];
 
   allParsed = map parse.mkSystemFromString all;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -15,6 +15,8 @@ let
 
     "x86_64-cygwin" "x86_64-darwin" "x86_64-freebsd" "x86_64-linux"
     "x86_64-netbsd" "x86_64-openbsd" "x86_64-solaris"
+
+    "x86_64-mingw32" "i686-mingw32"
   ];
 
   allParsed = map parse.mkSystemFromString all;
@@ -43,6 +45,7 @@ in rec {
   netbsd  = filterDoubles predicates.isNetBSD;
   openbsd = filterDoubles predicates.isOpenBSD;
   unix    = filterDoubles predicates.isUnix;
+  windows = filterDoubles predicates.isWindows;
 
   mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "powerpc64le-linux"];
 }

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -12,20 +12,21 @@ let
     expected = lib.sort lib.lessThan y;
   };
 in with lib.systems.doubles; lib.runTests {
-  all = assertTrue (mseteq all (linux ++ darwin ++ cygwin ++ freebsd ++ openbsd ++ netbsd ++ illumos));
+  testall = mseteq all (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ windows);
 
-  arm = assertTrue (mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv7l-linux" ]);
-  i686 = assertTrue (mseteq i686 [ "i686-linux" "i686-freebsd" "i686-netbsd" "i686-openbsd" "i686-cygwin" ]);
-  mips = assertTrue (mseteq mips [ "mipsel-linux" ]);
-  x86_64 = assertTrue (mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" ]);
+  testarm = mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv7l-linux" ];
+  testi686 = mseteq i686 [ "i686-linux" "i686-freebsd" "i686-netbsd" "i686-openbsd" "i686-cygwin" "i686-windows" ];
+  testmips = mseteq mips [ "mipsel-linux" ];
+  testx86_64 = mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" "x86_64-windows" ];
 
-  cygwin = assertTrue (mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ]);
-  darwin = assertTrue (mseteq darwin [ "x86_64-darwin" ]);
-  freebsd = assertTrue (mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ]);
-  gnu = assertTrue (mseteq gnu (linux /* ++ kfreebsd ++ ... */));
-  illumos = assertTrue (mseteq illumos [ "x86_64-solaris" ]);
-  linux = assertTrue (mseteq linux [ "i686-linux" "x86_64-linux" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mipsel-linux" ]);
-  netbsd = assertTrue (mseteq netbsd [ "i686-netbsd" "x86_64-netbsd" ]);
-  openbsd = assertTrue (mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ]);
-  unix = assertTrue (mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos));
+  testcygwin = mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ];
+  testdarwin = mseteq darwin [ "x86_64-darwin" ];
+  testfreebsd = mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ];
+  testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
+  testillumos = mseteq illumos [ "x86_64-solaris" ];
+  testlinux = mseteq linux [ "i686-linux" "x86_64-linux" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mipsel-linux" ];
+  testnetbsd = mseteq netbsd [ "i686-netbsd" "x86_64-netbsd" ];
+  testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
+  testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];
+  testunix = mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos ++ cygwin);
 }

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -101,6 +101,8 @@ stdenv.mkDerivation {
 
   inherit src;
 
+  patchFlags = "";
+
   patches = patches
     ++ optional stdenv.isDarwin ./darwin-no-system-python.patch;
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation {
     description = "Collection of C++ libraries";
     license = stdenv.lib.licenses.boost;
 
-    platforms = (if versionOlder version "1.59" then remove "aarch64-linux" else id) platforms.all;
+    platforms = (if versionOlder version "1.59" then remove "aarch64-linux" else id) (platforms.unix ++ platforms.windows);
     maintainers = with maintainers; [ peti wkennington ];
   };
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -135,7 +135,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ which buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ which ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
   buildInputs = [ expat zlib bzip2 libiconv ]
     ++ optional (stdenv.hostPlatform == stdenv.buildPlatform) icu
     ++ optional stdenv.isDarwin fixDarwinDylibNames

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -101,21 +101,15 @@ stdenv.mkDerivation {
 
   inherit src;
 
-  patchFlags = optionalString (stdenv.hostPlatform.libc == "msvcrt") "-p0";
   patches = patches
-    ++ optional stdenv.isDarwin ./darwin-no-system-python.patch
-    ++ optional (stdenv.hostPlatform.libc == "msvcrt") (fetchurl {
-      url = "https://svn.boost.org/trac/boost/raw-attachment/tickaet/7262/"
-          + "boost-mingw.patch";
-      sha256 = "0s32kwll66k50w6r5np1y5g907b7lcpsjhfgr7rsw7q5syhzddyj";
-    });
+    ++ optional stdenv.isDarwin ./darwin-no-system-python.patch;
 
   meta = {
     homepage = http://boost.org/;
     description = "Collection of C++ libraries";
     license = stdenv.lib.licenses.boost;
 
-    platforms = (if versionOlder version "1.59" then remove "aarch64-linux" else id) platforms.unix;
+    platforms = (if versionOlder version "1.59" then remove "aarch64-linux" else id) platforms.all;
     maintainers = with maintainers; [ peti wkennington ];
   };
 

--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0vnwmbvymw677k780kpb6sb8i3szdp89rzy8mz1fwg1657yw3ls5";
   };
 
+  configureFlags = if stdenv.hostPlatform.isWindows then [ "--disable-shared" "--enable-static" ] else null;
+
   # ares_android.h header is missing
   # see issue https://github.com/c-ares/c-ares/issues/216
   postPatch = if stdenv.hostPlatform.isAndroid then ''

--- a/pkgs/development/libraries/msgpack/generic.nix
+++ b/pkgs/development/libraries/msgpack/generic.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = []
     ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
                            "-DMSGPACK_BUILD_EXAMPLES=OFF"
-    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "msvcrt")
-                           "-DCMAKE_SYSTEM_NAME=Windows"
     ;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -6,6 +6,7 @@
 , enableAsioLib ? false, boost ? null
 , enableGetAssets ? false, libxml2 ? null
 , enableJemalloc ? false, jemalloc ? null
+, enableApp ? !stdenv.hostPlatform.isWindows
 }:
 
 assert enableHpack -> jansson != null;
@@ -35,8 +36,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = [ "--with-spdylay=no" "--disable-examples" "--disable-python-bindings" "--enable-app" ]
-    ++ optional enableAsioLib "--enable-asio-lib --with-boost-libdir=${boost}/lib";
+  configureFlags = [
+    "--with-spdylay=no"
+    "--disable-examples"
+    "--disable-python-bindings"
+    (stdenv.lib.enableFeature enableApp "app")
+  ] ++ optional enableAsioLib "--enable-asio-lib --with-boost-libdir=${boost}/lib";
 
   #doCheck = true;  # requires CUnit ; currently failing at test_util_localtime_date in util_test.cc
 

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBuildTests=${if doCheck then "ON" else "OFF"}"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform.libc == "msvcrt") [
-    "-DCMAKE_SYSTEM_NAME=Windows"
   ];
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.sqlite.org/;
     license = licenses.publicDomain;
     maintainers = with maintainers; [ eelco np ];
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
   };
 }

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -82,4 +82,6 @@ stdenv.mkDerivation (rec {
   preConfigure = ''
     export CHOST=${stdenv.hostPlatform.config}
   '';
+} // stdenv.lib.optionalAttrs (stdenv.hostPlatform.libc == "msvcrt") {
+  configurePhase = ":";
 })

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = [];
+
   outputs = [ "out" "dev" "lib" ];
 
   doCheck = true;

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -15,9 +15,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = stdenv.lib.optional
-    (stdenv.hostPlatform.libc == "msvcrt") "-DCMAKE_SYSTEM_NAME=Windows";
-
   outputs = [ "out" "dev" "lib" ];
 
   doCheck = true;
@@ -59,4 +56,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/tools/networking/curl/7_59.nix
+++ b/pkgs/tools/networking/curl/7_59.nix
@@ -77,7 +77,11 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${kerberos.dev}"
        # For the 'urandom', maybe it should be a cross-system option
     ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-       "--with-random=/dev/urandom";
+       "--with-random=/dev/urandom"
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isWindows [
+      "--disable-shared"
+      "--enable-static"
+    ];
 
   CXX = "${stdenv.cc.targetPrefix}c++";
   CXXCPP = "${stdenv.cc.targetPrefix}c++ -E";

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -81,7 +81,11 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional gssSupport "--with-gssapi=${kerberos.dev}"
        # For the 'urandom', maybe it should be a cross-system option
     ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-       "--with-random=/dev/urandom";
+       "--with-random=/dev/urandom"
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isWindows [
+      "--disable-shared"
+      "--enable-static"
+    ];
 
   CXX = "${stdenv.cc.targetPrefix}c++";
   CXXCPP = "${stdenv.cc.targetPrefix}c++ -E";

--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ];
 
+  cmakeFlags = [];
+
   # ATM bin/tidy is statically linked, as upstream provides no other option yet.
   # https://github.com/htacg/tidy-html5/issues/326#issuecomment-160322107
 

--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -13,9 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake libxslt/*manpage*/ ];
 
-  cmakeFlags = stdenv.lib.optional
-    (stdenv.hostPlatform.libc or null == "msvcrt") "-DCMAKE_SYSTEM_NAME=Windows";
-
   # ATM bin/tidy is statically linked, as upstream provides no other option yet.
   # https://github.com/htacg/tidy-html5/issues/326#issuecomment-160322107
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2075,7 +2075,7 @@ with pkgs;
     zlibSupport = true;
     sslSupport = zlibSupport;
     scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
-    gssSupport = true;
+    gssSupport = !stdenv.hostPlatform.isWindows;
   };
 
   curl = callPackage ../tools/networking/curl rec {
@@ -2084,7 +2084,7 @@ with pkgs;
     zlibSupport = true;
     sslSupport = zlibSupport;
     scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
-    gssSupport = true;
+    gssSupport = !stdenv.hostPlatform.isWindows;
   };
 
   curl_unix_socket = callPackage ../tools/networking/curl-unix-socket rec { };


### PR DESCRIPTION
###### Motivation for this change
This sets some new variables in make-derivation for cross compiling with CMAKE. Here is the list:

- CMAKE_SYSTEM_NAME
- CMAKE_SYSTEM_PROCESSOR
- CMAKE_SYSTEM_VERSION
- CMAKE_HOST_SYSTEM_NAME
- CMAKE_HOST_SYSTEM_PROCESSOR
- CMAKE_HOST_SYSTEM_VERSION

To do this, we need to start keeping track of uname values, respectively:

- uname -s (stdenv.buildPlatform.uname.system)
- uname -p (stdenv.buildPlatform.uname.processor)
- uname -r (stdenv.buildPlatform.uname.release)

We don't really have a way to get the last one, so leave it null for now.

Also remove some old hacks setting CMAKE_SYSTEM_NAME ad-hoc. And also add some windows doubles (were strangely missing).