### PR TITLE
fstrcmp: init at 0.7

### DIFF
--- a/pkgs/development/libraries/fstrcmp/default.nix
+++ b/pkgs/development/libraries/fstrcmp/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchzip, libtool, ghostscript, groff }:
+
+stdenv.mkDerivation rec {
+  name = "fstrcmp-${version}";
+  version = "0.7";
+
+  src = fetchzip {
+    url = "https://sourceforge.net/projects/fstrcmp/files/fstrcmp/${version}/fstrcmp-${version}.D001.tar.gz";
+    sha256 = "0yg3y3k0wz50gmhgigfi2dx725w1gc8snb95ih7vpcnj6kabgz9a";
+  };
+
+  outputs = [ "out" "dev" "doc" "man" "devman" ];
+
+  nativeBuildInputs = [ libtool ghostscript groff ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Make fuzzy comparisons of strings and byte arrays";
+    longDescription = ''
+      The fstrcmp project provides a library that is used to make fuzzy
+      comparisons of strings and byte arrays, including multi-byte character
+      strings.
+    '';
+    homepage = http://fstrcmp.sourceforge.net/;
+    downloadPage = https://sourceforge.net/projects/fstrcmp/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.sephalon ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9568,6 +9568,8 @@ with pkgs;
 
   frog = self.languageMachines.frog;
 
+  fstrcmp = callPackage ../development/libraries/fstrcmp { };
+
   fstrm = callPackage ../development/libraries/fstrm { };
 
   cfitsio = callPackage ../development/libraries/cfitsio { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

