### PR TITLE
piexif: 1.0.13 -> 1.1.2 (and bunch of other packages)

### DIFF
--- a/pkgs/development/python-modules/cairosvg/1_x.nix
+++ b/pkgs/development/python-modules/cairosvg/1_x.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, cairocffi, nose, fontconfig
+, cssselect2, defusedxml, pillow, tinycss2 }:
+
+# CairoSVG 2.x dropped support for Python 2 so offer CairoSVG 1.x as an
+# alternative
+buildPythonPackage rec {
+  pname = "CairoSVG";
+  version = "1.0.22";
+
+  # PyPI doesn't include tests so use GitHub
+  src = fetchFromGitHub {
+    owner = "Kozea";
+    repo = pname;
+    rev = version;
+    sha256 = "15z0cag5s79ghhrlgs5xc9ayvzzdr3v8151vf6k819f1drsfjfxl";
+  };
+
+  propagatedBuildInputs = [ cairocffi ];
+
+  checkInputs = [ nose fontconfig cssselect2 defusedxml pillow tinycss2 ];
+
+  # Almost all tests just fail. Not sure how to fix them.
+  doCheck = false;
+
+  # checkInputs = [ nose fontconfig cssselect2 defusedxml pillow tinycss2 ];
+
+  # checkPhase = ''
+  #   FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf nosetests .
+  # '';
+
+  meta = with stdenv.lib; {
+    homepage = https://cairosvg.org;
+    license = licenses.lgpl3;
+    description = "SVG converter based on Cairo";
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/nose-focus/default.nix
+++ b/pkgs/development/python-modules/nose-focus/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, nose, nose-of-yeti
+, nose-pattern-exclude, which }:
+
+buildPythonPackage rec {
+  pname = "nose-focus";
+  version = "0.1.3";
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ nose nose-of-yeti nose-pattern-exclude which ];
+
+  # PyPI doesn't contain tests so let's use GitHub. See:
+  # https://github.com/delfick/nose-focus/issues/4
+  #
+  # However, the versions aren't tagged on GitHub so need to use a manually
+  # checked revision. See: https://github.com/delfick/nose-focus/issues/5
+  src = fetchFromGitHub {
+    owner = "delfick";
+    repo = pname;
+    rev = "4dac785ba07ed6e1df61b0fe2854685eef3bd115";
+    sha256 = "0gpd4j4433dc5ifh31w08c3bx862md0qm1ix6aam1rz4ayxpq51f";
+  };
+
+  checkPhase = ''
+    patchShebangs test.sh
+    ./test.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Decorator and plugin to make nose focus on specific tests";
+    homepage = https://nose-focus.readthedocs.io/en/latest/;
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/nose-of-yeti/default.nix
+++ b/pkgs/development/python-modules/nose-of-yeti/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, nose, fudge, should-dsl }:
+
+buildPythonPackage rec {
+  pname = "nose-of-yeti";
+  version = "1.8";
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ nose fudge should-dsl ];
+
+  # PyPI doesn't contain tests so let's use GitHub.
+  src = fetchFromGitHub {
+    owner = "delfick";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1pq9bf47k0csv41vdh2g6n336p3pd11q91hj5ypk0ls3nj756gbx";
+  };
+
+  checkPhase = ''
+    patchShebangs test.sh
+    ./test.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Nose plugin providing BDD dsl for python";
+    homepage = https://github.com/delfick/nose-of-yeti;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/nose-pattern-exclude/default.nix
+++ b/pkgs/development/python-modules/nose-pattern-exclude/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "nose-pattern-exclude";
+  version = "0.1.3";
+
+  propagatedBuildInputs = [ nose ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0apzxx8lavsdlxlpaxqw1snx5p7q8v5dfbip6v32f9pj2vyain1i";
+  };
+
+  # There are no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Exclude specific files and directories from nosetests runs";
+    homepage = https://github.com/jakubroztocil/nose-pattern-exclude;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/piexif/default.nix
+++ b/pkgs/development/python-modules/piexif/default.nix
@@ -2,22 +2,15 @@
 
 buildPythonPackage rec {
   pname = "piexif";
-  version = "1.0.13";
+  version = "1.1.2";
 
-  # pillow needed for unit tests
-  buildInputs = [ pillow ];
-
-  postPatch = ''
-    # incompatibility with pillow => 4.2.0
-    # has been resolved in https://github.com/hMatoba/Piexif/commit/c3a8272f5e6418f223b25f6486d8ddda201bbdf1
-    # remove this in the next version
-    sed -i -e 's/RGBA/RGB/' tests/s_test.py
-  '';
+  # Pillow needed for unit tests
+  checkInputs = [ pillow ];
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "1d3dde03bd6298393645bc11d585b67a6ea98fd7e9e1aded6d5d6ec3e4cfbdda";
+    sha256 = "0dj6wiw4mk65zn7p0qpghra39mf88m3ph2xn7ff9jvasgczrgkb0";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/preggy/default.nix
+++ b/pkgs/development/python-modules/preggy/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, unidecode, nose, yanc }:
+
+buildPythonPackage rec {
+  pname = "preggy";
+  version = "1.4.2";
+
+  propagatedBuildInputs = [ six unidecode ];
+  checkInputs = [ nose yanc ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g4ifjh01dkmdzs4621ahk8hpkngid1xxhl51jvzy4h4li4590hw";
+  };
+
+  checkPhase = ''
+    nosetests .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Assertion library for Python";
+    homepage = http://heynemann.github.io/preggy/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/pyres/default.nix
+++ b/pkgs/development/python-modules/pyres/default.nix
@@ -1,11 +1,26 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, simplejson, redis, setproctitle, nose, pkgs }:
+{ stdenv, fetchPypi, buildPythonPackage, fetchFromGitHub, simplejson, redis, setproctitle, nose, pkgs }:
+
+let
+
+  # the requirements of `pyres` support Redis 3.x (due to a missing upper-bound),
+  # but it doesn't support Redis 3.x.
+  redis' = redis.overridePythonAttrs (old: rec {
+    pname = "redis";
+    version = "2.10.6";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "03vcgklykny0g0wpvqmy8p6azi2s078317wgb2xjv5m2rs9sjb52";
+    };
+  });
+
+in
 
 buildPythonPackage rec {
   pname = "pyres";
   version = "1.5";
 
   # ps is used in Worker.worker_pids method
-  propagatedBuildInputs = [ simplejson setproctitle redis pkgs.ps ];
+  propagatedBuildInputs = [ simplejson setproctitle redis' pkgs.ps ];
   checkInputs = [ nose pkgs.redis ];
 
   # PyPI tarball doesn't contain tests so let's use GitHub

--- a/pkgs/development/python-modules/pyres/default.nix
+++ b/pkgs/development/python-modules/pyres/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, simplejson, redis, setproctitle, nose, pkgs }:
+
+buildPythonPackage rec {
+  pname = "pyres";
+  version = "1.5";
+
+  # ps is used in Worker.worker_pids method
+  propagatedBuildInputs = [ simplejson setproctitle redis pkgs.ps ];
+  checkInputs = [ nose pkgs.redis ];
+
+  # PyPI tarball doesn't contain tests so let's use GitHub
+  src = fetchFromGitHub {
+    owner = "binarydud";
+    repo = pname;
+    rev = version;
+    sha256 = "1rkpv7gbjxl9h9g7kncmsrgmi77l7pgfq8d7dbnsr3ia2jmjqb8y";
+  };
+
+  checkPhase = ''
+    redis-server &
+    nosetests .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python resque clone";
+    homepage = https://github.com/binarydud/pyres;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/pyssim/default.nix
+++ b/pkgs/development/python-modules/pyssim/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, pillow }:
+
+buildPythonPackage rec {
+  pname = "pyssim";
+  version = "0.4";
+
+  propagatedBuildInputs = [ numpy scipy pillow ];
+
+  # PyPI tarball doesn't contain test images so let's use GitHub
+  src = fetchFromGitHub {
+    owner = "jterrace";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0rnj3xdhma1fc0fg0jjsdy74ar0hgr3w8kygbnijqjdms7m3asqm";
+  };
+
+  # Tests are copied from .travis.yml
+  checkPhase = ''
+    $out/bin/pyssim test-images/test1-1.png test-images/test1-1.png | grep 1
+    $out/bin/pyssim test-images/test1-1.png test-images/test1-2.png | grep 0.998
+    $out/bin/pyssim test-images/test1-1.png "test-images/*" | grep -E " 1| 0.998| 0.672| 0.648" | wc -l | grep 4
+    $out/bin/pyssim --cw --width 128 --height 128 test-images/test1-1.png test-images/test1-1.png | grep 1
+    $out/bin/pyssim --cw --width 128 --height 128 test-images/test3-orig.jpg test-images/test3-rot.jpg | grep 0.938
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Module for computing Structured Similarity Image Metric (SSIM) in Python";
+    homepage = https://github.com/jterrace/pyssim;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/remotecv/default.nix
+++ b/pkgs/development/python-modules/remotecv/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pillow, argparse, pyres, nose
+, preggy, numpy, yanc, nose-focus, mock, opencv }:
+
+buildPythonPackage rec {
+  pname = "remotecv";
+  version = "2.2.2";
+
+  propagatedBuildInputs = [ pillow argparse pyres ];
+
+  checkInputs = [ nose preggy numpy yanc nose-focus mock opencv ];
+
+  # PyPI tarball doesn't contain tests so let's use GitHub
+  src = fetchFromGitHub {
+    owner = "thumbor";
+    repo = pname;
+    rev = version;
+    sha256 = "0slalp1x626ajy2cbdfifhxf0ffzckqdz6siqsqr6s03hrl877hy";
+  };
+
+  # Remove unnecessary argparse dependency and some seemingly unnecessary
+  # version upper bounds because nixpkgs contains (or could contain) newer
+  # versions.
+  # See: https://github.com/thumbor/remotecv/issues/15
+  patches = [
+    ./install_requires.patch
+  ];
+
+  checkPhase = ''
+    nosetests --with-yanc -s tests/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OpenCV worker for facial and feature recognition";
+    homepage = https://github.com/thumbor/remotecv/wiki;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/remotecv/install_requires.patch
+++ b/pkgs/development/python-modules/remotecv/install_requires.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 70f765c..8003cda 100644
+--- a/setup.py
++++ b/setup.py
+@@ -53,9 +53,8 @@ remotecv is an OpenCV worker for facial and feature recognition
+     },
+ 
+     install_requires=[
+-        "argparse>=1.2.1,<1.3.0",
+-        "pyres>=1.5,<1.6",
+-        "Pillow>=4.3.0,<5.2.0",
++        "pyres>=1.5",
++        "Pillow>=4.3.0",
+     ],
+ 
+     entry_points={

--- a/pkgs/development/python-modules/should-dsl/default.nix
+++ b/pkgs/development/python-modules/should-dsl/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "should-dsl";
+  version = "2.1.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "should_dsl";
+    sha256 = "0ai30dxgygwzaj9sgdzyfr9p5b7gwc9piq59nzr4xy5x1zcm7xrn";
+  };
+
+  # There are no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Should assertions in Python as clear and readable as possible";
+    homepage = http://www.should-dsl.info/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/thumbor/default.nix
+++ b/pkgs/development/python-modules/thumbor/default.nix
@@ -1,6 +1,8 @@
-{ buildPythonPackage, tornado, pycrypto, pycurl, pytz
-, pillow, derpconf, python_magic, pexif, libthumbor, opencv, webcolors
-, piexif, futures, statsd, thumborPexif, fetchPypi, isPy3k, lib
+{ buildPythonPackage, python, tornado, pycrypto, pycurl, pytz
+, pillow, derpconf, python_magic, libthumbor, webcolors
+, piexif, futures, statsd, thumborPexif, fetchFromGitHub, isPy3k, lib
+, mock, raven, nose, yanc, remotecv, pyssim, cairosvg1, preggy, opencv3
+, pkgs, coreutils
 }:
 
 buildPythonPackage rec {
@@ -9,15 +11,37 @@ buildPythonPackage rec {
 
   disabled = isPy3k; # see https://github.com/thumbor/thumbor/issues/1004
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1icfnzwzi5lvnh576n7v3r819jaw15ph9ja2w3fwg5z9qs40xvl8";
+  # Tests aren't included in PyPI tarball so use GitHub instead
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1ys5ymwbvgh2ir85g9nyrzzf8vgi16j6pzzi53b0rgjx0kwlmnxg";
   };
 
   postPatch = ''
     substituteInPlace "setup.py" \
       --replace '"argparse",' "" ${lib.optionalString isPy3k ''--replace '"futures",' ""''}
+    substituteInPlace "tests/test_utils.py" \
+      --replace "/bin/ls" "${coreutils}/bin/ls"
+    substituteInPlace "tests/detectors/test_face_detector.py" \
+      --replace "./thumbor" "$out/lib/${python.libPrefix}/site-packages/thumbor"
+    substituteInPlace "tests/detectors/test_glasses_detector.py" \
+      --replace "./thumbor" "$out/lib/${python.libPrefix}/site-packages/thumbor"
   '';
+
+  checkInputs = [
+    nose
+    pyssim
+    preggy
+    mock
+    yanc
+    remotecv
+    cairosvg1
+    raven
+    pkgs.redis
+    pkgs.glibcLocales
+  ];
 
   propagatedBuildInputs = [
     tornado
@@ -27,18 +51,26 @@ buildPythonPackage rec {
     pillow
     derpconf
     python_magic
-    pexif
     libthumbor
-    opencv
+    opencv3
     webcolors
     piexif
     statsd
+    pkgs.exiftool
+    pkgs.libjpeg
+    pkgs.ffmpeg
+    pkgs.gifsicle
   ] ++ lib.optionals (!isPy3k) [ futures thumborPexif ];
 
-  # disabled due to too many impure tests and issues with native modules in
-  # the pure testing environment. See https://github.com/NixOS/nixpkgs/pull/37147
-  # for further reference.
-  doCheck = false;
+  # Remove the source tree before running nosetests because otherwise nosetests
+  # uses that instead of the installed package. Is there some other way to
+  # achieve this?
+  checkPhase = ''
+    redis-server --port 6668 --requirepass hey_you &
+    rm -r thumbor
+    export LC_ALL="en_US.UTF-8"
+    nosetests -v --with-yanc -s tests/
+  '';
 
   meta = with lib; {
     description = "A smart imaging service";

--- a/pkgs/development/python-modules/thumbor/default.nix
+++ b/pkgs/development/python-modules/thumbor/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace "setup.py" \
       --replace '"argparse",' "" ${lib.optionalString isPy3k ''--replace '"futures",' ""''}
+    substituteInPlace "setup.py" \
+      --replace "piexif>=1.0.13,<1.1.0" "piexif>=1.0.13"
     substituteInPlace "tests/test_utils.py" \
       --replace "/bin/ls" "${coreutils}/bin/ls"
     substituteInPlace "tests/detectors/test_face_detector.py" \

--- a/pkgs/development/python-modules/yanc/default.nix
+++ b/pkgs/development/python-modules/yanc/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, pythonOlder, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "yanc";
+  version = "0.3.3";
+
+  # Tests fail on Python>=3.5. See: https://github.com/0compute/yanc/issues/10
+  disabled = !(pythonOlder "3.5");
+
+  checkInputs = [ nose ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z35bkk9phs40lf5061k1plhjdl5fskm0dmdikrsqi1bjihnxp8w";
+  };
+
+  checkPhase = ''
+    nosetests .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Yet another nose colorer";
+    homepage = https://github.com/0compute/yanc;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4847,6 +4847,8 @@ in {
 
   packaging = callPackage ../development/python-modules/packaging { };
 
+  preggy = callPackage ../development/python-modules/preggy { };
+
   pytoml = callPackage ../development/python-modules/pytoml { };
 
   pypandoc = callPackage ../development/python-modules/pypandoc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -585,6 +585,8 @@ in {
 
   pyparser = callPackage ../development/python-modules/pyparser { };
 
+  pyres = callPackage ../development/python-modules/pyres { };
+
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
     pythonPackages = self;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3076,6 +3076,8 @@ in {
 
   nose-cprof = callPackage ../development/python-modules/nose-cprof { };
 
+  nose-pattern-exclude = callPackage ../development/python-modules/nose-pattern-exclude { };
+
   nose_warnings_filters = callPackage ../development/python-modules/nose_warnings_filters { };
 
   notebook = callPackage ../development/python-modules/notebook { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -611,6 +611,8 @@ in {
     slurm = pkgs.slurm;
   };
 
+  pyssim = callPackage ../development/python-modules/pyssim { };
+
   pystache = callPackage ../development/python-modules/pystache { };
 
   pytesseract = callPackage ../development/python-modules/pytesseract { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3843,6 +3843,8 @@ in {
 
   simplegeneric = callPackage ../development/python-modules/simplegeneric { };
 
+  should-dsl = callPackage ../development/python-modules/should-dsl { };
+
   simplejson = callPackage ../development/python-modules/simplejson { };
 
   simplekml = callPackage ../development/python-modules/simplekml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3066,6 +3066,8 @@ in {
 
   nose-exclude = callPackage ../development/python-modules/nose-exclude { };
 
+  nose-focus = callPackage ../development/python-modules/nose-focus { };
+
   nose2 = callPackage ../development/python-modules/nose2 { };
 
   nose-cover3 = callPackage ../development/python-modules/nose-cover3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -658,6 +658,8 @@ in {
 
   relatorio = callPackage ../development/python-modules/relatorio { };
 
+  remotecv = callPackage ../development/python-modules/remotecv { };
+
   pyzufall = callPackage ../development/python-modules/pyzufall { };
 
   rhpl = disabledIf isPy3k (callPackage ../development/python-modules/rhpl {});

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4849,6 +4849,8 @@ in {
 
   yamllint = callPackage ../development/python-modules/yamllint { };
 
+  yanc = callPackage ../development/python-modules/yanc { };
+
   yarl = callPackage ../development/python-modules/yarl { };
 
   suseapi = callPackage ../development/python-modules/suseapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1140,6 +1140,8 @@ in {
 
   cairocffi = callPackage ../development/python-modules/cairocffi {};
 
+  cairosvg1 = callPackage ../development/python-modules/cairosvg/1_x.nix {};
+
   cairosvg = callPackage ../development/python-modules/cairosvg {};
 
   carrot = callPackage ../development/python-modules/carrot {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3076,6 +3076,8 @@ in {
 
   nose-cprof = callPackage ../development/python-modules/nose-cprof { };
 
+  nose-of-yeti = callPackage ../development/python-modules/nose-of-yeti { };
+
   nose-pattern-exclude = callPackage ../development/python-modules/nose-pattern-exclude { };
 
   nose_warnings_filters = callPackage ../development/python-modules/nose_warnings_filters { };


### PR DESCRIPTION
###### Motivation for this change

I just wanted to upgrade Piexif but Thumbor didn't have tests enabled so I didn't dare to upgrade without having tests passing successfully. Well, enabling the tests required quite a few new packages to be added...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

