### PR TITLE
Linux headers: Cleanup

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -133,9 +133,7 @@ stdenv.mkDerivation ({
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ bison ];
-  # TODO make linuxHeaders unconditional next mass rebuild
-  buildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) linuxHeaders
-    ++ lib.optionals withGd [ gd libpng ];
+  buildInputs = [ linuxHeaders ] ++ lib.optionals withGd [ gd libpng ];
 
   # Needed to install share/zoneinfo/zone.tab.  Set to impure /bin/sh to
   # prevent a retained dependency on the bootstrap tools in the stdenv-linux

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  common = { version, sha256, patches ? [] }: stdenvNoCC.mkDerivation ({
+  common = { version, sha256, patches ? [] }: stdenvNoCC.mkDerivation {
     name = "linux-headers-${version}";
 
     src = fetchurl {
@@ -24,12 +24,11 @@ let
 
     extraIncludeDirs = lib.optional stdenvNoCC.hostPlatform.isPowerPC ["ppc"];
 
-    # "patches" array defaults to 'null' to avoid changing hash
-    # and causing mass rebuild
     inherit patches;
 
-    # TODO avoid native hack next rebuild
-    makeFlags = if stdenvNoCC.hostPlatform == stdenvNoCC.buildPlatform then null else [
+    hardeningDisable = lib.optional stdenvNoCC.buildPlatform.isDarwin "format";
+
+    makeFlags = [
       "SHELL=bash"
       # Avoid use of runtime build->host compilers for checks. These
       # checks only cared to work around bugs in very old compilers, so
@@ -41,11 +40,8 @@ let
       "HOSTCXX:=$(BUILD_CXX)"
     ];
 
-    # TODO avoid native hack next rebuild
     # Skip clean on darwin, case-sensitivity issues.
-    buildPhase = if stdenvNoCC.hostPlatform == stdenvNoCC.buildPlatform then ''
-      make mrproper headers_check SHELL=bash
-    '' else lib.optionalString (!stdenvNoCC.buildPlatform.isDarwin) ''
+    buildPhase = lib.optionalString (!stdenvNoCC.buildPlatform.isDarwin) ''
       make mrproper $makeFlags
     ''
     # For some reason, doing `make install_headers` twice, first without
@@ -55,17 +51,12 @@ let
       make headers_install $makeFlags
     '';
 
-    # TODO avoid native hack next rebuild
-    checkPhase = if stdenvNoCC.hostPlatform == stdenvNoCC.buildPlatform then null else ''
+    checkPhase = ''
       make headers_check $makeFlags
     '';
 
-    # TODO avoid native hack next rebuild
-    installPhase = (if stdenvNoCC.hostPlatform == stdenvNoCC.buildPlatform then ''
-      make INSTALL_HDR_PATH=$out headers_install
-    '' else ''
+    installPhase = ''
       make headers_install INSTALL_HDR_PATH=$out $makeFlags
-    '') + ''
 
       # Some builds (e.g. KVM) want a kernel.release.
       mkdir -p $out/include/config
@@ -77,17 +68,14 @@ let
       license = licenses.gpl2;
       platforms = platforms.linux;
     };
-  } // lib.optionalAttrs (stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform) {
-    # TODO Make unconditional next mass rebuild
-    hardeningDisable = lib.optional stdenvNoCC.buildPlatform.isDarwin "format";
-  });
+  };
 in {
 
   linuxHeaders = common {
     version = "4.18.3";
     sha256 = "1m23hjd02bg8mqnd8dc4z4m3kxds1cyrc6j5saiwnhzbz373rvc1";
     # TODO make unconditional next mass rebuild
-    patches = lib.optionals (stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform) [
+    patches = [
        ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
        ./no-dynamic-cc-version-check.patch # so we can use `stdenvNoCC`, see `makeFlags` above
     ];


### PR DESCRIPTION
###### Motivation for this change

The bootstrap-tools reference is fixed. It would be still nice to get upstream to fix building with just `HOSTCC` (linux parlance, `CC_FOR_BUILD` the more common term) and no `CC`, though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

