### PR TITLE
programs.sway-beta: module init (temporary until sway-beta becomes sway-1.0)

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -120,6 +120,7 @@
   ./programs/sysdig.nix
   ./programs/systemtap.nix
   ./programs/sway.nix
+  ./programs/sway-beta.nix
   ./programs/thefuck.nix
   ./programs/tmux.nix
   ./programs/udevil.nix

--- a/nixos/modules/programs/sway-beta.nix
+++ b/nixos/modules/programs/sway-beta.nix
@@ -1,0 +1,54 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.sway-beta;
+  swayPackage = cfg.package;
+in {
+  options.programs.sway-beta = {
+    enable = mkEnableOption ''
+      Sway, the i3-compatible tiling Wayland compositor. This module will be removed after the final release of Sway 1.0
+    '';
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.sway-beta;
+      defaultText = "pkgs.sway-beta";
+      description = ''
+        The package to be used for `sway`.
+      '';
+    };
+
+    extraPackages = mkOption {
+      type = with types; listOf package;
+      default = with pkgs; [
+        xwayland dmenu
+      ];
+      defaultText = literalExample ''
+        with pkgs; [ xwayland dmenu ];
+      '';
+      example = literalExample ''
+        with pkgs; [
+          xwayland
+          i3status i3status-rust
+          termite rofi light
+        ]
+      '';
+      description = ''
+        Extra packages to be installed system wide.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ swayPackage ] ++ cfg.extraPackages;
+    security.pam.services.swaylock = {};
+    hardware.opengl.enable = mkDefault true;
+    fonts.enableDefaultFonts = mkDefault true;
+    programs.dconf.enable = mkDefault true;
+  };
+
+  meta.maintainers = with lib.maintainers; [ gnidorah primeos colemickens ];
+}
+


### PR DESCRIPTION
###### Motivation for this change
Now that Sway-1.0-beta is in nixpkgs (https://github.com/NixOS/nixpkgs/pull/48829), we should discuss how to update the `sway` program module.

I have been running something like this with Sway 1.0-pre for sometime and it's been working well. Many of these changes were made due to suggestions from @srhb (and `emily` from IRC, I believe? Sorry for not remembering better to give credit and thanks!)

I'm looking for suggestions on how to handle this. Do we want a "sway-beta" program module? Seems messy in terms of upgrading/deprecations in the future, but also it may be too early to merge the change as-is now, since we still have older sway packaged as `sway`.

Thoughts? cc: @primeos @srhb @Synthetica9 @xeji 

(I'm sending this out for initial review/testing. I'm still working on rebasing my local branches to test out everything with the `sway-beta` that was packaged earlier.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

