### PR TITLE
git-bug: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3641,6 +3641,11 @@
     github = "roosemberth";
     name = "Roosembert (Roosemberth) Palacios";
   };
+  royneary = {
+    email = "christian@ulrich.earth";
+    github = "royneary";
+    name = "Christian Ulrich";
+  };
   rprospero = {
     email = "rprospero+nix@gmail.com";
     github = "rprospero";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -57,6 +57,8 @@ let
 
   git-annex-remote-rclone = callPackage ./git-annex-remote-rclone { };
 
+  git-bug = callPackage ./git-bug { };
+
   # support for bugzilla
   git-bz = callPackage ./git-bz { };
 

--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -19,6 +19,7 @@ buildGoPackage rec {
     cd go/src/${goPackagePath}
     install -D -m 0644 misc/bash_completion/git-bug "$bin/etc/bash_completion.d/git-bug"
     install -D -m 0644 misc/zsh_completion/git-bug "$bin/share/zsh/site-functions/git-bug"
+    install -D -m 0644 -t "$bin/share/man/man1" doc/man/*
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "git-bug-${version}";
+  version = "0.4.0";
+  rev = "2ab2412771d58a1b1f3bfeb5a6e9da2e683b0e12";
+  goPackagePath = "github.com/MichaelMure/git-bug";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "MichaelMure";
+    repo = "git-bug";
+    sha256 = "1zyvyg0p5h71wvyxrzkr1bwddxm3x8p44n6wh9ccfdxp8d2k6k25";
+  };
+
+  goDeps = ./deps.nix;
+
+  postInstall = ''
+    cd go/src/${goPackagePath}
+    install -D -m 0644 misc/bash_completion/git-bug "$bin/etc/bash_completion.d/git-bug"
+    install -D -m 0644 misc/zsh_completion/git-bug "$bin/share/zsh/site-functions/git-bug"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Distributed bug tracker embedded in Git";
+    homepage = https://github.com/MichaelMure/git-bug;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ royneary ];
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/git-bug/deps.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bug/deps.nix
@@ -1,0 +1,417 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/99designs/gqlgen";
+    fetch = {
+      type = "git";
+      url = "https://github.com/99designs/gqlgen";
+      rev =  "636435b68700211441303f1a5ed92f3768ba5774";
+      sha256 = "0d4sr6kpyn3zq3kpvk8lizy7hdpcw3fjmv7fbv2m1k9w8fzjawrz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/agnivade/levenshtein";
+    fetch = {
+      type = "git";
+      url = "https://github.com/agnivade/levenshtein";
+      rev =  "3d21ba515fe27b856f230847e856431ae1724adc";
+      sha256 = "0dym3k3ycsj0zj0p4dhdp7gd2hm7c7pyh2wii1mdbmpdyipy99cd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cheekybits/genny";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cheekybits/genny";
+      rev =  "9127e812e1e9e501ce899a18121d316ecb52e4ba";
+      sha256 = "1z57ga9c2sjnl5ngqgb1ap0zqv36sk0rarm02bbbkipz4m9yabjg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/corpix/uarand";
+    fetch = {
+      type = "git";
+      url = "https://github.com/corpix/uarand";
+      rev =  "2b8494104d86337cdd41d0a49cbed8e4583c0ab4";
+      sha256 = "06ml5m8l9wbr96gvyg6z1syawn797f8kmq74nhgry3vqpngyb6yn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev =  "20f5889cbdc3c73dbd2862796665e7c465ade7d1";
+      sha256 = "1w22dfdamsq63b5rvalh9k2y7rbwfkkjs7vm9vd4a13h2ql70lg2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev =  "9f541cc9db5d55bce703bd99987c9d5cb8eea45e";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-test/deep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-test/deep";
+      rev =  "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5";
+      sha256 = "0f4rbdl6qmlq4bzh0443i634bm675bbrkyzwp8wkc1yhdl9qsij7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "aa810b61a9c79d51363740d207bb46cf8e620ed5";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev =  "3af367b6b30c263d47e8895973edcca9a49cf029";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/context";
+      rev =  "08b5f424b9271eedf6f9f0ce86cb9396ed337a42";
+      sha256 = "03p4hn87vcmfih0p9w663qbx9lpsf7i7j3lc7yl7n84la3yz63m4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev =  "e3702bed27f0d39777b0b37b664b6280e8ef8fbf";
+      sha256 = "0pvzm23hklxysspnz52mih6h1q74vfrdhjfm1l3sa9r8hhqmmld2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
+      sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev =  "20f1fb78b0740ba8c3cb143a61e86ba5c8669768";
+      sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
+    };
+  }
+  {
+    goPackagePath  = "github.com/icrowley/fake";
+    fetch = {
+      type = "git";
+      url = "https://github.com/icrowley/fake";
+      rev =  "4178557ae428460c3780a381c824a1f3aceb6325";
+      sha256 = "1mv4bxfphaqbvacy49v4lf4gf2nmadzpmjq0jbdx93wi5bnkc977";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jroimartin/gocui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jroimartin/gocui";
+      rev =  "c055c87ae801372cd74a0839b972db4f7697ae5f";
+      sha256 = "1b1cbjg925l1c5v3ls8amni9716190yzf847cqs9wjnj82z8qa47";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "0360b2af4f38e8d38c7fce2a9f4e702702d73a39";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev =  "9e777a8366cce605130a531d2cd6363d07ad7317";
+      sha256 = "0vkrfrz3fzn5n6ix4k8s0cg0b448459sldq8bp4riavsxm932jzb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev =  "fa473d140ef3c6adf42d6b391fe76707f1f243c8";
+      sha256 = "0f06q4fpzg0c370cvmpsl0iq2apl5nkbz5cd3nba5x5ysmshv1lm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/nsf/termbox-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsf/termbox-go";
+      rev =  "5c94acc5e6eb520f1bcd183974e01171cc4c23b3";
+      sha256 = "1fi8imdgwvlsgifw2qfl3ww0lsrgkfsimkzz7bnrq41nar78s0fw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/phayes/freeport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/phayes/freeport";
+      rev =  "b8543db493a5ed890c5499e935e2cad7504f3a04";
+      sha256 = "1gwaan8fwmc5lfx4dzymq0jd6z2l1frg83jkmjpm4kw8ay4vr11q";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev =  "55d61fa8aa702f59229e6cff85793c22e580eaf5";
+      sha256 = "0qmavm5d14kj6im6sqzpqnlhpy524428vkn4hnfwknndr9rycmn0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/githubv4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/githubv4";
+      rev =  "b5f70540eee0ebfb6a27b52fc5b131be76415539";
+      sha256 = "0hrjk16l8jwkhrbzcasp4dflv6hl24hcc4q2md5rn6i8f73dl18h";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/go";
+      rev =  "9e1955d9fb6e1ee2345ba1f5e71669263e719e27";
+      sha256 = "1lad9bvs75jsn61cfza19739c2c057k0bqxg2b4xz3z3l4w1mkqj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/graphql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/graphql";
+      rev =  "365899397c9ad12805631fe4c9b2a64be9d74818";
+      sha256 = "10n4id76zpj5g4hr1ry8d9v5cvm039rygrpgdk4ygk198vhr0gwm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/httpfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/httpfs";
+      rev =  "809beceb23714880abc4a382a00c05f89d13b1cc";
+      sha256 = "1hvj5q5kjw83z7f77y03fqfg7fps7pqj2cj2c38x752m0pq4j2w3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/vfsgen";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/vfsgen";
+      rev =  "62bca832be04bd2bcaabd3b68a6b19a7ec044411";
+      sha256 = "1lh8sw7qxs43jj8k9pfn91kfy2033p3il9bcb63whz8zhqw2a16y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/skratchdot/open-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/skratchdot/open-golang";
+      rev =  "75fb7ed4208cf72d323d7d02fd1a5964a7a9073c";
+      sha256 = "1b67imqbsdvg19vif1q1dfmapxy3v2anagacbql95fwnnw0v8jga";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "ef82de70bb3f60c65fb8eebacbb2d122ef517385";
+      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "583c0c0531f06d5278b7d917446061adc344b5cd";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "f35b8ab0b5a2cef36673838d662e249dd9c94686";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/vektah/gqlgen";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vektah/gqlgen";
+      rev =  "636435b68700211441303f1a5ed92f3768ba5774";
+      sha256 = "0d4sr6kpyn3zq3kpvk8lizy7hdpcw3fjmv7fbv2m1k9w8fzjawrz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/vektah/gqlparser";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vektah/gqlparser";
+      rev =  "14e83ae06ec152e6d0afb9766a00e0c0918aa8fc";
+      sha256 = "162j259402pa2wb4645z6gplx5g1a2sfk393k2svwgws3bg2bws2";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "0e37d006457bf46f9e6692014ba72ef82c33022c";
+      sha256 = "1fj8rvrhgv5j8pmckzphvm3sqkzhcqp3idkxvgv13qrjdfycsa5r";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "2f5d2388922f370f4355f327fcf4cfe9f5583908";
+      sha256 = "03s92ygxfrd2c1m4697sd6iksgbar6c007w1yf3h6wmd79vr5dxs";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "d2e6202438beef2727060aa7cabdd924d92ebfd9";
+      sha256 = "0wbn75fd10485nb93bm4kqldqifdim5xqy4v7r5sdvimvf3fyhn7";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "ac767d655b305d4e9612f5f6e33120b9176c4ad4";
+      sha256 = "1ds29n5lh4j21hmzxz7vk7hv1k6sixc7f0zsdc9xqdg0j7d212zm";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev =  "a434f64ace81347eff0fb4a32bc80a235e0ad762";
+      sha256 = "0zngnxrxjync4caz6ikmv5v0cn895iqhqmzqg9qddfm5bvl2a2my";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06";
+      sha256 = "1iabxnqgxvvn1239i6fvfl375vlbvhfrc03m1x2rvalmx4d6w9c7";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath  = "gotest.tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gotestyourself/gotest.tools";
+      rev =  "b6e20af1ed078cd01a6413b734051a292450b4cb";
+      sha256 = "11k6hmfhaf0qxpddp3i5kfpacdx51q6pv4n1kn3jnf1hjs0yny2k";
+    };
+  }
+]


### PR DESCRIPTION
###### Motivation for this change
Add [git-bug](https://github.com/MichaelMure/git-bug/), a decentralized bug tracker and propose myself as a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

