### PR TITLE
mattercontrol: init at 1.7.5

### DIFF
--- a/pkgs/applications/misc/mattercontrol/default.nix
+++ b/pkgs/applications/misc/mattercontrol/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, mono, dpkg, makeWrapper, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "MatterControl-${version}";
+  version = "1.7.5";
+  src = fetchurl {
+    url = "https://mattercontrol.appspot.com/downloads/mattercontrol-linux/release";
+    sha256 = "0jq81a1vh7zc0m5gc7mp2dcha439d56b6mma5kczjzk5k8ilqn8y";
+  };
+  nativeBuildInputs = [ dpkg makeWrapper ];
+  unpackPhase = ''
+    dpkg-deb -x $src ./
+  '';
+  installPhase = ''
+    mv usr $out
+    makeWrapper ${mono}/bin/mono $out/bin/mattercontrol \
+      --add-flags $out/lib/mattercontrol/MatterControl.exe \
+      --prefix LD_LIBRARY_PATH : ${sqlite.out}/lib
+  '';
+  meta = {
+    description = "All-in-one software package that lets you design, slice, organize, and manage your 3D prints";
+    homepage = https://www.matterhackers.com/;
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = [ stdenv.lib.maintainers.puffnfresh ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18950,6 +18950,8 @@ with pkgs;
 
   lightdm-mini-greeter = callPackage ../applications/display-managers/lightdm-mini-greeter { };
 
+  mattercontrol = callPackage ../applications/misc/mattercontrol { };
+
   slic3r = callPackage ../applications/misc/slic3r { };
 
   slic3r-prusa3d = callPackage ../applications/misc/slic3r/prusa3d.nix { };


### PR DESCRIPTION
###### Motivation for this change

Allows me to use an old 3D printer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

