### PR TITLE
idrisPackages.{categories,derive}: Use upstream instead of forks

### DIFF
--- a/pkgs/development/idris-modules/categories.nix
+++ b/pkgs/development/idris-modules/categories.nix
@@ -6,11 +6,10 @@ build-idris-package  {
   name = "categories";
   version = "2018-07-02";
 
-  # https://github.com/danilkolikov/categories/pull/5
   src = fetchFromGitHub {
-    owner = "infinisil";
+    owner = "danilkolikov";
     repo = "categories";
-    rev = "9722d62297e5025431e91b271ab09c5d14867236";
+    rev = "a1e0ac0f0da2e336a7d3900051892ff7ed504c35";
     sha256 = "1bbmm8zif5d5wckdaddw6q3c39w6ms1cxrlrmkdn7bik88dawff2";
   };
 

--- a/pkgs/development/idris-modules/derive.nix
+++ b/pkgs/development/idris-modules/derive.nix
@@ -10,12 +10,11 @@ build-idris-package  {
 
   idrisDeps = [ contrib pruviloj ];
 
-  # https://github.com/david-christiansen/derive-all-the-instances/pull/9
   src = fetchFromGitHub {
-    owner = "infinisil";
+    owner = "david-christiansen";
     repo = "derive-all-the-instances";
-    rev = "61c3e12e26f599379299fcbb9c40a81bfc3e0604";
-    sha256 = "0g2lb8nrwqwf3gm5fir43cxz6db84n19xiwkv8cmmqc1fgy6v0qn";
+    rev = "0a9a5082d4ab6f879a2c141d1a7b645fa73fd950";
+    sha256 = "06za15m1kv9mijzll5712crry4iwx3b0fjv76gy9vv1p10gy2g4m";
   };
 
   meta = {


### PR DESCRIPTION
These forks were introduced in https://github.com/NixOS/nixpkgs/pull/42861 to
make the builds succeed. The changes have since been incorporated
upstream.

@GrahamcOfBorg build idrisPackages.categories idrisPackages.derive

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

