### PR TITLE
restic: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "restic-${version}";
-  version = "0.9.2";
+  version = "0.9.3";
 
   goPackagePath = "github.com/restic/restic";
 
@@ -10,12 +10,13 @@ buildGoPackage rec {
     owner = "restic";
     repo = "restic";
     rev = "v${version}";
-    sha256 = "0kl8yk636i3y7f2kd43pydjh4pv7hhq09p5k54jlysnrbf2kjb4h";
+    sha256 = "0l35pdrq1hhcz3cb2qm267m6846mxfwbl1adk2kp748b2q55pdma";
   };
+
 
   buildPhase = ''
     cd go/src/${goPackagePath}
-    go run build.go
+    GO111MODULE=on GOCACHE=`mktemp -d` go run -mod=vendor build.go
   '';
 
   installPhase = ''


### PR DESCRIPTION
restic recently switched to using Go 1.11 modules: https://github.com/restic/restic/pull/1920
I don't know any Go so tried to guess how to do that the right way in Nixpkgs. Please have a look.
Again: I have no idea whether I'm using `GO111MODULE` and `GOCACHE` the right way.

All I can say is that restic seems to run fine according to my short test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) **(new: 17178568, old: 16659688)**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @adisbladis @Mic92 