### PR TITLE
protonmail-bridge: 1.0.6-1 -> 1.1.0-1

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -2,7 +2,7 @@
   libsecret, libGL, libpulseaudio, glib, makeWrapper, makeDesktopItem }:
 
 let
-  version = "1.0.6-1";
+  version = "1.1.0-1";
 
   description = ''
     An application that runs on your computer in the background and seamlessly encrypts
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://protonmail.com/download/protonmail-bridge_${version}_amd64.deb";
-    sha256 = "1as4xdsik2w9clbrwp1k00491324cg6araz3jq2m013yg1cild28";
+    sha256 = "0l29z208krnd3dginc203m4p5dlmnxf08vpmbm9xzlckwmswizkb";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -38,10 +38,10 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/{bin,lib,share/applications}
-    # mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
+    mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
 
     cp -r usr/lib/protonmail/bridge/Desktop-Bridge{,.sh} $out/lib
-    # cp usr/share/icons/protonmail/Desktop-Bridge.svg $out/share/icons/hicolor/scalable/apps/desktop-bridge.svg
+    cp usr/share/icons/protonmail/Desktop-Bridge.svg $out/share/icons/hicolor/scalable/apps/desktop-bridge.svg
     cp ${desktopItem}/share/applications/* $out/share/applications
 
     ln -s $out/lib/Desktop-Bridge $out/bin/Desktop-Bridge


### PR DESCRIPTION
###### Motivation for this change

Update protonmail-bridge

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

