### PR TITLE
splix: add missing printer models

### DIFF
--- a/pkgs/misc/cups/drivers/splix/default.nix
+++ b/pkgs/misc/cups/drivers/splix/default.nix
@@ -31,6 +31,7 @@ in stdenv.mkDerivation {
   };
 
   postPatch = ''
+    cp *.ppd ppd/
     substituteInPlace src/pstoqpdl.cpp \
       --replace "RASTERDIR \"/\" RASTERTOQPDL" "\"$out/lib/cups/filter/rastertoqpdl\"" \
       --replace "RASTERDIR" "\"${cups-filters}/lib/cups/filter\"" \

--- a/pkgs/misc/cups/drivers/splix/default.nix
+++ b/pkgs/misc/cups/drivers/splix/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation {
   };
 
   postPatch = ''
-    cp *.ppd ppd/
+    mv -v *.ppd ppd/
     substituteInPlace src/pstoqpdl.cpp \
       --replace "RASTERDIR \"/\" RASTERTOQPDL" "\"$out/lib/cups/filter/rastertoqpdl\"" \
       --replace "RASTERDIR" "\"${cups-filters}/lib/cups/filter\"" \


### PR DESCRIPTION
Add support for ML-2160 ML-2165 ML-3310 ML-3310ND.
The PPD files were not picked up by the Makefile because they were
in the wrong directory of the original source.

Co-authored-by: Merlin Göttlinger <megoettlinger@gmail.com>

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

