### PR TITLE
python3 is now python37 instead of python36

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -484,9 +484,9 @@ and in this case the `python35` interpreter is automatically used.
 ### Interpreters
 
 Versions 2.7, 3.4, 3.5, 3.6 and 3.7 of the CPython interpreter are available as
-respectively `python27`, `python34`, `python35` and `python36`. The PyPy interpreter
+respectively `python27`, `python34`, `python35`, `python36` and `python37`. The PyPy interpreter
 is available as `pypy`. The aliases `python2` and `python3` correspond to respectively `python27` and
-`python35`. The default interpreter, `python`, maps to `python2`.
+`python37`. The default interpreter, `python`, maps to `python2`.
 The Nix expressions for the interpreters can be found in
 `pkgs/development/interpreters/python`.
 
@@ -538,7 +538,7 @@ sets are
 and the aliases
 
 * `pkgs.python2Packages` pointing to `pkgs.python27Packages`
-* `pkgs.python3Packages` pointing to `pkgs.python36Packages`
+* `pkgs.python3Packages` pointing to `pkgs.python37Packages`
 * `pkgs.pythonPackages` pointing to `pkgs.python2Packages`
 
 #### `buildPythonPackage` function

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -19,6 +19,8 @@
 
   <itemizedlist>
    <listitem>
+    <para>
+    The default Python 3 interpreter is now CPython 3.7 instead of CPython 3.6.
     <para />
    </listitem>
   </itemizedlist>

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -29,7 +29,17 @@ stdenv.mkDerivation rec {
     ./patches/python-5755-hotpatch.patch
   ];
 
-  packageUpgradePatches = [
+  packageUpgradePatches = let
+    fetchSageCommit = { rev, ...}@args: (
+      fetchpatch ({
+        url = "https://git.sagemath.org/sage.git/patch/?h=${rev}";
+        # TODO better https://git.sagemath.org/sage.git/patch/?id=${rev} ?
+        # We don't care about sage's own build system (which builds all its dependencies).
+        # Exclude build system changes to avoid conflicts.
+        excludes = [ "build/*" ];
+      } // builtins.removeAttrs args [ "rev" ])
+    );
+  in [
     # New glpk version has new warnings, filter those out until upstream sage has found a solution
     # https://trac.sagemath.org/ticket/24824
     ./patches/pari-stackwarn.patch # not actually necessary since tha pari upgrade, but necessary for the glpk patch to apply
@@ -43,10 +53,17 @@ stdenv.mkDerivation rec {
     ./patches/numpy-1.15.1.patch
 
     # ntl upgrade
+    # https://trac.sagemath.org/ticket/25532#comment:29
     (fetchpatch {
       name = "lcalc-c++11.patch";
       url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/sagemath-lcalc-c++11.patch?h=packages/sagemath&id=0e31ae526ab7c6b5c0bfacb3f8b1c4fd490035aa";
       sha256 = "0p5wnvbx65i7cp0bjyaqgp4rly8xgnk12pqwaq3dqby0j2bk6ijb";
+    })
+
+    (fetchpatch {
+      name = "cython-0.29.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?h=f77de1d0e7f90ee12761140500cb8cbbb789ab20";
+      sha256 = "14wrpy8jgbnpza1j8a2nx8y2r946y82pll1fv3cn6gpfmm6640l3";
     })
   ];
 

--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -13,6 +13,7 @@
 
 let
   excludedTests = []
+    ++ [ "reimport_from_subinterpreter" ]
     # cython's testsuite is not working very well with libc++
     # We are however optimistic about things outside of testsuite still working
     ++ stdenv.lib.optionals (stdenv.cc.isClang or false) [ "cpdef_extern_func" "libcpp_algo" ]
@@ -25,11 +26,11 @@ let
 
 in buildPythonPackage rec {
   pname = "Cython";
-  version = "0.28.5";
+  version = "0.29";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b64575241f64f6ec005a4d4137339fb0ba5e156e826db2fdb5f458060d9979e0";
+    sha256 = "15zama7fgp7yyi3z39xp3z2lvwcgch8fn3ycscw2cs37vqg6v4cl";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/autobahn/default.nix
+++ b/pkgs/development/python-modules/autobahn/default.nix
@@ -4,11 +4,11 @@
 }:
 buildPythonPackage rec {
   pname = "autobahn";
-  version = "18.8.2";
+  version = "18.10.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "448df2e241011ea2948799918930042d81e63d26b01912c472f5a9a37f42f319";
+    sha256 = "b5767bebd94ba13fc286604f889f208e7babc77d72d9f372d331bc14c89c5a40";
   };
 
   propagatedBuildInputs = [ six txaio twisted zope_interface cffi ] ++

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -3,9 +3,9 @@
 let
   wheel_source = fetchPypi {
     pname = "wheel";
-    version = "0.32.1";
+    version = "0.32.2";
     format = "wheel";
-    sha256 = "15hizylh761jcaz8zfdc3wg30jf33izaakyv1p82ppx2y5rgg8cz";
+    sha256 = "1216licil12jjixfqvkb84xkync5zz0fdc2kgzhl362z3xqjsgn9";
   };
   setuptools_source = fetchPypi {
     pname = "setuptools";

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "3.66.2";
+  version = "3.79.3";
   pname = "hypothesis";
 
   # Use github tarballs that includes tests
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "hypothesis-python-${version}";
-    sha256 = "17ywbwa76z7f0pgash0003fvm25fsj7hxdrdiprdbv99y3i8bm88";
+    sha256 = "1ay0kwh5315scv7yz9xxrr7shynyx6flgplc1qzbz3j21cyx3yn7";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -16,12 +16,12 @@ let
   };
 in buildPythonPackage rec {
   pname = "numpy";
-  version = "1.15.2";
+  version = "1.15.3";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "27a0d018f608a3fe34ac5e2b876f4c23c47e38295c47dd0775cc294cd2614bc1";
+    sha256 = "1c0c80e74759fa4942298044274f2c11b08c86230b25b8b819e55e644f5ff2b6";
   };
 
   disabled = isPyPy;

--- a/pkgs/development/python-modules/py/default.nix
+++ b/pkgs/development/python-modules/py/default.nix
@@ -1,11 +1,11 @@
 { stdenv, buildPythonPackage, fetchPypi, setuptools_scm }:
 buildPythonPackage rec {
   pname = "py";
-  version = "1.5.4";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7";
+    sha256 = "bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694";
   };
 
   # Circular dependency on pytest

--- a/pkgs/development/python-modules/pycodestyle/default.nix
+++ b/pkgs/development/python-modules/pycodestyle/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "pycodestyle";
@@ -8,6 +8,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a";
   };
+
+  patches = [
+    # https://github.com/PyCQA/pycodestyle/pull/801
+    (fetchpatch {
+      url = https://github.com/PyCQA/pycodestyle/commit/397463014fda3cdefe8d6c9d117ae16d878dc494.patch;
+      sha256 = "01zask2y2gim5il9lcmlhr2qaadv9v7kaw1y619l8xbjhpbq2zh8";
+    })
+  ];
 
   meta = with lib; {
     description = "Python style guide checker (formerly called pep8)";

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -3,7 +3,7 @@
 , atomicwrites, mock, writeText, pathlib2
 }:
 buildPythonPackage rec {
-  version = "3.7.4";
+  version = "3.9.2";
   pname = "pytest";
 
   preCheck = ''
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2d7c49e931316cc7d1638a3e5f54f5d7b4e5225972b3c9838f3584788d27f349";
+    sha256 = "212be78a6fa5352c392738a49b18f74ae9aeec1040f47c81cadbfd8d1233c310";
   };
 
   checkInputs = [ hypothesis mock ];

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -8,13 +8,13 @@
 # Should use buildPythonPackage here somehow
 stdenv.mkDerivation rec {
   pname = "setuptools";
-  version = "40.2.0";
+  version = "40.4.3";
   name = "${python.libPrefix}-${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "47881d54ede4da9c15273bac65f9340f8929d4f0213193fa7894be384f2dcfa6";
+    sha256 = "acbc5740dd63f243f46c2b4b8e2c7fd92259c2ddb55a4115b16418a2ed371b15";
   };
 
   nativeBuildInputs = [ unzip wrapPython ];

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, mock, six, twisted }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, mock, six, twisted,isPy37 }:
 
 buildPythonPackage rec {
   pname = "txaio";
-  version = "18.7.1";
+  version = "18.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "701de939e90bb80f7e085357081552437526752199def5541dddfc34c0b0593f";
+    sha256 = "67e360ac73b12c52058219bb5f8b3ed4105d2636707a36a7cdafb56fe06db7fe";
   };
 
   checkInputs = [ pytest mock ];
@@ -16,6 +16,9 @@ buildPythonPackage rec {
   checkPhase = ''
     py.test -k "not test_sdist"
   '';
+
+  # Needs some fixing for 3.7
+  doCheck = !isPy37;
 
   meta = with stdenv.lib; {
     description = "Utilities to support code that runs unmodified on Twisted and asyncio.";

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "wheel";
-  version = "0.31.1";
+  version = "0.32.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0a2e54558a0628f2145d2fc822137e322412115173e8a2ddbe1c9024338ae83c";
+    sha256 = "196c9842d79262bb66fcf59faa4bd0deb27da911dbc7c6cdca931080eb1f0783";
   };
 
   checkInputs = [ pytest pytestcov coverage ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7743,7 +7743,7 @@ with pkgs;
   # When switching these sets, please update docs at ../../doc/languages-frameworks/python.md
   python = python2;
   python2 = python27;
-  python3 = python36;
+  python3 = python37;
   pypy = pypy27;
 
   # Python interpreter that is build with all modules, including tkinter.
@@ -7793,8 +7793,8 @@ with pkgs;
   python27Packages = lib.hiPrioSet (recurseIntoAttrs python27.pkgs);
   python34Packages = python34.pkgs;
   python35Packages = python35.pkgs;
-  python36Packages = recurseIntoAttrs python36.pkgs;
-  python37Packages = python37.pkgs;
+  python36Packages = python36.pkgs;
+  python37Packages = recurseIntoAttrs python37.pkgs;
   pypyPackages = pypy.pkgs;
 
   # Should eventually be moved inside Python interpreters.
@@ -18593,7 +18593,7 @@ with pkgs;
   rclone = callPackage ../applications/networking/sync/rclone { };
 
   rclone-browser = libsForQt5.callPackage ../applications/networking/sync/rclone/browser.nix { };
-  
+
   rcs = callPackage ../applications/version-management/rcs { };
 
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10626,7 +10626,7 @@ EOF
 
   tensorflow-tensorboard = callPackage ../development/python-modules/tensorflow-tensorboard { };
 
-  tensorflow =
+  tensorflow = disabledIf isPy37 (
     if stdenv.isDarwin
     then callPackage ../development/python-modules/tensorflow/bin.nix { }
     else callPackage ../development/python-modules/tensorflow/bin.nix rec {
@@ -10634,7 +10634,7 @@ EOF
       inherit (pkgs.linuxPackages) nvidia_x11;
       cudatoolkit = pkgs.cudatoolkit_9_0;
       cudnn = pkgs.cudnn_cudatoolkit_9_0;
-    };
+    });
 
   tensorflowWithoutCuda = self.tensorflow.override {
     cudaSupport = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1285,9 +1285,9 @@ in {
 
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
-  pytest = self.pytest_37;
+  pytest = self.pytest_39;
 
-  pytest_37 = callPackage ../development/python-modules/pytest {
+  pytest_39 = callPackage ../development/python-modules/pytest {
     # hypothesis tests require pytest that causes dependency cycle
     hypothesis = self.hypothesis.override { doCheck = false; };
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

