### PR TITLE
sierra-gtk-theme: 2018-10-01 -> 2018-10-12

### DIFF
--- a/pkgs/misc/themes/sierra/default.nix
+++ b/pkgs/misc/themes/sierra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "sierra-gtk-theme-${version}";
-  version = "2018-10-01";
+  version = "2018-10-12";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "sierra-gtk-theme";
     rev = version;
-    sha256 = "10rjk2lyhlkhhfx6f6r0cykbkxa2jhri4wirc3h2wbzzsx7ch3ix";
+    sha256 = "0l8mhdy7x8nh5aqsvkk0maqg1cnfds7824g439f6cmifdiyksbgg";
   };
 
   nativeBuildInputs = [ libxml2 ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [2018-10-12](https://github.com/vinceliuice/Sierra-gtk-theme/releases).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).