### PR TITLE
perlPackages.ClusterSSH: init at 4.13.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -197,6 +197,11 @@
     github = "aij";
     name = "Ivan Jager";
   };
+  aither = {
+    email = "aither@havefun.cz";
+    github = "aither64";
+    name = "Jakub Skokan";
+  };
   ajgrf = {
     email = "a@ajgrf.com";
     github = "ajgrf";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2305,6 +2305,43 @@ let
      };
   };
 
+  ClusterSSH = buildPerlPackage rec {
+    name = "App-ClusterSSH-4.13.2";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/D/DU/DUNCS/App-ClusterSSH-v4.13.2.tar.gz;
+      sha256 = "0rmk2p3f2wz1h092anidjclh212rv3gxyk0c641qk3frlrjnw6mp";
+    };
+    propagatedBuildInputs = [
+      ExceptionClass FilePath GetoptLong LocaleMaketext Tk TryTiny X11Protocol
+      X11ProtocolOther pkgs.coreutils pkgs.openssh pkgs.xterm
+    ];
+    buildInputs = [
+      FileSlurp FileTemp FileWhich CPANChanges TestPerlTidy TestPod
+      TestPodCoverage Readonly TestDifferences TestDistManifest TestTrap
+    ];
+    preConfigure = ''
+      for fn in bin_PL/* t/external_cluster_command ; do
+        patchShebangs "$fn"
+      done
+    '';
+    postInstall = ''
+      mkdir -p $out/etc/bash_completion.d
+      mv $out/bin/clusterssh_bash_completion.dist \
+         $out/etc/bash_completion.d/clusterssh_bash_completion
+      substituteInPlace $out/etc/bash_completion.d/clusterssh_bash_completion \
+         --replace '/bin/true' '${pkgs.coreutils}/bin/true' \
+         --replace 'grep' '${pkgs.gnugrep}/bin/grep' \
+         --replace 'sed' '${pkgs.gnused}/bin/sed'
+    '';
+    meta = {
+      description = "Cluster administration tool";
+      platforms = [ "x86_64-linux" ];
+      broken = stdenv.lib.versionAtLeast perl.version "5.29";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.aither ];
+    };
+  };
+
   CodeTidyAll = buildPerlPackage rec {
      name = "Code-TidyAll-0.73";
      src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17365,6 +17365,19 @@ let
     doCheck = false; # requires an X server
   };
 
+  X11ProtocolOther = buildPerlPackage rec {
+    name = "X11-Protocol-Other-30";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/${name}.tar.gz";
+      sha256 = "1mambi57cdkj82wiw1l8y2f70a60qsamdas0165hlj10drryfgrj";
+    };
+    buildInputs = [ X11Protocol ];
+    meta = {
+      description = "Window manager things for client programs";
+      license = stdenv.lib.licenses.gpl3;
+    };
+  };
+
   X11GUITest = buildPerlPackage rec {
     name = "X11-GUITest-0.28";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Adds ClusterSSH with one dependency and myself as a maintainer. ClusterSSH is a tool that lets you interactively manage multiple servers over SSH at once.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

