### PR TITLE
defaultCrateOverrides: add serde_derive

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -88,6 +88,10 @@ in
     propagatedBuildInputs = [ Security ];
   };
 
+  serde_derive = attrs: {
+    buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+  };
+
   thrussh-libsodium = attrs: {
     buildInputs = [ pkgconfig libsodium ];
   };

--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -6,76 +6,93 @@ let
   inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
 in
 {
+  cairo-rs = attrs: {
+    buildInputs = [ cairo ];
+  };
+
   cargo = attrs: {
     buildInputs = [ openssl zlib curl ]
       ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation libiconv ];
     # TODO: buildRustCrate seems to use incorrect default inference
     crateBin = [ {  name = "cargo"; path = "src/bin/cargo.rs"; } ];
   };
+
   cargo-vendor = attrs: {
     buildInputs = [ openssl zlib curl ];
     # TODO: this defaults to cargo_vendor; needs to be cargo-vendor to
     # be considered a cargo subcommand.
     crateBin = [ { name = "cargo-vendor"; path = "src/main.rs"; } ];
   };
+
   curl-sys = attrs: {
     buildInputs = [ pkgconfig zlib curl ];
     propagatedBuildInputs = [ curl zlib ];
     extraLinkFlags = ["-L${zlib.out}/lib"];
   };
-  libgit2-sys = attrs: {
-    LIBGIT2_SYS_USE_PKG_CONFIG = true;
-    buildInputs = [ pkgconfig openssl zlib libgit2 ];
-  };
-  libsqlite3-sys = attrs: {
-    buildInputs = [ pkgconfig sqlite ];
-  };
-  libssh2-sys = attrs: {
-    buildInputs = [ pkgconfig openssl zlib libssh2 ];
-  };
-  openssl = attrs: {
-    buildInputs = [ openssl ];
-  };
-  openssl-sys = attrs: {
-    buildInputs = [ pkgconfig openssl ];
-  };
 
   dbus = attrs: {
     buildInputs = [ pkgconfig dbus ];
   };
-  libdbus-sys = attrs: {
-    buildInputs = [ pkgconfig dbus ];
-  };
+
   gobject-sys = attrs: {
     buildInputs = [ dbus-glib ];
   };
+
   gio-sys = attrs: {
     buildInputs = [ dbus-glib ];
   };
+
   gdk-pixbuf-sys = attrs: {
     buildInputs = [ dbus-glib ];
   };
+
   gdk-pixbuf = attrs: {
     buildInputs = [ gdk_pixbuf ];
   };
+
+  libgit2-sys = attrs: {
+    LIBGIT2_SYS_USE_PKG_CONFIG = true;
+    buildInputs = [ pkgconfig openssl zlib libgit2 ];
+  };
+
+  libsqlite3-sys = attrs: {
+    buildInputs = [ pkgconfig sqlite ];
+  };
+
+  libssh2-sys = attrs: {
+    buildInputs = [ pkgconfig openssl zlib libssh2 ];
+  };
+
+  libdbus-sys = attrs: {
+    buildInputs = [ pkgconfig dbus ];
+  };
+
+  openssl = attrs: {
+    buildInputs = [ openssl ];
+  };
+
+  openssl-sys = attrs: {
+    buildInputs = [ pkgconfig openssl ];
+  };
+
+  pq-sys = attr: {
+    buildInputs = [ pkgconfig postgresql ];
+  };
+
   rink = attrs: {
     buildInputs = [ gmp ];
     crateBin = [ {  name = "rink"; path = "src/bin/rink.rs"; } ];
   };
-  cairo-rs = attrs: {
-    buildInputs = [ cairo ];
-  };
-  xcb = attrs: {
-    buildInputs = [ python3 ];
+
+  security-framework-sys = attr: {
+    propagatedBuildInputs = [ Security ];
   };
 
   thrussh-libsodium = attrs: {
     buildInputs = [ pkgconfig libsodium ];
   };
-  pq-sys = attr: {
-    buildInputs = [ pkgconfig postgresql ];
-  };
-  security-framework-sys = attr: {
-    propagatedBuildInputs = [ Security ];
+
+  xcb = attrs: {
+    buildInputs = [ python3 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

hopefully fix macOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

