### PR TITLE
tests/docs: remove remnants of old allowPing default

### DIFF
--- a/nixos/doc/manual/configuration/firewall.xml
+++ b/nixos/doc/manual/configuration/firewall.xml
@@ -34,13 +34,4 @@
   Similarly, UDP port ranges can be opened through
   <xref linkend="opt-networking.firewall.allowedUDPPortRanges"/>.
  </para>
-
- <para>
-  Also of interest is
-<programlisting>
-<xref linkend="opt-networking.firewall.allowPing"/> = true;
-</programlisting>
-  to allow the machine to respond to ping requests. (ICMPv6 pings are always
-  allowed.)
- </para>
 </section>

--- a/nixos/tests/ceph.nix
+++ b/nixos/tests/ceph.nix
@@ -10,9 +10,8 @@ import ./make-test.nix ({pkgs, ...}: rec {
         emptyDiskImages = [ 20480 20480 ];
         vlans = [ 1 ];
       };
-      
+
       networking = {
-        firewall.allowPing = true;
         useDHCP = false;
         interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
           { address = "192.168.1.1"; prefixLength = 24; }
@@ -54,7 +53,7 @@ import ./make-test.nix ({pkgs, ...}: rec {
       };
     };
   };
-  
+
   testScript = { ... }: ''
     startAll;
 
@@ -83,7 +82,7 @@ import ./make-test.nix ({pkgs, ...}: rec {
 
     # Can't check ceph status until a mon is up
     $aio->succeed("ceph -s | grep 'mon: 1 daemons'");
-          
+
     # Start the ceph-mgr daemon, it has no deps and hardly any setup
     $aio->mustSucceed(
       "ceph auth get-or-create mgr.aio mon 'allow profile mgr' osd 'allow *' mds 'allow *' > /var/lib/ceph/mgr/ceph-aio/keyring",

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -13,9 +13,6 @@ let
 
       # CJDNS output is incompatible with the XML log.
       systemd.services.cjdns.serviceConfig.StandardOutput = "null";
-      #networking.firewall.enable = true;
-      networking.firewall.allowPing = true;
-      #networking.firewall.rejectPackets = true;
     };
 
 in

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -42,7 +42,6 @@ import ./make-test.nix ({ pkgs, ...} : {
             { services.httpd.enable = true;
               services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.firewall.allowPing = true;
             };
         };
 

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -43,7 +43,6 @@ import ./make-test.nix ({ pkgs, ...} : {
           config =
             {
               networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.firewall.allowPing = true;
             };
         };
 

--- a/nixos/tests/containers-ipv4.nix
+++ b/nixos/tests/containers-ipv4.nix
@@ -20,7 +20,6 @@ import ./make-test.nix ({ pkgs, ...} : {
             { services.httpd.enable = true;
               services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.firewall.allowPing = true;
               system.stateVersion = "18.03";
             };
         };

--- a/nixos/tests/containers-ipv6.nix
+++ b/nixos/tests/containers-ipv6.nix
@@ -25,7 +25,6 @@ import ./make-test.nix ({ pkgs, ...} : {
             { services.httpd.enable = true;
               services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.firewall.allowPing = true;
             };
         };
 

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -28,7 +28,6 @@ import ./make-test.nix ({ pkgs, ...} : {
             { services.httpd.enable = true;
               services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.firewall.allowPing = true;
             };
         };
 

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -10,7 +10,6 @@ let
       hostBridge = "br0";
       config = {
         networking.firewall.enable = false;
-        networking.firewall.allowPing = true;
         networking.interfaces.eth0.ipv4.addresses = [
           { address = "192.168.1.122"; prefixLength = 24; }
         ];

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -11,7 +11,6 @@ import ./make-test.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false,
       lib.mkMerge [
         { virtualisation.vlans = [ 2 1 ];
           networking.firewall.enable = withFirewall;
-          networking.firewall.allowPing = true;
           networking.nat.internalIPs = [ "192.168.1.0/24" ];
           networking.nat.externalInterface = "eth1";
         }
@@ -33,7 +32,6 @@ import ./make-test.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false,
           { pkgs, nodes, ... }:
           lib.mkMerge [
             { virtualisation.vlans = [ 1 ];
-              networking.firewall.allowPing = true;
               networking.defaultGateway =
                 (pkgs.lib.head nodes.router.config.networking.interfaces.eth2.ipv4.addresses).address;
             }

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -17,7 +17,6 @@ let
       networking = {
         useDHCP = false;
         useNetworkd = networkd;
-        firewall.allowPing = true;
         firewall.checkReversePath = true;
         firewall.allowedUDPPorts = [ 547 ];
         interfaces = mkOverride 0 (listToAttrs (flip map vlanIfs (n:
@@ -86,7 +85,6 @@ let
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = false;
           defaultGateway = "192.168.1.1";
           interfaces.eth1.ipv4.addresses = mkOverride 0 [
@@ -139,7 +137,6 @@ let
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = true;
           interfaces.eth1 = {
             ipv4.addresses = mkOverride 0 [ ];
@@ -194,7 +191,6 @@ let
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = false;
           interfaces.eth1 = {
             ipv4.addresses = mkOverride 0 [ ];
@@ -234,7 +230,6 @@ let
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = false;
           bonds.bond = {
             interfaces = [ "eth1" "eth2" ];
@@ -271,7 +266,6 @@ let
         virtualisation.vlans = [ vlan ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = false;
           interfaces.eth1.ipv4.addresses = mkOverride 0
             [ { inherit address; prefixLength = 24; } ];
@@ -285,7 +279,6 @@ let
         virtualisation.vlans = [ 1 2 ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = false;
           bridges.bridge.interfaces = [ "eth1" "eth2" ];
           interfaces.eth1.ipv4.addresses = mkOverride 0 [ ];
@@ -329,7 +322,6 @@ let
           # reverse path filtering rules for the macvlan interface seem
           # to be incorrect, causing the test to fail. Disable temporarily.
           firewall.checkReversePath = false;
-          firewall.allowPing = true;
           useDHCP = true;
           macvlans.macvlan.interface = "eth1";
           interfaces.eth1.ipv4.addresses = mkOverride 0 [ ];
@@ -415,7 +407,6 @@ let
         #virtualisation.vlans = [ 1 ];
         networking = {
           useNetworkd = networkd;
-          firewall.allowPing = true;
           useDHCP = false;
           vlans.vlan = {
             id = 1;

--- a/nixos/tests/quagga.nix
+++ b/nixos/tests/quagga.nix
@@ -66,7 +66,6 @@ import ./make-test.nix ({ pkgs, ... }:
             virtualisation.vlans = [ 3 ];
             networking.defaultGateway = ifAddr nodes.router2 "eth1";
             networking.firewall.allowedTCPPorts = [ 80 ];
-            networking.firewall.allowPing = true;
             services.httpd.enable = true;
             services.httpd.adminAddr = "foo@example.com";
           };


### PR DESCRIPTION
This has been defaulting to true since 16.03, we don't need this code
anymore, also the note in the documentation has been obsolete for quite
a while.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

