### PR TITLE
mdadm: 4.0 -> 4.1

### DIFF
--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -14,11 +14,11 @@ let
   '';
 in
 stdenv.mkDerivation rec {
-  name = "mdadm-4.0";
+  name = "mdadm-4.1";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/raid/mdadm/${name}.tar.xz";
-    sha256 = "1ad3mma641946wn5lsllwf0lifw9lps34fv1nnkhyfpd9krffshx";
+    sha256 = "0jjgjgqijpdp7ijh8slzzjjw690kydb1jjadf0x5ilq85628hxmb";
   };
 
   # This is to avoid self-references, which causes the initrd to explode
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
     description = "Programs for managing RAID arrays under Linux";
     homepage = http://neil.brown.name/blog/mdadm;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ ekleog ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bumping mdadm. I've also added myself as a maintainer, given no one was listed there yet and this update is already almost a month old.

The changelog mentions a lot of “enhancements and bug fixes”, so I'm not sure whether this should be backported: there is apparently no security fix, but it's a well-known part of the fundamental ecosystem which made a minor release. And a bug fix in mdadm can have big consequences… just as much as a bug introduced in mdadm. For the comparison, debian testing is at 4.1rc1, debian stable is at 3.4.4, fedora 29 is at 4.1rc2 (a bit older than the last version at their freeze), fedora 28 is at 4.0.

So overall I'd likely say not to backport, but without strong sentiments.

###### Things done

Tested by building the package and verifying that the `mdadm` and `mdmon` executables can actually run.

Tried to test with `nixos/tests/installer.nix`, but it OOM's both without and with this patch applied here…
@GrahamcOfBorg test installer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

