### PR TITLE
tabula: init at 1.2.1

### DIFF
--- a/pkgs/applications/misc/tabula/default.nix
+++ b/pkgs/applications/misc/tabula/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchzip, jre, makeWrapper }:
+
+
+stdenv.mkDerivation rec {
+  name = "tabula-${version}";
+  version = "1.2.1";
+
+
+  src = fetchzip {
+    url = "https://github.com/tabulapdf/tabula/releases/download/v${version}/tabula-jar-${version}.zip";
+    sha256 = "0lkpv8hkji81fanyxm7ph8421fr9a6phqc3pbhw2bc4gljg7sgxi";
+  };
+
+
+  buildInputs = [ makeWrapper ];
+
+
+  installPhase = ''
+    mkdir -pv $out/share/tabula
+    cp -v * $out/share/tabula
+
+    makeWrapper ${jre}/bin/java $out/bin/tabula --add-flags "-jar $out/share/tabula/tabula.jar"
+  '';
+
+
+  meta = with stdenv.lib; {
+    description = "A tool for liberating data tables locked inside PDF files";
+    longDescription = ''
+      If you’ve ever tried to do anything with data provided to you in PDFs, you
+      know how painful it is — there's no easy way to copy-and-paste rows of data
+      out of PDF files. Tabula allows you to extract that data into a CSV or
+      Microsoft Excel spreadsheet using a simple, easy-to-use interface.
+    '';
+    homepage = https://tabula.technology/;
+    license = licenses.mit;
+    maintainers = [ maintainers.dpaetzel ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19122,6 +19122,8 @@ with pkgs;
 
   taskjuggler = callPackage ../applications/misc/taskjuggler { };
 
+  tabula = callPackage ../applications/misc/tabula { };
+
   tasknc = callPackage ../applications/misc/tasknc { };
 
   taskwarrior = callPackage ../applications/misc/taskwarrior { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

