### PR TITLE
steam: patch missing udev option

### DIFF
--- a/pkgs/games/steam/0001-udev-fix.patch
+++ b/pkgs/games/steam/0001-udev-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/udev/rules.d/60-steam-input.rules b/lib/udev/rules.d/60-steam-input.rules
+index 99c115b..590cff7 100644
+--- a/lib/udev/rules.d/60-steam-input.rules
++++ b/lib/udev/rules.d/60-steam-input.rules
+@@ -1,7 +1,7 @@
+ # Valve USB devices
+ SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0666"
+ # Steam Controller udev write access
+-KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess"
++KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
+ 
+ # Valve HID devices over USB hidraw
+ KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0666"

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -12,6 +12,11 @@ in stdenv.mkDerivation rec {
     sha256 = "01jgp909biqf4rr56kb08jkl7g5xql6r2g4ch6lc71njgcsbn5fs";
   };
 
+  patches = [
+    # Fix https://github.com/ValveSoftware/steam-for-linux/issues/4794
+    ./0001-udev-fix.patch
+  ];
+
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/ValveSoftware/steam-for-linux/issues/4794

Close #50901

Without this, Xbox emulation doesn't work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

