### PR TITLE
xfce4-terminal: add missing gsettings schema dependency

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-terminal/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, gtk3, libxfce4ui, vte }:
+{ mkXfceDerivation, gtk3, libxfce4ui, wrapGAppsHook, vte }:
 
 mkXfceDerivation rec {
   category = "apps";
@@ -8,6 +8,7 @@ mkXfceDerivation rec {
   sha256 = "1s1dq560icg602jjb2ja58x7hxg4ikp3jrrf74v3qgi0ir950k2y";
 
   buildInputs = [ gtk3 libxfce4ui vte ];
+  nativeBuildInputs = [ wrapGAppsHook ];
 
   meta = {
     description = "A modern terminal emulator";


### PR DESCRIPTION
###### Motivation for this change
Currently, if you open xfce4-terminal, open "Preferences" and close the preferences window, all your xfce4-terminals will crash with the error:
`GLib-GIO-ERROR **: 18:49:55.854: No GSettings schemas are installed on the system`

This fixes that error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

