### PR TITLE
platformio: 3.5.3 -> 3.6.1

### DIFF
--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,17 +1,57 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, lib, buildPythonApplication, fetchFromGitHub
 , bottle, click, colorama
 , lockfile, pyserial, requests
-, semantic-version
+, pytest, semantic-version, tox
 , git
 }:
 
-buildPythonPackage rec {
-  pname = "platformio";
-  version = "3.5.3";
+let
+  args = lib.concatStringsSep " " ((map (e: "--deselect tests/${e}") [
+    "commands/test_ci.py::test_ci_boards"
+    "commands/test_ci.py::test_ci_project_conf"
+    "commands/test_ci.py::test_ci_lib_and_board"
+    "commands/test_init.py::test_init_enable_auto_uploading"
+    "commands/test_init.py::test_init_custom_framework"
+    "commands/test_init.py::test_init_incorrect_board"
+    "commands/test_init.py::test_init_ide_atom"
+    "commands/test_init.py::test_init_ide_eclipse"
+    "commands/test_init.py::test_init_duplicated_boards"
+    "commands/test_init.py::test_init_special_board"
+    "commands/test_lib.py::test_search"
+    "commands/test_lib.py::test_install_duplicates"
+    "commands/test_lib.py::test_global_lib_update_check"
+    "commands/test_lib.py::test_global_lib_update"
+    "commands/test_lib.py::test_global_lib_uninstall"
+    "commands/test_lib.py::test_lib_show"
+    "commands/test_lib.py::test_lib_stats"
+    "commands/test_lib.py::test_global_install_registry"
+    "commands/test_lib.py::test_global_install_archive"
+    "commands/test_lib.py::test_global_install_repository"
+    "commands/test_lib.py::test_global_lib_list"
+    "commands/test_test.py::test_local_env"
+    "test_builder.py::test_build_flags"
+    "test_builder.py::test_build_unflags"
+    "test_misc.py::test_api_cache"
+    "test_misc.py::test_ping_internet_ips"
+    "test_pkgmanifest.py::test_packages"
+  ]) ++ (map (e: "--ignore=tests/${e}") [
+    "commands/test_boards.py"
+    "commands/test_platform.py"
+    "commands/test_update.py"
+    "test_maintenance.py"
+    "test_ino2cpp.py"
+  ]));
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1l4s2xh1p9h767amk9zapzivz4irl2y3kff3dna6icvsgq6rz011";
+in buildPythonApplication rec {
+  pname = "platformio";
+  version = "3.6.1";
+
+  # pypi tarball doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "platformio";
+    repo = "platformio-core";
+    rev = "v${version}";
+    sha256 = "01xz9figqrzb0m9467q14lg51vmgq0hbaap0xdx08n5v2ycmzj0v";
   };
 
   propagatedBuildInputs =  [
@@ -19,12 +59,25 @@ buildPythonPackage rec {
     pyserial requests semantic-version
   ];
 
+  HOME = "/tmp";
+
+  checkInputs = [ pytest tox ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    py.test -v tests ${args}
+
+    runHook postCheck
+  '';
+
   patches = [ ./fix-searchpath.patch ];
 
   meta = with stdenv.lib; {
+    broken = stdenv.isAarch64;
     description = "An open source ecosystem for IoT development";
     homepage = http://platformio.org;
-    maintainers = with maintainers; [ mog makefu ];
     license = licenses.asl20;
+    maintainers = with maintainers; [ mog makefu ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I'll only get the chance to try this out properly on the weekend so not tested yet. It builds and runs but nothing more than ```pio --version``` and ```pio update``` has been attempted.

Cc: @makefu @mogorman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

