### PR TITLE
Backport breakpointHook [18.09]

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2451,16 +2451,19 @@ addEnvHooks "$hostOffset" myBashFunction
      </term>
      <listitem>
       <para>
-       This hook will make a build pause instead of stopping
-       when a failure happen. It prevents nix to cleanup the build
-       environment immediatly and allows the user to attach
-       to a build environemnt using the <varname>cntr</varname> command.
-       On build error it will print the instruction that are neccessary for cntr.
-       Note that <varname>cntr</varname> is not installed by default and
-       needs to be installed seperatly. <varname>cntr</varname> also needs to be executed
-       on the machine that is doing the build, which might be not the case
-       when remote builders are enabled. <varname>cntr</varname> is only supported
-       on linux based platforms.
+       This hook will make a build pause instead of stopping when a failure
+       happen. It prevents nix to cleanup the build environment immediatly and
+       allows the user to attach to a build environment using the
+       <command>cntr</command> command. On build error it will print the
+       instruction that are neccessary for <command>cntr</command>. Installing
+       cntr and running the command will provide shell access to the build
+       sandbox of failed build. At <filename>/var/lib/cntr</filename> the
+       sandbox filesystem is mounted. All commands and files of the system are
+       still accessible within the shell. To execute commands from the sandbox
+       use the cntr exec subcommand. Note that <command>cntr</command> also
+       needs to be executed on the machine that is doing the build, which might
+       be not the case when remote builders are enabled.
+       <command>cntr</command> is only supported on linux based platforms.
       </para>
      </listitem>
     </varlistentry>

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2445,6 +2445,25 @@ addEnvHooks "$hostOffset" myBashFunction
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term>
+      breakpointHook
+     </term>
+     <listitem>
+      <para>
+       This hook will make a build pause instead of stopping
+       when a failure happen. It prevents nix to cleanup the build
+       environment immediatly and allows the user to attach
+       to a build environemnt using the <varname>cntr</varname> command.
+       On build error it will print the instruction that are neccessary for cntr.
+       Note that <varname>cntr</varname> is not installed by default and
+       needs to be installed seperatly. <varname>cntr</varname> also needs to be executed
+       on the machine that is doing the build, which might be not the case
+       when remote builders are enabled. <varname>cntr</varname> is only supported
+       on linux based platforms.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </section>

--- a/pkgs/applications/virtualization/cntr/default.nix
+++ b/pkgs/applications/virtualization/cntr/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  name = "cntr-${version}";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "cntr";
+    rev = version;
+    sha256 = "0lmbsnjia44h4rskqkv9yc7xb6f3qjgbg8kcr9zqnr7ivr5fjcxg";
+  };
+
+  cargoSha256 = "0gainr5gfy0bbhr6078zvgx0kzp53slxjp37d3da091ikgzgfn51";
+
+  meta = with stdenv.lib; {
+    description = "A container debugging tool based on FUSE";
+    homepage = https://github.com/Mic92/cntr;
+    license = licenses.mit;
+    # aarch64 support will be fixed soon
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/build-support/setup-hooks/breakpoint-hook.sh
+++ b/pkgs/build-support/setup-hooks/breakpoint-hook.sh
@@ -1,0 +1,9 @@
+breakpointHook() {
+    local red='\033[0;31m'
+    local no_color='\033[0m'
+
+    echo -e "${red}build failed in ${curPhase} with exit code ${exitCode}${no_color}"
+    printf "To attach install cntr and run the following command as root:\n\n"
+    sh -c "echo '   cntr attach -t command cntr-${out}'; while true; do sleep 99999999; done"
+}
+failureHooks+=(breakpointHook)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15727,6 +15727,8 @@ with pkgs;
   cni = callPackage ../applications/networking/cluster/cni {};
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix {};
 
+  cntr = callPackage ../applications/virtualization/cntr { };
+
   communi = libsForQt5.callPackage ../applications/networking/irc/communi { };
 
   confclerk = callPackage ../applications/misc/confclerk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -959,6 +959,9 @@ with pkgs;
 
   bruteforce-luks = callPackage ../tools/security/bruteforce-luks { };
 
+  breakpointHook = assert stdenv.isLinux;
+    makeSetupHook { } ../build-support/setup-hooks/breakpoint-hook.sh;
+
   bsod = callPackage ../misc/emulators/bsod { };
 
   btrfs-progs = callPackage ../tools/filesystems/btrfs-progs { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

