### PR TITLE
gocode: 2018-07-27 -> 2018-10-22

### DIFF
--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -1,9 +1,9 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "gocode-${version}";
-  version = "20180727-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "00e7f5ac290aeb20a3d8d31e737ae560a191a1d5";
+  name = "gocode-unstable-${version}";
+  version = "2018-10-22";
+  rev = "e893215113e5f7594faa3a8eb176c2700c921276";
 
   goPackagePath = "github.com/mdempsky/gocode";
 
@@ -13,11 +13,14 @@ buildGoPackage rec {
   allowGoReference = true;
 
   src = fetchFromGitHub {
+    inherit rev;
+
     owner = "mdempsky";
     repo = "gocode";
-    inherit rev;
-    sha256 = "0vrwjq4r90za47hm88yx5h2mvkv7y4yaj2xbx3skg62wq2drsq31";
+    sha256 = "1zsll7yghv64890k7skl0g2lg9rsaiisgrfnb8kshsxrcxi1kc2l";
   };
+
+  goDeps = ./deps.nix;
 
   preBuild = ''
     # getting an error building the testdata because they contain invalid files

--- a/pkgs/development/tools/gocode/deps.nix
+++ b/pkgs/development/tools/gocode/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "6fe81c087942f588f40c3f67b41ce284f2f70eee";
+      sha256 = "04yl7rk2lf94bxz74ja5snh7ava9gcnf2yx6y002pfkk538r6w5d";
+    };
+  }
+]


### PR DESCRIPTION
github.com/nsf/gocode has also been deprecated in favor of github.com/mdempsky/gocode

Please backport this to 18.09 because I could not use the deoplete-go vim plugin with the current version of gocode as it panics on Go 1.11.

###### Motivation for this change

Fix deoplete-go vim plugin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

