### PR TITLE
speex: 1.2rc2 -> 1.2.0

### DIFF
--- a/pkgs/development/libraries/speex/default.nix
+++ b/pkgs/development/libraries/speex/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, fftw, speexdsp }:
 
 stdenv.mkDerivation rec {
-  name = "speex-1.2rc2";
+  name = "speex-1.2.0";
 
   src = fetchurl {
     url = "http://downloads.us.xiph.org/releases/speex/${name}.tar.gz";
-    sha256 = "14g8ph39inkrif749lzjm089g7kwk0hymq1a3i9ch5gz8xr7r8na";
+    sha256 = "150047wnllz4r94whb9r73l5qf0z5z3rlhy98bawfbblmkq8mbpa";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Manual update (fails in the auto update)

###### Things done
Tested building of all direct dependencies.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

