### PR TITLE
arrow-cpp: fix for zstd 1.3.6+

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
 
     # patch to fix python-test
     ./darwin.patch
+
+    # facebook/zstd#1385
+    ./zstd136.patch
     ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/arrow-cpp/zstd136.patch
+++ b/pkgs/development/libraries/arrow-cpp/zstd136.patch
@@ -1,0 +1,17 @@
+--- a/src/arrow/util/compression_zstd.cc
++++ b/src/arrow/util/compression_zstd.cc
+@@ -35,8 +35,13 @@ namespace util {
+ 
+ Status ZSTDCodec::Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
+                              uint8_t* output_buffer) {
++  void *safe_output_buffer = static_cast<void*>(output_buffer);
++  int dummy {};
++  if ((output_len == 0) && (output_buffer == NULL)) {
++    safe_output_buffer = static_cast<void*>(&dummy);
++  }
+   int64_t decompressed_size =
+-      ZSTD_decompress(output_buffer, static_cast<size_t>(output_len), input,
++      ZSTD_decompress(safe_output_buffer, static_cast<size_t>(output_len), input,
+                       static_cast<size_t>(input_len));
+   if (decompressed_size != output_len) {
+     return Status::IOError("Corrupt ZSTD compressed data.");


### PR DESCRIPTION
###### Motivation for this change

Workaround facebook/zstd#1385

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
