### PR TITLE
HybridReverb2: init at 2.1.1

### DIFF
--- a/pkgs/applications/audio/hybridreverb2/default.nix
+++ b/pkgs/applications/audio/hybridreverb2/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, fetchzip, cmake, pkgconfig, lv2, alsaLib, libjack2,
+  freetype, libX11, gtk3, pcre, libpthreadstubs, libXdmcp, libxkbcommon,
+  epoxy, at-spi2-core, dbus, curl, fftwFloat }:
+
+let
+  pname = "HybridReverb2";
+  version = "2.1.1";
+  owner = "jpcima";
+  DBversion = "1.0.0";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  impulseDB = fetchzip {
+    url = "https://github.com/${owner}/${pname}-impulse-response-database/archive/v${DBversion}.zip";
+    sha256 = "1hlfxbbkahm1k2sk3c3n2mjaz7k80ky3r55xil8nfbvbv0qan89z";
+  };
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15mba9qvlis0qrklr50wp3jdysvmk33m7pvclp0k1is9pirj97cb";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ lv2 alsaLib libjack2 freetype libX11 gtk3 pcre
+    libpthreadstubs libXdmcp libxkbcommon epoxy at-spi2-core dbus curl fftwFloat ];
+
+  cmakeFlags = [
+    "-DHybridReverb2_AdvancedJackStandalone=ON"
+    "-DHybridReverb2_UseLocalDatabase=ON"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/${pname}/
+    cp  -r ${impulseDB}/* $out/share/${pname}/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www2.ika.ruhr-uni-bochum.de/HybridReverb2;
+    description = "Reverb effect using hybrid impulse convolution";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3273,6 +3273,8 @@ with pkgs;
 
   hwinfo = callPackage ../tools/system/hwinfo { };
 
+  hybridreverb2 = callPackage ../applications/audio/hybridreverb2 { };
+
   hylafaxplus = callPackage ../servers/hylafaxplus { };
 
   i2c-tools = callPackage ../os-specific/linux/i2c-tools { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

