### PR TITLE
ndn-cxx: fixed broken build and updated to latest release

### DIFF
--- a/pkgs/development/libraries/ndn-cxx/default.nix
+++ b/pkgs/development/libraries/ndn-cxx/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchgit, openssl, doxygen, boost, sqlite, cryptopp, pkgconfig, python, pythonPackages }:
+{ stdenv, fetchFromGitHub, openssl, doxygen, boost, sqlite, pkgconfig, python, pythonPackages }:
 let
-  version = "4c32e7";
+  version = "0.6.3";
 in
 stdenv.mkDerivation {
-  name = "ndn-cxx-0.1-${version}";
-  src = fetchgit {
-    url = "https://github.com/named-data/ndn-cxx.git";
-    rev = "4c32e748863d5165cc0e3d6b54a8383f4836cdf1";
-    sha256 = "18szs3j3ig8wlcqngran0daxaj7j2qsmch0212ids6fymj1hgax4";
+  name = "ndn-cxx-${version}";
+  src = fetchFromGitHub {
+    owner = "named-data";
+    repo = "ndn-cxx";
+    rev = "a3bf4319ed483a4a6fe2c96b79ec4491d7217f00";
+    sha256 = "076jhrjigisqz5n8dgxwd5fhimg69zhm834m7w9yvf9afgzrr50h";
   };
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl doxygen boost sqlite cryptopp python pythonPackages.sphinx];
+  buildInputs = [ openssl doxygen boost sqlite python pythonPackages.sphinx];
   preConfigure = ''
     patchShebangs waf
     ./waf configure \
-      --with-cryptopp=${cryptopp} \
+      --prefix=$out \
+      --with-openssl=${openssl.dev} \
       --boost-includes=${boost.dev}/include \
-      --boost-libs=${boost.out}/lib \
-      --with-examples \
-      --prefix=$out
+      --boost-libs=${boost.out}/lib
   '';
   buildPhase = ''
     ./waf
@@ -45,6 +45,5 @@ stdenv.mkDerivation {
     license = licenses.lgpl3;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ maintainers.sjmackenzie ];
-    broken = true; # 2018-04-11
   };
 }


### PR DESCRIPTION
###### Motivation for this change
`ndn-cxx` is broken and out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

