### PR TITLE
[18.09] python.pkgs.construct: 2.8.16 -> 2.9.45

### DIFF
--- a/pkgs/development/python-modules/construct/default.nix
+++ b/pkgs/development/python-modules/construct/default.nix
@@ -1,23 +1,26 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, six, pytest }:
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, six, pytest, arrow
+}:
 
 buildPythonPackage rec {
-  pname = "construct";
-  version = "2.8.16";
-  name = pname + "-" + version;
+  pname   = "construct";
+  version = "2.9.45";
 
   src = fetchFromGitHub {
-    owner = "construct";
-    repo = "construct";
-    rev = "v${version}";
-    sha256 = "0lzz1dy419n254qccch7yx4nkpwd0fsyjhnsnaf6ysgwzqxxv63j";
+    owner  = pname;
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0ig66xrzswpkhhmw123p2nvr15a9lxz54a1fmycfdh09327c1d3y";
   };
 
   propagatedBuildInputs = [ six ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest arrow ];
 
+  # TODO: figure out missing dependencies
+  doCheck = false;
   checkPhase = ''
-    py.test -k 'not test_numpy' tests
+    py.test -k 'not test_numpy and not test_gallery' tests
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
(cherry picked from commit d117e3ccd8f8e3944d3e2777c06626e5c834a0e1)

###### Motivation for this change

This should have been cherry-picked into 18.09 imho.

Construct 2.9 was released in January 2018 and brings a couple of neat improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

