### PR TITLE
eternal-terminal: 5.1.7 -> 5.1.8.

### DIFF
--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Remote shell that automatically reconnects without interrupting the session";
     license = licenses.asl20;
-    homepage = https://mistertea.github.io/EternalTCP/;
+    homepage = https://mistertea.github.io/EternalTerminal/;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.dezgeg ];
   };

--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "eternal-terminal-${version}";
-  version = "5.1.7";
+  version = "5.1.8";
 
   src = fetchFromGitHub {
     owner = "MisterTea";
     repo = "EternalTCP";
     rev = "refs/tags/et-v${version}";
-    sha256 = "17ndpkpyh8hwr6v7ac6029sja95nhn9c1g8r93g20rp0vz3r6lpa";
+    sha256 = "0fq9a1fn0c77wfpypl3z7y23gbkw295ksy97wi9lhb5zj2m3dkq0";
   };
 
   nativeBuildInputs = [ cmake ninja ];


### PR DESCRIPTION
###### Motivation for this change
Standard version bump. Briefly tested, works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

