### PR TITLE
scuttlebot: add native build dependencies

### DIFF
--- a/pkgs/development/node-packages/default-v8.nix
+++ b/pkgs/development/node-packages/default-v8.nix
@@ -82,6 +82,10 @@ nodePackages // {
     '';
   };
 
+  scuttlebot = nodePackages.scuttlebot.override {
+    buildInputs = [ pkgs.automake pkgs.autoconf nodePackages.node-gyp-build ];
+  };
+
   statsd = nodePackages.statsd.override {
     # broken with node v8, dead upstream,
     # see #45946 and https://github.com/etsy/statsd/issues/646


### PR DESCRIPTION
###### Motivation for this change

`nodePackages.scuttlebot` currently fails to build due to lack of native build dependencies, cc @cryptix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

