### PR TITLE
clustergit: init at 2018-04-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1600,6 +1600,11 @@
     github = "globin";
     name = "Robin Gloster";
   };
+  gmarmstrong = {
+    email = "guthrie.armstrong@gmail.com";
+    github = "gmarmstrong";
+    name = "Guthrie McAfee Armstrong";
+  };
   gnidorah = {
     email = "gnidorah@yandex.com";
     github = "gnidorah";

--- a/pkgs/tools/misc/clustergit/default.nix
+++ b/pkgs/tools/misc/clustergit/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "clustergit-${version}";
+  version = "2018-04-18";
+
+  src = fetchFromGitHub {
+    owner = "mnagel";
+    repo = "clustergit";
+    rev = "0d94db95f965c0149eb8423eee991c4d18cf2d59";
+    sha256 = "10v5zq5m1mpzr1xr8y7dkxw654wl9r0hp7n64g4nbjx2ay26yyy4";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R ./clustergit $out/bin/clustergit
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mnagel/clustergit;
+    description = "Tool for running Git commands on multiple repositories at once";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.gmarmstrong ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1154,6 +1154,8 @@ with pkgs;
 
   clipster = callPackage ../tools/misc/clipster { };
 
+  clustergit = callPackage ../tools/misc/clustergit { };
+
   coprthr = callPackage ../development/libraries/coprthr {
     flex = flex_2_5_35;
   };


### PR DESCRIPTION
###### Motivation for this change

Add the [`clustergit`](https://github.com/mnagel/clustergit) command-line utility (a tool for running Git commands on multiple repositories at once) to the available packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
