### PR TITLE
texlive: provide repstopdf

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -218,8 +218,29 @@ in buildEnv {
         ln -sv "$(realpath $s)" "$out/bin/$tName" # wrapped below
       done
     )
+  '' +
+    # A hacky way to provide repstopdf
+    #  * Copy is done to have a correct "$0" so that epstopdf enables the restricted mode
+    #  * ./bin/repstopdf needs to be a symlink to be processed by wrapBin
+  ''
+    if [[ -e ./bin/epstopdf ]]; then
+      cp $(realpath ./bin/epstopdf) ./share/texmf/scripts/repstopdf
+      ln -s "$out"/share/texmf/scripts/repstopdf ./bin/repstopdf
+    fi
+  '' +
+    # finish up the wrappers
+  ''
     rm "$out"/bin/*-sys
     wrapBin
+  '' +
+    # Perform a small test to verify that the restricted mode get enabled when
+    # needed (detected by checking if it disallows --gscmd)
+  ''
+    if [[ -e ./bin/epstopdf ]]; then
+      echo "Testing restricted mode for {,r}epstopdf"
+      ! (epstopdf --gscmd echo /dev/null 2>&1 || true) | grep forbidden
+      (repstopdf --gscmd echo /dev/null 2>&1 || true) | grep forbidden
+    fi
   '' +
   # TODO: a context trigger https://www.preining.info/blog/2015/06/debian-tex-live-2015-the-new-layout/
     # http://wiki.contextgarden.net/ConTeXt_Standalone#Unix-like_platforms_.28Linux.2FMacOS_X.2FFreeBSD.2FSolaris.29


### PR DESCRIPTION
~~It is just a symlink to epstopdf. epstopdf will enable restricted mode
if exectuted as repstopdf.~~ Usually repstopdf is just a symlink to epstopdf. This will not work with our tricky wrappers. A care must be taken to ensure that restricted mode gets enabled.

###### Motivation for this change

Fix #49405

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
