### PR TITLE
nixos/hardware: add udev rules for Ledger Nano S

### DIFF
--- a/nixos/modules/hardware/ledger-nano-s.nix
+++ b/nixos/modules/hardware/ledger-nano-s.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.hardware.ledger-nano-s;
+
+in
+
+{
+  options.hardware.ledger-nano-s = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables udev rules for Ledger Nano S devices (https://www.ledger.com/products/ledger-nano-s).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = lib.singleton (pkgs.writeTextFile {
+      name = "ledger-nano-s-udev-rules";
+      destination = "/etc/udev/rules.d/51-ledger-nano-s.rules";
+      text = ''
+        SUBSYSTEMS=="usb", ATTRS{manufacturer}=="Ledger", ATTRS{product}=="Nano S", ENV{ID_SECURITY_TOKEN}="1"
+      '';
+    });
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -40,6 +40,7 @@
   ./hardware/digitalbitbox.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
+  ./hardware/ledger-nano-s.nix
   ./hardware/mcelog.nix
   ./hardware/network/b43.nix
   ./hardware/nitrokey.nix


### PR DESCRIPTION
They are enabled using the option

  hardware.ledger-nano-s.enabled = true;

###### Motivation for this change

In order to use a [Ledger Nano S](https://www.ledger.com/products/ledger-nano-s) the user needs access to the corresponding /dev/hidraw* devices. This change adds a config option to create a corresponding udev rule.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

