### PR TITLE
cmusfm: init at 2018-10-11

### DIFF
--- a/pkgs/applications/audio/cmusfm/default.nix
+++ b/pkgs/applications/audio/cmusfm/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, curl, libnotify, gdk_pixbuf }:
+
+stdenv.mkDerivation rec {
+  version = "2018-10-11";
+  name = "cmusfm-unstable-${version}";
+  src = fetchFromGitHub {
+    owner = "Arkq";
+    repo = "cmusfm";
+    rev = "ad2fd0aad3f4f1a25add1b8c2f179e8859885873";
+    sha256 = "0wpwdwgyrp64nvwc6shy0n387p31j6aw6cnmfi9x2y1jhl5hbv6b";
+  };
+  # building
+  configureFlags = [ "--enable-libnotify" ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ curl libnotify gdk_pixbuf ];
+
+  meta = with stdenv.lib; {
+    description = "Last.fm and Libre.fm standalone scrobbler for the cmus music player";
+    longDescription = ''
+      Features:
+      + Listening now notification support
+      + Off-line played track cache for later submission
+      + POSIX ERE-based file name parser
+      + Desktop notification support (optionally)
+      + Customizable scrobbling service
+      + Small memory footprint
+      Configuration:
+      + run `cmusfm init` to generate configuration file under ~/.config/cmus/cmusfm.conf
+      + Inside cmus run `:set status_display_program=cmusfm` to set up cmusfm
+    '';
+    homepage = https://github.com/Arkq/cmusfm/;
+    maintainers = with stdenv.lib.maintainers; [ CharlesHD ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16052,6 +16052,8 @@ with pkgs;
     pulseaudioSupport = config.pulseaudio or false;
   };
 
+  cmusfm = callPackage ../applications/audio/cmusfm { };
+
   cni = callPackage ../applications/networking/cluster/cni {};
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix {};
 


### PR DESCRIPTION
###### Motivation for this change
This is a program wich allows scrobbling from cmus to the audioscrobbler API of [Last.FM](https://www.last.fm/) and [Libre.FM](https://libre.fm/). I use it to keep trace of my listening habits. It may help cmus users to scrobble their songs. 

The configuration is explained in the meta.longDescription field and on [the project repository](https://github.com/Arkq/cmusfm). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

