### PR TITLE
grv: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/grv/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/grv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildGo19Package, fetchFromGitHub, curl, libgit2_0_27, ncurses, pkgconfig, readline }:
 let
-  version = "0.2.0";
+  version = "0.3.0";
 in
 buildGo19Package {
   name = "grv-${version}";
@@ -14,9 +14,13 @@ buildGo19Package {
     owner = "rgburke";
     repo = "grv";
     rev = "v${version}";
-    sha256 = "0hlqw6b51jglqzzjgazncckpgarp25ghshl0lxv1mff80jg8wd1a";
+    sha256 = "00v502mwnpv09l7fsbq3s72i5fz5dxbildwxgw0r8zzf6d54xrgl";
     fetchSubmodules = true;
   };
+
+  postPatch = ''
+    rm util/update_latest_release.go
+  '';
 
   buildFlagsArray = [ "-ldflags=" "-X main.version=${version}" ];
 


### PR DESCRIPTION
Remove 'update_latest_release.go' so we don't try to build it
since this fails due to unmet dependencies.

AFAICT this utility is only meant for developer use anyway,
and helps manage/create new github releases for the project.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---