### PR TITLE
rss2email module: init 

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -336,6 +336,7 @@
       solr = 309;
       alerta = 310;
       minetest = 311;
+      rss2email = 312;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -632,6 +633,7 @@
       solr = 309;
       alerta = 310;
       minetest = 311;
+      rss2email = 312;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -329,6 +329,7 @@
   ./services/mail/postgrey.nix
   ./services/mail/spamassassin.nix
   ./services/mail/rspamd.nix
+  ./services/mail/rss2email.nix
   ./services/mail/rmilter.nix
   ./services/mail/nullmailer.nix
   ./services/misc/airsonic.nix

--- a/nixos/modules/services/mail/rss2email.nix
+++ b/nixos/modules/services/mail/rss2email.nix
@@ -1,0 +1,136 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.rss2email;
+in {
+
+  ###### interface
+
+  options = {
+
+    services.rss2email = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable rss2email.";
+      };
+
+      to = mkOption {
+        type = types.str;
+        description = "Mail address to which to send emails";
+      };
+
+      interval = mkOption {
+        type = types.str;
+        default = "12h";
+        description = "How often to check the feeds, in systemd interval format";
+      };
+
+      config = mkOption {
+        type = with types; attrsOf (either str (either int bool));
+        default = {};
+        description = ''
+          The configuration to give rss2email.
+
+          Default will use system-wide <literal>sendmail</literal> to send the
+          email. This is rss2email's default when running
+          <literal>r2e new</literal>.
+
+          This set contains key-value associations that will be set in the
+          <literal>[DEFAULT]</literal> block along with the
+          <literal>to</literal> parameter.
+
+          See
+          <literal>https://github.com/rss2email/rss2email/blob/master/r2e.1</literal>
+          for more information on which parameters are accepted.
+        '';
+      };
+
+      feeds = mkOption {
+        description = "The feeds to watch.";
+        type = types.attrsOf (types.submodule {
+          options = {
+            url = mkOption {
+              type = types.str;
+              description = "The URL at which to fetch the feed.";
+            };
+
+            to = mkOption {
+              type = with types; nullOr str;
+              default = null;
+              description = ''
+                Email address to which to send feed items.
+
+                If <literal>null</literal>, this will not be set in the
+                configuration file, and rss2email will make it default to
+                <literal>rss2email.to</literal>.
+              '';
+            };
+          };
+        });
+      };
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    users.groups = {
+      rss2email.gid = config.ids.gids.rss2email;
+    };
+
+    users.users = {
+      rss2email = {
+        description = "rss2email user";
+        uid = config.ids.uids.rss2email;
+        group = "rss2email";
+      };
+    };
+
+    services.rss2email.config.to = cfg.to;
+
+    systemd.services.rss2email = let
+      conf = pkgs.writeText "rss2email.cfg" (lib.generators.toINI {} ({
+          DEFAULT = cfg.config;
+        } // lib.mapAttrs' (name: feed: nameValuePair "feed.${name}" (
+          { inherit (feed) url; } //
+          lib.optionalAttrs (feed.to != null) { inherit (feed) to; }
+        )) cfg.feeds
+      ));
+    in
+    {
+      preStart = ''
+        mkdir -p /var/rss2email
+        chmod 700 /var/rss2email
+
+        cp ${conf} /var/rss2email/conf.cfg
+        if [ ! -f /var/rss2email/db.json ]; then
+          echo '{"version":2,"feeds":[]}' > /var/rss2email/db.json
+        fi
+
+        chown -R rss2email:rss2email /var/rss2email
+      '';
+      path = [ pkgs.system-sendmail ];
+      serviceConfig = {
+        ExecStart =
+          "${pkgs.rss2email}/bin/r2e -c /var/rss2email/conf.cfg -d /var/rss2email/db.json run";
+        User = "rss2email";
+        PermissionsStartOnly = "true";
+      };
+    };
+
+    systemd.timers.rss2email = {
+      partOf = [ "rss2email.service" ];
+      wantedBy = [ "timers.target" ];
+      timerConfig.OnBootSec = "0";
+      timerConfig.OnUnitActiveSec = cfg.interval;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ ekleog ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -179,6 +179,7 @@ in
   radicale = handleTest ./radicale.nix {};
   redmine = handleTest ./redmine.nix {};
   rspamd = handleTest ./rspamd.nix {};
+  rss2email = handleTest ./rss2email.nix {};
   rsyslogd = handleTest ./rsyslogd.nix {};
   runInMachine = handleTest ./run-in-machine.nix {};
   rxe = handleTest ./rxe.nix {};

--- a/nixos/tests/common/webroot/news-rss.xml
+++ b/nixos/tests/common/webroot/news-rss.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:blogChannel="http://backend.userland.com/blogChannelModule" version="2.0"><channel><title>NixOS News</title><link>https://nixos.org</link><description>News for NixOS, the purely functional Linux distribution.</description><image><title>NixOS</title><url>https://nixos.org/logo/nixos-logo-only-hires.png</url><link>https://nixos.org/</link></image><item><title>
+      NixOS 18.09 released
+    </title><link>https://nixos.org/news.html</link><description>
+      <a href="https://github.com/NixOS/nixos-artwork/blob/master/releases/18.09-jellyfish/jellyfish.png">
+        <img class="inline" src="logo/nixos-logo-18.09-jellyfish-lores.png" alt="18.09 Jellyfish logo" with="100" height="87"/>
+      </a>
+      NixOS 18.09 “Jellyfish” has been released, the tenth stable release branch.
+      See the <a href="/nixos/manual/release-notes.html#sec-release-18.09">release notes</a>
+      for details. You can get NixOS 18.09 ISOs and VirtualBox appliances
+      from the <a href="nixos/download.html">download page</a>.
+      For information on how to upgrade from older release branches
+      to 18.09, check out the
+      <a href="/nixos/manual/index.html#sec-upgrading">manual section on upgrading</a>.
+    </description><pubDate>Sat Oct 06 2018 00:00:00 GMT</pubDate></item></channel></rss>

--- a/nixos/tests/rss2email.nix
+++ b/nixos/tests/rss2email.nix
@@ -1,0 +1,66 @@
+import ./make-test.nix {
+  name = "opensmtpd";
+
+  nodes = {
+    server = { pkgs, ... }: {
+      imports = [ common/user-account.nix ];
+      services.nginx = {
+        enable = true;
+        virtualHosts."127.0.0.1".root = ./common/webroot;
+      };
+      services.rss2email = {
+        enable = true;
+        to = "alice@localhost";
+        interval = "1";
+        config.from = "test@example.org";
+        feeds = {
+          nixos = { url = "http://127.0.0.1/news-rss.xml"; };
+        };
+      };
+      services.opensmtpd = {
+        enable = true;
+        extraServerArgs = [ "-v" ];
+        serverConfiguration = ''
+          listen on 127.0.0.1
+          action dovecot_deliver mda \
+            "${pkgs.dovecot}/libexec/dovecot/deliver -d %{user.username}"
+          match from any for local action dovecot_deliver
+        '';
+      };
+      services.dovecot2 = {
+        enable = true;
+        enableImap = true;
+        mailLocation = "maildir:~/mail";
+        protocols = [ "imap" ];
+      };
+      environment.systemPackages = let
+        checkMailLanded = pkgs.writeScriptBin "check-mail-landed" ''
+          #!${pkgs.python3.interpreter}
+          import imaplib
+
+          with imaplib.IMAP4('127.0.0.1', 143) as imap:
+            imap.login('alice', 'foobar')
+            imap.select()
+            status, refs = imap.search(None, 'ALL')
+            print("=====> Result of search for all:", status, refs)
+            assert status == 'OK'
+            assert len(refs) > 0
+            status, msg = imap.fetch(refs[0], 'BODY[TEXT]')
+            assert status == 'OK'
+        '';
+      in [ pkgs.opensmtpd checkMailLanded ];
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    $server->waitForUnit("network-online.target");
+    $server->waitForUnit("opensmtpd");
+    $server->waitForUnit("dovecot2");
+    $server->waitForUnit("nginx");
+    $server->waitForUnit("rss2email");
+
+    $server->waitUntilSucceeds('check-mail-landed >&2');
+  '';
+}

--- a/pkgs/applications/networking/feedreaders/rss2email/default.nix
+++ b/pkgs/applications/networking/feedreaders/rss2email/default.nix
@@ -1,11 +1,13 @@
-{ pythonPackages, fetchurl, lib }:
+{ pythonPackages, fetchurl, lib, nixosTests }:
 
 with pythonPackages;
 
 buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "rss2email";
-  version = "3.9";
+  version = "3.9"; # TODO: on next bump, the manpage will be updated.
+  # Update nixos/modules/services/mail/rss2email.nix to point to it instead of
+  # to the online r2e.1
 
   propagatedBuildInputs = [ feedparser beautifulsoup4 html2text ];
 
@@ -43,5 +45,8 @@ buildPythonApplication rec {
     homepage = https://pypi.python.org/pypi/rss2email;
     license = licenses.gpl2;
     maintainers = with maintainers; [ jb55 Profpatsch ];
+  };
+  passthru.tests = {
+    smoke-test = nixosTests.rss2email;
   };
 }

--- a/pkgs/servers/mail/system-sendmail/default.nix
+++ b/pkgs/servers/mail/system-sendmail/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, writeText }:
+
+let script = writeText "script" ''
+  #!/bin/sh
+
+  if command -v sendmail > /dev/null 2>&1 && [ "$(command -v sendmail)" != "{{MYPATH}}" ]; then
+    exec sendmail "$@"
+  elif [ -x /run/wrappers/bin/sendmail ]; then
+    exec /run/wrappers/bin/sendmail "$@"
+  elif [ -x /run/current-system/sw/bin/sendmail ]; then
+    exec /run/current-system/sw/bin/sendmail "$@"
+  else
+    echo "Unable to find system sendmail." >&2
+    exit 1
+  fi
+''; in
+stdenv.mkDerivation {
+  name = "system-sendmail-1.0";
+
+  src = script;
+
+  phases = [ "buildPhase" ];
+  buildPhase = ''
+    mkdir -p $out/bin
+    < $src sed "s#{{MYPATH}}#$out/bin/sendmail#" > $out/bin/sendmail
+    chmod +x $out/bin/sendmail
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      A sendmail wrapper that calls the system sendmail. Do not install as system-wide sendmail!
+    '';
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ekleog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13522,6 +13522,8 @@ with pkgs;
 
   pshs = callPackage ../servers/http/pshs { };
 
+  system-sendmail = lowPrio (callPackage ../servers/mail/system-sendmail { });
+
   # PulseAudio daemons
 
   pulseaudio = callPackage ../servers/pulseaudio {


### PR DESCRIPTION
Also adding `system-sendmail` package for sharing the code with other
modules or packages needing it.

The test for this module depends on #48901 being merged, as the configuration format of OpenSMTPD changed. Hence the fact it's based on the tip of #48901.

cc @Profpatsch 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

