### PR TITLE
weechat: add perl.withPackages

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -681,10 +681,10 @@ overrides = self: super: rec {
   </para>
 
   <para>
-   The python plugin allows the addition of extra libraries. For instance, the
-   <literal>inotify.py</literal> script in weechat-scripts requires D-Bus or
-   libnotify, and the <literal>fish.py</literal> script requires pycrypto. To
-   use these scripts, use the <literal>python</literal> plugin's
+   The python and perl plugins allows the addition of extra libraries. For
+   instance, the <literal>inotify.py</literal> script in weechat-scripts
+   requires D-Bus or libnotify, and the <literal>fish.py</literal> script
+   requires pycrypto. To use these scripts, use the plugin's
    <literal>withPackages</literal> attribute:
 <programlisting>weechat.override { configure = {availablePlugins, ...}: {
     plugins = with availablePlugins; [

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -6,7 +6,7 @@
 , asciidoctor # manpages
 , guileSupport ? true, guile
 , luaSupport ? true, lua5
-, perlSupport ? true, perl
+, perlSupport ? true, perl, perlPackages
 , pythonSupport ? true, pythonPackages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
@@ -108,6 +108,12 @@ in if configure == null then weechat else
           extraEnv = ''
             export PATH="${perlInterpreter}/bin:$PATH"
           '';
+          withPackages = pkgsFun: (perl // {
+            extraEnv = ''
+              ${perl.extraEnv}
+              export PERL5LIB=${lib.makeFullPerlPath (pkgsFun perlPackages)}
+            '';
+          });
         };
         tcl = simplePlugin "tcl";
         ruby = simplePlugin "ruby";


### PR DESCRIPTION
Allows for adding Perl libraries in the same way as for Python. Doesn't really need to be a function, since there's only one perlPackages in nixpkgs, but I went for consistency with the python plugin.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---