### PR TITLE
scalafix: init at 0.9.0

### DIFF
--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, jdk, jre, coursier, makeWrapper }:
+
+let
+  baseName = "scalafix";
+  version = "0.9.0";
+  deps = stdenv.mkDerivation {
+    name = "${baseName}-deps-${version}";
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      ${coursier}/bin/coursier fetch ch.epfl.scala:scalafix-cli_2.12.7:${version} > deps
+      mkdir -p $out/share/java
+      cp $(< deps) $out/share/java/
+    '';
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash     = "19j260prx7k010nxyvc1m9jj1ncxr73m2cym7if39360v5dc05c0";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "${baseName}-${version}";
+
+  buildInputs = [ jdk makeWrapper deps ];
+
+  doCheck = true;
+
+  phases = [ "installPhase" "checkPhase" ];
+
+  installPhase = ''
+    makeWrapper ${jre}/bin/java $out/bin/${baseName} \
+      --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
+  '';
+
+  checkPhase = ''
+    $out/bin/${baseName} --version | grep -q "${version}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Refactoring and linting tool for Scala";
+    homepage = https://scalacenter.github.io/scalafix/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.tomahna ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7375,6 +7375,7 @@ with pkgs;
   scala_2_12 = callPackage ../development/compilers/scala { jre = jre8; };
   scala = scala_2_12;
 
+  scalafix = callPackage ../development/tools/scalafix { };
   scalafmt = callPackage ../development/tools/scalafmt { };
 
   sdcc = callPackage ../development/compilers/sdcc {


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

