### PR TITLE
cudatoolkit, cudnn: many updates

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -149,8 +149,7 @@ let
       };
     };
 
-in {
-
+in rec {
   cudatoolkit_6 = common {
     version = "6.0.37";
     url = "http://developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run";
@@ -199,8 +198,8 @@ in {
     gcc = gcc6;
   };
 
-  cudatoolkit_9 = common {
-    version = "9.1.85.1";
+  cudatoolkit_9_1 = common {
+    version = "9.1.85.3";
     url = "https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.85_387.26_linux";
     sha256 = "0lz9bwhck1ax4xf1fyb5nicb7l1kssslj518z64iirpy2qmwg5l4";
     runPatches = [
@@ -208,9 +207,40 @@ in {
         url = "https://developer.nvidia.com/compute/cuda/9.1/Prod/patches/1/cuda_9.1.85.1_linux";
         sha256 = "1f53ij5nb7g0vb5pcpaqvkaj1x4mfq3l0mhkfnqbk8sfrvby775g";
       })
+      (fetchurl {
+        url = "https://developer.nvidia.com/compute/cuda/9.1/Prod/patches/2/cuda_9.1.85.2_linux";
+        sha256 = "16g0w09h3bqmas4hy1m0y6j5ffyharslw52fn25gql57bfihg7ym";
+      })
+      (fetchurl {
+        url = "https://developer.nvidia.com/compute/cuda/9.1/Prod/patches/3/cuda_9.1.85.3_linux";
+        sha256 = "12mcv6f8z33z8y41ja8bv5p5iqhv2vx91mv3b5z6fcj7iqv98422";
+      })
     ];
     gcc = gcc6;
   };
 
-}
+  cudatoolkit_9_2 = common {
+    version = "9.2.148.1";
+    url = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/local_installers/cuda_9.2.148_396.37_linux";
+    sha256 = "04c6v9b50l4awsf9w9zj5vnxvmc0hk0ypcfjksbh4vnzrz14wigm";
+    runPatches = [
+      (fetchurl {
+        url = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/patches/1/cuda_9.2.148.1_linux";
+        sha256 = "1kx6l4yzsamk6q1f4vllcpywhbfr2j5wfl4h5zx8v6dgfpsjm2lw";
+      })
+    ];
+    gcc = gcc6;
+  };
 
+  cudatoolkit_9 = cudatoolkit_9_2;
+
+  cudatoolkit_10_0 = common {
+    version = "10.0.130";
+    url = "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux";
+    sha256 = "16p3bv1lwmyqpxil8r951h385sy9asc578afrc7lssa68c71ydcj";
+
+    gcc = gcc6;
+  };
+
+  cudatoolkit_10 = cudatoolkit_10_0;
+}

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,13 +1,11 @@
-{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9 }:
+{ callPackage, cudatoolkit_7, cudatoolkit_7_5, cudatoolkit_8, cudatoolkit_9_0, cudatoolkit_9_1, cudatoolkit_9_2, cudatoolkit_10_0 }:
 
 let
   generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
     inherit (args) cudatoolkit;
   };
 
-in
-
-{
+in rec {
   cudnn_cudatoolkit_7 = generic rec {
     # Old URL is v4 instead of v4.0 for some reason...
     version = "4";
@@ -38,16 +36,34 @@ in
   };
 
   cudnn_cudatoolkit_9_0 = generic rec {
-    version = "7.0.5";
+    version = "7.3.0";
     cudatoolkit = cudatoolkit_9_0;
-    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.tgz";
-    sha256 = "03mbv4m5lhwnc181xz8li067pjzzhxqbxgnrfc68dffm8xj0fghs";
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.3.0.29.tgz";
+    sha256 = "16z4vgbcmbayk4hppz0xshgs3g07blkp4j25cxcjqyrczx1r0gs0";
   };
 
-  cudnn_cudatoolkit_9 = generic rec {
-    version = "7.0.5";
-    cudatoolkit = cudatoolkit_9;
-    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.tgz";
-    sha256 = "1rfmdd2v47p83fm3sfyvik31gci0q17qs6kjng6mvcsd6akmvb8y";
+  cudnn_cudatoolkit_9_1 = generic rec {
+    version = "7.1.3";
+    cudatoolkit = cudatoolkit_9_1;
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.1.tgz";
+    sha256 = "0a0237gpr0p63s92njai0xvxmkbailzgfsvh7n9fnz0njhvnsqfx";
   };
+
+  cudnn_cudatoolkit_9_2 = generic rec {
+    version = "7.2.1";
+    cudatoolkit = cudatoolkit_9_2;
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.2.1.38.tgz";
+    sha256 = "1sf215wm6zgr17gs6sxfhw61b7a0qmcxiwhgy1b4nqdyxpqgay1y";
+  };
+
+  cudnn_cudatoolkit_9 = cudnn_cudatoolkit_9_2;
+
+  cudnn_cudatoolkit_10_0 = generic rec {
+    version = "7.3.1";
+    cudatoolkit = cudatoolkit_10_0;
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.3.1.20.tgz";
+    sha256 = "1yp35mng4ym40g5rqp63dcpa6jg4q1pnjkspnhlakzzdy8is65af";
+  };
+
+  cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_0;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2058,8 +2058,12 @@ with pkgs;
     cudatoolkit_7
     cudatoolkit_7_5
     cudatoolkit_8
+    cudatoolkit_9
     cudatoolkit_9_0
-    cudatoolkit_9;
+    cudatoolkit_9_1
+    cudatoolkit_9_2
+    cudatoolkit_10
+    cudatoolkit_10_0;
 
   cudatoolkit = cudatoolkit_9;
 
@@ -2069,7 +2073,11 @@ with pkgs;
     cudnn6_cudatoolkit_8
     cudnn_cudatoolkit_8
     cudnn_cudatoolkit_9
-    cudnn_cudatoolkit_9_0;
+    cudnn_cudatoolkit_9_0
+    cudnn_cudatoolkit_9_1
+    cudnn_cudatoolkit_9_2
+    cudnn_cudatoolkit_10
+    cudnn_cudatoolkit_10_0;
 
   cudnn = cudnn_cudatoolkit_9;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2282,20 +2282,8 @@ in {
 
   grappelli_safe = callPackage ../development/python-modules/grappelli_safe { };
 
-  pytorch = let
-    # Fails with CUDA 9.1 and GCC 6.4:
-    # https://github.com/pytorch/pytorch/issues/5831
-    # https://devtalk.nvidia.com/default/topic/1028112
-    # We should be able to remove this when CUDA 9.2 is released.
-    cudatoolkit_9 = pkgs.cudatoolkit_9.override {
-      gcc6 = pkgs.gcc5;
-    };
-  in callPackage ../development/python-modules/pytorch {
+  pytorch = callPackage ../development/python-modules/pytorch {
     cudaSupport = pkgs.config.cudaSupport or false;
-    cudatoolkit = cudatoolkit_9;
-    cudnn = pkgs.cudnn_cudatoolkit_9.override {
-      inherit cudatoolkit_9;
-    };
   };
 
   pytorchWithCuda = self.pytorch.override {


### PR DESCRIPTION
cudatoolkit_9_1: 9.1.85.1 -> 9.1.85.3
cudatoolkit_9_2: init at 9.2.148.1
cudatoolkit_9: 9.1.85.1 -> 9.2.148.1
cudatoolkit_10, cudatoolkit_10_0: init at 10.0.130

cudnn_cudatoolkit_9_0: 7.0.5 -> 7.3.0
cudnn_cudatoolkit_9_1: init at 7.1.3
cudnn_cudatoolkit_9_2: init at 7.2.1
cudnn_cudatoolkit_9: 7.0.5 (9.1) -> 7.3.1 (9.2)
cudnn_cudatoolkit_10, cudnn_cudatoolkit_10_0: init at 7.3.1

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

