### PR TITLE
pythonPackages.memory_profiler: add plotting dependency, enable checks

### DIFF
--- a/pkgs/development/python-modules/memory_profiler/default.nix
+++ b/pkgs/development/python-modules/memory_profiler/default.nix
@@ -1,32 +1,28 @@
 { stdenv
-, buildPythonPackage
-, fetchPypi
-, psutil
 , python
 }:
 
-buildPythonPackage rec {
+python.pkgs.buildPythonPackage rec {
   pname = "memory_profiler";
   version = "0.54.0";
 
-  src = fetchPypi {
+  src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "d64342a23f32e105f4929b408a8b89d9222c3ce8afbbb3359817555811448d1a";
+    sha256 = "06ld8h8mhm8pk0sv7fxgx0y2q8nri65qlh4vjbs0bq9j7yi44hyn";
   };
 
-  propagatedBuildInputs = [ psutil ];
-
-  checkPhase = ''
-    make test PYTHON=${python.interpreter}
-  '';
-
-  # Tests don't import profile
-  # doCheck = false;
+  propagatedBuildInputs = with python.pkgs; [
+    psutil # needed to profile child processes
+    matplotlib # needed for plotting memory usage
+  ];
 
   meta = with stdenv.lib; {
-    description = "A module for monitoring memory usage of a python program";
+    description = "A module for monitoring memory usage of a process";
+    longDescription = ''
+      This is a python module for monitoring memory consumption of a process as
+      well as line-by-line analysis of memory consumption for python programs.
+    '';
     homepage = https://pypi.python.org/pypi/memory_profiler;
     license = licenses.bsd3;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

I still had a memory_profiler update laying around, waiting to be upstreamed. Somebody else did the update by now, but I also enabled the checks (which pass) and added a dependency necessary to produce plots.

@GrahamcOfBorg build python2Packages.memory_profiler python3Packages.memory_profiler

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

