### PR TITLE
coq: add ocamlPackages in passthru

### DIFF
--- a/doc/languages-frameworks/coq.xml
+++ b/doc/languages-frameworks/coq.xml
@@ -11,10 +11,9 @@
  </para>
 
  <para>
-  Some libraries require OCaml and sometimes also Camlp5 or findlib. The exact
-  versions that were used to build Coq are saved in the
-  <literal>coq.ocaml</literal> and <literal>coq.camlp5</literal> and
-  <literal>coq.findlib</literal> attributes.
+  Some extensions (plugins) might require OCaml and sometimes other OCaml
+  packages. The <literal>coq.ocamlPackages</literal> attribute can be used
+  to depend on the same package set Coq was built against.
  </para>
 
  <para>

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -37,6 +37,8 @@ self = stdenv.mkDerivation {
 
   passthru = {
     inherit coq-version;
+    inherit ocamlPackages;
+    # For compatibility
     inherit (ocamlPackages) ocaml camlp5 findlib num;
     emacsBufferSetup = pkgs: ''
       ; Propagate coq paths to children

--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 coq.findlib ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib ];
   propagatedBuildInputs = [ coq ssreflect ];
 
   enableParallelBuilding = false;

--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 coq.findlib coq ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib coq ];
 
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 

--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 coq.findlib ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib ];
   propagatedBuildInputs = [ coq ssreflect ];
 
   enableParallelBuilding = false;

--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -12,7 +12,7 @@ let mkContrib = repo: revs: param:
       sha256 = "${param.sha256}";
     };
 
-    buildInputs = [ coq.ocaml coq.camlp5 coq.findlib coq ];
+    buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib coq ];
 
     installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     inherit (param) sha256;
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 ];
   propagatedBuildInputs = [ coq ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 coq.findlib ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib ];
   propagatedBuildInputs = [ coq ssreflect ];
 
   enableParallelBuilding = false;

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, coq, ocamlPackages }:
+{ stdenv, fetchFromGitHub, autoreconfHook, coq }:
 
 let params = {
   "8.8" = {
@@ -34,8 +34,8 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ coq coq.camlp5 ]
-  ++ (with ocamlPackages; [ ocaml findlib ocamlgraph ]);
+  buildInputs = [ coq ]
+  ++ (with coq.ocamlPackages; [ ocaml camlp5 findlib ocamlgraph ]);
 
   preInstall = ''
     mkdir -p $out/bin

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     sha256 = "${param.sha256}";
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 coq.findlib coq ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib coq ];
 
   preBuild = "coq_makefile -f _CoqProject -o Makefile";
 

--- a/pkgs/development/coq-modules/fiat/HEAD.nix
+++ b/pkgs/development/coq-modules/fiat/HEAD.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0griqc675yylf9rvadlfsabz41qy5f5idya30p5rv6ysiakxya64";
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 python27 ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 python27 ];
   propagatedBuildInputs = [ coq ];
 
   doCheck = false;

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "13fv150dcwnjrk00d7zj2c5x9jwmxgrq0ay440gkr730l8mvk3l3";
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 bash which autoconf automake ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 bash which autoconf automake ];
   propagatedBuildInputs = [ coq ];
 
   buildPhase = ''

--- a/pkgs/development/coq-modules/heq/default.nix
+++ b/pkgs/development/coq-modules/heq/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "03y71c4qs6cmy3s2hjs05g7pcgk9sqma6flj15394yyxbvr9is1p";
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 unzip ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 unzip ];
   propagatedBuildInputs = [ coq ];
 
   preBuild = "cd src";

--- a/pkgs/development/coq-modules/mathcomp/generic.nix
+++ b/pkgs/development/coq-modules/mathcomp/generic.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   inherit src;
 
   nativeBuildInputs = stdenv.lib.optionals withDoc [ graphviz ];
-  buildInputs = [ coq.ocaml coq.findlib coq.camlp5 ncurses which ];
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib camlp5 ncurses which ];
   propagatedBuildInputs = [ coq ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.mit;
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 which coq lngen ott coq.findlib ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 which coq lngen ott findlib ];
   propagatedBuildInputs = [ coq ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lcmdr0y2d7gzyvr8dal3pi7fibbd60bpi1l32fw89xiyrgqhsqy";
   };
 
-  buildInputs = [ coq.ocaml coq.camlp5 unzip ];
+  buildInputs = with coq.ocamlPackages; [ ocaml camlp5 unzip ];
   propagatedBuildInputs = [ coq ];
 
   preBuild = "cd src";

--- a/pkgs/development/coq-modules/ssreflect/generic.nix
+++ b/pkgs/development/coq-modules/ssreflect/generic.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   inherit src;
 
   nativeBuildInputs = stdenv.lib.optionals withDoc [ graphviz ];
-  buildInputs = [ coq.ocaml coq.findlib coq.camlp5 ncurses which ];
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib camlp5 ncurses which ];
   propagatedBuildInputs = [ coq ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Some package depending on Coq might need OCaml packages that are not the ones Coq is depending on but they still need to come from the same package set (same OCaml version).

Mitigates coq/coq#8227 (in Coq's `default.nix` we have only `ocamlPackages` as a passthru attribute, not `ocaml`,  `camlp5`, `findlib` and `num`).

###### Things done

I only tested that the expression is evaluated correctly.

cc @vbgl 