### PR TITLE
dragonfly-reverb: 0.9.1 -> 0.9.4

### DIFF
--- a/pkgs/applications/audio/dragonfly-reverb/default.nix
+++ b/pkgs/applications/audio/dragonfly-reverb/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchgit, libjack2, libGL, pkgconfig, xorg }:
+{ stdenv, fetchFromGitHub, libjack2, libGL, pkgconfig, xorg }:
 
 stdenv.mkDerivation rec {
   name = "dragonfly-reverb-${src.rev}";
 
-  src = fetchgit {
-    url = "https://github.com/michaelwillis/dragonfly-reverb";
-    rev = "0.9.1";
-    sha256 = "1dbykx044h768bbzabdagl4jh65gqgfsxsrarjrkp07sqnhlnhpd";
+  src = fetchFromGitHub {
+    owner = "michaelwillis";
+    repo = "dragonfly-reverb";
+    rev = "0.9.4";
+    sha256 = "0lc45jybjwg4wrcz4s9lvzpvqawgj825rkqhz2xxvalfbvjazi53";
+    fetchSubmodules = true;
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

