### PR TITLE
cpuset: init at 1.5.8

### DIFF
--- a/pkgs/os-specific/linux/cpuset/default.nix
+++ b/pkgs/os-specific/linux/cpuset/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, python2Packages
+}:
+
+python2Packages.buildPythonApplication rec {
+  pname = "cpuset";
+  version = "1.5.8";
+
+  propagatedBuildInputs = [ ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  src = fetchFromGitHub {
+    owner = "wykurz";
+    repo = "cpuset";
+    rev = "v${version}";
+    sha256 = "19fl2sn470yrnm2q508giggjwy5b6r2gd94gvwfbdlhf0r9dsbbm";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Cpuset is a Python application that forms a wrapper around the standard Linux filesystem calls to make using the cpusets facilities in the Linux kernel easier.";
+    homepage    = https://github.com/wykurz/cpuset;
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ wykurz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14011,6 +14011,8 @@ with pkgs;
 
   cpufrequtils = callPackage ../os-specific/linux/cpufrequtils { };
 
+  cpuset = callPackage ../os-specific/linux/cpuset { };
+
   criu = callPackage ../os-specific/linux/criu { };
 
   cryptsetup = callPackage ../os-specific/linux/cryptsetup { };


### PR DESCRIPTION
###### Motivation for this change
Add cpuset (cset) to nixpkgs.

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).