### PR TITLE
sway-beta: init at 1.0-beta1

### DIFF
--- a/pkgs/applications/window-managers/sway/beta.nix
+++ b/pkgs/applications/window-managers/sway/beta.nix
@@ -1,40 +1,43 @@
 { stdenv, fetchFromGitHub
-, cmake, pkgconfig, asciidoc, libxslt, docbook_xsl
+, meson, ninja
+, pkgconfig, asciidoc, libxslt, docbook_xsl
 , wayland, wlc, libxkbcommon, pcre, json_c, dbus
 , pango, cairo, libinput, libcap, pam, gdk_pixbuf, libpthreadstubs
-, libXdmcp
+, libXdmcp, wlroots, wayland-protocols
 , buildDocs ? true
 }:
 
 stdenv.mkDerivation rec {
-  name = "sway-${version}";
-  version = "0.15.2";
+  name = "${pname}-${version}";
+  pname = "sway-beta";
+  version = "1.0-beta.1";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "1p9j5gv85lsgj4z28qja07dqyvqk41w6mlaflvvm9yxafx477g5n";
+    sha256 = "0h9kgrg9mh2acks63z72bw3lwff32pf2nb4i7i5xhd9i6l4gfnqa";
   };
 
   nativeBuildInputs = [
-    cmake pkgconfig
+    pkgconfig meson ninja
   ] ++ stdenv.lib.optional buildDocs [ asciidoc libxslt docbook_xsl ];
+
   buildInputs = [
     wayland wlc libxkbcommon pcre json_c dbus
     pango cairo libinput libcap pam gdk_pixbuf libpthreadstubs
-    libXdmcp
+    libXdmcp wlroots wayland-protocols
   ];
 
   enableParallelBuilding = true;
 
-  cmakeFlags = "-DVERSION=${version} -DLD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib";
+  mesonFlags = "-Dsway-version=${version}";
 
   meta = with stdenv.lib; {
     description = "i3-compatible window manager for Wayland";
     homepage    = http://swaywm.org;
     license     = licenses.mit;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ primeos ]; # Trying to keep it up-to-date.
+    maintainers = with maintainers; [ primeos synthetica ]; # Trying to keep it up-to-date.
   };
 }

--- a/pkgs/applications/window-managers/sway/beta.nix
+++ b/pkgs/applications/window-managers/sway/beta.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  pname = "sway-beta";
+  pname = "sway";
   version = "1.0-beta.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/window-managers/sway/beta.nix
+++ b/pkgs/applications/window-managers/sway/beta.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "i3-compatible window manager for Wayland";
-    homepage    = http://swaywm.org;
+    homepage    = https://swaywm.org;
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ primeos synthetica ]; # Trying to keep it up-to-date.

--- a/pkgs/applications/window-managers/sway/beta.nix
+++ b/pkgs/applications/window-managers/sway/beta.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub
 , meson, ninja
-, pkgconfig, asciidoc, libxslt, docbook_xsl
-, wayland, wlc, libxkbcommon, pcre, json_c, dbus
-, pango, cairo, libinput, libcap, pam, gdk_pixbuf, libpthreadstubs
-, libXdmcp, wlroots, wayland-protocols
+, pkgconfig, scdoc
+, wayland, libxkbcommon, pcre, json_c, dbus
+, pango, cairo, libinput, libcap, pam, gdk_pixbuf
+, wlroots, wayland-protocols
 , buildDocs ? true
 }:
 
@@ -21,12 +21,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig meson ninja
-  ] ++ stdenv.lib.optional buildDocs [ asciidoc libxslt docbook_xsl ];
+  ] ++ stdenv.lib.optional buildDocs scdoc;
 
   buildInputs = [
-    wayland wlc libxkbcommon pcre json_c dbus
-    pango cairo libinput libcap pam gdk_pixbuf libpthreadstubs
-    libXdmcp wlroots wayland-protocols
+    wayland libxkbcommon pcre json_c dbus
+    pango cairo libinput libcap pam gdk_pixbuf
+    wlroots wayland-protocols
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "i3-compatible window manager for Wayland";
-    homepage    = http://swaywm.org;
+    homepage    = https://swaywm.org;
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ primeos ]; # Trying to keep it up-to-date.

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -4,7 +4,7 @@
 , pkgconfig, asciidoc, libxslt, docbook_xsl
 , wayland, wlc, libxkbcommon, pcre, json_c, dbus
 , pango, cairo, libinput, libcap, pam, gdk_pixbuf, libpthreadstubs
-, libXdmcp, wlroots, wayland-protocols, git
+, libXdmcp, wlroots, wayland-protocols
 , buildDocs ? true
 }:
 
@@ -50,6 +50,7 @@ let
     enableParallelBuilding = true;
 
     cmakeFlags = "-DVERSION=${version} -DLD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:";
+    mesonFlags = "-Dsway-version=${version}";
 
     meta = with stdenv.lib; {
       description = "i3-compatible window manager for Wayland";

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -37,14 +37,14 @@ let
       pkgconfig
     ] ++ stdenv.lib.optional buildDocs [ asciidoc libxslt docbook_xsl
     ] ++ stdenv.lib.optional cmakeBuild [ cmake
-    ] ++ stdenv.lib.optional mesonBuild [ meson ninja
+    ] ++ stdenv.lib.optional mesonBuild [ meson ninja git
     ];
 
 
     buildInputs = [
       wayland wlc libxkbcommon pcre json_c dbus
       pango cairo libinput libcap pam gdk_pixbuf libpthreadstubs
-      libXdmcp wlroots wayland-protocols git
+      libXdmcp wlroots wayland-protocols
     ];
 
     enableParallelBuilding = true;

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,40 +1,62 @@
 { stdenv, fetchFromGitHub
-, cmake, pkgconfig, asciidoc, libxslt, docbook_xsl
+, cmake
+, meson, ninja
+, pkgconfig, asciidoc, libxslt, docbook_xsl
 , wayland, wlc, libxkbcommon, pcre, json_c, dbus
 , pango, cairo, libinput, libcap, pam, gdk_pixbuf, libpthreadstubs
-, libXdmcp
+, libXdmcp, wlroots, wayland-protocols, git
 , buildDocs ? true
 }:
 
-stdenv.mkDerivation rec {
-  name = "sway-${version}";
-  version = "0.15.2";
+let
+  versions = {
+    sway = {
+      version = "0.15.2";
+      sha256 = "1p9j5gv85lsgj4z28qja07dqyvqk41w6mlaflvvm9yxafx477g5n";
+      cmakeBuild = true;
+    };
 
-  src = fetchFromGitHub {
-    owner = "swaywm";
-    repo = "sway";
-    rev = version;
-    sha256 = "1p9j5gv85lsgj4z28qja07dqyvqk41w6mlaflvvm9yxafx477g5n";
+    sway-beta = {
+      version = "1.0-beta.1";
+      sha256 = "0h9kgrg9mh2acks63z72bw3lwff32pf2nb4i7i5xhd9i6l4gfnqa";
+      mesonBuild = true;
+    };
   };
 
-  nativeBuildInputs = [
-    cmake pkgconfig
-  ] ++ stdenv.lib.optional buildDocs [ asciidoc libxslt docbook_xsl ];
-  buildInputs = [
-    wayland wlc libxkbcommon pcre json_c dbus
-    pango cairo libinput libcap pam gdk_pixbuf libpthreadstubs
-    libXdmcp
-  ];
+  common = pname: {version, sha256, cmakeBuild ? false, mesonBuild ? false}: stdenv.mkDerivation rec {
+    name = "${pname}-${version}";
 
-  enableParallelBuilding = true;
+    src = fetchFromGitHub {
+      owner = "swaywm";
+      repo = "sway";
+      rev = version;
+      inherit sha256;
+    };
 
-  cmakeFlags = "-DVERSION=${version} -DLD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib";
+    nativeBuildInputs = [
+      pkgconfig
+    ] ++ stdenv.lib.optional buildDocs [ asciidoc libxslt docbook_xsl
+    ] ++ stdenv.lib.optional cmakeBuild [ cmake
+    ] ++ stdenv.lib.optional mesonBuild [ meson ninja
+    ];
 
-  meta = with stdenv.lib; {
-    description = "i3-compatible window manager for Wayland";
-    homepage    = http://swaywm.org;
-    license     = licenses.mit;
-    platforms   = platforms.linux;
-    maintainers = with maintainers; [ primeos ]; # Trying to keep it up-to-date.
+
+    buildInputs = [
+      wayland wlc libxkbcommon pcre json_c dbus
+      pango cairo libinput libcap pam gdk_pixbuf libpthreadstubs
+      libXdmcp wlroots wayland-protocols git
+    ];
+
+    enableParallelBuilding = true;
+
+    cmakeFlags = "-DVERSION=${version} -DLD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib:";
+
+    meta = with stdenv.lib; {
+      description = "i3-compatible window manager for Wayland";
+      homepage    = http://swaywm.org;
+      license     = licenses.mit;
+      platforms   = platforms.linux;
+      maintainers = with maintainers; [ primeos ]; # Trying to keep it up-to-date.
+    };
   };
-}
+in stdenv.lib.mapAttrs common versions

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17190,9 +17190,9 @@ with pkgs;
   wlroots = callPackage ../development/libraries/wlroots { };
   rootston = wlroots.bin;
   orbment = callPackage ../applications/window-managers/orbment { };
-  swayPkgs = callPackage ../applications/window-managers/sway { };
 
-  inherit (swayPkgs) sway sway-beta;
+  sway = callPackage ../applications/window-managers/sway { };
+  sway-beta = callPackage ../applications/window-managers/sway/beta.nix { };
 
   velox = callPackage ../applications/window-managers/velox {
     stConf = config.st.conf or null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17190,7 +17190,9 @@ with pkgs;
   wlroots = callPackage ../development/libraries/wlroots { };
   rootston = wlroots.bin;
   orbment = callPackage ../applications/window-managers/orbment { };
-  sway = callPackage ../applications/window-managers/sway { };
+  swayPkgs = callPackage ../applications/window-managers/sway { };
+
+  inherit (swayPkgs) sway sway-beta;
 
   velox = callPackage ../applications/window-managers/velox {
     stConf = config.st.conf or null;


### PR DESCRIPTION
###### Motivation for this change
~~Based on the meson and systemd update from https://github.com/NixOS/nixpkgs/pull/46020, reccomend merging that first.~~ Not anymore, due to f4615bef063265001f47ee7e8e351aa1708f773a

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

