### PR TITLE
nixdoc: init at 1.0.1

### DIFF
--- a/pkgs/tools/nix/nixdoc/default.nix
+++ b/pkgs/tools/nix/nixdoc/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, callPackage, fetchFromGitHub, rustPlatform, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  name    = "nixdoc-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "tazjin";
+    repo  = "nixdoc";
+    rev = "v${version}";
+    sha256 = "14d4dq06jdqazxvv7fq5872zy0capxyb0fdkp8qg06gxl1iw201s";
+  };
+
+  buildInputs =  stdenv.lib.optional stdenv.isDarwin [ darwin.Security ];
+
+  cargoSha256 = "1bfn1x1jhpyidai4cjwip5r1ibkqp26ivmqq3vjm71l00m6avb94";
+
+  meta = with stdenv.lib; {
+    description = "Generate documentation for Nix functions";
+    homepage    = https://github.com/tazjin/nixdoc;
+    license     = [ licenses.gpl3 ];
+    maintainers = [ maintainers.tazjin ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22095,6 +22095,8 @@ with pkgs;
 
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
+  nixdoc = callPackage ../tools/nix/nixdoc {};
+
   nix-bundle = callPackage ../tools/package-management/nix-bundle { };
 
   nix-delegate = haskell.lib.justStaticExecutables haskellPackages.nix-delegate;


### PR DESCRIPTION
Adds nixdoc, a tool to generate documentation for Nix functions in the
standard library.

See #49275 for some background information.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

