### PR TITLE
networkd: don't managed interfaces set up by script

### DIFF
--- a/nixos/modules/services/networking/zerotierone.nix
+++ b/nixos/modules/services/networking/zerotierone.nix
@@ -58,6 +58,7 @@ in
 
     # ZeroTier does not issue DHCP leases, but some strangers might...
     networking.dhcpcd.denyInterfaces = [ "zt*" ];
+    networking.networkdUnmanagedInterfaces = mkDefault "zt*";
 
     # ZeroTier receives UDP transmissions
     networking.firewall.allowedUDPPorts = [ cfg.port ];

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -476,9 +476,9 @@ let
               # Remove Dead Interfaces
               ip link show "${n}" >/dev/null 2>&1 && ip link delete "${n}"
               ip link add link "${v.interface}" name "${n}" type vlan id "${toString v.id}"
-              
-              # We try to bring up the logical VLAN interface. If the master 
-              # interface the logical interface is dependent upon is not up yet we will 
+
+              # We try to bring up the logical VLAN interface. If the master
+              # interface the logical interface is dependent upon is not up yet we will
               # fail to immediately bring up the logical interface. The resulting logical
               # interface will brought up later when the master interface is up.
               ip link set "${n}" up || true
@@ -518,6 +518,9 @@ in
     (mkIf (!cfg.useNetworkd) normalConfig)
     { # Ensure slave interfaces are brought up
       networking.interfaces = genAttrs slaves (i: {});
+    }
+    {
+      networking.networkdUnmanagedInterfaces = concatStringsSep " " (attrNames cfg.interfaces);
     }
   ];
 }

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -80,6 +80,8 @@ in
           # - https://github.com/NixOS/nixpkgs/issues/18962
           # - https://github.com/NixOS/nixpkgs/issues/61629
           matchConfig = mkDefault { Name = "*"; };
+        } // optionalAttrs (cfg.networkdUnmanagedInterfaces != "") {
+          name = "!${cfg.networkdUnmanagedInterfaces}";
         };
       }
       (mkMerge (forEach interfaces (i: {

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -72,16 +72,20 @@ in
           };
       in mkMerge [ {
         enable = true;
-        networks."99-main" = (genericNetwork mkDefault) // {
-          # We keep the "broken" behaviour of applying this to all interfaces.
-          # In general we want to get rid of this workaround but there hasn't
-          # been any work on that.
-          # See the following issues for details:
-          # - https://github.com/NixOS/nixpkgs/issues/18962
-          # - https://github.com/NixOS/nixpkgs/issues/61629
-          matchConfig = mkDefault { Name = "*"; };
-        } // optionalAttrs (cfg.networkdUnmanagedInterfaces != "") {
-          name = "!${cfg.networkdUnmanagedInterfaces}";
+        networks = {
+         "90-unmanaged" = optionalAttrs (cfg.networkdUnmanagedInterfaces != "") {
+            matchConfig.Name = "${cfg.networkdUnmanagedInterfaces}";
+            linkConfig.Unmanaged = true;
+          };
+          "99-main" = (genericNetwork mkDefault) // {
+            # We keep the "broken" behaviour of applying this to all interfaces.
+            # In general we want to get rid of this workaround by setting the interface in
+            # networkdUnmanagedInterfaces attribute.
+            # See the following issues for details:
+            # - https://github.com/NixOS/nixpkgs/issues/18962
+            # - https://github.com/NixOS/nixpkgs/issues/61629
+            matchConfig = mkDefault { Name = "*"; };
+          };
         };
       }
       (mkMerge (forEach interfaces (i: {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -916,6 +916,14 @@ in
       '';
     };
 
+    networking.networkdUnmanagedInterfaces = mkOption {
+      default = ""; # none
+      type = types.separatedString " ";
+      description = ''
+        Whether we should not use netword to managed these interfaces.
+      '';
+    };
+
   };
 
 

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -260,5 +260,7 @@ in {
       serviceConfig.ExecStart = "@${pkgs.libvirt}/sbin/virtlockd virtlockd";
       restartIfChanged = false;
     };
+
+    networking.networkdUnmanagedInterfaces = "virbr* vnet*";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

When using networkd, some weird bugs occur (no ip address, interface down). This patch avoids networkd to manage the interfaces configured by the scripted nixos module.

@fpletz @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

