### PR TITLE
bison: 3.1 -> 3.2.1

### DIFF
--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, m4, perl, help2man }:
 
 stdenv.mkDerivation rec {
-  name = "bison-3.1";
+  name = "bison-3.2";
 
   src = fetchurl {
     url = "mirror://gnu/bison/${name}.tar.gz";
-    sha256 = "0ip9krjf0lw57pk3wfbxgjhif1i18hm3vh35d1ifrvhnafskdjx7";
+    sha256 = "0zb1nbnwcpq464r5d0fpl1mm4w98sbwv5n6l8gwyv3vhrn0jv96i";
   };
 
   patches = []; # remove on another rebuild

--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, m4, perl, help2man }:
 
 stdenv.mkDerivation rec {
-  name = "bison-3.2";
+  name = "bison-3.2.1";
 
   src = fetchurl {
     url = "mirror://gnu/bison/${name}.tar.gz";
-    sha256 = "0zb1nbnwcpq464r5d0fpl1mm4w98sbwv5n6l8gwyv3vhrn0jv96i";
+    sha256 = "1pgcvwzzlckb83sdcljz75hg71zwbc2a4pl5ycwxsxw05423gwq1";
   };
 
   patches = []; # remove on another rebuild


### PR DESCRIPTION
http://lists.gnu.org/archive/html/info-gnu/2018-10/msg00008.html


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Mass-rebuild, have not tested beyond bison -> bootstrap gcc -> bison.