### PR TITLE
oraclejdk: 8u191 -> 8u192

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,11 +1,11 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "191";
+  patchVersion = "192";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "1dmnv3x28l0rdi92gpmcp38gpy3lf4pl441bijvjhi7j97kk60v4";
-  sha256.x86_64-linux = "0r8dvb0hahfybvf9wiv7904rn22n93bfc9x6pgypynj0w83rbhjk";
-  sha256.armv7l-linux = "0wgdr9ainzc2yc5qp6ncflnsdygpgrmv2af522djkc83skp5g70v";
-  sha256.aarch64-linux = "1rgwf0i9ikcjqbxkvr4x94y62m1kklfdhgqscxil479d5mg6akqz";
+  sha256.i686-linux = "1ki67svhh9i3qaqwq9yzvyzk5ipd7nbv2sl5l286vy9nk9kdgq8v";
+  sha256.x86_64-linux = "1hi3ldv8pwh24pr3hr9mj3i9biqi2kg6gd0kp43lqmn5gwaawd3d";
+  sha256.armv7l-linux = "0fz4f3dpgin9qp7556imry1x51p1c2vfwlbkv3j32mp1qpp2ppp8";
+  sha256.aarch64-linux = "1q56399kfn04nplr1hahrj9zhsnrvzgz0161i7lgihxw8fr88g5n";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

