### PR TITLE
pythonPackages.cypari2: 1.3.1 -> 2.0.1

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -113,6 +113,20 @@ stdenv.mkDerivation rec {
       rev = "db10d327ade93711da735a599a67580524e6f7b4";
       sha256 = "09v87id25fa5r9snfn4mv79syhc77jxfawj5aizmdpwdmpgxjk1f";
     })
+
+    # https://trac.sagemath.org/ticket/26493
+    (fetchpatch {
+      name = "cypari-upgrade-dependency.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?id=e93130960a1a20112bff096f53bc48ffcdfe5ab2";
+      sha256 = "03zh5288aasy47d964rs8vhaxds397rsp85ssbbrkap8702r4bjh";
+    })
+    # https://trac.sagemath.org/ticket/26442
+    (fetchpatch {
+      name = "cypari-2.0.0.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?h=7905b39a510c2e09b1ebf0d4a11342bfe3c0d236";
+      sha256 = "0v8p5x1b6mnkb2j3a95iva9dmq4pxi154zz4nmj79dcyqi51crwm";
+      excludes = [ "build/*" ];
+    })
   ];
 
   patches = nixPatches ++ packageUpgradePatches;

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -12,11 +12,11 @@
 buildPythonPackage rec {
   pname = "cypari2";
   # upgrade may break sage, please test the sage build or ping @timokau on upgrade
-  version = "1.3.1";
+  version = "2.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04f00xp8aaz37v00iqg1mv5wjq00a5qhk8cqa93s13009s9x984r";
+    sha256 = "11nqp40nji8bz4zn7j8sbzin93l65kf8s1sc76lvbsbkswaxdyij";
   };
 
   # This differs slightly from the default python installPhase in that it pip-installs


### PR DESCRIPTION
###### Motivation for this change

cypari2 upgrade. Local checks are still running, will merge once they pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

