### PR TITLE
nghttp2: 1.32.0 -> 1.34.0

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -17,11 +17,11 @@ let inherit (stdenv.lib) optional; in
 
 stdenv.mkDerivation rec {
   name = "nghttp2-${version}";
-  version = "1.32.0";
+  version = "1.34.0";
 
   src = fetchurl {
     url = "https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.bz2";
-    sha256 = "0jlndbp4bnyvdg8b59pznrzz0bvwb9nmag7zgcflg51lm1pq2q06";
+    sha256 = "1l5rir8d73x97p3p1x4l8cawjc9m2adnippnb27fmrbcd3rfaxbl";
   };
 
   outputs = [ "bin" "out" "dev" "lib" ];


### PR DESCRIPTION
* 1.33.0: https://nghttp2.org/blog/2018/09/02/nghttp2-v1-33-0/
* 1.34.0: https://nghttp2.org/blog/2018/10/04/nghttp2-v1-34-0/


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---