### PR TITLE
Kodi v18 with InputStream Adaptive

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, fetchurl, fetchFromGitHub, unzip
 , cmake, kodiPlain, libcec_platform, tinyxml
 , steam, libusb, pcre-cpp, jsoncpp, libhdhomerun, zlib
-, python2Packages }:
+, python2Packages, expat, glib, nspr, nss }:
 
 with stdenv.lib;
 
@@ -64,7 +64,8 @@ let self = rec {
     '';
   } // args));
 
-  mkKodiABIPlugin = { plugin, namespace, version, extraBuildInputs ? [], ... }@args:
+  mkKodiABIPlugin = { plugin, namespace, version, extraBuildInputs ? [],
+    extraRuntimeDependencies ? [], extraInstallPhase ? "", ... }@args:
   toKodiPlugin (stdenv.mkDerivation (rec {
     name = "kodi-plugin-${plugin}-${version}";
 
@@ -84,6 +85,7 @@ let self = rec {
     installPhase = let n = namespace; in ''
       make install
       ln -s $out/lib/addons/${n}/${n}.so.${version} $out${pluginDir}/${n}/${n}.so.${version}
+      ${extraInstallPhase}
     '';
   } // args));
 
@@ -469,5 +471,34 @@ let self = rec {
       license = licenses.gpl3;
     };
   });
+
+  inputstream-adaptive = mkKodiABIPlugin rec {
+
+    plugin = "inputstream-adaptive";
+    namespace = "inputstream.adaptive";
+    version = "2.3.12";
+
+    src = fetchFromGitHub {
+      owner = "peak3d";
+      repo = "inputstream.adaptive";
+      rev = "${version}";
+      sha256 = "09d9b35mpaf3g5m51viyan9hv7d2i8ndvb9wm0j7rs5gwsf0k71z";
+    };
+
+    extraBuildInputs = [ expat ];
+
+    extraRuntimeDependencies = [ glib nspr nss stdenv.cc.cc.lib ];
+
+    extraInstallPhase = let n = namespace; in ''
+      ln -s $out/lib/addons/${n}/libssd_wv.so $out/${pluginDir}/${n}/libssd_wv.so
+    '';
+
+    meta = {
+      homepage = https://github.com/peak3d/inputstream.adaptive;
+      description = "Kodi inputstream addon for several manifest types";
+      platforms = platforms.all;
+      maintainers = with maintainers; [ sephalon ];
+    };
+  };
 
 }; in self

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -14,7 +14,10 @@ buildEnv {
     do
       makeWrapper ${kodi}/bin/$exe $out/bin/$exe \
         --prefix PYTHONPATH : ${kodi.pythonPackages.makePythonPath plugins} \
-        --prefix KODI_HOME : $out/share/kodi
+        --prefix KODI_HOME : $out/share/kodi \
+        --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath
+          (stdenv.lib.concatMap
+            (plugin: plugin.extraRuntimeDependencies) plugins)}"
     done
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20128,6 +20128,7 @@ in
       ++ optional (config.kodi.enablePVRHTS or false) pvr-hts
       ++ optional (config.kodi.enablePVRHDHomeRun or false) pvr-hdhomerun
       ++ optional (config.kodi.enablePVRIPTVSimple or false) pvr-iptvsimple
+      ++ optional (config.kodi.enableInputStreamAdaptive or false) inputstream-adaptive
       );
   };
 


### PR DESCRIPTION
###### Motivation for this change

My primary motivation was to get the Amazon VOD plugin with InputStream Adaptive backend up and running.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

