### PR TITLE
firefoxPackages.tor-browser: 7.5.6 -> 8.0.2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,7 +1,7 @@
-{ pname, version, updateScript ? null
-, src, patches ? [], extraConfigureFlags ? [], extraMakeFlags ? []
-, overrides ? {}, extraNativeBuildInputs ? [], meta
-, isTorBrowserLike ? false }:
+{ pname, ffversion, meta, updateScript ? null
+, src, unpackPhase ? null, patches ? []
+, extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? []
+, isTorBrowserLike ? false, tbversion ? null }:
 
 { lib, stdenv, pkgconfig, pango, perl, python2, zip, libIDL
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
@@ -19,7 +19,7 @@
 , alsaSupport ? stdenv.isLinux, alsaLib
 , pulseaudioSupport ? true, libpulseaudio
 , ffmpegSupport ? true, gstreamer, gst-plugins-base
-, gtk3Support ? !isTorBrowserLike, gtk2, gtk3, wrapGAppsHook
+, gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
 , gssSupport ? true, kerberos
 
 ## privacy-related options
@@ -31,7 +31,7 @@
 
 # webrtcSupport breaks the aarch64 build on version >= 60.
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1434589
-, webrtcSupport ? (if lib.versionAtLeast version "60" && stdenv.isAarch64 then false else !privacySupport)
+, webrtcSupport ? (if lib.versionAtLeast ffversion "60" && stdenv.isAarch64 then false else !privacySupport)
 , geolocationSupport ? !privacySupport
 , googleAPISupport ? geolocationSupport
 , crashreporterSupport ? false
@@ -80,23 +80,24 @@ let
   browserName = if stdenv.isDarwin then "Firefox" else "firefox";
 in
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "${pname}-unwrapped-${version}";
+  version = if !isTorBrowserLike then ffversion else tbversion;
 
-  inherit src patches meta;
+  inherit src unpackPhase patches meta;
 
   buildInputs = [
     gtk2 perl zip libIDL libjpeg zlib bzip2
     dbus dbus-glib pango freetype fontconfig xorg.libXi xorg.libXcursor
     xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
-    nspr libnotify xorg.pixman yasm libGLU_combined
+    libnotify xorg.pixman yasm libGLU_combined
     xorg.libXScrnSaver xorg.scrnsaverproto
     xorg.libXext xorg.xextproto sqlite unzip makeWrapper
     libevent libstartup_notification libvpx /* cairo */
     icu libpng jemalloc glib
   ]
-  ++ lib.optionals (!isTorBrowserLike) [ nss ]
-  ++ lib.optional (lib.versionOlder version "61") hunspell
+  ++ lib.optionals (!isTorBrowserLike) [ nspr nss ]
+  ++ lib.optional (lib.versionOlder ffversion "61") hunspell
   ++ lib.optional  alsaSupport alsaLib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optionals ffmpegSupport [ gstreamer gst-plugins-base ]
@@ -106,12 +107,17 @@ stdenv.mkDerivation (rec {
                                      AVFoundation MediaToolbox CoreLocation
                                      Foundation libobjc AddressBook cups ];
 
-  NIX_CFLAGS_COMPILE = [ "-I${nspr.dev}/include/nspr"
-                         "-I${nss.dev}/include/nss"
-                         "-I${glib.dev}/include/gio-unix-2.0" ]
-                      ++ lib.optional stdenv.isDarwin [
-                         "-isystem ${llvmPackages.libcxx}/include/c++/v1"
-                         "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10" ];
+  NIX_CFLAGS_COMPILE = [
+    "-I${glib.dev}/include/gio-unix-2.0"
+  ]
+  ++ lib.optionals (!isTorBrowserLike) [
+    "-I${nspr.dev}/include/nspr"
+    "-I${nss.dev}/include/nss"
+  ]
+  ++ lib.optional stdenv.isDarwin [
+    "-isystem ${llvmPackages.libcxx}/include/c++/v1"
+    "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10"
+  ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace js/src/jsmath.cpp --replace 'defined(HAVE___SINCOS)' 0
@@ -128,14 +134,14 @@ stdenv.mkDerivation (rec {
     rm -f configure
     rm -f js/src/configure
     rm -f .mozconfig*
-  '' + (if lib.versionAtLeast version "58"
+  '' + (if lib.versionAtLeast ffversion "58"
   # this will run autoconf213
   then ''
     configureScript="$(realpath ./mach) configure"
   '' else ''
     make -f client.mk configure-files
     configureScript="$(realpath ./configure)"
-  '') + lib.optionalString (!isTorBrowserLike && lib.versionAtLeast version "53") ''
+  '') + lib.optionalString (lib.versionAtLeast ffversion "53") ''
     export MOZCONFIG=$(pwd)/mozconfig
 
     # Set C flags for Rust's bindgen program. Unlike ordinary C
@@ -158,7 +164,7 @@ stdenv.mkDerivation (rec {
     # please get your own set of keys.
     echo "AIzaSyDGi15Zwl11UNe6Y-5XW_upsfyw31qwZPI" > $TMPDIR/ga
     configureFlagsArray+=("--with-google-api-keyfile=$TMPDIR/ga")
-  '' + lib.optionalString (lib.versionOlder version "58") ''
+  '' + lib.optionalString (lib.versionOlder ffversion "58") ''
     cd obj-*
   '';
 
@@ -185,37 +191,29 @@ stdenv.mkDerivation (rec {
     "--disable-gconf"
     "--enable-default-toolkit=${default-toolkit}"
   ]
-  ++ lib.optional (stdenv.isDarwin && lib.versionAtLeast version "61") "--disable-xcode-checks"
-  ++ lib.optional (lib.versionOlder version "61") "--enable-system-hunspell"
-  ++ lib.optionals (lib.versionAtLeast version "56" && !stdenv.hostPlatform.isi686) [
+  ++ lib.optional (stdenv.isDarwin && lib.versionAtLeast ffversion "61") "--disable-xcode-checks"
+  ++ lib.optional (lib.versionOlder ffversion "61") "--enable-system-hunspell"
+  ++ lib.optionals (lib.versionAtLeast ffversion "56" && !stdenv.hostPlatform.isi686) [
     # on i686-linux: --with-libclang-path is not available in this configuration
     "--with-libclang-path=${llvmPackages.libclang}/lib"
     "--with-clang-path=${llvmPackages.clang}/bin/clang"
   ]
-  ++ lib.optionals (lib.versionAtLeast version "57") [
+  ++ lib.optionals (lib.versionAtLeast ffversion "57") [
     "--enable-webrender=build"
   ]
 
   # TorBrowser patches these
   ++ lib.optionals (!isTorBrowserLike) [
-    "--with-system-nss"
     "--with-system-nspr"
+    "--with-system-nss"
   ]
 
   # and wants these
   ++ lib.optionals isTorBrowserLike ([
-    "--with-tor-browser-version=${version}"
+    "--with-tor-browser-version=${tbversion}"
     "--enable-signmar"
     "--enable-verify-mar"
-
-    # We opt out of TorBrowser's nspr because that patch is useless on
-    # anything but Windows and produces zero fingerprinting
-    # possibilities on other platforms.
-    # Lets save some space instead.
-    "--with-system-nspr"
-  ] ++ flag geolocationSupport "mozril-geoloc"
-    ++ flag safeBrowsingSupport "safe-browsing"
-  )
+  ])
 
   ++ flag alsaSupport "alsa"
   ++ flag pulseaudioSupport "pulseaudio"
@@ -225,6 +223,11 @@ stdenv.mkDerivation (rec {
   ++ flag webrtcSupport "webrtc"
   ++ flag crashreporterSupport "crashreporter"
   ++ lib.optional drmSupport "--enable-eme=widevine"
+
+  ++ lib.optionals (lib.versionOlder ffversion "60") ([]
+    ++ flag geolocationSupport "mozril-geoloc"
+    ++ flag safeBrowsingSupport "safe-browsing"
+  )
 
   ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]
                     else [ "--disable-debug" "--enable-release"
@@ -239,11 +242,11 @@ stdenv.mkDerivation (rec {
   # top level and then run `make` in obj-*. (We can also run the
   # `make` at the top level in 58, but then we would have to `cd` to
   # `make install` anyway. This is ugly, but simple.)
-  postConfigure = lib.optionalString (lib.versionAtLeast version "58") ''
+  postConfigure = lib.optionalString (lib.versionAtLeast ffversion "58") ''
     cd obj-*
   '';
 
-  preBuild = lib.optionalString (enableOfficialBranding && isTorBrowserLike) ''
+  preBuild = lib.optionalString isTorBrowserLike ''
     buildFlagsArray=("MOZ_APP_DISPLAYNAME=Tor Browser")
   '';
 
@@ -302,4 +305,4 @@ stdenv.mkDerivation (rec {
     inherit browserName;
   } // lib.optionalAttrs gtk3Support { inherit gtk3; };
 
-} // overrides)
+}

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -100,14 +100,14 @@ rec {
     isTorBrowserLike = true;
 
     unpackPhase = ''
-        # fetchFromGitHub produces ro sources, root dir gets a name that
-        # is too long for shebangs. fixing
-        cp -a $src tor-browser
-        chmod -R +w tor-browser
-        cd tor-browser
+      # fetchFromGitHub produces ro sources, root dir gets a name that
+      # is too long for shebangs. fixing
+      cp -a $src tor-browser
+      chmod -R +w tor-browser
+      cd tor-browser
 
-        # set times for xpi archives
-        find . -exec touch -d'2010-01-01 00:00' {} \;
+      # set times for xpi archives
+      find . -exec touch -d'2010-01-01 00:00' {} \;
     '';
 
     patches = nixpkgsPatches;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -9,9 +9,15 @@ let
   ];
 
   firefox60_aarch64_skia_patch = fetchpatch {
-      name = "aarch64-skia.patch";
-      url = https://src.fedoraproject.org/rpms/firefox/raw/8cff86d95da3190272d1beddd45b41de3148f8ef/f/build-aarch64-skia.patch;
-      sha256 = "11acb0ms4jrswp7268nm2p8g8l4lv8zc666a5bqjbb09x9k6b78k";
+    name = "aarch64-skia.patch";
+    url = https://src.fedoraproject.org/rpms/firefox/raw/8cff86d95da3190272d1beddd45b41de3148f8ef/f/build-aarch64-skia.patch;
+    sha256 = "11acb0ms4jrswp7268nm2p8g8l4lv8zc666a5bqjbb09x9k6b78k";
+  };
+
+  firefox60_triplet_patch = fetchpatch {
+    name = "triplet.patch";
+    url = https://hg.mozilla.org/releases/mozilla-release/raw-rev/bc651d3d910c;
+    sha256 = "0iybkadsgsf6a3pq3jh8z1p110vmpkih8i35jfj8micdkhxzi89g";
   };
 
 in
@@ -110,7 +116,8 @@ rec {
       find . -exec touch -d'2010-01-01 00:00' {} \;
     '';
 
-    patches = nixpkgsPatches;
+    patches = nixpkgsPatches
+      ++ lib.optional (args.tbversion == "8.0.2") firefox60_triplet_patch;
 
     meta = {
       description = "A web browser built from TorBrowser source tree";

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -2,7 +2,7 @@
 
 let
 
-  common = opts: callPackage (import ./common.nix opts);
+  common = opts: callPackage (import ./common.nix opts) {};
 
   nixpkgsPatches = [
     ./env_var_for_system_dir.patch
@@ -20,9 +20,9 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "62.0.3";
+    ffversion = "62.0.3";
     src = fetchurl {
-      url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
+      url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
       sha512 = "0kvb664s47bmmdq2ppjsnyqy8yaiig1xj81r25s36c3i8igfq3zxvws10k2dlmmmrwyc5k4g9i9imgkxj7r3xwwqxc72dl429wvfys8";
     };
 
@@ -42,13 +42,13 @@ rec {
     updateScript = callPackage ./update.nix {
       attrPath = "firefox-unwrapped";
     };
-  } {};
+  };
 
   firefox-esr-52 = common rec {
     pname = "firefox-esr";
-    version = "52.9.0esr";
+    ffversion = "52.9.0esr";
     src = fetchurl {
-      url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
+      url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
       sha512 = "bfca42668ca78a12a9fb56368f4aae5334b1f7a71966fbba4c32b9c5e6597aac79a6e340ac3966779d2d5563eb47c054ab33cc40bfb7306172138ccbd3adb2b9";
     };
 
@@ -64,15 +64,15 @@ rec {
     };
     updateScript = callPackage ./update.nix {
       attrPath = "firefox-esr-52-unwrapped";
-      versionSuffix = "esr";
+      ffversionSuffix = "esr";
     };
-  } {};
+  };
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    version = "60.2.2esr";
+    ffversion = "60.2.2esr";
     src = fetchurl {
-      url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
+      url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
       sha512 = "2h2naaxx4lv90bjpcrsma4sdhl4mvsisx3zi09vakjwv2lad91gy41cmcpqprpcbsmlvpqf8yiv52ah4d02a8d9335xhw2ajw6asjc1";
     };
 
@@ -91,13 +91,15 @@ rec {
       attrPath = "firefox-esr-60-unwrapped";
       versionSuffix = "esr";
     };
-  } {};
+  };
 
 } // (let
 
-  commonAttrs = {
-    overrides = {
-      unpackPhase = ''
+  tbcommon = args: common (args // {
+    pname = "tor-browser";
+    isTorBrowserLike = true;
+
+    unpackPhase = ''
         # fetchFromGitHub produces ro sources, root dir gets a name that
         # is too long for shebangs. fixing
         cp -a $src tor-browser
@@ -106,8 +108,9 @@ rec {
 
         # set times for xpi archives
         find . -exec touch -d'2010-01-01 00:00' {} \;
-      '';
-    };
+    '';
+
+    patches = nixpkgsPatches;
 
     meta = {
       description = "A web browser built from TorBrowser source tree";
@@ -142,14 +145,13 @@ rec {
       platforms = lib.platforms.linux;
       license = lib.licenses.bsd3;
     };
-  };
+  });
 
 in rec {
 
-  tor-browser-7-5 = common (rec {
-    pname = "tor-browser";
-    version = "7.5.6";
-    isTorBrowserLike = true;
+  tor-browser-7-5 = (tbcommon rec {
+    ffversion = "52.9.0esr";
+    tbversion = "7.5.6";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
@@ -159,14 +161,13 @@ in rec {
       rev   = "95bb92d552876a1f4260edf68fda5faa3eb36ad8";
       sha256 = "1ykn3yg4s36g2cpzxbz7s995c33ij8kgyvghx38z4i8siaqxdddy";
     };
+  }).override {
+    gtk3Support = false;
+  };
 
-    patches = nixpkgsPatches;
-  } // commonAttrs) {};
-
-  tor-browser-8-0 = common (rec {
-    pname = "tor-browser";
-    version = "8.0.1";
-    isTorBrowserLike = true;
+  tor-browser-8-0 = tbcommon rec {
+    ffversion = "52.8.0esr";
+    tbversion = "8.0.1";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
@@ -176,9 +177,7 @@ in rec {
       rev   = "5d7e9e1cacbf70840f8f1a9aafe99f354f9ad0ca";
       sha256 = "0cwxwwc4m7331bbp3id694ffwxar0j5kfpgpn9l1z36rmgv92n21";
     };
-
-    patches = nixpkgsPatches;
-  } // commonAttrs) {};
+  };
 
   tor-browser = tor-browser-7-5;
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -166,19 +166,19 @@ in rec {
   };
 
   tor-browser-8-0 = tbcommon rec {
-    ffversion = "52.8.0esr";
-    tbversion = "8.0.1";
+    ffversion = "60.2.1esr";
+    tbversion = "8.0.2";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-52.8.0esr-8.0-1-slnos";
-      rev   = "5d7e9e1cacbf70840f8f1a9aafe99f354f9ad0ca";
-      sha256 = "0cwxwwc4m7331bbp3id694ffwxar0j5kfpgpn9l1z36rmgv92n21";
+      # branch "tor-browser-60.2.1esr-8.0-1-slnos"
+      rev   = "4f71403a3e6203baa349a8f81d8664782c5ea548";
+      sha256 = "0zxdi162gpnfca7g77hc0rw4wkmxhfzp9hfmw6dpn97d5kn1zqq3";
     };
   };
 
-  tor-browser = tor-browser-7-5;
+  tor-browser = tor-browser-8-0;
 
 })


### PR DESCRIPTION
###### Motivation for this change

Update.

###### Things done

- [X] Cleanup looked a bit scary, so I built all `firefoxPackages` and they still build fine.
- [X] `firefox` and both `tor-browser*` outputs still work as before.

`tor-browser-bundle` is likely to need changes after this.

/cc @joachifm