### PR TITLE
pythonPackages.networkx: 2.1 -> 2.2

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -77,6 +77,21 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch/?id=30cc778d46579bd0c7537ed33e8d7a4f40fd5c31";
       sha256 = "13vc2q799dh745sm59xjjabllfj0sfjzcacf8k59kwj04x755d30";
     })
+
+    # https://trac.sagemath.org/ticket/26326
+    # needs to be split because there is a merge commit in between
+    (fetchSageDiff {
+      name = "networkx-2.2-1.patch";
+      base = "8.4";
+      rev = "68f5ad068184745b38ba6716bf967c8c956c52c5";
+      sha256 = "112b5ywdqgyzgvql2jj5ss8la9i8rgnrzs8vigsfzg4shrcgh9p6";
+    })
+    (fetchSageDiff {
+      name = "networkx-2.2-2.patch";
+      base = "626485bbe5f33bf143d6dfba4de9c242f757f59b~1";
+      rev = "db10d327ade93711da735a599a67580524e6f7b4";
+      sha256 = "09v87id25fa5r9snfn4mv79syhc77jxfawj5aizmdpwdmpgxjk1f";
+    })
   ];
 
   patches = nixPatches ++ packageUpgradePatches ++ [

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -39,7 +39,19 @@ stdenv.mkDerivation rec {
     ./patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
   ];
 
-  packageUpgradePatches = [
+  packageUpgradePatches = let
+    # fetch a diff between base and rev on sage's git server
+    # used to fetch trac tickets by setting the base to the release and the
+    # revision to the last commit that should be included
+    fetchSageDiff = { base, rev, ...}@args: (
+      fetchpatch ({
+        url = "https://git.sagemath.org/sage.git/patch?id2=${base}&id=${rev}";
+        # We don't care about sage's own build system (which builds all its dependencies).
+        # Exclude build system changes to avoid conflicts.
+        excludes = [ "build/*" ];
+      } // builtins.removeAttrs args [ "rev" "base" ])
+    );
+  in [
     # New glpk version has new warnings, filter those out until upstream sage has found a solution
     # https://trac.sagemath.org/ticket/24824
     ./patches/pari-stackwarn.patch # not actually necessary since tha pari upgrade, but necessary for the glpk patch to apply

--- a/pkgs/development/python-modules/networkx/default.nix
+++ b/pkgs/development/python-modules/networkx/default.nix
@@ -7,12 +7,13 @@
 
 buildPythonPackage rec {
   pname = "networkx";
-  version = "2.1";
+  # upgrade may break sage, please test the sage build or ping @timokau on upgrade
+  version = "2.2";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "64272ca418972b70a196cb15d9c85a5a6041f09a2f32e0d30c0255f25d458bb1";
+    sha256 = "12swxb15299v9vqjsq4z8rgh5sdhvpx497xwnhpnb0gynrx6zra5";
   };
 
   checkInputs = [ nose ];


### PR DESCRIPTION
###### Motivation for this change

A new networkx version is out and needs sage fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

