### PR TITLE
sage: fix docbuild

### DIFF
--- a/pkgs/applications/science/math/sage/patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
+++ b/pkgs/applications/science/math/sage/patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
@@ -1,0 +1,26 @@
+From c8edfefbbec87ca776d3cf84ee895aac200dda40 Mon Sep 17 00:00:00 2001
+From: Timo Kaufmann <timokau@zoho.com>
+Date: Sun, 21 Oct 2018 17:52:40 +0200
+Subject: [PATCH] Only test py2/py3 optional tests when all of sage is tested
+
+---
+ src/sage/doctest/control.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/sage/doctest/control.py b/src/sage/doctest/control.py
+index bf18df8b2b..b04af0e2e8 100644
+--- a/src/sage/doctest/control.py
++++ b/src/sage/doctest/control.py
+@@ -362,7 +362,8 @@ class DocTestController(SageObject):
+                     if not optionaltag_regex.search(o):
+                         raise ValueError('invalid optional tag {!r}'.format(o))
+ 
+-                options.optional |= auto_optional_tags
++                if "sage" in options.optional:
++                    options.optional |= auto_optional_tags
+ 
+         self.options = options
+ 
+-- 
+2.18.1
+

--- a/pkgs/applications/science/math/sage/patches/revert-sphinx-always-fork.patch
+++ b/pkgs/applications/science/math/sage/patches/revert-sphinx-always-fork.patch
@@ -1,0 +1,71 @@
+commit f1c59929c3c180ac283334c2b3c901ac8c82f6b1
+Author: Timo Kaufmann <timokau@zoho.com>
+Date:   Sat Oct 20 20:07:41 2018 +0200
+
+    Revert "Something related to the sphinxbuild seems to be leaking memory"
+    
+    This reverts commit 7d85dc796c58c3de57401bc22d3587b94e205091.
+
+diff --git a/src/sage_setup/docbuild/__init__.py b/src/sage_setup/docbuild/__init__.py
+index 0b24b1a60b..084c3f89d7 100644
+--- a/src/sage_setup/docbuild/__init__.py
++++ b/src/sage_setup/docbuild/__init__.py
+@@ -265,29 +265,35 @@ class DocBuilder(object):
+     # import the customized builder for object.inv files
+     inventory = builder_helper('inventory')
+ 
+-def build_many(target, args):
+-    # Pool() uses an actual fork() to run each new instance. This is important
+-    # for performance reasons, i.e., don't use a forkserver when it becomes
+-    # available with Python 3: Here, sage is already initialized which is quite
+-    # costly, with a forkserver we would have to reinitialize it for every
+-    # document we build. At the same time, don't serialize this by taking the
+-    # pool (and thus the call to fork()) out completely: The call to Sphinx
+-    # leaks memory, so we need to build each document in its own process to
+-    # control the RAM usage.
+-    from multiprocessing import Pool
+-    pool = Pool(NUM_THREADS, maxtasksperchild=1)
+-    # map_async handles KeyboardInterrupt correctly. Plain map and
+-    # apply_async does not, so don't use it.
+-    x = pool.map_async(target, args, 1)
+-    try:
+-        ret = x.get(99999)
+-        pool.close()
+-        pool.join()
+-    except Exception:
+-        pool.terminate()
+-        if ABORT_ON_ERROR:
+-            raise
+-    return ret
++if NUM_THREADS > 1:
++    def build_many(target, args):
++        from multiprocessing import Pool
++        pool = Pool(NUM_THREADS, maxtasksperchild=1)
++        # map_async handles KeyboardInterrupt correctly. Plain map and
++        # apply_async does not, so don't use it.
++        x = pool.map_async(target, args, 1)
++        try:
++            ret = x.get(99999)
++            pool.close()
++            pool.join()
++        except Exception:
++            pool.terminate()
++            if ABORT_ON_ERROR:
++                raise
++        return ret
++else:
++    def build_many(target, args):
++        results = []
++
++        for arg in args:
++            try:
++                results.append(target(arg))
++            except Exception:
++                if ABORT_ON_ERROR:
++                    raise
++
++        return results
++
+ 
+ ##########################################
+ #      Parallel Building Ref Manual      #

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
     # https://trac.sagemath.org/ticket/25316
     # https://github.com/python/cpython/pull/7476
     ./patches/python-5755-hotpatch.patch
+
+    # Revert the commit that made the sphinx build fork even in the single thread
+    # case. For some yet unknown reason, that breaks the docbuild on nix and archlinux.
+    # See https://groups.google.com/forum/#!msg/sage-packaging/VU4h8IWGFLA/mrmCMocYBwAJ.
+    ./patches/revert-sphinx-always-fork.patch
   ];
 
   packageUpgradePatches = [

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
     # case. For some yet unknown reason, that breaks the docbuild on nix and archlinux.
     # See https://groups.google.com/forum/#!msg/sage-packaging/VU4h8IWGFLA/mrmCMocYBwAJ.
     ./patches/revert-sphinx-always-fork.patch
+
+    # Make sure py2/py3 tests are only run when their expected context (all "sage"
+    # tests) are also run. That is necessary to test dochtml individually. See
+    # https://trac.sagemath.org/ticket/26110 for an upstream discussion.
+    ./patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
   ];
 
   packageUpgradePatches = [


### PR DESCRIPTION
###### Motivation for this change

The docbuild broke with 8.4.beta2, see https://groups.google.com/forum/#!topic/sage-packaging/VU4h8IWGFLA.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

