### PR TITLE
r8168: init at 8.046.00

### DIFF
--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, lib, fetchFromGitHub, kernel }:
+
+
+let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/r8168";
+
+in stdenv.mkDerivation rec {
+  name = "r8168-${kernel.version}-${version}";
+  # on update please verify that the source matches the realtek version
+  version = "8.046.00";
+
+  # This is a mirror. The original website[1] doesn't allow non-interactive
+  # downloads, instead emailing you a download link.
+  # [1] http://www.realtek.com.tw/downloads/downloadsView.aspx?PFid=5&Level=5&Conn=4&DownTypeID=3
+  # I've verified manually (`diff -r`) that the source code for version 8.046.00
+  # is the same as the one available on the realtek website.
+  src = fetchFromGitHub {
+    owner = "mtorromeo";
+    repo = "r8168";
+    rev = version;
+    sha256 = "0y8w3biw5mshn5bvl24b9rybfh67f1s9gfzkcv9p4m7s7nchj2dg";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  # avoid using the Makefile directly -- it doesn't understand
+  # any kernel but the current.
+  # based on the ArchLinux pkgbuild: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/r8168
+  preBuild = ''
+    makeFlagsArray+=("-C${kernel.dev}/lib/modules/${kernel.modDirVersion}/build")
+    makeFlagsArray+=("SUBDIRS=$PWD/src")
+    makeFlagsArray+=("EXTRA_CFLAGS=-DCONFIG_R8168_NAPI -DCONFIG_R8168_VLAN")
+    makeFlagsArray+=("modules")
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    mkdir -p ${modDestDir}
+    find . -name '*.ko' -exec cp --parents '{}' ${modDestDir} \;
+    find ${modDestDir} -name '*.ko' -exec xz -f '{}' \;
+  '';
+
+  meta = with lib; {
+    description = "Realtek r8168 driver";
+    longDescription = ''
+      A kernel module for Realtek 8168 network cards.
+      If you want to use this driver, you might need to blacklist the r8169 driver
+      by adding "r8169" to boot.blacklistedKernelModules.
+    '';
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14329,6 +14329,8 @@ with pkgs;
 
     ply = callPackage ../os-specific/linux/ply { };
 
+    r8168 = callPackage ../os-specific/linux/r8168 { };
+
     rtl8192eu = callPackage ../os-specific/linux/rtl8192eu { };
 
     rtl8723bs = callPackage ../os-specific/linux/rtl8723bs { };


### PR DESCRIPTION
###### Motivation for this change

My network card defaults to the r8169 driver. That however has a bug where it sometimes stops working after a suspend. So I'm packaging the alternative, which works flawless.

@samueldr since just picking this package from the unstable channel isn't feasible (kernel versions have to match), would it be okay if I also add this to release-18.09?

Also this is my first kernel module so I'd appreciate it if someone reviews this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

