### PR TITLE
git-crypt: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub, git, gnupg1compat, makeWrapper, openssl, stdenv }:
 
 stdenv.mkDerivation rec {
-
-  name = "git-crypt-${meta.version}";
+  name = "git-crypt-${version}";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "AGWA";
     repo = "git-crypt";
-    rev = meta.version;
-    sha256 = "4fe45f903a4b3cc06a5fe11334b914c225009fe8440d9e91a54fdf21cf4dcc4d";
+    rev = "${version}";
+    sha256 = "13m9y0m6gc3mlw3pqv9x4i0him2ycbysizigdvdanhh514kga602";
     inherit name;
   };
 
@@ -40,7 +40,6 @@ stdenv.mkDerivation rec {
     '';
     downloadPage = "https://github.com/AGWA/git-crypt/releases";
     license = licenses.gpl3;
-    version = "0.5.0";
     maintainers = [ maintainers.dochang ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Changes: https://www.agwa.name/git/git-crypt.git/raw/master/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

