### PR TITLE
wolf-shaper: init at 0.1.6

### DIFF
--- a/pkgs/applications/audio/wolf-shaper/default.nix
+++ b/pkgs/applications/audio/wolf-shaper/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub , libjack2, lv2, xorg, liblo, libGL, libXcursor, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "wolf-shaper-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "pdesaulniers";
+    repo = "wolf-shaper";
+    rev = "v${version}";
+    sha256 = "01h5dm1nrr0i54ancwznr7wn4vpw08dw0b69v3axy32r5j7plw6s";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libjack2 lv2 xorg.libX11 liblo libGL libXcursor  ];
+
+  makeFlags = [
+    "BUILD_LV2=true"
+    "BUILD_DSSI=true"
+    "BUILD_VST2=true"
+    "BUILD_JACK=true"
+  ];
+
+  patchPhase = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2
+    mkdir -p $out/lib/dssi
+    mkdir -p $out/lib/vst
+    mkdir -p $out/bin/
+    cp -r bin/wolf-shaper.lv2    $out/lib/lv2/
+    cp -r bin/wolf-shaper-dssi*  $out/lib/dssi/
+    cp -r bin/wolf-shaper-vst.so $out/lib/vst/
+    cp -r bin/wolf-shaper        $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://pdesaulniers.github.io/wolf-shaper/;
+    description = "Waveshaper plugin with spline-based graph editor";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6188,6 +6188,8 @@ with pkgs;
 
   wol = callPackage ../tools/networking/wol { };
 
+  wolf-shaper = callPackage ../applications/audio/wolf-shaper { };
+
   wring = nodePackages.wring;
 
   wrk = callPackage ../tools/networking/wrk { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

