### PR TITLE
epson-workforce-635-nx625-series: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2060,6 +2060,11 @@
     github = "joncojonathan";
     name = "Jonathan Haddock";
   };
+  jorsn = {
+    name = "Johannes Rosenberger";
+    email = "johannes@jorsn.eu";
+    github = "jorsn";
+  };
   jpdoyle = {
     email = "joethedoyle@gmail.com";
     github = "jpdoyle";

--- a/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
+++ b/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
@@ -91,8 +91,8 @@ in stdenv.mkDerivation rec {
         };
     '';
     downloadPage = https://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=16857&DSCCHK=4334d3487503d7f916ccf5d58071b05b7687294f;
-    license = with licenses; [ lgpl21 epson ];
-    maintainers = [ maintainers.jorsn ];
+    license = with lib.licenses; [ lgpl21 epson ];
+    maintainers = [ lib.maintainers.jorsn ];
     platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }

--- a/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
+++ b/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
   name = "epson-inkjet-printer-workforce-635-nx625-series";
   version = "1.0.1";
 
-  src = builtins.fetchurl {
+  src = fetchurl {
     url = "https://download.ebz.epson.net/dsc/op/stable/SRPMS/${name}-${version}-1lsb3.2.src.rpm";
     sha256 = "19nb2h0y9rvv6rg7j262f8sqap9kjvz8kmisxnjg1w0v19zb9zf2";
   };

--- a/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
+++ b/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
@@ -1,0 +1,98 @@
+{
+  autoreconfHook, cups, gzip, libjpeg, rpmextract,
+  fetchurl, lib, stdenv
+}:
+
+let
+  srcdirs = {
+    filter = "epson-inkjet-printer-filter-1.0.0";
+    driver = "epson-inkjet-printer-workforce-635-nx625-series-1.0.1";
+  };
+in stdenv.mkDerivation rec {
+  name = "epson-inkjet-printer-workforce-635-nx625-series";
+  version = "1.0.1";
+
+  src = builtins.fetchurl {
+    url = "https://download.ebz.epson.net/dsc/op/stable/SRPMS/${name}-${version}-1lsb3.2.src.rpm";
+    sha256 = "19nb2h0y9rvv6rg7j262f8sqap9kjvz8kmisxnjg1w0v19zb9zf2";
+  };
+  sourceRoot = srcdirs.filter;
+
+  nativeBuildInputs = [ autoreconfHook gzip rpmextract ];
+  buildInputs = [ cups libjpeg ];
+
+  unpackPhase = ''
+    rpmextract "$src"
+    for i in ${lib.concatStringsSep " " (builtins.attrValues srcdirs)}; do
+        tar xvf "$i".tar.gz
+    done
+  '';
+
+  preConfigure = ''
+    chmod u+x configure
+  '';
+
+  installPhase =
+    let
+      filterdir = "$out/cups/lib/filter";
+      docdir  = "$out/share/doc";
+      ppddir  = "$out/share/cups/model/${name}";
+      libdir =
+        if stdenv.system == "x86_64-linux"    then "lib64"
+        else if stdenv.system == "i686_linux" then "lib"
+        else throw "other platforms than i686_linux and x86_64-linux are not yet supported";
+    in ''
+      mkdir -p "$out" "${docdir}" "${filterdir}" "${ppddir}"
+      cp src/epson_inkjet_printer_filter "${filterdir}"
+
+      cd ../${srcdirs.driver}
+      for ppd in ppds/*; do
+          substituteInPlace "$ppd" --replace '/opt/${name}' "$out"
+          gzip -c "$ppd" > "${ppddir}/''${ppd#*/}"
+      done
+      cp COPYING.EPSON README "${docdir}"
+      cp -r resource watermark ${libdir} "$out"
+    '';
+
+  meta = {
+    description = "Proprietary CUPS drivers for Epson inkjet printers";
+    longDescription = ''
+      This software is a filter program used with Common UNIX Printing
+      System (CUPS) from the Linux. This can supply the high quality print
+      with Seiko Epson Color Ink Jet Printers.
+
+      This printer driver is supporting the following printers.
+
+      WorkForce 60
+      WorkForce 625
+      WorkForce 630
+      WorkForce 633
+      WorkForce 635
+      WorkForce T42WD
+      Epson Stylus NX625
+      Epson Stylus SX525WD
+      Epson Stylus SX620FW
+      Epson Stylus TX560WD
+      Epson Stylus Office B42WD
+      Epson Stylus Office BX525WD
+      Epson Stylus Office BX625FWD
+      Epson Stylus Office TX620FWD
+      Epson ME OFFICE 82WD
+      Epson ME OFFICE 85ND
+      Epson ME OFFICE 900WD
+      Epson ME OFFICE 960FWD
+
+      License: LGPL and SEIKO EPSON CORPORATION SOFTWARE LICENSE AGREEMENT
+
+      To use the driver adjust your configuration.nix file:
+        services.printing = {
+          enable = true;
+          drivers = [ pkgs.${name} ];
+        };
+    '';
+    downloadPage = https://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=16857&DSCCHK=4334d3487503d7f916ccf5d58071b05b7687294f;
+    license = with licenses; [ lgpl21 epson ];
+    maintainers = [ maintainers.jorsn ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21726,6 +21726,8 @@ with pkgs;
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };
 
+  epson-workforce-635-nx625-series = callPackage ../misc/drivers/epson-workforce-635-nx625-series { };
+
   gutenprint = callPackage ../misc/drivers/gutenprint { };
 
   gutenprintBin = callPackage ../misc/drivers/gutenprint/bin.nix { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ]  Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) \
    ***`nix path-info -S nixpkgs.epson-workforce-635-nx625-series` or what? Before and after what?***
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### More

Tested with my Epson Stylus Office BX525WD wireless inkjet printer with success.