### PR TITLE
lxd: 3.0.0 -> 3.0.2

### DIFF
--- a/pkgs/development/libraries/dqlite/default.nix
+++ b/pkgs/development/libraries/dqlite/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libuv, sqlite-replication }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "dqlite-${version}";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "CanonicalLtd";
+    repo = "dqlite";
+    rev = "v${version}";
+    sha256 = "03dikhjppraagyvjx4zbp7f5jfg74jivighxkwrbzrcy0g8pmcvd";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ libuv sqlite-replication ];
+
+  meta = {
+    description = "Expose a SQLite database over the network and replicate it across a cluster of peers";
+    homepage = https://github.com/CanonicalLtd/dqlite/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ joko ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -1,16 +1,17 @@
 { stdenv, pkgconfig, lxc, buildGoPackage, fetchurl
 , makeWrapper, acl, rsync, gnutar, xz, btrfs-progs, gzip, dnsmasq
-, squashfsTools, iproute, iptables, ebtables
+, squashfsTools, iproute, iptables, ebtables, libcap, dqlite
+, sqlite-replication
 }:
 
 buildGoPackage rec {
-  name = "lxd-3.0.0";
+  name = "lxd-3.0.2";
 
   goPackagePath = "github.com/lxc/lxd";
 
   src = fetchurl {
     url = "https://github.com/lxc/lxd/releases/download/${name}/${name}.tar.gz";
-    sha256 = "0m5prdf9sk8k5bws1zva4n9ycggmy76wnjr6wb423066pszz24ww";
+    sha256 = "1ha8ijzblf15p0kcpgwshswz6s2rdd2b4qnzjw3l72ww620hr84j";
   };
 
   preBuild = ''
@@ -22,6 +23,8 @@ buildGoPackage rec {
     popd
   '';
 
+  buildFlags = [ "-tags libsqlite3" ];
+
   postInstall = ''
     # binaries from test/
     rm $bin/bin/{deps,macaroon-identity}
@@ -32,7 +35,7 @@ buildGoPackage rec {
   '';
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
-  buildInputs = [ lxc acl ];
+  buildInputs = [ lxc acl libcap dqlite sqlite-replication ];
 
   meta = with stdenv.lib; {
     description = "Daemon based on liblxc offering a REST API to manage containers";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12308,6 +12308,27 @@ with pkgs;
 
   sqlite-jdbc = callPackage ../servers/sql/sqlite/jdbc { };
 
+  sqlite-replication = sqlite.overrideAttrs (oldAttrs: rec {
+    name = "sqlite-${version}";
+    version = "3.24.0+replication3";
+    src = pkgs.fetchFromGitHub {
+      owner = "CanonicalLtd";
+      repo = "sqlite";
+      rev = "version-${version}";
+      sha256 = "19557b7aick1pxk0gw013cf5jy42i7539qn1ziza8dzy16a6zs8b";
+    };
+    nativeBuildInputs = [ pkgs.tcl ];
+    configureFlags = oldAttrs.configureFlags ++ [
+      "--enable-replication"
+      "--disable-amalgamation"
+      "--disable-tcl"
+    ];
+    preConfigure = ''
+      echo "D 2018-08-01T13:22:18" > manifest
+      echo -n "c94dbda1a570c1ab180e7694afd3cc7116268c06" > manifest.uuid
+    '';
+  });
+
   sqlcipher = lowPrio (callPackage ../development/libraries/sqlcipher {
     readline = null;
     ncurses = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12329,6 +12329,8 @@ with pkgs;
     '';
   });
 
+  dqlite = callPackage ../development/libraries/dqlite { };
+
   sqlcipher = lowPrio (callPackage ../development/libraries/sqlcipher {
     readline = null;
     ncurses = null;


### PR DESCRIPTION
###### Motivation for this change

LXD versions 3.0.1 and 3.0.2 offer several bugfixes. The last version introduced a dependency with a distributed sqlite3 implementation, so this is also packaged.

I have tested the new version with the respective service on nixos-unstable. As soon as this gets merged, I will create a backport for 18.09. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

