### PR TITLE
 docker-machine-kvm: 0.8.2 -> 0.10.0, docker-machine-kvm2: use minikube source

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/kvm.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "docker-machine-kvm-${version}";
-  version = "0.8.2";
+  version = "0.10.0";
 
   goPackagePath = "github.com/dhiltgen/docker-machine-kvm";
   goDeps = ./kvm-deps.nix;
@@ -12,7 +12,7 @@ buildGoPackage rec {
     rev    = "v${version}";
     owner  = "dhiltgen";
     repo   = "docker-machine-kvm";
-    sha256 = "1p7s340wlcjvna3xa2x13nsnixfhbn5b7dhf9cqvxds2slizlm3p";
+    sha256 = "0ch4zwb6h7hnr5l3skj1daypvpyms2i666lbnmakpw1fw3zvjmgy";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -1,19 +1,14 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, libvirt, pkgconfig }:
+{ stdenv, buildGoPackage, fetchFromGitHub, libvirt, pkgconfig, minikube }:
 
 buildGoPackage rec {
   pname = "docker-machine-kvm2";
   name = "${pname}-${version}";
-  version = "0.27.0";
+  version = minikube.version;
 
   goPackagePath = "k8s.io/minikube";
   subPackages = [ "cmd/drivers/kvm" ];
 
-  src = fetchFromGitHub {
-    owner = "kubernetes";
-    repo = "minikube";
-    rev = "v${version}";
-    sha256 = "00gj8x5p0vxwy0y0g5nnddmq049h7zxvhb73lb4gii5mghr9mkws";
-  };
+  src = minikube.src;
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libvirt ];


### PR DESCRIPTION
###### Motivation for this change

Update both docker-machine-kvm &  docker-machine-kvm2 to their current version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
