### PR TITLE
nomachine-client: init at 6.3.6_1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4143,6 +4143,11 @@
     github = "taku0";
     name = "Takuo Yonezawa";
   };
+  talyz = {
+    email = "kim.lindberger@gmail.com";
+    github = "talyz";
+    name = "Kim Lindberger";
+  };
   tari = {
     email = "peter@taricorp.net";
     github = "tari";

--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,0 +1,83 @@
+{ stdenv, lib, file, fetchurl, makeWrapper, autoPatchelfHook, jsoncpp }:
+let
+  versionMajor = "6.3";
+  versionMinor = "6_1";
+in
+  stdenv.mkDerivation rec {
+    name = "nomachine-client-${version}";
+    version = "${versionMajor}.${versionMinor}";
+  
+    src =
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_x86_64.tar.gz";
+          sha256 = "1035j2z2rqmdfb8cfm1pakd05c575640604b8lkljmilpky9mw5d";
+        }
+      else if stdenv.hostPlatform.system == "i686-linux" then
+        fetchurl {
+          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_i686.tar.gz";
+          sha256 = "07j9f6mlq9m01ch8ik5dybi283vrp5dlv156jr5n7n2chzk34kf3";
+        }
+      else
+        throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";
+    
+    postUnpack = ''
+      mv $(find . -type f -name nxclient.tar.gz) .
+      mv $(find . -type f -name nxplayer.tar.gz) .
+      rm -r NX/
+      tar xf nxclient.tar.gz
+      tar xf nxplayer.tar.gz
+      rm $(find . -maxdepth 1 -type f)
+    '';
+  
+    nativeBuildInputs = [ file makeWrapper autoPatchelfHook ];
+    buildInputs = [ jsoncpp ];
+
+    installPhase = ''
+      rm bin/nxplayer bin/nxclient
+
+      mkdir -p $out/NX
+      cp -r bin lib share $out/NX/
+
+      ln -s $out/NX/bin $out/bin
+
+      for i in share/icons/*; do
+        if [[ -d "$i" ]]; then
+          mkdir -p "$out/share/icons/hicolor/$(basename $i)/apps"
+          cp "$i"/* "$out/share/icons/hicolor/$(basename $i)/apps/"
+        fi
+      done
+  
+      mkdir $out/share/applications
+      cp share/applnk/player/xdg/*.desktop $out/share/applications/
+      cp share/applnk/client/xdg-mime/*.desktop $out/share/applications/
+
+      mkdir -p $out/share/mime/packages
+      cp share/applnk/client/xdg-mime/*.xml $out/share/mime/packages/
+
+      for i in $out/share/applications/*.desktop; do
+        substituteInPlace "$i" --replace /usr/NX/bin $out/bin
+      done
+    '';
+  
+    postFixup = ''
+      makeWrapper $out/bin/nxplayer.bin $out/bin/nxplayer --set NX_SYSTEM $out/NX
+      makeWrapper $out/bin/nxclient.bin $out/bin/nxclient --set NX_SYSTEM $out/NX
+    '';
+  
+    dontBuild = true;
+    dontStrip = true;
+
+    meta = with stdenv.lib; {
+      description = "NoMachine remote desktop client (nxplayer)";
+      homepage = https://www.nomachine.com/;
+      license = {
+        fullName = "NoMachine 6 End-User License Agreement";
+        url = https://www.nomachine.com/licensing-6;
+        free = false;
+      };
+      maintainers = with maintainers; [ talyz ];
+      platforms = [ "x86_64-linux" "i686-linux" ];
+    };
+  }
+  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4362,6 +4362,8 @@ with pkgs;
 
   nms = callPackage ../tools/misc/nms { };
 
+  nomachine-client = callPackage ../tools/admin/nomachine-client { };
+
   notify-desktop = callPackage ../tools/misc/notify-desktop {};
 
   nkf = callPackage ../tools/text/nkf {};


### PR DESCRIPTION
Packages mainly the nxplayer part of the client, since the tray
doesn't work very well without the server / a complete installation.

Use the shipped libs, since nxplayer really doesn't like any others. I
believe they use internally modified versions of many libs.

Audio doesn't work: the libasound.so shipped looks for the alsa config
files in the wrong place, and even if it finds them, it still doesn't
work. Using the one from alsaLib doesn't work either and adds
instability.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

