### PR TITLE
marble: Fix include install to dev output

### DIFF
--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -14,4 +14,7 @@ mkDerivation {
     qtscript qtsvg qtquickcontrols qtwebkit shared-mime-info krunner kparts
     knewstuff gpsd
   ];
+  preConfigure = ''
+    cmakeFlags+=" -DINCLUDE_INSTALL_DIR=''${!outputDev}/include"
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change

13c1f26807140e3821262022d43378864543ebb4 added a separate `dev` output, however the includes are still installed to `out` because `INCLUDE_INSTALL_DIR` defaults to `${CMAKE_INSTALL_PREFIX}/include`. They get automatically moved to `dev` by the builder, but `INTERFACE_INCLUDE_DIRECTORIES` in the CMake package config still points to the old location in `out`. This breaks the build of `kreport`.

Needs backport to `release-18.09`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

