### PR TITLE
featherpad: init at 0.9.1

### DIFF
--- a/pkgs/applications/editors/featherpad/default.nix
+++ b/pkgs/applications/editors/featherpad/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pkgconfig, qt5, fetchFromGitHub }:
+
+with qt5;
+
+stdenv.mkDerivation rec {
+  version = "0.9.1";
+  name = "featherpad-${version}";
+  src = fetchFromGitHub {
+    owner = "tsujan";
+    repo = "FeatherPad";
+    rev = "V${version}";
+    sha256 = "053j14f6fw31cdnfr8hqpxw6jh2v65z43qchdsymbrk5zji8gxla";
+  };
+  nativeBuildInputs = [ qmake pkgconfig qttools ];
+  buildInputs = [ qtbase qtsvg qtx11extras ];
+  meta = with stdenv.lib; {
+    description = "Lightweight Qt5 Plain-Text Editor for Linux";
+    homepage = https://github.com/tsujan/FeatherPad;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.flosse ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2544,6 +2544,8 @@ with pkgs;
 
   fdm = callPackage ../tools/networking/fdm {};
 
+  featherpad = callPackage ../applications/editors/featherpad {};
+
   feedreader = callPackage ../applications/networking/feedreaders/feedreader {};
 
   ferm = callPackage ../tools/networking/ferm { };


### PR DESCRIPTION
###### Motivation for this change

I like to use featherpad @ nixos ;-)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

