### PR TITLE
kitty: fix locating libstartup-notification-1

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, python3Packages, glfw, libunistring, harfbuzz,
-  fontconfig, pkgconfig, ncurses, imagemagick, xsel,
+{ stdenv, substituteAll, fetchFromGitHub, python3Packages, glfw, libunistring,
+  harfbuzz, fontconfig, pkgconfig, ncurses, imagemagick, xsel,
   libstartup_notification, libX11, libXrandr, libXinerama, libXcursor,
   libxkbcommon, libXi, libXext, wayland-protocols, wayland,
   which, dbus
@@ -28,10 +28,14 @@ buildPythonApplication rec {
 
   outputs = [ "out" "terminfo" ];
 
-  postPatch = ''
-    substituteInPlace kitty/utils.py \
-      --replace "find_library('startup-notification-1')" "'${libstartup_notification}/lib/libstartup-notification-1.so'"
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      libstartup_notification = "${libstartup_notification}/lib/libstartup-notification-1.so";
+    })
+  ];
 
+  postPatch = ''
     substituteInPlace docs/Makefile \
       --replace 'python3 .. +launch :sphinx-build' \
                 'PYTHONPATH=$PYTHONPATH:.. HOME=$TMPDIR/nowhere sphinx-build'

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -35,12 +35,6 @@ buildPythonApplication rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace docs/Makefile \
-      --replace 'python3 .. +launch :sphinx-build' \
-                'PYTHONPATH=$PYTHONPATH:.. HOME=$TMPDIR/nowhere sphinx-build'
-    '';
-
   buildPhase = ''
     python3 setup.py linux-package
   '';

--- a/pkgs/applications/misc/kitty/fix-paths.patch
+++ b/pkgs/applications/misc/kitty/fix-paths.patch
@@ -1,0 +1,11 @@
+--- a/kitty/desktop.c
++++ b/kitty/desktop.c
+@@ -30,7 +30,7 @@
+ static PyObject*
+ init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
+     static bool done = false;
+-    static const char* libname = "libstartup-notification-1.so";
++    static const char* libname = "@libstartup_notification@";
+     if (!done) {
+         done = true;
+

--- a/pkgs/applications/misc/kitty/fix-paths.patch
+++ b/pkgs/applications/misc/kitty/fix-paths.patch
@@ -9,3 +9,19 @@
      if (!done) {
          done = true;
 
+--- a/docs/Makefile
++++ b/docs/Makefile
+@@ -3,7 +3,7 @@
+# Patching is needed here for the following reasons:
+# * `sphinx-build` in nixpkgs is not a Python file but a wrapper shell script
+# * importing the `constants` package from Kitty has a side effect that it
+#   creates the user configuration directory. This package gets imported
+#   while sphinx scans the code for documentation strings.
+#
+ # You can set these variables from the command line.
+ SPHINXOPTS    = -T $(FAIL_WARN)
+-SPHINXBUILD   = python3 .. +launch :sphinx-build
++SPHINXBUILD   = PYTHONPATH=${PYTHONPATH}:.. HOME=${TMPDIR}/kitty-build-home sphinx-build
+ SPHINXPROJ    = kitty
+ SOURCEDIR     = .
+ BUILDDIR      = _build


### PR DESCRIPTION
Startup notification doesn't work in recent versions of Kitty:
> Traceback (most recent call last):
>   File "/nix/store/3a3b0xd952gp8jw70k5kh3a4zhgzf0p7-kitty-0.12.3/bin/../lib/kitty/kitty/utils.py", line 216, in init_startup_notification
>     return init_startup_notification_x11(window_handle, startup_id)
>   File "/nix/store/3a3b0xd952gp8jw70k5kh3a4zhgzf0p7-kitty-0.12.3/bin/../lib/kitty/kitty/utils.py", line 201, in init_startup_notification_x11
>     return init_x11_startup_notification(display, window_handle, sid)
> OSError: Failed to load libstartup-notification-1.so with error: libstartup-notification-1.so: cannot open shared object file: No such file or directory

###### Motivation for this change

Apparently dispatching of startup notification has been moved to a C
binding in kitty 0.6.0 [1] so the substituion had to be modified to reflect
that. Without this fix Kitty still works except that window managers
which depend on startup notifications to be fired (e.g. Awesome)
cannot apply special placement rules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

\[1\]: https://github.com/kovidgoyal/kitty/commit/b08f4ab5937199187581aa20e3a7aba7b2a34ac6
