### PR TITLE
kube-prompt: init at 1.0.4

### DIFF
--- a/pkgs/development/tools/kube-prompt/default.nix
+++ b/pkgs/development/tools/kube-prompt/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "kube-prompt-${version}";
+  version = "1.0.4";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/c-bata/kube-prompt";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "c-bata";
+    repo = "kube-prompt";
+    sha256 = "09c2kjsk8cl7qgxbr1s7qd9br5shf7gccxvbf7nyi6wjiass9yg5";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = {
+  description = "An interactive kubernetes client featuring auto-complete using go-prompt";
+    license = lib.licenses.mit;
+    homepage = https://github.com/c-bata/kube-prompt;
+    maintainers = [ lib.maintainers.vdemeester ];
+  };
+}

--- a/pkgs/development/tools/kube-prompt/deps.nix
+++ b/pkgs/development/tools/kube-prompt/deps.nix
@@ -1,0 +1,309 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "aad3f485ee528456e0768f20397b4d9dd941e755";
+      sha256 = "1cgabmg76axkbpm7zip3ym2mym6kwgc9cw9kil0inmckkh3x1ky8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/c-bata/go-prompt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/c-bata/go-prompt";
+      rev =  "c52492ff1b386e5c0ba5271b5eaad165fab09eca";
+      sha256 = "14k8anchf0rcpxfbb2acrajdqrfspscbkn47m4py1zh5rkk6b9p9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev =  "0ca9ea5df5451ffdf184b4428c902747c2c11cd7";
+      sha256 = "0skwmimpy7hlh7pva2slpcplnm912rp3igs98xnqmn859kwa5v8g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "636bf0302bc95575d69441b25a2603156ffdddf1";
+      sha256 = "1525pq7r6h3s8dncvq8gxi893p2nq8dxpzvq0nfl5b4p6mq0v1c2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev =  "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "b4deda0973fb4c70b50d226b1af49f3da59f5265";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev =  "e89373fe6b4a7413d7acd6da1725b83ef713e6e4";
+      sha256 = "0jlkjjlf8ilifgsb2bv0jfgl4cxl1bypx7a6pjkwz3xf6k8jd7mj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev =  "24818f796faf91cd76ec7bddd72458fbced7a6c1";
+      sha256 = "0cq90m2lgalrdfrwwyycrrmn785rgnxa3l3vp9yxkvnv88bymmlm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/googleapis/gnostic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gnostic";
+      rev =  "7c663266750e7d82587642f65e60bc4083f1f84e";
+      sha256 = "0yh3ckd7m0r9h50wmxxvba837d0wb1k5yd439zq4p1kpp4390z12";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gregjones/httpcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gregjones/httpcache";
+      rev =  "9cad4c3443a7200dd6400aef47183728de563a38";
+      sha256 = "0wjdwcwqqcx2d5y68qvhg6qyj977il5ijmnn9h9cd6wjbdy0ay6s";
+    };
+  }
+  {
+    goPackagePath  = "github.com/imdario/mergo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/imdario/mergo";
+      rev =  "9316a62528ac99aaecb4e47eadd6dc8aa6533d58";
+      sha256 = "1mvgn89vp39gcpvhiq4n7nw5ipj7fk6h03jgc6fjwgvwvss213pb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev =  "ab8a2e0c74be9d3be70b3184d9acc634935ded82";
+      sha256 = "1x3wz44p1238gpyzkiiilvvrq9q8dwjdm9kdidq65yjq0zcn0sq4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "0360b2af4f38e8d38c7fce2a9f4e702702d73a39";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev =  "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb";
+      sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-tty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-tty";
+      rev =  "931426f7535ac39720c8909d70ece5a41a2502a6";
+      sha256 = "00cb07v13xrfqm39m1j2h2zvj684gl9fzr51591i9a52a9m6xlj5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev =  "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev =  "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd";
+      sha256 = "1721y3yr3dpx5dx5ashf063qczk2awy5zjir1jvp1h5hn7qz4i49";
+    };
+  }
+  {
+    goPackagePath  = "github.com/petar/GoLLRB";
+    fetch = {
+      type = "git";
+      url = "https://github.com/petar/GoLLRB";
+      rev =  "53be0d36a84c2a886ca057d34b6aa4468df9ccb4";
+      sha256 = "01xp3lcamqkvl91jg6ly202gdsgf64j39rkrcqxi6v4pbrcv7hz0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/peterbourgon/diskv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/peterbourgon/diskv";
+      rev =  "5f041e8faa004a95c88a202771f4cc3e991971e6";
+      sha256 = "1mxpa5aad08x30qcbffzk80g9540wvbca4blc1r2qyzl65b8929b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/term";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/term";
+      rev =  "cda20d4ac917ad418d86e151eff439648b06185b";
+      sha256 = "08frhz411dwyli5spfxn32d3ni9mrgdav51lmg8a1wpdmw0r0wwp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "583c0c0531f06d5278b7d917446061adc344b5cd";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "a2144134853fc9a27a7b1e3eb4f19f1a76df13c9";
+      sha256 = "0hjjk6k9dq7zllwsw9icdfbli12ii379q2lajd6l7lyw72wy28by";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1";
+      sha256 = "018zmn4kmg2mbngcciqal54slc3pl4ry5vlv0bw36fcxvnazxnbp";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "ef147856a6ddbb60760db74283d2424e98c87bff";
+      sha256 = "1q1vm1z40fx1grlrm7az4rln6v5pj9xi5n1cjqg5xgq4dsk9132y";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "ac767d655b305d4e9612f5f6e33120b9176c4ad4";
+      sha256 = "1ds29n5lh4j21hmzxz7vk7hv1k6sixc7f0zsdc9xqdg0j7d212zm";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev =  "fbb02b2291d28baffd63558aa44b4b56f178d650";
+      sha256 = "0jjqcv6rzihlgg4i797q80g1f6ch5diz2kxqh6488gwkb6nds4h4";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "b1f26356af11148e710935ed1ac8a7f5702c7612";
+      sha256 = "1pz202zszg8f35dk5pfhwgcdi3r6dx1l4yk6x6ly7nb4j45zi96x";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/inf.v0";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-inf/inf";
+      rev =  "d2d2541c53f18d2a059457998ce2876cc8e67cbf";
+      sha256 = "00k5iqjcp371fllqxncv7jkf80hn1zww92zm78cclbcn4ybigkng";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/api";
+      rev =  "072894a440bdee3a891dea811fe42902311cd2a3";
+      sha256 = "1hlbfwak4adwkj74jdiw8kmapri9rqmmjssncqiq0xnwlkcyn0ig";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/apimachinery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apimachinery";
+      rev =  "103fd098999dc9c0c88536f5c9ad2e5da39373ae";
+      sha256 = "04navnpm59d75dhlz07rmay7m2izrf4m0i9xklxzqg7mlk9g20jc";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/client-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/client-go";
+      rev =  "7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65";
+      sha256 = "06rszpgckx9gmqz9gbq8wnl39d1dnl28wdgrygj2fhz5prhj0x4s";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8571,6 +8571,8 @@ with pkgs;
 
   kubectx = callPackage ../development/tools/kubectx { };
 
+  kube-prompt = callPackage ../development/tools/kube-prompt { };
+
   kustomize = callPackage ../development/tools/kustomize { };
 
   kythe = callPackage ../development/tools/kythe { };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Init kube-prompt: "An interactive kubernetes client featuring auto-complete using go-prompt."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

