### PR TITLE
Backports misc. fixes for the new ofborg eval time checks

### DIFF
--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fltk13, ghostscript, xlibs }:
+{ stdenv, fetchurl, fltk13, ghostscript }:
 
 stdenv.mkDerivation rec {
   name = "flpsed-${version}";

--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -3,7 +3,7 @@
 , kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
 , kio, kcrash
 , boost, libraw, fftw, eigen, exiv2, libheif, lcms2, gsl, openexr, giflib
-, openjpeg, opencolorio, vc, poppler_qt5, curl, ilmbase
+, openjpeg, opencolorio, vc, poppler, curl, ilmbase
 , qtmultimedia, qtx11extras
 , python3
 }:
@@ -23,7 +23,7 @@ mkDerivation rec {
     karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
     ki18n kitemmodels kitemviews kwindowsystem kio kcrash
     boost libraw fftw eigen exiv2 lcms2 gsl openexr libheif giflib
-    openjpeg opencolorio poppler_qt5 curl ilmbase
+    openjpeg opencolorio poppler curl ilmbase
     qtmultimedia qtx11extras
     python3
   ] ++ lib.optional (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) vc;

--- a/pkgs/applications/graphics/qcomicbook/default.nix
+++ b/pkgs/applications/graphics/qcomicbook/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools, qtx11extras, poppler_qt5 }:
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools, qtx11extras, poppler }:
 
 stdenv.mkDerivation rec {
   name = "qcomicbook-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    qtbase qttools qtx11extras poppler_qt5
+    qtbase qttools qtx11extras poppler
   ];
 
   postInstall = ''

--- a/pkgs/applications/window-managers/xmonad/log-applet/default.nix
+++ b/pkgs/applications/window-managers/xmonad/log-applet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, glib, dbus-glib
-, desktopSupport, xlibs
+, desktopSupport, xorg
 , gtk2
 , gtk3, gnome3, mate
 , libxfce4util, xfce4-panel
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "042307grf4zvn61gnflhsj5xsjykrk9sjjsprprm4iij0qpybxcw";
   };
 
-  buildInputs = [ glib dbus-glib xlibs.xcbutilwm ]
+  buildInputs = [ glib dbus-glib xorg.xcbutilwm ]
     ++ stdenv.lib.optionals (desktopSupport == "gnomeflashback") [ gtk3 gnome3.gnome-panel ]
     ++ stdenv.lib.optionals (desktopSupport == "mate") [ gtk3 mate.mate-panel ]
     ++ stdenv.lib.optionals (desktopSupport == "xfce4") [ gtk2 libxfce4util xfce4-panel ]

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -2,7 +2,7 @@
 , gtk3, gobjectIntrospection, libappindicator-gtk3, librsvg
 , evdev, pygobject3, pylibacl, pytest, bluez
 , linuxHeaders
-, libX11, libXext, libXfixes, libusb1, libudev
+, libX11, libXext, libXfixes, libusb1, udev
 }:
 
 buildPythonApplication rec {
@@ -34,7 +34,7 @@ buildPythonApplication rec {
     substituteInPlace scc/device_monitor.py --replace "find_library('bluetooth')" "'libbluetooth.so.3'"
   '';
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [ libX11 libXext libXfixes libusb1 libudev bluez ];
+  LD_LIBRARY_PATH = lib.makeLibraryPath [ libX11 libXext libXfixes libusb1 udev bluez ];
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH")

--- a/pkgs/tools/X11/ncview/default.nix
+++ b/pkgs/tools/X11/ncview/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, netcdf, x11, xorg, udunits, expat
+, netcdf, xlibsWrapper, xorg, udunits, expat
 }:
 
 let
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     sha256 = "1gliziyxil2fcz85hj6z0jq33avrxdcjs74d500lhxwvgd8drfp8";
   };
 
-  buildInputs = [ netcdf x11 xorg.libXaw udunits expat ];
+  buildInputs = [ netcdf xlibsWrapper xorg.libXaw udunits expat ];
 
   meta = with stdenv.lib; {
     description = "Visual browser for netCDF format files";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17197,7 +17197,6 @@ with pkgs;
 
   krita = libsForQt5.callPackage ../applications/graphics/krita {
     openjpeg = openjpeg_1;
-    poppler_qt5 = libsForQt5.poppler;
   };
 
   krusader = libsForQt5.callPackage ../applications/misc/krusader { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21963,11 +21963,6 @@ with pkgs;
     callPackage ../applications/networking/cluster/terraform-providers {}
   );
 
-  terraform-provider-libvirt = callPackage ../applications/networking/cluster/terraform-provider-libvirt {};
-
-  terraform-provider-ibm = callPackage ../applications/networking/cluster/terraform-provider-ibm {};
-
-
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
 
   terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape {};


### PR DESCRIPTION
###### Motivation for this change

The new ofborg check (named grahamcofborg-eval-package-list-no-aliases) currently fails on release-18.09.

![image](https://user-images.githubusercontent.com/132835/47192329-9a87c680-d31a-11e8-95e1-c296813df3cf.png)

This PR aims to correct this.

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ✔️ `time env -i nix-env --query --available --json --file . --arg config '{ allowAliases = false; }'`
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ryantm

in f91a79e there were changes to `pkgs/misc/vim-plugins/default.nix` which didn't seem to be needed. I have **not** backported those changes. Any explanations to help figure out whether they should have been needed?
