### PR TITLE
libinput-gestures: 2.33 -> 2.38, fixup

### DIFF
--- a/pkgs/tools/inputmethods/libinput-gestures/0001-hardcode-name.patch
+++ b/pkgs/tools/inputmethods/libinput-gestures/0001-hardcode-name.patch
@@ -1,5 +1,5 @@
 diff --git a/libinput-gestures b/libinput-gestures
-index f337ba3..fe56d66 100755
+index 66479b6..aca94ac 100755
 --- a/libinput-gestures
 +++ b/libinput-gestures
 @@ -6,7 +6,7 @@ from collections import OrderedDict

--- a/pkgs/tools/inputmethods/libinput-gestures/0002-paths.patch
+++ b/pkgs/tools/inputmethods/libinput-gestures/0002-paths.patch
@@ -1,29 +1,28 @@
 diff --git a/libinput-gestures b/libinput-gestures
-index f337ba3..5f5b05d 100755
+index aca94ac..c2f03ca 100755
 --- a/libinput-gestures
 +++ b/libinput-gestures
-@@ -75,17 +75,13 @@ def get_libinput_vers():
+@@ -77,7 +77,7 @@ def get_libinput_vers():
      'Return the libinput installed version number string'
      # Try to use newer libinput interface then fall back to old
      # (depreciated) interface.
 -    res = run(('libinput', '--version'), check=False)
 +    res = run(('@libinput@', '--version'), check=False)
-     return res.strip() if res else run(('libinput-list-devices', '--version'))
+     return res.strip() if res else \
+             run(('libinput-list-devices', '--version'), check=False)
  
- # Libinput changed the way in which it's utilities are called
- libvers = get_libinput_vers()
--if Version(libvers) >= Version('1.8'):
+@@ -87,8 +87,8 @@ if not libvers:
+     sys.exit('libinput helper tools do not seem to be installed?')
+ 
+ if Version(libvers) >= Version('1.8'):
 -    cmd_debug_events = 'libinput debug-events'
 -    cmd_list_devices = 'libinput list-devices'
--else:
--    cmd_debug_events = 'libinput-debug-events'
--    cmd_list_devices = 'libinput-list-devices'
-+cmd_debug_events = '@libinput@ debug-events'
-+cmd_list_devices = '@libinput@ list-devices'
- 
- def get_devices_list():
-     'Get list of devices and their attributes (as a dict) from libinput'
-@@ -187,7 +183,7 @@ class COMMAND_internal(COMMAND):
++    cmd_debug_events = '@libinput@ debug-events'
++    cmd_list_devices = '@libinput@ list-devices'
+ else:
+     cmd_debug_events = 'libinput-debug-events'
+     cmd_list_devices = 'libinput-list-devices'
+@@ -199,7 +199,7 @@ class COMMAND_internal(COMMAND):
  
      def run(self):
          'Get list of current workspaces and select next one'
@@ -32,7 +31,7 @@ index f337ba3..5f5b05d 100755
          if not stdout:
              # This command can fail on GNOME when you have only a single
              # dynamic workspace using Xorg (probably a GNOME bug) so let's
-@@ -220,7 +216,7 @@ class COMMAND_internal(COMMAND):
+@@ -233,7 +233,7 @@ class COMMAND_internal(COMMAND):
  
          # Switch to desired workspace
          if index >= minindex and index < maxindex:
@@ -41,3 +40,6 @@ index f337ba3..5f5b05d 100755
  
  # Table of gesture handlers
  handlers = OrderedDict()
+-- 
+2.19.1
+

--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper,
-  libinput, wmctrl,
+  libinput, wmctrl, python3,
   xdotool ? null,
   extraUtilsPath ? lib.optional (xdotool != null) xdotool
 }:
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ python3 ];
 
   postPatch =
     ''

--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -5,14 +5,14 @@
 }:
 stdenv.mkDerivation rec {
   pname = "libinput-gestures";
-  version = "2.33";
+  version = "2.38";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "bulletmark";
     repo = "libinput-gestures";
     rev = version;
-    sha256 = "0a4zq880da1rn0mxn1sq4cp6zkw4bfslr0vjczkbj4immjrj422j";
+    sha256 = "1nxvlifag04v56grdwxc3l92kmf51c4w2lq42a3w76yc6p4nxw1m";
   };
   patches = [
     ./0001-hardcode-name.patch


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---