### PR TITLE
dmrconfig: init at 2018-10-20

### DIFF
--- a/pkgs/applications/misc/dmrconfig/default.nix
+++ b/pkgs/applications/misc/dmrconfig/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub
+, libusb1, systemd }:
+
+stdenv.mkDerivation rec {
+  name = "dmrconfig-${version}";
+  version = "2018-10-20";
+
+  src = fetchFromGitHub {
+    owner = "sergev";
+    repo = "dmrconfig";
+    rev = "a4c5f893d2749727493427320c7f01768966ba51";
+    sha256 = "0h7hv6fv6v5g922nvgrb0w7hsqbhaw7xmdc6vydh2p3l7sp31vg2";
+  };
+
+  buildInputs = [
+    libusb1 systemd
+  ];
+
+  preConfigure = ''
+    substituteInPlace Makefile --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Configuration utility for DMR radios";
+    longDescription = ''
+      DMRconfig is a utility for programming digital radios via USB programming cable.
+    '';
+    homepage = https://github.com/sergev/dmrconfig;
+    license = licenses.asl20;
+    maintainers = [ maintainers.etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16149,6 +16149,8 @@ with pkgs;
     inherit (python3Packages) buildPythonApplication requests;
   };
 
+  dmrconfig = callPackage ../applications/misc/dmrconfig { };
+
   dmtx-utils = callPackage (callPackage ../tools/graphics/dmtx-utils) {
   };
 


### PR DESCRIPTION
###### Motivation for this change
dmrconfig is a util to configure a bunch of hamradio's for digital mode radio usage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

