### PR TITLE
[WIP] pythonPackages.numpy-mkl: refactor adding mkl support

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -1,5 +1,7 @@
 { stdenv, lib, fetchPypi, python, buildPythonPackage, isPyPy, gfortran, pytest, blas }:
 
+let blasImplementation = stdenv.lib.nameFromURL blas.name "-";
+in
 buildPythonPackage rec {
   pname = "numpy";
   version = "1.15.1";
@@ -38,7 +40,16 @@ buildPythonPackage rec {
     export NPY_NUM_BUILD_JOBS=$NIX_BUILD_CORES
   '';
 
-  preBuild = ''
+  preBuild = if blasImplementation == "mkl" then ''
+    echo "Creating site.cfg file..."
+    cat << EOF > site.cfg
+    [mkl]
+    include_dirs = ${blas}/include
+    library_dirs = ${blas}/lib
+    mkl_libs = mkl_rt
+  	lapack_libs =
+    EOF
+  '' else ''
     echo "Creating site.cfg file..."
     cat << EOF > site.cfg
     [openblas]

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8111,6 +8111,10 @@ in {
     blas = pkgs.openblasCompat;
   };
 
+  numpy-mkl = callPackage ../development/python-modules/numpy {
+    blas = pkgs.mkl;
+  };
+
   numpydoc = callPackage ../development/python-modules/numpydoc { };
 
   numpy-stl = callPackage ../development/python-modules/numpy-stl { };


### PR DESCRIPTION
###### Motivation for this change

Would love to see packaging python applications with mkl support similar to how `conda` packages `mkl`. I realize that this pull request is very trivial and probably not the correct approach to packaging mkl into numpy and would love any input. Hopefully this pull request gets enough input that it can be used as a guide on how to integrate mkl with python packages. Packages that I would like to eventually target are `NumExpr`, `SciPy`, and `Scikit-Learn`.

I would like to especially thank @bhipple for the `mkl` PR! I have been wanting that for a long time but did not know how to do it. If at all possible I  would like to hear input from @bhipple and @markuskowa. @smaret you provided great input making sure that it works with darwin and since I do not have a mac I would appreciate any help.

I am aware that this will cause mass rebuilds and will eventually move to staging when it is working. Currently if it is on staging it will require mass rebuilds making it harder to test.

###### Things done

Adding mkl support for `numpy`. As of now this PR does not succeed in building. The numpy tests fail.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

