### PR TITLE
lib.isStorePath: fix `false` result when given a path object

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -502,9 +502,12 @@ rec {
        => false
   */
   isStorePath = x:
-       isCoercibleToString x
-    && builtins.substring 0 1 (toString x) == "/"
-    && dirOf x == builtins.storeDir;
+    if isCoercibleToString x then
+      let str = toString x; in
+      builtins.substring 0 1 str == "/"
+      && dirOf str == builtins.storeDir
+    else
+      false;
 
   /* Convert string to int
      Obviously, it is a bit hacky to use fromJSON that way.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -112,7 +112,7 @@ runTests {
         storePathAppendix = isStorePath
           "${goodPath}/bin/python";
         nonAbsolute = isStorePath (concatStrings (tail (stringToCharacters goodPath)));
-        asPath = isStorePath goodPath;
+        asPath = isStorePath (/. + goodPath);
         otherPath = isStorePath "/something/else";
         otherVals = {
           attrset = isStorePath {};


### PR DESCRIPTION
###### Motivation for this change

Fixes #48743

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

