### PR TITLE
systemd: enable extra configuration to the [Service] section

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -354,6 +354,19 @@ in rec {
       apply = v: if isList v then v else [ v ];
     };
 
+    extraConfigService = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        PrivateTmp=true
+        LimitMEMLOCK=infinity
+        LimitNOFILE=65535
+      '';
+      description = ''
+        Extra configuration to add to the [Service] section.
+      '';
+    };
+
   };
 
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -327,6 +327,7 @@ let
           '' else ""}
           ${optionalString (!def.stopIfChanged) "X-StopIfChanged=false"}
           ${attrsToSection def.serviceConfig}
+          ${optionalString (def.extraConfigService != null) def.extraConfigService}
         '';
     };
 


### PR DESCRIPTION
###### Motivation for this change
Enable extra configuration to the [Service] section

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

