### PR TITLE
mono: Unbreak on aarch64

### DIFF
--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -86,7 +86,5 @@ stdenv.mkDerivation rec {
     platforms = with platforms; darwin ++ linux;
     maintainers = with maintainers; [ thoughtpolice obadz vrthra ];
     license = licenses.free; # Combination of LGPL/X11/GPL ?
-    # 2018-08-21: mono 5.x is broken on aarch64 since at least 2017-07-06
-    broken = stdenv.isAarch64 && (versionAtLeast version "5");
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Mono seems to work fine on aarch64 (at least `mono58`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

