### PR TITLE
sfxr-qt: init at 1.2.0

### DIFF
--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub
+, cmake
+, qtbase, qtquickcontrols2
+, SDL
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  name = "sfxr-qt-${version}";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "agateau";
+    repo = "sfxr-qt";
+    rev = version;
+    sha256 = "1ndw1dcmzvkrc6gnb0y057zb4lqlhwrv18jlbx26w3s4xrbxqr41";
+    fetchSubmodules = true;
+  };
+  nativeBuildInputs = [
+    cmake
+    (python3.withPackages (pp: with pp; [ pyyaml jinja2 ]))
+  ];
+  buildInputs = [
+    qtbase qtquickcontrols2
+    SDL
+  ];
+  configurePhase = "cmake . -DCMAKE_INSTALL_PREFIX=$out";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/agateau/sfxr-qt;
+    description = "A sound effect generator, QtQuick port of sfxr";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18846,6 +18846,8 @@ with pkgs;
 
   setbfree = callPackage ../applications/audio/setbfree { };
 
+  sfxr-qt = libsForQt5.callPackage ../applications/audio/sfxr-qt { };
+
   shadowfox = callPackage ../tools/networking/shadowfox { };
 
   shfmt = callPackage ../tools/text/shfmt { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

