### PR TITLE
nixos/networking: add ipvlan option

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -69,6 +69,12 @@ let
     (assertValueOneOf "Mode" ["private" "vepa" "bridge" "passthru"])
   ];
 
+  checkIpvlan = checkUnitConfig "IPVLAN" [
+    (assertOnlyFields ["Mode" "Flags"])
+    (assertValueOneOf "Mode" ["L2" "L3" "L3S"])
+    (assertValueOneOf "Flags" ["bridge" "private" "vepa"])
+  ];
+
   checkVxlan = checkUnitConfig "VXLAN" [
     (assertOnlyFields [
       "Id" "Remote" "Local" "TOS" "TTL" "MacLearning" "FDBAgeingSec"
@@ -344,6 +350,18 @@ let
       '';
     };
 
+    ipvlanConfig = mkOption {
+      default = {};
+      example = { Mode = "L2"; Flags = "bridge"; };
+      type = types.addCheck (types.attrsOf unitOption) checkIpvlan;
+      description = ''
+        Each attribute in this set specifies an option in the
+        <literal>[IPVLAN]</literal> section of the unit.  See
+        <citerefentry><refentrytitle>systemd.netdev</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     vxlanConfig = mkOption {
       default = {};
       example = { Id = "4"; };
@@ -614,6 +632,16 @@ let
       '';
     };
 
+    ipvlan = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = ''
+        A list of ipvlan interfaces to be added to the network section of the
+        unit.  See <citerefentry><refentrytitle>systemd.network</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+    };
+
     vxlan = mkOption {
       default = [ ];
       type = types.listOf types.str;
@@ -702,6 +730,11 @@ let
             ${attrsToSection def.macvlanConfig}
 
           ''}
+          ${optionalString (def.ipvlanConfig != { }) ''
+            [IPVLAN]
+            ${attrsToSection def.ipvlanConfig}
+
+          ''}
           ${optionalString (def.vxlanConfig != { }) ''
             [VXLAN]
             ${attrsToSection def.vxlanConfig}
@@ -757,6 +790,7 @@ let
           ${concatStringsSep "\n" (map (s: "VRF=${s}") def.vrf)}
           ${concatStringsSep "\n" (map (s: "VLAN=${s}") def.vlan)}
           ${concatStringsSep "\n" (map (s: "MACVLAN=${s}") def.macvlan)}
+          ${concatStringsSep "\n" (map (s: "IPVLAN=${s}") def.ipvlan)}
           ${concatStringsSep "\n" (map (s: "VXLAN=${s}") def.vxlan)}
           ${concatStringsSep "\n" (map (s: "Tunnel=${s}") def.tunnel)}
 

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -12,6 +12,7 @@ let
     ++ concatMap (i: i.interfaces) (attrValues cfg.bridges)
     ++ concatMap (i: i.interfaces) (attrValues cfg.vswitches)
     ++ concatMap (i: [i.interface]) (attrValues cfg.macvlans)
+    ++ concatMap (i: [i.interface]) (attrValues cfg.ipvlans)
     ++ concatMap (i: [i.interface]) (attrValues cfg.vlans);
 
   # We must escape interfaces due to the systemd interpretation
@@ -65,6 +66,7 @@ let
              (hasAttr dev cfg.bridges) ||
              (hasAttr dev cfg.bonds) ||
              (hasAttr dev cfg.macvlans) ||
+             (hasAttr dev cfg.ipvlans) ||
              (hasAttr dev cfg.sits) ||
              (hasAttr dev cfg.vlans) ||
              (hasAttr dev cfg.vswitches)
@@ -408,7 +410,7 @@ let
           (let
             deps = deviceDependency v.interface;
           in
-          { description = "Vlan Interface ${n}";
+          { description = "Macvlan Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
             bindsTo = deps;
             partOf = [ "network-setup.service" ];
@@ -422,6 +424,32 @@ let
               ip link show "${n}" >/dev/null 2>&1 && ip link delete "${n}"
               ip link add link "${v.interface}" name "${n}" type macvlan \
                 ${optionalString (v.mode != null) "mode ${v.mode}"}
+              ip link set "${n}" up
+            '';
+            postStop = ''
+              ip link delete "${n}" || true
+            '';
+          });
+
+        createIpvlanDevice = n: v: nameValuePair "${n}-netdev"
+          (let
+            deps = deviceDependency v.interface;
+          in
+          { description = "Ipvlan Interface ${n}";
+            wantedBy = [ "network-setup.service" (subsystemDevice n) ];
+            bindsTo = deps;
+            partOf = [ "network-setup.service" ];
+            after = [ "network-pre.target" ] ++ deps;
+            before = [ "network-setup.service" ];
+            serviceConfig.Type = "oneshot";
+            serviceConfig.RemainAfterExit = true;
+            path = [ pkgs.iproute ];
+            script = ''
+              # Remove Dead Interfaces
+              ip link show "${n}" >/dev/null 2>&1 && ip link delete "${n}"
+              ip link add link "${v.interface}" name "${n}" type ipvlan \
+                ${optionalString (v.mode != null) "mode ${toLower v.mode}"} \
+                ${optionalString (v.flags != null) v.flags}
               ip link set "${n}" up
             '';
             postStop = ''
@@ -493,6 +521,7 @@ let
          // mapAttrs' createVswitchDevice cfg.vswitches
          // mapAttrs' createBondDevice cfg.bonds
          // mapAttrs' createMacvlanDevice cfg.macvlans
+         // mapAttrs' createIpvlanDevice cfg.ipvlans
          // mapAttrs' createSitDevice cfg.sits
          // mapAttrs' createVlanDevice cfg.vlans
          // {

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -184,6 +184,23 @@ in
           macvlan = [ name ];
         } ]);
       })))
+      (mkMerge (flip mapAttrsToList cfg.ipvlans (name: ipvlan: {
+        netdevs."40-${name}" = {
+          netdevConfig = {
+            Name = name;
+            Kind = "ipvlan";
+          };
+          ipvlanConfig =
+            (optionalAttrs (ipvlan.mode != null) {
+              Mode = toUpper ipvlan.mode;
+            }) // (optionalAttrs (ipvlan.flags != null) {
+              Flags = ipvlan.flags;
+            });
+        };
+        networks."40-${ipvlan.interface}" = (mkMerge [ (genericNetwork (mkOverride 999)) {
+          ipvlan = [ name ];
+        } ]);
+      })))
       (mkMerge (flip mapAttrsToList cfg.sits (name: sit: {
         netdevs."40-${name}" = {
           netdevConfig = {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -692,6 +692,46 @@ in
       });
     };
 
+    networking.ipvlans = mkOption {
+      default = { };
+      example = literalExample {
+        wan = {
+          interface = "enp2s0";
+          mode = "vepa";
+        };
+      };
+      description = ''
+        This option allows you to define ipvlan interfaces which should
+        be automatically created.
+      '';
+      type = with types; attrsOf (submodule {
+        options = {
+
+          interface = mkOption {
+            example = "enp4s0";
+            type = types.str;
+            description = "The interface the ipvlan will transmit packets through.";
+          };
+
+          mode = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "L3S";
+            description = "The mode of the ipvlan device.";
+          };
+
+          flags = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "vepa";
+            description = "The mode flags of the ipvlan device.";
+          };
+
+        };
+
+      });
+    };
+
     networking.sits = mkOption {
       default = { };
       example = literalExample {

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -110,6 +110,10 @@ let
         extraFlags+=" --network-macvlan=$iface"
       done
 
+      for iface in $IPVLANS; do
+        extraFlags+=" --network-ipvlan=$iface"
+      done
+
       # If the host is 64-bit and the container is 32-bit, add a
       # --personality flag.
       ${optionalString (config.nixpkgs.localSystem.system == "x86_64-linux") ''
@@ -526,6 +530,17 @@ in
               '';
             };
 
+            ipvlans = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = [ "eth1" "eth2" ];
+              description = ''
+                The list of host interfaces from which ipvlans will be
+                created. For each interface specified, an ipvlan interface
+                will be created and moved to the container.
+              '';
+            };
+
             extraVeths = mkOption {
               type = with types; attrsOf (submodule { options = networkOptions; });
               default = {};
@@ -722,6 +737,7 @@ in
             ''}
             INTERFACES="${toString cfg.interfaces}"
             MACVLANS="${toString cfg.macvlans}"
+            IPVLANS="${toString cfg.ipvlans}"
             ${optionalString cfg.autoStart ''
               AUTO_START=1
             ''}

--- a/nixos/tests/containers-ipvlans.nix
+++ b/nixos/tests/containers-ipvlans.nix
@@ -1,0 +1,83 @@
+# Test for NixOS' container support.
+
+let
+  # containers IP on VLAN 1
+  containerIp1 = "192.168.1.253";
+  containerIp2 = "192.168.1.254";
+in
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-ipvlans";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ montag451 ];
+  };
+
+  nodes = {
+
+    machine1 =
+      { lib, ... }:
+      {
+        virtualisation.memorySize = 256;
+        virtualisation.vlans = [ 1 ];
+
+        # To be able to ping containers from the host, it is necessary
+        # to create an ipvlan on the host on the VLAN 1 network.
+        networking.ipvlans.iv-eth1-host = {
+          interface = "eth1";
+          mode = "L2";
+          flags = "bridge";
+        };
+        networking.interfaces.eth1.ipv4.addresses = lib.mkForce [];
+        networking.interfaces.iv-eth1-host = {
+          ipv4.addresses = [ { address = "192.168.1.1"; prefixLength = 24; } ];
+        };
+
+        containers.test1 = {
+          autoStart = true;
+          ipvlans = [ "eth1" ];
+
+          config = {
+            networking.interfaces.iv-eth1 = {
+              ipv4.addresses = [ { address = containerIp1; prefixLength = 24; } ];
+            };
+          };
+        };
+
+        containers.test2 = {
+          autoStart = true;
+          ipvlans = [ "eth1" ];
+
+          config = {
+            networking.interfaces.iv-eth1 = {
+              ipv4.addresses = [ { address = containerIp2; prefixLength = 24; } ];
+            };
+          };
+        };
+      };
+
+    machine2 =
+      { ... }:
+      {
+        virtualisation.memorySize = 256;
+        virtualisation.vlans = [ 1 ];
+      };
+
+  };
+
+  testScript = ''
+    startAll;
+    $machine1->waitForUnit("default.target");
+    $machine2->waitForUnit("default.target");
+
+    # Ping between containers to check that ipvlans are created in L2 bridge mode
+    $machine1->succeed("nixos-container run test1 -- ping -n -c 1 ${containerIp2}");
+
+    # Ping containers from the host (machine1)
+    $machine1->succeed("ping -n -c 1 ${containerIp1}");
+    $machine1->succeed("ping -n -c 1 ${containerIp2}");
+
+    # Ping containers from the second machine to check that containers are reachable from the outside
+    $machine2->succeed("ping -n -c 1 ${containerIp1}");
+    $machine2->succeed("ping -n -c 1 ${containerIp2}");
+  '';
+})


### PR DESCRIPTION
Largely adapted from the closely related macvlan implementation by @wkennington and @montag451. 

Eventually got DHCP working for the tests, thanks to @dcbw and @gleber:
* https://github.com/containernetworking/cni/issues/17
* https://gist.github.com/gleber/9429ea43e6beb114250c3529b5c9d522

###### Motivation for this change

This change makes ipvlans as easy to use as macvlans.

Ipvlans can be considered instead of macvlans when there are restrictions on the usage of additional MAC addresses i.e. switch port security enforced by VM hosts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - [X] networking.nix 
   - [X] containers-macvlans.nix
   - [X] containers-ipvlans.nix (**NEW!**)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). 

---

