### PR TITLE
scalapack: switch to openblas and add test

### DIFF
--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -1,11 +1,7 @@
-{ stdenv
-, fetchurl
-, gfortran
-, cmake
-, blas
-, liblapack
-, mpi
-}:
+{ stdenv, fetchurl, cmake, openssh
+, gfortran, mpi, openblasCompat
+} :
+
 
 stdenv.mkDerivation rec {
   name = "scalapack-${version}";
@@ -16,12 +12,38 @@ stdenv.mkDerivation rec {
     sha256 = "0p1r61ss1fq0bs8ynnx7xq4wwsdvs32ljvwjnx6yxr8gd6pawx0c";
   };
 
-  buildInputs = [ cmake mpi liblapack blas gfortran ];
+  nativeBuildInputs = [ cmake openssh ];
+  buildInputs = [ mpi gfortran openblasCompat ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF
+      -DLAPACK_LIBRARIES="-lopenblas"
+      -DBLAS_LIBRARIES="-lopenblas"
+      )
+  '';
+
+  checkPhase = ''
+    # make sure the test starts even if we have less than 4 cores
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+
+    # Run single threaded
+    export OMP_NUM_THREADS=1
+
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib
+    export CTEST_OUTPUT_ON_FAILURE=1
+
+    make test
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://www.netlib.org/scalapack/;
     description = "Library of high-performance linear algebra routines for parallel distributed memory machines";
-    license = licenses.bsdOriginal;
+    license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change
Use `openblas`  instead of the reference implementations of BLAS and LAPACK. 

CC @costrouc for testing and comments

###### Things done

* change from blas,lapack to openblas
* add check phase
* enable parallel building
* move `cmake` to `nativeBuildInputs` 
* fix license (it's a BSD 3-clause license)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

