### PR TITLE
parity: 1.11.10 -> 2.0.8; parity-beta: 2.0.3 -> 2.1.3

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,7 +1,9 @@
 let
-  version     = "2.0.3";
-  sha256      = "1yf3ln4ksk8613kqkpsh16cj8xwx761q6czy57rs8kfh7pgc2pzb";
-  cargoSha256 = "1jayk4ngwbg0rv7x1slkl2z46czgy2hnfcxc0dhaz4xpbp2bjqq8";
-  patches     = [ ./patches/vendored-sources-2.0.patch ];
+  version     = "2.1.3";
+  sha256      = "0il18r229r32jzwsjksp8cc63rp6cf6c0j5dvbfzrnv1zndw0cg3";
+  cargoSha256 = "08dyb0lgf66zfq9xmfkhcn6rj070d49dm0rjl3v39sfag6sryz20";
+  patches     = [
+    ./patches/vendored-sources-2.1.patch
+  ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,7 +1,7 @@
 let
-  version     = "1.11.10";
-  sha256      = "15sk6dvc8h1bdm6v7xlq517km0bakb9f13h1n7ixj311vahnmk15";
-  cargoSha256 = "0p2idd36cyzp2ax81k533bdma4hz0ws2981qj2s7jnhvmj4941l8";
-  patches     = [ ./patches/vendored-sources-1.11.patch ];
+  version     = "2.0.8";
+  sha256      = "1bz6dvx8wxhs3g447s62d9091sard2x7w2zd6iy7hf76wg0p73hr";
+  cargoSha256 = "0wj93md87fr7a9ag73h0rd9xxqscl0lhbj3g3kvnqrqz9xxajing";
+  patches     = [ ./patches/vendored-sources-2.0.patch ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/patches/vendored-sources-2.1.patch
+++ b/pkgs/applications/altcoins/parity/patches/vendored-sources-2.1.patch
@@ -1,8 +1,8 @@
 diff --git a/.cargo/config b/.cargo/config
-index 72652ad2f..57c5c2f8f 100644
+index 72652ad2f..3c0eca89a 100644
 --- a/.cargo/config
 +++ b/.cargo/config
-@@ -1,3 +1,108 @@
+@@ -1,3 +1,78 @@
  [target.x86_64-pc-windows-msvc]
  # Link the C runtime statically ; https://github.com/paritytech/parity/issues/6643
  rustflags = ["-Ctarget-feature=+crt-static"]
@@ -12,34 +12,14 @@ index 72652ad2f..57c5c2f8f 100644
 +branch = "master"
 +replace-with = "vendored-sources"
 +
-+[source."https://github.com/js-dist-paritytech/parity-master-1-10-shell.git"]
-+git = "https://github.com/js-dist-paritytech/parity-master-1-10-shell.git"
-+rev = "bd25b41cd642c6b822d820dded3aa601a29aa079"
-+replace-with = "vendored-sources"
-+
-+[source."https://github.com/js-dist-paritytech/parity-master-1-10-wallet.git"]
-+git = "https://github.com/js-dist-paritytech/parity-master-1-10-wallet.git"
-+rev = "4b6f112412716cd05123d32eeb7fda448288a6c6"
-+replace-with = "vendored-sources"
-+
 +[source."https://github.com/nikvolf/parity-tokio-ipc"]
 +git = "https://github.com/nikvolf/parity-tokio-ipc"
-+branch = "master"
++rev = "7c9bbe3bc45d8e72a92b0951acc877da228abd50"
 +replace-with = "vendored-sources"
 +
 +[source."https://github.com/nikvolf/tokio-named-pipes"]
 +git = "https://github.com/nikvolf/tokio-named-pipes"
 +branch = "master"
-+replace-with = "vendored-sources"
-+
-+[source."https://github.com/parity-js/dapp-wallet.git"]
-+git = "https://github.com/parity-js/dapp-wallet.git"
-+rev = "65deb02e7c007a0fd8aab0c089c93e3fd1de6f87"
-+replace-with = "vendored-sources"
-+
-+[source."https://github.com/parity-js/shell.git"]
-+git = "https://github.com/parity-js/shell.git"
-+rev = "eecaadcb9e421bce31e91680d14a20bbd38f92a2"
 +replace-with = "vendored-sources"
 +
 +[source."https://github.com/paritytech/app-dirs-rs"]
@@ -87,18 +67,8 @@ index 72652ad2f..57c5c2f8f 100644
 +branch = "master"
 +replace-with = "vendored-sources"
 +
-+[source."https://github.com/paritytech/rust-rocksdb"]
-+git = "https://github.com/paritytech/rust-rocksdb"
-+branch = "master"
-+replace-with = "vendored-sources"
-+
 +[source."https://github.com/paritytech/rust-secp256k1"]
 +git = "https://github.com/paritytech/rust-secp256k1"
-+branch = "master"
-+replace-with = "vendored-sources"
-+
-+[source."https://github.com/paritytech/rust-snappy"]
-+git = "https://github.com/paritytech/rust-snappy"
 +branch = "master"
 +replace-with = "vendored-sources"
 +


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/paritytech/parity-ethereum/releases/tag/v2.0.8
* https://github.com/paritytech/parity-ethereum/releases/tag/v2.1.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

