### PR TITLE
NixOS tests: Wait for shell for 10x longer (50m)

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -250,7 +250,8 @@ sub connect {
         $self->start;
 
         local $SIG{ALRM} = sub { die "timed out waiting for the VM to connect\n"; };
-        alarm 300;
+        # 50 minutes -- increased as a test, see #49441
+        alarm 3000;
         readline $self->{socket} or die "the VM quit before connecting\n";
         alarm 0;
 


### PR DESCRIPTION
###### Motivation for this change
#49384

This increases the timeout waiting for the shell to the virtual machine to connect by 10 times, to 50 minutes, in order to investigate the failures that frequently plague and block our tested set, especially the tests that have a restart incorporated (installer.*)

I have very low confidence that this is the actual issue, so it is mostly intended as a check. I find it more likely that the shell will never connect, even though the machine has finished booting, and that somehow we recently (~last month) introduced a single change that caused this, or caused this to occur much more frequently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

