### PR TITLE
rng-tools: 5 -> 6.6, jitterentropy: init at 2.1.2

### DIFF
--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -30,7 +30,7 @@ with lib;
 
       description = "Hardware RNG Entropy Gatherer Daemon";
 
-      serviceConfig.ExecStart = "${pkgs.rng_tools}/sbin/rngd -f -v" +
+      serviceConfig.ExecStart = "${pkgs.rng-tools}/sbin/rngd -f -v" +
         (if config.services.tcsd.enable then " --no-tpm=1" else "");
     };
   };

--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "jitterentropy-${version}";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "jitterentropy-library";
+    rev = "v${version}";
+    sha256 = "10yl1hi0hysr53wzy2i8brs0qqnxh46mz3dcjh5mk0ad03wvbfsl";
+  };
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    mkdir -p $out/include
+  '';
+
+  installFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    description = "Provides a noise source using the CPU execution timing jitter";
+    homepage = https://github.com/smuellerDD/jitterentropy-library;
+    license = with stdenv.lib.licenses; [ gpl2 bsd3 ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ johnazoidberg ];
+  };
+}

--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -5,6 +5,9 @@
 , curl ? null, libxml2 ? null, openssl ? null, withNistBeacon ? false
   # Systems that support RDRAND but not AES-NI require libgcrypt to use RDRAND as an entropy source
 , libgcrypt ? null, withGcrypt ? true
+  # Not sure if jitterentropy is safe to use for cryptography
+  # and thus a default entropy source
+, jitterentropy ? null, withJitterEntropy ? false
 }:
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -23,11 +26,12 @@ stdenv.mkDerivation rec {
   preConfigure = "./autogen.sh";
 
   configureFlags =
-       [ "--disable-jitterentropy" ]
+       optional (!withJitterEntropy) "--disable-jitterentropy"
     ++ optional (!withNistBeacon) "--without-nistbeacon"
     ++ optional (!withGcrypt) "--without-libgcrypt";
 
   buildInputs = [ sysfsutils ]
+    ++ optional withJitterEntropy [ jitterentropy ]
     ++ optional withGcrypt [ libgcrypt.dev ]
     ++ optional withNistBeacon [ openssl.dev curl.dev libxml2.dev ];
 

--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -1,24 +1,46 @@
-{ stdenv, fetchurl }:
-
+{ stdenv, fetchFromGitHub, libtool, autoconf, automake, pkgconfig
+, sysfsutils
+  # WARNING: DO NOT USE BEACON GENERATED VALUES AS SECRET CRYPTOGRAPHIC KEYS
+  # https://www.nist.gov/programs-projects/nist-randomness-beacon
+, curl ? null, libxml2 ? null, openssl ? null, withNistBeacon ? false
+  # Systems that support RDRAND but not AES-NI require libgcrypt to use RDRAND as an entropy source
+, libgcrypt ? null, withGcrypt ? true
+}:
+with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "rng-tools-5";
+  name = "rng-tools-${version}";
+  version = "6.6";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/gkernel/${name}.tar.gz";
-
-    sha256 = "13h7lc8wl9khhvkr0i3bl5j9bapf8anhqis1lcnwxg1vc2v058b0";
+  src = fetchFromGitHub {
+    owner = "nhorman";
+    repo = "rng-tools";
+    rev = "v${version}";
+    sha256 = "0c32sxfvngdjzfmxn5ngc5yxwi8ij3yl216nhzyz9r31qi3m14v7";
   };
+
+  nativeBuildInputs = [ libtool autoconf automake pkgconfig ];
+
+  preConfigure = "./autogen.sh";
+
+  configureFlags =
+       [ "--disable-jitterentropy" ]
+    ++ optional (!withNistBeacon) "--without-nistbeacon"
+    ++ optional (!withGcrypt) "--without-libgcrypt";
+
+  buildInputs = [ sysfsutils ]
+    ++ optional withGcrypt [ libgcrypt.dev ]
+    ++ optional withNistBeacon [ openssl.dev curl.dev libxml2.dev ];
+
+  enableParallelBuilding = true;
 
   # For cross-compilation
   makeFlags = [ "AR:=$(AR)" ];
 
   meta = {
     description = "A random number generator daemon";
-
-    homepage = https://sourceforge.net/projects/gkernel;
-
-    license = stdenv.lib.licenses.gpl2;
-
+    homepage = https://github.com/nhorman/rng-tools;
+    license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ johnazoidberg ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -234,6 +234,7 @@ mapAliases ({
   qwt6 = libsForQt5.qwt;  # added 2015-12-19
   rdiff_backup = rdiff-backup;  # added 2014-11-23
   rdmd = dtools;  # added 2017-08-19
+  rng_tools = rng-tools; # added 2018-10-24
   robomongo = robo3t; #added 2017-09-28
   rssglx = rss-glx; #added 2015-03-25
   ruby_2_0_0 = throw "deprecated 2018-0213: use a newer version of ruby";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5085,7 +5085,7 @@ with pkgs;
     inherit (pythonPackages) sphinx;
   };
 
-  rng_tools = callPackage ../tools/security/rng-tools { };
+  rng-tools = callPackage ../tools/security/rng-tools { };
 
   rnv = callPackage ../tools/text/xml/rnv { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3459,6 +3459,8 @@ with pkgs;
 
   jira-cli = callPackage ../development/tools/jira_cli { };
 
+  jitterentropy = callPackage ../development/libraries/jitterentropy { };
+
   jl = haskellPackages.callPackage ../development/tools/jl { };
 
   jmespath = callPackage ../development/tools/jmespath { };


### PR DESCRIPTION
###### Motivation for this change
New version :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

