### PR TITLE
MCFM: init at 8.2

### DIFF
--- a/pkgs/applications/science/physics/MCFM/default.nix
+++ b/pkgs/applications/science/physics/MCFM/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchurl, gfortran, lhapdf }:
+
+stdenv.mkDerivation rec {
+  name = "MCFM-${version}";
+  version = "8.2";
+
+  src = fetchurl {
+    url = "https://mcfm.fnal.gov/${name}.tar.gz";
+    sha256 = "1z9vm3dsy4sf3n8vhrkif5hh4yv59fwsfd98vhwjbsfbsf13fph7";
+  };
+
+  preConfigure = ''
+    patchShebangs ./
+    substituteInPlace makefile \
+      --replace "-Wl,-rpath=" "-Wl,-rpath,"
+  '';
+
+  buildInputs = [ gfortran ];
+  configurePhase = ''
+    runHook preConfigure
+
+    ./Install
+
+    runHook postConfigure
+  '';
+
+  makeFlags = [
+    "PDFROUTINES=LHAPDF"
+    "LHAPDFLIB=${lhapdf}/lib"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"/bin
+    mv Bin/mcfm_omp "$out"/bin/mcfm_omp
+    mkdir "$out"/share
+    mv Bin/ "$out"/share/MCFM/
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Monte Carlo for FeMtobarn processes";
+    homepage = https://mcfm.fnal.gov;
+    license = licenses.free;
+    maintainers = with maintainers; [ veprbl ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/physics/lhapdf/default.nix
+++ b/pkgs/development/libraries/physics/lhapdf/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "0bi02xcmq5as0wf0jn6i3hx0qy0hj61m02sbrbzd1gwjhpccwmvd";
   };
 
+  patches = [
+    # Fixes Fortran initpdfset interface to respect LHAPDF_DATA_PATH environment variable
+    ./join.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ python2 ];
 

--- a/pkgs/development/libraries/physics/lhapdf/join.patch
+++ b/pkgs/development/libraries/physics/lhapdf/join.patch
@@ -1,0 +1,12 @@
+diff --git a/include/LHAPDF/Utils.h b/include/LHAPDF/Utils.h
+--- a/include/LHAPDF/Utils.h
++++ b/include/LHAPDF/Utils.h
+@@ -85,7 +85,7 @@ namespace LHAPDF {
+     string rtn;
+     for (size_t i = 0; i < svec.size(); ++i) {
+       rtn += svec[i];
+-      if (i < svec.size()-1) rtn += ", ";
++      if (i < svec.size()-1) rtn += sep;
+     }
+     return rtn;
+   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21199,6 +21199,8 @@ with pkgs;
 
   ### PHYSICS
 
+  mcfm = callPackage ../applications/science/physics/MCFM { stdenv = gccStdenv; };
+
   sacrifice = callPackage ../applications/science/physics/sacrifice {};
 
   sherpa = callPackage ../applications/science/physics/sherpa {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

