### PR TITLE
gtest: Add pkgconfig support

### DIFF
--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchFromGitHub }:
+{ stdenv, cmake, ninja, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   name = "gtest-${version}";
   version = "1.8.1";
@@ -10,25 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0270msj6n7mggh4xqqjp54kswbl7mkcc8px1p5dqdpmw5ngh9fzk";
   };
 
-  buildInputs = [ cmake ];
-
-  configurePhase = ''
-    mkdir build
-    cd build
-    cmake ../ -DCMAKE_INSTALL_PREFIX=$out
-  '';
-
-  installPhase = ''
-    mkdir -p $out/lib/pkgconfig
-    cp -v googlemock/gtest/libgtest.a googlemock/gtest/libgtest_main.a googlemock/libgmock.a googlemock/libgmock_main.a $out/lib
-    cp -v googlemock/gtest/generated/gmock_main.pc googlemock/gtest/generated/gmock.pc googlemock/gtest/generated/gtest_main.pc googlemock/gtest/generated/gtest.pc $out/lib/pkgconfig
-    ln -s $out/lib/libgmock.a $out/lib/libgoogletest.a
-    mkdir -p $out/include
-    cp -v -r ../googlemock/include/gmock $out/include
-    cp -v -r ../googletest/include/gtest $out/include
-    mkdir -p $out/src
-    cp -v -r ../googlemock/src/* ../googletest/src/* $out/src
-  '';
+  nativeBuildInputs = [ cmake ninja ];
 
   meta = with stdenv.lib; {
     description = "Google's framework for writing C++ tests";

--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -19,8 +19,9 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/lib
+    mkdir -p $out/lib/pkgconfig
     cp -v googlemock/gtest/libgtest.a googlemock/gtest/libgtest_main.a googlemock/libgmock.a googlemock/libgmock_main.a $out/lib
+    cp -v googlemock/gtest/generated/gmock_main.pc googlemock/gtest/generated/gmock.pc googlemock/gtest/generated/gtest_main.pc googlemock/gtest/generated/gtest.pc $out/lib/pkgconfig
     ln -s $out/lib/libgmock.a $out/lib/libgoogletest.a
     mkdir -p $out/include
     cp -v -r ../googlemock/include/gmock $out/include


### PR DESCRIPTION
###### Motivation for this change
Googletest generated some nice pkg-config files, which are cool for `pkg_check_modules` checks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

