### PR TITLE
buildGoPackage: re-enable GOCACHE

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -103,6 +103,7 @@ go.stdenv.mkDerivation (
 
   '') + ''
     export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
+    export GOCACHE=$TMPDIR/go-cache
 
     runHook postConfigure
   '';
@@ -192,9 +193,6 @@ go.stdenv.mkDerivation (
   preFixup = preFixup + ''
     find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
   '';
-
-  # Disable go cache, which is not reused in nix anyway
-  GOCACHE = "off";
 
   shellHook = ''
     d=$(mktemp -d "--suffix=-$name")


### PR DESCRIPTION
If projects uses go1.11 modules GOCACHE is required.
Also if buildGoPackage is used in a nix-shell setting we don't
want to override GOCACHE to allow incremental builds.
This should be backported to 18.09

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

