### PR TITLE
pythonPackages.pyzmq: use zeromq4

### DIFF
--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -2,7 +2,7 @@
 , fetchPypi
 , pytest
 , tornado
-, zeromq3
+, zeromq
 , py
 , python
 }:
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [  pytest tornado ];
-  buildInputs = [ zeromq3];
+  buildInputs = [ zeromq ];
   propagatedBuildInputs = [ py ];
 
   # test_socket.py seems to be hanging


### PR DESCRIPTION
###### Motivation for this change

I can't find any reason anymore to use `zeromq4`. `nix-review` shows two failures: `python3.pkgs.robotframework-tools` and `zeromq4-haskell`. Both of those also fail without this commit. I'd mark them as broken, but the first would introduce a merge conflict with #49434 and I couldn't find out where the second is actually defined.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

