### PR TITLE
pythonPackages.gyp: add Xcode 10 support

### DIFF
--- a/pkgs/development/python-modules/gyp/xcode-10.patch
+++ b/pkgs/development/python-modules/gyp/xcode-10.patch
@@ -1,0 +1,11 @@
+--- a/pylib/gyp/xcode_emulation.py
++++ b/pylib/gyp/xcode_emulation.py
+@@ -1248,7 +1248,7 @@ def XcodeVersion():
+   except:
+     version = CLTVersion()
+     if version:
+-      version = re.match(r'(\d\.\d\.?\d*)', version).groups()[0]
++      version = re.match(r'(\d+\.\d+\.?\d*)', version).groups()[0]
+     else:
+       raise GypError("No Xcode or CLT version detected!")
+     # The CLT has no build information, so we return an empty string.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5709,6 +5709,7 @@ in {
     patches = optionals pkgs.stdenv.isDarwin [
       ../development/python-modules/gyp/no-darwin-cflags.patch
       ../development/python-modules/gyp/no-xcode.patch
+      ../development/python-modules/gyp/xcode-10.patch
     ];
 
     disabled = isPy3k;


### PR DESCRIPTION
###### Motivation for this change

Attempting to use it with Xcode 10 installed results in this:

```
Traceback (most recent call last):
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/bin/.gyp-wrapped", line 12, in <module>
    sys.exit(script_main())
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/__init__.py", line 545, in script_main
    return main(sys.argv[1:])
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/__init__.py", line 538, in main
    return gyp_main(args)
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/__init__.py", line 523, in gyp_main
    generator.GenerateOutput(flat_list, targets, data, params)
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/generator/make.py", line 2159, in GenerateOutput
    part_of_all=qualified_target in needed_targets)
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/generator/make.py", line 795, in Write
creating build/bdist.macosx-10.10-x86_64/wheel/hypothesis-3.66.2.dist-info/WHEEL
    self.Pchify))
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/generator/make.py", line 1190, in WriteSources
    cflags = self.xcode_settings.GetCflags(configname)
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/xcode_emulation.py", line 545, in GetCflags
    archs = self.GetActiveArchs(self.configname)
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/xcode_emulation.py", line 420, in GetActiveArchs
    xcode_archs_default = GetXcodeArchsDefault()
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/xcode_emulation.py", line 118, in GetXcodeArchsDefault
    xcode_version, _ = XcodeVersion()
  File "/nix/store/kz342hyzg84cakgh2iraz85c2xv6wn8z-python2.7-gyp-2015-06-11/lib/python2.7/site-packages/gyp/xcode_emulation.py", line 1240, in XcodeVersion
    version = re.match(r'(\d\.\d\.?\d*)', version).groups()[0]
AttributeError: 'NoneType' object has no attribute 'groups'
```

The fix is updating the regex to handle version numbers with multiple digits.

This is fixed in the nodejs fork of gyp (https://github.com/nodejs/node-gyp/issues/1454) but it's not fixed upstream, even on latest master. Given that upstream gyp is pretty much abandoned since the chromium project switched to GN, it might be worth switching to use the nodejs fork.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
