### PR TITLE
gitlab-shell: 8.3.3->8.4.1, fix hardcoded paths

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -241,8 +241,22 @@
      (<literal>networking.firewall.interfaces.default.*</literal>), and assigning
      to this pseudo device will override the (<literal>networking.firewall.allow*</literal>)
      options.
-    </para>
-   </listitem>
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+     GitLab Shell previously used the nix store paths for the
+     <literal>gitlab-shell</literal> command in its
+     <literal>authorized_keys</literal> file, which might stop working after
+     garbage collection. To circumvent that, we regenerated that file on each
+     startup.  As <literal>gitlab-shell</literal> has now been changed to use
+     <literal>/var/run/current-system/sw/bin/gitlab-shell</literal>, this is
+     not necessary anymore, but there might be leftover lines with a nix store
+     path. Regenerate the <literal>authorized_keys</literal> file via
+     <command>sudo -u git -H gitlab-rake gitlab:shell:setup</command> in that
+     case.
+   </para>
+  </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -609,10 +609,6 @@ in {
           touch "${cfg.statePath}/db-seeded"
         fi
 
-        # The gitlab:shell:setup regenerates the authorized_keys file so that
-        # the store path to the gitlab-shell in it gets updated
-        ${pkgs.sudo}/bin/sudo -u ${cfg.user} -H force=yes ${gitlab-rake}/bin/gitlab-rake gitlab:shell:setup
-
         # The gitlab:shell:create_hooks task seems broken for fixing links
         # so we instead delete all the hooks and create them anew
         rm -f ${cfg.statePath}/repositories/**/*.git/hooks

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/remove-hardcoded-locations.patch
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/remove-hardcoded-locations.patch
@@ -43,3 +43,16 @@ index 57c70f5..700569b 100644
    end
  
    def api
+diff --git a/lib/gitlab_keys.rb b/lib/gitlab_keys.rb
+index 0600a18..6814f0a 100644
+--- a/lib/gitlab_keys.rb
++++ b/lib/gitlab_keys.rb
+@@ -10,7 +10,7 @@ class GitlabKeys # rubocop:disable Metrics/ClassLength
+   attr_accessor :auth_file, :key
+
+   def self.command(whatever)
+-    "#{ROOT_PATH}/bin/gitlab-shell #{whatever}"
++    "/run/current-system/sw/bin/gitlab-shell #{whatever}"
+   end
+
+   def self.command_key(key_id)


### PR DESCRIPTION
###### Motivation for this change

This upgrades `gitlab-shell` to be current with `gitlab`.

In addition it fixes paths in the generated `authorized_keys` file, which hardcoded paths to the running gitlab-shell and broke upgrades.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x]Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

