### PR TITLE
pythonPackages.almost: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/almost/default.nix
+++ b/pkgs/development/python-modules/almost/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pytest, distribute }:
+
+buildPythonPackage rec {
+  pname = "almost";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nqgasnmjnjkg0vbdr8nlw1zgbhihnam5yqv01njgc3qn2gsz4p1";
+  };
+
+  buildInputs = [
+    distribute
+  ];
+
+  # Can't find file in own directory?
+  doCheck = false;
+
+  checkInputs = [
+    pytest
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A helper to compare two numbers generously";
+    homepage = "https://github.com/sublee/almost";
+    license = [
+      licenses.bsd
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -714,6 +714,10 @@ in {
 
   alembic = callPackage ../development/python-modules/alembic {};
 
+  almost = callPackage ../development/python-modules/almost {
+    inherit (self) pytest distribute;
+  };
+
   allpairspy = callPackage ../development/python-modules/allpairspy { };
 
   ansicolors = callPackage ../development/python-modules/ansicolors {};


### PR DESCRIPTION
###### Motivation for this change
Requires #49340. Because of distribute, it has only been successfully built on pythonPackages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

