### PR TITLE
atom, atom-beta: 1.31.2 -> 1.32.0, 1.32.0-beta0 -> 1.33.0-beta0

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -3,14 +3,14 @@
 let
   versions = {
     atom = {
-      version = "1.31.2";
-      sha256 = "1szx9p2nz1qzjpig0l8h4hj5mqwpjvkcynn8crh21drply4bpfr0";
+      version = "1.32.0";
+      sha256 = "0dha8zi4gshxj993ns7ybi7q86pfqwzsasrk3a7b5xrdqbrcm5md";
     };
 
     atom-beta = {
-      version = "1.32.0";
+      version = "1.33.0";
       beta = 0;
-      sha256 = "12k5cn70a0diyaqbmq6s6l2sbi9i3d9p7i38qnm97lnw0y1kh0jm";
+      sha256 = "1x4s12zvfd2gjy7mimndbhs6x9k37jq4dyy6r1mzhwfysix74val";
     };
   };
 

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,6 +1,19 @@
 { stdenv, pkgs, fetchurl, makeWrapper, wrapGAppsHook, gvfs, gtk3, atomEnv }:
 
 let
+  versions = {
+    atom = {
+      version = "1.31.2";
+      sha256 = "1szx9p2nz1qzjpig0l8h4hj5mqwpjvkcynn8crh21drply4bpfr0";
+    };
+
+    atom-beta = {
+      version = "1.32.0";
+      beta = 0;
+      sha256 = "12k5cn70a0diyaqbmq6s6l2sbi9i3d9p7i38qnm97lnw0y1kh0jm";
+    };
+  };
+
   common = pname: {version, sha256, beta ? null}:
       let fullVersion = version + stdenv.lib.optionalString (beta != null) "-beta${toString beta}";
       name = "${pname}-${fullVersion}";
@@ -71,15 +84,4 @@ let
       platforms = platforms.x86_64;
     };
   };
-in stdenv.lib.mapAttrs common {
-  atom = {
-    version = "1.31.2";
-    sha256 = "1szx9p2nz1qzjpig0l8h4hj5mqwpjvkcynn8crh21drply4bpfr0";
-  };
-
-  atom-beta = {
-    version = "1.32.0";
-    beta = 0;
-    sha256 = "12k5cn70a0diyaqbmq6s6l2sbi9i3d9p7i38qnm97lnw0y1kh0jm";
-  };
-}
+in stdenv.lib.mapAttrs common versions


### PR DESCRIPTION
###### Motivation for this change


###### Things done



- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

