### PR TITLE
znc: add option to enable unicode support

### DIFF
--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -3,6 +3,7 @@
 , withPython ? false, python3
 , withTcl ? false, tcl
 , withCyrus ? true, cyrus_sasl
+, withUnicode ? true, icu
 }:
 
 with stdenv.lib;
@@ -22,7 +23,8 @@ stdenv.mkDerivation rec {
     ++ optional withPerl perl
     ++ optional withPython python3
     ++ optional withTcl tcl
-    ++ optional withCyrus cyrus_sasl;
+    ++ optional withCyrus cyrus_sasl
+    ++ optional withUnicode icu;
 
   configureFlags = [
     (stdenv.lib.enableFeature withPerl "perl")


### PR DESCRIPTION
###### Motivation for this change
Add option to enable unicode support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

