### PR TITLE
mkl: wrap with openmp in LD_LIBRARY_PATH

### DIFF
--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -1,73 +1,17 @@
-{ stdenvNoCC, writeText, fetchurl, rpmextract, undmg }:
+{ stdenvNoCC, writeText, fetchurl, rpmextract, undmg, openmp }:
 /*
-  Some (but not all) mkl functions require openmp, but Intel does not add these
-  to SO_NEEDED and instructs users to put openmp on their LD_LIBRARY_PATH. If
-  you are using mkl and your library/application is using some of the functions
-  that require openmp, add a setupHook like this to your package:
-
-  setupHook = writeText "setup-hook.sh" ''
-    addOpenmp() {
-        addToSearchPath LD_LIBRARY_PATH ${openmp}/lib
-    }
-    addEnvHooks "$targetOffset" addOpenmp
-  '';
-
-  We do not add the setup hook here, because avoiding it allows this large
-  package to be a fixed-output derivation with better cache efficiency.
- */
-
-stdenvNoCC.mkDerivation rec {
-  name = "mkl-${version}";
+  Some mkl functions require openmp, but Intel does not add these to SO_NEEDED
+  and instructs users to put openmp on their LD_LIBRARY_PATH. Since the mkl
+  package is large and changes very infrequently, we make a fixed-output pkg
+  with the extracted RPM contents, then wrap it with an openmp-dependent
+  derivation with the appropriate setupHook. Note that we cannot add an
+  SO_NEEDED entry directly to the library via patchelf, since the license
+  prevents modification.
+*/
+let
   version = "${date}.${rel}";
   date = "2019.0";
   rel = "117";
-
-  src = if stdenvNoCC.isDarwin
-    then
-      (fetchurl {
-        url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13565/m_mkl_${version}.dmg";
-        sha256 = "1f1jppac7vqwn00hkws0p4njx38ajh0n25bsjyb5d7jcacwfvm02";
-      })
-    else
-      (fetchurl {
-        url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_${version}.tgz";
-        sha256 = "1bf7i54iqlf7x7fn8kqwmi06g30sxr6nq3ac0r871i6g0p3y47sf";
-      });
-
-  buildInputs = if stdenvNoCC.isDarwin then [ undmg ] else [ rpmextract ];
-
-  buildPhase = if stdenvNoCC.isDarwin then ''
-      for f in Contents/Resources/pkg/*.tgz; do
-          tar xzvf $f
-      done
-  '' else ''
-    rpmextract rpm/intel-mkl-common-c-${date}-${rel}-${date}-${rel}.noarch.rpm
-    rpmextract rpm/intel-mkl-core-rt-${date}-${rel}-${date}-${rel}.x86_64.rpm
-  '';
-
-  installPhase = if stdenvNoCC.isDarwin then ''
-      mkdir -p $out/lib
-      cp -r compilers_and_libraries_${version}/mac/mkl/include $out/
-      cp -r compilers_and_libraries_${version}/mac/mkl/lib/* $out/lib/
-      cp -r compilers_and_libraries_${version}/licensing/mkl/en/license.txt $out/lib/
-  '' else ''
-      mkdir -p $out/lib
-      cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/include $out/
-      cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/lib/intel64_lin/* $out/lib/
-      cp license.txt $out/lib/
-  '';
-
-  # Per license agreement, do not modify the binary
-  dontStrip = true;
-  dontPatchELF = true;
-
-  # Since these are unmodified binaries from Intel, they do not depend on stdenv
-  # and we can make them fixed-output derivations for cache efficiency.
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = if stdenvNoCC.isDarwin
-    then "1224dln7n8px1rk8biiggf77wjhxh8mzw0hd8zlyjm8i6j8w7i12"
-    else "0d8ai0wi8drp071acqkm1wv6vyg12010y843y56zzi1pql81xqvx";
 
   meta = with stdenvNoCC.lib; {
     description = "Intel Math Kernel Library";
@@ -81,5 +25,81 @@ stdenvNoCC.mkDerivation rec {
     license = [ licenses.issl licenses.unfreeRedistributable ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.bhipple ];
+  };
+
+  mkl-unwrapped = stdenvNoCC.mkDerivation rec {
+    name = "mkl-unwrapped-${version}";
+
+    src = if stdenvNoCC.isDarwin
+      then
+        (fetchurl {
+          url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13565/m_mkl_${version}.dmg";
+          sha256 = "1f1jppac7vqwn00hkws0p4njx38ajh0n25bsjyb5d7jcacwfvm02";
+        })
+      else
+        (fetchurl {
+          url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_${version}.tgz";
+          sha256 = "1bf7i54iqlf7x7fn8kqwmi06g30sxr6nq3ac0r871i6g0p3y47sf";
+        });
+
+    buildInputs = if stdenvNoCC.isDarwin then [ undmg ] else [ rpmextract ];
+
+    buildPhase = if stdenvNoCC.isDarwin then ''
+        for f in Contents/Resources/pkg/*.tgz; do
+            tar xzvf $f
+        done
+    '' else ''
+      rpmextract rpm/intel-mkl-common-c-${date}-${rel}-${date}-${rel}.noarch.rpm
+      rpmextract rpm/intel-mkl-core-rt-${date}-${rel}-${date}-${rel}.x86_64.rpm
+    '';
+
+    installPhase = if stdenvNoCC.isDarwin then ''
+        mkdir -p $out/lib
+        cp -r compilers_and_libraries_${version}/mac/mkl/include $out/
+        cp -r compilers_and_libraries_${version}/mac/mkl/lib/* $out/lib/
+        cp -r compilers_and_libraries_${version}/licensing/mkl/en/license.txt $out/lib/
+    '' else ''
+        mkdir -p $out/lib
+        cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/include $out/
+        cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/lib/intel64_lin/* $out/lib/
+        cp license.txt $out/lib/
+    '';
+
+    # Per license agreement, do not modify the binary
+    dontStrip = true;
+    dontPatchELF = true;
+
+    # Since these are unmodified binaries from Intel, they do not depend on stdenv
+    # and we can make them fixed-output derivations for cache efficiency.
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = if stdenvNoCC.isDarwin
+      then "1224dln7n8px1rk8biiggf77wjhxh8mzw0hd8zlyjm8i6j8w7i12"
+      else "0d8ai0wi8drp071acqkm1wv6vyg12010y843y56zzi1pql81xqvx";
+
+    inherit meta;
+  };
+
+  libvar = if stdenvNoCC.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+in {
+  inherit mkl-unwrapped;
+
+  mkl = stdenvNoCC.mkDerivation {
+    name = "mkl-${version}";
+    inherit meta;
+
+    buildCommand = ''
+      mkdir -p $out/nix-support
+      for f in ${mkl-unwrapped}/*; do
+          ln -s $f $out/
+      done
+
+      cat << EOM > $out/nix-support/setup-hook
+      addOpenmp() {
+          addToSearchPath ${libvar} ${openmp}/lib
+      }
+      addEnvHooks "$targetOffset" addOpenmp
+      EOM
+    '';
   };
 }

--- a/pkgs/development/python-modules/numexpr/default.nix
+++ b/pkgs/development/python-modules/numexpr/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , python
 , numpy
-, llvmPackages ? null
 }:
 
 buildPythonPackage rec {
@@ -16,15 +15,10 @@ buildPythonPackage rec {
   };
 
   # Remove existing site.cfg, use the one we built for numpy.
-  # Somehow openmp needs to be added to LD_LIBRARY_PATH
-  # https://software.intel.com/en-us/forums/intel-system-studio/topic/611682
   preBuild = ''
     rm site.cfg
     ln -s ${numpy.cfg} site.cfg
-    export LD_LIBRARY_PATH=${llvmPackages.openmp}/lib
   '';
-
-  buildInputs = [] ++ lib.optional (numpy.blasImplementation == "mkl") llvmPackages.openmp;
 
   propagatedBuildInputs = [ numpy ];
 

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -28,6 +28,9 @@ in buildPythonPackage rec {
   nativeBuildInputs = [ gfortran pytest ];
   buildInputs = [ blas ];
 
+  # If the blas imlementation is MKL, we need to propagate it for the setup-hook.
+  propagatedBuildInputs = [ ] ++ lib.optional (blasImplementation == "mkl") blas;
+
   patches = lib.optionals (python.hasDistutilsCxxPatch or false) [
     # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
     # Patching of numpy.distutils is needed to prevent it from undoing the
@@ -70,8 +73,6 @@ in buildPythonPackage rec {
     blas = blas;
     inherit blasImplementation cfg;
   };
-
-  doCheck = blasImplementation != "mkl";
 
   # Disable two tests
   # - test_f2py: f2py isn't yet on path.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21190,7 +21190,11 @@ with pkgs;
 
   m4rie = callPackage ../development/libraries/science/math/m4rie { };
 
-  mkl = callPackage ../development/libraries/science/math/mkl { };
+  mkl-pkgs = callPackage ../development/libraries/science/math/mkl {
+    inherit (llvmPackages) openmp;
+  };
+
+  inherit (mkl-pkgs) mkl mkl-unwrapped;
 
   nasc = callPackage ../applications/science/math/nasc { };
 


### PR DESCRIPTION
Fixes #48876. We could also fix this in `numpy` itself, but since any other
package using the multi-threaded portions of `mkl` needs this, it makes sense to
fix it in the source itself.

As mentioned, the upstream binary is very large, so we create a wrapper package
for the openmp-dependent setup hook to avoid rebuilding `mkl` itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

