### PR TITLE
libgit2: bump for bug fixes as well as security fixes

### DIFF
--- a/pkgs/development/libraries/git2/0.27.nix
+++ b/pkgs/development/libraries/git2/0.27.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.27.5";
+  version = "0.27.7";
   name = "libgit2-${version}";
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "1f6jxgw4pf6jln439v1pj8a0kgym5sq5xry8x0gq18dr5gv3wims";
+    sha256 = "1q3mp7xjpbmdsnk4sdzf2askbb4pgbxcmr1h7y7zk2738dndwkha";
   };
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation (rec {
   name = "libgit2-${version}";
-  version = "0.26.6";
+  version = "0.26.8";
   # keep the version in sync with pythonPackages.pygit2 and gnome3.libgit2-glib
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "17pjvprmdrx4h6bb1hhc98w9qi6ki7yl57f090n9kbhswxqfs7s3";
+    sha256 = "0wmjgvz8nrpk2dsn5bcc87nl0j5hb6pah2hzrj0b6jkk9mnin9fl";
   };
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];

--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, isPyPy, libgit2_0_27, six, cffi, pycparser }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, isPyPy, libgit2_0_27, six, cffi }:
 
 buildPythonPackage rec {
   pname = "pygit2";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "18x1fpmywhjjr4lvakwmy34zpxfqi8pqqj48g1wcib39lh3s7l4f";
   }) ];
 
-  propagatedBuildInputs = [ libgit2_0_27 six pycparser ] ++ lib.optional (!isPyPy) cffi;
+  propagatedBuildInputs = [ libgit2_0_27 six ] ++ lib.optional (!isPyPy) cffi;
 
   preCheck = ''
     # disable tests that require networking

--- a/pkgs/development/python-modules/pygit2/default.nix
+++ b/pkgs/development/python-modules/pygit2/default.nix
@@ -1,19 +1,25 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, isPyPy, libgit2, six, cffi }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, fetchpatch, isPyPy, libgit2_0_27, six, cffi, pycparser }:
 
 buildPythonPackage rec {
   pname = "pygit2";
-  version = "0.26.4";
+  version = "0.27.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a8a0ecce4aadac2675afa5bcda0f698bfe39ec61ac1e15b9264704d1b41bb390";
+    sha256 = "0d9bgxd6ch5jxz0j5cmx7c4kw933g8pgm2zxf3id1a6w9g2r7hpw";
   };
 
   preConfigure = lib.optionalString stdenv.isDarwin ''
-    export DYLD_LIBRARY_PATH="${libgit2}/lib"
+    export DYLD_LIBRARY_PATH="${libgit2_0_27}/lib"
   '';
 
-  propagatedBuildInputs = [ libgit2 six ] ++ lib.optional (!isPyPy) cffi;
+  patches = [ (fetchpatch {
+    name = "dont-require-old-pycparser"; # https://github.com/libgit2/pygit2/issues/819
+    url = https://github.com/libgit2/pygit2/commit/1eaba181577de206d3d43ec7886d0353fc0c9f2a.patch;
+    sha256 = "18x1fpmywhjjr4lvakwmy34zpxfqi8pqqj48g1wcib39lh3s7l4f";
+  }) ];
+
+  propagatedBuildInputs = [ libgit2_0_27 six pycparser ] ++ lib.optional (!isPyPy) cffi;
 
   preCheck = ''
     # disable tests that require networking


### PR DESCRIPTION
Bump pygit2 as well, not tested beyond building.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---