### PR TITLE
pythonPackages.distribute: init at 0.7.3

### DIFF
--- a/pkgs/development/python-modules/distribute/default.nix
+++ b/pkgs/development/python-modules/distribute/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, python, bootstrapped-pip
+, setuptools }:
+
+buildPythonPackage rec {
+  pname = "distribute";
+  version = "0.7.3";
+  format = "other";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0plc2dkmfd6p8lsqqvl1rryz03pf4i5198igml72zxywb78aiirx";
+  };
+
+  buildInputs = [
+    setuptools
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/${python.sitePackages}"
+    export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
+
+    mkdir -p dist
+    pushd dist
+
+    ${bootstrapped-pip}/bin/pip install *.whl --no-index --prefix=$out --no-cache --build tmpbuild ..
+    popd
+  '';
+
+  # No tests/ folder
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "distribute legacy wrapper";
+    homepage = "https://pypi.org/project/distribute";
+    license = [
+      licenses.psfl
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -324,6 +324,10 @@ in {
 
   distorm3 = callPackage ../development/python-modules/distorm3 { };
 
+  distribute = callPackage ../development/python-modules/distribute {
+    inherit (self) setuptools;
+  };
+
   distributed = callPackage ../development/python-modules/distributed { };
 
   docutils = callPackage ../development/python-modules/docutils { };


### PR DESCRIPTION
###### Motivation for this change
Somewhat hacky? Uses `build-python-package-common.nix` attrs.
Only built successfully on pythonPackages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

