### PR TITLE
libssh: 0.7.6 -> 0.8.4

### DIFF
--- a/pkgs/development/libraries/libssh/default.nix
+++ b/pkgs/development/libraries/libssh/default.nix
@@ -1,22 +1,12 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, cmake, zlib, openssl, libsodium }:
 
 stdenv.mkDerivation rec {
-  name = "libssh-0.7.6";
+  name = "libssh-0.8.4";
 
   src = fetchurl {
-    url = "https://www.libssh.org/files/0.7/libssh-0.7.6.tar.xz";
-    sha256 = "14hhdpn2hflywsi9d5bz2pfjxqkyi07znjij89cpakr7b4w7sq0x";
+    url = "https://www.libssh.org/files/0.8/${name}.tar.xz";
+    sha256 = "06xqfm1alfb6faqzjhyhjs0arjcd8rnc7ci046x8d18s089pgc3b";
   };
-
-  patches = [
-    # Fix mysql-workbench compilation
-    # https://bugs.mysql.com/bug.php?id=91923
-    (fetchpatch {
-      name = "include-fix-segfault-in-getissuebanner-add-missing-wrappers-in-libsshpp.patch";
-      url = https://git.libssh.org/projects/libssh.git/patch/?id=5ea81166bf885d0fd5d4bb232fc22633f5aaf3c4;
-      sha256 = "12q818l3nasqrfrsghxdvjcyya1bfcg0idvsf8xwm5zj7criln0a";
-    })
-  ];
 
   postPatch = ''
     # Fix headers to use libsodium instead of NaCl


### PR DESCRIPTION
###### Motivation for this change

Upstream update. Based on staging because it's a mass-rebuild for darwin iirc.

Note that this is unrelated to the security vulnerability in earlier
versions, which is already fixed in 0.7.6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

