### PR TITLE
crystal: fix "play" subcommand

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, makeWrapper
-, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which }:
+, boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which
+, openssl, zlib }:
 
 stdenv.mkDerivation rec {
   name = "crystal-${version}";
@@ -33,7 +34,7 @@ stdenv.mkDerivation rec {
 
   # crystal on Darwin needs libiconv to build
   libs = [
-    boehmgc libatomic_ops pcre libevent
+    boehmgc libatomic_ops pcre libevent openssl zlib
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     libiconv
   ];


### PR DESCRIPTION
(backport of commit 473c890034e8d25278a52157ce230b77c82f3116)

###### Motivation for this change
Backports https://github.com/NixOS/nixpkgs/pull/49252

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

