### PR TITLE
libdbusmenu-qt: 0.9.3+14 -> 0.9.3+16

### DIFF
--- a/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
+++ b/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
@@ -1,12 +1,13 @@
-{ stdenv, fetchbzr, cmake, qtbase }:
+{ stdenv, fetchgit, cmake, qtbase }:
 
-stdenv.mkDerivation {
-  name = "libdbusmenu-qt-0.9.3+14";
+stdenv.mkDerivation rec {
+  name = "libdbusmenu-qt-${version}";
+  version = "0.9.3+16";
 
-  src = fetchbzr {
-    url = "https://bazaar.launchpad.net/~dbusmenu-team/libdbusmenu-qt/trunk";
-    rev = "ps-jenkins@lists.canonical.com-20140619090718-mppiiax5atpnb8i2";
-    sha256 = "1dbhaljyivbv3wc184zpjfjmn24zb6aj72wgg1gg1xl5f783issd";
+  src = fetchgit {
+    url = https://git.launchpad.net/ubuntu/+source/libdbusmenu-qt;
+    rev = "import/${version}.04.20160218-1";
+    sha256 = "039yvklhbmfbcynrbqq9n5ywmj8bjfslnkzcnwpzyhnxdzb6yxlx";
   };
 
   buildInputs = [ qtbase ];


### PR DESCRIPTION
The upgraded version has memory leak fixes and test case fixes for qt5.

This also swaps to git due to difficulties in fetching src with `bzr` without
'not a branch' errors.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

