### PR TITLE
fmt: minor refactor

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -3,29 +3,41 @@
 stdenv.mkDerivation rec {
   version = "5.2.1";
   name = "fmt-${version}";
+
   src = fetchFromGitHub {
     owner = "fmtlib";
     repo = "fmt";
     rev = "${version}";
     sha256 = "1cd8yq8va457iir1hlf17ksx11fx2hlb8i4jml8gj1875pizm0pk";
   };
+
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DFMT_TEST=TRUE"
+    "-DBUILD_SHARED_LIBS=${if enableShared then "TRUE" else "FALSE"}"
+  ];
+
+  enableParallelBuilding = true;
+
   doCheck = true;
   # preCheckHook ensures the test binaries can find libfmt.so.5
   preCheck = if enableShared
              then "export LD_LIBRARY_PATH=\"$PWD\""
              else "";
-  cmakeFlags = [ "-DFMT_TEST=yes"
-                 "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}" ];
+
   meta = with stdenv.lib; {
-    homepage = http://fmtlib.net/;
     description = "Small, safe and fast formatting library";
     longDescription = ''
       fmt (formerly cppformat) is an open-source formatting library. It can be
       used as a fast and safe alternative to printf and IOStreams.
     '';
+    homepage = http://fmtlib.net/;
+    downloadPage = https://github.com/fmtlib/fmt/;
     maintainers = [ maintainers.jdehaas ];
     license = licenses.bsd2;
-    platforms = platforms.unix;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Add separate build outputs, enable parallel building, fix platforms,
adapt to styleguide.

###### Motivation for this change

I've packaged this library at the same instant of time by coincidence…

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

