### PR TITLE
libgnurl: 7.54.1 -> 7.61.1.

### DIFF
--- a/pkgs/development/libraries/libgnurl/default.nix
+++ b/pkgs/development/libraries/libgnurl/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, libtool, groff, perl, pkgconfig, python2, zlib, gnutls, libidn }:
+{ stdenv, fetchurl, libtool, groff, perl, pkgconfig, python2, zlib, gnutls,
+  libidn2, libunistring, nghttp2 }:
 
 stdenv.mkDerivation rec {
   version = "7.61.1";
@@ -6,13 +7,13 @@ stdenv.mkDerivation rec {
   name = "libgnurl-${version}";
 
   src = fetchurl {
-    url = "https://ftp.gnu.org/gnu/gnunet/gnurl-${version}.tar.gz";
+    url = "mirror://gnu/gnunet/gnurl-${version}.tar.gz";
     sha256 = "0y56k15vp3m2r8q6mnc6ivflwq9lv6npdhbbvxxcf4r8vwjhv91q";
   };
 
   nativeBuildInputs = [ libtool groff perl pkgconfig python2 ];
     
-  buildInputs = [ gnutls zlib libidn ];
+  buildInputs = [ gnutls zlib libidn2 libunistring nghttp2 ];
 
   configureFlags = [
     "--disable-ntlm-wb"

--- a/pkgs/development/libraries/libgnurl/default.nix
+++ b/pkgs/development/libraries/libgnurl/default.nix
@@ -1,31 +1,23 @@
-{ stdenv, fetchurl, autoreconfHook, perl, zlib, gnutls, gss, openssl
-, libidn }:
+{ stdenv, fetchurl, libtool, groff, perl, pkgconfig, python2, zlib, gnutls, libidn }:
 
 stdenv.mkDerivation rec {
-  version = "7.54.1";
+  version = "7.61.1";
 
   name = "libgnurl-${version}";
 
   src = fetchurl {
-    url = "https://gnunet.org/sites/default/files/gnurl-${version}.tar.bz2";
-    sha256 = "0szbj352h95sgc9kbx9wzkgjksmg3g5k6cvlc7hz3wrbdh5gb0a4";
+    url = "https://ftp.gnu.org/gnu/gnunet/gnurl-${version}.tar.gz";
+    sha256 = "0y56k15vp3m2r8q6mnc6ivflwq9lv6npdhbbvxxcf4r8vwjhv91q";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ perl gnutls gss openssl zlib libidn ];
-
-  preConfigure = ''
-    sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
-  '';
+  nativeBuildInputs = [ libtool groff perl pkgconfig python2 ];
+    
+  buildInputs = [ gnutls zlib libidn ];
 
   configureFlags = [
-    "--enable-ipv6" "--with-gnutls" "--without-libmetalink" "--without-winidn"
-    "--without-librtmp" "--without-nghttp2" "--without-nss" "--without-cyassl"
-    "--without-polarssl" "--without-ssl" "--without-winssl"
-    "--without-darwinssl" "--disable-sspi" "--disable-ntlm-wb" "--disable-ldap"
-    "--disable-rtsp" "--disable-dict" "--disable-telnet" "--disable-tftp"
-    "--disable-pop3" "--disable-imap" "--disable-smtp" "--disable-gopher"
-    "--disable-file" "--disable-ftp" "--disable-smb"
+    "--disable-ntlm-wb"
+    "--without-ca-bundle"
+    "--with-ca-fallback"
   ];
 
   meta = with stdenv.lib; {
@@ -33,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage    = https://gnunet.org/gnurl;
     maintainers = with maintainers; [ falsifian vrthra ];
     platforms = platforms.linux;
-    license = with licenses; [ bsdOriginal mit ];
+    license = licenses.curl;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bump to the latest version of libgnurl. In the previous version of the package HTTPS support was not compiled in.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

