### PR TITLE
kile: 2017-02-09 -> 2.9.92

### DIFF
--- a/pkgs/applications/editors/kile/default.nix
+++ b/pkgs/applications/editors/kile/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation
 , lib
-, fetchgit
+, fetchurl
 , extra-cmake-modules
 , kdoctools
 , wrapGAppsHook
@@ -22,13 +22,11 @@
 }:
 
 mkDerivation rec {
-  name = "kile-${version}";
-  version = "2017-02-09";
+  name = "kile-2.9.92";
 
-  src = fetchgit {
-    url = git://anongit.kde.org/kile.git;
-    rev = "f77f6e627487c152f111e307ad6dc71699ade746";
-    sha256 = "0wpqaix9ssa28cm7qqjj0zfrscjgk8s3kmi5b4kk8h583gsrikib";
+  src = fetchurl {
+    url = "mirror://sourceforge/kile/${name}.tar.bz2";
+    sha256 = "177372dc25b1d109e037a7dbfc64b5dab2efe538320c87f4a8ceada21e9097f2";
 
   };
 


### PR DESCRIPTION
No need to use an old git snapshot, since upstream has a proper beta version.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

