### PR TITLE
vscode-extensions.ms-python.python: 2018.8.0 -> 2018.9.1

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -4,10 +4,10 @@ let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 in
 #
-# Unless there is a good reason not to, we attemp to use the same name as the 
+# Unless there is a good reason not to, we attempt to use the same name as the
 # extension's unique identifier (the name the extension gets when installed
 # from vscode under `~/.vscode`) and found on the marketplace extension page.
-# So an extension's attribute name should be of the form: 
+# So an extension's attribute name should be of the form:
 # "${mktplcRef.publisher}.${mktplcRef.name}".
 #
 rec {
@@ -24,6 +24,6 @@ rec {
   };
 
   ms-vscode.cpptools = callPackage ./cpptools {};
-  
+
   ms-python.python = callPackage ./python {};
 }

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.8.0";
-    sha256 = "1x1wkqbc0d6h5w2m5qczv6gd5j6yrzhwp0c6wk49bhg2l0ibvyx6";
+    version = "2018.9.1";
+    sha256 = "050r1rb0xyfikfa6iq741s368xz600pqdk74w6cxszxpy8kl2hng";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

