### PR TITLE
polar-bookshelf: init at 1.0.11

### DIFF
--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -1,0 +1,98 @@
+{ stdenv, lib, makeWrapper, fetchurl
+, dpkg, wrapGAppsHook
+, gtk3, cairo, gnome2, atk, gdk_pixbuf, glib
+, at-spi2-atk, dbus, libX11, libxcb, libXi
+, libXcursor, libXdamage, libXrandr, libXcomposite
+, libXext, libXfixes, libXrender, libXtst, libXScrnSaver
+, nss, nspr, alsaLib, cups, fontconfig, expat
+, libudev0-shim, glibc, curl, openssl, nghttp2, gsettings_desktop_schemas }:
+
+
+stdenv.mkDerivation rec {
+  name = "polar-bookshelf-${version}";
+  version = "1.0.2";
+
+  src = fetchurl {
+    url = "https://github.com/burtonator/polar-bookshelf/releases/download/${version}/polar-bookshelf-${version}-amd64.deb";
+    sha256 = "0fz34qvd7zp5rd5rqljwhq8ya9x29cq5h8axb82z369nkbi1xpbs";
+  };
+
+  buildInputs = [
+    gsettings_desktop_schemas
+    glib
+    gtk3
+  ];
+
+  nativeBuildInputs = [ 
+    wrapGAppsHook
+    makeWrapper 
+    dpkg
+  ];
+
+  libPath = lib.makeLibraryPath [
+      gtk3
+      cairo
+      gnome2.pango
+      atk
+      gdk_pixbuf
+      glib
+      at-spi2-atk
+      dbus
+      libX11
+      libxcb
+      libXi
+      libXcursor
+      libXdamage
+      libXrandr
+      libXcomposite
+      libXext
+      libXfixes
+      libXrender
+      libXtst
+      libXScrnSaver
+      nss
+      nspr
+      alsaLib
+      cups
+      fontconfig
+      expat
+  ];
+
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl nghttp2 ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p $out/share/polar-bookshelf
+    mkdir -p $out/bin
+    mkdir -p $out/lib
+
+    mv opt/Polar\ Bookshelf/* $out/share/polar-bookshelf
+    mv $out/share/polar-bookshelf/*.so $out/lib
+
+    mv usr/share/* $out/share/
+
+    ln -s $out/share/polar-bookshelf/polar-bookshelf $out/bin/polar-bookshelf
+  '';
+
+  preFixup = ''
+    for lib in $out/lib/*.so; do
+      patchelf --set-rpath "$out/lib:${libPath}" $lib
+    done
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+             --set-rpath "$out/lib:${libPath}" \
+             $out/bin/polar-bookshelf 
+
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibs}" )
+  '';
+
+  meta = {
+    homepage = https://getpolarized.io/;
+    description = "Personal knowledge repository for PDF and web content supporting incremental reading and document annotation.";
+    license = stdenv.lib.licenses.gpl1Plus;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.noneucat ];
+  };
+
+}

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -5,7 +5,7 @@
 , libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver
 , nss, nspr, alsaLib, cups, fontconfig, expat
-, libudev0-shim, glibc, curl, openssl, nghttp2, gnome3 }:
+, libudev0-shim, glibc, curl, openssl, libnghttp2, gnome3 }:
 
 
 stdenv.mkDerivation rec {
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     gnome2.pango
     atk
     gdk_pixbuf
-    glib
     at-spi2-atk
     dbus
     libX11
@@ -56,7 +55,7 @@ stdenv.mkDerivation rec {
     dpkg
   ];
 
-  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl nghttp2 ];
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl libnghttp2 ];
 
   unpackPhase = "dpkg-deb -x $src .";
 
@@ -79,8 +78,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://getpolarized.io/;
-    description = "Personal knowledge repository for PDF and web content supporting incremental reading and document annotation.";
-    license = stdenv.lib.licenses.gpl2Plus;
+    description = "Personal knowledge repository for PDF and web content supporting incremental reading and document annotation";
+    license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.noneucat ];
   };

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   name = "polar-bookshelf-${version}";
-  version = "1.0.2";
+  version = "1.0.4";
 
   # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
     url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
-    sha256 = "0fz34qvd7zp5rd5rqljwhq8ya9x29cq5h8axb82z369nkbi1xpbs";
+    sha256 = "1lqzkknllvvicw3lpb9f3pibcrwak47j0b5lcbglml816s189q9x";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
-    url = "https://github.com/burtonator/polar-bookshelf/releases/download/${version}/polar-bookshelf-${version}-amd64.deb";
+    url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
     sha256 = "0fz34qvd7zp5rd5rqljwhq8ya9x29cq5h8axb82z369nkbi1xpbs";
   };
 

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -5,7 +5,7 @@
 , libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver
 , nss, nspr, alsaLib, cups, fontconfig, expat
-, libudev0-shim, glibc, curl, openssl, nghttp2, gsettings_desktop_schemas }:
+, libudev0-shim, glibc, curl, openssl, nghttp2, gnome3 }:
 
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    gsettings_desktop_schemas
+    gnome3.gsettings_desktop_schemas
     glib
     gtk3
   ];

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, makeWrapper, fetchurl
-, dpkg, wrapGAppsHook
+, dpkg, wrapGAppsHook, autoPatchelfHook
 , gtk3, cairo, gnome2, atk, gdk_pixbuf, glib
 , at-spi2-atk, dbus, libX11, libxcb, libXi
 , libXcursor, libXdamage, libXrandr, libXcomposite
@@ -22,41 +22,38 @@ stdenv.mkDerivation rec {
     gnome3.gsettings_desktop_schemas
     glib
     gtk3
+    cairo
+    gnome2.pango
+    atk
+    gdk_pixbuf
+    glib
+    at-spi2-atk
+    dbus
+    libX11
+    libxcb
+    libXi
+    libXcursor
+    libXdamage
+    libXrandr
+    libXcomposite
+    libXext
+    libXfixes
+    libXrender
+    libXtst
+    libXScrnSaver
+    nss
+    nspr
+    alsaLib
+    cups
+    fontconfig
+    expat
   ];
 
   nativeBuildInputs = [ 
     wrapGAppsHook
+    autoPatchelfHook
     makeWrapper 
     dpkg
-  ];
-
-  libPath = lib.makeLibraryPath [
-      gtk3
-      cairo
-      gnome2.pango
-      atk
-      gdk_pixbuf
-      glib
-      at-spi2-atk
-      dbus
-      libX11
-      libxcb
-      libXi
-      libXcursor
-      libXdamage
-      libXrandr
-      libXcomposite
-      libXext
-      libXfixes
-      libXrender
-      libXtst
-      libXScrnSaver
-      nss
-      nspr
-      alsaLib
-      cups
-      fontconfig
-      expat
   ];
 
   runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl nghttp2 ];
@@ -77,14 +74,6 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    for lib in $out/lib/*.so; do
-      patchelf --set-rpath "$out/lib:${libPath}" $lib
-    done
-
-    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-             --set-rpath "$out/lib:${libPath}" \
-             $out/bin/polar-bookshelf 
-
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibs}" )
   '';
 

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   name = "polar-bookshelf-${version}";
-  version = "1.0.4";
+  version = "1.0.11";
 
   # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
     url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
-    sha256 = "1lqzkknllvvicw3lpb9f3pibcrwak47j0b5lcbglml816s189q9x";
+    sha256 = "11rrwd5cr984nhgrib12hx6k74hzgmb3cfk6qnr1l604dk9pqfqx";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://getpolarized.io/;
     description = "Personal knowledge repository for PDF and web content supporting incremental reading and document annotation.";
-    license = stdenv.lib.licenses.gpl1Plus;
+    license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.noneucat ];
   };

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   name = "polar-bookshelf-${version}";
   version = "1.0.2";
 
+  # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
     url = "https://github.com/burtonator/polar-bookshelf/releases/download/${version}/polar-bookshelf-${version}-amd64.deb";
     sha256 = "0fz34qvd7zp5rd5rqljwhq8ya9x29cq5h8axb82z369nkbi1xpbs";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18427,6 +18427,8 @@ with pkgs;
 
   pmenu = callPackage ../applications/misc/pmenu { };
 
+  polar-bookshelf = callPackage ../applications/misc/polar-bookshelf { };
+
   poezio = python3Packages.poezio;
 
   pommed = callPackage ../os-specific/linux/pommed {};


### PR DESCRIPTION
###### Motivation for this change
Addition of `polar-bookshelf`, an application for document annotation and storage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

