### PR TITLE
qt59.qtwebkit: fix build on Darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -1,5 +1,5 @@
 { qtModule, stdenv, lib, fetchurl
-, qtbase, qtdeclarative, qtlocation, qtsensors, qtwebchannel
+, qtbase, qtdeclarative, qtlocation, qtmultimedia, qtsensors, qtwebchannel
 , fontconfig, gdk_pixbuf, gtk2, libwebp, libxml2, libxslt
 , sqlite, systemd, glib, gst_all_1, cmake
 , bison2, flex, gdb, gperf, perl, pkgconfig, python2, ruby
@@ -23,7 +23,9 @@ let
 in
 qtModule {
   name = "qtwebkit";
-  qtInputs = [ qtbase qtdeclarative qtlocation qtsensors ] ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ qtwebchannel ];
+  qtInputs = [ qtbase qtdeclarative qtlocation qtsensors ]
+    ++ optional (stdenv.isDarwin && lib.versionAtLeast qtbase.version "5.9.0") qtmultimedia
+    ++ optional (lib.versionAtLeast qtbase.version "5.11.0") qtwebchannel;
   buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite glib gst_all_1.gstreamer gst_all_1.gst-plugins-base ]
     ++ optionals (stdenv.isDarwin) (with darwin.apple_sdk.frameworks; [ OpenGL ])
     ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ hyphen ];


### PR DESCRIPTION
###### Motivation for this change

Why is qtmultimedia only needed on Darwin? Why does it only fix 5.9, not 5.11? These things I do not know. What I do know is that, for some reason, this makes qt59.qtwebkit build on Darwin.

I think the reason it hasn't also fixed 5.11 might be something to do with the version of qtmultimedia, but I don't know enough about Qt or cmake to figure it out. The error when trying to build qt511.qtwebkit (with or without these changes) is:

    CMake Error at Source/cmake/OptionsQt.cmake:739 (find_package):
      Could not find a package configuration file provided by "Qt5Multimedia"
      (requested version 5.2.0) with any of the following names:

        Qt5MultimediaConfig.cmake
        qt5multimedia-config.cmake

      Add the installation prefix of "Qt5Multimedia" to CMAKE_PREFIX_PATH or set
      "Qt5Multimedia_DIR" to a directory containing one of the above files.  If
      "Qt5Multimedia" provides a separate development package or SDK, be sure it
      has been installed.
    Call Stack (most recent call first):
      Source/cmake/WebKitCommon.cmake:50 (include)
      CMakeLists.txt:137 (include)

    -- Configuring incomplete, errors occurred!
    See also "/tmp/nix-build-qtwebkit-5.212-alpha-01-26-2018.drv-0/source/build/CMakeFiles/CMakeOutput.log".
    See also "/tmp/nix-build-qtwebkit-5.212-alpha-01-26-2018.drv-0/source/build/CMakeFiles/CMakeError.log".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

