### PR TITLE
kubicorn: init at 4c7f3623

### DIFF
--- a/pkgs/development/tools/kubicorn/default.nix
+++ b/pkgs/development/tools/kubicorn/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+with stdenv.lib;
+
+buildGoPackage rec {
+  name = "kubicorn-${version}";
+  version = "2018-10-13-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "4c7f3623e9188fba43778271afe161a4facfb657";
+
+  src = fetchFromGitHub {
+    rev = rev;
+    owner = "kubicorn";
+    repo = "kubicorn";
+    sha256 = "18h5sj4lcivrwjq2hzn7c3g4mblw17zicb5nma8sh7sakwzyg1k9";
+  };
+
+  subPackages = ["."];
+  goPackagePath = "github.com/kubicorn/kubicorn";
+
+  meta = {
+    description = "Simple, cloud native infrastructure for Kubernetes";
+    homepage = http://kubicorn.io/;
+    maintainers = with stdenv.lib.maintainers; [ offline ];
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8604,6 +8604,8 @@ with pkgs;
 
   kube-prompt = callPackage ../development/tools/kube-prompt { };
 
+  kubicorn = callPackage ../development/tools/kubicorn {  };
+
   kustomize = callPackage ../development/tools/kustomize { };
 
   kythe = callPackage ../development/tools/kythe { };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---