### PR TITLE
wlroots.examples: prefix example binaries

### DIFF
--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -71,11 +71,12 @@ in stdenv.mkDerivation rec {
     # screenshot output-layout multi-pointer rotation tablet touch pointer
     # simple
     mkdir -p $examples/bin
-    for binary in $(find ./examples -executable -type f | grep -vE '\.so'); do
+    cd ./examples
+    for binary in $(find . -executable -type f -printf '%P\n' | grep -vE '\.so'); do
       patchelf \
         --set-rpath "$examples/lib:${stdenv.lib.makeLibraryPath buildInputs}" \
         "$binary"
-      cp "$binary" $examples/bin/
+      cp "$binary" "$examples/bin/wlroots-$binary"
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change
cc: @primeos @Synthetica9 

The `wlroots` examples are somewhat generically named. Can we prefix them, like I've done here?

(For example, there is an example named `touch`, which might pop up in unexpected, unfun ways)

(Alternatively, we could prefix with `wlr-`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

