### PR TITLE
avldrums-lv2: init at 0.3.0

### DIFF
--- a/pkgs/applications/audio/avldrums-lv2/default.nix
+++ b/pkgs/applications/audio/avldrums-lv2/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, pkgconfig, pango, cairo, libGLU, lv2 }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "avldrums.lv2";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "x42";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0w51gdshq2i5bix2x5l3g3gnycy84nlzf5sj0jkrw0zrnbk6ghwg";
+    fetchSubmodules = true;
+  };
+
+  installFlags = "PREFIX=$(out)";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    pango cairo libGLU lv2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Dedicated AVLDrumkits LV2 Plugin";
+    homepage    = http://x42-plugins.com/x42/x42-avldrums;
+    license     = licenses.gpl2;
+    maintainers = [ maintainers.magnetophon ];
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -577,6 +577,8 @@ with pkgs;
 
   avfs = callPackage ../tools/filesystems/avfs { };
 
+  avldrums-lv2 = callPackage ../applications/audio/avldrums-lv2 { };
+
   aws-iam-authenticator = callPackage ../tools/security/aws-iam-authenticator {};
 
   awscli = callPackage ../tools/admin/awscli { };
@@ -21123,7 +21125,7 @@ with pkgs;
   liblapackWithAtlas = liblapack;
 
   liblbfgs = callPackage ../development/libraries/science/math/liblbfgs { };
-  
+
   lrs = callPackage ../development/libraries/science/math/lrs { };
 
   m4ri = callPackage ../development/libraries/science/math/m4ri { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

