### PR TITLE
miniflux: init at 2.0.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -495,6 +495,11 @@
     github = "bennofs";
     name = "Benno Fünfstück";
   };
+  benpye = {
+    email = "ben@curlybracket.co.uk";
+    github = "benpye";
+    name = "Ben Pye";
+  };
   benwbooth = {
     email = "benwbooth@gmail.com";
     github = "benwbooth";

--- a/pkgs/servers/miniflux/default.nix
+++ b/pkgs/servers/miniflux/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildGoPackage
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "miniflux-${version}";
+  version = "2.0.12";
+
+  goPackagePath = "miniflux.app";
+
+  src = fetchFromGitHub {
+    owner = "miniflux";
+    repo = "miniflux";
+    rev = "refs/tags/${version}";
+    sha256 = "13d1dwcwig7b5phymgxqm227k5l3zzzvx997cywarbl953ji2y1d";
+  };
+    
+  goDeps = ./deps.nix;
+
+  doCheck = true;
+
+  buildFlagsArray = ''
+    -ldflags=-X ${goPackagePath}/version.Version=${version}
+  '';
+
+  postInstall = ''
+    mv $bin/bin/miniflux.app $bin/bin/miniflux
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Miniflux is a minimalist and opinionated feed reader.";
+    homepage = https://miniflux.app/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ benpye ];
+  };
+}
+

--- a/pkgs/servers/miniflux/deps.nix
+++ b/pkgs/servers/miniflux/deps.nix
@@ -1,0 +1,153 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+
+  {
+    goPackagePath = "github.com/PuerkitoBio/goquery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/goquery";
+      rev = "v1.4.1";
+      sha256 = "11010z9ask21r0dskvm2pbh3z8951bnpcqg8aqa213if4h34gaa2";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/andybalholm/cascadia";
+    fetch = {
+      type = "git";
+      url = "https://github.com/andybalholm/cascadia";
+      rev = "v1.0.0";
+      sha256 = "09j8cavbhqqdxjqrkwbc40g8p0i49zf3184rpjm5p2rjbprcghcc";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.1.0";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/gorilla/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/context";
+      rev = "v1.1.1";
+      sha256 = "03p4hn87vcmfih0p9w663qbx9lpsf7i7j3lc7yl7n84la3yz63m4";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev = "v1.6.2";
+      sha256 = "0pvzm23hklxysspnz52mih6h1q74vfrdhjfm1l3sa9r8hhqmmld2";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev = "v1.0.0";
+      sha256 = "1zqnnyczaf00xi6xh53vq758v5bdlf0iz7kf22l02cal4i6px47i";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/tdewolff/minify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tdewolff/minify";
+      rev = "v2.3.5";
+      sha256 = "0x67kgjhc6mfzjhr4xmw0j3qapzhkgwwahvv5b44rb449ml2qx5m";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/tdewolff/parse";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tdewolff/parse";
+      rev = "v2.3.3";
+      sha256 = "190y2jykp8qyp6y58ky1v1fvmaqjnrsr1ksbqrrspf1gpjy69i94";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "614d502a4dac";
+      sha256 = "1rcyvsl8b8pk7h8lwl0fpiflrx8zs121wi5490ln0qnvkk8d4bwy";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "8a410e7b638d";
+      sha256 = "0hp0l8f6fir5gmgrjq0mhh5ikc0rlrm72774228800kfwqjrxxny";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "d2e6202438be";
+      sha256 = "0wbn75fd10485nb93bm4kqldqifdim5xqy4v7r5sdvimvf3fyhn7";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "1d60e4601c6f";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "4910a1d54f87";
+      sha256 = "0p2pp6mny34gjcvylx3ddzdaxn7hv008hppsr11w1bvyzj7s27by";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.1.0";
+      sha256 = "1pz202zszg8f35dk5pfhwgcdi3r6dx1l4yk6x6ly7nb4j45zi96x";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13537,6 +13537,8 @@ with pkgs;
 
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };
 
+  miniflux = callPackage ../servers/miniflux { };
+
   nagios = callPackage ../servers/monitoring/nagios { };
 
   munin = callPackage ../servers/monitoring/munin { };


### PR DESCRIPTION
###### Motivation for this change

Adds Miniflux feed reader server. It's similar to TT-RSS. It would be helpful to have a service config but I have yet to get that far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

