### PR TITLE
buildFHSUserEnv: use runScript in env

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -35,7 +35,7 @@ in runCommand name {
   passthru = passthru // {
     env = runCommand "${name}-shell-env" {
       shellHook = ''
-        exec ${chrootenv} ${init "bash"} "$(pwd)"
+        exec ${chrootenv} ${init runScript} "$(pwd)"
       '';
     } ''
       echo >&2 ""


### PR DESCRIPTION
###### Motivation for this change

The example in [buildFHSUserEnv's docs](https://nixos.org/nixpkgs/manual/#sec-fhs-environments) makes it seem like runScript will be run when using nix-shell, but currently it is only used when building. I would like to use another shell than bash in an FHS environment, so I think it should be fixed to work as implied in the docs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

