### PR TITLE
pythonPackages.entrypoints: fix python2 build

### DIFF
--- a/pkgs/development/python-modules/entrypoints/default.nix
+++ b/pkgs/development/python-modules/entrypoints/default.nix
@@ -4,6 +4,7 @@
 , configparser
 , pytest
 , isPy3k
+, isPy27
 }:
 
 buildPythonPackage rec {
@@ -19,8 +20,15 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = lib.optional (!isPy3k) configparser;
 
+  # On python2 with pytest 3.9.2 (not with pytest 3.7.4) the test_bad
+  # test fails. It tests that a warning (exectly one) is thrown on a "bad"
+  # path. The pytest upgrade added some warning, resulting in two warnings
+  # being thrown.
+  # upstream: https://github.com/takluyver/entrypoints/issues/23
+  pyTestArgs = if isPy27 then "-k 'not test_bad'" else "";
+
   checkPhase = ''
-    py.test tests
+    py.test ${pyTestArgs} tests
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The recent pytest upgrade in bea4b361a0e3a21b1e9a69d56f1ebd16fb38a296
broke the test suite.

Originally part of #49446, but since it seems like that'll take a while its probably better to push this fix now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

