### PR TITLE
Add mention of nix-prefetch-github.

### DIFF
--- a/doc/coding-conventions.xml
+++ b/doc/coding-conventions.xml
@@ -842,9 +842,12 @@ src = fetchFromGitHub {
   owner = "NixOS";
   repo = "nix";
   rev = "1f795f9f44607cc5bec70d1300150bfefcef2aae";
-  sha256 = "04yri911rj9j19qqqn6m82266fl05pz98inasni0vxr1cf1gdgv9";
+  sha256 = "1i2yxndxb6yc9l6c99pypbd92lfq5aac4klq7y2v93c9qvx2cgpc";
 }
 </programlisting>
+      Find the value to put as <literal>sha256</literal> by running
+      <literal>nix run -f '&lt;nixpkgs&gt;' nix-prefetch-github -c nix-prefetch-github --rev 1f795f9f44607cc5bec70d1300150bfefcef2aae NixOS nix</literal>
+      or <literal>nix-prefetch-url --unpack https://github.com/NixOS/nix/archive/1f795f9f44607cc5bec70d1300150bfefcef2aae.tar.gz</literal>.
      </para>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
###### Motivation for this change

I recently discovered `nix-prefetch-github` by browsing the sources of nixpkgs. If it had been documented where I'm adding it now, I would have known about it much earlier.

I also noticed in passing that the value that was given for `sha256` in this example was actually incorrect.