### PR TITLE
 pythonPackages.cypari2: 1.2.1 -> 1.3.1

### DIFF
--- a/pkgs/applications/science/math/sage/patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
+++ b/pkgs/applications/science/math/sage/patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
@@ -1,14 +1,14 @@
-From c8edfefbbec87ca776d3cf84ee895aac200dda40 Mon Sep 17 00:00:00 2001
+From 8218bd4fdeb4c92de8af0d3aabec55980fc4fb3d Mon Sep 17 00:00:00 2001
 From: Timo Kaufmann <timokau@zoho.com>
 Date: Sun, 21 Oct 2018 17:52:40 +0200
 Subject: [PATCH] Only test py2/py3 optional tests when all of sage is tested
 
 ---
- src/sage/doctest/control.py | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ src/sage/doctest/control.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/src/sage/doctest/control.py b/src/sage/doctest/control.py
-index bf18df8b2b..b04af0e2e8 100644
+index bf18df8b2b..935c67abf7 100644
 --- a/src/sage/doctest/control.py
 +++ b/src/sage/doctest/control.py
 @@ -362,7 +362,8 @@ class DocTestController(SageObject):
@@ -20,6 +20,15 @@ index bf18df8b2b..b04af0e2e8 100644
 +                    options.optional |= auto_optional_tags
  
          self.options = options
+ 
+@@ -765,7 +766,7 @@ class DocTestController(SageObject):
+             sage: DC = DocTestController(DD, [dirname])
+             sage: DC.expand_files_into_sources()
+             sage: sorted(DC.sources[0].options.optional)  # abs tol 1
+-            ['guava', 'magma', 'py2']
++            ['guava', 'magma']
+ 
+         We check that files are skipped appropriately::
  
 -- 
 2.18.1

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -11,11 +11,12 @@
 
 buildPythonPackage rec {
   pname = "cypari2";
-  version = "1.2.1";
+  # upgrade may break sage, please test the sage build or ping @timokau on upgrade
+  version = "1.3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0v2kikwf0advq8j76nwzhlacwj1yys9cvajm4fqgmasjdsnf1q4k";
+    sha256 = "04f00xp8aaz37v00iqg1mv5wjq00a5qhk8cqa93s13009s9x984r";
   };
 
   # This differs slightly from the default python installPhase in that it pip-installs


### PR DESCRIPTION
###### Motivation for this change

The sage fix is unrelated, I just noticed the error here and needed to fix it in order to test the cypari upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

