### PR TITLE
osmium-tool: init at 1.9.1 incl. dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -947,6 +947,11 @@
     github = "danielfullmer";
     name = "Daniel Fullmer";
   };
+  das-g = {
+    email = "nixpkgs@raphael.dasgupta.ch";
+    github = "das-g";
+    name = "Raphael Das Gupta";
+  };
   das_j = {
     email = "janne@hess.ooo";
     github = "dasJ";

--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, libosmium, protozero, boost, bzip2, zlib, expat }:
+
+stdenv.mkDerivation rec {
+  name = "osmium-tool-${version}";
+  version = "1.9.1";
+
+  src = fetchFromGitHub {
+    owner = "osmcode";
+    repo = "osmium-tool";
+    rev = "v${version}";
+    sha256 = "1cwabjbrdpqbi2gl7448sgniiwwa73avi9l6pnvh4r0jia2wi5wk";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libosmium protozero boost bzip2 zlib expat ];
+
+  meta = with stdenv.lib; {
+    description = "Multipurpose command line tool for working with OpenStreetMap data based on the Osmium library";
+    homepage = "https://osmcode.org/osmium-tool/";
+    license = with licenses; [ gpl3 mit bsd3 ];
+    maintainers = with maintainers; [ das-g ];
+  };
+}

--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, protozero, expat, zlib, bzip2, boost }:
+
+stdenv.mkDerivation rec {
+  name = "libosmium-${version}";
+  version = "2.14.2";
+
+  src = fetchFromGitHub {
+    owner = "osmcode";
+    repo = "libosmium";
+    rev = "v${version}";
+    sha256 = "123ri1l0a2b9fljgpwsl7z2w4i3kmgxz79d4ns9z4mwbp8sw0250";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ protozero zlib bzip2 expat boost ];
+
+
+  meta = with stdenv.lib; {
+    description = "Fast and flexible C++ library for working with OpenStreetMap data";
+    homepage = "https://osmcode.org/libosmium/";
+    license = licenses.boost;
+    maintainers = with maintainers; [ das-g ];
+  };
+}

--- a/pkgs/development/libraries/protozero/default.nix
+++ b/pkgs/development/libraries/protozero/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "protozero-${version}";
+  version = "1.6.3";
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = "protozero";
+    rev = "v${version}";
+    sha256 = "0lalk6hp7hqfn4fhhl2zb214idwm4y8dj32vi383arckzmsryhiw";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Minimalistic protocol buffer decoder and encoder in C++";
+    homepage = "https://github.com/mapbox/protozero";
+    license = with licenses; [ bsd2 asl20 ];
+    maintainers = with maintainers; [ das-g ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18267,6 +18267,8 @@ with pkgs;
 
   osmctools = callPackage ../applications/misc/osmctools { };
 
+  osmium-tool = callPackage ../applications/misc/osmium-tool { };
+
   owamp = callPackage ../applications/networking/owamp { };
 
   vivaldi = callPackage ../applications/networking/browsers/vivaldi {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10976,6 +10976,8 @@ with pkgs;
 
   libosip_3 = callPackage ../development/libraries/osip/3.nix {};
 
+  libosmium = callPackage ../development/libraries/libosmium { };
+
   libosmocore = callPackage ../applications/misc/libosmocore { };
 
   libosmpbf = callPackage ../development/libraries/libosmpbf {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11772,6 +11772,8 @@ with pkgs;
 
   protobufc = callPackage ../development/libraries/protobufc/1.3.nix { };
 
+  protozero = callPackage ../development/libraries/protozero { };
+
   flatbuffers = callPackage ../development/libraries/flatbuffers { };
 
   gnupth = callPackage ../development/libraries/pth { };


### PR DESCRIPTION
###### Motivation for this change

I'd like to use the osmium CLI tool for analyzing OpenStreetMap data or for preprocessing it for use in other analyzing software.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix run nixpkgs.nox -c nox-review wip --against origin/master`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note that the various [optional dependencies of libosmium](https://osmcode.org/libosmium/manual.html#extra-dependencies) aren't supported by this PR, yet.