### PR TITLE
albert: 0.14.21 -> 0.14.22 

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -3,7 +3,7 @@
 
 let
   pname = "albert";
-  version = "0.14.21";
+  version = "0.14.22";
 in
 mkDerivation rec {
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ mkDerivation rec {
     owner  = "albertlauncher";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "16nk9krn1mwr0bh57viig9hizqyp3slna0qg7s5a736nsfxy226w";
+    sha256 = "0i9kss5szirmd0pzw3cm692kl9rhkan1zfywfqrjdf3i3b6914sg";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -48,7 +48,7 @@ mkDerivation rec {
     homepage    = https://albertlauncher.github.io/;
     description = "Desktop agnostic launcher";
     license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ericsagnes synthetica ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

