### PR TITLE
x11vnc: 0.9.13 -> 0.9.15, adding maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3110,6 +3110,11 @@
     github = "olynch";
     name = "Owen Lynch";
   };
+  OPNA2608 = {
+    email = "christoph.neidahl@gmail.com";
+    github = "OPNA2608";
+    name = "Christoph Neidahl";
+  };
   orbekk = {
     email = "kjetil.orbekk@gmail.com";
     github = "orbekk";

--- a/pkgs/tools/X11/x11vnc/default.nix
+++ b/pkgs/tools/X11/x11vnc/default.nix
@@ -1,12 +1,19 @@
-{ stdenv, fetchurl, openssl, zlib, libjpeg, xorg, coreutils }:
+{ stdenv, fetchFromGitHub,
+  openssl, zlib, libjpeg, xorg, coreutils, libvncserver,
+  autoreconfHook, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "x11vnc-0.9.13";
+  name = "x11vnc-${version}";
+  version = "0.9.15";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libvncserver/${name}.tar.gz";
-    sha256 = "0fzib5xb1vbs8kdprr4z94v0fshj2c5hhaz69llaarwnc8p9z0pn";
+  src = fetchFromGitHub {
+    owner = "LibVNC";
+    repo = "x11vnc";
+    rev = version;
+    sha256 = "1a1b65k1hsy4nhg2sx1yrpaz3vx6s7rmrx8nwygpaam8wpdlkh8p";
   };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs =
     [ xorg.libXfixes xorg.fixesproto openssl xorg.libXdamage
@@ -14,21 +21,22 @@ stdenv.mkDerivation rec {
       xorg.libXtst xorg.libXinerama xorg.xineramaproto xorg.libXrandr
       xorg.randrproto xorg.libXext xorg.xextproto xorg.inputproto
       xorg.recordproto xorg.libXi xorg.libXrender xorg.renderproto
+      libvncserver
     ];
 
   preConfigure = ''
     configureFlags="--mandir=$out/share/man"
 
-    substituteInPlace x11vnc/unixpw.c \
+    substituteInPlace src/unixpw.c \
         --replace '"/bin/su"' '"/run/wrappers/bin/su"' \
         --replace '"/bin/true"' '"${coreutils}/bin/true"'
 
-    sed -i -e '/#!\/bin\/sh/a"PATH=${xorg.xdpyinfo}\/bin:${xorg.xauth}\/bin:$PATH\\n"' -e 's|/bin/su|/run/wrappers/bin/su|g' x11vnc/ssltools.h
+    sed -i -e '/#!\/bin\/sh/a"PATH=${xorg.xdpyinfo}\/bin:${xorg.xauth}\/bin:$PATH\\n"' -e 's|/bin/su|/run/wrappers/bin/su|g' src/ssltools.h
   '';
 
   meta = with stdenv.lib; {
     description = "A VNC server connected to a real X11 screen";
-    homepage = http://www.karlrunge.com/x11vnc/;
+    homepage = https://github.com/LibVNC/x11vnc/;
     platforms = platforms.linux;
     license = licenses.gpl2;
   };

--- a/pkgs/tools/X11/x11vnc/default.nix
+++ b/pkgs/tools/X11/x11vnc/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
         --replace '"/bin/true"' '"${coreutils}/bin/true"'
 
     sed -i -e '/#!\/bin\/sh/a"PATH=${xorg.xdpyinfo}\/bin:${xorg.xauth}\/bin:$PATH\\n"' -e 's|/bin/su|/run/wrappers/bin/su|g' src/ssltools.h
+    sed -i -e '/^\tXdummy.c\ \\$/,$d' -e 's/\tx11vnc_loop\ \\/\tx11vnc_loop/' misc/Makefile.am
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/X11/x11vnc/default.nix
+++ b/pkgs/tools/X11/x11vnc/default.nix
@@ -24,15 +24,19 @@ stdenv.mkDerivation rec {
       libvncserver
     ];
 
-  preConfigure = ''
-    configureFlags="--mandir=$out/share/man"
-
+  postPatch = ''
     substituteInPlace src/unixpw.c \
         --replace '"/bin/su"' '"/run/wrappers/bin/su"' \
         --replace '"/bin/true"' '"${coreutils}/bin/true"'
 
     sed -i -e '/#!\/bin\/sh/a"PATH=${xorg.xdpyinfo}\/bin:${xorg.xauth}\/bin:$PATH\\n"' -e 's|/bin/su|/run/wrappers/bin/su|g' src/ssltools.h
+
+    # Xdummy script is currently broken, so we avoid building it. This removes everything Xdummy-related from the affected Makefile
     sed -i -e '/^\tXdummy.c\ \\$/,$d' -e 's/\tx11vnc_loop\ \\/\tx11vnc_loop/' misc/Makefile.am
+  '';
+
+  preConfigure = ''
+    configureFlags="--mandir=$out/share/man"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/X11/x11vnc/default.nix
+++ b/pkgs/tools/X11/x11vnc/default.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/LibVNC/x11vnc/;
     platforms = platforms.linux;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ OPNA2608 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
redoing this PR as I broke the last one by accident (#48459).

> See my issue/request #48263.
> tl;dr 0.9.13 is the last release before official development seized from what I can tell. 0.9.15 is a newer community release of x11vnc.

I'd also adopt this package, as it's currently lacking a maintainer and I'm frequently using this application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

