### PR TITLE
ocamlformat: init at 0.8

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, dune }:
+
+with ocamlPackages;
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.05"
+then throw "ocamlformat is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.8";
+  pname = "ocamlformat";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = pname;
+    rev = version;
+    sha256 = "1i7rsbs00p43362yv7z7dw0qsnv7vjf630qk676qvfg7kg422w6j";
+  };
+
+  buildInputs = [
+    ocaml
+    dune
+    findlib
+    base
+    cmdliner
+    fpath
+    ocaml-migrate-parsetree
+    stdio
+  ];
+
+  configurePhase = ''
+    patchShebangs tools/gen_version.sh
+    tools/gen_version.sh src/Version.ml version
+  '';
+
+  buildPhase = ''
+    dune build -p ocamlformat
+  '';
+
+  inherit (dune) installPhase;
+
+  meta = {
+    homepage = "https://github.com/ocaml-ppx/ocamlformat";
+    description = "Auto-formatter for OCaml code";
+    maintainers = [ stdenv.lib.maintainers.Zimmi48 ];
+    license = stdenv.lib.licenses.mit;
+    inherit (ocamlPackages.ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7261,6 +7261,8 @@ with pkgs;
 
   ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;
 
+  ocamlformat = callPackage ../development/tools/ocaml/ocamlformat { };
+
   orc = callPackage ../development/compilers/orc { };
 
   metaocaml_3_09 = callPackage ../development/compilers/ocaml/metaocaml-3.09.nix { };
@@ -18597,7 +18599,7 @@ with pkgs;
   rclone = callPackage ../applications/networking/sync/rclone { };
 
   rclone-browser = libsForQt5.callPackage ../applications/networking/sync/rclone/browser.nix { };
-  
+
   rcs = callPackage ../applications/version-management/rcs { };
 
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };


### PR DESCRIPTION
###### Motivation for this change

Add `ocamlformat` (supported by Dune 1.4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested the result with `dune build @fmt` but not with Emacs because I'm not quite sure how to configure Emacs to use ocamlformat.