### PR TITLE
Updated mysql Package to support the change of root password of the mysql-server

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -353,7 +353,7 @@ in
               ${concatMapStrings (database: ''
                 echo "CREATE DATABASE IF NOT EXISTS ${database};"
               '') cfg.ensureDatabases}
-              ) | ${mysql}/bin/mysql -u root -N
+              ) | ${mysql}/bin/mysql -u root -p${cfg.rootPassword} -N
             ''}
 
             ${concatMapStrings (user:
@@ -362,7 +362,7 @@ in
                   ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
                   echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
                   '') user.ensurePermissions)}
-                ) | ${mysql}/bin/mysql -u root -N
+                ) | ${mysql}/bin/mysql -u root -p${cfg.rootPassword} -N
               '') cfg.ensureUsers}
 
           ''; # */


### PR DESCRIPTION
Ensure Databases and User does not work if the root password has changed

###### Motivation for this change
Trying to use mysqlBackup with changed root password. ... not working

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

