### PR TITLE
file: 5.34 -> 5.35

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "file-${version}";
-  version = "5.34";
+  version = "5.35";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.astron.com/pub/file/${name}.tar.gz"
       "https://distfiles.macports.org/file/${name}.tar.gz"
     ];
-    sha256 = "02mj4g34l13facacsc0ff8rchbh93ccqw7hns45yqgx8pzdm0npi";
+    sha256 = "0ijm1fabm68ykr1zbx0bxnka5jr3n42sj8y5mbkrnxs0fj0mxi1h";
   };
 
   nativeBuildInputs = stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
               else null;
 
   meta = with stdenv.lib; {
-    homepage = http://darwinsys.com/file;
+    homepage = https://darwinsys.com/file;
     description = "A program that shows the type of files";
     license = licenses.bsd2;
     platforms = platforms.all;


### PR DESCRIPTION
```
* Add FreeBSD ELF core file support (John Baldwin)
* PR/30: Allow all parameter values to be set (don't treat 0 specially)
* handle default annotations on the softmagic match instead at the
  end.
* PR/23: Recognize JSON files
* PR/18: file --mime-encoding should not print mime-type
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---