### PR TITLE
mumble: fix hang on reconfiguring audio

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -118,12 +118,21 @@ let
       sha256 = "1s60vaici3v034jzzi20x23hsj6mkjlc0glipjq4hffrg9qgnizh";
     };
 
-    # Fix compile error against boost 1.66 (#33655):
-    patches = singleton (fetchpatch {
-      url = "https://github.com/mumble-voip/mumble/commit/"
-          + "ea861fe86743c8402bbad77d8d1dd9de8dce447e.patch";
-      sha256 = "1r50dc8dcl6jmbj4abhnay9div7y56kpmajzqd7ql0pm853agwbh";
-    });
+    patches = [
+      # Fix compile error against boost 1.66 (#33655):
+      (fetchpatch {
+        url = "https://github.com/mumble-voip/mumble/commit/"
+            + "ea861fe86743c8402bbad77d8d1dd9de8dce447e.patch";
+        sha256 = "1r50dc8dcl6jmbj4abhnay9div7y56kpmajzqd7ql0pm853agwbh";
+      })
+      # Fixes hang on reconfiguring audio (often including startup)
+      # https://github.com/mumble-voip/mumble/pull/3418
+      (fetchpatch {
+        url = "https://github.com/mumble-voip/mumble/commit/"
+            + "fbbdf2e8ab7d93ed6f7680268ad0689b7eaa71ad.patch";
+        sha256 = "1yhj62mlwm6q42i4aclbia645ha97d3j4ycxhgafr46dbjs0gani";
+      })
+    ];
   };
 
   gitSource = rec {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/48004

Pulls in a proposed change to upstream (https://github.com/mumble-voip/mumble/pull/3418). Unfortunately it's not yet merged, and the PR has been inactive for a few months. However, it's a very small change, and makes mumble usable again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

