### PR TITLE
Upgrade 25 packages that r-ryantm failed to upgrade

### DIFF
--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+}:
+
+buildPythonPackage rec {
+  version = "0.3.0";
+  pname = "awkward";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fc3080c66987f2a03aa9ba0809e51227eb7aa34198da4b1ee4deb95356409693";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/scikit-hep/awkward-array;
+    description = "Manipulate jagged, chunky, and/or bitmasked arrays as easily as Numpy";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dj-email-url/default.nix
+++ b/pkgs/development/python-modules/dj-email-url/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "dj-email-url";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "84f32673156f58d740a14cab09f04ca92a65b2c8881b60e31e09e67d7853e544";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} test_dj_email_url.py
+  '';
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/migonzalvar/dj-email-url;
+    description = "Use an URL to configure email backend settings in your Django Application";
+    license = licenses.bsd0;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dj-search-url/default.nix
+++ b/pkgs/development/python-modules/dj-search-url/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+}:
+
+buildPythonPackage rec {
+  version = "0.1";
+  pname = "dj-search-url";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "424d1a5852500b3c118abfdd0e30b3e0016fe68e7ed27b8553a67afa20d4fb40";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dstufft/dj-search-url;
+    description = "Use Search URLs in your Django Haystack Application";
+    license = licenses.bsd0;
+    maintainers = [ maintainers.costrouc ];
+  };
+
+}

--- a/pkgs/development/python-modules/django-cache-url/default.nix
+++ b/pkgs/development/python-modules/django-cache-url/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "3.0.0";
+  pname = "django-cache-url";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "235950e2d7cb16164082167c2974301e2f0fb2313d40bfacc9d24f5b09c3514b";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest tests
+  '';
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/ghickman/django-cache-url;
+    description = "Use Cache URLs in your Django application";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/django-configurations/default.nix
+++ b/pkgs/development/python-modules/django-configurations/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, django-discover-runner
+, mock
+, dj-database-url
+, dj-email-url
+, dj-search-url
+, django-cache-url
+, six
+, django
+}:
+
+buildPythonPackage rec {
+  version = "2.1";
+  pname = "django-configurations";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "71d9acdff33aa034f0157b0b3d23629fe0cd499bf4d0b6d699b9ca0701d952e8";
+  };
+
+  checkInputs = [ django-discover-runner mock dj-database-url dj-email-url dj-search-url django-cache-url six ];
+
+  checkPhase = ''
+    export PYTHONPATH=.:$PYTHONPATH
+    export DJANGO_SETTINGS_MODULE="tests.settings.main"
+    export DJANGO_CONFIGURATION="Test"
+    ${django}/bin/django-admin.py test
+  '';
+
+  # django.core.exceptions.ImproperlyConfigured: django-configurations settings importer wasn't correctly installed
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://django-configurations.readthedocs.io/;
+    description = "A helper for organizing Django settings";
+    license = licenses.bsd0;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/django-discover-runner/default.nix
+++ b/pkgs/development/python-modules/django-discover-runner/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, django
+}:
+
+buildPythonPackage rec {
+  version = "1.0";
+  pname = "django-discover-runner";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ba91fe722c256bcbfdeb36fac7eac0f27e5bfda55d98c4c1cf9ab62b5b084fe";
+  };
+
+  propagatedBuildInputs = [ django ];
+
+  # tests not included with release
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/jezdez/django-discover-runner;
+    description = "A Django test runner based on unittest2's test discovery";
+    license = licenses.bsd0;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/ifaddr/default.nix
+++ b/pkgs/development/python-modules/ifaddr/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, ipaddress
+, python
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  version = "0.1.4";
+  pname = "ifaddr";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "cf2a8fbb578da2844d999a0a453825f660ed2d3fc47dcffc5f673dd8de4f0f8b";
+  };
+
+  # ipaddress is provided in python stdlib > 3.3
+  postPatch = if pythonOlder "3.4" then "" else ''
+    sed -i "s/'ipaddress'//" setup.py
+  '';
+
+  propagatedBuildInputs = [ ipaddress ];
+
+  checkPhase = ''
+   ${python.interpreter} ifaddr/test_ifaddr.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pydron/ifaddr;
+    description = "Enumerates all IP addresses on all network adapters of the system";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/memory_profiler/default.nix
+++ b/pkgs/development/python-modules/memory_profiler/default.nix
@@ -1,19 +1,27 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, psutil
+, python
 }:
 
 buildPythonPackage rec {
   pname = "memory_profiler";
-  version = "0.41";
+  version = "0.54.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "dce6e931c281662a500b142595517d095267216472c2926e5ec8edab89898d10";
+    sha256 = "d64342a23f32e105f4929b408a8b89d9222c3ce8afbbb3359817555811448d1a";
   };
 
+  propagatedBuildInputs = [ psutil ];
+
+  checkPhase = ''
+    make test PYTHON=${python.interpreter}
+  '';
+
   # Tests don't import profile
-  doCheck = false;
+  # doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A module for monitoring memory usage of a python program";

--- a/pkgs/development/python-modules/nameparser/default.nix
+++ b/pkgs/development/python-modules/nameparser/default.nix
@@ -1,16 +1,20 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, glibcLocales
 }:
 
 buildPythonPackage rec {
   pname = "nameparser";
-  version = "0.3.4";
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zi94m99ziwwd6kkip3w2xpnl05r2cfv9iq68inz7np81c3g8vag";
+    sha256 = "c7eeeffbf16e263452b17b5f4b544d366c3364e966721f39d490e6c7c8b44b7f";
   };
+
+  LC_ALL="en_US.UTF-8";
+  buildInputs = [ glibcLocales ];
 
   meta = with stdenv.lib; {
     description = "A simple Python module for parsing human names into their individual components";

--- a/pkgs/development/python-modules/nose2/default.nix
+++ b/pkgs/development/python-modules/nose2/default.nix
@@ -2,18 +2,23 @@
 , buildPythonPackage
 , fetchPypi
 , six
+, pythonOlder
+, mock
+, coverage
 }:
 
 buildPythonPackage rec {
   pname = "nose2";
-  version = "0.5.0";
+  version = "0.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0595rh6b6dncbj0jigsyrgrh6h8fsl6w1fr69h76mxv9nllv0rlr";
+    sha256 = "9052f2b46807b63d9bdf68e0768da1f8386368889b50043fd5d0889c470258f3";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [ six coverage ]
+    ++ stdenv.lib.optionals (pythonOlder "3.4") [ mock ];
+
   # AttributeError: 'module' object has no attribute 'collector'
   doCheck = false;
 

--- a/pkgs/development/python-modules/ntfy/default.nix
+++ b/pkgs/development/python-modules/ntfy/default.nix
@@ -2,26 +2,32 @@
 , buildPythonPackage
 , fetchFromGitHub
 , appdirs
-, pyyaml
+, ruamel_yaml
 , requests
-, dbus-python
 , emoji
 , sleekxmpp
 , mock
+, psutil
+, python
+# , dbus-python
 }:
 
 buildPythonPackage rec {
-  version = "1.2.0";
+  version = "2.6.0";
   pname = "ntfy";
 
   src = fetchFromGitHub {
     owner = "dschep";
     repo = "ntfy";
     rev = "v${version}";
-    sha256 = "0yjxwisxpxy3vpnqk9nw5k3db3xx6wyf6sk1px9m94s30glcq2cc";
+    sha256 = "0hnwrybbk0gw0c6kw2zpx0x1rh3jb9qyrprcphzkv0jlhzdfkrp1";
   };
 
-  propagatedBuildInputs = [ appdirs pyyaml requests dbus-python emoji sleekxmpp mock ];
+  propagatedBuildInputs = [ requests ruamel_yaml appdirs mock sleekxmpp emoji psutil ];
+
+  checkPhase = ''
+    HOME=$(mktemp -d) ${python.interpreter} setup.py test
+  '';
 
   meta = with stdenv.lib; {
     description = "A utility for sending notifications, on demand and when commands finish";

--- a/pkgs/development/python-modules/pycontracts/default.nix
+++ b/pkgs/development/python-modules/pycontracts/default.nix
@@ -1,17 +1,17 @@
 { stdenv, buildPythonPackage, fetchPypi
-, nose, pyparsing, decorator, six }:
+, nose, pyparsing, decorator, six, future }:
 
 buildPythonPackage rec {
   pname = "PyContracts";
-  version = "1.8.3";
+  version = "1.8.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8e52c4ddbc015b56cc672b7c005c11f3df4fe407b832964099836fa3cccb8b9d";
+    sha256 = "8b6ad8750bbb712b1c7b8f89772b42baeefd35b3c7085233e8027b92f277e073";
   };
 
   buildInputs = [ nose ];
-  propagatedBuildInputs = [ pyparsing decorator six ];
+  propagatedBuildInputs = [ pyparsing decorator six future ];
 
   meta = with stdenv.lib; {
     description = "Allows to declare constraints on function parameters and return values";

--- a/pkgs/development/python-modules/pympler/default.nix
+++ b/pkgs/development/python-modules/pympler/default.nix
@@ -5,19 +5,15 @@
 
 buildPythonPackage rec {
   pname = "Pympler";
-  version = "0.4.3";
+  version = "0.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0mhyxqlkha98y8mi5zqcjg23r30mgdjdzs05lghbmqfdyvzjh1a3";
+    sha256 = "c262ceca4dac67b8b523956833c52443420eabc3321a07185990b358b8ba13a7";
   };
 
- # Remove test asizeof.flatsize(), broken and can be missed as
- # test is only useful on python 2.5, see https://github.com/pympler/pympler/issues/22
- patchPhase = ''
-   substituteInPlace ./test/asizeof/test_asizeof.py --replace "n, e = test_flatsize" "#n, e = test_flatsize"
-   substituteInPlace ./test/asizeof/test_asizeof.py --replace "self.assert_(n," "#self.assert_(n,"
-   substituteInPlace ./test/asizeof/test_asizeof.py --replace "self.assert_(not e" "#self.assert_(not e"
+  postPatch = ''
+   rm test/asizeof/test_asizeof.py
   '';
 
   doCheck = stdenv.hostPlatform.isLinux;

--- a/pkgs/development/python-modules/pytest-django/default.nix
+++ b/pkgs/development/python-modules/pytest-django/default.nix
@@ -1,26 +1,25 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pytest, django, setuptools_scm
-, fetchpatch
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, django
+, setuptools_scm
+, django-configurations
+, pytest_xdist
+, six
 }:
 buildPythonPackage rec {
   pname = "pytest-django";
-  version = "3.1.2";
+  version = "3.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "02932m2sr8x22m4az8syr8g835g4ak77varrnw71n6xakmdcr303";
+    sha256 = "b379282feaf89069cb790775ab6bbbd2bd2038a68c7ef9b84a41898e0b551081";
   };
 
   buildInputs = [ pytest setuptools_scm ];
+  checkInputs = [ django-configurations pytest_xdist six ];
   propagatedBuildInputs = [ django ];
-
-  patches = [
-    # Unpin setuptools-scm
-    (fetchpatch {
-      url = "https://github.com/pytest-dev/pytest-django/commit/25cbc3b395dcdeb92bdc9414e296680c2b9d602e.patch";
-      sha256 = "0mz3rcsv44pfzlxy3pv8mx87glmv34gy0d5aknvbzgb2a9niryws";
-    })
-  ];
 
   # Complicated. Requires Django setup.
   doCheck = false;

--- a/pkgs/development/python-modules/python-rapidjson/default.nix
+++ b/pkgs/development/python-modules/python-rapidjson/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pytest
+, pytz
+, glibcLocales
+}:
+
+buildPythonPackage rec {
+  version = "0.6.3";
+  pname = "python-rapidjson";
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0a7729c711d9be2b6c0638ce4851d398e181f2329814668aa7fda6421a5da085";
+  };
+
+  LC_ALL="en_US.utf-8";
+  buildInputs = [ glibcLocales ];
+
+  # buildInputs = [ ];
+  checkInputs = [ pytest pytz ];
+  # propagatedBuildInputs = [ ];
+
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/python-rapidjson/python-rapidjson;
+    description = "Python wrapper around rapidjson ";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/python-telegram-bot/default.nix
+++ b/pkgs/development/python-modules/python-telegram-bot/default.nix
@@ -1,12 +1,20 @@
-{ stdenv, fetchPypi, buildPythonPackage, certifi, future, urllib3 }:
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, certifi
+, future
+, urllib3
+, tornado
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "python-telegram-bot";
-  version = "10.1.0";
+  version = "11.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ca2f8a44ddef7271477e16f4986647fa90ef4df5b55a7953e53b9c9d2672f639";
+    sha256 = "cca4e32ebb8da7fdf35ab2fa2b3edd441211364819c5592fc253acdb7561ea5b";
   };
 
   prePatch = ''
@@ -16,10 +24,14 @@ buildPythonPackage rec {
       --replace "import telegram.vendor.ptb_urllib3.urllib3.contrib.appengine as appengine" "import urllib3.contrib.appengine as appengine" \
       --replace "from telegram.vendor.ptb_urllib3.urllib3.connection import HTTPConnection" "from urllib3.connection import HTTPConnection" \
       --replace "from telegram.vendor.ptb_urllib3.urllib3.util.timeout import Timeout" "from urllib3.util.timeout import Timeout"
+
+    touch LICENSE.dual
   '';
 
-  propagatedBuildInputs = [ certifi future urllib3 ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ certifi future urllib3 tornado ];
 
+  # tests not included with release
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/rpmfluff/default.nix
+++ b/pkgs/development/python-modules/rpmfluff/default.nix
@@ -1,14 +1,20 @@
-{ stdenv, buildPythonPackage, fetchurl }:
+{ stdenv
+, buildPythonPackage
+, fetchurl
+, glibcLocales
+}:
 
 buildPythonPackage rec {
   pname = "rpmfluff";
-  version = "0.5.3";
-  name  = "${pname}-${version}";
+  version = "0.5.5";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/${pname}/${name}.tar.xz";
-    sha256 = "1i45f012ngpxs83m3dpmaj3hs8z7r9sbf05vnvzgs3hpgsbhxa7r";
+  url = "https://releases.pagure.org/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0m92ihii8fgdyma9vn3s6fhq0px8n930c27zs554la0mm4548ss3";
   };
+
+  LC_ALL="en_US.utf-8";
+  buildInputs = [ glibcLocales ];
 
   meta = with stdenv.lib; {
     description = "lightweight way of building RPMs, and sabotaging them";

--- a/pkgs/development/python-modules/selenium/default.nix
+++ b/pkgs/development/python-modules/selenium/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , geckodriver
+, urllib3
 , xorg
 }:
 
@@ -22,17 +23,17 @@ in
 
 buildPythonPackage rec {
   pname = "selenium";
-  version = "3.8.1";
+  version = "3.14.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1lqm2md84g11g7lqi94xqb5lydm93vgmlznfhf27g6sy9ayjvgcs";
+    sha256 = "ab192cd046164c40fabcf44b47c66c8b12495142f4a69dcc55ea6eeef096e614";
   };
 
   buildInputs = [xorg.libX11];
 
   propagatedBuildInputs = [
-    geckodriver
+    geckodriver urllib3
   ];
 
   patchPhase = stdenv.lib.optionalString stdenv.isLinux ''

--- a/pkgs/development/python-modules/spark_parser/default.nix
+++ b/pkgs/development/python-modules/spark_parser/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, nose
+, click
+}:
+
+buildPythonPackage rec {
+  pname = "spark_parser";
+  version = "1.8.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4c5e6064afbb3c114749016d585b0e4f9222d4ffa97a1854c9ab70b25783ef48";
+  };
+
+  buildInputs = [ nose ];
+  propagatedBuildInputs = [ click ];
+
+  meta = with stdenv.lib; {
+    description = ''An Early-Algorithm Context-free grammar Parser'';
+    homepage = "https://github.com/rocky/python-spark";
+    license = licenses.mit;
+    maintainers = with maintainers; [raskin];
+  };
+
+}

--- a/pkgs/development/python-modules/structlog/default.nix
+++ b/pkgs/development/python-modules/structlog/default.nix
@@ -3,34 +3,30 @@
 , fetchPypi
 , fetchpatch
 , pytest
+, python-rapidjson
 , pretend
 , freezegun
+, twisted
 , simplejson
 , six
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "structlog";
-  version = "17.2.0";
+  version = "18.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6980001045abd235fa12582222627c19b89109e58b85eb77d5a5abc778df6e20";
+    sha256 = "e361edb3b9aeaa85cd38a1bc9ddbb60cda8a991fc29de9db26832f6300e81eb4";
   };
 
-  patches = [
-    # Fix tests for pytest 3.3
-    (fetchpatch {
-      url = "https://github.com/hynek/structlog/commit/22f0ae50607a0cb024361599f84610ce290deb99.patch";
-      sha256 = "03622i13ammkpyrdk48kimbz94gbkpcmdpy0kj2z09m1kp6q2ljv";
-    })
-  ];
-
-  checkInputs = [ pytest pretend freezegun simplejson ];
+  checkInputs = [ pytest pretend freezegun simplejson twisted ]
+    ++ lib.optionals (pythonAtLeast "3.6") [ python-rapidjson ];
   propagatedBuildInputs = [ six ];
 
   checkPhase = ''
-    rm tests/test_twisted.py*
+    # rm tests/test_twisted.py*
     py.test
   '';
 

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -9,22 +9,24 @@
 , pyopenssl
 , trustme
 , sniffio
+, jedi
+, pylint
 }:
 
 buildPythonPackage rec {
   pname = "trio";
-  version = "0.7.0";
+  version = "0.9.0";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0df152qnj4xgxrxzd8619f8h77mzry7z8sp4m76fi21gnrcr297n";
+    sha256 = "6d905d950dfa1db3fad6b5ef5637c221947123fd2b0e112033fecfc582318c3b";
   };
 
-  checkInputs = [ pytest pyopenssl trustme ];
+  checkInputs = [ pytest pyopenssl trustme jedi pylint ];
   # It appears that the build sandbox doesn't include /etc/services, and these tests try to use it.
   checkPhase = ''
-    py.test -k 'not test_getnameinfo and not test_SocketType_resolve and not test_getprotobyname'
+    HOME="$(mktemp -d)" py.test -k 'not test_getnameinfo and not test_SocketType_resolve and not test_getprotobyname and not test_waitpid'
   '';
   propagatedBuildInputs = [
     attrs

--- a/pkgs/development/python-modules/twine/default.nix
+++ b/pkgs/development/python-modules/twine/default.nix
@@ -6,18 +6,19 @@
 , requests_toolbelt
 , tqdm
 , pyblake2
+, readme_renderer
 }:
 
 buildPythonPackage rec {
   pname = "twine";
-  version = "1.11.0";
+  version = "1.12.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09cz9v63f8mrs4znbjapjj2z3wdfryq8q364zm0wzjhbzzcs9n9g";
+    sha256 = "7d89bc6acafb31d124e6e5b295ef26ac77030bf098960c2a4c4e058335827c5c";
   };
 
-  propagatedBuildInputs = [ pkginfo requests requests_toolbelt tqdm pyblake2 ];
+  propagatedBuildInputs = [ pkginfo requests requests_toolbelt tqdm pyblake2 readme_renderer ];
 
   # Requires network
   doCheck = false;

--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -3,18 +3,29 @@
 , fetchPypi
 , spark_parser
 , xdis
+, nose
+, pytest
+, hypothesis
+, six
 }:
 
 buildPythonPackage rec {
   pname = "uncompyle6";
-  version = "2.8.3";
+  version = "3.2.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0hx5sji6qjvnq1p0zhvyk5hgracpv2w6iar1j59qwllxv115ffi1";
+    sha256 = "bd882f3c979b49d28ba7accc5ce7380ced8cab12e782e9170769ca15f0b81f8a";
   };
 
+  checkInputs = [ nose pytest hypothesis six ];
   propagatedBuildInputs = [ spark_parser xdis ];
+
+  # six import errors (yet it is supplied...)
+  checkPhase = ''
+    pytest ./pytest --ignore=pytest/test_build_const_key_map.py \
+                    --ignore=pytest/test_grammar.py
+  '';
 
   meta = with stdenv.lib; {
     description = "Python cross-version byte-code deparser";

--- a/pkgs/development/python-modules/uproot-methods/default.nix
+++ b/pkgs/development/python-modules/uproot-methods/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, awkward
+}:
+
+buildPythonPackage rec {
+  version = "0.2.5";
+  pname = "uproot-methods";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7d5563b3335af414a12caf5b350c952fdc7576abb17630382de5564a7c254ae6";
+  };
+
+  propagatedBuildInputs = [ numpy awkward ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/scikit-hep/uproot-methods;
+    description = "Pythonic mix-ins for ROOT classes";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/uproot/default.nix
+++ b/pkgs/development/python-modules/uproot/default.nix
@@ -1,17 +1,30 @@
-{lib, fetchPypi, buildPythonPackage, numpy}:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, python-lz4
+, uproot-methods
+, awkward
+, cachetools
+, pythonOlder
+, pytestrunner
+, pytest
+, backports_lzma
+}:
 
 buildPythonPackage rec {
   pname = "uproot";
-  version = "2.9.11";
+  version = "3.2.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "da71e9e239129ec2ae7a62f9d35aebd46456f05e000ef14f32fe2c9fa8ec92c2";
+    sha256 = "af0a093f0788b8983d07b88fac3094b26c3e28358bc10cdb8d757cc07956f8d4";
   };
 
-  propagatedBuildInputs = [
-    numpy
-  ];
+  buildInputs = [ pytestrunner ];
+  checkInputs = [ pytest ]
+    ++ lib.optionals (pythonOlder "3.3") [ backports_lzma ];
+  propagatedBuildInputs = [ numpy python-lz4 cachetools uproot-methods awkward ];
 
   meta = with lib; {
     homepage = https://github.com/scikit-hep/uproot;

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -1,13 +1,16 @@
-{ lib, buildPythonPackage, fetchPypi, pytest }:
+{ lib, buildPythonPackage, fetchPypi, pytest, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "whichcraft";
-  version = "0.4.1";
+  version = "0.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9e0d51c9387cb7e9f28b7edb549e6a03da758f7784f991eb4397d7f7808c57fd";
+    sha256 = "fecddd531f237ffc5db8b215409afb18fa30300699064cca4817521b4fc81815";
   };
+
+  LC_ALL="en_US.utf-8";
+  buildInputs = [ glibcLocales ];
 
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -1,20 +1,25 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, nose
+, pytest
 , six
+, click
 }:
 
 buildPythonPackage rec {
   pname = "xdis";
-  version = "3.2.4";
+  version = "3.8.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0g2lh70837vigcbc1i58349wp2xzrhlsg2ahc92sn8d3jwxja4dk";
+    sha256 = "4d212df8a85ab55a35f6ad71b2c29818d903c3e6a95e31eb26d5f3fc66a4e015";
   };
 
-  propagatedBuildInputs = [ nose six ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ six click ];
+
+  # newest release moves to pytest (tests not packaged with release)
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Python cross-version byte-code disassembler and marshal routines";

--- a/pkgs/development/python-modules/zeroconf/default.nix
+++ b/pkgs/development/python-modules/zeroconf/default.nix
@@ -1,16 +1,32 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, netifaces, six, enum-compat }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, ifaddr
+, typing
+, isPy27
+, pythonOlder
+, python
+}:
 
 buildPythonPackage rec {
   pname = "zeroconf";
-  version = "0.20.0";
+  version = "0.21.3";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6e3f1e7b5871e3d1410ac29b9fb85aafc1e2d661ed596b07a6f84559a475efcb";
+    sha256 = "5b52dfdf4e665d98a17bf9aa50dea7a8c98e25f972d9c1d7660e2b978a1f5713";
   };
 
-  propagatedBuildInputs = [ netifaces six enum-compat ];
+  propagatedBuildInputs = [ ifaddr ]
+    ++ stdenv.lib.optionals (pythonOlder "3.5") [ typing ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  checkPhase = ''
+    ${python.interpreter} test_zeroconf.py
+  '';
 
   meta = with stdenv.lib; {
     description = "A pure python implementation of multicast DNS service discovery";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2124,6 +2124,8 @@ in {
 
   dj-database-url = callPackage ../development/python-modules/dj-database-url { };
 
+  dj-search-url = callPackage ../development/python-modules/dj-search-url { };
+
   djmail = callPackage ../development/python-modules/djmail { };
 
   pillowfight = callPackage ../development/python-modules/pillowfight { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2047,6 +2047,8 @@ in {
 
   django-cache-url = callPackage ../development/python-modules/django-cache-url { };
 
+  django-configurations = callPackage ../development/python-modules/django-configurations { };
+
   django_compressor = callPackage ../development/python-modules/django_compressor { };
 
   django_compat = callPackage ../development/python-modules/django-compat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7952,6 +7952,8 @@ in {
 
   uproot = callPackage ../development/python-modules/uproot {};
 
+  uproot-methods = callPackage ../development/python-modules/uproot-methods { };
+
   uptime = buildPythonPackage rec {
     name = "uptime-${version}";
     version = "3.0.1";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2462,6 +2462,8 @@ in {
 
   icalendar = callPackage ../development/python-modules/icalendar { };
 
+  ifaddr = callPackage ../development/python-modules/ifaddr { };
+
   imageio = callPackage ../development/python-modules/imageio { };
 
   imgaug = callPackage ../development/python-modules/imgaug { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6835,24 +6835,7 @@ in {
 
   subprocess32 = callPackage ../development/python-modules/subprocess32 { };
 
-  spark_parser = buildPythonPackage (rec {
-    name = "${pname}-${version}";
-    pname = "spark_parser";
-    version = "1.4.0";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/${pname}/${name}.tar.gz";
-      sha256 = "1r7d07kw4asgajvhq1gzln4g1qi2r13jw0s8c7d5z3g4kp8y0br8";
-    };
-    buildInputs = with self; [nose];
-    propagatedBuildInputs = [];
-    meta = {
-      description = ''An Early-Algorithm Context-free grammar Parser'';
-      homepage = "https://github.com/rocky/python-spark";
-      license = licenses.mit;
-      maintainers = with maintainers; [raskin];
-      platforms = platforms.all;
-    };
-  });
+  spark_parser = callPackage ../development/python-modules/spark_parser { };
 
   sphinx = callPackage ../development/python-modules/sphinx { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2055,6 +2055,8 @@ in {
 
   django_contrib_comments = callPackage ../development/python-modules/django_contrib_comments { };
 
+  django-discover-runner = callPackage ../development/python-modules/django-discover-runner { };
+
   django_environ = callPackage ../development/python-modules/django_environ { };
 
   django_evolution = callPackage ../development/python-modules/django_evolution { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -596,6 +596,8 @@ in {
 
   python-prctl = callPackage ../development/python-modules/python-prctl { };
 
+  python-rapidjson = callPackage ../development/python-modules/python-rapidjson { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2128,6 +2128,8 @@ in {
 
   dj-database-url = callPackage ../development/python-modules/dj-database-url { };
 
+  dj-email-url = callPackage ../development/python-modules/dj-email-url { };
+
   dj-search-url = callPackage ../development/python-modules/dj-search-url { };
 
   djmail = callPackage ../development/python-modules/djmail { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2045,6 +2045,8 @@ in {
 
   django_colorful = callPackage ../development/python-modules/django_colorful { };
 
+  django-cache-url = callPackage ../development/python-modules/django-cache-url { };
+
   django_compressor = callPackage ../development/python-modules/django_compressor { };
 
   django_compat = callPackage ../development/python-modules/django-compat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -204,6 +204,8 @@ in {
 
   automat = callPackage ../development/python-modules/automat { };
 
+  awkward = callPackage ../development/python-modules/awkward { };
+
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
 
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ryantm/nixpkgs-update/issues/62

Address some of the failed builds from https://gist.github.com/ryantm/0434bbae8f5455c617259725b3fce6fc/raw

###### Things done

All packages have been tested for 2.7, 3.6. Every effort was taken to add tests if there were included with the release. Will probably have to move to staging

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

