### PR TITLE
deepin-movie-reborn: init at 3.2.10

### DIFF
--- a/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qttools, qtx11extras,
+  dtkcore, dtkwidget, ffmpeg, ffmpegthumbnailer, mpv, pulseaudio,
+  libdvdnav, libdvdread, xorg }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-movie-reborn";
+  version = "3.2.10";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0lqmbvl9yyxgkiipd9r8mgmxl2sm34l3gr3hkwlc7r2l6kc32933";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    qttools
+  ];
+
+  buildInputs = [
+    dtkcore
+    dtkwidget
+    ffmpeg
+    ffmpegthumbnailer
+    libdvdnav
+    libdvdread
+    mpv
+    pulseaudio
+    qtx11extras
+    xorg.libXdmcp
+    xorg.libXtst
+    xorg.libpthreadstubs
+    xorg.xcbproto
+  ];
+
+  NIX_LDFLAGS = "-ldvdnav";
+
+  postPatch = ''
+    sed -i src/CMakeLists.txt -e "s,/usr/lib/dtk2,${dtkcore}/lib/dtk2,"
+    sed -i src/libdmr/libdmr.pc.in -e "s,/usr,$out," -e 's,libdir=''${prefix}/,libdir=,'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Deepin movie player";
+    homepage = https://github.com/linuxdeepin/deepin-movie-reborn;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -15,6 +15,7 @@ let
     deepin-image-viewer = callPackage ./deepin-image-viewer { };
     deepin-menu = callPackage ./deepin-menu { };
     deepin-metacity = callPackage ./deepin-metacity { };
+    deepin-movie-reborn = callPackage ./deepin-movie-reborn { };
     deepin-mutter = callPackage ./deepin-mutter { };
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
     deepin-sound-theme = callPackage ./deepin-sound-theme { };


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-movie-reborn](https://github.com/linuxdeepin/deepin-movie-reborn), the Deepin Desktop Environment movie player.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).