### PR TITLE
wings: Fix runtime failure.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19453,6 +19453,7 @@ with pkgs;
   winswitch = callPackage ../tools/X11/winswitch { };
 
   wings = callPackage ../applications/graphics/wings {
+    esdl = esdl.override { erlang = erlangR18; };
     erlang = erlangR18;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #48305 

Erlang/OTP 18 [erts-7.3.1.4] [source] [64-bit] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V7.3.1.4  (abort with ^G)
1>
=ERROR REPORT==== 18-Oct-2018::21:29:53 ===
beam/beam_load.c(1189): Error loading module sdl:
  mandatory chunk of type 'Atom' not found

=ERROR REPORT==== 18-Oct-2018::21:29:53 ===
Loading of /nix/store/qalvdrzjqqm3a8nsavjbhfiv1pzhw82k-esdl-1.3.1/lib/erlang/lib/esdl-1.3.1/ebin/sdl.beam failed: badfile

=ERROR REPORT==== 18-Oct-2018::21:29:53 ===
Error in process <0.35.0> with exit value:
{undef,[{sdl,init,[1048608],[]},
        {wings_init,init,0,[{file,"wings_init.erl"},{line,28}]},
        {wings,init,1,[{file,"wings.erl"},{line,105}]}]}

Fatal internal error - log written to /home/milan/wings_crash.dump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

