### PR TITLE
Implement rfc0035: default `name` from `pname`

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -12,7 +12,9 @@ rec {
   # * https://nixos.org/nix/manual/#ssec-derivation
   #   Explanation about derivations in general
   mkDerivation =
-    { name ? ""
+    { name ? if builtins.hasAttr "pname" attrs && builtins.hasAttr "version" attrs
+        then "${attrs.pname}-${attrs.version}"
+        else ""
 
     # These types of dependencies are all exhaustively documented in
     # the "Specifying Dependencies" section of the "Standard

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -12,7 +12,7 @@ rec {
   # * https://nixos.org/nix/manual/#ssec-derivation
   #   Explanation about derivations in general
   mkDerivation =
-    { name ? if builtins.hasAttr "pname" attrs && builtins.hasAttr "version" attrs
+    { name ? if attrs ? pname && attrs ? version
         then "${attrs.pname}-${attrs.version}"
         else ""
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -82,6 +82,10 @@ rec {
 
     , ... } @ attrs:
 
+    # Check that the name is consistent with pname and version:
+    assert lib.lists.all (name: builtins.hasAttr name attrs) ["name" "pname" "version"]
+      -> lib.strings.hasSuffix "${attrs.pname}-${attrs.version}" attrs.name;
+
     let
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
       # no package has `doCheck = true`.

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -83,8 +83,10 @@ rec {
     , ... } @ attrs:
 
     # Check that the name is consistent with pname and version:
-    assert lib.lists.all (name: builtins.hasAttr name attrs) ["name" "pname" "version"]
-      -> lib.strings.hasSuffix "${attrs.pname}-${attrs.version}" attrs.name;
+    assert lib.assertMsg
+      (lib.lists.all (name: builtins.hasAttr name attrs) ["name" "pname" "version"]
+        -> lib.strings.hasSuffix "${attrs.pname}-${attrs.version}" attrs.name)
+      "mkDerivation: `name` must be consistent with `pname-version`";
 
     let
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -67,6 +67,8 @@ rec {
     , pos ? # position used in error messages and for meta.position
         (if attrs.meta.description or null != null
           then builtins.unsafeGetAttrPos "description" attrs.meta
+          else if attrs.version or null != null
+          then builtins.unsafeGetAttrPos "version" attrs
           else builtins.unsafeGetAttrPos "name" attrs)
     , separateDebugInfo ? false
     , outputs ? [ "out" ]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -86,7 +86,8 @@ rec {
     assert lib.assertMsg
       (lib.lists.all (name: builtins.hasAttr name attrs) ["name" "pname" "version"]
         -> lib.strings.hasSuffix "${attrs.pname}-${attrs.version}" attrs.name)
-      "mkDerivation: `name` must be consistent with `pname-version`";
+      ("mkDerivation: `name` (\"${attrs.name}\") must be consistent " +
+       "with `pname-version` \"${attrs.pname}-${attrs.version}\"");
 
     let
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when


### PR DESCRIPTION
###### Motivation for this change

Implements https://github.com/NixOS/rfcs/pull/35

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

