### PR TITLE
gusb: 0.2.11 → 0.3.0

### DIFF
--- a/pkgs/development/libraries/gusb/default.nix
+++ b/pkgs/development/libraries/gusb/default.nix
@@ -1,30 +1,38 @@
-{stdenv, fetchurl
-, automake, autoconf, libtool, which, gtkdoc, gettext, pkgconfig, gobjectIntrospection, libxslt
-, glib, systemd, libusb1, vala_0_38
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gobjectIntrospection
+, gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44
+, glib, systemd, libusb1, vala, hwdata
 }:
 stdenv.mkDerivation rec {
   name = "gusb-${version}";
-  version = "0.2.11";
-  enableParallelBuilding = true;
+  version = "0.3.0";
+
+  outputs = [ "bin" "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/libgusb-${version}.tar.xz";
-    sha256 = "1pppz17lw3khyz8by1dddxdqrv6qn4a23fpxs38c67db7x4l7ccw";
+    sha256 = "1p4f6jdjw6zl986f93gzdjg2hdcn5dlz6rcckcz4rbmnk47rbryq";
   };
 
-  preConfigure = "./autogen.sh";
-
-  nativeBuildInputs = [ pkgconfig autoconf automake libtool which gtkdoc gettext
-                        gobjectIntrospection libxslt vala_0_38 ];
-  buildInputs = [ systemd  glib ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig gettext
+    gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_44
+    gobjectIntrospection vala
+  ];
+  buildInputs = [ systemd glib ];
 
   propagatedBuildInputs = [ libusb1 ];
 
-  meta = {
+  mesonFlags = [
+    "-Dusb_ids=${hwdata}/share/hwdata/usb.ids"
+  ];
+
+  doCheck = false; # tests try to access USB
+
+  meta = with stdenv.lib; {
     description = "GLib libusb wrapper";
-    homepage = https://people.freedesktop.org/~hughsient/releases/;
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [stdenv.lib.maintainers.marcweber];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = https://github.com/hughsie/libgusb;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.marcweber ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--with-usb-ids-path=${hwdata}/data/hwdata/usb.ids"
-    "--with-pci-ids-path=${hwdata}/data/hwdata/pci.ids"
+    "--with-usb-ids-path=${hwdata}/share/hwdata/usb.ids"
+    "--with-pci-ids-path=${hwdata}/share/hwdata/pci.ids"
     "--enable-gtk-doc"
   ];
 

--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   name = "hwdata-${version}";
-  version = "0.314";
+  version = "0.316";
 
   src = fetchFromGitHub {
     owner = "vcrhonek";
     repo = "hwdata";
     rev = "v${version}";
-    sha256 = "12k466ndg152fqld1w5v1zfdyv000yypazcwy75ywlxvlknv4y90";
+    sha256 = "0k3fypykbq9943cnxlmmpk0xp9nhhf46pfdhkgm99iaa27b8s1gb";
   };
 
   preConfigure = "patchShebangs ./configure";
 
-  configureFlags = [ "--datadir=$(prefix)/data" ];
+  configureFlags = [ "--datadir=${placeholder "out"}/share" ];
 
   doCheck = false; # this does build machine-specific checks (e.g. enumerates PCI bus)
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "1w00y5kj8rd8slzydw1gw8cablxlkham4vq786kdd8zga286zabb";
+  outputHash = "0g2w4jr4p1hykracp2za7jb0rcr51kks1m43pzcaf7g99x8669ww";
 
   meta = {
     homepage = https://github.com/vcrhonek/hwdata;

--- a/pkgs/os-specific/linux/usbutils/default.nix
+++ b/pkgs/os-specific/linux/usbutils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   postInstall =
     ''
       substituteInPlace $out/bin/lsusb.py \
-        --replace /usr/share/usb.ids ${hwdata}/data/hwdata/usb.ids
+        --replace /usr/share/usb.ids ${hwdata}/share/hwdata/usb.ids
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9801,9 +9801,7 @@ with pkgs;
 
   gnonlin = callPackage ../development/libraries/gstreamer/legacy/gnonlin {};
 
-  gusb = callPackage ../development/libraries/gusb {
-    inherit (gnome2) gtkdoc;
-  };
+  gusb = callPackage ../development/libraries/gusb { };
 
   qt-mobility = callPackage ../development/libraries/qt-mobility {};
 


### PR DESCRIPTION
###### Motivation for this change
Size impact: 6% overall increase (115 MB → 122 MB due to 7 MB hwinfo). But we also split the outputs now, reducing the size of `out` to 51 MB.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

