### PR TITLE
xbps: 0.52 -> 0.53, update repo owner name (voidlinux -> void-linux)

### DIFF
--- a/pkgs/tools/package-management/xbps/default.nix
+++ b/pkgs/tools/package-management/xbps/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "xbps-${version}";
-  version = "0.52";
+  version = "0.53";
 
   src = fetchFromGitHub {
-    owner = "voidlinux";
+    owner = "void-linux";
     repo = "xbps";
     rev = version;
-    sha256 = "1sf6iy9l3dijsczsngzbhksshfm1374g2rrdasc04l6gz35l2cdp";
+    sha256 = "1zicin2z5j7vg2ixzpd6nahjhrjwdcavm817wzgs9x013b596paa";
   };
 
   nativeBuildInputs = [ pkgconfig which ];
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/voidlinux/xbps;
+    homepage = https://github.com/void-linux/xbps;
     description = "The X Binary Package System";
     platforms = platforms.linux; # known to not work on Darwin, at least
     license = licenses.bsd2;


### PR DESCRIPTION
Bump, fix source repo name.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---