### PR TITLE
Openjpeg Patching CVE-2018-7648

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -5,4 +5,13 @@ callPackage ./generic.nix (args // rec {
   branch = "2.3";
   revision = "v${version}";
   sha256 = "08plxrnfl33sn2vh5nwbsngyv6b1sfpplvx881crm1v1ai10m2lz";
+
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-7648.patch";
+      url = "https://github.com/uclouvain/openjpeg/commit/cc3824767bde397fedb8a1ae4786a222ba860c8d.patch";
+      sha256 = "1j5nxmlgyfkxldk2f1ij6h850xw45q3b5brxqa04dxsfsv8cdj5j";
+    })
+  ];
 })


### PR DESCRIPTION
###### Motivation for this change
- Openjpeg Patching CVE-2018-7648

###### Things done
- Adding a patch to Openjpeg

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

