### PR TITLE
pythonPackages.sievelib: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/sievelib/default.nix
+++ b/pkgs/development/python-modules/sievelib/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, mock
+, future, six, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "sievelib";
+  version = "1.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sl1fnwr5jdacrrnq2rvzh4vv1dyxd3x31vnqga36gj8h546h7mz";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/tonioo/sievelib/commit/1deef0e2bf039a0e817ea6f19aaf1947dc9fafbc.patch";
+      sha256 = "0vaj73mcij9dism8vfaai82irh8j1b2n8gf9jl1a19d2l26jrflk";
+    })
+  ];
+
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ future six ];
+  checkInputs = [ mock ];
+
+  meta = {
+    description = "Client-side Sieve and Managesieve library written in Python";
+    homepage    = https://github.com/tonioo/sievelib;
+    license     = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ leenaars ];
+    longDescription = ''
+      A library written in Python that implements RFC 5228 (Sieve: An Email
+      Filtering Language) and RFC 5804 (ManageSieve: A Protocol for
+      Remotely Managing Sieve Scripts), as well as the following extensions:
+
+       * Copying Without Side Effects (RFC 3894)
+       * Body (RFC 5173)
+       * Date and Index (RFC 5260)
+       * Vacation (RFC 5230)
+       * Imap4flags (RFC 5232)
+'';
+  };
+}

--- a/pkgs/development/python-modules/sievelib/default.nix
+++ b/pkgs/development/python-modules/sievelib/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
        * Date and Index (RFC 5260)
        * Vacation (RFC 5230)
        * Imap4flags (RFC 5232)
-'';
+    '';
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2001,6 +2001,8 @@ in {
 
   setuptools-git = callPackage ../development/python-modules/setuptools-git { };
 
+  sievelib = callPackage ../development/python-modules/sievelib { };
+
   watchdog = callPackage ../development/python-modules/watchdog { };
 
   zope_deprecation = callPackage ../development/python-modules/zope_deprecation { };


### PR DESCRIPTION
###### Motivation for this change

Useful library that implements various RFC's.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

