### PR TITLE
eigen3_3: 3.3.4 -> 3.3.5

### DIFF
--- a/pkgs/development/libraries/eigen/3.3.nix
+++ b/pkgs/development/libraries/eigen/3.3.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, fetchpatch, cmake}:
 
 let
-  version = "3.3.4";
+  version = "3.3.5";
 in
 stdenv.mkDerivation {
   name = "eigen-${version}";
@@ -9,18 +9,9 @@ stdenv.mkDerivation {
   src = fetchurl {
     url = "https://bitbucket.org/eigen/eigen/get/${version}.tar.gz";
     name = "eigen-${version}.tar.gz";
-    sha256 = "1q85bgd6hnsgn0kq73wa4jwh4qdwklfg73pgqrz4zmxvzbqyi1j2";
+    sha256 = "13p60x6k61zq2y2in7g4fy5p55cr5dbmj3zvw10zcazxraxbcm04";
   };
 
-  patches = [
-    # Remove for > 3.3.4
-    # Upstream commit from 6 Apr 2018 "Fix cmake scripts with no fortran compiler"
-    (fetchpatch {
-      url    = "https://bitbucket.org/eigen/eigen/commits/ba14974d054ae9ae4ba88e5e58012fa6c2729c32/raw";
-      sha256 = "0fskiy9sbzvp693fcyv3pfq8kxxx3d3mgmaqvjbl5bpfjivij8l1";
-    })
-  ];
-  
   nativeBuildInputs = [ cmake ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Changes: http://eigen.tuxfamily.org/index.php?title=ChangeLog#Eigen_3.3.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

