### PR TITLE
signify: init at v24

### DIFF
--- a/pkgs/tools/security/signify/default.nix
+++ b/pkgs/tools/security/signify/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, libbsd, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "signify-${version}";
+  version = "24";
+
+  src = fetchFromGitHub {
+    owner = "aperezdc";
+    repo = "signify";
+    rev = "v${version}";
+    sha256 = "0grdlrpxcflzmzzc30r8rvsmamvbsgqyni59flzzk4w5hpjh464w";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libbsd ];
+
+  preInstall = ''
+    export PREFIX=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenBSD signing tool";
+    longDescription = ''
+      OpenBSDs signing tool, which uses the Ed25519 public key signature system
+      for fast signing and verification of messages using small public keys.
+    '';
+    homepage = https://www.tedunangst.com/flak/post/signify;
+    license = licenses.isc;
+    maintainers = [ maintainers.rlupton20 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5277,6 +5277,8 @@ with pkgs;
 
   signal-desktop = callPackage ../applications/networking/instant-messengers/signal-desktop { };
 
+  signify = callPackage ../tools/security/signify { };
+
   # aka., pgp-tools
   signing-party = callPackage ../tools/security/signing-party { };
 


### PR DESCRIPTION
###### Motivation for this change

`signify` is a neat, simple and tidy signing utility built for OpenBSD. It is packaged on a couple of linux distributions already, and I thought it would be useful on nixos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

