### PR TITLE
gxplugins-lv2: init at 0.5

### DIFF
--- a/pkgs/applications/audio/gxplugins-lv2/default.nix
+++ b/pkgs/applications/audio/gxplugins-lv2/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, xorg, xproto, cairo, lv2, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "GxPlugins.lv2";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "16r5bj7w726d9327flg530fn0bli4crkxjss7i56yhb1bsi39mbv";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    xorg.libX11 xproto cairo lv2
+  ];
+
+  installFlags = [ "INSTALL_DIR=$(out)/lib/lv2" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/brummer10/GxPlugins.lv2;
+    description = "A set of extra lv2 plugins from the guitarix project";
+    maintainers = [ maintainers.magnetophon ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17103,6 +17103,8 @@ with pkgs;
 
   gxmessage = callPackage ../applications/misc/gxmessage { };
 
+  gxplugins-lv2 = callPackage ../applications/audio/gxplugins-lv2 { };
+
   hackrf = callPackage ../applications/misc/hackrf { };
 
   hakuneko = callPackage ../tools/misc/hakuneko { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

