### PR TITLE
nim: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/applications/science/biology/mosdepth/default.nix
+++ b/pkgs/applications/science/biology/mosdepth/default.nix
@@ -4,8 +4,8 @@ let
   hts-nim = fetchFromGitHub {
     owner = "brentp";
     repo = "hts-nim";
-    rev = "9cd83e30522ab64cd71eb8209be4154aa5579ce1";
-    sha256 = "10g408idy14667varq1syf06rrbpk63i3ib7i5dh1md4ib19av6f";
+    rev = "v0.2.5";
+    sha256 = "1fma99rjqxgg9dihkd10hm1jjp5amsk5wsxnvq1lk4mcsjix5xqb";
   };
 
   docopt = fetchFromGitHub {
@@ -28,7 +28,10 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ nim ];
 
-  buildPhase = "nim -p:${hts-nim}/src -p:${docopt}/src c -d:release mosdepth.nim";
+  buildPhase = ''
+    HOME=$TMPDIR
+    nim -p:${hts-nim}/src -p:${docopt}/src c --nilseqs:on -d:release mosdepth.nim
+  '';
   installPhase = "install -Dt $out/bin mosdepth";
   fixupPhase = "patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ stdenv.cc.cc htslib pcre ]} $out/bin/mosdepth";
 

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
 
   patchPhase =
     let disableTest = ''sed -i '1i discard \"\"\"\n  disabled: true\n\"\"\"\n\n' '';
+        disableStdLibTest = ''sed -i -e '/^when isMainModule/,/^END$/{s/^/#/}' '';
         disableCompile = ''sed -i -e 's/^/#/' '';
     in ''
       substituteInPlace ./tests/async/tioselectors.nim --replace "/bin/sleep" "sleep"
@@ -66,6 +67,9 @@ stdenv.mkDerivation rec {
 
       # disable tests requiring network access (not available in the build container)
       ${disableTest} ./tests/stdlib/thttpclient.nim
+    '' + lib.optionalString stdenv.isAarch64 ''
+      # disable test supposedly broken on aarch64
+      ${disableStdLibTest} ./lib/pure/stats.nim
     '';
 
   checkPhase = ''

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,14 +1,14 @@
 # based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
 
-{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-8_x, openssl, pcre, readline, sqlite, boehmgc, sfml, tzdata, coreutils }:
+{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-8_x, openssl, pcre, readline, boehmgc, sfml, tzdata, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
-  version = "0.18.0";
+  version = "0.19.0";
 
   src = fetchurl {
     url = "https://nim-lang.org/download/${name}.tar.xz";
-    sha256 = "45c74adb35f08dfa9add1112ae17330e5d902ebb4a36e7046caee8b79e6f3bd0";
+    sha256 = "0biwvw1gividp5lkf0daq1wp9v6ms4xy6dkf5zj0sn9w4m3n76d1";
   };
 
   doCheck = !stdenv.isDarwin;
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
     "-lcrypto"
     "-lpcre"
     "-lreadline"
-    "-lsqlite3"
     "-lgc"
   ];
 
@@ -30,10 +29,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     makeWrapper nodejs-slim-8_x tzdata coreutils
-    openssl pcre readline sqlite boehmgc sfml
+    openssl pcre readline boehmgc sfml
   ];
 
+  phases = [ "unpackPhase" "patchPhase" "buildPhase" "installPhase" "checkPhase" ];
+
   buildPhase = ''
+    # use gcc to trigger the linker since calling ld in build.sh causes an error 
+    LD=gcc
+    # build.sh wants to write to $HOME/.cache
+    HOME=$TMPDIR
     sh build.sh
     ./bin/nim c koch
     ./koch boot  -d:release \
@@ -51,7 +56,7 @@ stdenv.mkDerivation rec {
       --suffix PATH : ${lib.makeBinPath [ stdenv.cc ]}
   '';
 
-  postPatch =
+  patchPhase =
     let disableTest = ''sed -i '1i discard \"\"\"\n  disabled: true\n\"\"\"\n\n' '';
         disableCompile = ''sed -i -e 's/^/#/' '';
     in ''
@@ -59,25 +64,12 @@ stdenv.mkDerivation rec {
       substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin" "${coreutils}/bin"
       substituteInPlace ./tests/stdlib/ttimes.nim --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
 
-      # disable supposedly broken tests
-      ${disableTest} ./tests/errmsgs/tproper_stacktrace2.nim
-      ${disableTest} ./tests/vm/trgba.nim
-
       # disable tests requiring network access (not available in the build container)
       ${disableTest} ./tests/stdlib/thttpclient.nim
-      ${disableTest} ./tests/cpp/tasync_cpp.nim
-      ${disableTest} ./tests/niminaction/Chapter7/Tweeter/src/tweeter.nim
-
-      # disable tests requiring un-downloadable dependencies (using nimble, which isn't available in the fetch phase)
-      ${disableCompile} ./tests/manyloc/keineschweine/keineschweine.nim
-      ${disableTest} ./tests/manyloc/keineschweine/keineschweine.nim
-      ${disableCompile} ./tests/manyloc/nake/nakefile.nim
-      ${disableTest} ./tests/manyloc/nake/nakefile.nim
-      ${disableCompile} ./tests/manyloc/named_argument_bug/main.nim
-      ${disableTest} ./tests/manyloc/named_argument_bug/main.nim
     '';
 
   checkPhase = ''
+    PATH=$PATH:$out/bin
     ./koch tests
   '';
 

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
   phases = [ "unpackPhase" "patchPhase" "buildPhase" "installPhase" "checkPhase" ];
 
   buildPhase = ''
-    # use gcc to trigger the linker since calling ld in build.sh causes an error 
-    LD=gcc
+    # use $CC to trigger the linker since calling ld in build.sh causes an error
+    LD=$CC
     # build.sh wants to write to $HOME/.cache
     HOME=$TMPDIR
     sh build.sh

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -27,8 +27,11 @@ stdenv.mkDerivation rec {
   #    used for bootstrapping, but koch insists on moving the nim compiler around
   #    as part of building it, so it cannot be read-only
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper nodejs-slim-8_x tzdata coreutils
+  ];
+
+  buildInputs = [
     openssl pcre readline boehmgc sfml
   ];
 

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,6 +1,6 @@
 # based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
 
-{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-8_x, openssl, pcre, readline, boehmgc, sfml, tzdata, coreutils }:
+{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-10_x, openssl, pcre, readline, boehmgc, sfml, tzdata, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   #    as part of building it, so it cannot be read-only
 
   nativeBuildInputs = [
-    makeWrapper nodejs-slim-8_x tzdata coreutils
+    makeWrapper nodejs-slim-10_x tzdata coreutils
   ];
 
   buildInputs = [

--- a/pkgs/development/tools/nrpl/default.nix
+++ b/pkgs/development/tools/nrpl/default.nix
@@ -25,7 +25,10 @@ stdenv.mkDerivation rec {
     "-lpcre"
   ];
 
-  buildPhase = "nim c -d:release nrpl.nim";
+  buildPhase = ''
+    HOME=$TMPDIR
+    nim c -d:release nrpl.nim
+  '';
 
   installPhase = "install -Dt $out/bin nrpl";
 


### PR DESCRIPTION
- remove sqlite as dependency (I don't see why it's needed)
- run checkPhase after installPhase (at least one test assumes the
standard library in ../lib relative to the nim binary)
- the broken tests pass now or don't exist anymore
- two of the tests requiring network access pass now without network access
- the tests in manyloc do not download dependencies and are passing now

###### Motivation for this change
Update nim to 0.19.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

