### PR TITLE
cppclean: init at 2018-05-12

### DIFF
--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -3,7 +3,7 @@
 with python3Packages;
 
 buildPythonApplication rec {
-  name = "cppclean-${version}";
+  name = "cppclean-unstable-${version}";
   version = "2018-05-12";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  name = "cppclean-${version}";
+  version = "2018-05-12";
+
+  src = fetchFromGitHub {
+    owner  = "myint";
+    repo   = "cppclean";
+    rev    = "e7da41eca5e1fd2bd1dddd6655e50128bb96dc28";
+    sha256 = "0pymh6r7y19bwcypfkmgwyixrx36pmz338jd83yrjflsbjlriqm4";
+  };
+
+  postUnpack = ''
+    patchShebangs .
+    '';
+
+  checkPhase = ''
+    ./test.bash
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Finds problems in C++ source that slow development of large code bases";
+    homepage    = https://github.com/myint/cppclean;
+    license     = licenses.apache-2.0;
+    maintainers = with maintainers; [ nthorne ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -24,7 +24,7 @@ buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Finds problems in C++ source that slow development of large code bases";
     homepage    = https://github.com/myint/cppclean;
-    license     = licenses.apache-2.0;
+    license     = licenses.Apache-2.0;
     maintainers = with maintainers; [ nthorne ];
     platforms   = platforms.linux;
   };

--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -24,7 +24,7 @@ buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Finds problems in C++ source that slow development of large code bases";
     homepage    = https://github.com/myint/cppclean;
-    license     = "Apache-2.0";
+    license     = licenses.asl20;
     maintainers = with maintainers; [ nthorne ];
     platforms   = platforms.linux;
   };

--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -24,7 +24,7 @@ buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Finds problems in C++ source that slow development of large code bases";
     homepage    = https://github.com/myint/cppclean;
-    license     = licenses.Apache-2.0;
+    license     = "Apache-2.0";
     maintainers = with maintainers; [ nthorne ];
     platforms   = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1174,6 +1174,8 @@ with pkgs;
 
   coursier = callPackage ../development/tools/coursier {};
 
+  cppclean = callPackage ../development/tools/cppclean {};
+
   cri-tools = callPackage ../tools/virtualization/cri-tools {};
 
   crip = callPackage ../applications/audio/crip { };


### PR DESCRIPTION
###### Motivation for this change

To introduce the C++ linter cppclean.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

