### PR TITLE
Disallow references to nativeBuildInputs

### DIFF
--- a/pkgs/applications/audio/axoloti/default.nix
+++ b/pkgs/applications/audio/axoloti/default.nix
@@ -40,15 +40,6 @@ stdenv.mkDerivation rec {
     substituteInPlace "chibios/os/various/shell.c" \
       --replace "#ifdef __DATE__" "#if 0"
 
-    # Hardcode full path to compiler tools
-    for f in "firmware/Makefile.patch" \
-             "firmware/Makefile" \
-             "firmware/flasher/Makefile" \
-             "firmware/mounter/Makefile"; do
-      substituteInPlace "$f" \
-        --replace "arm-none-eabi-" "${gcc-arm-embedded}/bin/arm-none-eabi-"
-    done
-
     # Hardcode path to "make"
     for f in "firmware/compile_firmware_linux.sh" \
              "firmware/compile_patch_linux.sh"; do

--- a/pkgs/applications/editors/quilter/default.nix
+++ b/pkgs/applications/editors/quilter/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, fetchpatch, vala, pkgconfig, meson, ninja, python3
+{ stdenv, fetchFromGitHub, fetchpatch, vala_0_40, pkgconfig, meson, ninja, python3
 , granite, gtk3, desktop-file-utils, gnome3, gtksourceview, webkitgtk, gtkspell3
 , discount, gobjectIntrospection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "quilter";
-  version = "1.6.3";
+  version = "1.6.8";
 
   name = "${pname}-${version}";
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "lainsce";
     repo = pname;
     rev = version;
-    sha256 = "1wa0i6dgg6fgb7q9z33v9qmn1a1dn3ik58v1f3a49dvd5xyf8q6q";
+    sha256 = "07i9pivpddgixn1wzbr15gvzf0n5pklx0gkjjaa35kvj2z8k31x5";
   };
 
   nativeBuildInputs = [
@@ -22,40 +22,19 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     python3
-    vala
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     wrapGAppsHook
   ];
 
   buildInputs = [
     discount
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
+    gnome3.libgee
     granite
     gtk3
     gtksourceview
     gtkspell3
     webkitgtk
-    gnome3.libgee
-  ];
-
-  patches = [
-    # Fix build with vala 0.42 - Drop these in next release
-    (fetchpatch {
-      url = "https://github.com/lainsce/quilter/commit/a58838213cd7f2d33048c7b34b96dc8875612624.patch";
-      sha256 = "1a4w1zql4zfk8scgrrssrm9n3sh5fsc1af5zvrqk8skbv7f2c80n";
-    })
-    (fetchpatch {
-      url = "https://github.com/lainsce/quilter/commit/d1800ce830343a1715bc83da3339816554896be5.patch";
-      sha256 = "0xl5iz8bgx5661vbbq8qa1wkfvw9d3da67x564ckjfi05zq1vddz";
-    })
-    # Correct libMarkdown dependency discovery: See https://github.com/lainsce/quilter/pull/170
-    (fetchpatch {
-      url = "https://github.com/lainsce/quilter/commit/8b1f3a60bd14cb86c1c62f9917c5f0c12bc4e459.patch";
-      sha256 = "1kjc6ygf9yjvqfa4xhzxiava3338swp9wbjhpfaa3pyz3ayh188n";
-    })
-    # post_install script cleanups: See https://github.com/lainsce/quilter/pull/171
-    (fetchpatch {
-      url = "https://github.com/lainsce/quilter/commit/55bf3b10cd94fcc40b0867bbdb1931a09f577922.patch";
-      sha256 = "1330amichaif2qfrh4qkxwqbcpr87ipik7vzjbjdm2bv3jz9353r";
-    })
   ];
 
   postPatch = ''
@@ -65,9 +44,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Focus on your writing - designed for elementary OS";
-    homepage    = https://github.com/lainsce/quilter;
-    license     = licenses.gpl2Plus;
+    homepage = https://github.com/lainsce/quilter;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ worldofpeace ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, vala, pkgconfig, meson, ninja, python3, granite
+{ stdenv, fetchFromGitHub, vala_0_40, pkgconfig, meson, ninja, python3, granite
 , gtk3, gnome3, gtksourceview, json-glib, gobjectIntrospection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "notejot";
-  version = "1.4.5";
+  version = "1.4.7";
 
   name = "${pname}-${version}";
 
@@ -20,11 +20,12 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     python3
-    vala
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     wrapGAppsHook
   ];
 
   buildInputs = [
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
     gnome3.libgee
     granite
     gtk3
@@ -39,9 +40,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Stupidly-simple sticky notes applet";
-    homepage    = https://github.com/lainsce/notejot;
-    license     = licenses.gpl2Plus;
+    homepage = https://github.com/lainsce/notejot;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ worldofpeace ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -42,6 +42,7 @@ in stdenv.mkDerivation {
     # XXX I would prefer to include these here, though we will need to file a bug upstream to get that changed.
     #"-DDFU_UTIL_PATH=${dfu-util}/bin/dfu-util"
     #"-DAVRDUDE_PATH=${avrdude}/bin/avrdude"
+    "-DNANO=OFF"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -3,46 +3,50 @@
 , gettext
 , libxml2
 , pkgconfig
-, gtk3
+, glib
 , granite
+, gtk3
 , gnome3
-, cmake
+, meson
 , ninja
-, vala
-, elementary-cmake-modules
+, gobjectIntrospection
+, gsettings-desktop-schemas
+, vala_0_40
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "regextester-${version}";
-  version = "0.1.7";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "artemanufrij";
     repo = "regextester";
     rev = version;
-    sha256 = "07shdm10dc7jz2hka5dc51yp81a0dgc47nmkrp6fs6r9wqx0j30n";
+    sha256 = "1xwwv1hccni1mrbl58f7ly4qfq6738vn24bcbl2q346633cd7kx3";
   };
-
-  XDG_DATA_DIRS = stdenv.lib.concatStringsSep ":" [
-    "${granite}/share"
-    "${gnome3.libgee}/share"
-  ];
 
   nativeBuildInputs = [
     pkgconfig
-    wrapGAppsHook
-    vala
-    cmake
+    meson
     ninja
     gettext
+    gobjectIntrospection
     libxml2
-    elementary-cmake-modules
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
+    wrapGAppsHook
   ];
   buildInputs = [
-    gtk3
+    glib
     granite
+    gtk3
+    gnome3.defaultIconTheme
     gnome3.libgee
+    gsettings-desktop-schemas
   ];
+
+  postInstall = ''
+    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
 
   meta = with stdenv.lib; {
     description = "A desktop application to test regular expressions interactively";

--- a/pkgs/applications/office/aesop/default.nix
+++ b/pkgs/applications/office/aesop/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, fetchpatch, vala, pkgconfig, meson, ninja, python3, granite, gtk3
+{ stdenv, fetchFromGitHub, fetchpatch, vala_0_40, pkgconfig, meson, ninja, python3, granite, gtk3
 , gnome3, desktop-file-utils, json-glib, libsoup, poppler, gobjectIntrospection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "aesop";
-  version = "1.0.5";
+  version = "1.0.7";
 
   name = "${pname}-${version}";
 
@@ -21,25 +21,18 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     python3
-    vala
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     wrapGAppsHook
   ];
 
   buildInputs = [
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
     gnome3.libgee
     granite
     gtk3
     json-glib
     libsoup
     poppler
-  ];
-
-  # Fix build with vala 0.42
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/lainsce/aesop/commit/a90b3c711bd162583533370deb031c2c6254c82d.patch";
-      sha256 = "1zf831g6sqq3966q0i00x3jhlbfh9blcky6pnyp5qp59hxyxy169";
-    })
   ];
 
   postPatch = ''
@@ -49,9 +42,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The simplest PDF viewer around";
-    homepage    = https://github.com/lainsce/aesop;
-    license     = licenses.gpl2Plus;
+    homepage = https://github.com/lainsce/aesop;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ worldofpeace ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -1,44 +1,68 @@
-{ stdenv, fetchFromGitHub, vala, pkgconfig, libxml2, cmake, ninja, gtk3, granite, gnome3
-, gobjectIntrospection, sqlite, poppler, poppler_utils, html2text, unzip, unar, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, fetchpatch, vala_0_40, python3, python2, pkgconfig, libxml2, meson, ninja, gtk3, granite, gnome3
+, gobjectIntrospection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "bookworm";
-  version = "1.0.0";
+  version = "4f7b118281667d22f1b3205edf0b775341fa49cb";
 
-  name = "${pname}-${version}";
+  name = "${pname}-2018-10-21";
 
   src = fetchFromGitHub {
     owner = "babluboy";
     repo = pname;
     rev = version;
-    sha256 = "0nv1nxird0s0qfhh8fr82mkj4qimhklw1bwcjwmvjdsvsxxs9520";
+    sha256 = "0bcyim87zk4b4xmgfs158lnds3y8jg7ppzw54kjpc9rh66fpn3b9";
   };
 
+  # See: https://github.com/babluboy/bookworm/pull/220
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/worldofpeace/bookworm/commit/b2faf685c46b95d6a2d4ec3725e4e4122b61e99a.patch";
+      sha256 = "14az86cj5j65hngfflrp1rmnrkdrhg2a8pl7www3jgfwasxay975";
+    })
+  ];
+
   nativeBuildInputs = [
-    cmake
+    bash
     gobjectIntrospection
     libxml2
+    meson
     ninja
     pkgconfig
-    vala
+    python3
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     wrapGAppsHook
   ];
 
   buildInputs = with gnome3; [
     glib
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
     granite
     gtk3
     html2text
     libgee
     poppler
+    python2
     sqlite
     webkitgtk
   ];
 
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  # These programs are expected in PATH from the source code and scripts
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix PATH : "${stdenv.lib.makeBinPath [ unzip unar poppler_utils html2text ]}"
+      --prefix PATH : "${stdenv.lib.makeBinPath [ unzip unar poppler_utils html2text coreutils curl gnugrep ]}"
+      --prefix PATH : $out/bin
     )
+  '';
+
+  postFixup = ''
+    patchShebangs $out/share/bookworm/scripts/mobi_lib/*.py
+    patchShebangs $out/share/bookworm/scripts/tasks/*.sh
   '';
 
    meta = with stdenv.lib; {

--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -12,25 +12,27 @@
 , ninja
 , libgudev
 , libevdev
-, vala
+, libsoup
+, vala_0_40
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "spice-up-${version}";
-  version = "1.3.2";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "Philip-Scott";
     repo = "Spice-up";
     rev = version;
-    sha256 = "087cdi7na93pgz7vf046h94v5ydvpiccpwhllq85ix8g4pa5rp85";
+    sha256 = "1qb1hlw7g581dmgg5mh832ixjkcgqm3lqzj6xma2cz8wdncwwjaq";
   };
+
   USER = "nix-build-user";
 
   nativeBuildInputs = [
     pkgconfig
     wrapGAppsHook
-    vala
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     cmake
     ninja
     gettext
@@ -38,12 +40,14 @@ stdenv.mkDerivation rec {
     gobjectIntrospection # For setup hook
   ];
   buildInputs = [
-    gtk3
-    granite
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
     gnome3.libgee
+    granite
+    gtk3
     json-glib
-    libgudev
     libevdev
+    libgudev
+    libsoup
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -7,49 +7,39 @@
 , gnome3
 , cmake
 , ninja
-, vala
+, vala_0_40
 , libqalculate
 , gobjectIntrospection
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "nasc-${version}";
-  version = "0.4.7";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "parnold-x";
     repo = "nasc";
     rev = version;
-    sha256 = "0p74953pdgsijvqj3msssqiwm6sc1hzp68dlmjamqrqirwgqv5aa";
+    sha256 = "1rrp3djsv7lrgsqjn7x50msv0c5ffhz90lj1v11di0kp05m6q9j9";
   };
-
-  patches = [
-    # Install libqalculatenasc.so
-    (fetchpatch {
-      url = https://github.com/parnold-x/nasc/commit/93a799f9afb3e32f3f1a54e056b59570aae2e437.patch;
-      sha256 = "1m32w2zaswzxnzbr7p3lf8s6fac4mjvfhm8v9k59b4jyzmvrl631";
-    })
-    (fetchpatch {
-      url = https://github.com/parnold-x/nasc/commit/570b49169326de154af2cf43c5f12268fff1dc6d.patch;
-      sha256 = "1y3w6rxn0453iscx2xg427wy1bd5kv4z1c41hhbjmg614ycp6bka";
-    })
-  ];
 
   nativeBuildInputs = [
     pkgconfig
     wrapGAppsHook
-    vala
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     cmake
     ninja
     gobjectIntrospection # for setup-hook
   ];
+  
   buildInputs = [
-    libqalculate
-    gtk3
-    granite
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
+    gnome3.gtksourceview
     gnome3.libgee
     gnome3.libsoup
-    gnome3.gtksourceview
+    granite
+    gtk3
+    libqalculate
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1159,4 +1159,7 @@ self: super: {
   # https://github.com/danfran/cabal-macosx/issues/13
   cabal-macosx = dontCheck super.cabal-macosx;
 
+  # https://github.com/DanielG/cabal-helper/issues/59
+  cabal-helper = doJailbreak super.cabal-helper;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -69,6 +69,7 @@ self: super: {
   megaparsec = dontCheck (doJailbreak super.megaparsec);
   neat-interpolation = dontCheck super.neat-interpolation;  # test suite depends on broken HTF
   patience = markBrokenVersion "0.1.1" super.patience;
+  polyparse = self.polyparse_1_12_1;
   primitive = self.primitive_0_6_4_0;
   QuickCheck = self.QuickCheck_2_12_6_1;
   semigroupoids = self.semigroupoids_5_3_1;

--- a/pkgs/development/misc/avr/libc/default.nix
+++ b/pkgs/development/misc/avr/libc/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "a C runtime library for AVR microcontrollers";
     homepage = http://savannah.nongnu.org/projects/avr-libc/;
     license = licenses.bsd3;
-    platforms = platforms.all;
+    platforms = [ "avr-none" ];
     maintainers = with maintainers; [ mguentner ];
   };
 }

--- a/pkgs/development/misc/stm32/betaflight/default.nix
+++ b/pkgs/development/misc/stm32/betaflight/default.nix
@@ -32,6 +32,9 @@ in stdenv.mkDerivation rec {
   postPatch = ''
     sed -ri "s/REVISION.*=.*git log.*/REVISION = ${builtins.substring 0 10 src.rev}/" Makefile # Simulate abbrev'd rev.
     sed -ri "s/binary hex/hex/" Makefile # No need for anything besides .hex
+
+    substitutateInPlace Makefile \
+      --replace "--specs=nano.specs" ""
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/misc/stm32/inav/default.nix
+++ b/pkgs/development/misc/stm32/inav/default.nix
@@ -26,6 +26,9 @@ in stdenv.mkDerivation rec {
     sed -ri "s/REVISION.*=.*shell git.*/REVISION = ${builtins.substring 0 10 src.rev}/" Makefile # Simulate abbrev'd rev.
     sed -ri "s/-j *[0-9]+//" Makefile # Eliminate parallel build args in submakes
     sed -ri "s/binary hex/hex/" Makefile # No need for anything besides .hex
+
+    substitutateInPlace Makefile \
+      --replace "--specs=nano.specs" ""
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -226,6 +226,22 @@ rec {
           inherit doCheck doInstallCheck;
 
           inherit outputs;
+        } // lib.optionalAttrs strictDeps {
+          # Make sure "build" dependencies don’t leak into outputs. We
+          # want to disallow references to depsBuildBuild,
+          # nativeBuildInputs, and depsBuildTarget. But depsHostHost,
+          # buildInputs, and depsTargetTarget is okay, so we subtract
+          # those from disallowedReferences in case a dependency is
+          # listed in multiple dependency lists. We also include
+          # propagated dependencies here as well.
+          disallowedReferences = (attrs.disallowedReferences or [])
+          ++ (lib.subtractLists
+              (lib.concatLists ( (lib.elemAt propagatedDependencies 1) ++
+                                 (lib.elemAt dependencies 1) ++
+                                 (lib.elemAt propagatedDependencies 2) ++
+                                 (lib.elemAt dependencies 2) ) )
+              (lib.concatLists ( (lib.elemAt propagatedDependencies 0) ++
+                                 (lib.elemAt dependencies 0) ) ) );
         } // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
           cmakeFlags =
             (/**/ if lib.isString cmakeFlags then [cmakeFlags]

--- a/pkgs/tools/misc/hashit/default.nix
+++ b/pkgs/tools/misc/hashit/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, cmake, vala, python3, gnome3, gtk3, granite, gobjectIntrospection, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, cmake, vala_0_40, python3, gnome3, gtk3, granite, gobjectIntrospection, desktop-file-utils, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "hashit";
-  version = "0.2.0";
+  version = "1.0.0";
 
   name = "${pname}-${version}";
 
@@ -10,30 +10,37 @@ stdenv.mkDerivation rec {
     owner = "artemanufrij";
     repo = pname;
     rev = version;
-    sha256 = "1d2g7cm7hhs354waidak9xkhhcvqlwnsl9d0bar9p82gfnpjdg7v";
+    sha256 = "1ba38qmwdk7vkarsxqn89irbymzx52gbks4isx0klg880xm2z4dv";
   };
 
   nativeBuildInputs = [
+    desktop-file-utils
     gobjectIntrospection
     meson
     ninja
     pkgconfig
     python3
-    vala
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     wrapGAppsHook
   ];
 
   buildInputs = [
+    gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged
+    gnome3.libgee
     granite
     gtk3
-    gnome3.libgee
   ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
 
   meta = with stdenv.lib; {
     description = "A simple app for checking usual checksums";
-    homepage    = https://github.com/artemanufrij/hashit;
-    license     = licenses.gpl2Plus;
+    homepage = https://github.com/artemanufrij/hashit;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ worldofpeace ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Someone at NixCon asked why we don't disallow references to GCC by default. I thought that was a good idea but realized it could be generalized to disallowing any native build input from appearing in the outputs. With strictDeps separation of native & non-native inputs, this is pretty straightforward and pretty generalizable.

If your package does need for instance "gcc" in the output (for instance a wrapper around gcc), you just need to also list it in buildInputs & it will no longer be in disallowed references.
