### PR TITLE
cedille bug fixes

### DIFF
--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -32,9 +32,12 @@ stdenv.mkDerivation rec {
     chmod -R 755 ial
   '';
 
+  outputs = ["out" "lib"];
+
   installPhase = ''
     mkdir -p $out/bin
     mv cedille $out/bin/cedille
+    mv lib $lib
   '';
 
   meta = {

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -1,5 +1,13 @@
 { stdenv, lib, fetchFromGitHub, alex, happy, Agda, agdaIowaStdlib,
-  buildPlatform, buildPackages, ghcWithPackages }:
+  buildPlatform, buildPackages, ghcWithPackages, fetchpatch }:
+let
+  options-patch =
+    fetchpatch {
+      url = https://github.com/cedille/cedille/commit/ee62b0fabde6c4f7299a3778868519255cc4a64f.patch;
+      name = "options.patch";
+      sha256 = "19xzn9sqpfnfqikqy1x9lb9mb6722kbgvrapl6cf8ckcw8cfj8cz";
+      };
+in
 stdenv.mkDerivation rec {
   version = "1.0.0";
   name = "cedille-${version}";
@@ -10,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "08c2vgg8i6l3ws7hd5gsj89mki36lxm7x7s8hi1qa5gllq04a832";
   };
   buildInputs = [ alex happy Agda (ghcWithPackages (ps: [ps.ieee])) ];
+
+  patches = [options-patch];
 
   LANG = "en_US.UTF-8";
   LOCALE_ARCHIVE =


### PR DESCRIPTION
###### Motivation for this change

Without these two patches then it isn't possible to use any libraries with cedille. 

cc @Infinisil 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

