### PR TITLE
[18.09] pythonPackages.pyarrow: fix running tests on hydra

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, isPy3k, fetchurl, arrow-cpp, cmake, cython, futures, numpy, pandas, pytest, pytestrunner, parquet-cpp, pkgconfig, setuptools_scm, six }:
+{ lib, buildPythonPackage, python, isPy3k, fetchurl, arrow-cpp, cmake, cython, futures, numpy, pandas, pytest, parquet-cpp, pkgconfig, setuptools_scm, six }:
 
 let
   _arrow-cpp = arrow-cpp.override { inherit python;};
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cmake cython pkgconfig setuptools_scm ];
   propagatedBuildInputs = [ numpy six ] ++ lib.optionals (!isPy3k) [ futures ];
-  checkInputs = [ pandas pytest pytestrunner ];
+  checkInputs = [ pandas pytest ];
 
   PYARROW_BUILD_TYPE = "release";
   PYARROW_CMAKE_OPTIONS = "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib;${PARQUET_HOME}/lib";
@@ -54,6 +54,14 @@ buildPythonPackage rec {
   PARQUET_HOME = _parquet-cpp;
 
   setupPyBuildFlags = ["--with-parquet" ];
+
+  checkPhase = ''
+    mv pyarrow/tests tests
+    rm -rf pyarrow
+    mkdir pyarrow
+    mv tests pyarrow/tests
+    pytest -v
+  '';
 
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";


### PR DESCRIPTION
This replaces standard checkPhase using setup.py that uses pytest-runner
with an explicit call to pytest. One reason to do that is because
setup.py triggers another rebuild when asked to do "test". Another
reason is that there seems to be a conflict between possible imports for
pyarrow: `pwd`/pyarrow vs $out/pyarrow. By some unknown reason this
triggers an import error on hydra and ofborg, but not on my machine. The
solution here is to remove `pwd`/pyarrow, keep the tests and use direct
call to pytest (setup.py needs `pwd`/pyarrow). The added benefit is that
we are now testing what is installed in $out.

(cherry picked from commit 6ae3cb4d36079d4738c656c4bef6615ba3f064a1)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

