### PR TITLE
ahoviewer: 1.5.0 -> 1.6.4

### DIFF
--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -8,13 +8,13 @@ assert useUnrar -> unrar != null;
 
 stdenv.mkDerivation rec {
   name = "ahoviewer-${version}";
-  version = "1.5.0";
+  version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "ahodesuka";
     repo = "ahoviewer";
     rev = version;
-    sha256 = "1adzxp30fwh41y339ha8i5qp89zf21dw18vcicqqnzvyxbk5r3ig";
+    sha256 = "144jmk8w7dnmqy4w81b3kzama7i97chx16pgax2facn72a92921q";
   };
 
   enableParallelBuilding = true;
@@ -28,11 +28,6 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-libav
     gst_all_1.gst-plugins-base
   ] ++ stdenv.lib.optional useUnrar unrar;
-
-  # https://github.com/ahodesuka/ahoviewer/issues/60
-  # Already fixed in the master branch
-  # TODO: remove this next release
-  makeFlags = [ ''LIBS=-lssl -lcrypto'' ];
 
   postPatch = ''patchShebangs version.sh'';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

