### PR TITLE
Add dhallPackages and add current Prelude

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,3 +113,7 @@
 /nixos/modules/services/databases/postgresql.xml @thoughtpolice
 /nixos/modules/services/databases/postgresql.nix @thoughtpolice
 /nixos/tests/postgresql.nix @thoughtpolice
+
+# Dhall
+/pkgs/development/dhall-modules      @Gabriel439 @Profpatsch
+/pkgs/development/interpreters/dhall @Gabriel439 @Profpatsch

--- a/pkgs/development/dhall-modules/default.nix
+++ b/pkgs/development/dhall-modules/default.nix
@@ -1,0 +1,9 @@
+{ pkgs }:
+
+# TODO: add into the toplevel fixpoint instead of using rec
+rec {
+
+  prelude = prelude_3_0_0;
+  prelude_3_0_0 = pkgs.callPackage ./prelude/v3.nix {};
+
+}

--- a/pkgs/development/dhall-modules/prelude/v3.nix
+++ b/pkgs/development/dhall-modules/prelude/v3.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "dhall-prelude";
+
+  src = fetchFromGitHub {
+    owner = "dhall-lang";
+    repo = "dhall-lang";
+    # Commit where the v3.0.0 prelude folder was merged into dhall-lang
+    # and a LICENSE file has been added.
+    rev = "f6aa9399f1ac831d66c34104abe6856023c5b2df";
+    sha256 = "0kqjgh3y1l3cb3rj381j7c09547g1vh2dsfzpm08y1qajhhf9vgf";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    cp -r Prelude $out
+  '';
+
+  meta = {
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ Profpatsch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7549,6 +7549,8 @@ with pkgs;
 
   dhall-text = haskell.lib.justStaticExecutables haskellPackages.dhall-text;
 
+  dhallPackages = import ../development/dhall-modules { inherit pkgs; };
+
   duktape = callPackage ../development/interpreters/duktape { };
 
   beam = callPackage ./beam-packages.nix { };


### PR DESCRIPTION
Dhall is a non-turing-complete programming language.

Waiting on https://github.com/dhall-lang/Prelude/issues/13

Should we update the `dhall.prelude` argument to point to `dhallPackages.prelude`? Or just keep it as-is, as the same version that is in the haskell source code?

cc @f-f @Gabriel439