### PR TITLE
argp-standalone: init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -206,6 +206,11 @@
     github = "alunduil";
     name = "Alex Brandt";
   };
+  amar1729 = {
+    email = "amar.paul16@gmail.com";
+    github = "amar1729";
+    name = "Amar Paul";
+  };
   ambrop72 = {
     email = "ambrop7@gmail.com";
     github = "ambrop72";

--- a/pkgs/development/libraries/argp-standalone/default.nix
+++ b/pkgs/development/libraries/argp-standalone/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name = "argp-standalone-1.3";
+
+  src = fetchurl {
+    url = "https://www.lysator.liu.se/~nisse/misc/argp-standalone-1.3.tar.gz";
+    sha256 = "dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be";
+  };
+
+  patches = [
+    (if stdenv.hostPlatform.isDarwin then
+    fetchpatch {
+      name = "patch-argp-fmtstream.h";
+      url = "https://raw.githubusercontent.com/Homebrew/formula-patches/b5f0ad3/argp-standalone/patch-argp-fmtstream.h";
+      sha256 = "5656273f622fdb7ca7cf1f98c0c9529bed461d23718bc2a6a85986e4f8ed1cb8";
+    }
+    else null)
+  ];
+
+  patchFlags = "-p0";
+
+  postInstall = 
+    ''
+      mkdir -p $out/lib $out/include
+      cp libargp.a $out/lib
+      cp argp.h $out/include
+    '';
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.lysator.liu.se/~nisse/misc/";
+    description = "Standalone version of arguments parsing functions from GLIBC";
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ amar1729 ];
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9047,6 +9047,8 @@ with pkgs;
   arb = callPackage ../development/libraries/arb {};
   arb-git = callPackage ../development/libraries/arb/git.nix {};
 
+  argp-standalone = callPackage ../development/libraries/argp-standalone {};
+
   armadillo = callPackage ../development/libraries/armadillo {};
 
   arrow-cpp = callPackage ../development/libraries/arrow-cpp {};


### PR DESCRIPTION
###### Motivation for this change

This library ships the `argp.h` header for the argparse lib. Lack of it can result in build issues with certain packages on Mac (notably, the [goxel nixpkg](https://github.com/NixOS/nixpkgs/pull/33882) fails on macOS builds partly because of lack of `argp.h`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

- can't currently run `nix path-info -S` on macOS - returns error on master.
- this library is also available for linux (which is why I wrote the conditional fetchpatch), but I can't test it there. I suspect that [these patches](https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-libs/argp-standalone/files?id=cb196546c62e9894a46900e8078f753388d4cc1a) will be required to get it compiling on linux.
- this PR includes a commit I made adding myself to the maintainers list, hope that's ok.