### PR TITLE
jemalloc: 5.0.1 -> 5.1.0

### DIFF
--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -12,11 +12,7 @@ stdenv.mkDerivation (rec {
   # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
   # then stops downstream builds (mariadb in particular) from detecting it. This
   # option should remove the prefix and give us a working jemalloc.
-  configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix="
-                   # jemalloc is unable to correctly detect transparent hugepage support on
-                   # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
-                   # kernel ARMv6/7 kernel does not enable it, so we explicitly disable support
-                   ++ stdenv.lib.optional stdenv.isAarch32 "--disable-thp";
+  configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix=";
   doCheck = true;
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,10 +1,6 @@
 { stdenv, fetchurl, fetchpatch }:
 import ./common.nix {
   inherit stdenv fetchurl;
-  version = "5.0.1";
-  sha256 = "4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9";
-  patches = stdenv.lib.optional stdenv.isAarch64 (fetchpatch {
-    url = "https://patch-diff.githubusercontent.com/raw/jemalloc/jemalloc/pull/1035.patch";
-    sha256 = "02y0q3dp253bipxv4r954nqipbjbj92p6ww9bx5bk3d8pa81wkqq";
-  });
+  version = "5.1.0";
+  sha256 = "0s3jpcyhzia8d4k0xyc67is78kg416p9yc3c2f9w6fhhqqffd5jk";
 }


### PR DESCRIPTION
###### Motivation for this change
new jemalloc upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- - Built several manually: rustc, cargo, clickhouse, mariadb, okular. The automated CI is probably better at this than my laptop.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

