### PR TITLE
squashfsTools: incorporate 4k-alignment option patch

### DIFF
--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -15,13 +15,17 @@ stdenv.mkDerivation rec {
     rev = "9c1db6d13a51a2e009f0027ef336ce03624eac0d";
   };
 
-  # These patches ensures that mksquashfs output is reproducible.
-  # See also https://reproducible-builds.org/docs/system-images/
-  # and https://github.com/NixOS/nixpkgs/issues/40144.
   patches = [
+    # These patches ensures that mksquashfs output is reproducible.
+    # See also https://reproducible-builds.org/docs/system-images/
+    # and https://github.com/NixOS/nixpkgs/issues/40144.
     ./0001-If-SOURCE_DATE_EPOCH-is-set-override-timestamps-with.patch
     ./0002-If-SOURCE_DATE_EPOCH-is-set-also-clamp-content-times.patch
     ./0003-remove-frag-deflator-thread.patch
+
+    # This patch adds an option to pad filesystems (increasing size) in
+    # exchange for better chunking / binary diff calculation.
+    ./squashfs-tools-4.3-4k-align.patch
   ] ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
 
   buildInputs = [ zlib xz ]

--- a/pkgs/tools/filesystems/squashfs/squashfs-tools-4.3-4k-align.patch
+++ b/pkgs/tools/filesystems/squashfs/squashfs-tools-4.3-4k-align.patch
@@ -1,0 +1,92 @@
+From 7bda7c75748f36b0a50f93e46144d5a4de4974ad Mon Sep 17 00:00:00 2001
+From: Amin Hassani <ahassani@google.com>
+Date: Thu, 15 Dec 2016 10:43:15 -0800
+Subject: [PATCH] mksquashfs 4K aligns the files inside the squashfs image
+
+Files inside a squashfs image are not necessarily 4k (4096)
+aligned. This patch starts each file in a 4k aligned address and pads
+zero to the end of the file until it reaches the next 4k aligned
+address. This will not change the size of the compressed
+blocks (especially the last one) and hence it will not change how the
+files are being loaded in kernel or unsquashfs. However on average this
+increases the size of the squashfs image which can be calculated by the
+following formula:
+
+increased_size = (number_of_unfragmented_files_in_image + number of fragments) * 2048
+
+The 4k alignment can be enabled by flag '-4k-align'
+---
+ squashfs-tools/mksquashfs.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/squashfs-tools/mksquashfs.c b/squashfs-tools/mksquashfs.c
+index 8b1376f..683973d 100644
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -99,6 +99,8 @@ int old_exclude = TRUE;
+ int use_regex = FALSE;
+ int nopad = FALSE;
+ int exit_on_error = FALSE;
++int do_4k_align = FALSE;
++#define ALIGN_UP(bytes, size) (bytes = (bytes + size - 1) & ~(size - 1))
+ 
+ long long global_uid = -1, global_gid = -1;
+ 
+@@ -1513,6 +1515,9 @@ void unlock_fragments()
+ 	 * queue at this time.
+ 	 */
+ 	while(!queue_empty(locked_fragment)) {
++		// 4k align the start of remaining queued fragments.
++		if(do_4k_align)
++			ALIGN_UP(bytes, 4096);
+ 		write_buffer = queue_get(locked_fragment);
+ 		frg = write_buffer->block;	
+ 		size = SQUASHFS_COMPRESSED_SIZE_BLOCK(fragment_table[frg].size);
+@@ -2420,6 +2420,9 @@
+ 	compressed_size = SQUASHFS_COMPRESSED_SIZE_BLOCK(c_byte);
+ 	write_buffer->size = compressed_size;
+ 	if(fragments_locked == FALSE) {
++		// 4k align the start of each fragment.
++		if(do_4k_align)
++			ALIGN_UP(bytes, 4096);
+ 		fragment_table[file_buffer->block].size = c_byte;
+ 		fragment_table[file_buffer->block].start_block = bytes;
+ 		write_buffer->block = bytes;
+@@ -2761,6 +2769,10 @@ int write_file_blocks(squashfs_inode *inode, struct dir_ent *dir_ent,
+ 	long long sparse = 0;
+ 	struct file_buffer *fragment_buffer = NULL;
+ 
++	// 4k align the start of each file.
++	if(do_4k_align)
++		ALIGN_UP(bytes, 4096);
++
+ 	if(pre_duplicate(read_size))
+ 		return write_file_blocks_dup(inode, dir_ent, read_buffer, dup);
+ 
+@@ -4692,6 +4704,7 @@ void write_filesystem_tables(struct squashfs_super_block *sBlk, int nopad)
+ 		"compressed", no_fragments ? "no" : noF ? "uncompressed" :
+ 		"compressed", no_xattrs ? "no" : noX ? "uncompressed" :
+ 		"compressed");
++	printf("\t4k %saligned\n", do_4k_align ? "" : "un");
+ 	printf("\tduplicates are %sremoved\n", duplicate_checking ? "" :
+ 		"not ");
+ 	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n", bytes / 1024.0,
+@@ -5346,6 +5359,8 @@ print_compressor_options:
+ 			root_name = argv[i];
+ 		} else if(strcmp(argv[i], "-version") == 0) {
+ 			VERSION();
++		} else if(strcmp(argv[i], "-4k-align") == 0) {
++			do_4k_align = TRUE;
+ 		} else {
+ 			ERROR("%s: invalid option\n\n", argv[0]);
+ printOptions:
+@@ -5387,6 +5402,7 @@ printOptions:
+ 			ERROR("\t\t\tdirectory containing that directory, "
+ 				"rather than the\n");
+ 			ERROR("\t\t\tcontents of the directory\n");
++			ERROR("-4k-align\t\tenables 4k alignment of all files\n");
+ 			ERROR("\nFilesystem filter options:\n");
+ 			ERROR("-p <pseudo-definition>\tAdd pseudo file "
+ 				"definition\n");
+-- 
+2.14.1.480.gb18f417b89-goog (previously; hand-patched by charles-dyfis-net)


### PR DESCRIPTION
###### Motivation for this change

Padding the space between files in squashfs images increases the size of that image, but can greatly improve efficiency both of block- or extent-based on-disk deduplication (such as bees) and chunking-based software distribution systems (such as casync or desync).

This incorporates a patch from Chromium adding an option to enable such alignment, trivially tweaked so it applies to our tree. See https://chromium-review.googlesource.com/c/chromiumos/overlays/portage-stable/+/612449 for upstream discussion of said patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

