### PR TITLE
corosync: update RDMA support to rdma-core

### DIFF
--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig, nss, nspr, libqb
-, dbus, librdmacm, libibverbs, libstatgrab, net_snmp
+, dbus, rdma-core, libstatgrab, net_snmp
 , enableDbus ? false
 , enableInfiniBandRdma ? false
 , enableMonitoring ? false
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     nss nspr libqb
   ] ++ optional enableDbus dbus
-    ++ optional enableInfiniBandRdma [ librdmacm libibverbs ]
+    ++ optional enableInfiniBandRdma rdma-core
     ++ optional enableMonitoring libstatgrab
     ++ optional enableSnmp net_snmp;
 
@@ -43,6 +43,17 @@ stdenv.mkDerivation rec {
     "INITDDIR=$(out)/etc/init.d"
     "LOGROTATEDIR=$(out)/etc/logrotate.d"
   ];
+
+  preConfigure = optionalString enableInfiniBandRdma ''
+    # configure looks for the pkg-config files
+    # of librdmacm and libibverbs
+    # Howver, rmda-core does not provide a pkg-config file
+    # We give the flags manually here:
+    export rdmacm_LIBS=-lrdmacm
+    export rdmacm_CFLAGS=" "
+    export ibverbs_LIBS=-libverbs
+    export ibverbs_CFLAGS=" "
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/corosync-blackbox \


### PR DESCRIPTION
###### Motivation for this change
The packages `librdmacm` and `libibverbs` are deprecated and are replaced by `rdma-core`.

see https://github.com/NixOS/nixpkgs/issues/34314

###### Things done
Replaced `librdmacm` and `libibverbs` with `rdma-core`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

