### PR TITLE
networkmanager: include option for iwd backend

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -34,6 +34,8 @@ let
 
     [device]
     wifi.scan-rand-mac-address=${if cfg.wifi.scanRandMacAddress then "yes" else "no"}
+    ${optionalString (cfg.backend == "iwd")
+      ''wifi.backend=iwd''}
 
     ${cfg.extraConfig}
   '';
@@ -186,6 +188,14 @@ in {
         description = ''
           A list of name servers that should be inserted before
           the ones configured in NetworkManager or received by DHCP.
+        '';
+      };
+
+      backend = mkOption {
+        type = types.enum [ "wpa_supplicant" "iwd" ];
+        default = "wpa_supplicant";
+        description = ''
+          Sets the tool used for the wifi backend.
         '';
       };
 
@@ -502,9 +512,11 @@ in {
 
     # Turn off NixOS' network management
     networking = {
-      useDHCP = false;
+      useDHCP = cfg.backend == "iwd";
       # use mkDefault to trigger the assertion about the conflict above
       wireless.enable = lib.mkDefault false;
+
+      wireless.iwd.enable = cfg.backend == "iwd";
     };
 
     security.polkit.extraConfig = polkitConf;


### PR DESCRIPTION
###### Motivation for this change
Works on my XPS 9570.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

