### PR TITLE
chromium: propagate stdenv for "chromium.override{ stdenv=gcc8Stdenv; }"

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -18,6 +18,8 @@ let
   callPackage = newScope chromium;
 
   chromium = {
+    inherit stdenv;
+  
     upstream-info = (callPackage ./update.nix {}).getChannel channel;
 
     mkChromiumDerivation = callPackage ./common.nix {


### PR DESCRIPTION
###### Motivation for this change

Propagate ```stdenv``` to ```chromium``` scope to allow using another C++ compiler.

It seems that ```chromium```'s developers are using GCC8 and often write code with too modern features which GCC7 does not understand, then in a month or two backport the fixes which we have to cherry-pick 

_(examples which currently need to add to chromium derivation in order to fix ```chromiumDev``` build: https://github.com/chromium/chromium/commit/cbdb8bd6567c8143dc8c1e5e86a21a8ea064eea4 https://github.com/chromium/chromium/commit/c9580757cfd9f7fd73e3f6d71e8a31a18b7e2dd5 https://github.com/chromium/chromium/commit/7c9af6c257d681159b8764c8d3d7b70f1d2f7d3a)_

So switching to ```GCC8``` is desirable, at least for ```chromiumDev``` and ```chromiumCanary```.

This PR just makes it possible to override the default compiler

cc @aszlig for introducion the chromium scope in https://github.com/NixOS/nixpkgs/commit/88a939c2d116236fbfb48d9a27741584b6a6e055