### PR TITLE
wireshark: include headers in wireshark.dev, to support building wireshark plugins

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -17,6 +17,7 @@ let
 
 in stdenv.mkDerivation {
   name = "wireshark-${variant}-${version}";
+  outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
@@ -87,6 +88,16 @@ in stdenv.mkDerivation {
       --replace "Exec=wireshark" "Exec=$out/bin/wireshark"
 
     install -Dm644 ../image/wsicon.svg $out/share/icons/wireshark.svg
+    mkdir $dev/include/{epan/{wmem,ftypes,dfilter},wsutil,wiretap} -pv
+
+    cp config.h $dev/include/
+    cp ../ws_*.h $dev/include
+    cp ../epan/*.h $dev/include/epan/
+    cp ../epan/wmem/*.h $dev/include/epan/wmem/
+    cp ../epan/ftypes/*.h $dev/include/epan/ftypes/
+    cp ../epan/dfilter/*.h $dev/include/epan/dfilter/
+    cp ../wsutil/*.h $dev/include/wsutil/
+    cp ../wiretap/*.h $dev/include/wiretap
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION


###### Motivation for this change
this allows building wireshark plugins via nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

