### PR TITLE
Update Monero for upcoming hard fork (backports #48301)

### DIFF
--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "0.12.0.0";
+  version = "0.12.3.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1mg5ival8a2wdp14yib4wzqax4xyvd40zjy9anhszljds1439jhl";
+    sha256 = "1ry0455cgirkc6n46qnlv5p49axjllil78xmx6469nbp3a2r3z7i";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];
@@ -70,7 +70,8 @@ stdenv.mkDerivation rec {
     cp ${desktopItem}/share/applications/* $out/share/applications
 
     # install translations
-    cp -r release/bin/translations $out/share/
+    mkdir -p $out/share/translations
+    cp translations/*.qm $out/share/translations/
 
     # install icons
     for n in 16 24 32 48 64 96 128 256; do

--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -5,20 +5,20 @@
 , qtlocation, qtquickcontrols2, qtwebchannel
 , qtwebengine, qtx11extras, qtxmlpatterns
 , monero, unbound, readline, boost, libunwind
-, pcsclite, zeromq, cppzmq, pkgconfig
+, libsodium, pcsclite, zeromq, cppzmq, pkgconfig
 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "0.12.3.0";
+  version = "0.13.0.2";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1ry0455cgirkc6n46qnlv5p49axjllil78xmx6469nbp3a2r3z7i";
+    sha256 = "02419rqi3zfy6yjyw3b3gvkbxh2ypdfpijiiklc7lyblb9nnjr68";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
     qtdeclarative qtlocation qtquickcontrols2
     qtwebchannel qtwebengine qtx11extras
     qtxmlpatterns monero unbound readline
-    boost libunwind pcsclite zeromq cppzmq
-    makeWrapper
+    boost libunwind libsodium pcsclite zeromq
+    cppzmq makeWrapper
   ];
 
   patches = [

--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "0.13.0.2";
+  version = "0.13.0.3";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "02419rqi3zfy6yjyw3b3gvkbxh2ypdfpijiiklc7lyblb9nnjr68";
+    sha256 = "1rvxwz7p1yw9c817n07m60xvmv2p97s82sfzwkg2x880fpxb0gj9";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];

--- a/pkgs/applications/altcoins/monero-gui/move-log-file.patch
+++ b/pkgs/applications/altcoins/monero-gui/move-log-file.patch
@@ -1,38 +1,27 @@
 diff --git a/main.cpp b/main.cpp
-index c03b160..a8ea263 100644
+index 79223c0..e80b317 100644
 --- a/main.cpp
 +++ b/main.cpp
-@@ -80,14 +80,16 @@ int main(int argc, char *argv[])
- //    qDebug() << "High DPI auto scaling - enabled";
- //#endif
- 
--    // Log settings
--    Monero::Wallet::init(argv[0], "monero-wallet-gui");
--//    qInstallMessageHandler(messageHandler);
--
-     MainApp app(argc, argv);
- 
-     qDebug() << "app startd";
- 
-+    // Log settings
-+    QString logfile =
-+      QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
-+      + "/monero-wallet-gui.log";
-+    Monero::Wallet::init(argv[0], logfile.toUtf8().constData());
-+
-     app.setApplicationName("monero-core");
-     app.setOrganizationDomain("getmonero.org");
-     app.setOrganizationName("monero-project");
-diff --git a/src/libwalletqt/Wallet.cpp b/src/libwalletqt/Wallet.cpp
-index 74649ce..fe1efc6 100644
---- a/src/libwalletqt/Wallet.cpp
-+++ b/src/libwalletqt/Wallet.cpp
-@@ -729,7 +729,7 @@ QString Wallet::getWalletLogPath() const
- #ifdef Q_OS_MACOS
-     return QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0) + "/Library/Logs/" + filename;
- #else
--    return QCoreApplication::applicationDirPath() + "/" + filename;
-+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + filename;
+@@ -115,6 +115,9 @@ int main(int argc, char *argv[])
+     QCommandLineOption logPathOption(QStringList() << "l" << "log-file",
+         QCoreApplication::translate("main", "Log to specified file"),
+         QCoreApplication::translate("main", "file"));
++    logPathOption.setDefaultValue(
++        QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
++        + "/monero-wallet-gui.log");
+     parser.addOption(logPathOption);
+     parser.addHelpOption();
+     parser.process(app);
+diff --git a/Logger.cpp b/Logger.cpp
+index 660bafc..dae24d4 100644
+--- a/Logger.cpp
++++ b/Logger.cpp
+@@ -15,7 +15,7 @@ static const QString default_name = "monero-wallet-gui.log";
+ #elif defined(Q_OS_MAC)
+     static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0) + "/Library/Logs";
+ #else // linux + bsd
+-    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
++    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::CacheLocation).at(0);
  #endif
- }
+ 
  

--- a/pkgs/applications/altcoins/monero-gui/move-translations-dir.patch
+++ b/pkgs/applications/altcoins/monero-gui/move-translations-dir.patch
@@ -1,14 +1,13 @@
 diff --git a/TranslationManager.cpp b/TranslationManager.cpp
-index fa39d35..5a410f7 100644
+index e7fc52a..83534cc 100644
 --- a/TranslationManager.cpp
 +++ b/TranslationManager.cpp
-@@ -29,7 +29,7 @@ bool TranslationManager::setLanguage(const QString &language)
- #ifdef Q_OS_MACX
-     QString dir = qApp->applicationDirPath() + "/../Resources/translations";
- #else
+@@ -25,7 +25,7 @@ bool TranslationManager::setLanguage(const QString &language)
+         return true;
+     }
+ 
 -    QString dir = qApp->applicationDirPath() + "/translations";
 +    QString dir = qApp->applicationDirPath() + "/../share/translations";
- #endif
- 
      QString filename = "monero-core_" + language;
-
+ 
+     qDebug("%s: loading translation file '%s' from '%s'",

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch
+{ stdenv, fetchgit
 , cmake, pkgconfig, git
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline
@@ -11,24 +11,15 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "monero-${version}";
-  version = "0.12.0.0";
+  version = "0.12.3.0";
 
-  src = fetchFromGitHub {
-    owner  = "monero-project";
-    repo   = "monero";
+  src = fetchgit {
+    url    = "https://github.com/monero-project/monero.git";
     rev    = "v${version}";
-    sha256 = "1lc9mkrl1m8mdbvj88y8y5rv44vinxf7dyv221ndmw5c5gs5zfgk";
+    sha256 = "1609k1qn9xx37a92ai36rajds9cmdjlkqyka95hks5xjr3l5ca8i";
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];
-
-  patches = [
-    # fix daemon crash, remove with 0.12.1.0 update
-    (fetchpatch {
-      url    = "https://github.com/monero-project/monero/commit/08343ab.diff";
-      sha256 = "0f1snrl2mk2czwk1ysympzr8ismjx39fcqgy13276vcmw0cfqi83";
-    })
-  ];
 
   buildInputs = [
     boost miniupnpc openssl unbound
@@ -39,7 +30,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_GUI_DEPS=ON"
     "-DReadline_ROOT_DIR=${readline.dev}"
-  ];
+  ] ++ optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit
 , cmake, pkgconfig, git
 , boost, miniupnpc, openssl, unbound, cppzmq
-, zeromq, pcsclite, readline
+, zeromq, pcsclite, readline, libsodium
 , CoreData, IOKit, PCSC
 }:
 
@@ -11,12 +11,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "monero-${version}";
-  version = "0.12.3.0";
+  version = "0.13.0.2";
 
   src = fetchgit {
     url    = "https://github.com/monero-project/monero.git";
     rev    = "v${version}";
-    sha256 = "1609k1qn9xx37a92ai36rajds9cmdjlkqyka95hks5xjr3l5ca8i";
+    sha256 = "078iw76ajvaj08rgnx3c13pnq8fxah1z9wwyz54fcnj2349sjbf5";
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost miniupnpc openssl unbound
     cppzmq zeromq pcsclite readline
+    libsodium
   ] ++ optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 
   cmakeFlags = [

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -11,12 +11,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "monero-${version}";
-  version = "0.13.0.2";
+  version = "0.13.0.3";
 
   src = fetchgit {
     url    = "https://github.com/monero-project/monero.git";
     rev    = "v${version}";
-    sha256 = "078iw76ajvaj08rgnx3c13pnq8fxah1z9wwyz54fcnj2349sjbf5";
+    sha256 = "03qx8y74zxnmabdi5r3a274pp8zvm3xhkdwi1xf5sb40vf4sfmwb";
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];

--- a/pkgs/applications/misc/xmr-stak/default.nix
+++ b/pkgs/applications/misc/xmr-stak/default.nix
@@ -12,13 +12,13 @@ in
 
 stdenv'.mkDerivation rec {
   name = "xmr-stak-${version}";
-  version = "2.4.7";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "fireice-uk";
     repo = "xmr-stak";
     rev = "${version}";
-    sha256 = "072gapchmd05ir5ygrvbgdhpjhm7pdjyl61n1ykxzvnvi81z6817";
+    sha256 = "1qls0rai9c1cszcqqqmhcdvcsmm23w1jxzlq2b035apkz7ywbxjl";
   };
 
   NIX_CFLAGS_COMPILE = "-O3";


### PR DESCRIPTION
Things done:

 * Built using sandbox
 * Cherry-picked using `-x`.

Backports #48301
This also cherry-picks #48634 since there apparently was an (upstream) issue with the 0.13.0.2 releases :/.
And finally, backports the previous updates, as there was a change (see comments).

cc @rnhmjoj 
