### PR TITLE
urh: add support for airspy and limesdr

### DIFF
--- a/pkgs/applications/misc/urh/default.nix
+++ b/pkgs/applications/misc/urh/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, python3Packages, hackrf, rtl-sdr }:
+{ stdenv, fetchFromGitHub, python3Packages
+, hackrf, rtl-sdr, airspy, limesuite }:
 
 python3Packages.buildPythonApplication rec {
   name = "urh-${version}";
@@ -11,7 +12,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0cwbqcv0yffg6fa3g4zknwffa6119i6827w6jm74fhlfa9kwy34c";
   };
 
-  buildInputs = [ hackrf rtl-sdr ];
+  buildInputs = [ hackrf rtl-sdr airspy limesuite ];
   propagatedBuildInputs = with python3Packages; [
     pyqt5 numpy psutil cython pyzmq
   ];


### PR DESCRIPTION
###### Motivation for this change
URH has native support for the Airspy and LimeSDR devices.

CC @fpletz 
##### Things done
Tested with Airspy mini LimeSDR-mini

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

