### PR TITLE
Add cudnn7.3 over cuda9.0 and make tensorflow use it

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -50,4 +50,14 @@ in
     srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.tgz";
     sha256 = "1rfmdd2v47p83fm3sfyvik31gci0q17qs6kjng6mvcsd6akmvb8y";
   };
+
+  cudnn_7_3_cudatoolkit_9_0 = generic rec {
+    version = "7.3.1.20";
+    cudatoolkit = cudatoolkit_9_0;
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v${version}.tgz";
+    sha256 = "15miqnyp8i204y8ay7qf0fyhz51i4rxa1fa3y3lfd9v36v6q0ygw"; # Download won't work
+    # This version must be downloaded from nvidia manually. Use then nix-prefetch-url file:<absolute-path>
+  };
+
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2065,7 +2065,8 @@ with pkgs;
     cudnn6_cudatoolkit_8
     cudnn_cudatoolkit_8
     cudnn_cudatoolkit_9
-    cudnn_cudatoolkit_9_0;
+    cudnn_cudatoolkit_9_0
+    cudnn_7_3_cudatoolkit_9_0;
 
   cudnn = cudnn_cudatoolkit_9;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10616,7 +10616,7 @@ EOF
       cudaSupport = pkgs.config.cudaSupport or false;
       inherit (pkgs.linuxPackages) nvidia_x11;
       cudatoolkit = pkgs.cudatoolkit_9_0;
-      cudnn = pkgs.cudnn_cudatoolkit_9_0;
+      cudnn = pkgs.cudnn_7_3_cudatoolkit_9_0;
     };
 
   tensorflowWithoutCuda = self.tensorflow.override {


### PR DESCRIPTION
###### Motivation for this change

Tensorflow over cuda is currently broken because it depends on an incompatible version of cudnn.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

