### PR TITLE
mxnet: fix error when building with cudaSupport

### DIFF
--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags =
     (if cudaSupport then [
+      "-DUSE_OLDCMAKECUDA=ON"  # see https://github.com/apache/incubator-mxnet/issues/10743
       "-DCUDA_ARCH_NAME=All"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
     ] else [ "-DUSE_CUDA=OFF" ])


### PR DESCRIPTION
###### Motivation for this change

Mxnet doesn't build with cudaSupport:

```
$ nix run "(with import <nixpkgs> { config = { allowUnfree=true; cudaSupport=true; cudnnSupport=true; }; };
python3.withPackages (ps: [ ps.mxnet ]))"

builder for '/nix/store/f5zwrjv4ad0y8p2qk6472d4ryx7nvzm8-mxnet-1.2.1.drv' failed with exit code 1; last 10 log lines:
  CMake Error: CMAKE_CUDA_COMPILER not set, after EnableLanguage
  CMake Error at cmake/FirstClassLangCuda.cmake:79 (try_run):
    Failed to configure test project build system.
  Call Stack (most recent call first):
    cmake/FirstClassLangCuda.cmake:147 (mshadow_detect_installed_gpus)
    CMakeLists.txt:534 (mshadow_select_nvcc_arch_flags)
  
  -- Configuring incomplete, errors occurred!
  See also "/build/apache-mxnet-src-1.2.1-incubating/build/CMakeFiles/CMakeOutput.log".
cannot build derivation '/nix/store/cqkmsv1kldxahdl6klzgn42p6s0vwwq3-python3.6-mxnet-1.2.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/xxha232lplcg7zzgv52lmd8qh43bpwqn-python3-3.6.6-env.drv': 1 dependencies couldn't be built
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/xxha232lplcg7zzgv52lmd8qh43bpwqn-python3-3.6.6-env.drv' failed
```

###### Things done

Set the cmake flag `OLDCMAKECUDA=ON`, as suggested in https://github.com/apache/incubator-mxnet/issues/10743.
Tested on nixos-unstable.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

