### PR TITLE
bats: add missing grep dependency

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchzip, gnugrep }:
 
 stdenv.mkDerivation rec {
   name = "bats-${version}";
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1kkh0j2alql3xiyhw9wsvcc3xclv52g0ivgyk8h85q9fn3qdqakz";
   };
 
-  patchPhase = "patchShebangs ./install.sh";
+  patchPhase = ''
+    patchShebangs ./install.sh
+    substituteInPlace ./libexec/bats-core/bats-format-tap-stream --replace grep ${gnugrep}/bin/grep
+  '';
 
   installPhase = "./install.sh $out";
 


### PR DESCRIPTION
###### Motivation for this change

bats needs `grep` to work which was missing before

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
