### PR TITLE
thunderbolt: cleanup

### DIFF
--- a/pkgs/os-specific/linux/thunderbolt/default.nix
+++ b/pkgs/os-specific/linux/thunderbolt/default.nix
@@ -16,22 +16,13 @@ stdenv.mkDerivation rec {
     sha256 = "02w1bfm7xvq0dzkhwqiq0camkzz9kvciyhnsis61c8vzp39cwx0x";
   };
 
-  buildInputs = [
-    boost
-    cmake
-    pkgconfig
-    txt2tags
-  ];
+  nativeBuildInputs = [ cmake pkgconfig txt2tags ];
+  buildInputs = [ boost ];
 
-  # These can't go in the normal nix cmakeFlags because $out needs to be
-  # expanded by the shell, not by cmake or nix.  $ENV{out} doesn't work right
-  # either; it results in /build/source/build//nix/store/blahblahblahblah/bin/
-  # TODO: use ${placeholder "out"} when possible.
-  #       See https://github.com/NixOS/nixpkgs/pull/37693
-  preConfigure = ''
-    cmakeFlags+=" -DUDEV_BIN_DIR=$out/bin"
-    cmakeFlags+=" -DUDEV_RULES_DIR=$out/etc/udev/rules.d"
-  '';
+  cmakeFlags = [
+    "-DUDEV_BIN_DIR=${placeholder "out"}/bin"
+    "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
+  ];
 
   meta = {
     description = "Thunderbolt(TM) user-space components";


### PR DESCRIPTION
* Use placeholder to simplify, as comments request
* categorize inputs appropriately


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---