### PR TITLE
firefox: fix darwin build

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -42,7 +42,7 @@
 
 # macOS dependencies
 , xcbuild, CoreMedia, ExceptionHandling, Kerberos, AVFoundation, MediaToolbox
-, CoreLocation, Foundation, AddressBook, libobjc, cups, rsync
+, CoreLocation, Foundation, AddressBook, cf-private, libobjc, cups, rsync
 
 ## other
 
@@ -103,9 +103,15 @@ stdenv.mkDerivation rec {
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optional  gtk3Support gtk3
   ++ lib.optional  gssSupport kerberos
-  ++ lib.optionals stdenv.isDarwin [ CoreMedia ExceptionHandling Kerberos
-                                     AVFoundation MediaToolbox CoreLocation
-                                     Foundation libobjc AddressBook cups ];
+  ++ lib.optionals stdenv.isDarwin [
+    CoreMedia ExceptionHandling Kerberos
+    AVFoundation MediaToolbox CoreLocation
+    Foundation AddressBook libobjc cups
+
+    # Needed for CFURLGetFSRef, etc. which have deen deprecated
+    # since 10.9 and are not part of swift-corelibs CoreFoundation.
+    cf-private
+  ];
 
   NIX_CFLAGS_COMPILE = [
     "-I${glib.dev}/include/gio-unix-2.0"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16874,7 +16874,7 @@ with pkgs;
       inherit (darwin.apple_sdk.frameworks) CoreMedia ExceptionHandling
                                             Kerberos AVFoundation MediaToolbox
                                             CoreLocation Foundation AddressBook;
-      inherit (darwin) libobjc;
+      inherit (darwin) cf-private libobjc;
     };
   });
 


### PR DESCRIPTION
    nix.cpp:2357:26: error: no member named 'CFURLCreateFromFSRef' in the global namespace
      CFURLRef newURLRef = ::CFURLCreateFromFSRef(kCFAllocatorDefault, aFSRef);
                           ~~^
    /private/tmp/nix-build-firefox-unwrapped-62.0.3.drv-0/firefox-62.0.3/xpcom/io/nsLocalFileUnix.cpp:2393:11: error: no member named 'CFURLGetFSRef' in the global namespace
        if (::CFURLGetFSRef(url, aResult)) {
            ~~^
    2 errors generated.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

