### PR TITLE
minor fixes in Nixpkgs stdenv docs

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2100,7 +2100,7 @@ someVar=$(stripHash $name)
 
   <para>
    In order to alleviate this burden, the <firstterm>setup
-   hook></firstterm>mechanism was written, where any package can include a
+   hook</firstterm>mechanism was written, where any package can include a
    shell script that [by convention rather than enforcement by Nix], any
    downstream reverse-dependency will source as part of its build process. That
    allows the downstream dependency to merely specify its dependencies, and

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -372,7 +372,7 @@ let f(h, h + 1, i) = i + h
       They are programs/libraries used at build time that furthermore produce
       programs/libraries also used at build time. If the dependency doesn't
       care about the target platform (i.e. isn't a compiler or similar tool),
-      put it in <varname>nativeBuildInputs</varname>instead. The most common
+      put it in <varname>nativeBuildInputs</varname> instead. The most common
       use for this <literal>buildPackages.stdenv.cc</literal>, the default C
       compiler for this role. That example crops up more than one might think
       in old commonly used C libraries.
@@ -2100,7 +2100,7 @@ someVar=$(stripHash $name)
 
   <para>
    In order to alleviate this burden, the <firstterm>setup
-   hook</firstterm>mechanism was written, where any package can include a
+   hook</firstterm> mechanism was written, where any package can include a
    shell script that [by convention rather than enforcement by Nix], any
    downstream reverse-dependency will source as part of its build process. That
    allows the downstream dependency to merely specify its dependencies, and


### PR DESCRIPTION
###### Motivation for this change

Text is displayed wrong in the docs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

