### PR TITLE
kustomize: 1.0.8 -> 1.0.9

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -3,9 +3,9 @@
 
 buildGoPackage rec {
   name = "kustomize-${version}";
-  version = "1.0.8";
+  version = "1.0.9";
   # rev is the 1.0.8 commit, mainly for kustomize version command output
-  rev = "58492e2d83c59ed63881311f46ad6251f77dabc3";
+  rev = "ec86b30d2b01a8fa62e645f024f26bfea5dcd30d";
 
   goPackagePath = "sigs.k8s.io/kustomize";
 
@@ -17,7 +17,7 @@ buildGoPackage rec {
   '';
 
   src = fetchFromGitHub {
-    sha256 = "0y6dqwhm7lczjy0zk2fnc1i43lvnjhcvihvm7qknky05z9f0v8bx";
+    sha256 = "06a0iic8sp745q71bh0k2zbcdhppp85bx9c3fwwr4wl77dlybz4f";
     rev = "v${version}";
     repo = "kustomize";
     owner = "kubernetes-sigs";
@@ -32,6 +32,6 @@ buildGoPackage rec {
     '';
     homepage = https://github.com/kubernetes-sigs/kustomize;
     license = licenses.asl20;
-    maintainers = [ maintainers.carlosdagos maintainers.vdemeester ];
+    maintainers = with maintainers; [ carlosdagos vdemeester periklis ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bump version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

