### PR TITLE
NetLogo: init 6.0.4

### DIFF
--- a/pkgs/applications/science/misc/netlogo/default.nix
+++ b/pkgs/applications/science/misc/netlogo/default.nix
@@ -1,0 +1,58 @@
+{ jre, stdenv, fetchurl, makeWrapper, makeDesktopItem }:
+
+let
+
+  desktopItem = makeDesktopItem rec {
+    name = "netlogo";
+    exec = name;
+    icon = name;
+    comment = "A multi-agent programmable modeling environment";
+    desktopName = "NetLogo";
+    categories = "Science;";
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "netlogo-${version}";
+  version = "6.0.4";
+
+  src = fetchurl {
+    url = "https://ccl.northwestern.edu/netlogo/${version}/NetLogo-${version}-64.tgz";
+    sha256 = "0dcd9df4dfb218826a74f9df42163fa588908a1dfe58864106936f8dfb76acec";
+  };
+
+  src1 = fetchurl {
+    name = "netlogo.png";
+    url = "https://netlogoweb.org/assets/images/desktopicon.png";
+    sha256 = "1i43lhr31lzva8d2r0dxpcgr58x496gb5vmb0h2da137ayvifar8";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -pv $out/share/netlogo $out/share/icons/hicolor/256x256/apps $out/share/applications $out/share/doc
+    cp -rv app $out/share/netlogo
+    cp -v readme.md $out/share/doc/
+
+    # launcher with `cd` is required b/c otherwise the model library isn't usable
+    makeWrapper "${jre}/bin/java" "$out/bin/netlogo" \
+      --run "cd $out/share/netlogo/app" \
+      --add-flags "-jar netlogo-${version}.jar"
+
+    cp $src1 $out/share/icons/hicolor/256x256/apps/netlogo.png
+    cp ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A multi-agent programmable modeling environment";
+    longDescription = ''
+      NetLogo is a multi-agent programmable modeling environment. It is used by
+      many tens of thousands of students, teachers and researchers worldwide.
+    '';
+    homepage = https://ccl.northwestern.edu/netlogo/index.shtml;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.dpaetzel ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21712,6 +21712,8 @@ with pkgs;
 
   megam = callPackage ../applications/science/misc/megam { };
 
+  netlogo = callPackage ../applications/science/misc/netlogo { };
+
   ns-3 = callPackage ../development/libraries/science/networking/ns3 { };
 
   root = callPackage ../applications/science/misc/root {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

