### PR TITLE
arc-theme: 20180715 -> 20181022

### DIFF
--- a/pkgs/misc/themes/arc/default.nix
+++ b/pkgs/misc/themes/arc/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, sassc, autoreconfHook, pkgconfig, gtk3
-, gnome-themes-extra, gtk-engine-murrine, optipng, inkscape}:
+{ stdenv, fetchFromGitHub, sassc, autoreconfHook, pkgconfig, gtk3, gnome3
+, gtk-engine-murrine, optipng, inkscape }:
 
 let
   pname = "arc-theme";
@@ -7,40 +7,45 @@ in
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "20180715";
+  version = "20181022";
 
   src = fetchFromGitHub {
     owner  = "NicoHood";
     repo   = pname;
     rev    = version;
-    sha256 = "1kkfnkiih0i3pds5mgd1v9lrdrp4nh4hk42mw7sa4fpbjff4jh6j";
+    sha256 = "08951dk1irfadwpr3p323a4fprmxg53rk2r2niwq3v62ryhi3663";
   };
 
-  preBuild = ''
-    # Shut up inkscape's warnings
-    export HOME="$NIX_BUILD_ROOT"
-  '';
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    sassc
+    optipng
+    inkscape
+    gtk3
+    gnome3.gnome-shell
+  ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig sassc optipng inkscape ];
-  buildInputs = [ gtk3 ];
+  propagatedUserEnvPkgs = [
+    gnome3.gnome-themes-extra
+    gtk-engine-murrine
+  ];
 
-  propagatedUserEnvPkgs = [ gnome-themes-extra gtk-engine-murrine ];
+  enableParallelBuilding = true;
 
   postPatch = ''
-    find . -name render-assets.sh |
-    while read filename
-    do
-      substituteInPlace "$filename" \
-        --replace "/usr/bin/inkscape" "${inkscape.out}/bin/inkscape" \
-        --replace "/usr/bin/optipng" "${optipng.out}/bin/optipng"
-    done
     patchShebangs .
+  '';
+
+  preBuild = ''
+    # Shut up inkscape's warnings about creating profile directory
+    export HOME="$NIX_BUILD_ROOT"
   '';
 
   configureFlags = [ "--disable-unity" ];
 
   postInstall = ''
-    install -Dm644 -t $out/share/doc/${pname}        AUTHORS *.md
+    install -Dm644 -t $out/share/doc/${pname} AUTHORS *.md
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

- Update to version [20181022](https://github.com/NicoHood/arc-theme/releases/tag/20181022)
- Gtk3 and gnome-shell are required only for auto-detecting the GTK and GNOME Shell versions, so they are needed only as a build dependency.
- Some cleanups.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).