### PR TITLE
homely: init at 0.15.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1859,6 +1859,11 @@
     github = "infinisil";
     name = "Silvan Mosberger";
   };
+  lokke = {
+    email = "lokke@lokke.me";
+    github = "lokke-me";
+    name = "Grischa Wende";
+  };
   ironpinguin = {
     email = "michele@catalano.de";
     github = "ironpinguin";

--- a/pkgs/applications/misc/homely/default.nix
+++ b/pkgs/applications/misc/homely/default.nix
@@ -20,7 +20,7 @@ pythonPackages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Dotfile management utility written in python";
     license = licenses.mit;
-    homepage = https://homely.readthedocs.io;
+    homepage = "https://homely.readthedocs.io";
     maintainers = [ maintainers.lokke ];
   };
 }

--- a/pkgs/applications/misc/homely/default.nix
+++ b/pkgs/applications/misc/homely/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  version = "0.15.3";
+  pname = "homely";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "2aa7461b583660bf8d9ad776c184fa7a1272141a5c0faaf78a76bc3e8c39db6d";
+  };
+
+  buildInputs = with pythonPackages; [ attrs setuptools_scm ];
+  propagatedBuildInputs = with pythonPackages; [
+    requests
+    simplejson
+    click
+    pythondaemon
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Dotfile management utility written in python";
+    license = licenses.mit;
+    homepage = https://homely.readthedocs.io;
+    maintainers = [ maintainers.lokke ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17273,6 +17273,8 @@ with pkgs;
 
   hovercraft = python3Packages.callPackage ../applications/misc/hovercraft { };
 
+  homely = callPackage ../applications/misc/homely {};
+
   howl = callPackage ../applications/editors/howl { };
 
   ht = callPackage ../applications/editors/ht { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

