### PR TITLE
znc: add configure options

### DIFF
--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -4,6 +4,7 @@
 , withTcl ? false, tcl
 , withCyrus ? true, cyrus_sasl
 , withUnicode ? true, icu
+, withZlib ? true, zlib
 , withIPv6 ? true
 , withDebug ? false
 }:
@@ -26,7 +27,8 @@ stdenv.mkDerivation rec {
     ++ optional withPython python3
     ++ optional withTcl tcl
     ++ optional withCyrus cyrus_sasl
-    ++ optional withUnicode icu;
+    ++ optional withUnicode icu
+    ++ optional withZlib zlib;
 
   configureFlags = [
     (stdenv.lib.enableFeature withPerl "perl")

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -5,6 +5,7 @@
 , withCyrus ? true, cyrus_sasl
 , withUnicode ? true, icu
 , withIPv6 ? true
+, withDebug ? false
 }:
 
 with stdenv.lib;
@@ -33,7 +34,8 @@ stdenv.mkDerivation rec {
     (stdenv.lib.enableFeature withTcl "tcl")
     (stdenv.lib.withFeatureAs withTcl "tcl" "${tcl}/lib")
     (stdenv.lib.enableFeature withCyrus "cyrus")
-  ] ++ optional (!withIPv6) [ "--disable-ipv6" ];
+  ] ++ optional (!withIPv6) [ "--disable-ipv6" ]
+    ++ optional withDebug [ "--enable-debug" ];
 
   meta = with stdenv.lib; {
     description = "Advanced IRC bouncer";

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -4,6 +4,7 @@
 , withTcl ? false, tcl
 , withCyrus ? true, cyrus_sasl
 , withUnicode ? true, icu
+, withIPv6 ? true
 }:
 
 with stdenv.lib;
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
     (stdenv.lib.enableFeature withTcl "tcl")
     (stdenv.lib.withFeatureAs withTcl "tcl" "${tcl}/lib")
     (stdenv.lib.enableFeature withCyrus "cyrus")
-  ];
+  ] ++ optional (!withIPv6) [ "--disable-ipv6" ];
 
   meta = with stdenv.lib; {
     description = "Advanced IRC bouncer";

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -9,6 +9,8 @@ let
     inherit buildPhase;
     inherit installPhase;
 
+    buildInputs = znc.buildInputs;
+
     meta = a.meta // { platforms = stdenv.lib.platforms.unix; };
     passthru.module_name = module_name;
   });


### PR DESCRIPTION
###### Motivation for this change
Add options to build znc without IPv6 and enable debugging

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

