### PR TITLE
youtube-dl: backports

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -16,29 +16,21 @@
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.09.01";
+  version = "2018.09.10";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0h8x8agl4s5cnfzwmshbcg4pxcgg3iyb86w8krs21y2k9d1ng036";
+    sha256 = "12gd84i5drc2z4wzah7r2vj8fkj9yilm7q8dm7q9n95abrdb7sh8";
   };
-
-  patches = [
-    # https://github.com/rg3/youtube-dl/pull/17464
-    (fetchpatch {
-      name = "youtube-js-player-fix.patch";
-      url = "https://github.com/rg3/youtube-dl/pull/17464/commits/6d7359775ae4eef1d1213aae81e092467a2c675c.patch";
-      sha256 = "12mwfmp7iwlawpx6r4rhz546b3anxrx6zc4nyjs8grbh5vxhj9yg";
-    })
-  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ zip ] ++ lib.optional generateManPage pandoc;
   propagatedBuildInputs = lib.optional hlsEncryptedSupport pycryptodome;
 
-  # Ensure ffmpeg is available in $PATH for post-processing & transcoding support.
-  # rtmpdump is required to download files over RTMP
-  # atomicparsley for embedding thumbnails
+  # Ensure these utilities are available in $PATH:
+  # - ffmpeg: post-processing & transcoding support
+  # - rtmpdump: download files over RTMP
+  # - atomicparsley: embedding thumbnails
   makeWrapperArgs = let
       packagesToBinPath =
         [ atomicparsley ]

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -16,11 +16,14 @@
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.10.05";
+  # The websites youtube-dl deals with are a very moving target. That means that
+  # downloads break constantly. Because of that, updates should always be backported
+  # to the latest stable release.
+  version = "2018.10.29";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1iq02kwxdgh07bf0w0fvbsjbdshs4kja35gy8m70ji9cj10l1mbw";
+    sha256 = "1ndkkpnmjdyz5gjjmvaf18761lxa2c0kypicm9bpqpaj7sdr9s27";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -16,11 +16,11 @@
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.09.10";
+  version = "2018.09.18";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "12gd84i5drc2z4wzah7r2vj8fkj9yilm7q8dm7q9n95abrdb7sh8";
+    sha256 = "0mlsdmddmyy3xaqy366k48xds14g17l81al3kglndjkbrrji63sb";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -16,11 +16,11 @@
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.09.26";
+  version = "2018.10.05";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0b26cnzdzai82d2bsy91jy1aas8m8psakdrs789xy0v4kwwgrk3n";
+    sha256 = "1iq02kwxdgh07bf0w0fvbsjbdshs4kja35gy8m70ji9cj10l1mbw";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -16,11 +16,11 @@
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.09.18";
+  version = "2018.09.26";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0mlsdmddmyy3xaqy366k48xds14g17l81al3kglndjkbrrji63sb";
+    sha256 = "0b26cnzdzai82d2bsy91jy1aas8m8psakdrs789xy0v4kwwgrk3n";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Backport the last couple youtube-dl releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

