### PR TITLE
pbpst: init at unstable-2018-01-11

### DIFF
--- a/pkgs/applications/misc/pbpst/default.nix
+++ b/pkgs/applications/misc/pbpst/default.nix
@@ -1,0 +1,49 @@
+{ llvmPackages, stdenv, fetchFromGitHub
+, python36Packages, which, pkgconfig, curl, git, gettext, jansson
+
+# Optional overrides
+, maxFileSize ? 64 # in MB
+, provider ? "https://ptpb.pw/"
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+  version = "unstable-2018-01-11";
+  name = "pbpst-${version}";
+
+  src = fetchFromGitHub {
+    owner = "HalosGhost";
+    repo = "pbpst";
+    rev = "ecbe08a0b72a6e4212f09fc6cf52a73506992346";
+    sha256 = "0dwhmw1dg4hg75nlvk5kmvv3slz2n3b9x65q4ig16agwqfsp4mdm";
+  };
+
+  nativeBuildInputs = [
+    python36Packages.sphinx
+    which
+    pkgconfig
+    curl
+    git
+    gettext
+  ];
+  buildInputs = [ curl jansson ];
+
+  patchPhase = ''
+    patchShebangs ./configure
+
+    # Remove hardcoded check for libs in /usr/lib/
+    sed -e '64,67d' -i ./configure
+  '';
+
+  configureFlags = [
+    "--file-max=${toString (maxFileSize * 1024 * 1024)}" # convert to bytes
+    "--provider=${provider}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A command-line libcurl C client for pb deployments";
+    inherit (src.meta) homepage;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tmplt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1529,6 +1529,8 @@ with pkgs;
 
   patdiff = callPackage ../tools/misc/patdiff { };
 
+  pbpst = callPackage ../applications/misc/pbpst { };
+
   pbzx = callPackage ../tools/compression/pbzx { };
 
   pev = callPackage ../development/tools/analysis/pev { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm only unsure of two things:
* should a package from latest master HEAD be versioned with a "-git" suffix instead of a short hash?
* the code I sed out is a `for i in curl jansson; do check_file /usr/lib/lib$i; done`; should it be handled some other way?
