### PR TITLE
git-ssb: add build dependency

### DIFF
--- a/pkgs/development/node-packages/default-v8.nix
+++ b/pkgs/development/node-packages/default-v8.nix
@@ -49,6 +49,10 @@ nodePackages // {
     buildInputs = [ pkgs.phantomjs2 ];
   };
 
+  git-ssb = nodePackages.git-ssb.override {
+    buildInputs = [ nodePackages.node-gyp-build ];
+  };
+
   node-inspector = nodePackages.node-inspector.override {
     buildInputs = [ nodePackages.node-pre-gyp ];
   };


### PR DESCRIPTION
###### Motivation for this change

`nodePackages.git-ssb` currently fails to build because of a missing build dependency, cc @cryptix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

