### PR TITLE
deepin-gtk-theme: 17.10.8 -> 17.10.9

### DIFF
--- a/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   name = "deepin-gtk-theme-${version}";
-  version = "17.10.8";
+  version = "17.10.9";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-gtk-theme";
     rev = version;
-    sha256 = "1z5f5dnda18gixkjcxpvsavhv9m5l2kq61958fdfm1idi0cbr7fp";
+    sha256 = "02yn76h007hlmrd7syd82f0mz1c79rlkz3gy1w17zxfy0gdvagz3";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Deepin GTK Theme";
     homepage = https://github.com/linuxdeepin/deepin-gtk-theme;
-    license = stdenv.lib.licenses.lgpl3;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version 17.10.9.

[CHANGELOG](https://github.com/linuxdeepin/deepin-gtk-theme/blob/master/CHANGELOG.md)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).