### PR TITLE
pythonPackages.owslib: init at 0.17.0

### DIFF
--- a/pkgs/development/python-modules/owslib/default.nix
+++ b/pkgs/development/python-modules/owslib/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, dateutil, requests, pytz, pyproj , pytest } :
+buildPythonPackage rec {
+  pname = "OWSLib";
+  version = "0.17.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1px2nmbpbpp556kjq0ym0a7j24nbvs4w829727b2gr4a4ff86hxc";
+  };
+
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ dateutil pyproj pytz requests ];
+
+  # 'tests' dir not included in pypy distribution archive.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "client for Open Geospatial Consortium web service interface standards";
+    license = licenses.bsd3;
+    homepage = https://www.osgeo.org/projects/owslib/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4435,6 +4435,8 @@ in {
     };
   };
 
+  owslib = callPackage ../development/python-modules/owslib { };
+
   PyICU = buildPythonPackage rec {
     name = "PyICU-2.0.3";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

