### PR TITLE
 wxmac: 3.0.2 -> 3.0.4 (darwin)

### DIFF
--- a/pkgs/development/libraries/wxwidgets/3.0/mac.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/mac.nix
@@ -1,10 +1,8 @@
 { stdenv, fetchurl, fetchpatch, expat, libiconv, libjpeg, libpng, libtiff, zlib
 # darwin only attributes
-, derez, rez, setfile
+, cf-private, derez, rez, setfile
 , AGL, Cocoa, Kernel
 }:
-
-with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "3.0.2";
@@ -55,6 +53,10 @@ stdenv.mkDerivation rec {
     expat libiconv libjpeg libpng libtiff zlib
     derez rez setfile
     Cocoa Kernel
+
+    # Needed for CFURLGetFSRef, etc. which have deen deprecated
+    # since 10.9 and are not part of swift-corelibs CoreFoundation.
+    cf-private
   ];
 
   propagatedBuildInputs = [ AGL ];
@@ -98,7 +100,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     platforms = platforms.darwin;
     license = licenses.wxWindows;
     maintainers = [ maintainers.lnl7 ];

--- a/pkgs/development/libraries/wxwidgets/3.0/mac.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/mac.nix
@@ -1,53 +1,17 @@
-{ stdenv, fetchurl, fetchpatch, expat, libiconv, libjpeg, libpng, libtiff, zlib
+{ stdenv, fetchzip, fetchpatch, expat, libiconv, libjpeg, libpng, libtiff, zlib
 # darwin only attributes
 , cf-private, derez, rez, setfile
 , AGL, Cocoa, Kernel
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.0.2";
+  version = "3.0.4";
   name = "wxmac-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/wxwindows/wxWidgets-${version}.tar.bz2";
-    sha256 = "346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d";
+  src = fetchzip {
+    url = "https://github.com/wxWidgets/wxWidgets/archive/v${version}.tar.gz";
+    sha256 = "19mqglghjjqjgz4rbybn3qdgn2cz9xc511nq1pvvli9wx2k8syl1";
   };
-
-  patches =
-    [ # Use std::abs() from <cmath> instead of abs() from <math.h> to avoid problems
-      # with abiguous overloads for clang-3.8 and gcc6.
-      (fetchpatch {
-        name = "patch-stc-abs.diff";
-        url = https://github.com/wxWidgets/wxWidgets/commit/73e9e18ea09ffffcaac50237def0d9728a213c02.patch;
-        sha256 = "0w5whmfzm8waw62jmippming0zffa9064m5b3aw5nixph21rlcvq";
-      })
-
-      # Various fixes related to Yosemite. Revisit in next stable release.
-      # Please keep an eye on http://trac.wxwidgets.org/ticket/16329 as well
-      # Theoretically the above linked patch should still be needed, but it isn't.
-      # Try to find out why.
-      (fetchpatch {
-        name = "patch-yosemite.diff";
-        url = https://raw.githubusercontent.com/Homebrew/formula-patches/bbf4995/wxmac/patch-yosemite.diff;
-        sha256 = "0ss66z2a79v976mvlrskyj1zmkyaz8hbwm98p29bscfvcx5845jb";
-      })
-
-      # Remove uncenessary <QuickTime/QuickTime.h> includes
-      # http://trac.wxwidgets.org/changeset/f6a2d1caef5c6d412c84aa900cb0d3990b350938/git-wxWidgets
-      (fetchpatch {
-        name = "patch-quicktime-removal.diff";
-        url = https://raw.githubusercontent.com/Homebrew/formula-patches/bbf4995/wxmac/patch-quicktime-removal.diff;
-        sha256 = "0mzvdk8r70p9s1wj7qzdsqmdrlxlf2dalh9gqs8xjkqq2666yp0y";
-      })
-
-      # Patch for wxOSXPrintData, custom paper not applied
-      # http://trac.wxwidgets.org/ticket/16959
-      (fetchpatch {
-        name = "wxPaperCustomPatch.patch";
-        url = http://trac.wxwidgets.org/raw-attachment/ticket/16959/wxPaperCustomPatch.patch;
-        sha256 = "0xgscv86f8dhggn9n8bhlq9wlj3ydsicgy9v35sraxyma18cbjvl";
-      })
-    ];
 
   buildInputs = [
     expat libiconv libjpeg libpng libtiff zlib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12692,6 +12692,7 @@ with pkgs;
   wxmac = callPackage ../development/libraries/wxwidgets/3.0/mac.nix {
     inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel;
     inherit (darwin.stubs) setfile rez derez;
+    inherit (darwin) cf-private;
   };
 
   wxSVG = callPackage ../development/libraries/wxSVG {
@@ -21133,7 +21134,7 @@ with pkgs;
   liblapackWithAtlas = liblapack;
 
   liblbfgs = callPackage ../development/libraries/science/math/liblbfgs { };
-  
+
   lrs = callPackage ../development/libraries/science/math/lrs { };
 
   m4ri = callPackage ../development/libraries/science/math/m4ri { };

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -31,7 +31,9 @@ in
     libcxxabi = pkgs.libcxxabi;
   };
 
-  cf-private = callPackage ../os-specific/darwin/cf-private { inherit (darwin) CF apple_sdk; };
+  cf-private = callPackage ../os-specific/darwin/cf-private {
+    inherit (darwin) CF apple_sdk osx_private_sdk;
+  };
 
   DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
 
@@ -74,7 +76,7 @@ in
   CoreSymbolication = callPackage ../os-specific/darwin/CoreSymbolication { };
 
   CF = callPackage ../os-specific/darwin/swift-corelibs/corefoundation.nix { inherit (darwin) objc4 ICU; };
-  
+
   # As the name says, this is broken, but I don't want to lose it since it's a direction we want to go in
   # libdispatch-broken = callPackage ../os-specific/darwin/swift-corelibs/libdispatch.nix { inherit (darwin) apple_sdk_sierra xnu; };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

