### PR TITLE
qemu_test: disable features that are not needed for tests (closure 641 -> 335.3M)

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests-interactively.xml
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.xml
@@ -9,7 +9,7 @@
   The test itself can be run interactively. This is particularly useful when
   developing or debugging a test:
 <screen>
-<prompt>$ </prompt>nix-build nixos/tests/login.nix -A driver
+<prompt>$ </prompt>nix-build nixos/tests/login.nix -A driverInteractive
 <prompt>$ </prompt>./result/bin/nixos-test-driver
 starting VDE switch for network 1
 <prompt>&gt;</prompt>
@@ -30,7 +30,7 @@ starting VDE switch for network 1
  <para>
   To just start and experiment with the VMs, run:
 <screen>
-<prompt>$ </prompt>nix-build nixos/tests/login.nix -A driver
+<prompt>$ </prompt>nix-build nixos/tests/login.nix -A driverInteractive
 <prompt>$ </prompt>./result/bin/nixos-run-vms
 </screen>
   The script <command>nixos-run-vms</command> starts the virtual machines

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -172,7 +172,8 @@ rec {
       else
         test // {
           inherit nodes test;
-          driver = driver testDriverInteractive;
+          driver = driver testDriver;
+          driverInteractive = driver testDriverInteractive;
         };
 
   runInMachine =

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -17,9 +17,9 @@ rec {
   inherit pkgs;
 
 
-  testDriver = let
+  mkTestDriver = let
     testDriverScript = ./test-driver/test-driver.py;
-  in stdenv.mkDerivation {
+  in qemu_pkg: stdenv.mkDerivation {
     name = "nixos-test-driver";
 
     nativeBuildInputs = [ makeWrapper ];
@@ -47,10 +47,12 @@ rec {
         # TODO: copy user script part into this file (append)
 
         wrapProgram $out/bin/nixos-test-driver \
-          --prefix PATH : "${lib.makeBinPath [ qemu_test vde2 netpbm coreutils ]}" \
+          --prefix PATH : "${lib.makeBinPath [ qemu_pkg vde2 netpbm coreutils ]}" \
       '';
   };
 
+  testDriver = mkTestDriver qemu_test;
+  testDriverInteractive = mkTestDriver qemu_kvm;
 
   # Run an automated test suite in the given virtual network.
   # `driver' is the script that runs the network.
@@ -113,7 +115,11 @@ rec {
       # Generate convenience wrappers for running the test driver
       # interactively with the specified network, and for starting the
       # VMs from the command line.
-      driver = let warn = if skipLint then lib.warn "Linting is disabled!" else lib.id; in warn (runCommand testDriverName
+      driver = testDriver:
+        let
+          warn = if skipLint then lib.warn "Linting is disabled!" else lib.id;
+        in
+        warn (runCommand testDriverName
         { buildInputs = [ makeWrapper];
           testScript = testScript';
           preferLocalBuild = true;
@@ -148,7 +154,7 @@ rec {
         meta = (drv.meta or {}) // t.meta;
       };
 
-      test = passMeta (runTests driver);
+      test = passMeta (runTests (driver testDriver));
 
       nodeNames = builtins.attrNames nodes;
       invalidNodeNames = lib.filter
@@ -165,7 +171,8 @@ rec {
         ''
       else
         test // {
-          inherit nodes driver test;
+          inherit nodes test;
+          driver = driver testDriverInteractive;
         };
 
   runInMachine =

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -116,6 +116,10 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
     users.users.root.initialHashedPassword = mkOverride 150 "";
 
     services.xserver.displayManager.job.logToJournal = true;
+
+    # Make sure we use the Guest Agent from the QEMU package for testing
+    # to reduce the closure size required for the tests.
+    services.qemuGuest.package = pkgs.qemu_test.ga;
   };
 
 }

--- a/nixos/modules/virtualisation/qemu-guest-agent.nix
+++ b/nixos/modules/virtualisation/qemu-guest-agent.nix
@@ -12,6 +12,11 @@ in {
         default = false;
         description = "Whether to enable the qemu guest agent.";
       };
+      package = mkOption {
+        type = types.package;
+        default = pkgs.qemu.ga;
+        description = "The QEMU guest agent package.";
+      };
   };
 
   config = mkIf cfg.enable (
@@ -25,7 +30,7 @@ in {
       systemd.services.qemu-guest-agent = {
         description = "Run the QEMU Guest Agent";
         serviceConfig = {
-          ExecStart = "${pkgs.qemu.ga}/bin/qemu-ga";
+          ExecStart = "${cfg.package}/bin/qemu-ga";
           Restart = "always";
           RestartSec = 0;
         };

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -6,12 +6,13 @@
 , CoreServices, Cocoa, Hypervisor, rez, setfile
 , numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
 , seccompSupport ? stdenv.isLinux, libseccomp
-, pulseSupport ? !stdenv.isDarwin, libpulseaudio
-, sdlSupport ? !stdenv.isDarwin, SDL2
-, gtkSupport ? !stdenv.isDarwin && !xenSupport, gtk3, gettext, vte, wrapGAppsHook
-, vncSupport ? true, libjpeg, libpng
-, smartcardSupport ? true, libcacard
-, spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
+, alsaSupport ? stdenv.lib.hasSuffix "linux" stdenv.hostPlatform.system && !nixosTestRunner
+, pulseSupport ? !stdenv.isDarwin && !nixosTestRunner, libpulseaudio
+, sdlSupport ? !stdenv.isDarwin && !nixosTestRunner, SDL2
+, gtkSupport ? !stdenv.isDarwin && !xenSupport && !nixosTestRunner, gtk3, gettext, vte, wrapGAppsHook
+, vncSupport ? !nixosTestRunner, libjpeg, libpng
+, smartcardSupport ? !nixosTestRunner, libcacard
+, spiceSupport ? !stdenv.isDarwin && !nixosTestRunner, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
 , cephSupport ? false, ceph
@@ -29,7 +30,7 @@
 
 with stdenv.lib;
 let
-  audio = optionalString (hasSuffix "linux" stdenv.hostPlatform.system) "alsa,"
+  audio = optionalString alsaSupport "alsa,"
     + optionalString pulseSupport "pa,"
     + optionalString sdlSupport "sdl,";
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, python, zlib, pkgconfig, glib
-, ncurses, perl, pixman, vde2, alsaLib, texinfo, flex
+, perl, pixman, vde2, alsaLib, texinfo, flex
 , bison, lzo, snappy, libaio, gnutls, nettle, curl
 , makeWrapper
 , attr, libcap, libcap_ng
@@ -13,6 +13,7 @@
 , vncSupport ? !nixosTestRunner, libjpeg, libpng
 , smartcardSupport ? !nixosTestRunner, libcacard
 , spiceSupport ? !stdenv.isDarwin && !nixosTestRunner, spice, spice-protocol
+, ncursesSupport ? !nixosTestRunner, ncurses
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
 , cephSupport ? false, ceph
@@ -51,10 +52,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ python python.pkgs.sphinx pkgconfig flex bison ]
     ++ optionals gtkSupport [ wrapGAppsHook ];
   buildInputs =
-    [ zlib glib ncurses perl pixman
+    [ zlib glib perl pixman
       vde2 texinfo makeWrapper lzo snappy
       gnutls nettle curl
     ]
+    ++ optionals ncursesSupport [ ncurses ]
     ++ optionals stdenv.isDarwin [ CoreServices Cocoa Hypervisor rez setfile ]
     ++ optionals seccompSupport [ libseccomp ]
     ++ optionals numaSupport [ numactl ]

--- a/pkgs/development/libraries/libndctl/default.nix
+++ b/pkgs/development/libraries/libndctl/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook
 , asciidoctor, pkgconfig, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt
-, json_c, kmod, which, utillinux, systemd, keyutils
+, json_c, kmod, which, utillinux, udev, keyutils
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     ];
 
   buildInputs =
-    [ json_c kmod utillinux systemd keyutils
+    [ json_c kmod utillinux udev keyutils
     ];
 
   configureFlags =

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , meson, ninja, pkgconfig, gettext, libxslt, docbook_xsl_ns
-, libcap, systemd, libidn2
+, libcap, libidn2
 }:
 
 with stdenv.lib;
@@ -22,6 +22,12 @@ in stdenv.mkDerivation rec {
     sha256 = "1jhbcz75a4ij1myyyi110ma1d8d5hpm3scz9pyw7js6qym50xvh4";
   };
 
+  postPatch = ''
+    # Enable the systemd units even without systemd being an input. We set the
+    # unitdir manually anyway.
+    sed -e 's/systemd\.found()/true/g' -i meson.build
+  '';
+
   mesonFlags = [
     "-DBUILD_RARPD=true"
     "-DBUILD_TRACEROUTE6=true"
@@ -33,7 +39,7 @@ in stdenv.mkDerivation rec {
     ++ optional stdenv.hostPlatform.isMusl "-DUSE_IDN=false";
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext libxslt.bin docbook_xsl_ns ];
-  buildInputs = [ libcap systemd ]
+  buildInputs = [ libcap ]
     ++ optional (!stdenv.hostPlatform.isMusl) libidn2;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This is an attempt to change the NixOS test runner in a way that allows faster iteration on lower-level parts of the system by reducing the number of packages that contribute to the test closure size.

While `qemu_test` has always been a bit slimmer then one of its siblings it wasn't really "slim" in comparison. With this PR we reduce the closure size of `qemu_test` to about 335MB from previously > 640MB.

One of the changes this introduces (based on the discussion when this PR was first opened) is that test drivers will now come without any graphical support by default. There is a new attribute to the tests (`driverInteractive`) that comes with the full feature set of QEMU including the graphical output and sound.

Also, while running VM tests, we will use the QEMU Guest Agent from the corresponding QEMU package as otherwise we'd not have gained much.

I removed `systemd ` from `iputils` as that was only used to toggle the systemd unit generation (that we aren't using on systemd anyway). There are no references to systemd in the runtime closure. The required patch has been submitted upstream and is awaiting feedback.

###### Things done
- I executed a few tests nothing more fancy. What are good candidates to verify it doesn't break more fancy tests?
   - [X] tests.installer.simple.x86_64-linux
   - [X] tests.installer.zfsroot.x86_64-linux
   - [X] tests.vault.x86_64-linux
   - [X] tests.mpd.x86_64-linux
   - [X] tests.containers-ipv4.x86_64-linux