### PR TITLE
remmina: clean up

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, cmake, pkgconfig, wrapGAppsHook
+{ stdenv, fetchFromGitLab, cmake, ninja, pkgconfig, wrapGAppsHook
 , glib, gtk3, gettext, libxkbfile, libX11
 , freerdp, libssh, libgcrypt, gnutls, makeDesktopItem
 , pcre, libdbusmenu-gtk3, libappindicator-gtk3
@@ -7,24 +7,11 @@
 , openssl, gsettings-desktop-schemas, json-glib
 # The themes here are soft dependencies; only icons are missing without them.
 , hicolor-icon-theme, adwaita-icon-theme
-, gnomeSupport ? true, libgnome-keyring
 }:
 
 with stdenv.lib;
 
-let
-
-  desktopItem = makeDesktopItem {
-    name = "remmina";
-    desktopName = "Remmina";
-    genericName = "Remmina Remote Desktop Client";
-    exec = "remmina";
-    icon = "remmina";
-    comment = "Connect to remote desktops";
-    categories = "GTK;GNOME;X-GNOME-NetworkSettings;Network;";
-  };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "remmina-${version}";
   version = "1.2.32";
 
@@ -35,22 +22,16 @@ in stdenv.mkDerivation rec {
     sha256 = "15szv1xs6drxq6qyksmxcfdz516ja4zm52r4yf6hwij3fgl8qdpw";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake ninja pkgconfig wrapGAppsHook ];
   buildInputs = [
-    cmake wrapGAppsHook gsettings-desktop-schemas
+    gsettings-desktop-schemas
     glib gtk3 gettext libxkbfile libX11
     freerdp libssh libgcrypt gnutls
     pcre libdbusmenu-gtk3 libappindicator-gtk3
     libvncserver libpthreadstubs libXdmcp libxkbcommon
     libsecret libsoup spice-protocol spice-gtk epoxy at-spi2-core
     openssl hicolor-icon-theme adwaita-icon-theme json-glib
-  ]
-  ++ optional gnomeSupport libgnome-keyring;
-
-  preConfigure = optionalString (!gnomeSupport) ''
-    substituteInPlace CMakeLists.txt \
-      --replace "add_subdirectory(remmina-plugins-gnome)" ""
-  '';
+  ];
 
   cmakeFlags = [
     "-DWITH_VTE=OFF"
@@ -68,13 +49,8 @@ in stdenv.mkDerivation rec {
     )
   '';
 
-  postInstall = ''
-    mkdir -pv $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
-  '';
-
   meta = {
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
     homepage = https://gitlab.com/Remmina/Remmina;
     description = "Remote desktop client written in GTK+";
     maintainers = with maintainers; [ melsigl ryantm ];


### PR DESCRIPTION
###### Motivation for this change
Follow-up to https://github.com/NixOS/nixpkgs/pull/48722

- Desktop file is included now, so no need to create it manually.
- libgnome-keyring is not used anymore, libsecret replaced it.

/cc maintainers @melsigl @ryantm
/cc @oxij

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

