### PR TITLE
vagrant: 2.1.2 -> 2.2.0 + vagrant-libvirt: init at 2.2.0

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive, writeText, withLibvirt ? false, libvirt, pkgconfig }:
+{ lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive, writeText, withLibvirt ? true, libvirt, pkgconfig }:
 
 let
   # NOTE: bumping the version and updating the hash is insufficient;

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -3,9 +3,9 @@
 let
   # NOTE: bumping the version and updating the hash is insufficient;
   # you must use bundix to generate a new gemset.nix in the Vagrant source.
-  version = "2.1.2";
+  version = "2.2.0";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
-  sha256 = "0fb90v43d30whhyjlgb9mmy93ccbpr01pz97kp5hrg3wfd7703b1";
+  sha256 = "1wa8l3j6hpy0m0snz7wvfcf0wsjikp22c2z29crpk10f7xl7c56b";
 
   deps = bundlerEnv rec {
     name = "${pname}-${version}";

--- a/pkgs/development/tools/vagrant/gemset.nix
+++ b/pkgs/development/tools/vagrant/gemset.nix
@@ -70,10 +70,10 @@
   ffi = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zw6pbyvmj8wafdc7l5h7w20zkp1vbr2805ql5d941g2b20pk4zr";
+      sha256 = "0jpm2dis1j7zvvy3lg7axz9jml316zrn7s0j59vyq3qr127z0m7q";
       type = "gem";
     };
-    version = "1.9.23";
+    version = "1.9.25";
   };
   gssapi = {
     dependencies = ["ffi"];
@@ -172,18 +172,18 @@
     dependencies = ["mime-types-data"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
+      sha256 = "0fjxy1jm52ixpnv3vg9ld9pr9f35gy0jp66i1njhqjvmnvq0iwwk";
       type = "gem";
     };
-    version = "3.1";
+    version = "3.2.2";
   };
   mime-types-data = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04my3746hwa4yvbx1ranhfaqkgf6vavi1kyijjnw8w3dy37vqhkm";
+      sha256 = "07wvp0aw2gjm4njibb70as6rh5hi1zzri5vky1q6jx95h8l56idc";
       type = "gem";
     };
-    version = "3.2016.0521";
+    version = "3.2018.0812";
   };
   multi_json = {
     source = {
@@ -214,10 +214,10 @@
   net-ssh = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "07c4v97zl1daabmri9zlbzs6yvkl56z1q14bw74d53jdj0c17nhx";
+      sha256 = "0qfanf71yv8w7yl9l9wqcy68i2x1ghvnf8m581yy4pl0anfdhqw8";
       type = "gem";
     };
-    version = "4.2.0";
+    version = "5.0.2";
   };
   netrc = {
     source = {
@@ -238,10 +238,10 @@
   public_suffix = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0mvzd9ycjw8ydb9qy3daq3kdzqs2vpqvac4dqss6ckk4rfcjc637";
+      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
       type = "gem";
     };
-    version = "3.0.1";
+    version = "3.0.3";
   };
   rake = {
     source = {
@@ -358,10 +358,10 @@
   rubyzip = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "06js4gznzgh8ac2ldvmjcmg9v1vg9llm357yckkpylaj6z456zqz";
+      sha256 = "1n1lb2sdwh9h27y244hxzg1lrxxg2m53pk1vq7p33bna003qkyrj";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.2.2";
   };
   safe_yaml = {
     source = {
@@ -397,18 +397,27 @@
     version = "0.0.7.5";
   };
   vagrant = {
-    dependencies = ["childprocess" "erubis" "hashicorp-checkpoint" "i18n" "listen" "log4r" "net-scp" "net-sftp" "net-ssh" "rb-kqueue" "rest-client" "ruby_dep" "wdm" "winrm" "winrm-elevated" "winrm-fs"];
+    dependencies = ["childprocess" "erubis" "hashicorp-checkpoint" "i18n" "listen" "log4r" "net-scp" "net-sftp" "net-ssh" "rb-kqueue" "rest-client" "ruby_dep" "rubyzip" "vagrant_cloud" "wdm" "winrm" "winrm-elevated" "winrm-fs"];
   };
   vagrant-spec = {
     dependencies = ["childprocess" "log4r" "rspec" "thor"];
     source = {
       fetchSubmodules = false;
-      rev = "9413ab298407114528766efefd1fb1ff24589636";
-      sha256 = "1z77m3p6x82hipa7y4i71zafy0rdfajw2vhqdxczjmrlwp0pvisl";
+      rev = "abfc34474d122235d56e4c6b6fb5d3e35bedfa90";
+      sha256 = "08xy2c82lrxkwjlvrbx1v32968a6psni3952y3knriqgygv2kzbn";
       type = "git";
       url = "https://github.com/hashicorp/vagrant-spec.git";
     };
     version = "0.0.1";
+  };
+  vagrant_cloud = {
+    dependencies = ["rest-client"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0k325a1cblj3jd2av8a6j3xsjjm36g578gpbmxw7h5dbffp49il1";
+      type = "gem";
+    };
+    version = "2.0.1";
   };
   wdm = {
     source = {
@@ -431,10 +440,10 @@
     dependencies = ["builder" "erubis" "gssapi" "gyoku" "httpclient" "logging" "nori" "rubyntlm"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "02lzbixdbjvhmb0byqx9rl9x4xx9pqc8jwm7y6mmp7w7mri72zh6";
+      sha256 = "05c1xji4afwxx4vgim5n4nj62zbyppmm67ci3kwi0jjrqaj9y11q";
       type = "gem";
     };
-    version = "2.2.3";
+    version = "2.3.0";
   };
   winrm-elevated = {
     dependencies = ["winrm" "winrm-fs"];
@@ -449,9 +458,9 @@
     dependencies = ["erubis" "logging" "rubyzip" "winrm"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1i3w2j2rmhjqj8lynca2m1dm1m5fv1x35xwhk3vyr15dn260z56g";
+      sha256 = "12g9grzp03knh1nxcicnm93pmlf4r264lhvl5yviyri8swmqlbz5";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.1";
   };
 }

--- a/pkgs/development/tools/vagrant/gemset_libvirt.nix
+++ b/pkgs/development/tools/vagrant/gemset_libvirt.nix
@@ -1,0 +1,19 @@
+{
+  mini_portile2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gzfmcywp1da8nzfqsql2zqi648mfnx6qwkig3cv36n9m0yy676y";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2"];
+      source = {
+        remotes = ["https://rubygems.org"];
+        sha256 = "0byyxrazkfm29ypcx5q4syrv126nvjnf7z6bqi01sqkv4llsi4qz";
+        type = "gem";
+      };
+    version = "1.8.5";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8956,7 +8956,6 @@ with pkgs;
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };
 
   vagrant = callPackage ../development/tools/vagrant {};
-  vagrant-libvirt = self.vagrant.override { withLibvirt = true; };
 
   bashdb = callPackage ../development/tools/misc/bashdb { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8956,6 +8956,7 @@ with pkgs;
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };
 
   vagrant = callPackage ../development/tools/vagrant {};
+  vagrant-libvirt = self.vagrant.override { withLibvirt = true; };
 
   bashdb = callPackage ../development/tools/misc/bashdb { };
 


### PR DESCRIPTION
###### Motivation for this change
* Newer vagrant version available.
* libvirt support was already tried to achieve like in  #19202, also this PR partly obsoletes #26202 with the difference that this does not build and install the vagrant-libvirt plugin but enables one to install it by ```vagrant plugin install vagrant-libvirt``` 
###### Things done
* closure size
  * vagrant without libvirt
  ```
  nix path-info -rS $(which vagrant) | awk '{print $2}' | paste -sd+ | bc
  6355939856
  nix path-info -S $(which vagrant) | awk '{print $2}' | paste -sd+ | bc
  252213208
  ```
  * vagrant with libvirt
  ```
  nix path-info -rS $(which vagrant) | awk '{print $2}' | paste -sd+ | bc
  11342383160
  nix path-info -S $(which vagrant) | awk '{print $2}' | paste -sd+ | bc
  551161720
  ```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against 591ba7335bae245733777c1c4eeedb4d34ef57af"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

