### PR TITLE
nixos/lib/eval-config.nix: toString modulesPath

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -49,7 +49,8 @@ in rec {
     inherit prefix check;
     modules = modules ++ extraModules ++ baseModules ++ [ pkgsModule ];
     args = extraArgs;
-    specialArgs = { modulesPath = ../modules; } // specialArgs;
+    specialArgs =
+      { modulesPath = builtins.toString ../modules; } // specialArgs;
   }) config options;
 
   # These are the extra arguments passed to every module.  In


### PR DESCRIPTION

###### Motivation for this change

Referencing `modulesPath` in NixOS configurations can cause evaluation errors in restricted mode.
If used as `${modulesPath}` (as in all use-sites in `nixpkgs`) the modules subtree is copied into its own store path. Access to this path will be forbidden in restricted mode.

Converting to a string solves this issue. `${builtins.toString modulesPath}` will point to a subdirectory of the nixpkgs tree out of which `evalModules` is called.

This change converts `modulesPath` to a string by default so that the call-site doesn't have to anymore.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    None of the tests seems to use `modulesPath` directly. But, I picked `nixos/tests/nsd.nix` at random and it still passes.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @grahamc 