### PR TITLE
nixos/sshd: restart on "sshd_config" change (back to 18.03 behaviour)

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -374,6 +374,8 @@ in
                 '')}
               '';
 
+            # restart sshd on "/etc/ssh/sshd_config" content change. this does not abort established connections
+            restartTriggers = [ (builtins.hashString "sha256" config.environment.etc."ssh/sshd_config".text) ];
             serviceConfig =
               { ExecStart =
                   (optionalString cfg.startWhenNeeded "-") +


### PR DESCRIPTION
###### Motivation for this change

The main motivaion is to restart ```sshd``` in sync with firewall which in NixOS opens ```sshd```'s port.
Delayed or manual restarting of ```sshs``` puts system into state where (the port sshd listens) != (the port firewall opens).

Fixes https://github.com/NixOS/nixpkgs/issues/43341, see more discussion there;

This works for me, restarting ```sshd``` does not abort establishes connections and ```'nixos-rebuild switch --upgrade' over ssh``` works too (problems in https://github.com/NixOS/nixpkgs/issues/39118 are not relevant to ```sshd``` restart but caused by disabing network link ```stopping the following units: , network-link-enp24s0.service,```)

cc @davidak 

----

```sshd``` had been restarting on config change in NixOS ```18.03```, the problem has been unintentionally introduced in https://github.com/NixOS/nixpkgs/pull/41744 so I assume it is a regression bug, the was no idea to prevent ```sshd``` from restart
cc @Izorkin