### PR TITLE
fakeroot: 1.22 -> 1.23

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, fetchpatch, getopt, libcap }:
 
 stdenv.mkDerivation rec {
-  version = "1.22";
+  version = "1.23";
   name = "fakeroot-${version}";
 
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/main/f/fakeroot/fakeroot_${version}.orig.tar.bz2";
-    sha256 = "1zn67sp066q63vx95r671v0ki878i40a2wa57pmh64k43r56m05x";
+    url = "http://http.debian.net/debian/pool/main/f/fakeroot/fakeroot_${version}.orig.tar.xz";
+    sha256 = "1xpl0s2yjyjwlf832b6kbkaa5921liybaar13k7n45ckd9lxd700";
   };
 
   patches = stdenv.lib.optional stdenv.isLinux ./einval.patch


### PR DESCRIPTION
###### Motivation for this change

The shell wrapper for fakeroot 1.22 parses command-line arguments in such a way as to permit arguments which should be passed through as literal data to be evaluated as shell syntax; 1.23 fixes this.

If programs pass untrusted data through the argument list of commands run with fakeroot, this could potentially be security-impacting. Whether or not fakeroot is used in such a context, it's definitely a correctness issue.

Consider the below transcript, showing a simple command line correctly executed when invoked on its own or via fakeroot 1.23, but incorrectly executed from fakeroot 1.22:

```
$ cmd=( sh -xc $'printf \'%s\\n\' "$@"' _ one two three )

$ "${cmd[@]}"
+ printf '%s\n' one two three
one
two
three

$ /nix/store/2wi31rvbkyzadix44i0d1a2xsmlgdxy9-fakeroot-1.22/bin/fakeroot -- "${cmd[@]}"
+ printf
printf: usage: printf [-v var] format [arguments]

$ /nix/store/s0j7487g3g4davd2wniw268c4b12zgs1-fakeroot-1.23/bin/fakeroot -- "${cmd[@]}"
+ printf '%s\n' one two three
one
two
three
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

