### PR TITLE
libmtp: 1.1.15 -> 1.1.16

### DIFF
--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libusb1, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "libmtp-1.1.15";
+  name = "libmtp-1.1.16";
 
   src = fetchurl {
     url = "mirror://sourceforge/libmtp/${name}.tar.gz";
-    sha256 = "089h79nkz7wcr3lbqi7025l8p75hbp0aigxk3wdk2zkm8q5r0h6h";
+    sha256 = "185vh9bds6dcy00ycggg69g4v7m3api40zv8vrcfb3fk3vfzjs2v";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

This fixes the problem of connecting android phones via MTP in kde/dolphin.

Symptom: clicking android device in plasma connection popup fails with something like
> The file or folder udi=/org/kde/solid/udev/sys/devices/pci0000:00/0000:00:14.0/usb3/3-1 does not exist

Original Bug description: https://bugs.kde.org/show_bug.cgi?id=387454

###### Things done

Test procedure: built system (nixos-18.03, nixos-18.09) with updated package, reloaded udev rules,
watched mounting android device work

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

