### PR TITLE
chromium: use clang (compilation with gcc is still possible too)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, gn, ninja, which, nodejs, fetchurl, fetchpatch, gnutar
+{ stdenv, llvmPackages, gn, ninja, which, nodejs, fetchurl, fetchpatch, gnutar
 
 # default dependencies
 , bzip2, flac, speex, libopus
@@ -130,14 +130,16 @@ let
     patches = optional enableWideVine ./patches/widevine.patch ++ [
       ./patches/nix_plugin_paths_68.patch
       ./patches/remove-webp-include-69.patch
+
       # Unfortunately, chromium regularly breaks on major updates and
-      # then needs various patches backported. Good sources for such patches and other hints:
+      # then needs various patches backported in order to be compiled with GCC.
+      # Good sources for such patches and other hints:
       # - https://gitweb.gentoo.org/repo/gentoo.git/plain/www-client/chromium/
       # - https://git.archlinux.org/svntogit/packages.git/tree/trunk?h=packages/chromium
       # - https://github.com/chromium/chromium/search?q=GCC&s=committer-date&type=Commits
       #
       # ++ optional (versionRange "68" "72") ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" )
-    ]  ++ optionals (versionOlder version "71") [
+    ] ++ optionals (!stdenv.cc.isClang && (versionRange "70" "71")) [
        ( githubPatch "cbdb8bd6567c8143dc8c1e5e86a21a8ea064eea4" "0258qlffp6f6izswczb11p8zdpn550z5yqa9z7gdg2rg5171n5i8" )
        ( githubPatch "e98f8ef8b2f236ecbb01df8c39e6ee1c8fbe8d7d" "1ky5xrzch6aya87kn0bgb31lksl3g8kh2v8k676ks7pdl2v132p9" )
        ( githubPatch "a4de8da116585357c123d71e5f54d1103824c6df" "1y7afnjrsz6j2l3vy1ms8mrkbb51xhcafw9r371algi48il7rajm" )
@@ -159,7 +161,7 @@ let
                 sha256    = "018fbdzyw9rvia8m0qkk5gv8q8gl7x34rrjbn7mi1fgxdsayn22s";
               }
             );
-            
+
     postPatch = ''
       # We want to be able to specify where the sandbox is via CHROME_DEVEL_SANDBOX
       substituteInPlace sandbox/linux/suid/client/setuid_sandbox_host.cc \
@@ -207,10 +209,16 @@ let
     '' + optionalString stdenv.isAarch64 ''
       substituteInPlace build/toolchain/linux/BUILD.gn \
         --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
+    '' + optionalString stdenv.cc.isClang ''
+      mkdir -p third_party/llvm-build/Release+Asserts/bin
+      ln -s ${stdenv.cc}/bin/clang              third_party/llvm-build/Release+Asserts/bin/clang
+      ln -s ${stdenv.cc}/bin/clang++            third_party/llvm-build/Release+Asserts/bin/clang++
+      ln -s ${llvmPackages.llvm}/bin/llvm-ar    third_party/llvm-build/Release+Asserts/bin/llvm-ar
     '';
 
     gnFlags = mkGnFlags ({
       linux_use_bundled_binutils = false;
+      use_lld = false;
       use_gold = true;
       gold_path = "${stdenv.cc}/bin";
       is_debug = false;
@@ -224,7 +232,7 @@ let
       use_cups = cupsSupport;
 
       treat_warnings_as_errors = false;
-      is_clang = false;
+      is_clang = stdenv.cc.isClang;
       clang_use_chrome_plugins = false;
       remove_webcore_debug_symbols = true;
       enable_swiftshader = false;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, makeWrapper, makeDesktopItem, ed
+{ newScope, stdenv, llvmPackages, makeWrapper, makeDesktopItem, ed
 , glib, gtk3, gnome3, gsettings-desktop-schemas
 
 # package customization
@@ -14,12 +14,13 @@
 , commandLineArgs ? ""
 }:
 
+assert stdenv.cc.isClang -> (stdenv == llvmPackages.stdenv);
 let
   callPackage = newScope chromium;
 
   chromium = {
-    inherit stdenv;
-  
+    inherit stdenv llvmPackages;
+
     upstream-info = (callPackage ./update.nix {}).getChannel channel;
 
     mkChromiumDerivation = callPackage ./common.nix {

--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenv, gcc
 , jshon
 , glib
 , nspr
@@ -69,7 +69,7 @@ let
       ! find -iname '*.so' -exec ldd {} + | grep 'not found'
     '';
 
-    PATCH_RPATH = mkrpath [ stdenv.cc.cc glib nspr nss ];
+    PATCH_RPATH = mkrpath [ gcc.cc glib nspr nss ];
 
     patchPhase = ''
       chmod +x libwidevinecdm.so libwidevinecdmadapter.so
@@ -110,7 +110,7 @@ let
 
     patchPhase = ''
       chmod +x libpepflashplayer.so
-      patchelf --set-rpath "${mkrpath [ stdenv.cc.cc ]}" libpepflashplayer.so
+      patchelf --set-rpath "${mkrpath [ gcc.cc ]}" libpepflashplayer.so
     '';
 
     doCheck = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15957,13 +15957,19 @@ with pkgs;
 
   bookworm = callPackage ../applications/office/bookworm { };
 
-  chromium = callPackage ../applications/networking/browsers/chromium {
+  chromium = callPackage ../applications/networking/browsers/chromium ({
     channel = "stable";
     pulseSupport = config.pulseaudio or true;
     enablePepperFlash = config.chromium.enablePepperFlash or false;
     enableWideVine = config.chromium.enableWideVine or false;
     gnome = gnome2;
-  };
+  } // (if stdenv.isAarch64 then {
+          stdenv = gcc8Stdenv;
+        } else {
+          llvmPackages = llvmPackages_7;
+          stdenv = llvmPackages_7.stdenv;
+        })
+   );
 
   chronos = callPackage ../applications/networking/cluster/chronos { };
 


### PR DESCRIPTION
###### Motivation for this change

 * <s>update ```chromium```</s>
 * switch to ```clang``` because upstream uses ```clang``` as primary compiler and then fix GCC problems (discussed in https://github.com/NixOS/nixpkgs/pull/48615#issuecomment-431168564). Fixes https://github.com/NixOS/nixpkgs/issues/28822

Tested ```chromium``` and ```chromiumDev``` on ```x86_64-linux``` (aarch64 is out of stock at Pocket )