### PR TITLE
beancount: fix build

### DIFF
--- a/pkgs/development/python-modules/beancount/default.nix
+++ b/pkgs/development/python-modules/beancount/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy3k
 , beautifulsoup4, bottle, chardet, dateutil
 , google_api_python_client, lxml, ply, python_magic
-, nose, requests }:
+, nose, requests, pytest }:
 
 buildPythonPackage rec {
   version = "2.1.3";
@@ -32,6 +32,7 @@ buildPythonPackage rec {
     ply
     python_magic
     requests
+    pytest
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/49483
###### Things done

Add pytest to the `propagatedBuildInputs`

I am not sure this is the right fix but it fixes building the pkg.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

