### PR TITLE
pythonPackages.spacy: 2.0.12 -> 2.0.16

### DIFF
--- a/pkgs/development/python-modules/cymem/default.nix
+++ b/pkgs/development/python-modules/cymem/default.nix
@@ -6,19 +6,24 @@
 }:
 buildPythonPackage rec {
   pname = "cymem";
-  version = "1.31.2";
+  version = "2.0.2";
   name = pname + "-" + version;
 
   src = fetchFromGitHub {
     owner = "explosion";
     repo = "cymem";
-    rev = "1.31.2";
-    sha256 = "0miznr4kbdzw8yik3m96jmrlmln4qv7z3i3qdp7wjqr51zpqfm1k";
+    rev = "v${version}";
+    sha256 = "109i67vwgql9za8mfvgbrd6rgraz4djkvpzb4gqvzl13214s6ava";
   };
 
   propagatedBuildInputs = [
    cython
   ];
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
+  '';
 
   checkPhase = ''
     cd cymem/tests

--- a/pkgs/development/python-modules/preshed/default.nix
+++ b/pkgs/development/python-modules/preshed/default.nix
@@ -8,20 +8,26 @@
 }:
 buildPythonPackage rec {
   pname = "preshed";
-  version = "1.0.1";
+  version = "2.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7b99ace606143a922163a7ff7ad4969b296288f5b20b9c9bda328caec3b92f71";
+    sha256 = "1rd943zp4gyspajqm5qxzndxziyh51grx0zcw23w8r9r65s1rq6s";
   };
 
   propagatedBuildInputs = [
    cython
    cymem
   ];
+
   buildInputs = [
     pytest
   ];
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
+  '';
 
   checkPhase = ''
     ${python.interpreter} setup.py test

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -23,22 +23,19 @@
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "2.0.12";
+  version = "2.0.16";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b220ebee412c19613c26b2c1870b60473834bd686cec49553ce5f184164d3359";
+    sha256 = "1ghgbv819ff4777904p1kzayq1dj34i7853anvg859sak59r7pj1";
   };
 
   prePatch = ''
     substituteInPlace setup.py \
-      --replace "html5lib==" "html5lib>=" \
       --replace "regex==" "regex>=" \
-      --replace "ftfy==" "ftfy>=" \
-      --replace "msgpack-python==" "msgpack-python>=" \
-      --replace "msgpack-numpy==" "msgpack-numpy>=" \
-      --replace "thinc>=6.10.3,<6.11.0" "thinc>=6.10.3" \
-      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6"
+      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6" \
+      --replace "thinc>=6.12.0,<6.13.0" "thinc>=6.12.0" \
+      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -26,20 +26,12 @@
 
 buildPythonPackage rec {
   pname = "thinc";
-  version = "6.11.2";
+  version = "6.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "028a014192e1914c151222794781d14e1c9fddf47a859aa36077f07871d0c30a";
+    sha256 = "0lfdf08v7rrj9b29z2vf8isaqa0zh16acw9im8chkqsh8bay4ykm";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "msgpack-python==" "msgpack-python>=" \
-      --replace "msgpack-numpy==" "msgpack-numpy>=" \
-      --replace "plac>=0.9,<1.0" "plac>=0.9" \
-      --replace "hypothesis>=2,<3" "hypothesis>=2"
-  '';
 
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     Accelerate CoreFoundation CoreGraphics CoreVideo
@@ -71,13 +63,10 @@ buildPythonPackage rec {
   ];
 
   prePatch = ''
-    substituteInPlace setup.py --replace \
-      "'pathlib>=1.0.0,<2.0.0'," \
-      "\"pathlib>=1.0.0,<2.0.0; python_version<'3.4'\","
-
-    substituteInPlace setup.py --replace \
-      "'cytoolz>=0.8,<0.9'," \
-      "'cytoolz>=0.8',"
+    substituteInPlace setup.py \
+      --replace "pathlib==1.0.1" "pathlib>=1.0.0,<2.0.0" \
+      --replace "plac>=0.9.6,<1.0.0" "plac>=0.9.6" \
+      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
   '';
 
   # Cannot find cython modules.


### PR DESCRIPTION
###### Motivation for this change

Update spaCy and other Explosion AI packages that spaCy depends on.

Changes:

https://github.com/explosion/spaCy/releases

Tested using the `en_core_web_sm` model and the example from the spaCy main page.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

