### PR TITLE
avocode: 3.4.0 -> 3.6.2

### DIFF
--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -1,23 +1,24 @@
 { stdenv, makeDesktopItem, fetchurl, unzip
-, gdk_pixbuf, glib, gtk2, atk, pango, cairo, freetype, fontconfig, dbus, nss, nspr, alsaLib, cups, expat, udev, gnome2
-, xorg, mozjpeg
+, gdk_pixbuf, glib, gtk3, atk, at-spi2-atk, pango, cairo, freetype, fontconfig, dbus, nss, nspr, alsaLib, cups, expat, udev, gnome3
+, xorg, mozjpeg, makeWrapper, gsettings-desktop-schemas
 }:
 
 stdenv.mkDerivation rec {
   name = "avocode-${version}";
-  version = "3.4.0";
+  version = "3.6.2";
 
   src = fetchurl {
     url = "https://media.avocode.com/download/avocode-app/${version}/avocode-${version}-linux.zip";
-    sha256 = "1dk4vgam9r5nl8dvpfwrn52gq6r4zxs4zz63p3c4gk73d8qnh4dl";
+    sha256 = "1slxxr3j0djqdnbk645sriwl99jp9imndyxiwd8aqggmmlp145a2";
   };
 
-  libPath = stdenv.lib.makeLibraryPath (with xorg; with gnome2; [
+  libPath = stdenv.lib.makeLibraryPath (with xorg; with gnome3; [
     stdenv.cc.cc.lib
     gdk_pixbuf
     glib
-    gtk2
+    gtk3
     atk
+    at-spi2-atk
     pango
     cairo
     freetype
@@ -29,7 +30,6 @@ stdenv.mkDerivation rec {
     cups
     expat
     udev
-    GConf
     libX11
     libxcb
     libXi
@@ -54,7 +54,8 @@ stdenv.mkDerivation rec {
     comment = "The bridge between designers and developers";
   };
 
-  buildInputs = [ unzip ];
+  nativeBuildInputs = [makeWrapper];
+  buildInputs = [ unzip gtk3 gsettings-desktop-schemas];
 
   # src is producing multiple folder on unzip so we must
   # override unpackCmd to extract it into newly created folder
@@ -84,6 +85,10 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/avocode
     for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
       patchelf --set-rpath ${libPath}:$out/ $file
+    done
+    for file in $out/bin/*; do
+      wrapProgram $file \
+        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${gtk3.out}/share:${gsettings-desktop-schemas}/share:$out/share:$GSETTINGS_SCHEMAS_PATH"
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade avocode to 3.6.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

