### PR TITLE
ocamlPackages.vg: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -11,7 +11,7 @@ let
   inherit (stdenv.lib) optionals versionAtLeast;
 
   pname = "vg";
-  version = "0.9.0";
+  version = "0.9.1";
   webpage = "http://erratique.ch/software/${pname}";
 in
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "1czd2fq85hy24w5pllarsq4pvbx9rda5zdikxfxdng8s9kff2h3f";
+    sha256 = "07h9a464v0x066mjg3ldkaq94ah47b7rvh54z4rndrg7v6bk7kyp";
   };
 
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
@@ -54,8 +54,8 @@ stdenv.mkDerivation rec {
     module. An API allows to implement new renderers.
     '';
     homepage = "${webpage}";
-    platforms = ocaml.meta.platforms or [];
-    license = licenses.bsd3;
+    inherit (ocaml.meta) platforms;
+    license = licenses.isc;
     maintainers = [ maintainers.jirkamarsik ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bugfix release. Correct the `meta.license` field.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

