### PR TITLE
Update android sdk, add license config option and selectable build tools

### DIFF
--- a/pkgs/development/mobile/androidenv/addon.xml
+++ b/pkgs/development/mobile/androidenv/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-addon xmlns:sdk="http://schemas.android.com/sdk/android/addon/7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2017-09-08 08:19:28.153828 with ADRT.-->
+	<!--Generated on 2018-09-27 12:07:52.862255 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -35,7 +35,7 @@ This is the Android Software Development Kit License Agreement
 
 3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
+3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK.
 
 3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement.
 
@@ -587,7 +587,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:49 2016.-->
+				<!--Built on: Sat May 19 22:41:19 2018.-->
 				<sdk:size>34908058</sdk:size>
 				<sdk:checksum type="sha1">1f92abf3a76be66ae8032257fc7620acbd2b2e3a</sdk:checksum>
 				<sdk:url>google_apis-3-r03.zip</sdk:url>
@@ -614,7 +614,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:49 2016.-->
+				<!--Built on: Sun Jun  3 14:03:04 2018.-->
 				<sdk:size>42435735</sdk:size>
 				<sdk:checksum type="sha1">9b6e86d8568558de4d606a7debc4f6049608dbd0</sdk:checksum>
 				<sdk:url>google_apis-4_r02.zip</sdk:url>
@@ -641,7 +641,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:51 2016.-->
+				<!--Built on: Tue Jun  5 17:50:33 2018.-->
 				<sdk:size>49123776</sdk:size>
 				<sdk:checksum type="sha1">46eaeb56b645ee7ffa24ede8fa17f3df70db0503</sdk:checksum>
 				<sdk:url>google_apis-5_r01.zip</sdk:url>
@@ -668,7 +668,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:51 2016.-->
+				<!--Built on: Sun Jun 10 12:37:49 2018.-->
 				<sdk:size>53382941</sdk:size>
 				<sdk:checksum type="sha1">5ff545d96e031e09580a6cf55713015c7d4936b2</sdk:checksum>
 				<sdk:url>google_apis-6_r01.zip</sdk:url>
@@ -695,7 +695,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:52 2016.-->
+				<!--Built on: Wed May 30 22:32:20 2018.-->
 				<sdk:size>53691339</sdk:size>
 				<sdk:checksum type="sha1">2e7f91e0fe34fef7f58aeced973c6ae52361b5ac</sdk:checksum>
 				<sdk:url>google_apis-7_r01.zip</sdk:url>
@@ -722,7 +722,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:52 2016.-->
+				<!--Built on: Mon Jun 11 03:39:55 2018.-->
 				<sdk:size>59505020</sdk:size>
 				<sdk:checksum type="sha1">3079958e7ec87222cac1e6b27bc471b27bf2c352</sdk:checksum>
 				<sdk:url>google_apis-8_r02.zip</sdk:url>
@@ -749,7 +749,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:50 2016.-->
+				<!--Built on: Wed May 23 15:52:14 2018.-->
 				<sdk:size>63401546</sdk:size>
 				<sdk:checksum type="sha1">78664645a1e9accea4430814f8694291a7f1ea5d</sdk:checksum>
 				<sdk:url>google_apis-9_r02.zip</sdk:url>
@@ -776,7 +776,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:52 2016.-->
+				<!--Built on: Tue May 29 03:55:38 2018.-->
 				<sdk:size>65781578</sdk:size>
 				<sdk:checksum type="sha1">cc0711857c881fa7534f90cf8cc09b8fe985484d</sdk:checksum>
 				<sdk:url>google_apis-10_r02.zip</sdk:url>
@@ -807,7 +807,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Thu Jun 14 15:13:30 2018.-->
 				<sdk:size>83477179</sdk:size>
 				<sdk:checksum type="sha1">5eab5e81addee9f3576d456d205208314b5146a5</sdk:checksum>
 				<sdk:url>google_apis-11_r01.zip</sdk:url>
@@ -834,7 +834,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:51 2016.-->
+				<!--Built on: Mon Jun 11 10:52:20 2018.-->
 				<sdk:size>86099835</sdk:size>
 				<sdk:checksum type="sha1">e9999f4fa978812174dfeceec0721c793a636e5d</sdk:checksum>
 				<sdk:url>google_apis-12_r01.zip</sdk:url>
@@ -865,7 +865,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Sun May 27 03:09:43 2018.-->
 				<sdk:size>88615525</sdk:size>
 				<sdk:checksum type="sha1">3b153edd211c27dc736c893c658418a4f9041417</sdk:checksum>
 				<sdk:url>google_apis-13_r01.zip</sdk:url>
@@ -896,7 +896,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:53 2016.-->
+				<!--Built on: Wed Jun 13 22:44:43 2018.-->
 				<sdk:size>106533714</sdk:size>
 				<sdk:checksum type="sha1">f8eb4d96ad0492b4c0db2d7e4f1a1a3836664d39</sdk:checksum>
 				<sdk:url>google_apis-14_r02.zip</sdk:url>
@@ -925,7 +925,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Fri Jun 15 19:37:58 2018.-->
 				<sdk:size>106624396</sdk:size>
 				<sdk:checksum type="sha1">d0d2bf26805eb271693570a1aaec33e7dc3f45e9</sdk:checksum>
 				<sdk:url>google_apis-15_r03.zip</sdk:url>
@@ -958,7 +958,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Sun Jun 10 20:07:39 2018.-->
 				<sdk:size>127341982</sdk:size>
 				<sdk:checksum type="sha1">ee6acf1b01020bfa8a8e24725dbc4478bee5e792</sdk:checksum>
 				<sdk:url>google_apis-16_r04.zip</sdk:url>
@@ -991,7 +991,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:55 2016.-->
+				<!--Built on: Wed May 30 17:17:51 2018.-->
 				<sdk:size>137231243</sdk:size>
 				<sdk:checksum type="sha1">a076be0677f38df8ca5536b44dfb411a0c808c4f</sdk:checksum>
 				<sdk:url>google_apis-17_r04.zip</sdk:url>
@@ -1024,7 +1024,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Sun May 27 23:13:56 2018.-->
 				<sdk:size>143195183</sdk:size>
 				<sdk:checksum type="sha1">6109603409debdd40854d4d4a92eaf8481462c8b</sdk:checksum>
 				<sdk:url>google_apis-18_r04.zip</sdk:url>
@@ -1057,7 +1057,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>20</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:16:31 2016.-->
+				<!--Built on: Sat Jun  2 14:21:02 2018.-->
 				<sdk:size>147081</sdk:size>
 				<sdk:checksum type="sha1">5b933abe830b2f25b4c0f171d45e9e0651e56311</sdk:checksum>
 				<sdk:url>google_apis-19_r20.zip</sdk:url>
@@ -1090,7 +1090,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Sep  8 15:11:39 2016.-->
+				<!--Built on: Fri Jun  1 04:12:18 2018.-->
 				<sdk:size>154865</sdk:size>
 				<sdk:checksum type="sha1">31361c2868f27343ee917fbd259c1463821b6145</sdk:checksum>
 				<sdk:url>google_apis-24_r1.zip</sdk:url>
@@ -1123,7 +1123,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr 25 23:37:40 2017.-->
+				<!--Built on: Tue Jun 12 20:09:06 2018.-->
 				<sdk:size>154871</sdk:size>
 				<sdk:checksum type="sha1">550e83eea9513ab11c44919ac6da54b36084a9f3</sdk:checksum>
 				<sdk:url>google_apis-25_r1.zip</sdk:url>
@@ -1156,7 +1156,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:45 2016.-->
+				<!--Built on: Mon Jun 11 05:08:59 2018.-->
 				<sdk:size>179499</sdk:size>
 				<sdk:checksum type="sha1">66a754efb24e9bb07cc51648426443c7586c9d4a</sdk:checksum>
 				<sdk:url>google_apis-21_r01.zip</sdk:url>
@@ -1189,7 +1189,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:45 2016.-->
+				<!--Built on: Fri Jun 15 06:11:24 2018.-->
 				<sdk:size>179259</sdk:size>
 				<sdk:checksum type="sha1">5def0f42160cba8acff51b9c0c7e8be313de84f5</sdk:checksum>
 				<sdk:url>google_apis-22_r01.zip</sdk:url>
@@ -1222,7 +1222,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:45 2016.-->
+				<!--Built on: Sun Jun 10 08:57:09 2018.-->
 				<sdk:size>179900</sdk:size>
 				<sdk:checksum type="sha1">04c5cc1a7c88967250ebba9561d81e24104167db</sdk:checksum>
 				<sdk:url>google_apis-23_r01.zip</sdk:url>
@@ -1256,7 +1256,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Sun May 27 03:16:19 2018.-->
 				<sdk:size>78266751</sdk:size>
 				<sdk:checksum type="sha1">92128a12e7e8b0fb5bac59153d7779b717e7b840</sdk:checksum>
 				<sdk:url>google_tv-12_r02.zip</sdk:url>
@@ -1278,7 +1278,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 05:06:54 2016.-->
+				<!--Built on: Tue Jun 19 05:04:20 2018.-->
 				<sdk:size>87721879</sdk:size>
 				<sdk:checksum type="sha1">b73f7c66011ac8180b44aa4e83b8d78c66ea9a09</sdk:checksum>
 				<sdk:url>google_tv-13_r01.zip</sdk:url>
@@ -1303,7 +1303,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Mar 22 18:05:52 2017.-->
+				<!--Built on: Mon Jun 11 04:51:54 2018.-->
 				<sdk:size>355529608</sdk:size>
 				<sdk:checksum type="sha1">a0d22beacc106a6977321f2b07d692ce4979e96a</sdk:checksum>
 				<sdk:url>android_m2repository_r47.zip</sdk:url>
@@ -1323,7 +1323,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Wed Sep  6 06:12:47 2017.-->
+				<!--Built on: Mon Jun 11 11:10:27 2018.-->
 				<sdk:size>215426029</sdk:size>
 				<sdk:checksum type="sha1">05086add9e3a0eb1b67111108d7757a4337c3f10</sdk:checksum>
 				<sdk:url>google_m2repository_gms_v11_3_rc05_wear_2_0_5.zip</sdk:url>
@@ -1343,7 +1343,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:38:56 2016.-->
+				<!--Built on: Sun Jun 10 01:20:16 2018.-->
 				<sdk:size>75109</sdk:size>
 				<sdk:checksum type="sha1">355e8dc304a92a5616db235af8ee7bd554356254</sdk:checksum>
 				<sdk:url>market_licensing-r02.zip</sdk:url>
@@ -1364,7 +1364,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:38:59 2016.-->
+				<!--Built on: Sun Jun 17 19:31:02 2018.-->
 				<sdk:size>110201</sdk:size>
 				<sdk:checksum type="sha1">5305399dc1a56814e86b8459ce24871916f78b8c</sdk:checksum>
 				<sdk:url>market_apk_expansion-r03.zip</sdk:url>
@@ -1386,7 +1386,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:02 2016.-->
+				<!--Built on: Sun May 27 10:44:16 2018.-->
 				<sdk:size>5265389</sdk:size>
 				<sdk:checksum type="sha1">92558dbc380bba3d55d0ec181167fb05ce7c79d9</sdk:checksum>
 				<sdk:url>google_play_services_3265130_r12.zip</sdk:url>
@@ -1401,16 +1401,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:path>google_play_services_froyo</sdk:path>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:164902609, branch:perforce-->
+		<!--Generated from bid:189640690, branch:perforce-->
 		<sdk:revision>
-			<sdk:major>44</sdk:major>
+			<sdk:major>49</sdk:major>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Aug 10 14:27:42 2017.-->
-				<sdk:size>13796755</sdk:size>
-				<sdk:checksum type="sha1">d2bb583a3f62b068d448df10544c1852d910526f</sdk:checksum>
-				<sdk:url>google_play_services_v12_1_rc11.zip</sdk:url>
+				<!--Built on: Mon Jun 11 08:08:54 2018.-->
+				<sdk:size>15456884</sdk:size>
+				<sdk:checksum type="sha1">f95bf19634e2ab0430923247fe2c50246432d2e9</sdk:checksum>
+				<sdk:url>google_play_services_v16_1_rc09.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -1428,7 +1428,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:08 2016.-->
+				<!--Built on: Thu Jun  7 01:53:27 2018.-->
 				<sdk:size>8682859</sdk:size>
 				<sdk:checksum type="sha1">dc8a2ed2fbd7246d4caf9ab10ffe7749dc35d1cc</sdk:checksum>
 				<sdk:url>usb_driver_r11-windows.zip</sdk:url>
@@ -1444,28 +1444,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:path>usb_driver</sdk:path>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:53928043, branch:perforce-->
-		<sdk:revision>
-			<sdk:major>5</sdk:major>
-		</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:11 2016.-->
-				<sdk:size>436654</sdk:size>
-				<sdk:checksum type="sha1">bd2ac5ce7127070ac3229003eb69cfb806628ac9</sdk:checksum>
-				<sdk:url>play_billing_r05.zip</sdk:url>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="android-sdk-license"/>
-		<sdk:vendor-id>google</sdk:vendor-id>
-		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
-		<sdk:description>Google Play Billing files and sample code</sdk:description>
-		<sdk:desc-url>http://developer.android.com/google/play/billing/index.html</sdk:desc-url>
-		<sdk:name-display>Google Play Billing Library</sdk:name-display>
-		<sdk:path>play_billing</sdk:path>
-		<sdk:old-paths>market_billing</sdk:old-paths>
-	</sdk:extra>
-	<sdk:extra>
 		<!--Generated from bid:45484492, branch:perforce-->
 		<sdk:obsolete/>
 		<sdk:revision>
@@ -1473,7 +1451,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:14 2016.-->
+				<!--Built on: Thu Jun  7 11:48:51 2018.-->
 				<sdk:size>704512</sdk:size>
 				<sdk:checksum type="sha1">0102859d9575baa0bf4fd5eb422af2ad0fe6cb82</sdk:checksum>
 				<sdk:url>GoogleAdMobAdsSdkAndroid-6.4.1.zip</sdk:url>
@@ -1495,7 +1473,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:17 2016.-->
+				<!--Built on: Tue Jun  5 05:29:27 2018.-->
 				<sdk:size>211432</sdk:size>
 				<sdk:checksum type="sha1">dc14026bf0ce78315cb5dd00552607de0894de83</sdk:checksum>
 				<sdk:url>GoogleAnalyticsAndroid_2.0beta5.zip</sdk:url>
@@ -1516,7 +1494,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:20 2016.-->
+				<!--Built on: Thu May 31 20:21:33 2018.-->
 				<sdk:size>4055193</sdk:size>
 				<sdk:checksum type="sha1">13f3a3b2670a5fc04a7342861644be9a01b07e38</sdk:checksum>
 				<sdk:url>webdriver_r02.zip</sdk:url>
@@ -1538,7 +1516,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:23 2016.-->
+				<!--Built on: Sun May 27 10:27:10 2018.-->
 				<sdk:size>5901400</sdk:size>
 				<sdk:checksum type="sha1">ad066fd0dc7fc99d8aadac09c65a3c2519fbc7bf</sdk:checksum>
 				<sdk:url>gcm_r03.zip</sdk:url>
@@ -1559,7 +1537,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:26 2016.-->
+				<!--Built on: Tue Jun  5 14:06:56 2018.-->
 				<sdk:size>2167286</sdk:size>
 				<sdk:checksum type="sha1">4fb5344e34e8faab4db18af07dace44c50db26a7</sdk:checksum>
 				<sdk:url>simulator_r01.zip</sdk:url>
@@ -1581,21 +1559,21 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:34 2016.-->
+				<!--Built on: Sat Jun 16 20:44:31 2018.-->
 				<sdk:size>1346009</sdk:size>
 				<sdk:checksum type="sha1">202a6e1b3009a0eb815f8c672d2d5b3717de6169</sdk:checksum>
 				<sdk:url>desktop-head-unit-linux_r01.1.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:35 2016.-->
+				<!--Built on: Tue Jun 12 06:56:07 2018.-->
 				<sdk:size>2375533</sdk:size>
 				<sdk:checksum type="sha1">8179cbb3914493ebc5eb65b731cba061582f2e84</sdk:checksum>
 				<sdk:url>desktop-head-unit-macosx_r01.1.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Apr  5 11:39:34 2016.-->
+				<!--Built on: Tue Jun 12 13:47:09 2018.-->
 				<sdk:size>2691901</sdk:size>
 				<sdk:checksum type="sha1">99c4a7172d73673552119347bc24c58b47da177b</sdk:checksum>
 				<sdk:url>desktop-head-unit-windows_r01.1.zip</sdk:url>
@@ -1611,26 +1589,26 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
 		<sdk:path>auto</sdk:path>
 	</sdk:extra>
 	<sdk:extra>
-		<!--Generated from bid:155747253, branch:perforce-->
+		<!--Generated from bid:214678223, branch:perforce-->
 		<sdk:revision>
 			<sdk:major>1</sdk:major>
-			<sdk:minor>0</sdk:minor>
+			<sdk:minor>5</sdk:minor>
 			<sdk:micro>0</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu May 11 08:10:37 2017.-->
-				<sdk:size>450468876</sdk:size>
-				<sdk:checksum type="sha1">50074a0f0312ee1d0d81d2cddc3d84a8a9e97a53</sdk:checksum>
-				<sdk:url>aiasdk-1.0.0.zip</sdk:url>
+				<!--Built on: Wed Sep 26 15:20:22 2018.-->
+				<sdk:size>33351418</sdk:size>
+				<sdk:checksum type="sha1">6c282b9c686e819fe7f5ac8f2249d2479acb63b4</sdk:checksum>
+				<sdk:url>iasdk-1.5.0-1538000167.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 		<sdk:vendor-id>google</sdk:vendor-id>
 		<sdk:vendor-display>Google Inc.</sdk:vendor-display>
-		<sdk:description>Android Instant Apps Development SDK</sdk:description>
-		<sdk:desc-url>https://developer.android.com/topic/instant-apps/index.html</sdk:desc-url>
-		<sdk:name-display>Instant Apps Development SDK</sdk:name-display>
+		<sdk:description>Google Play Instant Development SDK</sdk:description>
+		<sdk:desc-url>https://developer.android.com/topic/google-play-instant/</sdk:desc-url>
+		<sdk:name-display>Google Play Instant Development SDK</sdk:name-display>
 		<sdk:path>instantapps</sdk:path>
 	</sdk:extra>
 </sdk:sdk-addon>

--- a/pkgs/development/mobile/androidenv/addons.nix
+++ b/pkgs/development/mobile/androidenv/addons.nix
@@ -296,8 +296,8 @@ in
   google_play_services = buildGoogleApis {
     name = "google_play_services";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/google_play_services_v12_1_rc11.zip;
-      sha1 = "d2bb583a3f62b068d448df10544c1852d910526f";
+      url = https://dl.google.com/android/repository/google_play_services_v16_1_rc09.zip;
+      sha1 = "f95bf19634e2ab0430923247fe2c50246432d2e9";
     };
     meta = {
       description = "Google Play services client library and sample code";
@@ -308,13 +308,14 @@ in
   instant_apps = buildGoogleApis {
     name = "instant_apps_sdk";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/aiasdk-1.0.0.zip;
-      sha1 = "50074a0f0312ee1d0d81d2cddc3d84a8a9e97a53";
+      url = https://dl.google.com/android/repository/iasdk-1.5.0-1538000167.zip;
+      sha1 = "6c282b9c686e819fe7f5ac8f2249d2479acb63b4";
     };
     meta = {
       description = "Android Instant Apps Development SDK";
       url = "https://developer.android.com/";
     };
   };
+
 
 }

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -89,6 +89,16 @@ let
       do
           wrapProgram "$(pwd)/$i" --prefix PATH : "${runtime_paths}"
       done
+
+      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
+        for i in ${pkg_path}/prebuilt/linux-x86_64/bin/*
+        do
+            if ! isELF $i; then continue; fi
+            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
+            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64 $i
+        done
+      ''}
+
       # make some executables available in PATH
       mkdir -pv ${bin_path}
       for i in \

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -6,7 +6,7 @@
 , includeSources
 , licenseAccepted
 }:
-{ platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false
+{ platformVersions, abiVersions, useGoogleAPIs, buildToolsVersions ? [], useExtraSupportLibs ? false
 , useGooglePlayServices ? false, useInstantApps ? false }:
 
 if !licenseAccepted then throw ''
@@ -120,8 +120,16 @@ stdenv.mkDerivation rec {
 
     cd ..
     ln -s ${platformTools}/platform-tools
-    ln -s ${buildTools}/build-tools
     ln -s ${support}/support
+
+    mkdir -p build-tools
+    cd build-tools
+
+    ${stdenv.lib.concatMapStrings
+       (v: "ln -s ${builtins.getAttr "v${builtins.replaceStrings ["."] ["_"] v}" buildTools}/build-tools/*")
+       (if (builtins.length buildToolsVersions) == 0 then platformVersions else buildToolsVersions)}
+
+    cd ..
 
     # Symlink required Google API add-ons
 

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -4,9 +4,17 @@
 , freetype, fontconfig, glib, gtk2, atk, file, jdk, coreutils, libpulseaudio, dbus
 , zlib, glxinfo, xkeyboardconfig
 , includeSources
+, licenseAccepted
 }:
 { platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false
 , useGooglePlayServices ? false, useInstantApps ? false }:
+
+if !licenseAccepted then throw ''
+    You must accept the Android Software Development Kit License Agreement at
+    https://developer.android.com/studio/terms
+    by setting nixpkgs config option 'android_sdk.accept_license = true;'
+  ''
+else assert licenseAccepted;
 
 let inherit (stdenv.lib) makeLibraryPath;
 
@@ -20,16 +28,16 @@ in
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "25.2.5";
+  version = "26.1.1";
 
   src = if (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
     then fetchurl {
-      url = "https://dl.google.com/android/repository/tools_r${version}-linux.zip";
-      sha256 = "0gnk49pkwy4m0nqwm1xnf3w4mfpi9w0kk7841xlawpwbkj0icxap";
+      url = "https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip";
+      sha256 = "1yfy0qqxz1ixpsci1pizls1nrncmi8p16wcb9rimdn4q3mdfxzwj";
     }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then fetchurl {
-      url = "http://dl.google.com/android/repository/tools_r${version}-macosx.zip";
-      sha256 = "0yg7wjmyw70xsh8k4hgbqb5rilam2a94yc8dwbh7fjwqcmpxgwqb";
+      url = "https://dl.google.com/android/repository/sdk-tools-darwin-4333796.zip";
+      sha256 = "0gl5c30m40kx0vvrpbaa8cw8wq2vb89r14hgzb1df4qgpic97cpc";
     }
     else throw "platform not ${stdenv.hostPlatform.system} supported!";
 
@@ -39,7 +47,7 @@ stdenv.mkDerivation rec {
     unpackFile $src
     cd tools
 
-    for f in android traceview draw9patch hierarchyviewer monitor ddms screenshot2 uiautomatorviewer monkeyrunner jobb lint
+    for f in monitor bin/monkeyrunner bin/uiautomatorviewer
     do
         sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
     done
@@ -54,24 +62,6 @@ stdenv.mkDerivation rec {
           patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib $i
       done
 
-      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        for i in bin64/{mkfs.ext4,fsck.ext4,e2fsck,tune2fs,resize2fs}
-        do
-            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
-            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64 $i
-        done
-      ''}
-
-      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        # We must also patch the 64-bit emulator instances, if needed
-
-        for i in emulator emulator64-arm emulator64-mips emulator64-x86 emulator64-crash-service emulator-check qemu/linux-x86_64/qemu-system-*
-        do
-            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
-            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64 $i
-        done
-      ''}
-
       # The following scripts used SWT and wants to dynamically load some GTK+ stuff.
       # Creating these wrappers ensure that they can be found:
 
@@ -79,22 +69,18 @@ stdenv.mkDerivation rec {
         --prefix PATH : ${jdk}/bin \
         --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ glib gtk2 libXtst ]}
 
-      wrapProgram `pwd`/uiautomatorviewer \
-        --prefix PATH : ${jdk}/bin \
-        --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
-
-      wrapProgram `pwd`/hierarchyviewer \
+      wrapProgram `pwd`/bin/uiautomatorviewer \
         --prefix PATH : ${jdk}/bin \
         --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
 
       # The emulators need additional libraries, which are dynamically loaded => let's wrap them
 
       ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        for i in emulator emulator64-arm emulator64-mips emulator64-x86 emulator64-crash-service
+        for i in emulator emulator-check
         do
             wrapProgram `pwd`/$i \
               --prefix PATH : ${stdenv.lib.makeBinPath [ file glxinfo ]} \
-              --suffix LD_LIBRARY_PATH : `pwd`/lib64:`pwd`/lib64/qt/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \
+              --suffix LD_LIBRARY_PATH : `pwd`/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \
               --suffix QT_XKB_CONFIG_ROOT : ${xkeyboardconfig}/share/X11/xkb
         done
       ''}
@@ -245,6 +231,14 @@ stdenv.mkDerivation rec {
         fi
     done
 
+    for i in $out/libexec/tools/bin/*
+    do
+        if [ ! -d $i ] && [ -x $i ]
+        then
+            ln -sf $i $out/bin/$(basename $i)
+        fi
+    done
+
     for i in $out/libexec/platform-tools/*
     do
         if [ ! -d $i ] && [ -x $i ]
@@ -260,6 +254,11 @@ stdenv.mkDerivation rec {
             ln -sf $i $out/bin/$(basename $i)
         fi
     done
+
+    wrapProgram $out/bin/sdkmanager \
+      --set JAVA_HOME ${jdk}
+
+    yes | ANDROID_SDK_HOME=$(mktemp -d) $out/bin/sdkmanager --licenses || true
   '';
 
   buildInputs = [ unzip makeWrapper ];

--- a/pkgs/development/mobile/androidenv/build-tools-srcs-linux.nix
+++ b/pkgs/development/mobile/androidenv/build-tools-srcs-linux.nix
@@ -1,0 +1,376 @@
+
+# This file is generated from generate-tools.sh. DO NOT EDIT.
+# Execute generate-tools.sh or fetch.sh to update the file.
+{ fetchurl }:
+
+{
+    
+  v17 = {
+    version = "17.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r17-linux.zip;
+      sha1 = "2c2872bc3806aabf16a12e3959c2183ddc866e6d";
+    };
+  };
+
+  v18_0_1 = {
+    version = "18.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.0.1-linux.zip;
+      sha1 = "f11618492b0d2270c332325d45d752d3656a9640";
+    };
+  };
+
+  v18_1_0 = {
+    version = "18.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1-linux.zip;
+      sha1 = "f314a0599e51397f0886fe888b50dd98f2f050d8";
+    };
+  };
+
+  v18_1_1 = {
+    version = "18.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1.1-linux.zip;
+      sha1 = "68c9acbfc0cec2d51b19efaed39831a17055d998";
+    };
+  };
+
+  v19 = {
+    version = "19.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19-linux.zip;
+      sha1 = "55c1a6cf632e7d346f0002b275ec41fd3137fd83";
+    };
+  };
+
+  v19_0_1 = {
+    version = "19.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.1-linux.zip;
+      sha1 = "18d2312dc4368858914213087f4e61445aca4517";
+    };
+  };
+
+  v19_0_2 = {
+    version = "19.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.2-linux.zip;
+      sha1 = "a03a6bdea0091aea32e1b35b90a7294c9f04e3dd";
+    };
+  };
+
+  v19_0_3 = {
+    version = "19.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.3-linux.zip;
+      sha1 = "c2d6055478e9d2d4fba476ee85f99181ddd1160c";
+    };
+  };
+
+  v19_1_0 = {
+    version = "19.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.1-linux.zip;
+      sha1 = "1ff20ac15fa47a75d00346ec12f180d531b3ca89";
+    };
+  };
+
+  v20 = {
+    version = "20.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r20-linux.zip;
+      sha1 = "b688905526a5584d1327a662d871a635ff502758";
+    };
+  };
+
+  v21 = {
+    version = "21.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21-linux.zip;
+      sha1 = "4933328fdeecbd554a29528f254f4993468e1cf4";
+    };
+  };
+
+  v21_0_1 = {
+    version = "21.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.1-linux.zip;
+      sha1 = "e573069eea3e5255e7a65bedeb767f4fd0a5f49a";
+    };
+  };
+
+  v21_0_2 = {
+    version = "21.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.2-linux.zip;
+      sha1 = "e1236ab8897b62b57414adcf04c132567b2612a5";
+    };
+  };
+
+  v21_1_0 = {
+    version = "21.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1-linux.zip;
+      sha1 = "b7455e543784d52a8925f960bc880493ed1478cb";
+    };
+  };
+
+  v21_1_1 = {
+    version = "21.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.1-linux.zip;
+      sha1 = "1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d";
+    };
+  };
+
+  v21_1_2 = {
+    version = "21.1.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.2-linux.zip;
+      sha1 = "5e35259843bf2926113a38368b08458735479658";
+    };
+  };
+
+  v22 = {
+    version = "22.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22-linux.zip;
+      sha1 = "a8a1619dd090e44fac957bce6842e62abf87965b";
+    };
+  };
+
+  v22_0_1 = {
+    version = "22.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22.0.1-linux.zip;
+      sha1 = "da8b9c5c3ede39298e6cf0283c000c2ee9029646";
+    };
+  };
+
+  v23 = {
+    version = "23.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23-linux.zip;
+      sha1 = "c1d6209212b01469f80fa804e0c1d39a06bc9060";
+    };
+  };
+
+  v23_0_1 = {
+    version = "23.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.1-linux.zip;
+      sha1 = "b6ba7c399d5fa487d95289d8832e4ad943aed556";
+    };
+  };
+
+  v23_0_2 = {
+    version = "23.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.2-linux.zip;
+      sha1 = "8a9f2b37f6fcf7a9fa784dc21aeaeb41bbb9f2c3";
+    };
+  };
+
+  v23_0_3 = {
+    version = "23.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.3-linux.zip;
+      sha1 = "368f2600feac7e9b511b82f53d1f2240ae4a91a3";
+    };
+  };
+
+  v24 = {
+    version = "24.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24-linux.zip;
+      sha1 = "c6271c4d78a5612ea6c7150688bcd5b7313de8d1";
+    };
+  };
+
+  v24_0_1 = {
+    version = "24.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.1-linux.zip;
+      sha1 = "84f18c392919a074fcbb9b1d967984e6b2fef8b4";
+    };
+  };
+
+  v24_0_2 = {
+    version = "24.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.2-linux.zip;
+      sha1 = "f199a7a788c3fefbed102eea34d6007737b803cf";
+    };
+  };
+
+  v24_0_3 = {
+    version = "24.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.3-linux.zip;
+      sha1 = "9e8cc49d66e03fa1a8ecc1ac3e58f1324f5da304";
+    };
+  };
+
+  v25 = {
+    version = "25.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25-linux.zip;
+      sha1 = "f2bbda60403e75cabd0f238598c3b4dfca56ea44";
+    };
+  };
+
+  v25_0_1 = {
+    version = "25.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.1-linux.zip;
+      sha1 = "ff063d252ab750d339f5947d06ff782836f22bac";
+    };
+  };
+
+  v25_0_2 = {
+    version = "25.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.2-linux.zip;
+      sha1 = "ff953c0177e317618fda40516f3e9d95fd43c7ae";
+    };
+  };
+
+  v25_0_3 = {
+    version = "25.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.3-linux.zip;
+      sha1 = "db95f3a0ae376534d4d69f4cdb6fad20649f3509";
+    };
+  };
+
+  v26 = {
+    version = "26.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-linux.zip;
+      sha1 = "1cbe72929876f8a872ab1f1b1040a9f720261f59";
+    };
+  };
+
+  v26_rc1 = {
+    version = "26.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc1-linux.zip;
+      sha1 = "8cd6388dc96db2d7a49d06159cf990d3bbc78d04";
+    };
+  };
+
+  v26_rc2 = {
+    version = "26.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc2-linux.zip;
+      sha1 = "629bbd8d2e415bf64871fb0b4c0540fd6d0347a0";
+    };
+  };
+
+  v26_0_1 = {
+    version = "26.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.1-linux.zip;
+      sha1 = "5378c2c78091b414d0eac40a6bd37f2faa31a365";
+    };
+  };
+
+  v26_0_2 = {
+    version = "26.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.2-linux.zip;
+      sha1 = "5b2b7b66c7bf2151f2af183b5b50a17808850592";
+    };
+  };
+
+  v26_0_3 = {
+    version = "26.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.3-linux.zip;
+      sha1 = "8a2e6c1bcd845844523a68aa17e5442f0dce328c";
+    };
+  };
+
+  v27 = {
+    version = "27.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27-linux.zip;
+      sha1 = "28542332ba97cf4a08c3eddfcf5edd70e3cf1260";
+    };
+  };
+
+  v27_0_1 = {
+    version = "27.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.1-linux.zip;
+      sha1 = "7f4eedb1077ef948b848040dcd15de9e8a759f4a";
+    };
+  };
+
+  v27_0_2 = {
+    version = "27.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.2-linux.zip;
+      sha1 = "b687ddf6be84f11607871138aad32cf857d0b837";
+    };
+  };
+
+  v27_0_3 = {
+    version = "27.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.3-linux.zip;
+      sha1 = "d85e7a6320eddffe7eeace3437605079dac938ca";
+    };
+  };
+
+  v28 = {
+    version = "28.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-linux.zip;
+      sha1 = "d9f8a754d833ccd334f56fcc6089c5925cd82abb";
+    };
+  };
+
+  v28_rc1 = {
+    version = "28.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc1-linux.zip;
+      sha1 = "1601977fae25fd478bcfaa0481ca5ea3c609d840";
+    };
+  };
+
+  v28_rc2 = {
+    version = "28.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc2-linux.zip;
+      sha1 = "efe9c0dde0646a07544c864276390ca6e96b24dc";
+    };
+  };
+
+  v28_0_1 = {
+    version = "28.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.1-linux.zip;
+      sha1 = "ee70dfa1fccb58b37cebc9544830511f36a137a0";
+    };
+  };
+
+  v28_0_2 = {
+    version = "28.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.2-linux.zip;
+      sha1 = "b4492209810a3fd48deaa982f9852fef12433d55";
+    };
+  };
+
+  v28_0_3 = {
+    version = "28.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.3-linux.zip;
+      sha1 = "ea6f2f7103cd9da9ff0bdf6e37fbbba548fa4165";
+    };
+  };
+
+}

--- a/pkgs/development/mobile/androidenv/build-tools-srcs-macosx.nix
+++ b/pkgs/development/mobile/androidenv/build-tools-srcs-macosx.nix
@@ -1,0 +1,376 @@
+
+# This file is generated from generate-tools.sh. DO NOT EDIT.
+# Execute generate-tools.sh or fetch.sh to update the file.
+{ fetchurl }:
+
+{
+    
+  v17 = {
+    version = "17.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r17-macosx.zip;
+      sha1 = "602ee709be9dbb8f179b1e4075148a57f9419930";
+    };
+  };
+
+  v18_0_1 = {
+    version = "18.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.0.1-macosx.zip;
+      sha1 = "d84f5692fb44d60fc53e5b2507cebf9f24626902";
+    };
+  };
+
+  v18_1_0 = {
+    version = "18.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1-macosx.zip;
+      sha1 = "16ddb299b8b43063e5bb3387ec17147c5053dfd8";
+    };
+  };
+
+  v18_1_1 = {
+    version = "18.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1.1-macosx.zip;
+      sha1 = "a9d9d37f6ddf859e57abc78802a77aaa166e48d4";
+    };
+  };
+
+  v19 = {
+    version = "19.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19-macosx.zip;
+      sha1 = "86ec1c12db1bc446b7bcaefc5cc14eb361044e90";
+    };
+  };
+
+  v19_0_1 = {
+    version = "19.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.1-macosx.zip;
+      sha1 = "efaf50fb19a3edb8d03efbff76f89a249ad2920b";
+    };
+  };
+
+  v19_0_2 = {
+    version = "19.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.2-macosx.zip;
+      sha1 = "145bc43065d45f756d99d87329d899052b9a9288";
+    };
+  };
+
+  v19_0_3 = {
+    version = "19.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.3-macosx.zip;
+      sha1 = "651cf8754373b2d52e7f6aab2c52eabffe4e9ea4";
+    };
+  };
+
+  v19_1_0 = {
+    version = "19.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.1-macosx.zip;
+      sha1 = "0d11aae3417de1efb4b9a0e0a7855904a61bcec1";
+    };
+  };
+
+  v20 = {
+    version = "20.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r20-macosx.zip;
+      sha1 = "1240f629411c108a714c4ddd756937c7fab93f83";
+    };
+  };
+
+  v21 = {
+    version = "21.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21-macosx.zip;
+      sha1 = "9bef7989b51436bd4e5114d8a0330359f077cbfa";
+    };
+  };
+
+  v21_0_1 = {
+    version = "21.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.1-macosx.zip;
+      sha1 = "b60c8f9b810c980abafa04896706f3911be1ade7";
+    };
+  };
+
+  v21_0_2 = {
+    version = "21.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.2-macosx.zip;
+      sha1 = "f17471c154058f3734729ef3cc363399b1cd3de1";
+    };
+  };
+
+  v21_1_0 = {
+    version = "21.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1-macosx.zip;
+      sha1 = "df619356c2359aa5eacdd48699d15b335d9bd246";
+    };
+  };
+
+  v21_1_1 = {
+    version = "21.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.1-macosx.zip;
+      sha1 = "836a146eab0504aa9387a5132e986fe7c7381571";
+    };
+  };
+
+  v21_1_2 = {
+    version = "21.1.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.2-macosx.zip;
+      sha1 = "e7c906b4ba0eea93b32ba36c610dbd6b204bff48";
+    };
+  };
+
+  v22 = {
+    version = "22.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22-macosx.zip;
+      sha1 = "af95429b24088d704bc5db9bd606e34ac1b82c0d";
+    };
+  };
+
+  v22_0_1 = {
+    version = "22.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22.0.1-macosx.zip;
+      sha1 = "53dad7f608e01d53b17176ba11165acbfccc5bbf";
+    };
+  };
+
+  v23 = {
+    version = "23.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23-macosx.zip;
+      sha1 = "90ba6e716f7703a236cd44b2e71c5ff430855a03";
+    };
+  };
+
+  v23_0_1 = {
+    version = "23.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.1-macosx.zip;
+      sha1 = "d96ec1522721e9a179ae2c591c99f75d31d39718";
+    };
+  };
+
+  v23_0_2 = {
+    version = "23.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.2-macosx.zip;
+      sha1 = "482c4cbceef8ff58aefd92d8155a38610158fdaf";
+    };
+  };
+
+  v23_0_3 = {
+    version = "23.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.3-macosx.zip;
+      sha1 = "fbc98cd303fd15a31d472de6c03bd707829f00b0";
+    };
+  };
+
+  v24 = {
+    version = "24.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24-macosx.zip;
+      sha1 = "97fc4ed442f23989cc488d02c1d1de9bdde241de";
+    };
+  };
+
+  v24_0_1 = {
+    version = "24.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.1-macosx.zip;
+      sha1 = "5c6457fcdfa07724fb086d8ff4e8316fc0742848";
+    };
+  };
+
+  v24_0_2 = {
+    version = "24.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.2-macosx.zip;
+      sha1 = "8bb8fc575477491d5957de743089df412de55cda";
+    };
+  };
+
+  v24_0_3 = {
+    version = "24.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.3-macosx.zip;
+      sha1 = "a01c15f1b105c34595681075e1895d58b3fff48c";
+    };
+  };
+
+  v25 = {
+    version = "25.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25-macosx.zip;
+      sha1 = "273c5c29a65cbed00e44f3aa470bbd7dce556606";
+    };
+  };
+
+  v25_0_1 = {
+    version = "25.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.1-macosx.zip;
+      sha1 = "7bf7f22d7d48ef20b6ab0e3d7a2912e5c088340f";
+    };
+  };
+
+  v25_0_2 = {
+    version = "25.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.2-macosx.zip;
+      sha1 = "12a5204bb3b6e39437535469fde7ddf42da46b16";
+    };
+  };
+
+  v25_0_3 = {
+    version = "25.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.3-macosx.zip;
+      sha1 = "160d2fefb5ce68e443427fc30a793a703b63e26e";
+    };
+  };
+
+  v26 = {
+    version = "26.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-macosx.zip;
+      sha1 = "d01a1aeca03747245f1f5936b3cb01759c66d086";
+    };
+  };
+
+  v26_rc1 = {
+    version = "26.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc1-macosx.zip;
+      sha1 = "5c5a1de7d5f4f000d36ae349229fe0be846d6137";
+    };
+  };
+
+  v26_rc2 = {
+    version = "26.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc2-macosx.zip;
+      sha1 = "cb1eb738a1f7003025af267a9b8cc2d259533c70";
+    };
+  };
+
+  v26_0_1 = {
+    version = "26.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.1-macosx.zip;
+      sha1 = "cbde59de198916b390777dd0227921bfa2120832";
+    };
+  };
+
+  v26_0_2 = {
+    version = "26.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.2-macosx.zip;
+      sha1 = "d9ed7c7f149ce38be5dc08979aea8acec1459ca0";
+    };
+  };
+
+  v26_0_3 = {
+    version = "26.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.3-macosx.zip;
+      sha1 = "5bb90ed935d99e5bc90686f43b852e68c5ad40df";
+    };
+  };
+
+  v27 = {
+    version = "27.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27-macosx.zip;
+      sha1 = "fb4e8d7e6b8d29a77090e34024077a80458d5ae1";
+    };
+  };
+
+  v27_0_1 = {
+    version = "27.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.1-macosx.zip;
+      sha1 = "1edd07bfdbadd95652d093040e16d858f7489594";
+    };
+  };
+
+  v27_0_2 = {
+    version = "27.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.2-macosx.zip;
+      sha1 = "6d5d9cf2a47877f273f4b742b19e712a051a31be";
+    };
+  };
+
+  v27_0_3 = {
+    version = "27.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.3-macosx.zip;
+      sha1 = "61d9fb18790c68d66ff73bf1e7ad56bc1f1eef2d";
+    };
+  };
+
+  v28 = {
+    version = "28.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-macosx.zip;
+      sha1 = "72088d32d1d82cc3c2cf7cf6618b6130c0c84ade";
+    };
+  };
+
+  v28_rc1 = {
+    version = "28.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc1-macosx.zip;
+      sha1 = "2c77821967a2330b7b227072d0b1c02ef19fe2fc";
+    };
+  };
+
+  v28_rc2 = {
+    version = "28.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc2-macosx.zip;
+      sha1 = "0d0314b353589feb10e528b44c5a685b6658d797";
+    };
+  };
+
+  v28_0_1 = {
+    version = "28.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.1-macosx.zip;
+      sha1 = "aeef42ad953f1630dd6f5d71eefdc0b825211462";
+    };
+  };
+
+  v28_0_2 = {
+    version = "28.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.2-macosx.zip;
+      sha1 = "c10dd5a7825578622fb362a8a34f76eb3ba0c0a9";
+    };
+  };
+
+  v28_0_3 = {
+    version = "28.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.3-macosx.zip;
+      sha1 = "f8c333a2991b1ab05a671bc6248b78e00edcd83a";
+    };
+  };
+
+}

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,4 +1,4 @@
-{stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses}:
+{stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses, coreutils}:
 
 stdenv.mkDerivation rec {
   version = "28.0.3";
@@ -20,9 +20,14 @@ stdenv.mkDerivation rec {
     unzip $src
     mv android-* ${version}
 
+    cd ${version}
+
+    for f in $(grep -Rl /bin/ls .); do
+      sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
+    done
+
     ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
       ''
-        cd ${version}
 
         ln -s ${ncurses.out}/lib/libncurses.so.5 `pwd`/lib64/libtinfo.so.5
 

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,16 +1,16 @@
 {stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses}:
 
 stdenv.mkDerivation rec {
-  version = "26.0.2";
+  version = "28.0.3";
   name = "android-build-tools-r${version}";
   src = if (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-linux.zip";
-      sha256 = "1kii880bwhjkc343zwx1ysxyisxhczrwhphnxbwsgi45mjgq8lm7";
+      sha256 = "16klhw9yk8znvbgvg967km4y5sb87z1cnf6njgv8hg3381m9am3r";
     }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/build-tools_r${version}-macosx.zip";
-      sha256 = "1x0ycprl6hgsm23kck5ind7x00hzydc5k3h3ch4a13407xbpvzvx";
+      sha256 = "1src9g7058bl2z9y6v404gwqwpixb8b71awxhrb0w5iwnfabhymq";
     }
     else throw "System ${stdenv.hostPlatform.system} not supported!";
 

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,61 +1,53 @@
-{stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses, coreutils}:
+{stdenv, lib, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses, coreutils, buildToolsSources}:
 
-stdenv.mkDerivation rec {
-  version = "28.0.3";
-  name = "android-build-tools-r${version}";
-  src = if (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
-    then fetchurl {
-      url = "https://dl.google.com/android/repository/build-tools_r${version}-linux.zip";
-      sha256 = "16klhw9yk8znvbgvg967km4y5sb87z1cnf6njgv8hg3381m9am3r";
-    }
-    else if stdenv.hostPlatform.system == "x86_64-darwin" then fetchurl {
-      url = "https://dl.google.com/android/repository/build-tools_r${version}-macosx.zip";
-      sha256 = "1src9g7058bl2z9y6v404gwqwpixb8b71awxhrb0w5iwnfabhymq";
-    }
-    else throw "System ${stdenv.hostPlatform.system} not supported!";
+let buildBuildTools = name: { version, src }:
+  stdenv.mkDerivation rec {
+    inherit version src;
+    name = "android-build-tools-r${version}";
+    buildCommand = ''
+      mkdir -p $out/build-tools
+      cd $out/build-tools
+      unzip $src
+      mv android-* ${version}
 
-  buildCommand = ''
-    mkdir -p $out/build-tools
-    cd $out/build-tools
-    unzip $src
-    mv android-* ${version}
+      cd ${version}
 
-    cd ${version}
+      for f in $(grep -Rl /bin/ls .); do
+        sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
+      done
 
-    for f in $(grep -Rl /bin/ls .); do
-      sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
-    done
+      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
+        ''
 
-    ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
-      ''
+          ln -s ${ncurses.out}/lib/libncurses.so.5 `pwd`/lib64/libtinfo.so.5
 
-        ln -s ${ncurses.out}/lib/libncurses.so.5 `pwd`/lib64/libtinfo.so.5
-
-        find . -type f -print0 | while IFS= read -r -d "" file
-        do
-          type=$(file "$file")
-          ## Patch 64-bit binaries
-          if grep -q "ELF 64-bit" <<< "$type"
-          then
-            if grep -q "interpreter" <<< "$type"
+          find . -type f -print0 | while IFS= read -r -d "" file
+          do
+            type=$(file "$file")
+            ## Patch 64-bit binaries
+            if grep -q "ELF 64-bit" <<< "$type"
             then
-              patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 "$file"
-            fi
-            patchelf --set-rpath `pwd`/lib64:${stdenv.cc.cc.lib.out}/lib:${zlib.out}/lib:${ncurses.out}/lib "$file"
-          ## Patch 32-bit binaries
-          elif grep -q "ELF 32-bit" <<< "$type"
-          then
-            if grep -q "interpreter" <<< "$type"
+              if grep -q "interpreter" <<< "$type"
+              then
+                patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 "$file"
+              fi
+              patchelf --set-rpath `pwd`/lib64:${stdenv.cc.cc.lib.out}/lib:${zlib.out}/lib:${ncurses.out}/lib "$file"
+            ## Patch 32-bit binaries
+            elif grep -q "ELF 32-bit" <<< "$type"
             then
-              patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 "$file"
+              if grep -q "interpreter" <<< "$type"
+              then
+                patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 "$file"
+              fi
+              patchelf --set-rpath ${stdenv_32bit.cc.cc.lib.out}/lib:${zlib_32bit.out}/lib:${ncurses_32bit.out}/lib "$file"
             fi
-            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib.out}/lib:${zlib_32bit.out}/lib:${ncurses_32bit.out}/lib "$file"
-          fi
-        done
-      ''}
+          done
+        ''}
 
-      patchShebangs .
-  '';
+        patchShebangs .
+    '';
 
-  buildInputs = [ unzip file ];
-}
+    buildInputs = [ unzip file ];
+  };
+in
+  lib.mapAttrs buildBuildTools buildToolsSources

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,5 +1,5 @@
 { buildPackages, pkgs, pkgs_i686, targetPackages
-, includeSources ? true
+, includeSources ? true, licenseAccepted ? false
 }:
 
 # TODO: use callPackage instead of import to avoid so many inherits
@@ -57,7 +57,7 @@ rec {
 
     inherit platformTools buildTools support
             supportRepository platforms sysimages
-            addons sources includeSources;
+            addons sources includeSources licenseAccepted;
 
     stdenv_32bit = pkgs_i686.stdenv;
   };

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -222,7 +222,37 @@ rec {
     useInstantApps = true;
   };
 
-  androidsdk_latest = androidsdk_8_0;
+  androidsdk_8_1 = androidsdk {
+    platformVersions = [ "27" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+  };
+
+  androidsdk_8_1_extras = androidsdk {
+    platformVersions = [ "27" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+    useExtraSupportLibs = true;
+    useGooglePlayServices = true;
+    useInstantApps = true;
+  };
+
+  androidsdk_9_0 = androidsdk {
+    platformVersions = [ "28" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+  };
+
+  androidsdk_9_0_extras = androidsdk {
+    platformVersions = [ "28" ];
+    abiVersions = [ "x86" "x86_64"];
+    useGoogleAPIs = true;
+    useExtraSupportLibs = true;
+    useGooglePlayServices = true;
+    useInstantApps = true;
+  };
+
+  androidsdk_latest = androidsdk_9_0;
 
   androidndk_10e = pkgs.callPackage ./androidndk.nix {
     inherit (buildPackages)

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -10,7 +10,7 @@ rec {
   };
 
   buildTools = import ./build-tools.nix {
-    inherit (pkgs) stdenv fetchurl unzip zlib file;
+    inherit (pkgs) stdenv fetchurl unzip zlib file coreutils;
     stdenv_32bit = pkgs_i686.stdenv;
     zlib_32bit = pkgs_i686.zlib;
     ncurses_32bit = pkgs_i686.ncurses5;

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -9,8 +9,19 @@ rec {
     inherit buildPackages pkgs;
   };
 
+  buildToolsSources = let
+    system = pkgs.stdenv.hostPlatform.system;
+    path = if (system == "i686-linux" || system == "x86_64-linux")
+      then ./build-tools-srcs-linux.nix
+      else if system == "x86_64-darwin"
+      then ./build-tools-srcs-macosx.nix
+      else throw "System: ${system} not supported!";
+  in
+    import path { inherit (pkgs) fetchurl; };
+
   buildTools = import ./build-tools.nix {
-    inherit (pkgs) stdenv fetchurl unzip zlib file coreutils;
+    inherit (pkgs) stdenv lib fetchurl unzip zlib file coreutils;
+    inherit buildToolsSources;
     stdenv_32bit = pkgs_i686.stdenv;
     zlib_32bit = pkgs_i686.zlib;
     ncurses_32bit = pkgs_i686.ncurses5;

--- a/pkgs/development/mobile/androidenv/fetch.sh
+++ b/pkgs/development/mobile/androidenv/fetch.sh
@@ -1,8 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash --pure -p androidsdk curl libxslt
-
-# this shows a list of available xmls
-android list sdk | grep 'Parse XML:' | cut -f8- -d\  # | xargs -n 1 curl -O
+#! nix-shell -i bash --pure -p curl libxslt
 
 # we skip the intel addons, as they are Windows+osX only
 # we skip the default sys-img (arm?) because it is empty

--- a/pkgs/development/mobile/androidenv/fetch.sh
+++ b/pkgs/development/mobile/androidenv/fetch.sh
@@ -11,3 +11,4 @@ curl -o sys-img.xml       https://dl.google.com/android/repository/sys-img/andro
 ./generate-platforms.sh
 ./generate-sysimages.sh
 ./generate-sources.sh
+./generate-tools.sh

--- a/pkgs/development/mobile/androidenv/generate-tools.sh
+++ b/pkgs/development/mobile/androidenv/generate-tools.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+xsltproc --stringparam os linux generate-tools.xsl repository-11.xml > build-tools-srcs-linux.nix
+xsltproc --stringparam os macosx generate-tools.xsl repository-11.xml > build-tools-srcs-macosx.nix

--- a/pkgs/development/mobile/androidenv/generate-tools.xsl
+++ b/pkgs/development/mobile/androidenv/generate-tools.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:sdk="http://schemas.android.com/sdk/android/repository/11">
+
+  <xsl:param name="os" />
+  <xsl:output omit-xml-declaration="yes" indent="no" />
+
+  <xsl:template name="repository-url">
+    <xsl:variable name="raw-url" select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:url"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($raw-url, 'http')">
+        <xsl:value-of select="$raw-url"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>https://dl.google.com/android/repository/</xsl:text>
+        <xsl:value-of select="$raw-url"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="/sdk:sdk-repository">
+# This file is generated from generate-tools.sh. DO NOT EDIT.
+# Execute generate-tools.sh or fetch.sh to update the file.
+{ fetchurl }:
+
+{
+    <xsl:for-each select="sdk:build-tool">
+      <xsl:sort select="sdk:revision/sdk:major" data-type="number"/>
+      <xsl:sort select="sdk:revision/sdk:minor" data-type="number"/>
+      <xsl:sort select="sdk:revision/sdk:micro" data-type="number"/>
+      <xsl:sort select="sdk:revision/sdk:preview" data-type="number"/>
+  v<xsl:value-of select="sdk:revision/sdk:major"/><xsl:if test="sdk:revision/sdk:minor + sdk:revision/sdk:micro > 0">_<xsl:value-of select="sdk:revision/sdk:minor" />_<xsl:value-of select="sdk:revision/sdk:micro"/></xsl:if><xsl:if test="sdk:revision/sdk:preview > 0">_rc<xsl:value-of select="sdk:revision/sdk:preview"/></xsl:if> = {
+    version = "<xsl:value-of select="sdk:revision/sdk:major"/>.<xsl:value-of select="sdk:revision/sdk:minor" />.<xsl:value-of select="sdk:revision/sdk:micro"/><xsl:if test="sdk:revision/sdk:preview > 0">-rc<xsl:value-of select="sdk:revision/sdk:preview"/></xsl:if>";
+    src = fetchurl {
+      url = <xsl:call-template name="repository-url"/>;
+      sha1 = "<xsl:value-of select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:checksum[@type='sha1']" />";
+    };
+  };
+</xsl:for-each>
+}
+</xsl:template>
+</xsl:stylesheet>

--- a/pkgs/development/mobile/androidenv/platforms-linux.nix
+++ b/pkgs/development/mobile/androidenv/platforms-linux.nix
@@ -316,4 +316,28 @@ in
     };
   };
 
+  platform_27 = buildPlatform {
+    name = "android-platform-8.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-27_r03.zip;
+      sha1 = "35f747e7e70b2d16e0e4246876be28d15ea1c353";
+    };
+    meta = {
+      description = "Android SDK Platform 27";
+      homepage = http://developer.android.com/sdk/;
+    };
+  };
+
+  platform_28 = buildPlatform {
+    name = "android-platform-9";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-28_r06.zip;
+      sha1 = "9a4e52b1d55bd2e24216b150aafae2503d3efba6";
+    };
+    meta = {
+      description = "Android SDK Platform 28";
+      homepage = http://developer.android.com/sdk/;
+    };
+  };
+
 }

--- a/pkgs/development/mobile/androidenv/platforms-macosx.nix
+++ b/pkgs/development/mobile/androidenv/platforms-macosx.nix
@@ -316,4 +316,28 @@ in
     };
   };
 
+  platform_27 = buildPlatform {
+    name = "android-platform-8.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-27_r03.zip;
+      sha1 = "35f747e7e70b2d16e0e4246876be28d15ea1c353";
+    };
+    meta = {
+      description = "Android SDK Platform 27";
+      homepage = http://developer.android.com/sdk/;
+    };
+  };
+
+  platform_28 = buildPlatform {
+    name = "android-platform-9";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/platform-28_r06.zip;
+      sha1 = "9a4e52b1d55bd2e24216b150aafae2503d3efba6";
+    };
+    meta = {
+      description = "Android SDK Platform 28";
+      homepage = http://developer.android.com/sdk/;
+    };
+  };
+
 }

--- a/pkgs/development/mobile/androidenv/repository-11.xml
+++ b/pkgs/development/mobile/androidenv/repository-11.xml
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 <sdk:sdk-repository xmlns:sdk="http://schemas.android.com/sdk/android/repository/11" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2017-09-08 08:20:34.788412 with ADRT.-->
+	<!--Generated on 2018-10-17 16:21:19.063228 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -50,7 +50,7 @@ This is the Android Software Development Kit License Agreement
 
 3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
+3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK.
 
 3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement.
 
@@ -296,45 +296,93 @@ This is the Android SDK Preview License Agreement (the &quot;License Agreement&q
 
 June 2014.</sdk:license>
 	<sdk:ndk>
-		<!--Generated from bid:4203891, branch:aosp-ndk-r15-release-->
+		<!--Generated from bid:5063045, branch:aosp-ndk-release-r18-->
 		<sdk:description>NDK</sdk:description>
-		<sdk:revision>15</sdk:revision>
+		<sdk:revision>18</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Jul 24 11:35:28 2017.-->
-				<sdk:size>960251267</sdk:size>
-				<sdk:checksum type="sha1">ea4b5d76475db84745aa8828000d009625fc1f98</sdk:checksum>
-				<sdk:url>android-ndk-r15c-darwin-x86_64.zip</sdk:url>
+				<!--Built on: Thu Oct 11 14:06:10 2018.-->
+				<sdk:size>542911996</sdk:size>
+				<sdk:checksum type="sha1">98cb9909aa8c2dab32db188bbdc3ac6207e09440</sdk:checksum>
+				<sdk:url>android-ndk-r18b-darwin-x86_64.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 				<sdk:host-bits>64</sdk:host-bits>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Jul 24 11:35:55 2017.-->
-				<sdk:size>974976754</sdk:size>
-				<sdk:checksum type="sha1">0bf02d4e8b85fd770fd7b9b2cdec57f9441f27a2</sdk:checksum>
-				<sdk:url>android-ndk-r15c-linux-x86_64.zip</sdk:url>
+				<!--Built on: Thu Oct 11 14:06:26 2018.-->
+				<sdk:size>557038702</sdk:size>
+				<sdk:checksum type="sha1">500679655da3a86aecf67007e8ab230ea9b4dd7b</sdk:checksum>
+				<sdk:url>android-ndk-r18b-linux-x86_64.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 				<sdk:host-bits>64</sdk:host-bits>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Jul 24 11:34:34 2017.-->
-				<sdk:size>784778144</sdk:size>
-				<sdk:checksum type="sha1">f2e47121feb73ec34ced5e947cbf1adc6b56246e</sdk:checksum>
-				<sdk:url>android-ndk-r15c-windows-x86.zip</sdk:url>
+				<!--Built on: Thu Oct 11 14:05:37 2018.-->
+				<sdk:size>504605336</sdk:size>
+				<sdk:checksum type="sha1">4b8b6a4edc0fa967b429c1d6d25adf69acc28803</sdk:checksum>
+				<sdk:url>android-ndk-r18b-windows-x86.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 				<sdk:host-bits>32</sdk:host-bits>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Jul 24 11:35:03 2017.-->
-				<sdk:size>849733996</sdk:size>
-				<sdk:checksum type="sha1">970bb2496de0eada74674bb1b06d79165f725696</sdk:checksum>
-				<sdk:url>android-ndk-r15c-windows-x86_64.zip</sdk:url>
+				<!--Built on: Thu Oct 11 14:05:53 2018.-->
+				<sdk:size>522489470</sdk:size>
+				<sdk:checksum type="sha1">6b6d4138aaaad7166679fdfa4780e177f95cee6f</sdk:checksum>
+				<sdk:url>android-ndk-r18b-windows-x86_64.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 				<sdk:host-bits>64</sdk:host-bits>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:ndk>
+	<sdk:platform>
+		<!--Generated from bid:4913185, branch:pi-sdk-release-->
+		<sdk:version>9</sdk:version>
+		<sdk:api-level>28</sdk:api-level>
+		<sdk:description>Android SDK Platform 28</sdk:description>
+		<sdk:revision>6</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Jul 25 20:19:20 2018.-->
+				<sdk:size>75565084</sdk:size>
+				<sdk:checksum type="sha1">9a4e52b1d55bd2e24216b150aafae2503d3efba6</sdk:checksum>
+				<sdk:url>platform-28_r06.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>15</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
+	<sdk:platform>
+		<!--Generated from bid:4774931, branch:git_oc-mr1-sdk-release-->
+		<sdk:version>8.1.0</sdk:version>
+		<sdk:api-level>27</sdk:api-level>
+		<sdk:description>Android SDK Platform 27</sdk:description>
+		<sdk:revision>3</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri May 11 15:44:04 2018.-->
+				<sdk:size>65635348</sdk:size>
+				<sdk:checksum type="sha1">35f747e7e70b2d16e0e4246876be28d15ea1c353</sdk:checksum>
+				<sdk:url>platform-27_r03.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:min-tools-rev>
+			<sdk:major>22</sdk:major>
+		</sdk:min-tools-rev>
+		<sdk:desc-url>http://developer.android.com/sdk/</sdk:desc-url>
+		<sdk:layoutlib>
+			<sdk:api>15</sdk:api>
+			<sdk:revision>1</sdk:revision>
+		</sdk:layoutlib>
+	</sdk:platform>
 	<sdk:platform>
 		<!--Generated from bid:4187382, branch:git_oc-release-->
 		<sdk:version>8.0.0</sdk:version>
@@ -343,7 +391,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Jul 18 10:38:38 2017.-->
+				<!--Built on: Wed May 23 00:35:53 2018.-->
 				<sdk:size>63623734</sdk:size>
 				<sdk:checksum type="sha1">e4ae5d7aa557a3c827135838ee400da8443ac4ef</sdk:checksum>
 				<sdk:url>platform-26_r02.zip</sdk:url>
@@ -367,7 +415,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Dec  5 10:12:38 2016.-->
+				<!--Built on: Sat May 26 06:47:38 2018.-->
 				<sdk:size>85424763</sdk:size>
 				<sdk:checksum type="sha1">00c2c5765e8988504be10a1eb66ed71fcdbd7fe8</sdk:checksum>
 				<sdk:url>platform-25_r03.zip</sdk:url>
@@ -391,7 +439,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 22 11:05:39 2016.-->
+				<!--Built on: Tue Jun  5 15:00:21 2018.-->
 				<sdk:size>82648154</sdk:size>
 				<sdk:checksum type="sha1">8912da3d4bfe7a9f28f0e5ce92d3a8dc96342aee</sdk:checksum>
 				<sdk:url>platform-24_r02.zip</sdk:url>
@@ -415,7 +463,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 22 14:26:20 2016.-->
+				<!--Built on: Mon May 21 15:53:43 2018.-->
 				<sdk:size>70433421</sdk:size>
 				<sdk:checksum type="sha1">027fede3de6aa1649115bbd0bffff30ccd51c9a0</sdk:checksum>
 				<sdk:url>platform-23_r03.zip</sdk:url>
@@ -439,7 +487,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<!--Built on: Mon May 21 03:54:34 2018.-->
 				<sdk:size>66852371</sdk:size>
 				<sdk:checksum type="sha1">5d1bd10fea962b216a0dece1247070164760a9fc</sdk:checksum>
 				<sdk:url>android-22_r02.zip</sdk:url>
@@ -463,7 +511,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:12 2016.-->
+				<!--Built on: Tue Jun 19 02:28:04 2018.-->
 				<sdk:size>65897960</sdk:size>
 				<sdk:checksum type="sha1">53536556059bb29ae82f414fd2e14bc335a4eb4c</sdk:checksum>
 				<sdk:url>android-21_r02.zip</sdk:url>
@@ -487,7 +535,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:12 2016.-->
+				<!--Built on: Sun Jun  3 18:11:51 2018.-->
 				<sdk:size>63567784</sdk:size>
 				<sdk:checksum type="sha1">a9251f8a3f313ab05834a07a963000927637e01d</sdk:checksum>
 				<sdk:url>android-20_r02.zip</sdk:url>
@@ -511,7 +559,7 @@ June 2014.</sdk:license>
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:11 2016.-->
+				<!--Built on: Fri May 25 15:40:05 2018.-->
 				<sdk:size>63871092</sdk:size>
 				<sdk:checksum type="sha1">2ff20d89e68f2f5390981342e009db5a2d456aaa</sdk:checksum>
 				<sdk:url>android-19_r04.zip</sdk:url>
@@ -535,7 +583,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:11 2016.-->
+				<!--Built on: Fri May 18 13:24:37 2018.-->
 				<sdk:size>57771739</sdk:size>
 				<sdk:checksum type="sha1">e6b09b3505754cbbeb4a5622008b907262ee91cb</sdk:checksum>
 				<sdk:url>android-18_r03.zip</sdk:url>
@@ -559,7 +607,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:11 2016.-->
+				<!--Built on: Sat May 26 21:15:56 2018.-->
 				<sdk:size>57030216</sdk:size>
 				<sdk:checksum type="sha1">dbe14101c06e6cdb34e300393e64e64f8c92168a</sdk:checksum>
 				<sdk:url>android-17_r03.zip</sdk:url>
@@ -583,7 +631,7 @@ June 2014.</sdk:license>
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:10 2016.-->
+				<!--Built on: Wed May 23 08:20:21 2018.-->
 				<sdk:size>48128695</sdk:size>
 				<sdk:checksum type="sha1">12a5ce6235a76bc30f62c26bda1b680e336abd07</sdk:checksum>
 				<sdk:url>android-16_r05.zip</sdk:url>
@@ -607,7 +655,7 @@ June 2014.</sdk:license>
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:10 2016.-->
+				<!--Built on: Sat Jun  2 14:02:31 2018.-->
 				<sdk:size>44533475</sdk:size>
 				<sdk:checksum type="sha1">69ab4c443b37184b2883af1fd38cc20cbeffd0f3</sdk:checksum>
 				<sdk:url>android-15_r05.zip</sdk:url>
@@ -631,7 +679,7 @@ June 2014.</sdk:license>
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:09 2016.-->
+				<!--Built on: Mon Jun  4 10:33:42 2018.-->
 				<sdk:size>46038082</sdk:size>
 				<sdk:checksum type="sha1">d4f1d8fbca25225b5f0e7a0adf0d39c3d6e60b3c</sdk:checksum>
 				<sdk:url>android-14_r04.zip</sdk:url>
@@ -652,7 +700,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue May 24 11:44:04 2016.-->
+				<!--Built on: Sat Jun  2 07:27:36 2018.-->
 				<sdk:size>108426536</sdk:size>
 				<sdk:checksum type="sha1">6189a500a8c44ae73a439604363de93591163cd9</sdk:checksum>
 				<sdk:url>android-3.2_r01.zip</sdk:url>
@@ -675,7 +723,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue May 24 11:45:54 2016.-->
+				<!--Built on: Thu May 24 23:42:26 2018.-->
 				<sdk:size>106472351</sdk:size>
 				<sdk:checksum type="sha1">4a50a6679cd95bb68bb5fc032e754cd7c5e2b1bf</sdk:checksum>
 				<sdk:url>android-3.1_r03.zip</sdk:url>
@@ -698,7 +746,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue May 24 11:45:33 2016.-->
+				<!--Built on: Sun Jun 17 05:58:58 2018.-->
 				<sdk:size>104513908</sdk:size>
 				<sdk:checksum type="sha1">2c7d4bd13f276e76f6bbd87315fe27aba351dd37</sdk:checksum>
 				<sdk:url>android-3.0_r02.zip</sdk:url>
@@ -721,7 +769,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue May 24 11:46:21 2016.-->
+				<!--Built on: Wed Jun 13 04:35:13 2018.-->
 				<sdk:size>85470907</sdk:size>
 				<sdk:checksum type="sha1">887e37783ec32f541ea33c2c649dda648e8e6fb3</sdk:checksum>
 				<sdk:url>android-2.3.3_r02.zip</sdk:url>
@@ -744,7 +792,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue May 24 11:47:02 2016.-->
+				<!--Built on: Tue Jun 19 00:10:28 2018.-->
 				<sdk:size>78732563</sdk:size>
 				<sdk:checksum type="sha1">209f8a7a8b2cb093fce858b8b55fed3ba5206773</sdk:checksum>
 				<sdk:url>android-2.3.1_r02.zip</sdk:url>
@@ -767,7 +815,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<!--Built on: Mon Jun 11 13:26:30 2018.-->
 				<sdk:size>74652366</sdk:size>
 				<sdk:checksum type="sha1">231262c63eefdff8fd0386e9ccfefeb27a8f9202</sdk:checksum>
 				<sdk:url>android-2.2_r03.zip</sdk:url>
@@ -790,7 +838,7 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<!--Built on: Fri May 25 18:43:17 2018.-->
 				<sdk:size>70142829</sdk:size>
 				<sdk:checksum type="sha1">5ce51b023ac19f8738500b1007a1da5de2349a1e</sdk:checksum>
 				<sdk:url>android-2.1_r03.zip</sdk:url>
@@ -814,21 +862,21 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:15 2016.-->
+				<!--Built on: Sun May 27 03:48:57 2018.-->
 				<sdk:size>79192618</sdk:size>
 				<sdk:checksum type="sha1">ce2c971dce352aa28af06bda92a070116aa5ae1a</sdk:checksum>
 				<sdk:url>android-2.0.1_r01-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:15 2016.-->
+				<!--Built on: Fri Jun 15 10:07:34 2018.-->
 				<sdk:size>79035527</sdk:size>
 				<sdk:checksum type="sha1">c3096f80d75a6fc8cb38ef8a18aec920e53d42c0</sdk:checksum>
 				<sdk:url>android-2.0.1_r01-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:15 2016.-->
+				<!--Built on: Fri Jun  8 14:23:45 2018.-->
 				<sdk:size>80385601</sdk:size>
 				<sdk:checksum type="sha1">255781ebe4509d9707d0e77edda2815e2bc216e6</sdk:checksum>
 				<sdk:url>android-2.0.1_r01-windows.zip</sdk:url>
@@ -853,21 +901,21 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<!--Built on: Sat May 19 10:03:45 2018.-->
 				<sdk:size>75095268</sdk:size>
 				<sdk:checksum type="sha1">be9be6a99ca32875c96ec7f91160ca9fce7e3c7d</sdk:checksum>
 				<sdk:url>android-2.0_r01-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<!--Built on: Sat May 19 16:50:28 2018.-->
 				<sdk:size>74956356</sdk:size>
 				<sdk:checksum type="sha1">2a866d0870dbba18e0503cd41e5fae988a21b314</sdk:checksum>
 				<sdk:url>android-2.0_r01-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:13 2016.-->
+				<!--Built on: Thu Jun 14 00:45:58 2018.-->
 				<sdk:size>76288040</sdk:size>
 				<sdk:checksum type="sha1">aeb623217ff88b87216d6eb7dbc846ed53f68f57</sdk:checksum>
 				<sdk:url>android-2.0_r01-windows.zip</sdk:url>
@@ -892,21 +940,21 @@ June 2014.</sdk:license>
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<!--Built on: Sat May 26 23:29:51 2018.-->
 				<sdk:size>63454485</sdk:size>
 				<sdk:checksum type="sha1">483ed088e45bbdf3444baaf9250c8b02e5383cb0</sdk:checksum>
 				<sdk:url>android-1.6_r03-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<!--Built on: Sat Jun  2 07:57:24 2018.-->
 				<sdk:size>62418496</sdk:size>
 				<sdk:checksum type="sha1">bdafad44f5df9f127979bdb21a1fdd87ee3cd625</sdk:checksum>
 				<sdk:url>android-1.6_r03-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:17 2016.-->
+				<!--Built on: Mon Jun  4 04:34:06 2018.-->
 				<sdk:size>64654625</sdk:size>
 				<sdk:checksum type="sha1">ce0b5e4ffaf12ca4fd07c2da71a8a1ab4a03dc22</sdk:checksum>
 				<sdk:url>android-1.6_r03-windows.zip</sdk:url>
@@ -931,21 +979,21 @@ June 2014.</sdk:license>
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:14 2016.-->
+				<!--Built on: Thu May 17 22:23:16 2018.-->
 				<sdk:size>53348669</sdk:size>
 				<sdk:checksum type="sha1">5c134b7df5f4b8bd5b61ba93bdaebada8fa3468c</sdk:checksum>
 				<sdk:url>android-1.5_r04-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:14 2016.-->
+				<!--Built on: Mon Jun  4 15:31:36 2018.-->
 				<sdk:size>52440607</sdk:size>
 				<sdk:checksum type="sha1">d3a67c2369afa48b6c3c7624de5031c262018d1e</sdk:checksum>
 				<sdk:url>android-1.5_r04-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:14 2016.-->
+				<!--Built on: Thu Jun 14 02:58:08 2018.-->
 				<sdk:size>54624370</sdk:size>
 				<sdk:checksum type="sha1">5bb106d2e40d481edd337b0833093843e15fe49a</sdk:checksum>
 				<sdk:url>android-1.5_r04-windows.zip</sdk:url>
@@ -970,21 +1018,21 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:08 2016.-->
+				<!--Built on: Sun May 20 23:48:42 2018.-->
 				<sdk:size>45476658</sdk:size>
 				<sdk:checksum type="sha1">c054d25c9b4c6251fa49c2f9c54336998679d3fe</sdk:checksum>
 				<sdk:url>android-1.1_r1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:08 2016.-->
+				<!--Built on: Sat May 19 16:29:20 2018.-->
 				<sdk:size>45584305</sdk:size>
 				<sdk:checksum type="sha1">e21dbcff45b7356657449ebb3c7e941be2bb5ebe</sdk:checksum>
 				<sdk:url>android-1.1_r1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:08 2016.-->
+				<!--Built on: Fri Jun  8 18:57:19 2018.-->
 				<sdk:size>46828615</sdk:size>
 				<sdk:checksum type="sha1">a4060f29ed39fc929c302836d488998c53c3002e</sdk:checksum>
 				<sdk:url>android-1.1_r1-windows.zip</sdk:url>
@@ -1001,12 +1049,54 @@ June 2014.</sdk:license>
 		</sdk:layoutlib>
 	</sdk:platform>
 	<sdk:source>
+		<!--Generated from bid:4898911, branch:git_pi-release-->
+		<sdk:api-level>28</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Aug  8 15:54:23 2018.-->
+				<sdk:size>42552241</sdk:size>
+				<sdk:checksum type="sha1">5610e0c24235ee3fa343c899ddd551be30315255</sdk:checksum>
+				<sdk:url>sources-28_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:4402310, branch:git_oc-mr1-release-->
+		<sdk:api-level>27</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jun  8 01:46:30 2018.-->
+				<sdk:size>36997618</sdk:size>
+				<sdk:checksum type="sha1">7b714670561d08f54751af42aca929867b806596</sdk:checksum>
+				<sdk:url>sources-27_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
+		<!--Generated from bid:4187382, branch:git_oc-release-->
+		<sdk:api-level>26</sdk:api-level>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jun  8 01:15:38 2018.-->
+				<sdk:size>35138547</sdk:size>
+				<sdk:checksum type="sha1">2af701ee3223d580409288540b1d06932fd8f9b9</sdk:checksum>
+				<sdk:url>sources-26_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:source>
+	<sdk:source>
 		<!--Generated from bid:3544217, branch:git_nyc-mr1-sdk-dev-->
 		<sdk:api-level>25</sdk:api-level>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Dec  5 10:12:27 2016.-->
+				<!--Built on: Tue Jun  5 06:06:13 2018.-->
 				<sdk:size>30822685</sdk:size>
 				<sdk:checksum type="sha1">bbc72efd1a9bad87cc507e308f0d29aad438c52c</sdk:checksum>
 				<sdk:url>sources-25_r01.zip</sdk:url>
@@ -1020,7 +1110,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 22 11:05:30 2016.-->
+				<!--Built on: Fri Jun  8 14:43:03 2018.-->
 				<sdk:size>30270410</sdk:size>
 				<sdk:checksum type="sha1">6b96115830a83d654479f32ce4b724ca9011148b</sdk:checksum>
 				<sdk:url>sources-24_r01.zip</sdk:url>
@@ -1034,7 +1124,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:21 2016.-->
+				<!--Built on: Sun Jun 10 14:12:23 2018.-->
 				<sdk:size>31771965</sdk:size>
 				<sdk:checksum type="sha1">b0f15da2762b42f543c5e364c2b15b198cc99cc2</sdk:checksum>
 				<sdk:url>sources-23_r01.zip</sdk:url>
@@ -1048,7 +1138,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:21 2016.-->
+				<!--Built on: Mon Jun  4 23:43:02 2018.-->
 				<sdk:size>28861236</sdk:size>
 				<sdk:checksum type="sha1">98320e13976d11597a4a730a8d203ac9a03ed5a6</sdk:checksum>
 				<sdk:url>sources-22_r01.zip</sdk:url>
@@ -1062,7 +1152,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:20 2016.-->
+				<!--Built on: Sat Jun 16 09:12:37 2018.-->
 				<sdk:size>28274751</sdk:size>
 				<sdk:checksum type="sha1">137a5044915d32bea297a8c1552684802bbc2e25</sdk:checksum>
 				<sdk:url>sources-21_r01.zip</sdk:url>
@@ -1076,7 +1166,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:20 2016.-->
+				<!--Built on: Sat Jun  2 19:46:05 2018.-->
 				<sdk:size>23367603</sdk:size>
 				<sdk:checksum type="sha1">8da3e40f2625f9f7ef38b7e403f49f67226c0d76</sdk:checksum>
 				<sdk:url>sources-20_r01.zip</sdk:url>
@@ -1090,7 +1180,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:23 2016.-->
+				<!--Built on: Tue May 29 10:39:58 2018.-->
 				<sdk:size>21819439</sdk:size>
 				<sdk:checksum type="sha1">433a1d043ef77561571250e94cb7a0ef24a202e7</sdk:checksum>
 				<sdk:url>sources-19_r02.zip</sdk:url>
@@ -1104,7 +1194,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:23 2016.-->
+				<!--Built on: Fri May 18 03:14:54 2018.-->
 				<sdk:size>20226735</sdk:size>
 				<sdk:checksum type="sha1">8b49fdf7433f4881a2bfb559b5dd05d8ec65fb78</sdk:checksum>
 				<sdk:url>sources-18_r01.zip</sdk:url>
@@ -1118,7 +1208,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:22 2016.-->
+				<!--Built on: Thu May 17 17:14:50 2018.-->
 				<sdk:size>18976816</sdk:size>
 				<sdk:checksum type="sha1">6f1f18cd2d2b1852d7f6892df9cee3823349d43a</sdk:checksum>
 				<sdk:url>sources-17_r01.zip</sdk:url>
@@ -1132,7 +1222,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:22 2016.-->
+				<!--Built on: Wed May 30 05:17:35 2018.-->
 				<sdk:size>17876720</sdk:size>
 				<sdk:checksum type="sha1">0f83c14ed333c45d962279ab5d6bc98a0269ef84</sdk:checksum>
 				<sdk:url>sources-16_r02.zip</sdk:url>
@@ -1146,7 +1236,7 @@ June 2014.</sdk:license>
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:22 2016.-->
+				<!--Built on: Sat Jun 16 23:00:27 2018.-->
 				<sdk:size>16468746</sdk:size>
 				<sdk:checksum type="sha1">e5992a5747c9590783fbbdd700337bf0c9f6b1fa</sdk:checksum>
 				<sdk:url>sources-15_r02.zip</sdk:url>
@@ -1161,7 +1251,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:21 2016.-->
+				<!--Built on: Sat Jun  9 09:00:50 2018.-->
 				<sdk:size>16152383</sdk:size>
 				<sdk:checksum type="sha1">eaf4ed7dcac46e68516a1b4aa5b0d9e5a39a7555</sdk:checksum>
 				<sdk:url>sources-14_r01.zip</sdk:url>
@@ -1169,6 +1259,392 @@ June 2014.</sdk:license>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:source>
+	<sdk:build-tool>
+		<!--Generated from bid:5016651, branch:pi-sdk-release-->
+		<sdk:revision>
+			<sdk:major>28</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Sep 18 17:02:14 2018.-->
+				<sdk:size>57830695</sdk:size>
+				<sdk:checksum type="sha1">ea6f2f7103cd9da9ff0bdf6e37fbbba548fa4165</sdk:checksum>
+				<sdk:url>build-tools_r28.0.3-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Sep 18 17:02:10 2018.-->
+				<sdk:size>57133581</sdk:size>
+				<sdk:checksum type="sha1">f8c333a2991b1ab05a671bc6248b78e00edcd83a</sdk:checksum>
+				<sdk:url>build-tools_r28.0.3-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Sep 18 17:02:07 2018.-->
+				<sdk:size>58393729</sdk:size>
+				<sdk:checksum type="sha1">05bd35bb48d11c848da2b393c6f864eb609aacba</sdk:checksum>
+				<sdk:url>build-tools_r28.0.3-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4913185, branch:pi-sdk-release-->
+		<sdk:revision>
+			<sdk:major>28</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Jul 25 20:19:09 2018.-->
+				<sdk:size>57754663</sdk:size>
+				<sdk:checksum type="sha1">b4492209810a3fd48deaa982f9852fef12433d55</sdk:checksum>
+				<sdk:url>build-tools_r28.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jul 25 20:19:05 2018.-->
+				<sdk:size>57057554</sdk:size>
+				<sdk:checksum type="sha1">c10dd5a7825578622fb362a8a34f76eb3ba0c0a9</sdk:checksum>
+				<sdk:url>build-tools_r28.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jul 25 20:19:01 2018.-->
+				<sdk:size>58317692</sdk:size>
+				<sdk:checksum type="sha1">e9c570c568a0c2a32e88ee3204279019ebefd949</sdk:checksum>
+				<sdk:url>build-tools_r28.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4860066, branch:pi-preview4-release-->
+		<sdk:revision>
+			<sdk:major>28</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Jun 26 16:23:22 2018.-->
+				<sdk:size>57610954</sdk:size>
+				<sdk:checksum type="sha1">ee70dfa1fccb58b37cebc9544830511f36a137a0</sdk:checksum>
+				<sdk:url>build-tools_r28.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Jun 26 16:23:20 2018.-->
+				<sdk:size>56913869</sdk:size>
+				<sdk:checksum type="sha1">aeef42ad953f1630dd6f5d71eefdc0b825211462</sdk:checksum>
+				<sdk:url>build-tools_r28.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Tue Jun 26 16:23:17 2018.-->
+				<sdk:size>58173989</sdk:size>
+				<sdk:checksum type="sha1">29c6342835734be25b9e458ab3fad5750ad6a355</sdk:checksum>
+				<sdk:url>build-tools_r28.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4799589, branch:pi-preview3-release-->
+		<sdk:revision>
+			<sdk:major>28</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed May 23 16:22:51 2018.-->
+				<sdk:size>37157769</sdk:size>
+				<sdk:checksum type="sha1">d9f8a754d833ccd334f56fcc6089c5925cd82abb</sdk:checksum>
+				<sdk:url>build-tools_r28-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed May 23 16:22:49 2018.-->
+				<sdk:size>36458977</sdk:size>
+				<sdk:checksum type="sha1">72088d32d1d82cc3c2cf7cf6618b6130c0c84ade</sdk:checksum>
+				<sdk:url>build-tools_r28-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed May 23 16:22:47 2018.-->
+				<sdk:size>37718995</sdk:size>
+				<sdk:checksum type="sha1">d4b0638a877ed570e07876264e69fdbd86409610</sdk:checksum>
+				<sdk:url>build-tools_r28-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4758566, branch:pi-preview2-release-->
+		<sdk:revision>
+			<sdk:major>28</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+			<sdk:preview>2</sdk:preview>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Thu May  3 14:26:31 2018.-->
+				<sdk:size>37151124</sdk:size>
+				<sdk:checksum type="sha1">efe9c0dde0646a07544c864276390ca6e96b24dc</sdk:checksum>
+				<sdk:url>build-tools_r28-rc2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Thu May  3 14:26:27 2018.-->
+				<sdk:size>36449480</sdk:size>
+				<sdk:checksum type="sha1">0d0314b353589feb10e528b44c5a685b6658d797</sdk:checksum>
+				<sdk:url>build-tools_r28-rc2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Thu May  3 14:26:24 2018.-->
+				<sdk:size>37716459</sdk:size>
+				<sdk:checksum type="sha1">a94bfb52b4ec74b95c116236c3e382e923cad6c4</sdk:checksum>
+				<sdk:url>build-tools_r28-rc2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4614665, branch:git_pi-release-->
+		<sdk:revision>
+			<sdk:major>28</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+			<sdk:preview>1</sdk:preview>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Sat Jun 16 20:06:20 2018.-->
+				<sdk:size>38703535</sdk:size>
+				<sdk:checksum type="sha1">1601977fae25fd478bcfaa0481ca5ea3c609d840</sdk:checksum>
+				<sdk:url>build-tools_r28-rc1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Sun Jun 10 21:05:54 2018.-->
+				<sdk:size>38004795</sdk:size>
+				<sdk:checksum type="sha1">2c77821967a2330b7b227072d0b1c02ef19fe2fc</sdk:checksum>
+				<sdk:url>build-tools_r28-rc1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Sat Jun  9 11:13:53 2018.-->
+				<sdk:size>39273232</sdk:size>
+				<sdk:checksum type="sha1">fbf46c33d1268f6532911707b2a05033fd5c5b41</sdk:checksum>
+				<sdk:url>build-tools_r28-rc1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4507799, branch:git_oc-mr1-sdk-release-->
+		<sdk:revision>
+			<sdk:major>27</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri Jun 15 01:14:40 2018.-->
+				<sdk:size>54478554</sdk:size>
+				<sdk:checksum type="sha1">d85e7a6320eddffe7eeace3437605079dac938ca</sdk:checksum>
+				<sdk:url>build-tools_r27.0.3-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Fri Jun 15 02:46:10 2018.-->
+				<sdk:size>53867966</sdk:size>
+				<sdk:checksum type="sha1">61d9fb18790c68d66ff73bf1e7ad56bc1f1eef2d</sdk:checksum>
+				<sdk:url>build-tools_r27.0.3-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Jun 18 21:09:43 2018.-->
+				<sdk:size>55194255</sdk:size>
+				<sdk:checksum type="sha1">0df61e11713a2838d2cc9a911219dddf5e6a2749</sdk:checksum>
+				<sdk:url>build-tools_r27.0.3-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4458339, branch:git_oc-mr1-sdk-release-->
+		<sdk:revision>
+			<sdk:major>27</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Mon Jun  4 08:42:16 2018.-->
+				<sdk:size>54458153</sdk:size>
+				<sdk:checksum type="sha1">b687ddf6be84f11607871138aad32cf857d0b837</sdk:checksum>
+				<sdk:url>build-tools_r27.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Jun 11 15:49:30 2018.-->
+				<sdk:size>53846615</sdk:size>
+				<sdk:checksum type="sha1">6d5d9cf2a47877f273f4b742b19e712a051a31be</sdk:checksum>
+				<sdk:url>build-tools_r27.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon May 21 01:11:23 2018.-->
+				<sdk:size>55173070</sdk:size>
+				<sdk:checksum type="sha1">b80466c13b75e3ebf3c546964f40775db5898b2a</sdk:checksum>
+				<sdk:url>build-tools_r27.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4429804, branch:git_oc-mr1-release-->
+		<sdk:revision>
+			<sdk:major>27</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>1</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed Jun 13 21:53:36 2018.-->
+				<sdk:size>54450260</sdk:size>
+				<sdk:checksum type="sha1">7f4eedb1077ef948b848040dcd15de9e8a759f4a</sdk:checksum>
+				<sdk:url>build-tools_r27.0.1-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Thu May 17 21:44:36 2018.-->
+				<sdk:size>53838762</sdk:size>
+				<sdk:checksum type="sha1">1edd07bfdbadd95652d093040e16d858f7489594</sdk:checksum>
+				<sdk:url>build-tools_r27.0.1-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Sun Jun 10 07:28:26 2018.-->
+				<sdk:size>55171114</sdk:size>
+				<sdk:checksum type="sha1">18109db020c6d088d0157d1df201d31bc6970875</sdk:checksum>
+				<sdk:url>build-tools_r27.0.1-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4402310, branch:git_oc-mr1-release-->
+		<sdk:revision>
+			<sdk:major>27</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>0</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Sun Jun  3 03:24:44 2018.-->
+				<sdk:size>54441725</sdk:size>
+				<sdk:checksum type="sha1">28542332ba97cf4a08c3eddfcf5edd70e3cf1260</sdk:checksum>
+				<sdk:url>build-tools_r27-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Sat Jun  9 15:50:22 2018.-->
+				<sdk:size>53831513</sdk:size>
+				<sdk:checksum type="sha1">fb4e8d7e6b8d29a77090e34024077a80458d5ae1</sdk:checksum>
+				<sdk:url>build-tools_r27-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jun 13 05:13:49 2018.-->
+				<sdk:size>55163097</sdk:size>
+				<sdk:checksum type="sha1">4f1df22a6d99261d2160d624b81445da0a027dbe</sdk:checksum>
+				<sdk:url>build-tools_r27-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4420879, branch:git_oc-mr1-release-->
+		<sdk:revision>
+			<sdk:major>26</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>3</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Fri May 18 19:01:05 2018.-->
+				<sdk:size>54449983</sdk:size>
+				<sdk:checksum type="sha1">8a2e6c1bcd845844523a68aa17e5442f0dce328c</sdk:checksum>
+				<sdk:url>build-tools_r26.0.3-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Sat May 26 11:11:32 2018.-->
+				<sdk:size>53839758</sdk:size>
+				<sdk:checksum type="sha1">5bb90ed935d99e5bc90686f43b852e68c5ad40df</sdk:checksum>
+				<sdk:url>build-tools_r26.0.3-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Jun  4 23:32:18 2018.-->
+				<sdk:size>55170919</sdk:size>
+				<sdk:checksum type="sha1">460e511a9616b4661cc8dba0102d9d990ae60160</sdk:checksum>
+				<sdk:url>build-tools_r26.0.3-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
+	<sdk:build-tool>
+		<!--Generated from bid:4355572, branch:git_oc-mr1-release-->
+		<sdk:revision>
+			<sdk:major>26</sdk:major>
+			<sdk:minor>0</sdk:minor>
+			<sdk:micro>2</sdk:micro>
+		</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Wed May 23 14:33:19 2018.-->
+				<sdk:size>54440678</sdk:size>
+				<sdk:checksum type="sha1">5b2b7b66c7bf2151f2af183b5b50a17808850592</sdk:checksum>
+				<sdk:url>build-tools_r26.0.2-linux.zip</sdk:url>
+				<sdk:host-os>linux</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Wed Jun  6 07:17:54 2018.-->
+				<sdk:size>53830573</sdk:size>
+				<sdk:checksum type="sha1">d9ed7c7f149ce38be5dc08979aea8acec1459ca0</sdk:checksum>
+				<sdk:url>build-tools_r26.0.2-macosx.zip</sdk:url>
+				<sdk:host-os>macosx</sdk:host-os>
+			</sdk:archive>
+			<sdk:archive>
+				<!--Built on: Mon Jun 11 07:41:38 2018.-->
+				<sdk:size>55161474</sdk:size>
+				<sdk:checksum type="sha1">39ca02d3faa49859cd9d1bc0adc2f331017b699b</sdk:checksum>
+				<sdk:url>build-tools_r26.0.2-windows.zip</sdk:url>
+				<sdk:host-os>windows</sdk:host-os>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+	</sdk:build-tool>
 	<sdk:build-tool>
 		<!--Generated from bid:4187382, branch:git_oc-release-->
 		<sdk:revision>
@@ -1178,21 +1654,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Jul 18 10:38:26 2017.-->
+				<!--Built on: Fri Jun  8 18:48:52 2018.-->
 				<sdk:size>54113329</sdk:size>
 				<sdk:checksum type="sha1">5378c2c78091b414d0eac40a6bd37f2faa31a365</sdk:checksum>
 				<sdk:url>build-tools_r26.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Jul 18 10:38:23 2017.-->
+				<!--Built on: Wed Jun 13 12:42:53 2018.-->
 				<sdk:size>53266653</sdk:size>
 				<sdk:checksum type="sha1">cbde59de198916b390777dd0227921bfa2120832</sdk:checksum>
 				<sdk:url>build-tools_r26.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Jul 18 10:38:21 2017.-->
+				<!--Built on: Tue Jun  5 10:41:28 2018.-->
 				<sdk:size>54936185</sdk:size>
 				<sdk:checksum type="sha1">02494c80ffbe65bfff0aaa7463c9692693327b7d</sdk:checksum>
 				<sdk:url>build-tools_r26.0.1-windows.zip</sdk:url>
@@ -1210,21 +1686,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jun  2 13:22:18 2017.-->
+				<!--Built on: Sat May 26 02:59:29 2018.-->
 				<sdk:size>53854197</sdk:size>
 				<sdk:checksum type="sha1">1cbe72929876f8a872ab1f1b1040a9f720261f59</sdk:checksum>
 				<sdk:url>build-tools_r26-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jun  2 13:22:15 2017.-->
+				<!--Built on: Sat Jun  9 20:38:32 2018.-->
 				<sdk:size>53010814</sdk:size>
 				<sdk:checksum type="sha1">d01a1aeca03747245f1f5936b3cb01759c66d086</sdk:checksum>
 				<sdk:url>build-tools_r26-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jun  2 13:22:13 2017.-->
+				<!--Built on: Thu May 31 06:40:23 2018.-->
 				<sdk:size>54681641</sdk:size>
 				<sdk:checksum type="sha1">896ebd31117c09db220f7a3116cc0e5121c78b9d</sdk:checksum>
 				<sdk:url>build-tools_r26-windows.zip</sdk:url>
@@ -1243,21 +1719,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri May 12 23:05:09 2017.-->
+				<!--Built on: Tue May 22 14:01:05 2018.-->
 				<sdk:size>53847560</sdk:size>
 				<sdk:checksum type="sha1">629bbd8d2e415bf64871fb0b4c0540fd6d0347a0</sdk:checksum>
 				<sdk:url>build-tools_r26-rc2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri May 12 23:05:07 2017.-->
+				<!--Built on: Sat May 26 08:16:12 2018.-->
 				<sdk:size>53003874</sdk:size>
 				<sdk:checksum type="sha1">cb1eb738a1f7003025af267a9b8cc2d259533c70</sdk:checksum>
 				<sdk:url>build-tools_r26-rc2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri May 12 23:05:05 2017.-->
+				<!--Built on: Mon Jun 18 00:43:07 2018.-->
 				<sdk:size>54678375</sdk:size>
 				<sdk:checksum type="sha1">ddaba77db0557a98f6330fbd579ad0bd12cbb152</sdk:checksum>
 				<sdk:url>build-tools_r26-rc2-windows.zip</sdk:url>
@@ -1276,21 +1752,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 21 10:10:45 2017.-->
+				<!--Built on: Sun May 27 22:43:40 2018.-->
 				<sdk:size>53648603</sdk:size>
 				<sdk:checksum type="sha1">8cd6388dc96db2d7a49d06159cf990d3bbc78d04</sdk:checksum>
 				<sdk:url>build-tools_r26-rc1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Mar 21 10:10:34 2017.-->
+				<!--Built on: Tue Jun 12 18:41:58 2018.-->
 				<sdk:size>52821129</sdk:size>
 				<sdk:checksum type="sha1">5c5a1de7d5f4f000d36ae349229fe0be846d6137</sdk:checksum>
 				<sdk:url>build-tools_r26-rc1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Mar 21 10:10:25 2017.-->
+				<!--Built on: Sat May 26 12:23:48 2018.-->
 				<sdk:size>54379108</sdk:size>
 				<sdk:checksum type="sha1">43c2ddad3b67a5c33712ae14331a60673e69be91</sdk:checksum>
 				<sdk:url>build-tools_r26-rc1-windows.zip</sdk:url>
@@ -1308,21 +1784,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Apr 13 13:27:23 2017.-->
+				<!--Built on: Mon Jun  4 10:03:34 2018.-->
 				<sdk:size>50757258</sdk:size>
 				<sdk:checksum type="sha1">db95f3a0ae376534d4d69f4cdb6fad20649f3509</sdk:checksum>
 				<sdk:url>build-tools_r25.0.3-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Thu Apr 13 13:27:21 2017.-->
+				<!--Built on: Sat Jun 16 17:57:45 2018.-->
 				<sdk:size>50545085</sdk:size>
 				<sdk:checksum type="sha1">160d2fefb5ce68e443427fc30a793a703b63e26e</sdk:checksum>
 				<sdk:url>build-tools_r25.0.3-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Thu Apr 13 13:27:19 2017.-->
+				<!--Built on: Sat Jun  2 16:26:03 2018.-->
 				<sdk:size>51337442</sdk:size>
 				<sdk:checksum type="sha1">1edcb109ae5133aebfed573cf0bc84e0c353c28d</sdk:checksum>
 				<sdk:url>build-tools_r25.0.3-windows.zip</sdk:url>
@@ -1340,21 +1816,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Dec  5 10:11:59 2016.-->
+				<!--Built on: Wed Jun 13 09:54:19 2018.-->
 				<sdk:size>49880329</sdk:size>
 				<sdk:checksum type="sha1">ff953c0177e317618fda40516f3e9d95fd43c7ae</sdk:checksum>
 				<sdk:url>build-tools_r25.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Dec  5 10:11:57 2016.-->
+				<!--Built on: Tue May 29 08:01:46 2018.-->
 				<sdk:size>49667185</sdk:size>
 				<sdk:checksum type="sha1">12a5204bb3b6e39437535469fde7ddf42da46b16</sdk:checksum>
 				<sdk:url>build-tools_r25.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Dec  5 10:11:55 2016.-->
+				<!--Built on: Thu Jun  7 23:11:35 2018.-->
 				<sdk:size>50458908</sdk:size>
 				<sdk:checksum type="sha1">2fee3c0704d6ecc480570450d8b8069b2c4a2dd4</sdk:checksum>
 				<sdk:url>build-tools_r25.0.2-windows.zip</sdk:url>
@@ -1372,21 +1848,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Nov 14 23:49:02 2016.-->
+				<!--Built on: Fri May 25 11:51:28 2018.-->
 				<sdk:size>49880178</sdk:size>
 				<sdk:checksum type="sha1">ff063d252ab750d339f5947d06ff782836f22bac</sdk:checksum>
 				<sdk:url>build-tools_r25.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Nov 14 23:49:00 2016.-->
+				<!--Built on: Mon May 21 03:26:16 2018.-->
 				<sdk:size>49667353</sdk:size>
 				<sdk:checksum type="sha1">7bf7f22d7d48ef20b6ab0e3d7a2912e5c088340f</sdk:checksum>
 				<sdk:url>build-tools_r25.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Nov 14 23:48:57 2016.-->
+				<!--Built on: Wed May 30 20:26:28 2018.-->
 				<sdk:size>50458759</sdk:size>
 				<sdk:checksum type="sha1">c6c61393565ccf46349e7f44511e5db7c1c6169d</sdk:checksum>
 				<sdk:url>build-tools_r25.0.1-windows.zip</sdk:url>
@@ -1404,21 +1880,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Oct 17 14:57:00 2016.-->
+				<!--Built on: Sun Jun  3 08:35:42 2018.-->
 				<sdk:size>49872921</sdk:size>
 				<sdk:checksum type="sha1">f2bbda60403e75cabd0f238598c3b4dfca56ea44</sdk:checksum>
 				<sdk:url>build-tools_r25-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Oct 17 14:56:58 2016.-->
+				<!--Built on: Tue Jun  5 22:55:37 2018.-->
 				<sdk:size>49659466</sdk:size>
 				<sdk:checksum type="sha1">273c5c29a65cbed00e44f3aa470bbd7dce556606</sdk:checksum>
 				<sdk:url>build-tools_r25-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Oct 17 14:56:56 2016.-->
+				<!--Built on: Fri Jun  1 02:28:01 2018.-->
 				<sdk:size>50451378</sdk:size>
 				<sdk:checksum type="sha1">f9258f2308ff8b62cfc4513d40cb961612d07b6a</sdk:checksum>
 				<sdk:url>build-tools_r25-windows.zip</sdk:url>
@@ -1436,21 +1912,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Sep 27 10:00:17 2016.-->
+				<!--Built on: Sun Jun 10 09:52:06 2018.-->
 				<sdk:size>49779151</sdk:size>
 				<sdk:checksum type="sha1">9e8cc49d66e03fa1a8ecc1ac3e58f1324f5da304</sdk:checksum>
 				<sdk:url>build-tools_r24.0.3-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Sep 27 10:00:14 2016.-->
+				<!--Built on: Tue May 22 10:05:55 2018.-->
 				<sdk:size>49568967</sdk:size>
 				<sdk:checksum type="sha1">a01c15f1b105c34595681075e1895d58b3fff48c</sdk:checksum>
 				<sdk:url>build-tools_r24.0.3-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Sep 27 10:00:12 2016.-->
+				<!--Built on: Thu May 17 23:44:20 2018.-->
 				<sdk:size>50354788</sdk:size>
 				<sdk:checksum type="sha1">8b960d693fd4163caeb8dc5f5f5f80b10987089c</sdk:checksum>
 				<sdk:url>build-tools_r24.0.3-windows.zip</sdk:url>
@@ -1468,21 +1944,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 22 11:05:10 2016.-->
+				<!--Built on: Fri Jun 15 23:52:09 2018.-->
 				<sdk:size>48936295</sdk:size>
 				<sdk:checksum type="sha1">f199a7a788c3fefbed102eea34d6007737b803cf</sdk:checksum>
 				<sdk:url>build-tools_r24.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 22 11:05:08 2016.-->
+				<!--Built on: Fri Jun  8 05:11:05 2018.-->
 				<sdk:size>48726190</sdk:size>
 				<sdk:checksum type="sha1">8bb8fc575477491d5957de743089df412de55cda</sdk:checksum>
 				<sdk:url>build-tools_r24.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 22 11:05:05 2016.-->
+				<!--Built on: Fri Jun 15 23:26:15 2018.-->
 				<sdk:size>49512513</sdk:size>
 				<sdk:checksum type="sha1">09586a1f1c39bcfa7db5205c9a07837247deb67e</sdk:checksum>
 				<sdk:url>build-tools_r24.0.2-windows.zip</sdk:url>
@@ -1500,21 +1976,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Aug 23 11:42:33 2016.-->
+				<!--Built on: Mon May 28 07:24:53 2018.-->
 				<sdk:size>48936286</sdk:size>
 				<sdk:checksum type="sha1">84f18c392919a074fcbb9b1d967984e6b2fef8b4</sdk:checksum>
 				<sdk:url>build-tools_r24.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Aug 23 11:42:31 2016.-->
+				<!--Built on: Thu Jun 14 02:41:05 2018.-->
 				<sdk:size>48726085</sdk:size>
 				<sdk:checksum type="sha1">5c6457fcdfa07724fb086d8ff4e8316fc0742848</sdk:checksum>
 				<sdk:url>build-tools_r24.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Tue Aug 23 11:42:30 2016.-->
+				<!--Built on: Tue Jun 12 21:59:52 2018.-->
 				<sdk:size>49511883</sdk:size>
 				<sdk:checksum type="sha1">ac4a7cea42c3ef74d7fbf1b992fad311c550034e</sdk:checksum>
 				<sdk:url>build-tools_r24.0.1-windows.zip</sdk:url>
@@ -1532,21 +2008,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:09 2016.-->
+				<!--Built on: Thu May 31 15:18:44 2018.-->
 				<sdk:size>48960919</sdk:size>
 				<sdk:checksum type="sha1">c6271c4d78a5612ea6c7150688bcd5b7313de8d1</sdk:checksum>
 				<sdk:url>build-tools_r24-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:36 2016.-->
+				<!--Built on: Sun Jun 10 20:05:01 2018.-->
 				<sdk:size>48747930</sdk:size>
 				<sdk:checksum type="sha1">97fc4ed442f23989cc488d02c1d1de9bdde241de</sdk:checksum>
 				<sdk:url>build-tools_r24-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:02 2016.-->
+				<!--Built on: Sun Jun 10 15:13:01 2018.-->
 				<sdk:size>49535326</sdk:size>
 				<sdk:checksum type="sha1">dc61b9e5b451a0c3ec42ae2b1ce27c4d3c8da9f7</sdk:checksum>
 				<sdk:url>build-tools_r24-windows.zip</sdk:url>
@@ -1564,21 +2040,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:06 2016.-->
+				<!--Built on: Sat May 19 00:00:21 2018.-->
 				<sdk:size>39071201</sdk:size>
 				<sdk:checksum type="sha1">8a9f2b37f6fcf7a9fa784dc21aeaeb41bbb9f2c3</sdk:checksum>
 				<sdk:url>build-tools_r23.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:01 2016.-->
+				<!--Built on: Sun May 27 14:18:27 2018.-->
 				<sdk:size>38060914</sdk:size>
 				<sdk:checksum type="sha1">482c4cbceef8ff58aefd92d8155a38610158fdaf</sdk:checksum>
 				<sdk:url>build-tools_r23.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:55 2016.-->
+				<!--Built on: Mon Jun 18 16:23:02 2018.-->
 				<sdk:size>38217626</sdk:size>
 				<sdk:checksum type="sha1">fc3a92c744d3ba0a16ccb5d2b41eea5974ce0a96</sdk:checksum>
 				<sdk:url>build-tools_r23.0.2-windows.zip</sdk:url>
@@ -1596,21 +2072,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:13 2016.-->
+				<!--Built on: Tue Jun 12 12:39:27 2018.-->
 				<sdk:size>40733174</sdk:size>
 				<sdk:checksum type="sha1">368f2600feac7e9b511b82f53d1f2240ae4a91a3</sdk:checksum>
 				<sdk:url>build-tools_r23.0.3-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:36 2016.-->
+				<!--Built on: Fri Jun  8 14:28:55 2018.-->
 				<sdk:size>39679533</sdk:size>
 				<sdk:checksum type="sha1">fbc98cd303fd15a31d472de6c03bd707829f00b0</sdk:checksum>
 				<sdk:url>build-tools_r23.0.3-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:59 2016.-->
+				<!--Built on: Sat Jun  9 16:05:42 2018.-->
 				<sdk:size>39869945</sdk:size>
 				<sdk:checksum type="sha1">c6d8266c6a3243c8f1e41b786c0e3cee4c781263</sdk:checksum>
 				<sdk:url>build-tools_r23.0.3-windows.zip</sdk:url>
@@ -1628,21 +2104,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:55 2016.-->
+				<!--Built on: Sun Jun 17 12:24:05 2018.-->
 				<sdk:size>39069295</sdk:size>
 				<sdk:checksum type="sha1">b6ba7c399d5fa487d95289d8832e4ad943aed556</sdk:checksum>
 				<sdk:url>build-tools_r23.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:55 2016.-->
+				<!--Built on: Tue Jun 12 04:52:07 2018.-->
 				<sdk:size>38059328</sdk:size>
 				<sdk:checksum type="sha1">d96ec1522721e9a179ae2c591c99f75d31d39718</sdk:checksum>
 				<sdk:url>build-tools_r23.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:55 2016.-->
+				<!--Built on: Sat May 26 01:11:05 2018.-->
 				<sdk:size>38558889</sdk:size>
 				<sdk:checksum type="sha1">cc1d37231d228f7a6f130e1f8d8c940052f0f8ab</sdk:checksum>
 				<sdk:url>build-tools_r23.0.1-windows.zip</sdk:url>
@@ -1661,21 +2137,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:06 2016.-->
+				<!--Built on: Sat Jun  2 10:17:50 2018.-->
 				<sdk:size>39080519</sdk:size>
 				<sdk:checksum type="sha1">c1d6209212b01469f80fa804e0c1d39a06bc9060</sdk:checksum>
 				<sdk:url>build-tools_r23-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:19 2016.-->
+				<!--Built on: Wed Jun 13 23:09:27 2018.-->
 				<sdk:size>38070540</sdk:size>
 				<sdk:checksum type="sha1">90ba6e716f7703a236cd44b2e71c5ff430855a03</sdk:checksum>
 				<sdk:url>build-tools_r23-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:20:17 2016.-->
+				<!--Built on: Sat May 19 18:49:10 2018.-->
 				<sdk:size>38570715</sdk:size>
 				<sdk:checksum type="sha1">3874948f35f2f8946597679cc6e9151449f23b5d</sdk:checksum>
 				<sdk:url>build-tools_r23-windows.zip</sdk:url>
@@ -1693,21 +2169,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:01 2016.-->
+				<!--Built on: Thu Jun 14 19:03:49 2018.-->
 				<sdk:size>33104577</sdk:size>
 				<sdk:checksum type="sha1">da8b9c5c3ede39298e6cf0283c000c2ee9029646</sdk:checksum>
 				<sdk:url>build-tools_r22.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:48 2016.-->
+				<!--Built on: Mon Jun 11 09:42:44 2018.-->
 				<sdk:size>33646102</sdk:size>
 				<sdk:checksum type="sha1">53dad7f608e01d53b17176ba11165acbfccc5bbf</sdk:checksum>
 				<sdk:url>build-tools_r22.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:49 2016.-->
+				<!--Built on: Sat Jun  2 09:57:53 2018.-->
 				<sdk:size>33254137</sdk:size>
 				<sdk:checksum type="sha1">61d8cbe069d9e0a57872a83e5e5abe164b7d52cf</sdk:checksum>
 				<sdk:url>build-tools_r22.0.1-windows.zip</sdk:url>
@@ -1726,21 +2202,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:17:57 2016.-->
+				<!--Built on: Wed May 30 05:04:37 2018.-->
 				<sdk:size>33104280</sdk:size>
 				<sdk:checksum type="sha1">a8a1619dd090e44fac957bce6842e62abf87965b</sdk:checksum>
 				<sdk:url>build-tools_r22-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:14 2016.-->
+				<!--Built on: Sat May 26 11:13:48 2018.-->
 				<sdk:size>33646090</sdk:size>
 				<sdk:checksum type="sha1">af95429b24088d704bc5db9bd606e34ac1b82c0d</sdk:checksum>
 				<sdk:url>build-tools_r22-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:09 2016.-->
+				<!--Built on: Sat May 26 03:19:55 2018.-->
 				<sdk:size>33254114</sdk:size>
 				<sdk:checksum type="sha1">08fcca41e81b172bd9f570963b90d3a84929e043</sdk:checksum>
 				<sdk:url>build-tools_r22-windows.zip</sdk:url>
@@ -1758,21 +2234,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:17:59 2016.-->
+				<!--Built on: Wed Jun 13 11:02:29 2018.-->
 				<sdk:size>32637678</sdk:size>
 				<sdk:checksum type="sha1">5e35259843bf2926113a38368b08458735479658</sdk:checksum>
 				<sdk:url>build-tools_r21.1.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:34 2016.-->
+				<!--Built on: Tue May 29 13:57:42 2018.-->
 				<sdk:size>33152878</sdk:size>
 				<sdk:checksum type="sha1">e7c906b4ba0eea93b32ba36c610dbd6b204bff48</sdk:checksum>
 				<sdk:url>build-tools_r21.1.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:25 2016.-->
+				<!--Built on: Tue May 29 12:10:34 2018.-->
 				<sdk:size>32792587</sdk:size>
 				<sdk:checksum type="sha1">1d944759c47f60e634d2b8a1f3a4259be2f8d652</sdk:checksum>
 				<sdk:url>build-tools_r21.1.2-windows.zip</sdk:url>
@@ -1791,21 +2267,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:17:59 2016.-->
+				<!--Built on: Sun Jun  3 21:41:00 2018.-->
 				<sdk:size>32642454</sdk:size>
 				<sdk:checksum type="sha1">1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d</sdk:checksum>
 				<sdk:url>build-tools_r21.1.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:16 2016.-->
+				<!--Built on: Mon May 28 13:35:06 2018.-->
 				<sdk:size>33157676</sdk:size>
 				<sdk:checksum type="sha1">836a146eab0504aa9387a5132e986fe7c7381571</sdk:checksum>
 				<sdk:url>build-tools_r21.1.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:32 2016.-->
+				<!--Built on: Thu Jun 14 17:16:57 2018.-->
 				<sdk:size>32797356</sdk:size>
 				<sdk:checksum type="sha1">53fc4201237f899d5cd92f0b76ad41fb89da188b</sdk:checksum>
 				<sdk:url>build-tools_r21.1.1-windows.zip</sdk:url>
@@ -1824,21 +2300,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:17:58 2016.-->
+				<!--Built on: Tue Jun 12 23:37:47 2018.-->
 				<sdk:size>32642820</sdk:size>
 				<sdk:checksum type="sha1">b7455e543784d52a8925f960bc880493ed1478cb</sdk:checksum>
 				<sdk:url>build-tools_r21.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:34 2016.-->
+				<!--Built on: Sun Jun  3 03:22:22 2018.-->
 				<sdk:size>33158159</sdk:size>
 				<sdk:checksum type="sha1">df619356c2359aa5eacdd48699d15b335d9bd246</sdk:checksum>
 				<sdk:url>build-tools_r21.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:31 2016.-->
+				<!--Built on: Wed Jun 13 10:53:39 2018.-->
 				<sdk:size>32797810</sdk:size>
 				<sdk:checksum type="sha1">c79d63ac6b713a1e326ad4dae43f2ee76708a2f4</sdk:checksum>
 				<sdk:url>build-tools_r21.1-windows.zip</sdk:url>
@@ -1857,21 +2333,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:17:56 2016.-->
+				<!--Built on: Sat May 26 15:43:32 2018.-->
 				<sdk:size>22153122</sdk:size>
 				<sdk:checksum type="sha1">e1236ab8897b62b57414adcf04c132567b2612a5</sdk:checksum>
 				<sdk:url>build-tools_r21.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:09 2016.-->
+				<!--Built on: Sun Jun 10 08:07:31 2018.-->
 				<sdk:size>22668597</sdk:size>
 				<sdk:checksum type="sha1">f17471c154058f3734729ef3cc363399b1cd3de1</sdk:checksum>
 				<sdk:url>build-tools_r21.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:19:02 2016.-->
+				<!--Built on: Mon Jun  4 04:34:43 2018.-->
 				<sdk:size>22306371</sdk:size>
 				<sdk:checksum type="sha1">37496141b23cbe633167927b7abe6e22d9f1a1c1</sdk:checksum>
 				<sdk:url>build-tools_r21.0.2-windows.zip</sdk:url>
@@ -1890,21 +2366,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:17:55 2016.-->
+				<!--Built on: Mon May 21 01:06:40 2018.-->
 				<sdk:size>22153013</sdk:size>
 				<sdk:checksum type="sha1">e573069eea3e5255e7a65bedeb767f4fd0a5f49a</sdk:checksum>
 				<sdk:url>build-tools_r21.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:08 2016.-->
+				<!--Built on: Sat Jun  9 12:04:35 2018.-->
 				<sdk:size>22668616</sdk:size>
 				<sdk:checksum type="sha1">b60c8f9b810c980abafa04896706f3911be1ade7</sdk:checksum>
 				<sdk:url>build-tools_r21.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Aug 15 04:18:21 2016.-->
+				<!--Built on: Mon Jun 11 17:48:54 2018.-->
 				<sdk:size>22306243</sdk:size>
 				<sdk:checksum type="sha1">d68e7e6fd7a48c8759aa41d713c9d4f0e4c1c1df</sdk:checksum>
 				<sdk:url>build-tools_r21.0.1-windows.zip</sdk:url>
@@ -1923,21 +2399,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<!--Built on: Tue Jun 12 23:16:22 2018.-->
 				<sdk:size>22153145</sdk:size>
 				<sdk:checksum type="sha1">4933328fdeecbd554a29528f254f4993468e1cf4</sdk:checksum>
 				<sdk:url>build-tools_r21-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<!--Built on: Mon Jun  4 10:47:41 2018.-->
 				<sdk:size>22668456</sdk:size>
 				<sdk:checksum type="sha1">9bef7989b51436bd4e5114d8a0330359f077cbfa</sdk:checksum>
 				<sdk:url>build-tools_r21-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:49 2016.-->
+				<!--Built on: Mon Jun  4 08:31:36 2018.-->
 				<sdk:size>22306371</sdk:size>
 				<sdk:checksum type="sha1">5bc8fd399bc0135a9bc91eec78ddc5af4f54bf32</sdk:checksum>
 				<sdk:url>build-tools_r21-windows.zip</sdk:url>
@@ -1955,21 +2431,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<!--Built on: Wed May 30 04:41:59 2018.-->
 				<sdk:size>21445463</sdk:size>
 				<sdk:checksum type="sha1">b688905526a5584d1327a662d871a635ff502758</sdk:checksum>
 				<sdk:url>build-tools_r20-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<!--Built on: Thu Jun  7 14:45:22 2018.-->
 				<sdk:size>21650508</sdk:size>
 				<sdk:checksum type="sha1">1240f629411c108a714c4ddd756937c7fab93f83</sdk:checksum>
 				<sdk:url>build-tools_r20-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<!--Built on: Mon Jun  4 07:14:07 2018.-->
 				<sdk:size>20828006</sdk:size>
 				<sdk:checksum type="sha1">cf20720e452b642d5eb59dabe05c0c729b36ec75</sdk:checksum>
 				<sdk:url>build-tools_r20-windows.zip</sdk:url>
@@ -1987,21 +2463,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<!--Built on: Mon May 21 21:37:00 2018.-->
 				<sdk:size>21490972</sdk:size>
 				<sdk:checksum type="sha1">1ff20ac15fa47a75d00346ec12f180d531b3ca89</sdk:checksum>
 				<sdk:url>build-tools_r19.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<!--Built on: Tue May 29 05:26:30 2018.-->
 				<sdk:size>21590160</sdk:size>
 				<sdk:checksum type="sha1">0d11aae3417de1efb4b9a0e0a7855904a61bcec1</sdk:checksum>
 				<sdk:url>build-tools_r19.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:48 2016.-->
+				<!--Built on: Fri Jun  1 00:37:10 2018.-->
 				<sdk:size>20812533</sdk:size>
 				<sdk:checksum type="sha1">13b367fbdbff8132cb4356f716e8dc8a8df745c5</sdk:checksum>
 				<sdk:url>build-tools_r19.1-windows.zip</sdk:url>
@@ -2020,21 +2496,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<!--Built on: Sat May 26 14:59:05 2018.-->
 				<sdk:size>21462150</sdk:size>
 				<sdk:checksum type="sha1">c2d6055478e9d2d4fba476ee85f99181ddd1160c</sdk:checksum>
 				<sdk:url>build-tools_r19.0.3-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<!--Built on: Sun May 20 19:28:53 2018.-->
 				<sdk:size>21563992</sdk:size>
 				<sdk:checksum type="sha1">651cf8754373b2d52e7f6aab2c52eabffe4e9ea4</sdk:checksum>
 				<sdk:url>build-tools_r19.0.3-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:47 2016.-->
+				<!--Built on: Wed Jun 13 12:26:28 2018.-->
 				<sdk:size>20730715</sdk:size>
 				<sdk:checksum type="sha1">cb46b433b67a0a6910ff00db84be8b527ea3102f</sdk:checksum>
 				<sdk:url>build-tools_r19.0.3-windows.zip</sdk:url>
@@ -2053,21 +2529,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:46 2016.-->
+				<!--Built on: Mon Jun  4 07:15:16 2018.-->
 				<sdk:size>21352552</sdk:size>
 				<sdk:checksum type="sha1">a03a6bdea0091aea32e1b35b90a7294c9f04e3dd</sdk:checksum>
 				<sdk:url>build-tools_r19.0.2-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:46 2016.-->
+				<!--Built on: Wed Jun 13 06:24:09 2018.-->
 				<sdk:size>21453726</sdk:size>
 				<sdk:checksum type="sha1">145bc43065d45f756d99d87329d899052b9a9288</sdk:checksum>
 				<sdk:url>build-tools_r19.0.2-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:46 2016.-->
+				<!--Built on: Sat May 19 22:57:09 2018.-->
 				<sdk:size>20621117</sdk:size>
 				<sdk:checksum type="sha1">af664672d0d709c9ae30937b1062317d3ade7f95</sdk:checksum>
 				<sdk:url>build-tools_r19.0.2-windows.zip</sdk:url>
@@ -2086,21 +2562,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<!--Built on: Sat Jun  2 09:30:45 2018.-->
 				<sdk:size>21229048</sdk:size>
 				<sdk:checksum type="sha1">18d2312dc4368858914213087f4e61445aca4517</sdk:checksum>
 				<sdk:url>build-tools_r19.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<!--Built on: Fri Jun 15 19:07:47 2018.-->
 				<sdk:size>21450597</sdk:size>
 				<sdk:checksum type="sha1">efaf50fb19a3edb8d03efbff76f89a249ad2920b</sdk:checksum>
 				<sdk:url>build-tools_r19.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<!--Built on: Sun Jun 10 05:45:57 2018.-->
 				<sdk:size>20500648</sdk:size>
 				<sdk:checksum type="sha1">5ef422bac5b28f4ced108319ed4a6bc7050a6234</sdk:checksum>
 				<sdk:url>build-tools_r19.0.1-windows.zip</sdk:url>
@@ -2119,21 +2595,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<!--Built on: Wed May 30 04:04:22 2018.-->
 				<sdk:size>21339943</sdk:size>
 				<sdk:checksum type="sha1">55c1a6cf632e7d346f0002b275ec41fd3137fd83</sdk:checksum>
 				<sdk:url>build-tools_r19-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<!--Built on: Fri Jun 15 01:37:33 2018.-->
 				<sdk:size>21441270</sdk:size>
 				<sdk:checksum type="sha1">86ec1c12db1bc446b7bcaefc5cc14eb361044e90</sdk:checksum>
 				<sdk:url>build-tools_r19-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:03 2016.-->
+				<!--Built on: Wed Jun  6 05:47:57 2018.-->
 				<sdk:size>20611447</sdk:size>
 				<sdk:checksum type="sha1">6edf505c20f5ece9c48fa0aff9a90488f9654d52</sdk:checksum>
 				<sdk:url>build-tools_r19-windows.zip</sdk:url>
@@ -2152,21 +2628,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<!--Built on: Thu May 24 00:01:04 2018.-->
 				<sdk:size>20229760</sdk:size>
 				<sdk:checksum type="sha1">68c9acbfc0cec2d51b19efaed39831a17055d998</sdk:checksum>
 				<sdk:url>build-tools_r18.1.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<!--Built on: Tue May 22 07:45:01 2018.-->
 				<sdk:size>20452157</sdk:size>
 				<sdk:checksum type="sha1">a9d9d37f6ddf859e57abc78802a77aaa166e48d4</sdk:checksum>
 				<sdk:url>build-tools_r18.1.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:02 2016.-->
+				<!--Built on: Sun May 27 16:32:56 2018.-->
 				<sdk:size>19660000</sdk:size>
 				<sdk:checksum type="sha1">c4605066e2f851387ea70bc1442b1968bd7b4a15</sdk:checksum>
 				<sdk:url>build-tools_r18.1.1-windows.zip</sdk:url>
@@ -2185,21 +2661,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:01 2016.-->
+				<!--Built on: Mon Jun  4 05:17:04 2018.-->
 				<sdk:size>20229298</sdk:size>
 				<sdk:checksum type="sha1">f314a0599e51397f0886fe888b50dd98f2f050d8</sdk:checksum>
 				<sdk:url>build-tools_r18.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:01 2016.-->
+				<!--Built on: Sun Jun 17 12:29:46 2018.-->
 				<sdk:size>20451524</sdk:size>
 				<sdk:checksum type="sha1">16ddb299b8b43063e5bb3387ec17147c5053dfd8</sdk:checksum>
 				<sdk:url>build-tools_r18.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:01 2016.-->
+				<!--Built on: Thu Jun 14 15:56:37 2018.-->
 				<sdk:size>19659547</sdk:size>
 				<sdk:checksum type="sha1">3a9810fc8559ab03c09378f07531e8cae2f1db30</sdk:checksum>
 				<sdk:url>build-tools_r18.1-windows.zip</sdk:url>
@@ -2218,21 +2694,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<!--Built on: Sun Jun 10 13:17:31 2018.-->
 				<sdk:size>16627330</sdk:size>
 				<sdk:checksum type="sha1">f11618492b0d2270c332325d45d752d3656a9640</sdk:checksum>
 				<sdk:url>build-tools_r18.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<!--Built on: Mon May 21 16:08:02 2018.-->
 				<sdk:size>16633121</sdk:size>
 				<sdk:checksum type="sha1">d84f5692fb44d60fc53e5b2507cebf9f24626902</sdk:checksum>
 				<sdk:url>build-tools_r18.0.1-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<!--Built on: Fri Jun  1 08:16:51 2018.-->
 				<sdk:size>15413527</sdk:size>
 				<sdk:checksum type="sha1">a6c2afd0b6289d589351956d2f5212b37014ca7d</sdk:checksum>
 				<sdk:url>build-tools_r18.0.1-windows.zip</sdk:url>
@@ -2251,21 +2727,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:56:59 2016.-->
+				<!--Built on: Sat Jun  2 14:13:23 2018.-->
 				<sdk:size>11696007</sdk:size>
 				<sdk:checksum type="sha1">2c2872bc3806aabf16a12e3959c2183ddc866e6d</sdk:checksum>
 				<sdk:url>build-tools_r17-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<!--Built on: Tue Jun 19 09:33:42 2018.-->
 				<sdk:size>12208114</sdk:size>
 				<sdk:checksum type="sha1">602ee709be9dbb8f179b1e4075148a57f9419930</sdk:checksum>
 				<sdk:url>build-tools_r17-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Mar 28 00:57:00 2016.-->
+				<!--Built on: Fri Jun  8 13:26:17 2018.-->
 				<sdk:size>11004914</sdk:size>
 				<sdk:checksum type="sha1">899897d327b0bad492d3a40d3db4d96119c15bc0</sdk:checksum>
 				<sdk:url>build-tools_r17-windows.zip</sdk:url>
@@ -2275,32 +2751,32 @@ June 2014.</sdk:license>
 		<sdk:uses-license ref="android-sdk-license"/>
 	</sdk:build-tool>
 	<sdk:platform-tool>
-		<!--Generated from bid:4062713a, branch:git_oc-preview3-sdk-->
+		<!--Generated from bid:4986621, branch:aosp-sdk-release-->
 		<sdk:revision>
-			<sdk:major>26</sdk:major>
+			<sdk:major>28</sdk:major>
 			<sdk:minor>0</sdk:minor>
-			<sdk:micro>0</sdk:micro>
+			<sdk:micro>1</sdk:micro>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Jun  2 13:22:20 2017.-->
-				<sdk:size>7771750</sdk:size>
-				<sdk:checksum type="sha1">e75b6137dc444f777eb02f44a6d9819b3aabff82</sdk:checksum>
-				<sdk:url>platform-tools_r26.0.0-darwin.zip</sdk:url>
+				<!--Built on: Fri Aug 31 09:51:45 2018.-->
+				<sdk:size>6848749</sdk:size>
+				<sdk:checksum type="sha1">ed1edad4a48c27655ce98d0a5821e7296e9de145</sdk:checksum>
+				<sdk:url>platform-tools_r28.0.1-darwin.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jun  2 13:22:19 2017.-->
-				<sdk:size>7859155</sdk:size>
-				<sdk:checksum type="sha1">00de8a6631405b617c10f68cd11ff2e1cd528e23</sdk:checksum>
-				<sdk:url>platform-tools_r26.0.0-linux.zip</sdk:url>
+				<!--Built on: Fri Aug 31 09:51:40 2018.-->
+				<sdk:size>6843966</sdk:size>
+				<sdk:checksum type="sha1">74ff83bc203f01c4f04bd9316ab5a2573f023fd1</sdk:checksum>
+				<sdk:url>platform-tools_r28.0.1-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Fri Jun  2 13:22:20 2017.-->
-				<sdk:size>7511554</sdk:size>
-				<sdk:checksum type="sha1">a4128ebc3d1b6372d981810920e3fa01637f891a</sdk:checksum>
-				<sdk:url>platform-tools_r26.0.0-windows.zip</sdk:url>
+				<!--Built on: Fri Aug 31 09:51:43 2018.-->
+				<sdk:size>6183783</sdk:size>
+				<sdk:checksum type="sha1">5a44d10d41725aa718c71b6e44bc2dea6f1a7f49</sdk:checksum>
+				<sdk:url>platform-tools_r28.0.1-windows.zip</sdk:url>
 				<sdk:host-os>windows</sdk:host-os>
 			</sdk:archive>
 		</sdk:archives>
@@ -2315,21 +2791,21 @@ June 2014.</sdk:license>
 		</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Mon Dec 12 17:20:14 2016.-->
+				<!--Built on: Mon May 21 14:06:04 2018.-->
 				<sdk:size>277894900</sdk:size>
 				<sdk:checksum type="sha1">72df3aa1988c0a9003ccdfd7a13a7b8bd0f47fc1</sdk:checksum>
 				<sdk:url>tools_r25.2.5-linux.zip</sdk:url>
 				<sdk:host-os>linux</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Dec 12 17:20:09 2016.-->
+				<!--Built on: Thu May 31 17:55:03 2018.-->
 				<sdk:size>200529982</sdk:size>
 				<sdk:checksum type="sha1">d2168d963ac5b616e3d3ddaf21511d084baf3659</sdk:checksum>
 				<sdk:url>tools_r25.2.5-macosx.zip</sdk:url>
 				<sdk:host-os>macosx</sdk:host-os>
 			</sdk:archive>
 			<sdk:archive>
-				<!--Built on: Mon Dec 12 17:20:05 2016.-->
+				<!--Built on: Thu Jun  7 09:09:48 2018.-->
 				<sdk:size>306785944</sdk:size>
 				<sdk:checksum type="sha1">a7f7ebeae1c8d8f62d3a8466e9c81baee7cc31ca</sdk:checksum>
 				<sdk:url>tools_r25.2.5-windows.zip</sdk:url>
@@ -2347,7 +2823,7 @@ June 2014.</sdk:license>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Sep  8 15:25:04 2016.-->
+				<!--Built on: Thu Jun 14 09:35:24 2018.-->
 				<sdk:size>419477967</sdk:size>
 				<sdk:checksum type="sha1">eef58238949ee9544876cb3e002f2d58e4ee7b5d</sdk:checksum>
 				<sdk:url>docs-24_r01.zip</sdk:url>

--- a/pkgs/development/mobile/androidenv/sources.nix
+++ b/pkgs/development/mobile/androidenv/sources.nix
@@ -148,4 +148,37 @@ in
     };
   };
 
+  source_26 = buildSource {
+    name = "android-source-26";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-26_r01.zip;
+      sha1 = "2af701ee3223d580409288540b1d06932fd8f9b9";
+    };
+    meta = {
+      description = "Source code for Android API 26";
+    };
+  };
+
+  source_27 = buildSource {
+    name = "android-source-27";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-27_r01.zip;
+      sha1 = "7b714670561d08f54751af42aca929867b806596";
+    };
+    meta = {
+      description = "Source code for Android API 27";
+    };
+  };
+
+  source_28 = buildSource {
+    name = "android-source-28";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sources-28_r01.zip;
+      sha1 = "5610e0c24235ee3fa343c899ddd551be30315255";
+    };
+    meta = {
+      description = "Source code for Android API 28";
+    };
+  };
+
 }

--- a/pkgs/development/mobile/androidenv/sys-img.xml
+++ b/pkgs/development/mobile/androidenv/sys-img.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdk:sdk-sys-img xmlns:sdk="http://schemas.android.com/sdk/android/sys-img/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<!--Generated on 2017-08-28 14:42:29.488243 with ADRT.-->
+	<!--Generated on 2018-09-27 12:07:51.414125 with ADRT.-->
 	<sdk:license id="android-sdk-license" type="text">Terms and Conditions
 
 This is the Android Software Development Kit License Agreement
@@ -35,7 +35,7 @@ This is the Android Software Development Kit License Agreement
 
 3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. &quot;Intellectual Property Rights&quot; means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.
 
-3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not: (a) copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK; or (b) load any part of the SDK onto a mobile handset or any other hardware device except a personal computer, combine any part of the SDK with other software, or distribute any software or device incorporating a part of the SDK.
+3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement.  Except to the extent required by applicable third party licenses, you may not copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK.
 
 3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement.
 
@@ -411,7 +411,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Sep 16 16:38:16 2016.-->
+				<!--Built on: Fri Jul 27 08:50:45 2018.-->
 				<sdk:size>67918042</sdk:size>
 				<sdk:checksum type="sha1">54680383118eb5c95a11e1cc2a14aa572c86ee69</sdk:checksum>
 				<sdk:url>armv7-10_r04.zip</sdk:url>
@@ -428,7 +428,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:05 2016.-->
+				<!--Built on: Thu Jul 26 20:46:32 2018.-->
 				<sdk:size>99621822</sdk:size>
 				<sdk:checksum type="sha1">d8991b0c06b18d7d6ed4169d67460ee1add6661b</sdk:checksum>
 				<sdk:url>sysimg_armv7a-14_r02.zip</sdk:url>
@@ -445,7 +445,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:19:27 2016.-->
+				<!--Built on: Fri Jul 27 08:53:17 2018.-->
 				<sdk:size>102079727</sdk:size>
 				<sdk:checksum type="sha1">363223bd62f5afc0b2bd760b54ce9d26b31eacf1</sdk:checksum>
 				<sdk:url>armeabi-v7a-15_r04.zip</sdk:url>
@@ -462,7 +462,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:24:59 2016.-->
+				<!--Built on: Thu Jul 26 16:01:22 2018.-->
 				<sdk:size>112608076</sdk:size>
 				<sdk:checksum type="sha1">39c093ea755098f0ee79f607be7df9e54ba4943f</sdk:checksum>
 				<sdk:url>sysimg_armv7a-16_r04.zip</sdk:url>
@@ -479,7 +479,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:19:54 2016.-->
+				<!--Built on: Fri Jul 27 08:53:02 2018.-->
 				<sdk:size>124238679</sdk:size>
 				<sdk:checksum type="sha1">7460e8110f4a87f9644f1bdb5511a66872d50fd9</sdk:checksum>
 				<sdk:url>armeabi-v7a-17_r05.zip</sdk:url>
@@ -496,7 +496,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:20:07 2016.-->
+				<!--Built on: Fri Jul 27 08:53:09 2018.-->
 				<sdk:size>130394401</sdk:size>
 				<sdk:checksum type="sha1">0bf34ecf4ddd53f6b1b7fe7dfa12f2887c17e642</sdk:checksum>
 				<sdk:url>armeabi-v7a-18_r04.zip</sdk:url>
@@ -513,7 +513,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:20:23 2016.-->
+				<!--Built on: Fri Jul 27 08:53:25 2018.-->
 				<sdk:size>159871567</sdk:size>
 				<sdk:checksum type="sha1">d1a5fd4f2e1c013c3d3d9bfe7e9db908c3ed56fa</sdk:checksum>
 				<sdk:url>armeabi-v7a-19_r05.zip</sdk:url>
@@ -530,7 +530,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Sep 16 16:35:34 2016.-->
+				<!--Built on: Fri Jul 27 08:50:26 2018.-->
 				<sdk:size>187163871</sdk:size>
 				<sdk:checksum type="sha1">8c606f81306564b65e41303d2603e4c42ded0d10</sdk:checksum>
 				<sdk:url>armeabi-v7a-21_r04.zip</sdk:url>
@@ -547,7 +547,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>2</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Sep 16 16:35:50 2016.-->
+				<!--Built on: Fri Jul 27 08:50:08 2018.-->
 				<sdk:size>194596267</sdk:size>
 				<sdk:checksum type="sha1">2114ec015dbf3a16cbcb4f63e8a84a1b206a07a1</sdk:checksum>
 				<sdk:url>armeabi-v7a-22_r02.zip</sdk:url>
@@ -564,7 +564,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>6</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Sep 16 16:41:26 2016.-->
+				<!--Built on: Fri Jul 27 08:50:36 2018.-->
 				<sdk:size>238333358</sdk:size>
 				<sdk:checksum type="sha1">7cf2ad756e54a3acfd81064b63cb0cb9dff2798d</sdk:checksum>
 				<sdk:url>armeabi-v7a-23_r06.zip</sdk:url>
@@ -582,7 +582,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>7</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Sep  6 08:28:18 2016.-->
+				<!--Built on: Fri Jul 27 08:51:39 2018.-->
 				<sdk:size>283677512</sdk:size>
 				<sdk:checksum type="sha1">3454546b4eed2d6c3dd06d47757d6da9f4176033</sdk:checksum>
 				<sdk:url>armeabi-v7a-24_r07.zip</sdk:url>
@@ -599,7 +599,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>7</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Sep  6 08:28:58 2016.-->
+				<!--Built on: Fri Jul 27 08:51:37 2018.-->
 				<sdk:size>384556503</sdk:size>
 				<sdk:checksum type="sha1">e8ab2e49e4efe4b064232b33b5eeaded61437d7f</sdk:checksum>
 				<sdk:url>arm64-v8a-24_r07.zip</sdk:url>
@@ -610,30 +610,13 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:1741834, branch:git_ics-mr1-->
-		<sdk:api-level>15</sdk:api-level>
-		<sdk:description>MIPS System Image</sdk:description>
-		<sdk:revision>1</sdk:revision>
-		<sdk:archives>
-			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:24:59 2016.-->
-				<sdk:size>117503178</sdk:size>
-				<sdk:checksum type="sha1">a753bb4a6783124dad726c500ce9aec9d2c1b2d9</sdk:checksum>
-				<sdk:url>sysimg_mips-15_r01.zip</sdk:url>
-			</sdk:archive>
-		</sdk:archives>
-		<sdk:uses-license ref="mips-android-sysimage-license"/>
-		<sdk:abi>mips</sdk:abi>
-		<sdk:tag-id>default</sdk:tag-id>
-	</sdk:system-image>
-	<sdk:system-image>
 		<!--Generated from bid:1741836, branch:git_jb-dev-->
 		<sdk:api-level>16</sdk:api-level>
 		<sdk:description>MIPS System Image</sdk:description>
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:00 2016.-->
+				<!--Built on: Thu Jul 26 16:01:28 2018.-->
 				<sdk:size>122482530</sdk:size>
 				<sdk:checksum type="sha1">67943c54fb3943943ffeb05fdd39c0b753681f6e</sdk:checksum>
 				<sdk:url>sysimg_mips-16_r04.zip</sdk:url>
@@ -650,7 +633,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>1</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Tue Mar 29 18:25:00 2016.-->
+				<!--Built on: Thu Jul 26 16:01:38 2018.-->
 				<sdk:size>131781761</sdk:size>
 				<sdk:checksum type="sha1">f0c6e153bd584c29e51b5c9723cfbf30f996a05d</sdk:checksum>
 				<sdk:url>sysimg_mips-17_r01.zip</sdk:url>
@@ -667,7 +650,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Fri Sep 16 16:10:43 2016.-->
+				<!--Built on: Fri Jul 27 08:50:47 2018.-->
 				<sdk:size>75382637</sdk:size>
 				<sdk:checksum type="sha1">655ffc5cc89dd45a3aca154b254009016e473aeb</sdk:checksum>
 				<sdk:url>x86-10_r04.zip</sdk:url>
@@ -684,7 +667,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:20:36 2016.-->
+				<!--Built on: Fri Jul 27 08:53:18 2018.-->
 				<sdk:size>115324561</sdk:size>
 				<sdk:checksum type="sha1">e45c728b64881c0e86529a8f7ea9c103a3cd14c1</sdk:checksum>
 				<sdk:url>x86-15_r04.zip</sdk:url>
@@ -695,16 +678,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:3462064, branch:git_jb-emu-release-->
+		<!--Generated from bid:4875369, branch:git_jb-emu-release-->
 		<sdk:api-level>16</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>5</sdk:revision>
+		<sdk:revision>6</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:20:52 2016.-->
-				<sdk:size>134339698</sdk:size>
-				<sdk:checksum type="sha1">7ea16da3a8fdb880b1b290190fcc1bde2821c1e0</sdk:checksum>
-				<sdk:url>x86-16_r05.zip</sdk:url>
+				<!--Built on: Tue Jul 17 16:27:13 2018.-->
+				<sdk:size>134926152</sdk:size>
+				<sdk:checksum type="sha1">bf1bf8c5591346118d2235da1ad20e7be8a3e9cd</sdk:checksum>
+				<sdk:url>x86-16_r06.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -712,16 +695,16 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
-		<!--Generated from bid:3453820, branch:git_jb-mr1.1-emu-release-->
+		<!--Generated from bid:4875371, branch:git_jb-mr1.1-emu-release-->
 		<sdk:api-level>17</sdk:api-level>
 		<sdk:description>Intel x86 Atom System Image</sdk:description>
-		<sdk:revision>3</sdk:revision>
+		<sdk:revision>4</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:21:06 2016.-->
-				<sdk:size>142951842</sdk:size>
-				<sdk:checksum type="sha1">eb30274460ff0d61f3ed37862b567811bebd8270</sdk:checksum>
-				<sdk:url>x86-17_r03.zip</sdk:url>
+				<!--Built on: Tue Jul 17 16:30:45 2018.-->
+				<sdk:size>143278662</sdk:size>
+				<sdk:checksum type="sha1">03c6d022ab2dcbbcf655d78ba5ccb0431cadcaec</sdk:checksum>
+				<sdk:url>x86-17_r04.zip</sdk:url>
 			</sdk:archive>
 		</sdk:archives>
 		<sdk:uses-license ref="android-sdk-license"/>
@@ -735,7 +718,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>3</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Nov 10 17:21:19 2016.-->
+				<!--Built on: Fri Jul 27 08:53:12 2018.-->
 				<sdk:size>149657535</sdk:size>
 				<sdk:checksum type="sha1">03a0cb23465c3de15215934a1dbc9715b56e9458</sdk:checksum>
 				<sdk:url>x86-18_r03.zip</sdk:url>
@@ -752,7 +735,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>6</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:41:20 2017.-->
+				<!--Built on: Wed Jun 13 18:42:22 2018.-->
 				<sdk:size>185886274</sdk:size>
 				<sdk:checksum type="sha1">2ac82153aae97f7eae4c5a0761224fe04321d03d</sdk:checksum>
 				<sdk:url>x86-19_r06.zip</sdk:url>
@@ -769,7 +752,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:42:18 2017.-->
+				<!--Built on: Tue May 22 03:41:51 2018.-->
 				<sdk:size>208212529</sdk:size>
 				<sdk:checksum type="sha1">00f0eb0a1003efe3316347f762e20a85d8749cff</sdk:checksum>
 				<sdk:url>x86-21_r05.zip</sdk:url>
@@ -786,7 +769,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>6</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:43:18 2017.-->
+				<!--Built on: Sun May 20 00:45:19 2018.-->
 				<sdk:size>214268954</sdk:size>
 				<sdk:checksum type="sha1">e33e2a6cc3f1cc56b2019dbef3917d2eeb26f54e</sdk:checksum>
 				<sdk:url>x86-22_r06.zip</sdk:url>
@@ -803,7 +786,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>10</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:44:25 2017.-->
+				<!--Built on: Tue Jun  5 22:05:27 2018.-->
 				<sdk:size>260804863</sdk:size>
 				<sdk:checksum type="sha1">f6c3e3dd7bd951454795aa75c3a145fd05ac25bb</sdk:checksum>
 				<sdk:url>x86-23_r10.zip</sdk:url>
@@ -820,7 +803,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>8</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:45:47 2017.-->
+				<!--Built on: Tue May 22 10:30:01 2018.-->
 				<sdk:size>313489224</sdk:size>
 				<sdk:checksum type="sha1">c1cae7634b0216c0b5990f2c144eb8ca948e3511</sdk:checksum>
 				<sdk:url>x86-24_r08.zip</sdk:url>
@@ -831,13 +814,84 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:tag-id>default</sdk:tag-id>
 	</sdk:system-image>
 	<sdk:system-image>
+		<!--Generated from bid:4931657, branch:git_nyc-mr1-emu-release-->
+		<sdk:api-level>25</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug  7 14:04:45 2018.-->
+				<sdk:size>316695942</sdk:size>
+				<sdk:checksum type="sha1">78ce7eb1387d598685633b9f7cbb300c3d3aeb5f</sdk:checksum>
+				<sdk:url>x86-25_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4931640, branch:git_oc-emu-release-->
+		<sdk:api-level>26</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug  7 14:05:14 2018.-->
+				<sdk:size>350195807</sdk:size>
+				<sdk:checksum type="sha1">e613d6e0da668e30daf547f3c6627a6352846f90</sdk:checksum>
+				<sdk:url>x86-26_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+		<sdk:tag-display>Default Android System Image</sdk:tag-display>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4931629, branch:git_oc-mr1-emu-release-->
+		<sdk:api-level>27</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug  7 14:05:43 2018.-->
+				<sdk:size>360984187</sdk:size>
+				<sdk:checksum type="sha1">4ec990fac7b62958decd12e18a4cd389dfe7c582</sdk:checksum>
+				<sdk:url>x86-27_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+		<sdk:tag-display>Default Android System Image</sdk:tag-display>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4923214, branch:git_pi-emu-release-->
+		<sdk:api-level>28</sdk:api-level>
+		<sdk:description>Intel x86 Atom System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Jul 31 17:43:13 2018.-->
+				<sdk:size>437320152</sdk:size>
+				<sdk:checksum type="sha1">ce03c42d80c0fc6dc47f6455dbee7aa275d02780</sdk:checksum>
+				<sdk:url>x86-28_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>x86</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+		<sdk:tag-display>Default Android System Image</sdk:tag-display>
+	</sdk:system-image>
+	<sdk:system-image>
 		<!--Generated from bid:4174711, branch:git_lmp-emu-release-->
 		<sdk:api-level>21</sdk:api-level>
 		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
 		<sdk:revision>5</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:46:57 2017.-->
+				<!--Built on: Wed Jun  6 04:05:38 2018.-->
 				<sdk:size>292623982</sdk:size>
 				<sdk:checksum type="sha1">9078a095825a69e5e215713f0866c83cef65a342</sdk:checksum>
 				<sdk:url>x86_64-21_r05.zip</sdk:url>
@@ -854,7 +908,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>6</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:48:15 2017.-->
+				<!--Built on: Sun May 27 01:45:29 2018.-->
 				<sdk:size>299976630</sdk:size>
 				<sdk:checksum type="sha1">5db3b27f78cd9c4c5092b1cad5a5dd479fb5b2e4</sdk:checksum>
 				<sdk:url>x86_64-22_r06.zip</sdk:url>
@@ -871,7 +925,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>10</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:49:37 2017.-->
+				<!--Built on: Tue Jun 12 05:59:42 2018.-->
 				<sdk:size>365009313</sdk:size>
 				<sdk:checksum type="sha1">7cbc291483ca07dc67b71268c5f08a5755f50f51</sdk:checksum>
 				<sdk:url>x86_64-23_r10.zip</sdk:url>
@@ -888,7 +942,7 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:revision>8</sdk:revision>
 		<sdk:archives>
 			<sdk:archive>
-				<!--Built on: Thu Jul 13 12:51:15 2017.-->
+				<!--Built on: Sat Jun 16 05:29:19 2018.-->
 				<sdk:size>419261998</sdk:size>
 				<sdk:checksum type="sha1">f6559e1949a5879f31a9662f4f0e50ad60181684</sdk:checksum>
 				<sdk:url>x86_64-24_r08.zip</sdk:url>
@@ -897,5 +951,76 @@ ANY PRE-RELEASE MATERIALS ARE NON-QUALIFIED AND, AS SUCH, ARE PROVIDED â€œAS ISâ
 		<sdk:uses-license ref="android-sdk-license"/>
 		<sdk:abi>x86_64</sdk:abi>
 		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4931657, branch:git_nyc-mr1-emu-release-->
+		<sdk:api-level>25</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug  7 14:06:13 2018.-->
+				<sdk:size>422702097</sdk:size>
+				<sdk:checksum type="sha1">7093d7b39216020226ff430a3b7b81c94d31ad37</sdk:checksum>
+				<sdk:url>x86_64-25_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4931640, branch:git_oc-emu-release-->
+		<sdk:api-level>26</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug  7 14:06:52 2018.-->
+				<sdk:size>474178332</sdk:size>
+				<sdk:checksum type="sha1">432f149c048bffce7f9de526ec65b336daf7a0a3</sdk:checksum>
+				<sdk:url>x86_64-26_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+		<sdk:tag-display>Default Android System Image</sdk:tag-display>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4931629, branch:git_oc-mr1-emu-release-->
+		<sdk:api-level>27</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>1</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Aug  7 14:07:35 2018.-->
+				<sdk:size>491675204</sdk:size>
+				<sdk:checksum type="sha1">2878261011a59ca3de29dc5b457a495fdb268d60</sdk:checksum>
+				<sdk:url>x86_64-27_r01.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+		<sdk:tag-display>Default Android System Image</sdk:tag-display>
+	</sdk:system-image>
+	<sdk:system-image>
+		<!--Generated from bid:4923214, branch:git_pi-emu-release-->
+		<sdk:api-level>28</sdk:api-level>
+		<sdk:description>Intel x86 Atom_64 System Image</sdk:description>
+		<sdk:revision>4</sdk:revision>
+		<sdk:archives>
+			<sdk:archive>
+				<!--Built on: Tue Jul 31 17:43:48 2018.-->
+				<sdk:size>564792723</sdk:size>
+				<sdk:checksum type="sha1">d47a85c8f4e9fd57df97814ad8884eeb0f3a0ef0</sdk:checksum>
+				<sdk:url>x86_64-28_r04.zip</sdk:url>
+			</sdk:archive>
+		</sdk:archives>
+		<sdk:uses-license ref="android-sdk-preview-license"/>
+		<sdk:abi>x86_64</sdk:abi>
+		<sdk:tag-id>default</sdk:tag-id>
+		<sdk:tag-display>Default Android System Image</sdk:tag-display>
 	</sdk:system-image>
 </sdk:sdk-sys-img>

--- a/pkgs/development/mobile/androidenv/sysimages.nix
+++ b/pkgs/development/mobile/androidenv/sysimages.nix
@@ -47,14 +47,6 @@ in
     };
   };
 
-  sysimg_mips_15 = buildSystemImage {
-    name = "sysimg-mips-15";
-    src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/sysimg_mips-15_r01.zip;
-      sha1 = "a753bb4a6783124dad726c500ce9aec9d2c1b2d9";
-    };
-  };
-
   sysimg_x86_15 = buildSystemImage {
     name = "sysimg-x86-15";
     src = fetchurl {
@@ -82,8 +74,8 @@ in
   sysimg_x86_16 = buildSystemImage {
     name = "sysimg-x86-16";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/x86-16_r05.zip;
-      sha1 = "7ea16da3a8fdb880b1b290190fcc1bde2821c1e0";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-16_r06.zip;
+      sha1 = "bf1bf8c5591346118d2235da1ad20e7be8a3e9cd";
     };
   };
 
@@ -106,8 +98,8 @@ in
   sysimg_x86_17 = buildSystemImage {
     name = "sysimg-x86-17";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/x86-17_r03.zip;
-      sha1 = "eb30274460ff0d61f3ed37862b567811bebd8270";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-17_r04.zip;
+      sha1 = "03c6d022ab2dcbbcf655d78ba5ccb0431cadcaec";
     };
   };
 
@@ -250,17 +242,64 @@ in
   sysimg_x86_25 = buildSystemImage {
     name = "sysimg-x86-25";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/x86-25_r03.zip;
-      sha1 = "7dd19cfee4e43a1f60e0f5f058404d92d9544b33";
+      url = https://dl.google.com/android/repository/sys-img/android/x86-25_r01.zip;
+      sha1 = "78ce7eb1387d598685633b9f7cbb300c3d3aeb5f";
     };
   };
 
   sysimg_x86_64_25 = buildSystemImage {
     name = "sysimg-x86_64-25";
     src = fetchurl {
-      url = https://dl.google.com/android/repository/sys-img/android/x86_64-25_r03.zip;
-      sha1 = "4593ee04811df21c339f3374fc5917843db06f8d";
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-25_r01.zip;
+      sha1 = "7093d7b39216020226ff430a3b7b81c94d31ad37";
+    };
+  };
+
+  sysimg_x86_26 = buildSystemImage {
+    name = "sysimg-x86-26";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-26_r01.zip;
+      sha1 = "e613d6e0da668e30daf547f3c6627a6352846f90";
+    };
+  };
+
+  sysimg_x86_64_26 = buildSystemImage {
+    name = "sysimg-x86_64-26";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-26_r01.zip;
+      sha1 = "432f149c048bffce7f9de526ec65b336daf7a0a3";
+    };
+  };
+
+  sysimg_x86_27 = buildSystemImage {
+    name = "sysimg-x86-27";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-27_r01.zip;
+      sha1 = "4ec990fac7b62958decd12e18a4cd389dfe7c582";
+    };
+  };
+
+  sysimg_x86_64_27 = buildSystemImage {
+    name = "sysimg-x86_64-27";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-27_r01.zip;
+      sha1 = "2878261011a59ca3de29dc5b457a495fdb268d60";
+    };
+  };
+
+  sysimg_x86_28 = buildSystemImage {
+    name = "sysimg-x86-28";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-28_r04.zip;
+      sha1 = "ce03c42d80c0fc6dc47f6455dbee7aa275d02780";
+    };
+  };
+
+  sysimg_x86_64_28 = buildSystemImage {
+    name = "sysimg-x86_64-28";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-28_r04.zip;
+      sha1 = "d47a85c8f4e9fd57df97814ad8884eeb0f3a0ef0";
     };
   };
 }
-

--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
         --add-flags "-jar $out/libexec/apktool/apktool.jar" \
-        --prefix PATH : "${buildTools}/build-tools/25.0.1/"
+        --prefix PATH : "${buildTools.v25_0_1}/build-tools/25.0.1/"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -766,6 +766,7 @@ with pkgs;
 
   androidenv = callPackage ../development/mobile/androidenv {
     pkgs_i686 = pkgsi686Linux;
+    licenseAccepted = (config.android_sdk.accept_license or false);
   };
 
   inherit (androidenv) androidndk;


### PR DESCRIPTION
I followed #36112 and some other license-requiring packages.




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---