### PR TITLE
nixos/pulseaudio: Add extraModules config option 

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -154,6 +154,18 @@ in {
         '';
       };
 
+      extraModules = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = literalExample "[ pkgs.pulseaudio-modules-bt ]";
+        description = ''
+          Extra pulseaudio modules to use. This is intended for out-of-tree
+          pulseaudio modules like extra bluetooth codecs.
+
+          Extra modules take precedence over built-in pulseaudio modules.
+        '';
+      };
+
       daemon = {
         logLevel = mkOption {
           type = types.str;
@@ -234,6 +246,18 @@ in {
       security.rtkit.enable = true;
 
       systemd.packages = [ overriddenPackage ];
+    })
+
+    (mkIf (cfg.extraModules != []) {
+      hardware.pulseaudio.daemon.config.dl-search-path = let
+        overriddenModules = builtins.map
+          (drv: drv.override { pulseaudio = overriddenPackage; })
+          cfg.extraModules;
+        modulePaths = builtins.map
+          (drv: "${drv}/lib/pulse-${overriddenPackage.version}/modules")
+          # User-provided extra modules take precedence
+          (overriddenModules ++ [ overriddenPackage ]);
+      in lib.concatStringsSep ":" modulePaths;
     })
 
     (mkIf hasZeroconf {

--- a/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , runCommand
 , fetchFromGitHub
-, libpulseaudio
 , pulseaudio
 , pkgconfig
 , ffmpeg_4
@@ -44,7 +43,6 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libpulseaudio
     pulseaudio
     ffmpeg_4
     libtool
@@ -67,7 +65,7 @@ in stdenv.mkDerivation rec {
     for so in $out/lib/pulse-${pulseaudio.version}/modules/*.so; do
       orig_rpath=$(patchelf --print-rpath "$so")
       patchelf \
-        --set-rpath "$orig_rpath:${lib.getLib ffmpeg_4}/lib:$out/lib/pulse-${pulseaudio.version}/modules" \
+        --set-rpath "${lib.getLib ffmpeg_4}/lib:$out/lib/pulse-${pulseaudio.version}/modules:$orig_rpath" \
         "$so"
     done
   '';


### PR DESCRIPTION
###### Motivation for this change
Previously the method to use `pulseaudio-modules-bt` was very hacky.
With this PR the mechanism to use out-of-tree PA modules becomes:
```nix
  hardware.pulseaudio = {
    enable = true;
    extraModules = [ pkgs.pulseaudio-modules-bt ];
    package = pkgs.pulseaudioFull;
  };
```

The caveats are that any derivations in `extraModules` is expected to follow the same directory structure as `pulseaudio` does internally, that is:
```nix
"lib/pulse-${pulseaudio.version}/modules/module.so"
```
and the derivation is expected to take an argument `pulseaudio` that is the package specified in `hardware.pulseaudio.package`.
Any `extraModules` are built with the specified package as an override.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @teto @lovek323 

edit: Additional documentation for any archeologists.