### PR TITLE
libva{,-utils}: 2.1.0 -> 2.3.0, bump vaapiIntel to 2.2.0 since no 2.3.0

### DIFF
--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner  = "01org";
     repo   = "libva-utils";
     rev    = version;
-    sha256 = "113wdmi4r0qligizj9zmd4a8ml1996x9g2zp2i4pmhb8frv9m8j2";
+    sha256 = "0k5v72prcq462x780j9vpqf4ckrpqf536z6say81wpna0l0qbd98";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -6,14 +6,14 @@
 
 stdenv.mkDerivation rec {
   name = "libva-${lib.optionalString minimal "minimal-"}${version}";
-  version = "2.1.0";
+  version = "2.3.0";
 
   # update libva-utils and vaapiIntel as well
   src = fetchFromGitHub {
     owner  = "01org";
     repo   = "libva";
     rev    = version;
-    sha256 = "1a60lrgr65hx9b2qp0gjky1298c4d4zp3ap6vnmmz850sxx5rm8w";
+    sha256 = "0zip22b5qwyjygsmrmjq62hdpl9z77d84h5hni8cn6xz5cmbw29z";
   };
 
   outputs = [ "dev" "out" ];

--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "intel-vaapi-driver-${version}";
-  inherit (libva) version;
+  version = "2.2.0"; # generally try to match libva version, but not required
 
   src = fetchFromGitHub {
     owner  = "intel";
     repo   = "intel-vaapi-driver";
     rev    = version;
-    sha256 = "15ag4al9h6b8f8sw1zpighyhsmr5qfqp1882q7r3gsh5g4cnj763";
+    sha256 = "1z8iqnswias2gph61yzyal53456y71ff98f21cs17hw4qjfkwa6k";
   };
 
   patchPhase = ''

--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, libdrm, libpciaccess, cairo, dri2proto, udev
 , libX11, libXext, libXv, libXrandr, glib, bison, libunwind, python3, kmod
-, procps, utilmacros, gnome2, openssl }:
+, procps, utilmacros, gnome2, openssl, peg }:
 
 stdenv.mkDerivation rec {
   name = "intel-gpu-tools-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig utilmacros ];
   buildInputs = [ libdrm libpciaccess cairo dri2proto udev libX11 kmod
     libXext libXv libXrandr glib bison libunwind python3 procps
-    gnome2.gtkdoc openssl ];
+    gnome2.gtkdoc openssl peg ];
 
   preConfigure = ''
     ./autogen.sh


### PR DESCRIPTION
Also, provide 'peg' dependency so intel-gpu-overlay is enabled in intel-gpu-tools.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---