### PR TITLE
sage: fix attrname, add sagemath alias

### DIFF
--- a/pkgs/applications/science/math/sage/sage-wrapper.nix
+++ b/pkgs/applications/science/math/sage/sage-wrapper.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   version = sage.version;
-  name = "sage-wrapper-${version}";
+  name = "sage-${version}";
 
   buildInputs = [
     makeWrapper

--- a/pkgs/applications/science/math/sage/sage.nix
+++ b/pkgs/applications/science/math/sage/sage.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   version = sage-with-env.version;
-  name = "sage-${version}";
+  name = "sage-tests-${version}";
 
   buildInputs = [
     makeWrapper

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -250,6 +250,7 @@ mapAliases ({
   s6Networking = s6-networking; # added 2018-07-23
   s6LinuxUtils = s6-linux-utils; # added 2018-07-23
   s6PortableUtils = s6-portable-utils; # added 2018-07-23
+  sagemath = sage; # added 2018-10-27
   sam = deadpixi-sam; # added 2018-04-25
   samsungUnifiedLinuxDriver = samsung-unified-linux-driver; # added 2016-01-25
   saneBackends = sane-backends; # added 2016-01-02


### PR DESCRIPTION
###### Motivation for this change

Improve discoverability and repology report.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

