### PR TITLE
nodejs: init at 11.5.0

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -12,12 +12,16 @@ with stdenv.lib;
 { enableNpm ? true, version, sha256, patches ? [] } @args:
 
 let
-
   inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
+
+  majorVersion = versions.major version;
+  minorVersion = versions.minor version;
 
   baseName = if enableNpm then "nodejs" else "nodejs-slim";
 
-  sharedLibDeps = { inherit openssl zlib libuv; } // (optionalAttrs (!stdenv.isDarwin) { inherit http-parser; });
+  useSharedHttpParser = !stdenv.isDarwin && versionOlder "${majorVersion}.${minorVersion}" "11.4";
+
+  sharedLibDeps = { inherit openssl zlib libuv; } // (optionalAttrs useSharedHttpParser { inherit http-parser; });
 
   sharedConfigureFlags = concatMap (name: [
     "--shared-${name}"
@@ -103,7 +107,7 @@ in
     passthru.updateScript = import ./update.nix {
       inherit stdenv writeScript coreutils gnugrep jq curl common-updater-scripts gnupg nix;
       inherit (stdenv) lib;
-      majorVersion = with stdenv.lib; elemAt (splitString "." version) 0;
+      inherit majorVersion;
     };
 
     meta = {

--- a/pkgs/development/web/nodejs/v11.nix
+++ b/pkgs/development/web/nodejs/v11.nix
@@ -1,0 +1,10 @@
+{ stdenv, callPackage, lib, openssl, enableNpm ? true }:
+
+let
+  buildNodejs = callPackage ./nodejs.nix { inherit openssl; };
+in
+  buildNodejs {
+    inherit enableNpm;
+    version = "11.5.0";
+    sha256 = "07fdpl8wzkcdd8iyaiwf2ah1rgishk2hrl0g73i8aggwplrl69fx";
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3875,6 +3875,13 @@ in
     enableNpm = false;
     openssl = openssl_1_1;
   };
+  nodejs-11_x = callPackage ../development/web/nodejs/v11.nix {
+    openssl = openssl_1_1;
+  };
+  nodejs-slim-11_x = callPackage ../development/web/nodejs/v11.nix {
+    enableNpm = false;
+    openssl = openssl_1_1;
+  };
 
   nodePackages_10_x = callPackage ../development/node-packages/default-v10.nix {
     nodejs = pkgs.nodejs-10_x;


### PR DESCRIPTION
###### Motivation for this change

New major release of nodejs.
[Release Notes](https://nodejs.org/en/blog/release/v11.0.0/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

