### PR TITLE
powerline-rs: 0.1.8 -> 0.1.9

### DIFF
--- a/pkgs/tools/misc/powerline-rs/default.nix
+++ b/pkgs/tools/misc/powerline-rs/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkgconfig, file, perl, curl, cmake, openssl, libssh2, libgit2, libzip, Security }:
+{ stdenv, lib, rustPlatform, fetchFromGitLab, pkgconfig, file, perl, curl, cmake, openssl, libssh2, libgit2, libzip, Security }:
 rustPlatform.buildRustPackage rec {
   pname = "powerline-rs";
   name = "${pname}-${version}";
-  version = "0.1.8";
+  version = "0.1.9";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "jD91mZM2";
     repo = "powerline-rs";
-    rev = version;
+    #rev = version;
 
-    sha256 = "018i9qq98afbgv0nxs1n83zb09lqhqxpdrd95f2maic3rr5ngnj5";
+    # Support for $COMPLETION_OUT:
+    rev = "44679385a95dd9f3ebd9b093f9ef8925610e9a23";
+
+    sha256 = "1mxkw6ydnqjyplbki2j9pbnlhxmkw9qqw54443a3cjmn2g08jyzp";
   };
 
-  cargoSha256 = "184s432a6damzvl0lv6jar1iml9dq60r190aqjy44lcg938981zc";
+  cargoSha256 = "1sr9vbfk5bb3n0lv93y19in1clyvbj0w3p1gmp4sbw8lx84zwxhc";
 
   nativeBuildInputs = [ pkgconfig file perl cmake curl ];
   buildInputs = [ openssl libssh2 libgit2 libzip ] ++ lib.optional stdenv.isDarwin Security;
 
+  COMPLETION_OUT = "out";
   postInstall = ''
-    install -Dm 755 "${pname}.bash" "$out/etc/bash_completion.d/${pname}"
-    install -Dm 755 "${pname}.fish" "$out/share/fish/vendor_completions.d/${pname}"
+    install -Dm 755 "${COMPLETION_OUT}/${pname}.bash" "$out/etc/bash_completion.d/${pname}"
+    install -Dm 755 "${COMPLETION_OUT}/${pname}.fish" "$out/share/fish/vendor_completions.d/${pname}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: Due to the latest rust derivation not yet being binary cached, I wrote this change based on the 18.09 tag and then cherry picked. I hope this won't cause any issues with sha256 hashes or anything.