### PR TITLE
pijul: 0.8.0 -> 0.10.0

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,24 +1,35 @@
-{ stdenv, fetchurl, rustPlatform, darwin }:
+{ stdenv, fetchurl, rustPlatform, darwin, openssl, libsodium, pkgconfig }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "pijul-${version}";
-  version = "0.8.0";
+  version = "0.10.0";
 
   src = fetchurl {
     url = "https://pijul.org/releases/${name}.tar.gz";
-    sha256 = "00pi03yp2bgnjpsz2hgaapxfw2i4idbjqc88cagpvn4yr1612wqx";
+    sha256 = "1lkipcp83rfsj9yqddvb46dmqdf2ch9njwvjv8f3g91rmfjcngys";
   };
 
-  sourceRoot = "${name}/pijul";
+  cargoPatches = [
+    ./libpijul.patch
+  ];
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin
+  nativeBuildInputs = [ pkgconfig ];
+
+  postInstall = ''
+    mkdir -p $out/share/{bash-completion/completions,zsh/site-functions,fish/vendor_completions.d}
+    $out/bin/pijul generate-completions --bash > $out/share/bash-completion/completions/pijul
+    $out/bin/pijul generate-completions --zsh > $out/share/zsh/site-functions/_pijul
+    $out/bin/pijul generate-completions --fish > $out/share/fish/vendor_completions.d/pijul.fish
+  '';
+
+  buildInputs = [ openssl libsodium ] ++ stdenv.lib.optionals stdenv.isDarwin
     (with darwin.apple_sdk.frameworks; [ Security ]);
 
   doCheck = false;
 
-  cargoSha256 = "1cnr08qbpia3336l37k1jli20d7kwnrw2gys8s9mg271cb4vdx03";
+  cargoSha256 = "1419mlxa4p53hm5qzfd1yi2k0n1bcv8kaslls1nyx661vknhfamw";
 
   meta = with stdenv.lib; {
     description = "A distributed version control system";

--- a/pkgs/applications/version-management/pijul/libpijul.patch
+++ b/pkgs/applications/version-management/pijul/libpijul.patch
@@ -1,0 +1,61 @@
+--- 2/pijul-0.10.0/Cargo.lock	1970-01-01 01:00:00.000000000 +0100
++++ pijul-0.10.0/Cargo.lock	2018-10-28 10:09:48.557639255 +0000
+@@ -552,7 +552,7 @@
+ 
+ [[package]]
+ name = "libpijul"
+-version = "0.10.0"
++version = "0.10.1"
+ dependencies = [
+  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -577,9 +577,29 @@
+ 
+ [[package]]
+ name = "libpijul"
+-version = "0.10.0"
++version = "0.10.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-replace = "libpijul 0.10.0"
++dependencies = [
++ "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "sanakirja 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "thrussh-keys 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
+ 
+ [[package]]
+ name = "line"
+@@ -917,7 +937,7 @@
+  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "isatty 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libpijul 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libpijul 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "line 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pager 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1796,7 +1816,7 @@
+ "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
+ "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+ "checksum libflate 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1a429b86418868c7ea91ee50e9170683f47fd9d94f5375438ec86ec3adb74e8e"
+-"checksum libpijul 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80fd579ba6762eac3f12c9624d5496edaba5a2f2e8785bcf8310372328e06ebe"
++"checksum libpijul 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cf6fc1aa0e9402f8283bdeb2507cfb6798d2f2f973da34c3f4b0c96a456b74cd"
+ "checksum line 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ecdd22a3856203276b7854e16213139428e82922530438f36356e5b361ea4a42"
+ "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+ "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"


### PR DESCRIPTION
###### Motivation for this change

This has been also done in https://github.com/NixOS/nixpkgs/pull/39317
but this version does not require 3000 lines of nix expressions.
Also installs shell completions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

