### PR TITLE
gpa: 0.9.10 -> 0.10.0

### DIFF
--- a/pkgs/applications/misc/gpa/default.nix
+++ b/pkgs/applications/misc/gpa/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, intltool, pkgconfig, gtk2, gpgme, libgpgerror, libassuan }:
 
 stdenv.mkDerivation rec {
-  name = "gpa-0.9.10";
+  name = "gpa-0.10.0";
 
   src = fetchurl {
     url = "mirror://gnupg/gpa/${name}.tar.bz2";
-    sha256 = "09xphbi2456qynwqq5n0yh0zdmdi2ggrj3wk4hsyh5lrzlvcrff3";
+    sha256 = "1cbpc45f8qbdkd62p12s3q2rdq6fa5xdzwmcwd3xrj55bzkspnwm";
   };
 
   nativeBuildInputs = [ intltool pkgconfig ];


### PR DESCRIPTION
https://lists.gnupg.org/pipermail/gnupg-announce/2018q4/000430.html


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---