### PR TITLE
xidlehook: 0.4.9 -> 0.5.0

### DIFF
--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -1,22 +1,22 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub
+{ lib, stdenv, rustPlatform, fetchFromGitLab
 , xlibsWrapper, xorg, libpulseaudio, pkgconfig, patchelf }:
 
 rustPlatform.buildRustPackage rec {
   name = "xidlehook-${version}";
-  version = "0.4.9";
+  version = "0.5.0";
 
   doCheck = false;
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "jD91mZM2";
     repo = "xidlehook";
     rev = version;
 
-    sha256 = "1l2kmymwxal9v5g3q21i985yc201dpybp85qfws2n5rzw8qpg1dw";
+    sha256 = "1qrjwk91i31rww5lwgp84hc4h3b1prm60y45jm1f28g2bbv2qy19";
   };
 
   cargoBuildFlags = lib.optionals (!stdenv.isLinux) ["--no-default-features" "--features" "pulse"];
-  cargoSha256 = "1mrg59flmmqg5wwi2l8lw6p1xpgdw597fdfsmpn8b126rgzqmjl8";
+  cargoSha256 = "1pdhbqnkgwp2v5zyin8z8049aq8c3kfk04v9wsbz8qla34rgi99s";
 
   buildInputs = [ xlibsWrapper xorg.libXScrnSaver libpulseaudio ];
   nativeBuildInputs = [ pkgconfig patchelf ];


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: Due to the latest rust derivation not yet being binary cached, I wrote this change based on the 18.09 tag and then cherry picked. I hope this won't cause any issues with sha256 hashes or anything.