### PR TITLE
easysnap: init at 2018-10-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3900,6 +3900,11 @@
     github = "sjagoe";
     name = "Simon Jagoe";
   };
+  sjau = {
+    email = "nixos@sjau.ch";
+    github = "sjau";
+    name = "Stephan Jau";
+  };
   sjmackenzie = {
     email = "setori88@gmail.com";
     github = "sjmackenzie";

--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchFromGitHub, zfs }:
+
+stdenv.mkDerivation rec {
+  name = "easysnap-${version}";
+  version = "unstable-2018-10-28";
+
+  src = fetchFromGitHub {
+    owner = "sjau";
+    repo = "easysnap";
+    rev = "aa2768762da7730aa3eb90fdc2190a8359976edc";
+    sha256 = "0csn7capsmlkin4cf1fgl766gvszvqfllqkiyz0g9bvbapxv7nba";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -n easysnap* $out/bin/
+
+    for i in $out/bin/*; do
+      substituteInPlace $i \
+        --replace zfs ${zfs}/bin/zfs
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/sjau/easysnap;
+    description = "Customizable ZFS Snapshotting tool with zfs send/recv pulling";
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ sjau ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2335,6 +2335,8 @@ with pkgs;
 
   easyrsa2 = callPackage ../tools/networking/easyrsa/2.x.nix { };
 
+  easysnap = callPackage ../tools/backup/easysnap { };
+
   ebook_tools = callPackage ../tools/text/ebook-tools { };
 
   ecryptfs = callPackage ../tools/security/ecryptfs { };


### PR DESCRIPTION
###### Motivation for this change

Adding easysnap to nixpkgs/NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

