### PR TITLE
dde-session-ui: init at 4.5.1.10

### DIFF
--- a/pkgs/desktops/deepin/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/dde-session-ui/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtsvg, qttools,
+  qtx11extras, xkeyboard_config, xorg, lightdm_qt, gsettings-qt,
+  dde-qt-dbus-factory, deepin-gettext-tools, dtkcore, dtkwidget,
+  hicolor-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-session-ui";
+  version = "4.5.1.10";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0cr3g9jbgpp8k41i86lr4pg88gn690nzili7ah745vf1kdwvi1w0";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    qttools
+    deepin-gettext-tools
+  ];
+
+  buildInputs = [
+    dde-qt-dbus-factory
+    dtkcore
+    dtkwidget
+    gsettings-qt
+    lightdm_qt
+    qtsvg
+    qtx11extras
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXtst
+    xkeyboard_config
+    hicolor-icon-theme
+  ];
+
+  postPatch = ''
+    patchShebangs .
+    sed -i translate_desktop.sh -e "s,/usr/bin/deepin-desktop-ts-convert,deepin-desktop-ts-convert,"
+    find -type f -exec sed -i -e "s,path = /etc,path = $out/etc," {} +
+    find -type f -exec sed -i -e "s,path = /usr,path = $out," {} +
+    find -type f -exec sed -i -e "s,Exec=/usr,Exec=$out," {} +
+    find -type f -exec sed -i -e "s,/usr/share/dde-session-ui,$out/share/dde-session-ui," {} +
+    sed -i global_util/xkbparser.h -e "s,/usr/share/X11/xkb/rules/base.xml,${xkeyboard_config}/share/X11/xkb/rules/base.xml,"
+    sed -i lightdm-deepin-greeter/Scripts/lightdm-deepin-greeter -e "s,/usr/bin/lightdm-deepin-greeter,$out/bin/lightdm-deepin-greeter,"
+    # fix default background url
+    sed -i widgets/*.cpp boxframe/*.cpp -e 's,/usr/share/backgrounds/default_background.jpg,/usr/share/backgrounds/deepin/desktop.jpg,'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Deepin desktop-environment - Session UI module";
+    homepage = https://github.com/linuxdeepin/dde-session-ui;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -8,6 +8,7 @@ let
     dde-calendar = callPackage ./dde-calendar { };
     dde-polkit-agent = callPackage ./dde-polkit-agent { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
+    dde-session-ui = callPackage ./dde-session-ui { };
     deepin-desktop-base = callPackage ./deepin-desktop-base { };
     deepin-desktop-schemas = callPackage ./deepin-desktop-schemas { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };


### PR DESCRIPTION
###### Motivation for this change

Add [dde-session-ui](https://github.com/linuxdeepin/dde-session-ui) (UI components for Deepin Desktop Environment session manager)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

