### PR TITLE
pythonPackages.bitarray: init at 0.8.3

### DIFF
--- a/pkgs/development/python-modules/bitarray/0001-Buffer-Protocol-Py3.patch
+++ b/pkgs/development/python-modules/bitarray/0001-Buffer-Protocol-Py3.patch
@@ -1,0 +1,106 @@
+From c636f0cc386c9ded9f31947bbd74affccc93c21a Mon Sep 17 00:00:00 2001
+From: yoch <yoch.melka@gmail.com>
+Date: Mon, 14 May 2018 21:55:00 +0300
+Subject: [PATCH] Adding buffer protocol support for Python 3
+
+---
+ bitarray/_bitarray.c      | 12 ++++++++++--
+ bitarray/test_bitarray.py | 14 +++++++-------
+ 2 files changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/bitarray/_bitarray.c b/bitarray/_bitarray.c
+index d2c19cb..be6b379 100644
+--- a/bitarray/_bitarray.c
++++ b/bitarray/_bitarray.c
+@@ -48,7 +48,7 @@ int PyIndex_Check(PyObject *o)
+ #define Py_SIZE(ob)   (((PyVarObject *) (ob))->ob_size)
+ #endif
+ 
+-#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
++#if PY_MAJOR_VERSION == 3 || (PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7)
+ /* (new) buffer protocol */
+ #define WITH_BUFFER
+ #endif
+@@ -2787,6 +2787,8 @@ static PyTypeObject BitarrayIter_Type = {
+ 
+ /********************* Bitarray Buffer Interface ************************/
+ #ifdef WITH_BUFFER
++
++#if PY_MAJOR_VERSION == 2
+ static Py_ssize_t
+ bitarray_buffer_getreadbuf(bitarrayobject *self,
+                            Py_ssize_t index, const void **ptr)
+@@ -2831,6 +2833,8 @@ bitarray_buffer_getcharbuf(bitarrayobject *self,
+     return Py_SIZE(self);
+ }
+ 
++#endif
++
+ static int
+ bitarray_getbuffer(bitarrayobject *self, Py_buffer *view, int flags)
+ {
+@@ -2857,14 +2861,18 @@ bitarray_releasebuffer(bitarrayobject *self, Py_buffer *view)
+ }
+ 
+ static PyBufferProcs bitarray_as_buffer = {
++#if PY_MAJOR_VERSION == 2   // old buffer protocol
+     (readbufferproc) bitarray_buffer_getreadbuf,
+     (writebufferproc) bitarray_buffer_getwritebuf,
+     (segcountproc) bitarray_buffer_getsegcount,
+     (charbufferproc) bitarray_buffer_getcharbuf,
++#endif
+     (getbufferproc) bitarray_getbuffer,
+     (releasebufferproc) bitarray_releasebuffer,
+ };
++
+ #endif  /* WITH_BUFFER */
++
+ /************************** Bitarray Type *******************************/
+ 
+ static PyTypeObject Bitarraytype = {
+@@ -2898,7 +2906,7 @@ static PyTypeObject Bitarraytype = {
+     0,                                        /* tp_as_buffer */
+ #endif
+     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_WEAKREFS
+-#ifdef WITH_BUFFER
++#if defined(WITH_BUFFER) && PY_MAJOR_VERSION == 2
+     | Py_TPFLAGS_HAVE_NEWBUFFER
+ #endif
+     ,                                         /* tp_flags */
+diff --git a/bitarray/test_bitarray.py b/bitarray/test_bitarray.py
+index 44de2f0..b72b554 100644
+--- a/bitarray/test_bitarray.py
++++ b/bitarray/test_bitarray.py
+@@ -2113,10 +2113,10 @@ def test_read1(self):
+         a = bitarray('01000001' '01000010' '01000011', endian='big')
+         v = memoryview(a)
+         self.assertEqual(len(v), 3)
+-        self.assertEqual(v[0], 'A')
+-        self.assertEqual(v[:].tobytes(), 'ABC')
++        #self.assertEqual(v[0], 'A')
++        self.assertEqual(v[:].tobytes(), b'ABC')
+         a[13] = 1
+-        self.assertEqual(v[:].tobytes(), 'AFC')
++        self.assertEqual(v[:].tobytes(), b'AFC')
+ 
+     def test_read2(self):
+         a = bitarray([randint(0, 1) for d in range(8000)])
+@@ -2131,14 +2131,14 @@ def test_write(self):
+         a.setall(0)
+         v = memoryview(a)
+         self.assertFalse(v.readonly)
+-        v[50000] = '\xff'
++        v[50000] = 255 if is_py3k else '\xff'
+         self.assertEqual(a[399999:400009], bitarray('0111111110'))
+         a[400003] = 0
+         self.assertEqual(a[399999:400009], bitarray('0111011110'))
+-        v[30001:30004] = 'ABC'
+-        self.assertEqual(a[240000:240040].tobytes(), '\x00ABC\x00')
++        v[30001:30004] = b'ABC'
++        self.assertEqual(a[240000:240040].tobytes(), b'\x00ABC\x00')
+ 
+-if sys.version_info[:2] == (2, 7):
++if sys.version_info[:2] >= (2, 7):
+     tests.append(BufferInterfaceTests)
+ 
+ # ---------------------------------------------------------------------------

--- a/pkgs/development/python-modules/bitarray/default.nix
+++ b/pkgs/development/python-modules/bitarray/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "0.8.3";
+  pname = "bitarray";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pl9p4j3dhlyffsqra6h28q7jph6v3hgppg786lkmnqdh45x6305";
+  };
+
+  # Delete once https://github.com/ilanschnell/bitarray/pull/55 is merged
+  patches = [ ./0001-Buffer-Protocol-Py3.patch ];
+
+  meta = with lib; {
+    description = "Efficient arrays of booleans";
+    homepage = https://github.com/ilanschnell/bitarray;
+    license = licenses.psfl;
+    maintainers = [ maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -250,6 +250,8 @@ in {
 
   bayespy = callPackage ../development/python-modules/bayespy { };
 
+  bitarray = callPackage ../development/python-modules/bitarray { };
+
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };
 
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

