### PR TITLE
dmrconfig: 2018-10-20 -> 2018-10-29

### DIFF
--- a/pkgs/applications/misc/dmrconfig/default.nix
+++ b/pkgs/applications/misc/dmrconfig/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "dmrconfig-${version}";
-  version = "2018-10-20";
+  version = "2018-10-29";
 
   src = fetchFromGitHub {
     owner = "sergev";
     repo = "dmrconfig";
-    rev = "a4c5f893d2749727493427320c7f01768966ba51";
-    sha256 = "0h7hv6fv6v5g922nvgrb0w7hsqbhaw7xmdc6vydh2p3l7sp31vg2";
+    rev = "4924d00283c3c81a4b8251669e42aecd96b6145a";
+    sha256 = "00a4hmbr71g0d4faskb8q96y6z212g2r4n533yvp88z8rq8vbxxn";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Support for more devices were added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

