### PR TITLE
pgcenter: init at 0.5.0

### DIFF
--- a/pkgs/tools/misc/pgcenter/default.nix
+++ b/pkgs/tools/misc/pgcenter/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "pgcenter-${version}";
+  version = "0.5.0";
+
+  goPackagePath = "github.com/lesovsky/pgcenter";
+
+  src = fetchFromGitHub {
+    owner  = "lesovsky";
+    repo   = "pgcenter";
+    rev    = "v${version}";
+    sha256 = "1bbpzli8hh5356gink6byk085zyfwxi8wigdy5cbadppx4qnk078";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    homepage = https://pgcenter.org/;
+    description = "Command-line admin tool for observing and troubleshooting PostgreSQL";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/tools/misc/pgcenter/deps.nix
+++ b/pkgs/tools/misc/pgcenter/deps.nix
@@ -1,0 +1,112 @@
+[
+
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev = "v1.0.0";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/jehiah/go-strftime";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jehiah/go-strftime";
+      rev = "1d33003b3869";
+      sha256 = "056zagn4zhmrcqg8y5k5wql01x4ijbxn4pv75bh1bn45by6qx1gv";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/jroimartin/gocui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jroimartin/gocui";
+      rev = "v0.4.0";
+      sha256 = "1b1cbjg925l1c5v3ls8amni9716190yzf847cqs9wjnj82z8qa47";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev = "v1.0.0";
+      sha256 = "1zqnnyczaf00xi6xh53vq758v5bdlf0iz7kf22l02cal4i6px47i";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "v0.0.3";
+      sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/nsf/termbox-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsf/termbox-go";
+      rev = "b66b20ab708e";
+      sha256 = "0wrgnwfdxrspni5q15vzr5q1bxnzb7m6q4xjhllcyddgn2zqprsa";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.0";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "v0.0.3";
+      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.2";
+      sha256 = "005598piihl3l83a71ahj10cpq9pbhjck4xishx1b4dzc02r9xr2";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "0e37d006457b";
+      sha256 = "1fj8rvrhgv5j8pmckzphvm3sqkzhcqp3idkxvgv13qrjdfycsa5r";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "ee1b12c67af4";
+      sha256 = "0cgp0xzbhg3fr77n2qrfmmsvhc287srnwi4mghwcjdxp6rx0s988";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4794,6 +4794,8 @@ with pkgs;
 
   pg_top = callPackage ../tools/misc/pg_top { };
 
+  pgcenter = callPackage ../tools/misc/pgcenter { };
+
   pgmetrics = callPackage ../tools/misc/pgmetrics { };
 
   pdsh = callPackage ../tools/networking/pdsh {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

