### PR TITLE
hugo: 0.49.2 -> 0.50

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "hugo-${version}";
-  version = "0.49.2";
+  version = "0.50";
 
   goPackagePath = "github.com/gohugoio/hugo";
 
@@ -10,15 +10,8 @@ buildGoPackage rec {
     owner  = "gohugoio";
     repo   = "hugo";
     rev    = "v${version}";
-    sha256 = "0a320mv6x770vppbz0aw5ikywmy0mxqq1lhc0syp48hgg42d46is";
+    sha256 = "1shrw7pxwrz9g5x9bq6k5qvhn3fqmwznadpw7i07msh97p8b3dyn";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/gohugoio/hugo/commit/b137ad4dbd6d14d0a9af68c044aaee61f2c87fe5.diff";
-      sha256 = "0w1gpg11idqywqcpwzvx4xabn02kk8y4jmyz4h67mc3yh2dhq3ll";
-    })
-  ];
 
   goDeps = ./deps.nix;
 

--- a/pkgs/applications/misc/hugo/deps.nix
+++ b/pkgs/applications/misc/hugo/deps.nix
@@ -555,8 +555,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/spf13/jwalterweatherman";
-      rev = "4a4406e478ca";
-      sha256 = "093fmmvavv84pv4q84hav7ph3fmrq87bvspjj899q0qsx37yvdr8";
+      rev = "94f6ae3ed3bc";
+      sha256 = "1ywmkwci5zyd88ijym6f30fj5c0k2yayxarkmnazf5ybljv50q7b";
     };
   }
 
@@ -605,8 +605,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/minify";
-      rev = "v2.3.5";
-      sha256 = "0x67kgjhc6mfzjhr4xmw0j3qapzhkgwwahvv5b44rb449ml2qx5m";
+      rev = "v2.3.6";
+      sha256 = "0p4v4ab49lm5y438k5aks06fpiagbjw2j2x7i8jaa273mkgicrbb";
     };
   }
 
@@ -615,8 +615,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/parse";
-      rev = "v2.3.3";
-      sha256 = "190y2jykp8qyp6y58ky1v1fvmaqjnrsr1ksbqrrspf1gpjy69i94";
+      rev = "fced451e0bed";
+      sha256 = "1n6wcapk8xbck2zjxd4l5cgfn1v12rr7znrdpd5y2xp1nc3739c3";
     };
   }
 
@@ -625,8 +625,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/test";
-      rev = "265427085153";
-      sha256 = "1h0cmsjjia92w50dzr06c5h10zd5c7snhpixqjv94wbl7dv80yp0";
+      rev = "v1.0.0";
+      sha256 = "10vyp4bhanzg3yl9k8zqfdrxpsmx8yc53xv4lqxfymd7jjyqgssj";
     };
   }
 


### PR DESCRIPTION
###### Motivation for this change

Changelog: https://github.com/gohugoio/hugo/releases/tag/v0.50

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

