### PR TITLE
pythonPackages.aioprocessing: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/aioprocessing/default.nix
+++ b/pkgs/development/python-modules/aioprocessing/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "aioprocessing";
+  version = "1.0.1";
+  disabled = !(pythonAtLeast "3.4");
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yq1gfsky2kjimwdmzqk893sp6387vbl4bw0sbha5hl6cm3jp5dn";
+  };
+
+  # Tests aren't included in pypi package
+  doCheck = false;
+
+  meta = {
+    description = "A library that integrates the multiprocessing module with asyncio";
+    homepage = https://github.com/dano/aioprocessing;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ uskudnik ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -706,6 +706,8 @@ in {
 
   aiohttp-jinja2 = callPackage ../development/python-modules/aiohttp-jinja2 { };
 
+  aioprocessing = callPackage ../development/python-modules/aioprocessing { };
+
   ajpy = callPackage ../development/python-modules/ajpy { };
 
   alabaster = callPackage ../development/python-modules/alabaster {};


### PR DESCRIPTION
###### Motivation for this change
Add aioprocessing module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

