### PR TITLE
doh-proxy: init at 0.0.8

### DIFF
--- a/pkgs/development/python-modules/aioh2/default.nix
+++ b/pkgs/development/python-modules/aioh2/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, isPy3k, fetchPypi, h2, priority }:
+
+buildPythonPackage rec {
+  pname = "aioh2";
+  version = "0.2.2";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03i24wzpw0mrnrpck3w6qy83iigwl7n99sdrndqzxfyrc69b99wd";
+  };
+
+  propagatedBuildInputs = [ h2 priority ];
+
+  doCheck = false; # https://github.com/decentfox/aioh2/issues/17
+
+  meta = with lib; {
+    homepage = https://github.com/decentfox/aioh2;
+    description = "HTTP/2 implementation with hyper-h2 on Python 3 asyncio";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.qyliss ];
+  };
+}

--- a/pkgs/development/python-modules/aiohttp-remotes/default.nix
+++ b/pkgs/development/python-modules/aiohttp-remotes/default.nix
@@ -1,0 +1,34 @@
+{ lib, fetchpatch, buildPythonPackage, fetchPypi
+, aiohttp, pytest, pytestcov, pytest-aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "aiohttp_remotes";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "43c3f7e1c5ba27f29fb4dbde5d43b900b5b5fc7e37bf7e35e6eaedabaec4a3fc";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/aio-libs/aiohttp-remotes/commit/188772abcea038c31dae7d607e487eeed44391bc.patch;
+      sha256 = "0pb1y4jb8ar1szhnjiyj2sdmdk6z9h6c3wrxw59nv9kr3if5igvs";
+    })
+  ];
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [ pytest pytestcov pytest-aiohttp ];
+  checkPhase = ''
+    python -m pytest
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/wikibusiness/aiohttp-remotes;
+    description = "A set of useful tools for aiohttp.web server";
+    license = licenses.mit;
+    maintainers = [ maintainers.qyliss ];
+  };
+}

--- a/pkgs/development/python-modules/priority/default.nix
+++ b/pkgs/development/python-modules/priority/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pytest, hypothesis }:
+
+buildPythonPackage rec {
+  pname = "priority";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gpzn9k9zgks0iw5wdmad9b4dry8haiz2sbp6gycpjkzdld9dhbb";
+  };
+
+  checkInputs = [ pytest hypothesis ];
+  checkPhase = ''
+    PYTHONPATH="src:$PYTHONPATH" pytest
+  '';
+
+  meta = with lib; {
+    homepage = https://python-hyper.org/priority/;
+    description = "A pure-Python implementation of the HTTP/2 priority tree";
+    license = licenses.mit;
+    maintainers = [ maintainers.qyliss ];
+  };
+}

--- a/pkgs/servers/dns/doh-proxy/default.nix
+++ b/pkgs/servers/dns/doh-proxy/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "doh-proxy";
+  version = "0.0.8";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0mfl84mcklby6cnsw29kpcxj7mh1cx5yw6mjs4sidr1psyni7x6c";
+  };
+
+  propagatedBuildInputs = with python3Packages;
+    [ aioh2 dnspython aiohttp-remotes pytestrunner flake8 ];
+  doCheck = false; # Trouble packaging unittest-data-provider
+
+  meta = with lib; {
+    homepage = https://facebookexperimental.github.io/doh-proxy/;
+    description = "A proof of concept DNS-Over-HTTPS proxy";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.qyliss ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13208,6 +13208,8 @@ with pkgs;
 
   dex-oidc = callPackage ../servers/dex { };
 
+  doh-proxy = callPackage ../servers/dns/doh-proxy { };
+
   dgraph = callPackage ../servers/dgraph { };
 
   dico = callPackage ../servers/dico { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -708,6 +708,8 @@ in {
 
   aiohttp-jinja2 = callPackage ../development/python-modules/aiohttp-jinja2 { };
 
+  aiohttp-remotes = callPackage ../development/python-modules/aiohttp-remotes { };
+
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
   ajpy = callPackage ../development/python-modules/ajpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1856,6 +1856,8 @@ in {
 
   poyo = callPackage ../development/python-modules/poyo { };
 
+  priority = callPackage ../development/python-modules/priority { };
+
   prov = callPackage ../development/python-modules/prov { };
 
   pudb = callPackage ../development/python-modules/pudb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -702,6 +702,8 @@ in {
 
   aiofiles = callPackage ../development/python-modules/aiofiles { };
 
+  aioh2 = callPackage ../development/python-modules/aioh2 { };
+
   aiohttp = callPackage ../development/python-modules/aiohttp { };
 
   aiohttp-cors = callPackage ../development/python-modules/aiohttp/cors.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)