### PR TITLE
asterisk: 15.3.0 -> 15.6.1 & 13.20.0 -> 13.23.1

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -70,8 +70,8 @@ let
   };
 
   pjproject-27 = fetchurl {
-    url = http://www.pjsip.org/release/2.7.1/pjproject-2.7.1.tar.bz2;
-    sha256 = "09ii5hgl5s7grx4fiimcl3s77i385h7b3kwpfa2q0arbl1ibryjr";
+    url = http://www.pjsip.org/release/2.7.2/pjproject-2.7.2.tar.bz2;
+    sha256 = "0wiph6g51wanzwjjrpwsz63amgvly8g08jz033gnwqmppa584b4w";
   };
 
   mp3-202 = fetchsvn {
@@ -84,19 +84,19 @@ in
 {
 
   asterisk-lts = common {
-    version = "13.20.0";
-    sha256 = "a3d6d953f844867ea11e0be22ee6225049cd4f5870df6ab23454623bcfbc94d5";
+    version = "13.23.1";
+    sha256 = "c772acbfdddb9250bfe07f7e20a7efb6a79a6c123832727429486c78d44fc78c";
     externals = {
-      "externals_cache/pjproject-2.7.1.tar.bz2" = pjproject-27;
+      "externals_cache/pjproject-2.7.2.tar.bz2" = pjproject-27;
       "addons/mp3" = mp3-202;
     };
   };
 
   asterisk-stable = common {
-    version = "15.3.0";
-    sha256 = "f424f89f23b72f267ff9baab82d449bebbbf00c54e54fcd06b8fca13788b012c";
+    version = "15.6.1";
+    sha256 = "9cb86585fb4efcd86423fa7586e55d9d3c74fda43a2e0b1b9c9eb3742df73155";
     externals = {
-      "externals_cache/pjproject-2.7.1.tar.bz2" = pjproject-27;
+      "externals_cache/pjproject-2.7.2.tar.bz2" = pjproject-27;
       "addons/mp3" = mp3-202;
     };
   };


### PR DESCRIPTION
###### Motivation for this change
Update Asterisk and Asterisk LTS.

Note: A few days ago Asterisk 16.0.0 was released, this is also the new LTS version. Building and testing this new majorversion should be done in the next few weeks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

