### PR TITLE
brlaser: fix install dir

### DIFF
--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib cups ];
 
-  cmakeFlags = [ "-DCUPS_SERVER_BIN=$out/lib/cups" "-DCUPS_DATA_DIR=$out/share/cups" ];
+  cmakeFlags = [ "-DCUPS_SERVER_BIN=lib/cups" "-DCUPS_DATA_DIR=share/cups" ];
 
   meta = with stdenv.lib; {
     description = "A CUPS driver for Brother laser printers";


### PR DESCRIPTION
###### Motivation for this change

Hopefully fixes #49092

The new tree is:
```
result
├── lib
│   └── cups
│       └── filter
│           └── rastertobrlaser
└── share
    └── cups
        └── drv
            └── brlaser.drv
```
without the strange `$out` dir.

@wagnerf42: can you check if this fixes you issue ?




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

