### PR TITLE
Revert "ocamlPackages.ocamlbuild: 0.12.0 -> 0.13.0"

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, ocaml, findlib }:
 let
-  version = "0.13.0";
+  version = "0.12.0";
 in
 stdenv.mkDerivation {
   name = "ocamlbuild-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     owner = "ocaml";
     repo = "ocamlbuild";
     rev = version;
-    sha256 = "13r9q8c209gkgcmbjhj9z4r5bmi90rxahdsiqm5jx8sr2pia5xbh";
+    sha256 = "1shyim50ms0816fphc4mk0kldcx3pnba2i6m10q0cbm18m9d7chq";
   };
 
   createFindlibDestdir = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#46992 because it breaks ocamlPackages.wasm.