### PR TITLE
python.pkgs.pyqt5: 5.10.1 -> 5.11.3

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -6,9 +6,9 @@
 
 let
   pname = "PyQt";
-  version = "5.10.1";
+  version = "5.11.3";
 
-  inherit (pythonPackages) buildPythonPackage python dbus-python sip;
+  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python sip enum34;
 
 in buildPythonPackage {
   pname = pname;
@@ -25,7 +25,7 @@ in buildPythonPackage {
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/PyQt5/PyQt-${version}/PyQt5_gpl-${version}.tar.gz";
-    sha256 = "1vz9c4v0k8azk2b08swwybrshzw32x8djjpq13mf9v15x1qyjclr";
+    sha256 = "0wqh4srqkcc03rvkwrcshaa028psrq58xkys6npnyhqxc0apvdf9";
   };
 
   outputs = [ "out" "dev" ];
@@ -36,7 +36,7 @@ in buildPythonPackage {
 
   propagatedBuildInputs = [
     sip qtbase qtsvg qtwebkit qtwebengine
-  ] ++ lib.optional withWebSockets qtwebsockets ++ lib.optional withConnectivity qtconnectivity;
+  ] ++ lib.optional (!isPy3k) enum34 ++ lib.optional withWebSockets qtwebsockets ++ lib.optional withConnectivity qtconnectivity;
 
   configurePhase = ''
     runHook preConfigure
@@ -63,27 +63,6 @@ in buildPythonPackage {
 
     runHook postConfigure
   '';
-
-  patches = [
-    # This patch from Arch Linux fixes Cura segfaulting on startup
-    # https://github.com/Ultimaker/Cura/issues/3438
-    # It can probably removed on 5.10.3
-    (fetchpatch {
-      name = "pyqt5-cura-crash.patch";
-      url = https://git.archlinux.org/svntogit/packages.git/plain/repos/extra-x86_64/pyqt5-cura-crash.patch?id=6cfe64a3d1827e0ed9cc62f1683a53b582315f4f;
-      sha256 = "02a0mw1z8p9hhqhl4bgjrmf1xq82xjmpivn5bg6r4yv6pidsh7ck";
-    })
-    (fetchpatch {
-      name = "pyqt-qt5.11.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/pyqt-qt5.11.patch?h=packages/pyqt5&id=d01240b801203d3865b2f61fa19090cc20e55a97";
-      sha256 = "0qa7w1agjg9da99lvnqwwxnm3pp7qd683h7zggq4c269y2km812h";
-    })
-    (fetchpatch {
-      name = "pyqt-support-new-qt.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/pyqt-support-new-qt.patch?h=packages/pyqt5&id=d01240b801203d3865b2f61fa19090cc20e55a97";
-      sha256 = "1nkl96f4bki37zw6iwvd4vq8z8gg45q5m1cbkbaw72395i0m7p5j";
-    })
-  ];
 
   postInstall = ''
     for i in $out/bin/*; do

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "sip";
-  version = "4.19.8";
+  version = "4.19.13";
   format = "other";
 
   disabled = isPyPy;
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/sip/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "1g4pq9vj753r2s061jc4y9ydzgb48ibhc9bdvmb8mlyllwp7mbvy";
+    sha256 = "0pniq03jk1n5bs90yjihw3s3rsmjd8m89y9zbnymzgwrcl2sflz3";
   };
 
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change
Qutebrowser complains about needing Qt 5.11 when setting `content.cookies.accept` to `no-3rdparty`.

When running qutebrowser with this version of pyqt5, I get `ModuleNotFoundError: No module named 'PyQt5.sip'`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @svanderburg 