### PR TITLE
nixos/containers: Introduce several tweaks to systemd-nspawn from upstream systemd

### DIFF
--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -112,6 +112,7 @@ in {
 
       environment.etc."systemd/nspawn".source = generateUnits "nspawn" units [] [];
 
+      systemd.targets."multi-user".wants = [ "machines.target "];
   };
 
 }

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -243,6 +243,9 @@ let
 
     Restart = "on-failure";
 
+    Slice = "machine.slice";
+    Delegate = true;
+
     # Hack: we don't want to kill systemd-nspawn, since we call
     # "machinectl poweroff" in preStop to shut down the
     # container cleanly. But systemd requires sending a signal
@@ -657,6 +660,8 @@ in
       serviceConfig = serviceDirectives dummyConfig;
     };
   in {
+    systemd.targets."multi-user".wants = [ "machines.target" ];
+
     systemd.services = listToAttrs (filter (x: x.value != null) (
       # The generic container template used by imperative containers
       [{ name = "container@"; value = unit; }]
@@ -680,7 +685,7 @@ in
           } // (
           if config.autoStart then
             {
-              wantedBy = [ "multi-user.target" ];
+              wantedBy = [ "machines.target" ];
               wants = [ "network.target" ];
               after = [ "network.target" ];
               restartTriggers = [ config.path ];


### PR DESCRIPTION

    nixos/containers: Introduce several tweaks to systemd-nspawn from upstream systemd
    
    * Lets container@.service  be activated by machines.target instead of
      multi-user.target
    
      According to the systemd manpages, all containers that are registered
      by machinectl, should be inside machines.target for easy stopping
      and starting container units altogether
    
    * make sure container@.service and container.slice instances are
      actually located in machine.slice
    
      https://plus.google.com/112206451048767236518/posts/SYAueyXHeEX
      See original commit: https://github.com/NixOS/systemd/commit/45d383a3b8
    
    * Enable Cgroup delegation for nixos-containers
    
      Delegate=yes should be set for container scopes where a systemd instance
      inside the container shall manage the hierarchies below its own cgroup
      and have access to all controllers.
    
      This is equivalent to enabling all accounting options on the systemd
      process inside the system container.  This means that systemd inside
      the container is responsible for managing Cgroup resources for
      unit files that enable accounting options inside.  Without this
      option, units that make use of cgroup features within system
      containers might misbehave
    
      See original commit: https://github.com/NixOS/systemd/commit/a931ad47a8
    
      from the manpage:
        Turns on delegation of further resource control partitioning to
        processes of the unit. Units where this is enabled may create and
        manage their own private subhierarchy of control groups below the
        control group of the unit itself. For unprivileged services (i.e.
        those using the User= setting) the unit's control group will be made
        accessible to the relevant user. When enabled the service manager
        will refrain from manipulating control groups or moving processes
        below the unit's control group, so that a clear concept of ownership
        is established: the control group tree above the unit's control
        group (i.e. towards the root control group) is owned and managed by
        the service manager of the host, while the control group tree below
        the unit's control group is owned and managed by the unit itself.
        Takes either a boolean argument or a list of control group
        controller names. If true, delegation is turned on, and all
        supported controllers are enabled for the unit, making them
        available to the unit's processes for management. If false,
        delegation is turned off entirely (and no additional controllers are
        enabled). If set to a list of controllers, delegation is turned on,
        and the specified controllers are enabled for the unit. Note that
        additional controllers than the ones specified might be made
        available as well, depending on configuration of the containing
        slice unit or other units contained in it. Note that assigning the
        empty string will enable delegation, but reset the list of
        controllers, all assignments prior to this will have no effect.
        Defaults to false.
    
        Note that controller delegation to less privileged code is only safe
        on the unified control group hierarchy. Accordingly, access to the
        specified controllers will not be granted to unprivileged services
        on the legacy hierarchy, even when requested.
    
        The following controller names may be specified: cpu, cpuacct, io,
        blkio, memory, devices, pids. Not all of these controllers are
        available on all kernels however, and some are specific to the
        unified hierarchy while others are specific to the legacy hierarchy.
        Also note that the kernel might support further controllers, which
        aren't covered here yet as delegation is either not supported at all
        for them or not defined cleanly.


###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

