### PR TITLE
rambox: fix crash when downloading files to disk

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, newScope, makeWrapper, electron, xdg_utils, makeDesktopItem
+{ stdenv, newScope, makeWrapper
+, wrapGAppsHook, gnome3, glib
+, electron, xdg_utils, makeDesktopItem
 , auth0ClientID ? "0spuNKfIGeLAQ_Iki9t3fGxbfJl3k8SU"
 , auth0Domain ? "nixpkgs.auth0.com" }:
 
@@ -26,16 +28,25 @@ with self;
 stdenv.mkDerivation {
   name = "rambox-${rambox-bare.version}";
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
 
+  buildInputs = [ glib gnome3.gsettings_desktop_schemas ];
   unpackPhase = ":";
 
+  dontWrapGApps = true; # we only want $gappsWrapperArgs here
+
   installPhase = ''
-    makeWrapper ${electron}/bin/electron $out/bin/rambox \
-      --add-flags "${rambox-bare} --without-update" \
-      --prefix PATH : ${xdg_utils}/bin
+    runHook preInstall
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/rambox \
+      --add-flags "${rambox-bare} --without-update" \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix PATH : ${xdg_utils}/bin
   '';
 
   inherit (rambox-bare.meta // {

--- a/pkgs/applications/networking/instant-messengers/rambox/sencha/bare.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/sencha/bare.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, gzip, which, unzip, jdk }:
 
 let
-  version = "6.5.3.6";
+  version = "6.6.0.13";
   srcs = {
     i686-linux = fetchurl {
       url = "https://cdn.sencha.com/cmd/${version}/no-jre/SenchaCmd-${version}-linux-i386.sh.zip";
-      sha256 = "0g3hk3fdgmkdsr6ck1fgsmaxa9wbj2fpk84rk382ff9ny55bbzv9";
+      sha256 = "15b197108b49mf0afpihkh3p68lxm7580zz2w0xsbahglnvhwyfz";
     };
     x86_64-linux = fetchurl {
       url = "https://cdn.sencha.com/cmd/${version}/no-jre/SenchaCmd-${version}-linux-amd64.sh.zip";
-      sha256 = "08j8gak1xsxdjgkv6s24jv97jc49pi5yf906ynjmxb27wqpxn9mz";
+      sha256 = "1cxhckmx1802p9qiw09cgb1v5f30wcvnrwkshmia8p8n0q47lpp4";
     };
   };
 in


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

