### PR TITLE
eternal-terminal: 4.1.2 -> 5.1.6.

### DIFF
--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, cmake, gflags, glog, libsodium, protobuf }:
+{ stdenv, fetchFromGitHub, cmake, gflags, libsodium, protobuf }:
 
 stdenv.mkDerivation rec {
   name = "eternal-terminal-${version}";
-  version = "4.1.2";
+  version = "5.1.6";
 
   src = fetchFromGitHub {
     owner = "MisterTea";
     repo = "EternalTCP";
     rev = "refs/tags/et-v${version}";
-    sha256 = "1zy30ccsddgs2wqwxphnx5i00j4gf69lr68mzg9x6imqfz0sbcjz";
+    sha256 = "0df573c5hi3hxa0d3m02zf2iyh841540dklj9lmp6faik8cp39jz";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ gflags glog libsodium protobuf ];
+  buildInputs = [ gflags libsodium protobuf ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, gflags, libsodium, protobuf }:
+{ stdenv, fetchFromGitHub, cmake, ninja, gflags, libsodium, protobuf }:
 
 stdenv.mkDerivation rec {
   name = "eternal-terminal-${version}";
@@ -11,10 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0df573c5hi3hxa0d3m02zf2iyh841540dklj9lmp6faik8cp39jz";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ninja ];
   buildInputs = [ gflags libsodium protobuf ];
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Remote shell that automatically reconnects without interrupting the session";


### PR DESCRIPTION
###### Motivation for this change
Standard update. Also remove an unneeded dependency, as highlighted in #45834.

This supersedes #45834.

I've tested this on a macOS->NixOS connection, and it seems to work just fine!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

