### PR TITLE
regextester: 0.1.7 -> 1.0.1

### DIFF
--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -6,43 +6,46 @@
 , gtk3
 , granite
 , gnome3
-, cmake
+, meson
 , ninja
+, gobjectIntrospection
+, gsettings-desktop-schemas
 , vala
-, elementary-cmake-modules
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "regextester-${version}";
-  version = "0.1.7";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "artemanufrij";
     repo = "regextester";
     rev = version;
-    sha256 = "07shdm10dc7jz2hka5dc51yp81a0dgc47nmkrp6fs6r9wqx0j30n";
+    sha256 = "1xwwv1hccni1mrbl58f7ly4qfq6738vn24bcbl2q346633cd7kx3";
   };
-
-  XDG_DATA_DIRS = stdenv.lib.concatStringsSep ":" [
-    "${granite}/share"
-    "${gnome3.libgee}/share"
-  ];
 
   nativeBuildInputs = [
     pkgconfig
-    wrapGAppsHook
-    vala
-    cmake
+    meson
     ninja
     gettext
+    gobjectIntrospection
     libxml2
-    elementary-cmake-modules
+    vala
+    wrapGAppsHook
   ];
   buildInputs = [
     gtk3
     granite
+    gnome3.defaultIconTheme
+    gnome3.glib
     gnome3.libgee
+    gsettings-desktop-schemas
   ];
+
+  postInstall = ''
+    ${gnome3.glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
 
   meta = with stdenv.lib; {
     description = "A desktop application to test regular expressions interactively";

--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -3,8 +3,9 @@
 , gettext
 , libxml2
 , pkgconfig
-, gtk3
+, glib
 , granite
+, gtk3
 , gnome3
 , meson
 , ninja
@@ -35,10 +36,10 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
   ];
   buildInputs = [
-    gtk3
+    glib
     granite
+    gtk3
     gnome3.defaultIconTheme
-    gnome3.glib
     gnome3.libgee
     gsettings-desktop-schemas
   ];


### PR DESCRIPTION
* uses meson now
* crashes on start complaining schema not installed,
  so I added a postInstall that compiles the schema?
  Fixes the problem but I'm not particularly familiar
  with these bits so review appreciated.





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---