### PR TITLE
bat: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -4,17 +4,17 @@
 
 rustPlatform.buildRustPackage rec {
   name    = "bat-${version}";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
     repo   = "bat";
     rev    = "v${version}";
-    sha256 = "1fzk0z7r70rjvv2c6531zaa1jzbcb7j9wbi0xqb9y4dls538bmz0";
+    sha256 = "1xvjw61q0qbnzj95g7g8xckcqha9jrf2172b5l7faj7i0jhmz2kx";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "19syz0sxcpk3i4675bfq5gpb9i6hp81in36w820kkvamaimq10nd";
+  cargoSha256 = "0xv769f2iqrgnbmb7ma9p3gbb2xpx2lhqc0kq5nizf8w8xdc5m11";
 
   nativeBuildInputs = [ cmake pkgconfig zlib ];
 
@@ -22,6 +22,13 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     install -m 444 -Dt $out/share/man/man1 doc/bat.1
+
+    install -Dm644 target/release/build/bat-*/out/_bat \
+      "$out/share/zsh/site-functions/_bat"
+    install -Dm644 target/release/build/bat-*/out/bat.bash \
+      "$out/share/bash-completions/completions/bat.bash"
+    install -Dm644 target/release/build/bat-*/out/bat.fish \
+      "$out/share/fish/vendor_completions.d/bat.fish"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
https://github.com/sharkdp/bat/releases/tag/v0.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

