### PR TITLE
vivaldi: 2.0.1309.29-2 -> 2.1.1337.36-1; vivaldi-ffmpeg-codecs: 69.0.3497.73 -> 70.0.3538.77

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -13,11 +13,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "2.0.1309.29-2";
+  version = "2.1.1337.36-1";
 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "09vaf191djbrfijvhklivh2ifj8w68car2vz956gsw4lhz07kzck";
+    sha256 = "14qf3gk46m65yfc7q7gsnkj6av8yhg7byi0h1yv24sr7n4rrnrsc";
   };
 
   unpackPhase = ''

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi-ffmpeg-codecs";
-  version = "69.0.3497.73";
+  version = "70.0.3538.77";
 
   src = fetchurl {
     url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-    sha512 = "3qyzxdybiszwy62izr35wffnh1a1plg9y536vrmd4b2xl8p4nz18c7439blr0cdzsr5qplgrdl64446a27mkyhbw8c3iy0gb4zgb5j9";
+    sha512 = "128hvkcbyw70j31dj4jviqqjrzyfx38689nb8v0kk5vi2zlgfy5ibz2gyrv4bvrb53ld262y9pvam51nbdmrx2vqd9xrs173py7v0a0";
   };
 
   buildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change

- Update vivaldi to version vivaldi to version [2.1.1337.36-1](https://vivaldi.com/blog/vivaldi-2-1-launches-with-improved-quick-commands/)
- Update vivaldi-ffmpeg-codecs to version 70.0.3538.77

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).