### PR TITLE
Unity3D: 5.6.1 -> 2017.4.10

### DIFF
--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, coreutils, file, getopt, gnugrep, gnused
+{ stdenv, lib, fetchurl, makeWrapper, file, getopt
 , gtk2, gdk_pixbuf, glib, libGLU, nss, nspr, udev, tbb
 , alsaLib, GConf, cups, libcap, fontconfig, freetype, pango
 , cairo, dbus, expat, zlib, libpng12, nodejs, gnutar, gcc, gcc_32bit
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   nosuidLib = ./unity-nosuid.c;
 
-  nativeBuildInputs = [ makeWrapper coreutils file getopt gnugrep gnused ];
+  nativeBuildInputs = [ makeWrapper file getopt ];
 
   outputs = [ "out" ];
 

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -1,31 +1,23 @@
-{ stdenv, lib, fetchurl, makeWrapper, fakeroot, file, getopt
-, gtk2, gdk_pixbuf, glib, libGLU, postgresql, nss, nspr, udev
+{ stdenv, lib, fetchurl, makeWrapper, file, getopt
+, gtk2, gdk_pixbuf, glib, libGLU, nss, nspr, udev, tbb
 , alsaLib, GConf, cups, libcap, fontconfig, freetype, pango
 , cairo, dbus, expat, zlib, libpng12, nodejs, gnutar, gcc, gcc_32bit
 , libX11, libXcursor, libXdamage, libXfixes, libXrender, libXi
-, libXcomposite, libXext, libXrandr, libXtst, libSM, libICE, libxcb
-, mono, libgnomeui, gnome_vfs, gnome-sharp, gtk-sharp-2_0, chromium
+, libXcomposite, libXext, libXrandr, libXtst, libSM, libICE, libxcb, chromium
 }:
 
 let
   libPath64 = lib.makeLibraryPath [
-    gcc.cc gtk2 gdk_pixbuf glib libGLU postgresql nss nspr
+    gcc.cc gtk2 gdk_pixbuf glib libGLU nss nspr
     alsaLib GConf cups libcap fontconfig freetype pango
-    cairo dbus expat zlib libpng12 udev
+    cairo dbus expat zlib libpng12 udev tbb
     libX11 libXcursor libXdamage libXfixes libXrender libXi
     libXcomposite libXext libXrandr libXtst libSM libICE libxcb
   ];
   libPath32 = lib.makeLibraryPath [ gcc_32bit.cc ];
   binPath = lib.makeBinPath [ nodejs gnutar ];
-  developBinPath = lib.makeBinPath [ mono ];
-  developLibPath = lib.makeLibraryPath [
-    glib libgnomeui gnome_vfs gnome-sharp gtk-sharp-2_0 gtk-sharp-2_0.gtk
-  ];
-  developDotnetPath = lib.concatStringsSep ":" [
-    gnome-sharp gtk-sharp-2_0
-  ];
 
-  ver = "5.6.1";
+  ver = "2017.4.10";
   build = "f1";
 
 in stdenv.mkDerivation rec {
@@ -33,20 +25,20 @@ in stdenv.mkDerivation rec {
   version = "${ver}x${build}";
 
   src = fetchurl {
-    url = "http://beta.unity3d.com/download/6a86e542cf5c/unity-editor-installer-${version}Linux.sh";
-    sha256 = "10z4h94c9h967gx4b3gwb268zn7bnrb7ylnqnmnqhx6byac7cf4m";
+    url = "https://beta.unity3d.com/download/14396d76537e/LinuxEditorInstaller/Unity.tar.xz";
+    sha256 = "e1b4fe41c0ff793f7a9146c49a8eca8c71d30abdfa3e81922bd69699810b3f67";
   };
 
   nosuidLib = ./unity-nosuid.c;
 
-  nativeBuildInputs = [ makeWrapper fakeroot file getopt ];
+  nativeBuildInputs = [ makeWrapper file getopt ];
 
-  outputs = [ "out" "monodevelop" ];
+  outputs = [ "out" ];
 
-  sourceRoot = "unity-editor-${version}Linux";
+  sourceRoot = ".";
 
   unpackPhase = ''
-    echo -e 'q\ny' | fakeroot sh $src
+    tar xJf $src
   '';
 
   buildPhase = ''
@@ -65,32 +57,10 @@ in stdenv.mkDerivation rec {
     mv Editor/* $unitydir
     ln -sf /run/wrappers/bin/${chromium.sandboxExecutableName} $unitydir/chrome-sandbox
 
-    mkdir -p $out/share/applications
-    sed "/^Exec=/c\Exec=$out/bin/unity-editor" \
-      < unity-editor.desktop \
-      > $out/share/applications/unity-editor.desktop
-
-    install -D unity-editor-icon.png $out/share/icons/hicolor/256x256/apps/unity-editor-icon.png
-
     mkdir -p $out/bin
     makeWrapper $unitydir/Unity $out/bin/unity-editor \
       --prefix LD_PRELOAD : "$unitydir/libunity-nosuid.so" \
       --prefix PATH : "${binPath}"
-
-    developdir="$monodevelop/opt/Unity/MonoDevelop"
-    mkdir -p $developdir
-    mv MonoDevelop/* $developdir
-
-    mkdir -p $monodevelop/share/applications
-    sed "/^Exec=/c\Exec=$monodevelop/bin/unity-monodevelop" \
-      < unity-monodevelop.desktop \
-      > $monodevelop/share/applications/unity-monodevelop.desktop
-
-    mkdir -p $monodevelop/bin
-    makeWrapper $developdir/bin/monodevelop $monodevelop/bin/unity-monodevelop \
-      --prefix PATH : "${developBinPath}" \
-      --prefix LD_LIBRARY_PATH : "${developLibPath}" \
-      --prefix MONO_GAC_PREFIX : "${developDotnetPath}"
   '';
 
   preFixup = ''
@@ -121,10 +91,45 @@ in stdenv.mkDerivation rec {
       fi
     }
 
+    upm_linux=$unitydir/Data/Resources/Upm/upm-linux
+
+    orig_size=$(stat --printf=%s $upm_linux)
+
     # Exclude PlaybackEngines to build something that can be run on FHS-compliant Linuxes
     find $unitydir -name PlaybackEngines -prune -o -type f -print | while read path; do
       patchFile "$path"
     done
+
+    new_size=$(stat --printf=%s $upm_linux)
+
+    ###### zeit-pkg fixing starts here.
+    # we're replacing plaintext js code that looks like
+    # PAYLOAD_POSITION = '1234                  ' | 0
+    # [...]
+    # PRELUDE_POSITION = '1234                  ' | 0
+    # ^-----20-chars-----^^------22-chars------^
+    # ^-- grep points here
+    #
+    # var_* are as described above
+    # shift_by seems to be safe so long as all patchelf adjustments occur 
+    # before any locations pointed to by hardcoded offsets
+
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+
+    function fix_offset {
+      # $1 = name of variable to adjust
+      location=$(grep -obUam1 "$1" $upm_linux | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+      value=$(dd if=$upm_linux iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+      echo -n $value | dd of=$upm_linux bs=1 seek=$location conv=notrunc
+    }
+
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
   '';
 
   dontStrip = true;

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -73,16 +73,9 @@ in stdenv.mkDerivation rec {
         # Save origin-relative parts of rpath.
         originRpath="$(patchelf --print-rpath "$1" | sed "s/:/\n/g" | grep "^\$ORIGIN" | paste -sd ":" - || echo "")"
         rpath="$originRpath:$rpath"
-        if [[ "$ftype" =~ LSB\ shared ]]; then
-          patchelf \
-            --set-rpath "$rpath" \
-            "$1"
-        elif [[ "$ftype" =~ LSB\ executable ]]; then
-          patchelf \
-            --set-rpath "$rpath" \
-            --interpreter "$intp" \
-            "$1"
-        fi
+
+        patchelf --set-rpath "$rpath" "$1"
+        patchelf --set-interpreter "$intp" "$1" 2> /dev/null || true
       fi
     }
 

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -37,12 +37,7 @@ in stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  unpackPhase = ''
-    tar xJf $src
-  '';
-
   buildPhase = ''
-
     cd Editor
 
     $CC -fPIC -shared -o libunity-nosuid.so $nosuidLib -ldl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22357,7 +22357,7 @@ with pkgs;
   unity3d = callPackage ../development/tools/unity3d {
     stdenv = stdenv_32bit;
     gcc_32bit = pkgsi686Linux.gcc;
-    inherit (gnome2) GConf libgnomeui gnome_vfs;
+    inherit (gnome2) GConf;
   };
 
   urbit = callPackage ../misc/urbit { };


### PR DESCRIPTION
###### Motivation for this change
Fixes #34399
2017.4 is used instead of 2017.3 because 2017.4 is LTS release.
`zeit/pkg` fixing algorithm I've taken from #48193.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

