### PR TITLE
nvidia_x11: 390.87 -> 410.66

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, fetchurl }:
+{ lib, callPackage, fetchurl, stdenv }:
 
 let
   generic = args: callPackage (import ./generic.nix args) { };
@@ -16,7 +16,17 @@ let
 in
 rec {
   # Policy: use the highest stable version as the default (on our master).
-  stable = generic {
+  stable = if stdenv.hostPlatform.system == "x86_64-linux" then stable_410 else stable_390;
+
+  stable_410 = generic {
+    version = "410.66";
+    sha256_64bit = "05xjzvj0fgmkpz36dbd7hy2vzl6xxiflzx7kml3k7ad9gy2svdlg";
+    settingsSha256 = "1nsxz1byshgjs3c03lyx6ya36dp0f2vg2l0d9pkh1i6cpzkp53kz";
+    persistencedSha256 = "0m4wdpb8w4y323d8py105p9hizwmf2ai8frkl7h77sn3ski17zw6";
+  };
+
+  # Last one supporting x86
+  stable_390 = generic {
     version = "390.87";
     sha256_32bit = "0rlr1f4lnpb8c4qz4w5r8xw5gdy9bzz26qww45qyl1qav3wwaaaw";
     sha256_64bit = "07k1kq8lkgbvjyr2dnbxcz6nppcwpq17wf925w8kfq78345hla9q";

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -36,12 +36,8 @@ rec {
     patches = lib.optional (kernel.meta.branch == "4.19") ./drm_mode_connector.patch;
   };
 
-  beta = generic {
-    version = "410.57";
-    sha256_64bit = "08534rv3wcmzslbwq11kd3s7cxm72p48dia6540c0586xwgjwg2w";
-    settingsSha256 = "1phhhzlc8n3rqdhrn757mnlqmsp616d079a6h1qjpa6jba9z9915";
-    persistencedSha256 = "1z7c1ff0y486yp9i5w0siwh9dnprml22x2avarbjfgqwm4f652lw";
-  };
+  # No active beta right now
+  beta = stable;
 
   legacy_340 = generic {
     version = "340.104";


### PR DESCRIPTION
###### Motivation for this change

Nvidia stable branch driver was updated to [410.66](https://www.nvidia.com/object/unix.html). With the work from #45030 this change is simple.

**Note:** Nvidia dropped support for x86. There are legacy versions present, but the last driver for x86 is 390.87. So maybe I should add it as a separate version like the legacy versions below?

/cc @Infinisil, @eadwu, @tenten8401
see also #44461

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Added x86 switch for latest supported driver
- [x] Removed beta
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

