### PR TITLE
mailcatcher: repackage using bundlerApp

### DIFF
--- a/pkgs/development/web/mailcatcher/default.nix
+++ b/pkgs/development/web/mailcatcher/default.nix
@@ -1,29 +1,11 @@
-{ stdenv, bundlerEnv, ruby, makeWrapper }:
+{ lib, bundlerApp }:
 
-stdenv.mkDerivation rec {
-  name = "mailcatcher-${version}";
+bundlerApp {
+  pname = "mailcatcher";
+  gemdir = ./.;
+  exes = [ "mailcatcher" "catchmail" ];
 
-  version = (import ./gemset.nix).mailcatcher.version;
-
-  env = bundlerEnv {
-    name = "${name}-gems";
-
-    inherit ruby;
-
-    gemdir = ./.;
-  };
-
-  buildInputs = [ makeWrapper ];
-
-  unpackPhase = ":";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/mailcatcher $out/bin/mailcatcher
-    makeWrapper ${env}/bin/catchmail $out/bin/catchmail
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "SMTP server and web interface to locally test outbound emails";
     homepage    = https://mailcatcher.me/;
     license     = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
Get to use new packaging standard for gems that are utilities

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

