### PR TITLE
nixos/znc: Fix regressions introduced in #45470

### DIFF
--- a/nixos/modules/services/networking/znc/options.nix
+++ b/nixos/modules/services/networking/znc/options.nix
@@ -254,8 +254,9 @@ in
             listToAttrs (map (n: nameValuePair "#${n}" (mkDefault {})) net.channels);
           extraConfig = if net.extraConf == "" then mkDefault null else net.extraConf;
         }) c.networks;
-        extraConfig = [ c.passBlock ] ++ optional (c.extraZncConf != "") c.extraZncConf;
+        extraConfig = [ c.passBlock ];
       };
+      extraConfig = optional (c.extraZncConf != "") c.extraZncConf;
     };
   };
 

--- a/nixos/modules/services/networking/znc/options.nix
+++ b/nixos/modules/services/networking/znc/options.nix
@@ -239,6 +239,7 @@ in
         IPv4 = mkDefault true;
         IPv6 = mkDefault true;
         SSL = mkDefault c.useSSL;
+        URIPrefix = c.uriPrefix;
       };
       User.${c.userName} = {
         Admin = mkDefault true;


### PR DESCRIPTION
These bugs were introduced in #45470 
###### Motivation for this change
hyper_ch reported the `extraZncConf` one on IRC. I mistakenly moved the `extraZncConf` lines to the user config section, when it should have stayed in the global section.

Then I noticed the `uriPrefix` one myself when double checking that I didn't miss anything in the cleanup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

