### PR TITLE
pythonPackages.sh: 1.11 -> 1.12.14

### DIFF
--- a/pkgs/development/python-modules/python-packer/default.nix
+++ b/pkgs/development/python-modules/python-packer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, sh }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, sh }:
 
 buildPythonPackage rec {
   pname = "python-packer";
@@ -7,6 +7,12 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "fd363dae9bd2efd447739bbf7a4f29c1e4741596ae7b02d252fe525b2b4176e7";
+  };
+
+  patches = fetchpatch {
+    url = "${meta.homepage}/commit/de3421bf13bf7c3ec11fe0a381f0944e102b1d97.patch";
+    excludes = [ "dev-requirements.txt" ];
+    sha256 = "0rgmkyn7i6y1xs8m75dpl8hq7j2ns2s3dvp7kv9j4zwic93rrlsc";
   };
 
   propagatedBuildInputs = [ sh ];

--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, coverage }:
+
+buildPythonPackage rec {
+  pname = "sh";
+  version = "1.12.14";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
+  };
+
+  checkInputs = [ coverage ];
+
+  # A test needs the HOME directory to be different from $TMPDIR.
+  preCheck = ''
+    HOME=$(mktemp -d)
+  '';
+
+  meta = {
+    description = "Python subprocess interface";
+    homepage = https://pypi.python.org/pypi/sh/;
+    license = stdenv.lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6729,18 +6729,25 @@ in {
 
 
   sh = buildPythonPackage rec {
-    name = "sh-1.11";
+    pname = "sh";
+    version = "1.12.14";
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/sh/${name}.tar.gz";
-      sha256 = "590fb9b84abf8b1f560df92d73d87965f1e85c6b8330f8a5f6b336b36f0559a4";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
     };
 
-    doCheck = false;
+    buildInputs = with self; [ coverage ];
+
+    # A test needs the HOME directory to be different from $TMPDIR.
+    preCheck = ''
+    HOME=$(mktemp -d)
+    '';
 
     meta = {
       description = "Python subprocess interface";
       homepage = https://pypi.python.org/pypi/sh/;
+      license = licenses.mit;
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6727,30 +6727,7 @@ in {
     };
   };
 
-
-  sh = buildPythonPackage rec {
-    pname = "sh";
-    version = "1.12.14";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
-    };
-
-    buildInputs = with self; [ coverage ];
-
-    # A test needs the HOME directory to be different from $TMPDIR.
-    preCheck = ''
-    HOME=$(mktemp -d)
-    '';
-
-    meta = {
-      description = "Python subprocess interface";
-      homepage = https://pypi.python.org/pypi/sh/;
-      license = licenses.mit;
-    };
-  };
-
+  sh = callPackage ../development/python-modules/sh { };
 
   sipsimple = buildPythonPackage rec {
     name = "sipsimple-${version}";


### PR DESCRIPTION
###### Motivation for this change
Package update. 

###### Things done

- "Modernize" to the best of my knowledge. 
- Enable unit tests.
- Add MIT license.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (python2 and 3)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

