### PR TITLE
hub: 2.5.1 -> 2.6.0, cleanup a bit

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hub/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "hub-${version}";
-  version = "2.5.1";
+  version = "2.6.0";
 
   goPackagePath = "github.com/github/hub";
 
@@ -10,10 +10,11 @@ buildGoPackage rec {
     owner = "github";
     repo = "hub";
     rev = "v${version}";
-    sha256 = "0a5i351v998vdwf883qhh39c15x56db01fr9hscz4ha7r9550pqg";
+    sha256 = "0hxmbpyv2yjxg4v3z50x5ikgcz7mgv5prya8jcpi277vq2s0wwa1";
   };
 
-  buildInputs = [ groff ronn ruby utillinux ] ++
+  nativeBuildInputs = [ groff ronn utillinux ];
+  buildInputs = [ ruby ] ++
     stdenv.lib.optional stdenv.isDarwin Security;
 
   postPatch = ''
@@ -29,7 +30,7 @@ buildGoPackage rec {
     install -D etc/hub.fish_completion  "$bin/share/fish/vendor_completions.d/hub.fish"
 
     make man-pages
-    cp -r share/man $bin/share/man
+    cp -vr --parents share/man/man[1-9]/*.[1-9] $bin/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
* categorize inputs appropriately
* only put man pages into share/man; previously we copied other formats
  as well as intermediate files used in man page generation.
  (which 'man' complained about but otherwise seemed to ignore)


Submitting this PR using the new version! :)


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---