### PR TITLE
nixos/eternal-terminal: init new module.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -504,6 +504,7 @@
   ./services/networking/dnsmasq.nix
   ./services/networking/ejabberd.nix
   ./services/networking/epmd.nix
+  ./services/networking/eternal-terminal.nix
   ./services/networking/fakeroute.nix
   ./services/networking/ferm.nix
   ./services/networking/firefox/sync-server.nix

--- a/nixos/modules/services/networking/eternal-terminal.nix
+++ b/nixos/modules/services/networking/eternal-terminal.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.eternal-terminal;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.eternal-terminal = {
+
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable the Eternal Terminal server.
+        '';
+      };
+
+      port = mkOption {
+        default = null;
+        type = types.nullOr types.int;
+        description = ''
+          The port the server should listen on. Will use the server's default (2022) if not specified.
+        '';
+      };
+
+      verbosity = mkOption {
+        default = 0;
+        type = types.int;
+        description = ''
+          The verbosity level (0-9).
+        '';
+      };
+
+      silence = mkOption {
+        default = 0;
+        type = types.int;
+        description = ''
+          Silence.
+        '';
+      };
+
+      logSize = mkOption {
+        default = 20971520;
+        type = types.int;
+        description = ''
+          The maximum log size.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    # We need to ensure the et package is fully installed because
+    # the (remote) et client runs the `etterminal` binary when it
+    # connects.
+    environment.systemPackages = [ pkgs.eternal-terminal ];
+
+    systemd.services = {
+      eternal-terminal = {
+        description = "Eternal Terminal server.";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "syslog.target" "network.target" ];
+        serviceConfig = {
+          Type = "forking";
+          ExecStart = "${pkgs.eternal-terminal}/bin/etserver --daemon --cfgfile=${pkgs.writeText "et.cfg" ''
+            ; et.cfg : Config file for Eternal Terminal
+            ;
+
+            ${optionalString (cfg.port != null) ''
+              [Networking]
+              port = ${toString cfg.port}
+            ''}
+            [Debug]
+            verbose = ${toString cfg.verbosity}
+            silent = ${toString cfg.silence}
+            logsize = ${toString cfg.logSize}
+          ''}";
+          Restart = "on-failure";
+          KillMode = "process";
+        };
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/eternal-terminal.nix
+++ b/nixos/modules/services/networking/eternal-terminal.nix
@@ -77,7 +77,7 @@ in
 
             [Debug]
             verbose = ${toString cfg.verbosity}
-            silent = ${if cfg.silent then "true" else "false"}
+            silent = ${if cfg.silent then "1" else "0"}
             logsize = ${toString cfg.logSize}
           ''}";
           Restart = "on-failure";

--- a/nixos/modules/services/networking/eternal-terminal.nix
+++ b/nixos/modules/services/networking/eternal-terminal.nix
@@ -16,17 +16,11 @@ in
 
     services.eternal-terminal = {
 
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Enable the Eternal Terminal server.
-        '';
-      };
+      enable = mkEnableOption "Eternal Terminal server";
 
       port = mkOption {
-        default = null;
-        type = types.nullOr types.int;
+        default = 2022;
+        type = types.int;
         description = ''
           The port the server should listen on. Will use the server's default (2022) if not specified.
         '';
@@ -34,17 +28,17 @@ in
 
       verbosity = mkOption {
         default = 0;
-        type = types.int;
+        type = types.enum (lib.range 0 9);
         description = ''
           The verbosity level (0-9).
         '';
       };
 
-      silence = mkOption {
-        default = 0;
-        type = types.int;
+      silent = mkOption {
+        default = false;
+        type = types.bool;
         description = ''
-          Silence.
+          If enabled, disables all logging.
         '';
       };
 
@@ -78,13 +72,12 @@ in
             ; et.cfg : Config file for Eternal Terminal
             ;
 
-            ${optionalString (cfg.port != null) ''
-              [Networking]
-              port = ${toString cfg.port}
-            ''}
+            [Networking]
+            port = ${toString cfg.port}
+
             [Debug]
             verbose = ${toString cfg.verbosity}
-            silent = ${toString cfg.silence}
+            silent = ${if cfg.silent then "true" else "false"}
             logsize = ${toString cfg.logSize}
           ''}";
           Restart = "on-failure";


### PR DESCRIPTION
###### Motivation for this change
`eternal-terminal` is like `ssh`; it requires a daemon to be running if you want to allow remote machines to connect to you. This module provides this.

I have based the generated systemd unit and config file on the files provided in the et repo ([systemd unit](https://github.com/MisterTea/EternalTerminal/blob/master/systemctl/et.service) and [cfg file](https://github.com/MisterTea/EternalTerminal/blob/master/etc/et.cfg)). However, if anyone has experience or expertise with better ways to configure it, I am all ears. In particular, I have made `verbose`, `silent` and `logsize` as module parameters, but these aren't really described on the ET website and I'm not sure exactly how to control them.

In addition, I think that when the remote `et` connects to the server, it logs in and then runs `etterminal`. Because of this, the `etterminal` binary needs to be available to it at that time. To solve this, I added the `eternal-terminal` package to `environment.systemPackages`, but this doesn't seem that elegant. If there is a better way, we can change to that.

This is the first unit I have made. So all feedback is very welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

