### PR TITLE
mdadm: use shared system-sendmail 

### DIFF
--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -1,18 +1,5 @@
-{ stdenv, writeScript
-, fetchurl, groff
-}:
+{ stdenv, writeScript, fetchurl, groff, system-sendmail }:
 
-let
-  sendmail-script = writeScript "sendmail-script" ''
-    #!/bin/sh
-
-    if [ -x /run/wrappers/bin/sendmail ]; then
-      /run/wrappers/bin/sendmail "$@"
-    else
-      /run/current-system/sw/bin/sendmail "$@"
-    fi
-  '';
-in
 stdenv.mkDerivation rec {
   name = "mdadm-4.1";
 
@@ -23,7 +10,7 @@ stdenv.mkDerivation rec {
 
   # This is to avoid self-references, which causes the initrd to explode
   # in size and in turn prevents mdraid systems from booting.
-  allowedReferences = [ stdenv.cc.libc.out sendmail-script ];
+  allowedReferences = [ stdenv.cc.libc.out system-sendmail ];
 
   patches = [ ./no-self-references.patch ];
 
@@ -40,7 +27,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     sed -e 's@/lib/udev@''${out}/lib/udev@' \
         -e 's@ -Werror @ @' \
-        -e 's@/usr/sbin/sendmail@${sendmail-script}@' -i Makefile
+        -e 's@/usr/sbin/sendmail@${system-sendmail}@' -i Makefile
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Use system-sendmail introduced by (not-yet-merged) https://github.com/NixOS/nixpkgs/pull/49228. Thus this PR is based on it, and currently the overall diff includes lots of useless things. The last commit is the only one important here.

This shares more code across nixpkgs. Hopefully other packages will follow.

Also noticed that mdadm currently had no maintainer, and added myself as one, so that someone feels responsible for future updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

