### PR TITLE
opensmtpd: 6.0.3p1 -> 6.4.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -137,6 +137,14 @@
      make sure to update your configuration if you want to keep <literal>proglodyte-wasm</literal>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     OpenSMTPD has been upgraded to version 6.4.0p1. This release makes
+     backwards-incompatible changes to the configuration file format. See
+     <command>man smtpd.conf</command> for more information on the new file
+     format.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/tests/opensmtpd.nix
+++ b/nixos/tests/opensmtpd.nix
@@ -17,11 +17,12 @@ import ./make-test.nix {
         extraServerArgs = [ "-v" ];
         serverConfiguration = ''
           listen on 0.0.0.0
+          action do_relay relay
           # DO NOT DO THIS IN PRODUCTION!
           # Setting up authentication requires a certificate which is painful in
           # a test environment, but THIS WOULD BE DANGEROUS OUTSIDE OF A
           # WELL-CONTROLLED ENVIRONMENT!
-          accept from any for any relay
+          match from any for any action do_relay
         '';
       };
     };
@@ -41,8 +42,9 @@ import ./make-test.nix {
         extraServerArgs = [ "-v" ];
         serverConfiguration = ''
           listen on 0.0.0.0
-          accept from any for local deliver to mda \
+          action dovecot_deliver mda \
             "${pkgs.dovecot}/libexec/dovecot/deliver -d %{user.username}"
+          match from any for local action dovecot_deliver
         '';
       };
       services.dovecot2 = {

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -1,43 +1,33 @@
 { stdenv, lib, fetchurl, fetchpatch, autoconf, automake, libtool, bison
-, libasr, libevent, zlib, openssl, db, pam
-
-# opensmtpd requires root for no reason to encrypt passwords, this patch fixes it
-# see also https://github.com/OpenSMTPD/OpenSMTPD/issues/678
-, unpriviledged_smtpctl_encrypt ? true
-
-# Deprecated: use the subaddressing-delimiter in the config file going forward
-, tag_char ? null
+, libasr, libevent, zlib, libressl, db, pam
 }:
 
-if (tag_char != null)
-then throw "opensmtpd: the tag_char argument is deprecated as it can now be specified at runtime via the 'subaddressing-delimiter' option of the configuration file"
-else stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "opensmtpd-${version}";
-  version = "6.0.3p1";
+  version = "6.4.0p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
-  buildInputs = [ libasr libevent zlib openssl db pam ];
+  buildInputs = [ libasr libevent zlib libressl db pam ];
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "291881862888655565e8bbe3cfb743310f5dc0edb6fd28a889a9a547ad767a81";
+    sha256 = "1qxxhnlsmpfh9v4azgl0634955r085gsic1c66jdll21bd5w2mq8";
   };
 
   patches = [
     ./proc_path.diff
-    (fetchpatch {
-      url = "https://github.com/OpenSMTPD/OpenSMTPD/commit/725ba4fa2ddf23bbcd1ff9ec92e86bbfaa6825c8.diff";
-      sha256 = "19rla0b2r53jpdiz25fcza29c2msz6j6paivxhp9jcy1xl457dqa";
-    })
+    ./fix-build.diff # See https://github.com/OpenSMTPD/OpenSMTPD/pull/884
   ];
 
-  postPatch = with builtins; with lib;
-    optionalString unpriviledged_smtpctl_encrypt ''
-      substituteInPlace smtpd/smtpctl.c --replace \
-        'if (geteuid())' \
-        'if (geteuid() != 0 && !(argc > 1 && !strcmp(argv[1], "encrypt")))'
-      substituteInPlace mk/smtpctl/Makefile.in --replace "chmod 2555" "chmod 0555"
-    '';
+  # See https://github.com/OpenSMTPD/OpenSMTPD/issues/885 for the `sh bootstrap`
+  # requirement
+  postPatch = ''
+    substituteInPlace smtpd/parse.y \
+      --replace "/usr/libexec/" "$out/libexec/opensmtpd/"
+    substituteInPlace mk/smtpctl/Makefile.am --replace "chgrp" "true"
+    substituteInPlace mk/smtpctl/Makefile.am --replace "chmod 2555" "chmod 0555"
+    sh bootstrap
+  '';
 
   configureFlags = [
     "--sysconfdir=/etc"
@@ -54,6 +44,9 @@ else stdenv.mkDerivation rec {
     "--with-table-db"
   ];
 
+  # See https://github.com/OpenSMTPD/OpenSMTPD/pull/884
+  makeFlags = [ "CFLAGS=-ffunction-sections" "LDFLAGS=-Wl,--gc-sections" ];
+
   installFlags = [
     "sysconfdir=\${out}/etc"
     "localstatedir=\${TMPDIR}"
@@ -67,6 +60,6 @@ else stdenv.mkDerivation rec {
     '';
     license = licenses.isc;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ rickynils obadz ];
+    maintainers = with maintainers; [ rickynils obadz ekleog ];
   };
 }

--- a/pkgs/servers/mail/opensmtpd/fix-build.diff
+++ b/pkgs/servers/mail/opensmtpd/fix-build.diff
@@ -1,0 +1,12 @@
+diff --git a/mk/smtpctl/Makefile.am b/mk/smtpctl/Makefile.am
+index 5af0b713..f0fce735 100644
+--- a/mk/smtpctl/Makefile.am
++++ b/mk/smtpctl/Makefile.am
+@@ -4,6 +4,7 @@ sbin_PROGRAMS=          smtpctl
+ 
+ smtpctl_SOURCES=	$(smtpd_srcdir)/enqueue.c
+ smtpctl_SOURCES+=	$(smtpd_srcdir)/parser.c
++smtpctl_SOURCES+=	$(smtpd_srcdir)/config.c
+ smtpctl_SOURCES+=	$(smtpd_srcdir)/log.c
+ smtpctl_SOURCES+=	$(smtpd_srcdir)/envelope.c
+ smtpctl_SOURCES+=	$(smtpd_srcdir)/queue_backend.c


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

