### PR TITLE
autobahn: 18.8.2 -> 18.9.2, txaio: 18.7.1 -> 18.8.1

### DIFF
--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -4,11 +4,11 @@
 }:
 buildPythonPackage rec {
   pname = "autobahn";
-  version = "18.8.2";
+  version = "18.9.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "448df2e241011ea2948799918930042d81e63d26b01912c472f5a9a37f42f319";
+    sha256 = "1mhj64rsnbi6rc0hskmllw280rvd99z045p6dq8h0mw60r7r52yr";
   };
 
   propagatedBuildInputs = [ six txaio twisted zope_interface cffi ] ++

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "txaio";
-  version = "18.7.1";
+  version = "18.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "701de939e90bb80f7e085357081552437526752199def5541dddfc34c0b0593f";
+    sha256 = "1zmpdph6zddgrnkkcykh6qk5s46l7s5mzfqrh82m4b5iffn61qv7";
   };
 
   checkInputs = [ pytest mock ];


### PR DESCRIPTION
###### Motivation for this change

I'm using the newer versions without problems elsewhere. The newer autobahn depends on a newer txaio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

