### PR TITLE
mesa: 18.2.2 -> 18.2.3

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -67,7 +67,7 @@ let
 in
 
 let
-  version = "18.2.2";
+  version = "18.2.3";
   branch  = head (splitString "." version);
 in
 
@@ -81,7 +81,7 @@ let self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "1i3ky3d210vi3f5hlr9la1kspdyv093npndxsbzdklw95aqq5fn3";
+    sha256 = "0krhfq1wqxa2ydh5xsb3z4wams975rjj5bw1xsqyrg8sgv0q7gz2";
   };
 
   prePatch = "patchShebangs .";

--- a/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -1,4 +1,4 @@
-From 9c9df280b318c26aece9873cf77b32e4f95634c1 Mon Sep 17 00:00:00 2001
+From 2a1e32b4105fe95413a615a44d40938920ea1a19 Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Mon, 6 Aug 2018 15:52:11 -0300
 Subject: [PATCH] disk_cache: include dri driver path in cache key
@@ -11,10 +11,10 @@ timestamps in /nix/store are zero.
  2 files changed, 6 insertions(+)
 
 diff --git a/src/util/Makefile.am b/src/util/Makefile.am
-index 07bf052175..aea09f60b3 100644
+index bafb57439a..a22e2e41eb 100644
 --- a/src/util/Makefile.am
 +++ b/src/util/Makefile.am
-@@ -30,6 +30,9 @@ noinst_LTLIBRARIES = \
+@@ -35,6 +35,9 @@ noinst_LTLIBRARIES = \
  	libmesautil.la \
  	libxmlconfig.la
  
@@ -25,28 +25,28 @@ index 07bf052175..aea09f60b3 100644
  	$(PTHREAD_CFLAGS) \
  	-I$(top_srcdir)/include
 diff --git a/src/util/disk_cache.c b/src/util/disk_cache.c
-index 4a762eff20..8086c0be75 100644
+index 368ec41792..071220b2ba 100644
 --- a/src/util/disk_cache.c
 +++ b/src/util/disk_cache.c
-@@ -388,8 +388,10 @@ disk_cache_create(const char *gpu_name, const char *timestamp,
+@@ -388,8 +388,10 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
  
     /* Create driver id keys */
-    size_t ts_size = strlen(timestamp) + 1;
+    size_t id_size = strlen(driver_id) + 1;
 +   size_t key_size = strlen(DISK_CACHE_KEY) + 1;
     size_t gpu_name_size = strlen(gpu_name) + 1;
-    cache->driver_keys_blob_size += ts_size;
+    cache->driver_keys_blob_size += id_size;
 +   cache->driver_keys_blob_size += key_size;
     cache->driver_keys_blob_size += gpu_name_size;
  
     /* We sometimes store entire structs that contains a pointers in the cache,
-@@ -410,6 +412,7 @@ disk_cache_create(const char *gpu_name, const char *timestamp,
+@@ -410,6 +412,7 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
     uint8_t *drv_key_blob = cache->driver_keys_blob;
     DRV_KEY_CPY(drv_key_blob, &cache_version, cv_size)
-    DRV_KEY_CPY(drv_key_blob, timestamp, ts_size)
+    DRV_KEY_CPY(drv_key_blob, driver_id, id_size)
 +   DRV_KEY_CPY(drv_key_blob, DISK_CACHE_KEY, key_size)
     DRV_KEY_CPY(drv_key_blob, gpu_name, gpu_name_size)
     DRV_KEY_CPY(drv_key_blob, &ptr_size, ptr_size_size)
     DRV_KEY_CPY(drv_key_blob, &driver_flags, driver_flags_size)
 -- 
-2.18.0
+2.19.1
 


### PR DESCRIPTION
https://lists.freedesktop.org/archives/mesa-dev/2018-October/207343.html

Optimistically drop disk cache patch, changelog mentions related
changes to cache behavior.

Not sure if those changes address our problem
(can we count on build-id?) so someone more familiar with
this should probably take a look before merging :).





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---