### PR TITLE
androidsdk: Re-add emulator

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -41,10 +41,16 @@ stdenv.mkDerivation rec {
     }
     else throw "platform not ${stdenv.hostPlatform.system} supported!";
 
+  emulator = fetchurl {
+     url = "https://dl.google.com/android/repository/emulator-linux-4969155.zip";
+     sha256 = "0iw0j6j3w9zpfalsa7xq2czz4vzgq96zk2zddjhanwwx4p8fhrfd";
+  };
+
   buildCommand = ''
     mkdir -p $out/libexec
     cd $out/libexec
     unpackFile $src
+    unpackFile $emulator
     cd tools
 
     for f in monitor bin/monkeyrunner bin/uiautomatorviewer
@@ -76,13 +82,16 @@ stdenv.mkDerivation rec {
       # The emulators need additional libraries, which are dynamically loaded => let's wrap them
 
       ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        for i in emulator emulator-check
+        cd ..
+        for i in emulator/emulator* tools/emulator* emulator/qemu/linux-x86_64/qemu-system-*
         do
+            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
             wrapProgram `pwd`/$i \
               --prefix PATH : ${stdenv.lib.makeBinPath [ file glxinfo ]} \
               --suffix LD_LIBRARY_PATH : `pwd`/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \
               --suffix QT_XKB_CONFIG_ROOT : ${xkeyboardconfig}/share/X11/xkb
         done
+        cd tools
       ''}
     ''}
 


### PR DESCRIPTION
###### Motivation for this change
```
<clefru> I can't execute <nixpkgs-unstable>.androidenv.android_8_0/libexec/tools/emulator. This will give "./emulator: line 5: /nix/store/[...]-android-sdk-26.1.1/libexec/tools/.emulator-wrapped: No such file or directory". The file is clearly there however. This smells like a linker error. "ldd -d"-ing the file shows no missing dependencies. "objdump -x" shows no crazy rpath's. Running that wrapped file with LD_DEBUG=all doesn't even produce a single line of 
<clefru> output. strace-ing shows the execve call fails right there. I am bit puzzled. 
<clever> clefru: what about file on the binary?
<clefru> file-ing "/nix/store/[...]-android-sdk-26.1.1/libexec/tools/.emulator-wrapped" gives  ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.15, stripped, so I don't even have an arch mismatch
<clever> clefru: yep, its /lib64/ld-linux-x86-64.so.2 thats not found
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

