### PR TITLE
doc/breakpointHook: improve documentation

### DIFF
--- a/doc/languages-frameworks/coq.xml
+++ b/doc/languages-frameworks/coq.xml
@@ -12,8 +12,8 @@
 
  <para>
   Some extensions (plugins) might require OCaml and sometimes other OCaml
-  packages. The <literal>coq.ocamlPackages</literal> attribute can be used
-  to depend on the same package set Coq was built against.
+  packages. The <literal>coq.ocamlPackages</literal> attribute can be used to
+  depend on the same package set Coq was built against.
  </para>
 
  <para>

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2451,16 +2451,19 @@ addEnvHooks "$hostOffset" myBashFunction
      </term>
      <listitem>
       <para>
-       This hook will make a build pause instead of stopping
-       when a failure happen. It prevents nix to cleanup the build
-       environment immediatly and allows the user to attach
-       to a build environemnt using the <varname>cntr</varname> command.
-       On build error it will print the instruction that are neccessary for cntr.
-       Note that <varname>cntr</varname> is not installed by default and
-       needs to be installed seperatly. <varname>cntr</varname> also needs to be executed
-       on the machine that is doing the build, which might be not the case
-       when remote builders are enabled. <varname>cntr</varname> is only supported
-       on linux based platforms.
+       This hook will make a build pause instead of stopping when a failure
+       happen. It prevents nix to cleanup the build environment immediatly and
+       allows the user to attach to a build environment using the
+       <command>cntr</command> command. On build error it will print the
+       instruction that are neccessary for <command>cntr</command>. Installing
+       cntr and running the command will provide shell access to the build
+       sandbox of failed build. At <filename>/var/lib/cntr</filename> the
+       sandbox filesystem is mounted. All commands and files of the system are
+       still accessible within the shell. To execute commands from the sandbox
+       use the cntr exec subcommand. Note that <command>cntr</command> also
+       needs to be executed on the machine that is doing the build, which might
+       be not the case when remote builders are enabled.
+       <command>cntr</command> is only supported on linux based platforms.
       </para>
      </listitem>
     </varlistentry>

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2099,13 +2099,13 @@ someVar=$(stripHash $name)
   </para>
 
   <para>
-   In order to alleviate this burden, the <firstterm>setup
-   hook</firstterm> mechanism was written, where any package can include a
-   shell script that [by convention rather than enforcement by Nix], any
-   downstream reverse-dependency will source as part of its build process. That
-   allows the downstream dependency to merely specify its dependencies, and
-   lets those dependencies effectively initialize themselves. No boilerplate
-   mirroring the list of dependencies is needed.
+   In order to alleviate this burden, the <firstterm>setup hook</firstterm>
+   mechanism was written, where any package can include a shell script that [by
+   convention rather than enforcement by Nix], any downstream
+   reverse-dependency will source as part of its build process. That allows the
+   downstream dependency to merely specify its dependencies, and lets those
+   dependencies effectively initialize themselves. No boilerplate mirroring the
+   list of dependencies is needed.
   </para>
 
   <para>


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

