### PR TITLE
minishift: init at 1.25.0

### DIFF
--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -1,0 +1,67 @@
+{ lib, buildGoPackage, fetchFromGitHub, go-bindata, pkgconfig, makeWrapper
+, glib, gtk3, libappindicator-gtk3, gpgme, ostree, libselinux, btrfs-progs
+, lvm2, docker-machine-kvm
+}:
+
+let
+  version = "1.25.0";
+
+  # Update these on version bumps according to Makefile
+  b2dIsoVersion = "v1.3.0";
+  centOsIsoVersion = "v1.12.0";
+  openshiftVersion = "v3.11.0";
+
+in buildGoPackage rec {
+  name = "minishift-${version}";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "minishift";
+    repo = "minishift";
+    rev = "v${version}";
+    sha256 = "12a1irj92lplzkr88g049blpjsdsfwfihs2xix971cq7v0w38fkf";
+  };
+
+  nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];
+  buildInputs = [ glib gtk3 libappindicator-gtk3 gpgme ostree libselinux btrfs-progs lvm2 ];
+
+  goPackagePath = "github.com/minishift/minishift";
+  subPackages = [ "cmd/minishift" ];
+
+  postPatch = ''
+    substituteInPlace vendor/github.com/containers/image/storage/storage_image.go \
+      --replace 'nil, diff' 'diff'
+  '';
+
+  buildFlagsArray = ''
+    -ldflags=
+      -X ${goPackagePath}/pkg/version.minishiftVersion=${version}
+      -X ${goPackagePath}/pkg/version.b2dIsoVersion=${b2dIsoVersion}
+      -X ${goPackagePath}/pkg/version.centOsIsoVersion=${centOsIsoVersion}
+      -X ${goPackagePath}/pkg/version.openshiftVersion=${openshiftVersion}
+  '';
+
+  preBuild = ''
+    (cd go/src/github.com/minishift/minishift
+      mkdir -p out/bindata
+      go-bindata -prefix addons -o out/bindata/addon_assets.go -pkg bindata addons/...)
+  '';
+
+  postInstall = ''
+    wrapProgram "$bin/bin/minishift" \
+      --prefix PATH ':' '${lib.makeBinPath [ docker-machine-kvm ]}'
+  '';
+
+  meta = with lib; {
+    description = "Run OpenShift locally";
+    longDescription = ''
+      Minishift is a tool that helps you run OpenShift locally by running
+      a single-node OpenShift cluster inside a VM. You can try out OpenShift
+      or develop with it, day-to-day, on your local host.
+    '';
+    homepage = https://github.com/minishift/minishift;
+    maintainers = with maintainers; [ fpletz ];
+    platforms = platforms.linux;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17726,6 +17726,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) vmnet;
   };
 
+  minishift = callPackage ../applications/networking/cluster/minishift { };
+
   minitube = libsForQt5.callPackage ../applications/video/minitube { };
 
   mimic = callPackage ../applications/audio/mimic {


### PR DESCRIPTION
###### Motivation for this change

New package to set up a local developer instance of OpenShift.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
