### PR TITLE
Split pinentry flavours and enable udisks2 on install media again

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -137,6 +137,16 @@
      make sure to update your configuration if you want to keep <literal>proglodyte-wasm</literal>
     </para>
    </listitem>
+   <listitem>
+    <para>
+      GnuPG is now built without support for a graphical passphrase entry
+      by default. Please enable the <literal>gpg-agent</literal> user service
+      via the NixOS option <literal>programs.gnupg.agent.enable</literal>.
+      Note that upstream recommends using <literal>gpg-agent</literal> and
+      will spawn a <literal>gpg-agent</literal> on the first invocation of
+      GnuPG anyway.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -596,7 +596,11 @@ $bootLoaderConfig
   # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;
-  # programs.gnupg.agent = { enable = true; enableSSHSupport = true; };
+  # programs.gnupg.agent = {
+  #   enable = true;
+  #   enableSSHSupport = true;
+  #   flavour = "gtk2";
+  # };
 
   # List services that you want to enable:
 

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -33,7 +33,6 @@ with lib;
 
     # Disable some other stuff we don't need.
     security.sudo.enable = mkDefault false;
-    services.udisks2.enable = mkDefault false;
 
     # Automatically log in at the virtual consoles.
     services.mingetty.autologinUser = "root";

--- a/pkgs/desktops/gnome-3/core/gcr/default.nix
+++ b/pkgs/desktops/gnome-3/core/gcr/default.nix
@@ -24,10 +24,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection libxslt makeWrapper vala ];
 
-  buildInputs = let
-    gpg = gnupg.override { guiSupport = false; }; # prevent build cycle with pinentry_gnome
-  in [
-    gpg libgcrypt libtasn1 dbus-glib pango gdk_pixbuf atk
+  buildInputs = [
+    gnupg libgcrypt libtasn1 dbus-glib pango gdk_pixbuf atk
   ];
 
   propagatedBuildInputs = [ glib gtk p11-kit ];

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -3,7 +3,7 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, guiSupport ? true
+, pinentry ? null, guiSupport ? false
 , openldap ? null, bzip2 ? null, libusb ? null, curl ? null
 }:
 

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -3,7 +3,7 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, guiSupport ? true
+, pinentry ? null, guiSupport ? false
 , adns ? null, gnutls ? null, libusb ? null, openldap ? null
 , readline ? null, zlib ? null, bzip2 ? null
 }:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2894,10 +2894,12 @@ with pkgs;
   gnupg1compat = callPackage ../tools/security/gnupg/1compat.nix { };
   gnupg1 = gnupg1compat;    # use config.packageOverrides if you prefer original gnupg1
   gnupg20 = callPackage ../tools/security/gnupg/20.nix {
-    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
+    guiSupport = stdenv.isDarwin;
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry_gtk2;
   };
   gnupg22 = callPackage ../tools/security/gnupg/22.nix {
-    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
+    guiSupport = stdenv.isDarwin;
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry_gtk2;
   };
   gnupg = gnupg22;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4735,26 +4735,19 @@ with pkgs;
 
   pinentry = callPackage ../tools/security/pinentry {
     libcap = if stdenv.isDarwin then null else libcap;
-  };
-
-  pinentry_ncurses = self.pinentry.override {
-    gtk2 = null;
-  };
-
-  pinentry_emacs = self.pinentry.override {
-    enableEmacs = true;
-  };
-
-  pinentry_gnome = self.pinentry.override {
+    qt = qt5.qtbase;
     gcr = gnome3.gcr;
   };
 
-  pinentry_qt4 = self.pinentry.override {
-    qt = qt4;
-  };
+  pinentry_curses = pinentry.curses;
+  pinentry_emacs = pinentry.emacs;
+  pinentry_gtk2 = pinentry.gtk2;
+  pinentry_qt = pinentry.qt;
+  pinentry_gnome = pinentry.gnome3;
 
-  pinentry_qt5 = self.pinentry.override {
-    qt = qt5.qtbase;
+  pinentry_qt4 = pinentry.override {
+    qt = qt4;
+    flavours = [ "qt" "curses" "tty" ];
   };
 
   pinentry_mac = callPackage ../tools/security/pinentry/mac.nix {


### PR DESCRIPTION
###### Motivation for this change

Due to the udisks2 update in #41723 its closure size exploded and was subsequently disabled on installation media. This PR refactors the pinentry derivation to be able to split out the different flavours and adds a NixOS option to select the desired flavour with a sensible fallback depending on the configured desktop environment.

Also this disables GUI support in GnuPG by default to resolve the dependency cycle in gcr. This way we won't have two versions of GnuPG in all systems closures that include gcr (i.e. due to udisks2).

Finally, we can enable udisks2 on install mediums again.

Everything except the breaking GnuPG change can and should be backported to 18.03 imho.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

