### PR TITLE
neovim: take withExtraPackages and add them to the PATH

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -12,6 +12,7 @@ let
   wrapper = {
       withPython ? true,  extraPythonPackages ? (_: []) /* the function you would have passed to python.withPackages */
     , withPython3 ? true,  extraPython3Packages ? (_: []) /* the function you would have passed to python.withPackages */
+    , withExtraPackages ? []
     , withRuby ? true
     , withPyGUI ? false
     , vimAlias ? false
@@ -50,6 +51,8 @@ let
         ++ (extraPython3PackagesFun ps)
         ++ (concatMap (f: f ps) pluginPython3Packages));
 
+  binPath = makeBinPath (withExtraPackages ++ optionals withRuby [rubyEnv]);
+
   in
   stdenv.mkDerivation {
       name = "neovim-${stdenv.lib.getVersion neovim}";
@@ -65,7 +68,8 @@ let
         --cmd \"${if withPython then "let g:python_host_prog='$out/bin/nvim-python'" else "let g:loaded_python_provider = 1"}\" \
         --cmd \"${if withPython3 then "let g:python3_host_prog='$out/bin/nvim-python3'" else "let g:loaded_python3_provider = 1"}\" \
         --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
-         ${optionalString withRuby '' --suffix PATH : ${rubyEnv}/bin --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
+        --suffix PATH : ${binPath} \
+         ${optionalString withRuby '' --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
 
       ''
       + optionalString (!stdenv.isDarwin) ''


### PR DESCRIPTION
###### Motivation for this change

I use the [vim-go](https://github.com/fatih/vim-go) plugin which depends on some Go tools such as gorename, gocode etc.. This allows me to override neovim to add packages to make available in the PATH.

I'm not sure if this is the best way, please advise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

