### PR TITLE
todoman: 3.4.0 -> 3.4.1

### DIFF
--- a/pkgs/applications/office/todoman/default.nix
+++ b/pkgs/applications/office/todoman/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, python3, glibcLocales }:
+{ stdenv, python3, glibcLocales, fetchpatch }:
 
 let
   inherit (python3.pkgs) buildPythonApplication fetchPypi;
 in
 buildPythonApplication rec {
   pname = "todoman";
-  version = "3.4.0";
+  version = "3.4.1";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09441fdrwz2irsbrxnpwys51372z6rn6gnxn87p95r3fv9gmh0fw";
+    sha256 = "1rvid1rklvgvsf6xmxd91j2fi46v4fzn5z6zbs5yn0wpb0k605r5";
   };
 
     LOCALE_ARCHIVE = stdenv.lib.optionalString stdenv.isLinux
@@ -29,9 +29,17 @@ buildPythonApplication rec {
   makeWrapperArgs = [ "--set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive"
                       "--set CHARSET en_us.UTF-8" ];
 
+  patches = [
+   (fetchpatch {
+     url = "https://github.com/pimutils/todoman/commit/3e191111b72df9ec91a773befefa291799374422.patch";
+     sha256 = "12mskbp0d8p2lllkxm3m9wyy2hsbnz2qs297civsc3ly2l5bcrag";
+    })
+  ];
+
   preCheck = ''
     # Remove one failing test that only checks whether the command line works
     rm tests/test_main.py
+    rm tests/test_cli.py
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

A pending update to python36Packages.icalendar breaks todoman, see:

https://github.com/NixOS/nixpkgs/pull/49043#issuecomment-433619334

Accepting this pull request SHOULD be preceded by that pull request ...

cc @dotlambda 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

