### PR TITLE
zathura: symlinkJoin all plugins

### DIFF
--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -1,17 +1,13 @@
 { symlinkJoin, lib, makeWrapper, zathura_core, plugins ? [] }:
-
-let
-  pluginsPath = lib.makeSearchPath "lib/zathura" plugins;
-
-in symlinkJoin {
+symlinkJoin {
   name = "zathura-with-plugins-${zathura_core.version}";
 
-  paths = [ zathura_core ];
+  paths = [ zathura_core ] ++ plugins;
 
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/zathura --add-flags --plugins-dir=${pluginsPath}
+    wrapProgram $out/bin/zathura --add-flags --plugins-dir="''${out}/lib/zathura"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Zathura is not registered as a pdf reader, for instance nautilus doesn't propose it as a pdf reader.
It's because the default .desktop file doesn't contain any MimeType, these are provided by the plugins see https://git.pwmt.org/pwmt/zathura/issues/45#note_416.

Instead of copying the .desktop entries, I relied on the already present symlinkJoin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

