### PR TITLE
nixos/xrdp: allow extra keymap files to be installed

### DIFF
--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -32,6 +32,12 @@ let
     LANG=${config.i18n.defaultLocale}\
     LOCALE_ARCHIVE=${config.i18n.glibcLocales}/lib/locale/locale-archive
     ' $out/sesman.ini
+
+    ${concatStringsSep "\n"
+      (mapAttrsToList (outFilename: inFilePath: ''
+         ${pkgs.coreutils}/bin/cp -f "${inFilePath}" "$out/${outFilename}"
+        '') cfg.extraKeymapFiles)
+    }
   '';
 in
 {
@@ -88,6 +94,22 @@ in
         description = ''
           The script to run when user log in, usually a window manager, e.g. "icewm", "xfce4-session"
           This is per-user overridable, if file ~/startwm.sh exists it will be used instead.
+        '';
+      };
+
+      extraKeymapFiles = mkOption {
+        type = types.attrsOf types.path;
+        default = {};
+        example = literalExample ''
+          { "km-00000c0c.ini" = ./custom_km_files/km-00000c0c.ini;
+            "xrdp_keyboard.ini" = ./custom_km_files/xrdp_keyboard.ini;
+          }
+        '';
+        description = ''
+          Allow one to add some extra keymap files. Useful for machines with
+          non english keymaps. Those files are generated using the
+          <literal>/my/xrdp/prefix/sbin/xrdp-genkeymap</literal> utility. More info at:
+          <literal>https://www.mankier.com/8/xrdp-genkeymap</literal>.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Allow one to use non us keyboards inside xrdp session.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested in separatly using `nixos-rebuild build-vm`.
