### PR TITLE
kernel: Turn on TCP_CONG_ADVANCED which allows TCP BBR to be a module.

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -116,6 +116,7 @@ let
       CLS_U32_MARK       = yes;
       BPF_JIT            = when (stdenv.hostPlatform.system == "x86_64-linux") yes;
       WAN                = yes;
+      TCP_CONG_ADVANCED  = yes;
       # Required by systemd per-cgroup firewalling
       CGROUP_BPF                  = option yes;
       CGROUP_NET_PRIO             = yes; # Required by systemd


### PR DESCRIPTION
It looks like TCP_CONG_ADVANCED gates the TCP BBR module.

###### Motivation for this change
This allows people to use the TCP BBR module by twiddling sysctl. Without this, they are required to rebuild the entire kernel. I personally want to use TCP BBR which is why I'm adding this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

