### PR TITLE
vlc: shrink runtime closure size by removing CONFIGURE_LINE

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -12,6 +12,7 @@
 , withQt5 ? true, qtbase ? null, qtsvg ? null, qtx11extras ? null
 , jackSupport ? false
 , fetchpatch
+, removeReferencesTo
 }:
 
 with stdenv.lib;
@@ -42,7 +43,7 @@ stdenv.mkDerivation rec {
   ] ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
     ++ optional jackSupport libjack2;
 
-  nativeBuildInputs = [ autoreconfHook perl pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook perl pkgconfig removeReferencesTo ];
 
   enableParallelBuilding = true;
 
@@ -60,10 +61,14 @@ stdenv.mkDerivation rec {
       /usr/share/fonts/truetype/freefont ${freefont_ttf}/share/fonts/truetype
   '';
 
-  # https://github.com/NixOS/nixpkgs/pull/35124#issuecomment-370552830
+  # - Touch plugins (plugins cache keyed off mtime and file size:
+  #     https://github.com/NixOS/nixpkgs/pull/35124#issuecomment-370552830
+  # - Remove references to the Qt development headers (used in error messages)
   postFixup = ''
     find $out/lib/vlc/plugins -exec touch -d @1 '{}' ';'
     $out/lib/vlc/vlc-cache-gen $out/vlc/plugins
+
+    remove-references-to -t "${qtbase.dev}" $out/lib/vlc/plugins/gui/libqt_plugin.so
   '';
 
   # Most of the libraries are auto-detected so we don't need to set a bunch of

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -72,6 +72,11 @@ stdenv.mkDerivation rec {
     "--with-kde-solid=$out/share/apps/solid/actions"
   ] ++ optional onlyLibVLC "--disable-vlc";
 
+  # Remove runtime dependencies on libraries
+  postConfigure = ''
+    sed -i 's|^#define CONFIGURE_LINE.*$|#define CONFIGURE_LINE "<removed>"|g' config.h
+  '';
+
   meta = with stdenv.lib; {
     description = "Cross-platform media player and streaming server";
     homepage = http://www.videolan.org/vlc/;


### PR DESCRIPTION
###### Motivation for this change
Shrink the runtime closure size for VLC by removing the `./configure` flags from compiled binaries.

Before/after sizes, tested on NixOS 18.09:
```
/nix/store/fw6gpwlcdj6j4796biglvwv7wkjn1y5p-vlc-3.0.4 1273486712
/nix/store/js9fhzp2fhyzv0nzcn33k98cf2xzzaln-vlc-3.0.4 892909424
```
(about 1.2GiB to 0.83GiB)

Fixes #49287 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

