### PR TITLE
gmime3: 3.2.0 -> 3.2.1, enable tests, now uses libidn2

### DIFF
--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, glib, zlib, gnupg, gpgme, libidn, gobjectIntrospection }:
+{ stdenv, fetchurl, pkgconfig, glib, zlib, gnupg, gpgme, libidn2, libunistring, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  version = "3.2.0";
+  version = "3.2.1";
   name = "gmime-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gmime/3.2/${name}.tar.xz";
-    sha256 = "1q6palbpf6lh6bvy9ly26q5apl5k0z0r4mvl6zzqh90rz4rn1v3m";
+    sha256 = "0q65nalxzpyjg37gdlpj9v6028wp0qx47z96q0ff6znw217nzzjn";
   };
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ gobjectIntrospection zlib gpgme libidn ];
+  buildInputs = [ gobjectIntrospection zlib gpgme libidn2 libunistring ];
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib ];
   configureFlags = [ "--enable-introspection=yes" ];
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
   '';
 
   checkInputs = [ gnupg ];
+
+  doCheck = true;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
NEWS:

https://raw.githubusercontent.com/jstedfast/gmime/87405143bb870a6977b7170706a04d747341b425/NEWS



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---