### PR TITLE
pythonPackages.zstd: init at 1.3.5.1

### DIFF
--- a/pkgs/development/python-modules/zstd/default.nix
+++ b/pkgs/development/python-modules/zstd/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, pkgconfig, fetchpatch, fetchFromGitHub, buildPythonPackage
+, zstd, pytest }:
+
+buildPythonPackage rec {
+  pname = "zstd";
+  version = "1.3.5.1";
+
+  # Switch back to fetchPypi when tests/ is included, see https://github.com/NixOS/nixpkgs/pull/49339
+  src = fetchFromGitHub {
+    owner = "sergey-dryabzhinsky";
+    repo = "python-zstd";
+    rev = "v${version}";
+    sha256 = "08n1vz4zavas4cgzpdfcbpy33lnv39xxhq5mgj0zv3xi03ypc1rl";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "/usr/bin/pkg-config" "${pkgconfig}/bin/pkg-config"
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ zstd ];
+
+  setupPyBuildFlags = [
+    "--external"
+    "--include-dirs=${zstd}/include"
+    "--libraries=zstd"
+    "--library-dirs=${zstd}/lib"
+  ];
+
+  # Running tests via setup.py triggers an attempt to recompile with the vendored zstd
+  ZSTD_EXTERNAL = 1;
+  VERSION = zstd.version;
+  PKG_VERSION = version;
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple python bindings to Yann Collet ZSTD compression library";
+    homepage = https://github.com/sergey-dryabzhinsky/python-zstd;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [
+      eadwu
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10917,6 +10917,10 @@ EOF
 
   todoist = callPackage ../development/python-modules/todoist { };
 
+  zstd = callPackage ../development/python-modules/zstd {
+    inherit (pkgs) zstd pkgconfig;
+  };
+
   zxcvbn-python = callPackage ../development/python-modules/zxcvbn-python { };
 
   incremental = callPackage ../development/python-modules/incremental { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

