### PR TITLE
python3Packages.gplaycli: 3.21 -> 3.25

### DIFF
--- a/pkgs/development/python-modules/gplaycli/default.nix
+++ b/pkgs/development/python-modules/gplaycli/default.nix
@@ -4,18 +4,18 @@
 
 buildPythonPackage rec {
   pname = "gplaycli";
-  version = "3.21";
+  version = "3.25";
 
   src = fetchFromGitHub {
     owner = "matlink";
     repo = "gplaycli";
     rev = version;
-    sha256 = "1r5nzi9yzswam0866gypjcvv3f1rw13jwx9s49chp8byxy1dyrs2";
+    sha256 = "1rygx5cg4b1vwpkiaq6jcpbc1ly7cspslv3sy7x8n8ba61ryq6h4";
   };
 
- disabled = !isPy3k;
+  disabled = !isPy3k;
 
- propagatedBuildInputs = [ libffi pyasn1 clint ndg-httpsclient protobuf requests args gpapi pyaxmlparser ];
+  propagatedBuildInputs = [ libffi pyasn1 clint ndg-httpsclient protobuf requests args gpapi pyaxmlparser ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/matlink/gplaycli;


### PR DESCRIPTION
###### Motivation for this change

The version 3.21 isn't compatible with our currently packaged
`pythonPackages.gpapi` which is now at version 0.4.3.

See https://hydra.nixos.org/build/83154918

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

