### PR TITLE
crystal: fix "play" subcommand

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, makeWrapper
 , gmp, openssl, readline, tzdata, libxml2, libyaml
-, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which }:
+, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which, zlib }:
 
 let
   binaryVersion = "0.26.0";
@@ -57,7 +57,7 @@ let
 
     buildInputs = [
       boehmgc libatomic_ops pcre libevent
-      llvm
+      llvm zlib openssl
     ] ++ stdenv.lib.optionals stdenv.isDarwin [
       libiconv
     ];


### PR DESCRIPTION
Co-authored-by: Merlin Göttlinger <megoettlinger@gmail.com>

###### Motivation for this change

Add dependencies needed by the Crystal web REPL

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

