### PR TITLE
[18.09] xorg.xf86videovmware: fix for GFX support

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -2,10 +2,10 @@
   stdenv, makeWrapper, lib, fetchurl, fetchpatch,
 
   automake, autoconf, libtool, intltool, mtdev, libevdev, libinput,
-  python, freetype, apple_sdk, tradcpp, fontconfig, mesa_drivers,
+  python, freetype, apple_sdk, tradcpp, fontconfig,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm,
   mesa_noglu, udev, bootstrap_cmds, bison, flex, clangStdenv, autoreconfHook,
-  mcpp, epoxy, openssl, pkgconfig }:
+  mcpp, epoxy, openssl, pkgconfig, llvm_6 }:
 
 let
   inherit (stdenv) lib isDarwin;
@@ -394,7 +394,7 @@ self: super:
   });
 
   xf86videovmware = super.xf86videovmware.overrideAttrs (attrs: {
-    buildInputs =  attrs.buildInputs ++ [ mesa_drivers ]; # for libxatracker
+    buildInputs =  attrs.buildInputs ++ [ mesa_noglu llvm_6 ]; # for libxatracker
     meta = attrs.meta // {
       platforms = ["i686-linux" "x86_64-linux"];
     };


### PR DESCRIPTION
Fix the mesa dependency for `xorg.xf86videovmware`. Add `llvm_6` because
`mesa_noglu` has a runtime dependency on clang (see TODO in
`development/libraries/mesa`).

###### Motivation for this change
Backport of #49115 to NixOS 18.09

###### Things done

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
