### PR TITLE
jwm-settings-manager: init at 2018-10-19

### DIFF
--- a/pkgs/applications/window-managers/jwm/jwm-settings-manager.nix
+++ b/pkgs/applications/window-managers/jwm/jwm-settings-manager.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gettext, libXpm, libGL, fltk, hicolor-icon-theme, glib, gnome2, which }:
+
+stdenv.mkDerivation rec {
+  name = "jwm-settings-manager-${version}";
+  version = "2018-10-19";
+  
+  src = fetchFromGitHub {
+    owner = "Israel-D";
+    repo = "jwm-settings-manager";
+    rev = "cb32a70563cf1f3927339093481542b85ec3c8c8";
+    sha256 = "0d5bqf74p8zg8azns44g46q973blhmp715k8kcd73x88g7sfir8s";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    gettext
+  ];
+
+  buildInputs = [
+    libXpm
+    libGL
+    fltk
+    hicolor-icon-theme
+    which # needed at runtime to locate optional programs
+    glib.bin # provides gsettings
+    gnome2.GConf # provides gconftool-2
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'CMAKE_INSTALL_PREFIX "/usr"' "CMAKE_INSTALL_PREFIX $out"
+    substituteInPlace data/CMakeLists.txt \
+      --replace 'DESTINATION usr/share' "DESTINATION share"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A full configuration manager for JWM";
+    homepage = https://joewing.net/projects/jwm;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17403,6 +17403,8 @@ with pkgs;
 
   jwm = callPackage ../applications/window-managers/jwm { };
 
+  jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };
+
   k3d = callPackage ../applications/graphics/k3d {
     inherit (pkgs.gnome2) gtkglext;
     stdenv = overrideCC stdenv gcc6;


### PR DESCRIPTION
###### Motivation for this change

Add [jwm-settings-manager](https://github.com/Israel-D/jwm-settings-manager).

> A full configuration manager for JWM, enabling the average user the ability to customize JWM to their liking. Built using FLTK and pugixml, this is a fast and light application to configure one of the fastest lightest Window Managers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).