### PR TITLE
factor-lang: 0.97 -> 0.98

### DIFF
--- a/pkgs/development/compilers/factor-lang/default.nix
+++ b/pkgs/development/compilers/factor-lang/default.nix
@@ -1,57 +1,58 @@
-{ stdenv, fetchurl, fetchFromGitHub, glib, git,
+{ stdenv, fetchurl, glib, glibc, git,
   rlwrap, curl, pkgconfig, perl, makeWrapper, tzdata, ncurses,
-  libX11, pango, cairo, gtk2, gdk_pixbuf, gtkglext,
-  libGLU, libXmu, libXt, libICE, libSM }:
+  pango, cairo, gtk2, gdk_pixbuf, gtkglext,
+  mesa, xorg, openssl, unzip }:
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.lib) optional;
+
+in stdenv.mkDerivation rec {
   name = "factor-lang-${version}";
-  version = "0.97";
-  rev = "eb3ca179740e6cfba696b55a999caa13369e6182";
+  version = "0.98";
+  rev = "7999e72aecc3c5bc4019d43dc4697f49678cc3b4";
 
-  src = fetchFromGitHub {
-    owner = "factor";
-    repo = "factor";
-    rev = rev;
-    sha256 = "16zlbxbad3d19jq01nk824i19bypqzn8l3yfxys40z06vjjncapd";
+  src = fetchurl {
+    url = http://downloads.factorcode.org/releases/0.98/factor-src-0.98.zip;
+    sha256 = "01ip9mbnar4sv60d2wcwfz62qaamdvbykxw3gbhzqa25z36vi3ri";
   };
 
-  factorimage = fetchurl {
-    url = http://downloads.factorcode.org/releases/0.97/factor-linux-x86-64-0.97.tar.gz;
-    sha256 = "06y125c8vbng54my5fxdr3crpxkvhhcng2n35cxddd3wcg6vhxhp";
-    name = "factorimage";
-  };
+  patches = [
+    ./staging-command-line-0.98-pre.patch
+    ./workdir-0.98-pre.patch
+    ./fuel-dir.patch
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ git rlwrap curl perl makeWrapper
+  buildInputs = with xorg; [ git rlwrap curl pkgconfig perl makeWrapper
     libX11 pango cairo gtk2 gdk_pixbuf gtkglext
-    libGLU libXmu libXt libICE libSM ];
+    mesa libXmu libXt libICE libSM openssl unzip ];
 
   buildPhase = ''
-    make $(bash ./build-support/factor.sh make-target) GIT_LABEL=heads/master-${rev}
+    sed -ie '4i GIT_LABEL = heads/master-${rev}' GNUmakefile
+    make linux-x86-64
+    # De-memoize xdg-* functions, otherwise they break the image.
+    sed -ie 's/^MEMO:/:/' basis/xdg/xdg.factor
   '';
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/factor
-    # First, get a workable image. Unfortunately, no boot-image
-    # is available with release info. So fetch a released image.
     # The released image has library path info embedded, so we
-    # have to first recreate the boot image with Nix paths, and
+    # first have to recreate the boot image with Nix paths, and
     # then use it to build the Nix release image.
-    zcat ${factorimage} | (cd $out/lib && tar -xvpf - factor/factor.image )
+    cp boot.unix-x86.64.image $out/lib/factor/factor.image
 
-    cp -r basis core extra unmaintained $out/lib/factor
+    cp -r basis core extra $out/lib/factor
 
-    # Factor uses the home directory for cache during compilation.
-    # We cant have that. So set it to $TMPDIR/.home
-    export HOME=$TMPDIR/.home && mkdir -p $HOME
+    # Factor uses XDG_CACHE_HOME for cache during compilation.
+    # We can't have that. So set it to $TMPDIR/.cache
+    export XDG_CACHE_HOME=$TMPDIR/.cache && mkdir -p $XDG_CACHE_HOME
 
-    # there is no ld.so.cache in NixOS so we construct one
+    # There is no ld.so.cache in NixOS so we construct one
     # out of known libraries. The side effect is that find-lib
     # will work only on the known libraries. There does not seem
     # to be a generic solution here.
-    find $(echo ${stdenv.lib.makeLibraryPath [
+    find $(echo ${stdenv.lib.makeLibraryPath (with xorg; [
         glib libX11 pango cairo gtk2 gdk_pixbuf gtkglext
-        libGLU libXmu libXt libICE libSM ]} | sed -e 's#:# #g') -name \*.so.\* > $TMPDIR/so.lst
+        mesa libXmu libXt libICE libSM ])} | sed -e 's#:# #g') -name \*.so.\* > $TMPDIR/so.lst
 
     (echo $(cat $TMPDIR/so.lst | wc -l) "libs found in cache \`/etc/ld.so.cache'";
     for l in $(<$TMPDIR/so.lst);
@@ -70,18 +71,29 @@ stdenv.mkDerivation rec {
 
     cp ./factor $out/bin
     wrapProgram $out/bin/factor --prefix LD_LIBRARY_PATH : \
-      "${stdenv.lib.makeLibraryPath [ glib
+      "${stdenv.lib.makeLibraryPath (with xorg; [ glib
         libX11 pango cairo gtk2 gdk_pixbuf gtkglext
-        libGLU libXmu libXt libICE libSM ]}"
+        mesa libXmu libXt libICE libSM openssl])}"
 
     sed -ie 's#/bin/.factor-wrapped#/lib/factor/factor#g' $out/bin/factor
     mv $out/bin/.factor-wrapped $out/lib/factor/factor
 
-    # make a new bootstrap image
+    # build full factor image from boot image
     (cd $out/bin && ./factor  -script -e='"unix-x86.64" USING: system bootstrap.image memory ; make-image save 0 exit' )
-    mv $out/lib/factor/boot.unix-x86.64.image $out/lib/factor/factor.image
-    # now make the full system image, it overwrites $out/lib/factor/factor.image
-    $out/bin/factor -i=$out/lib/factor/factor.image
+
+    # make a new bootstrap image
+    (cd $out/bin && ./factor  -script -e='"unix-x86.64" USING: system tools.deploy.backend ; make-boot-image 0 exit' )
+
+    # rebuild final full factor image to include all patched sources
+    (cd $out/lib/factor && ./factor -i=boot.unix-x86.64.image)
+
+    # install fuel mode for emacs
+    mkdir -p $out/share/emacs/site-lisp
+    # update default paths in factor-listener.el for fuel mode
+    substituteInPlace misc/fuel/fuel-listener.el \
+      --subst-var-by fuel_factor_root_dir $out/lib/factor \
+      --subst-var-by fuel_listener_factor_binary $out/bin/factor
+    cp misc/fuel/*.el $out/share/emacs/site-lisp/
   '';
 
   meta = with stdenv.lib; {
@@ -89,7 +101,7 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     description = "A concatenative, stack-based programming language";
 
-    maintainers = [ maintainers.vrthra ];
+    maintainers = [ maintainers.vrthra maintainers.spacefrogg ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/factor-lang/fuel-dir.patch
+++ b/pkgs/development/compilers/factor-lang/fuel-dir.patch
@@ -1,0 +1,20 @@
+diff --git a/misc/fuel/fuel-listener.el b/misc/fuel/fuel-listener.el
+index 2d1b182a75..bf2e573425 100644
+--- a/misc/fuel/fuel-listener.el
++++ b/misc/fuel/fuel-listener.el
+@@ -30,13 +30,13 @@
+   "Interacting with a Factor listener inside Emacs."
+   :group 'fuel)
+ 
+-(defcustom fuel-factor-root-dir nil
++(defcustom fuel-factor-root-dir "@fuel_factor_root_dir@"
+   "Full path to the factor root directory when starting a listener."
+   :type 'directory
+   :group 'fuel-listener)
+ 
+ ;;; Is factor.com still valid on Windows...?
+-(defcustom fuel-listener-factor-binary nil
++(defcustom fuel-listener-factor-binary "@fuel_listener_factor_binary@"
+   "Full path to the factor executable to use when starting a listener."
+   :type '(file :must-match t)
+   :group 'fuel-listener)

--- a/pkgs/development/compilers/factor-lang/staging-command-line-0.98-pre.patch
+++ b/pkgs/development/compilers/factor-lang/staging-command-line-0.98-pre.patch
@@ -1,0 +1,13 @@
+diff --git a/basis/tools/deploy/backend/backend.factor b/basis/tools/deploy/backend/backend.factor
+index ec86089dbe..b146168ec9 100644
+--- a/basis/tools/deploy/backend/backend.factor
++++ b/basis/tools/deploy/backend/backend.factor
+@@ -69,7 +69,7 @@ ERROR: can't-deploy-library-file library ;
+             [ staging-image-name "-output-image=" prepend , ]
+             [ " " join "-include=" prepend , ] bi
+         ] [
+-            input-image-name "-i=" prepend ,
++            input-image-name resource-path "-i=" prepend ,
+             "-resource-path=" "" resource-path append ,
+             "-run=tools.deploy.restage" ,
+         ] bi

--- a/pkgs/development/compilers/factor-lang/workdir-0.98-pre.patch
+++ b/pkgs/development/compilers/factor-lang/workdir-0.98-pre.patch
@@ -1,0 +1,24 @@
+diff --git a/core/io/pathnames/pathnames.factor b/core/io/pathnames/pathnames.factor
+index 2d382e49d1..d4d9228d6c 100644
+--- a/core/io/pathnames/pathnames.factor
++++ b/core/io/pathnames/pathnames.factor
+@@ -144,7 +144,10 @@ GENERIC: vocab-path ( path -- newpath )
+ GENERIC: absolute-path ( path -- path' )
+ 
+ M: string absolute-path
+-    "resource:" ?head [
++    "resource:work" ?head [
++        trim-head-separators "/var/lib/factor" prepend-path
++        absolute-path ]
++    [ "resource:" ?head [
+         trim-head-separators resource-path
+         absolute-path
+     ] [
+@@ -158,6 +161,7 @@ M: string absolute-path
+         ] [
+             current-directory get prepend-path
+         ] if ] if
++      ] if
+     ] if ;
+ 
+ M: object normalize-path ( path -- path' )


### PR DESCRIPTION
Much improved build with support for GUI libraries and FUEL, the emacs
development environment.

Also directs the work vocabulary to point to /var/lib/factor as a machine-local
writable location. So, scaffolding should work as intended, now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

