### PR TITLE
mono46: mark as insecure (CVE-2018-1002208)

### DIFF
--- a/pkgs/development/compilers/mono/4.6.nix
+++ b/pkgs/development/compilers/mono/4.6.nix
@@ -5,4 +5,5 @@ callPackage ./generic.nix (rec {
   version = "4.6.2.16";
   sha256 = "190f7kcrm1y5x61s1xwdmjnwc3czsg50s3mml4xmix7byh3x2rc9";
   enableParallelBuilding = false; # #32386, https://hydra.nixos.org/build/65617511
+  meta.knownVulnerabilities = [ "CVE-2018-1002208" ];
 })


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

