### PR TITLE
[18.03] Security backport for fuse (CVE-2018-10906)

### DIFF
--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -63,7 +63,7 @@ in stdenv.mkDerivation rec {
   postFixup = "cd $out\n" + (if isFuse3 then ''
     mv bin/mount.fuse3 bin/mount.fuse
 
-    install -D -m555 etc/fuse.conf $common/etc/fuse.conf
+    install -D -m444 etc/fuse.conf $common/etc/fuse.conf
     install -D -m444 etc/udev/rules.d/99-fuse3.rules $common/etc/udev/rules.d/99-fuse.rules
     install -D -m444 share/man/man8/mount.fuse.8.gz $common/share/man/man8/mount.fuse.8.gz
   '' else ''

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -51,22 +51,18 @@ in stdenv.mkDerivation rec {
       # The configure phase will delete these files (temporary workaround for
       # ./fuse3-install_man.patch)
       install -D -m444 doc/fusermount3.1 $out/share/man/man1/fusermount3.1
-      install -D -m444 doc/mount.fuse.8 $out/share/man/man8/mount.fuse.8
+      install -D -m444 doc/mount.fuse3.8 $out/share/man/man8/mount.fuse3.8
     '' else ''
       sed -e 's@CONFIG_RPATH=/usr/share/gettext/config.rpath@CONFIG_RPATH=${gettext}/share/gettext/config.rpath@' -i makeconf.sh
       ./makeconf.sh
     '');
 
   postFixup = "cd $out\n" + (if isFuse3 then ''
-    mv bin/mount.fuse3 bin/mount.fuse
-
     install -D -m444 etc/fuse.conf $common/etc/fuse.conf
     install -D -m444 etc/udev/rules.d/99-fuse3.rules $common/etc/udev/rules.d/99-fuse.rules
-    install -D -m444 share/man/man8/mount.fuse.8.gz $common/share/man/man8/mount.fuse.8.gz
   '' else ''
     cp ${fusePackages.fuse_3.common}/etc/fuse.conf etc/fuse.conf
     cp ${fusePackages.fuse_3.common}/etc/udev/rules.d/99-fuse.rules etc/udev/rules.d/99-fuse.rules
-    cp ${fusePackages.fuse_3.common}/share/man/man8/mount.fuse.8.gz share/man/man8/mount.fuse.8.gz
   '');
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -1,4 +1,4 @@
-{ version, sha256Hash, maintainers }:
+{ version, sha256Hash }:
 
 { stdenv, fetchFromGitHub, fetchpatch
 , fusePackages, utillinux, gettext
@@ -25,10 +25,7 @@ in stdenv.mkDerivation rec {
         url = "https://github.com/libfuse/libfuse/commit/914871b20a901e3e1e981c92bc42b1c93b7ab81b.patch";
         sha256 = "1w4j6f1awjrycycpvmlv0x5v9gprllh4dnbjxl4dyl2jgbkaw6pa";
       })
-    ++ stdenv.lib.optional isFuse3 ./fuse3-install.patch
-    # TODO: Only relevant for 3.2.2 (opened an upstream issue)
-    ++ stdenv.lib.optional isFuse3 ./fuse3-fix-version.patch;
-
+    ++ stdenv.lib.optional isFuse3 ./fuse3-install.patch;
 
   nativeBuildInputs = if isFuse3
     then [ meson ninja pkgconfig ]
@@ -74,10 +71,10 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "Kernel module and library that allows filesystems to be implemented in user space";
-    platforms = stdenv.lib.platforms.linux;
-    inherit maintainers;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.primeos ];
   };
 }

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -25,7 +25,9 @@ in stdenv.mkDerivation rec {
         url = "https://github.com/libfuse/libfuse/commit/914871b20a901e3e1e981c92bc42b1c93b7ab81b.patch";
         sha256 = "1w4j6f1awjrycycpvmlv0x5v9gprllh4dnbjxl4dyl2jgbkaw6pa";
       })
-    ++ stdenv.lib.optional isFuse3 ./fuse3-install.patch;
+    ++ stdenv.lib.optional isFuse3 ./fuse3-install.patch
+    # TODO: Only relevant for 3.2.2 (opened an upstream issue)
+    ++ stdenv.lib.optional isFuse3 ./fuse3-fix-version.patch;
 
 
   nativeBuildInputs = if isFuse3
@@ -61,11 +63,11 @@ in stdenv.mkDerivation rec {
   postFixup = "cd $out\n" + (if isFuse3 then ''
     mv bin/mount.fuse3 bin/mount.fuse
 
-    install -D -m555 bin/mount.fuse $common/bin/mount.fuse
-    install -D -m444 etc/udev/rules.d/99-fuse.rules $common/etc/udev/rules.d/99-fuse.rules
+    install -D -m555 etc/fuse.conf $common/etc/fuse.conf
+    install -D -m444 etc/udev/rules.d/99-fuse3.rules $common/etc/udev/rules.d/99-fuse.rules
     install -D -m444 share/man/man8/mount.fuse.8.gz $common/share/man/man8/mount.fuse.8.gz
   '' else ''
-    cp ${fusePackages.fuse_3.common}/bin/mount.fuse bin/mount.fuse
+    cp ${fusePackages.fuse_3.common}/etc/fuse.conf etc/fuse.conf
     cp ${fusePackages.fuse_3.common}/etc/udev/rules.d/99-fuse.rules etc/udev/rules.d/99-fuse.rules
     cp ${fusePackages.fuse_3.common}/share/man/man8/mount.fuse.8.gz share/man/man8/mount.fuse.8.gz
   '');

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -13,8 +13,8 @@ in {
   };
 
   fuse_3 = mkFuse {
-    version = "3.2.1";
-    sha256Hash = "19bsvb5lc8k1i0h5ld109kixn6mdshzvg3y7820k9mnw34kh09y0";
+    version = "3.2.2";
+    sha256Hash = "1a0x4vpyg9lc6clwvx995mk0v6jqd37xabzp9rpdir37x814g3wh";
     maintainers = [ maintainers.primeos ];
   };
 }

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -4,17 +4,14 @@ let
   mkFuse = args: callPackage (import ./common.nix args) {
     inherit utillinux;
   };
-  maintainers = stdenv.lib.maintainers;
 in {
   fuse_2 = mkFuse {
     version = "2.9.7";
     sha256Hash = "1wyjjfb7p4jrkk15zryzv33096a5fmsdyr2p4b00dd819wnly2n2";
-    maintainers = [ ];
   };
 
   fuse_3 = mkFuse {
-    version = "3.2.2";
-    sha256Hash = "1a0x4vpyg9lc6clwvx995mk0v6jqd37xabzp9rpdir37x814g3wh";
-    maintainers = [ maintainers.primeos ];
+    version = "3.2.3";
+    sha256Hash = "185p1vjcsyzpcdkrcyw06zpapv4jc43qw9i8a4amzpgk1rsgg19d";
   };
 }

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -11,7 +11,7 @@ in {
   };
 
   fuse_3 = mkFuse {
-    version = "3.2.3";
-    sha256Hash = "185p1vjcsyzpcdkrcyw06zpapv4jc43qw9i8a4amzpgk1rsgg19d";
+    version = "3.2.4";
+    sha256Hash = "1ybgd4s7naiyvaris7j6fzp604cgi5mgrn715x8l4kn5k9d840im";
   };
 }

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -11,7 +11,7 @@ in {
   };
 
   fuse_3 = mkFuse {
-    version = "3.2.4";
-    sha256Hash = "1ybgd4s7naiyvaris7j6fzp604cgi5mgrn715x8l4kn5k9d840im";
+    version = "3.2.5";
+    sha256Hash = "0ibf2isbkm8p1gfaqpqblwsg0lm4s1rmcipv1qcg0wc4wwsbnqpx";
   };
 }

--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -6,8 +6,8 @@ let
   };
 in {
   fuse_2 = mkFuse {
-    version = "2.9.7";
-    sha256Hash = "1wyjjfb7p4jrkk15zryzv33096a5fmsdyr2p4b00dd819wnly2n2";
+    version = "2.9.8";
+    sha256Hash = "0s04ln4k9zvvbjih8ybaa19fxg8xv7dcsz2yrlbk35psnf3l67af";
   };
 
   fuse_3 = mkFuse {

--- a/pkgs/os-specific/linux/fuse/fuse3-fix-version.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-fix-version.patch
@@ -1,0 +1,8 @@
+--- a/meson.build	2018-04-01 01:05:19.612723597 +0200
++++ b/meson.build	2018-04-01 01:40:58.171109615 +0200
+@@ -1,4 +1,4 @@
+-project('libfuse3', 'c', version: '3.2.1',
++project('libfuse3', 'c', version: '3.2.2',
+         meson_version: '>= 0.38',
+         default_options: [ 'buildtype=debugoptimized' ])
+

--- a/pkgs/os-specific/linux/fuse/fuse3-fix-version.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-fix-version.patch
@@ -1,8 +1,0 @@
---- a/meson.build	2018-04-01 01:05:19.612723597 +0200
-+++ b/meson.build	2018-04-01 01:40:58.171109615 +0200
-@@ -1,4 +1,4 @@
--project('libfuse3', 'c', version: '3.2.1',
-+project('libfuse3', 'c', version: '3.2.2',
-         meson_version: '>= 0.38',
-         default_options: [ 'buildtype=debugoptimized' ])
-

--- a/pkgs/os-specific/linux/fuse/fuse3-install.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-install.patch
@@ -1,6 +1,6 @@
---- a/util/install_helper.sh	1970-01-01 01:00:01.000000000 +0100
-+++ b/util/install_helper.sh	2017-09-21 23:43:50.703942577 +0200
-@@ -11,19 +11,11 @@
+--- a/util/install_helper.sh	2018-04-01 01:05:19.613723599 +0200
++++ b/util/install_helper.sh	2018-04-01 01:06:02.952845382 +0200
+@@ -11,22 +11,14 @@
  udevrulesdir="$3"
  prefix="${MESON_INSTALL_DESTDIR_PREFIX}"
  
@@ -14,11 +14,15 @@
 -
  install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
 -        "${DESTDIR}/${udevrulesdir}/99-fuse3.rules"
-+        "${prefix}/${udevrulesdir}/99-fuse.rules"
++        "${prefix}/${udevrulesdir}/99-fuse3.rules"
  
  install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
 -        "${DESTDIR}/etc/init.d/fuse3"
 +        "${prefix}/etc/init.d/fuse3"
  
+ install -D -m 644 "${MESON_SOURCE_ROOT}/util/fuse.conf" \
+-	"${DESTDIR}/etc/fuse.conf"
++	"${prefix}/etc/fuse.conf"
+
  if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
      /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true


### PR DESCRIPTION
###### Motivation for this change

Delayed security backport for CVE-2018-10906. SSHFS works, I'm currently testing some rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

