### PR TITLE
google-fonts: fix on macOS

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -37,9 +37,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     dest=$out/share/fonts/truetype
-    mkdir -p $dest
-    find . -name "*.ttf" -exec cp -v {} $dest \;
-    chmod -x $dest/*.ttf
+    find . -name '*.ttf' -exec install -m 444 -Dt $dest '{}' +
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done:

Small change to the way `chmod -x` is invoked so that the argument list will not be too long for macOS.

macOS has a lower limit on the argument list size and `nix-build '<nixpkgs>' -A google-fonts` fails because the argument list passed to `chmod` is too long.

- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### More

Fixes issue #<insert id>

cc @<maintainer>


---

_Please note, that points are not mandatory, but rather desired._
