### PR TITLE
tikzit: init at 2.0

### DIFF
--- a/pkgs/applications/graphics/tikzit/default.nix
+++ b/pkgs/applications/graphics/tikzit/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, qmake, bison, flex }:
+
+stdenv.mkDerivation rec {
+  name = "tikzit-${version}";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "https://github.com/tikzit/tikzit/archive/v${version}.tar.gz";
+    sha256 = "15gjnkm4nzm49bmmsfs4xs24vknr7i16fwi1830rh8mcp0qlba6i";
+  };
+
+  nativeBuildInputs = [ qmake bison flex ];
+
+  meta = with stdenv.lib; {
+    description = "TikZiT is a graphical tool for rapidly creating graphs and string diagrams using PGF/TikZ";
+    longDescription = ''
+      TikZiT is a super simple GUI editor for graphs and string diagrams. Its
+      native file format is a subset of PGF/TikZ, which means TikZiT files can
+      be included directly in papers typeset using LaTeX.
+    '';
+    homepage = https://tikzit.github.io/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nickhu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5610,6 +5610,8 @@ with pkgs;
 
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
+  tikzit = libsForQt5.callPackage ../applications/graphics/tikzit { };
+
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };
 
   timemachine = callPackage ../applications/audio/timemachine { };


### PR DESCRIPTION
New package for typesetting string diagrams


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---