### PR TITLE
hugo: remove obsolete dependencies

### DIFF
--- a/pkgs/applications/misc/hugo/deps.nix
+++ b/pkgs/applications/misc/hugo/deps.nix
@@ -1,721 +1,505 @@
 [
-
   {
     goPackagePath = "github.com/BurntSushi/locker";
     fetch = {
       type = "git";
       url = "https://github.com/BurntSushi/locker";
-      rev = "a6e239ea1c69";
+      rev = "a6e239ea1c69bff1cfdb20c4b73dadf52f784b6a";
       sha256 = "1xak4aync4klswq5217qvw191asgla51jr42y94vp109lirm5dzg";
     };
   }
-
   {
     goPackagePath = "github.com/BurntSushi/toml";
     fetch = {
       type = "git";
       url = "https://github.com/BurntSushi/toml";
-      rev = "a368813c5e64";
-      sha256 = "1sjxs2lwc8jpln80s4rlzp7nprbcljhy5mz4rf9995gq93wqnym5";
+      rev = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
     };
   }
-
   {
     goPackagePath = "github.com/PuerkitoBio/purell";
     fetch = {
       type = "git";
       url = "https://github.com/PuerkitoBio/purell";
-      rev = "v1.1.0";
-      sha256 = "0vsxyn1fbm7g873b8kf3hcsgqgncb5nmfq3zfsc35a9yhzarka91";
+      rev = "975f53781597ed779763b7b65566e74c4004d8de";
+      sha256 = "1j5l793zxrjv09z3cdgs05qn45sbhbm9njsw5cfv168x8z88pd3l";
     };
   }
-
   {
     goPackagePath = "github.com/PuerkitoBio/urlesc";
     fetch = {
       type = "git";
       url = "https://github.com/PuerkitoBio/urlesc";
-      rev = "de5bf2ad4578";
+      rev = "de5bf2ad457846296e2031421a34e2568e304e35";
       sha256 = "0n0srpqwbaan1wrhh2b7ysz543pjs1xw2rghvqyffg9l0g8kzgcw";
     };
   }
-
-  {
-    goPackagePath = "github.com/alecthomas/assert";
-    fetch = {
-      type = "git";
-      url = "https://github.com/alecthomas/assert";
-      rev = "405dbfeb8e38";
-      sha256 = "1l567pi17k593nrd1qlbmiq8z9jy3qs60px2a16fdpzjsizwqx8l";
-    };
-  }
-
   {
     goPackagePath = "github.com/alecthomas/chroma";
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/chroma";
-      rev = "v0.5.0";
-      sha256 = "150jv4vhsdi1gj3liwkgicdrwnzgv5qkq2fwznlnzf64vmfb0b9f";
+      rev = "5a473179cfe450c6d80407452c241428de387f6b";
+      sha256 = "1xj00hq8k0q506rxxz7m9ldhahm7v37nypg82041pl0k7147pcdr";
     };
   }
-
-  {
-    goPackagePath = "github.com/alecthomas/colour";
-    fetch = {
-      type = "git";
-      url = "https://github.com/alecthomas/colour";
-      rev = "60882d9e2721";
-      sha256 = "0iq566534gbzkd16ixg7fk298wd766821vvs80838yifx9yml5vs";
-    };
-  }
-
-  {
-    goPackagePath = "github.com/alecthomas/repr";
-    fetch = {
-      type = "git";
-      url = "https://github.com/alecthomas/repr";
-      rev = "117648cd9897";
-      sha256 = "05v1rgzdqc8razf702laagrvhvx68xd9yxxmzd3dyz0d6425pdrp";
-    };
-  }
-
   {
     goPackagePath = "github.com/bep/debounce";
     fetch = {
       type = "git";
       url = "https://github.com/bep/debounce";
-      rev = "v1.1.0";
+      rev = "844797fa1dd9ba969d71b62797ff19d1e49d4eac";
       sha256 = "1sh4zv0hv7f454mhzpl2mbv7ar5rm00wyy5qr78x1h84bgph87wy";
     };
   }
-
   {
     goPackagePath = "github.com/bep/gitmap";
     fetch = {
       type = "git";
       url = "https://github.com/bep/gitmap";
-      rev = "v1.0.0";
+      rev = "ecb6fe06dbfd6bb4225e7fda7dc15612ecc8d960";
       sha256 = "0zqdl5h4ayi2gi5aqf35f1sjszhbcriksm2bf84fkrg7ngr48jn6";
     };
   }
-
   {
     goPackagePath = "github.com/bep/go-tocss";
     fetch = {
       type = "git";
       url = "https://github.com/bep/go-tocss";
-      rev = "v0.5.0";
+      rev = "2abb118dc8688b6c7df44e12f4152c2bded9b19c";
       sha256 = "12q7h6nydklq4kg65kcgd85209rx7zf64ba6nf3k7y16knj4233q";
     };
   }
-
   {
     goPackagePath = "github.com/chaseadamsio/goorgeous";
     fetch = {
       type = "git";
       url = "https://github.com/chaseadamsio/goorgeous";
-      rev = "v1.1.0";
+      rev = "dcf1ef873b8987bf12596fe6951c48347986eb2f";
       sha256 = "07qdqi46klizq3wigxqbiksnlgbrdc8hvmizgzg0aas5iqy88dcb";
     };
   }
-
   {
     goPackagePath = "github.com/cpuguy83/go-md2man";
     fetch = {
       type = "git";
       url = "https://github.com/cpuguy83/go-md2man";
-      rev = "v1.0.8";
-      sha256 = "1w22dfdamsq63b5rvalh9k2y7rbwfkkjs7vm9vd4a13h2ql70lg2";
+      rev = "691ee98543af2f262f35fbb54bdd42f00b9b9cc5";
+      sha256 = "1864g10y9n6ni0p1yqjhvwyjdh0lgxnf7dlb0c4njazdg5rppww9";
     };
   }
-
   {
     goPackagePath = "github.com/danwakefield/fnmatch";
     fetch = {
       type = "git";
       url = "https://github.com/danwakefield/fnmatch";
-      rev = "cbb64ac3d964";
+      rev = "cbb64ac3d964b81592e64f957ad53df015803288";
       sha256 = "0cbf511ppsa6hf59mdl7nbyn2b2n71y0bpkzbmfkdqjhanqh1lqz";
     };
   }
-
-  {
-    goPackagePath = "github.com/davecgh/go-spew";
-    fetch = {
-      type = "git";
-      url = "https://github.com/davecgh/go-spew";
-      rev = "v1.1.1";
-      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
-    };
-  }
-
   {
     goPackagePath = "github.com/disintegration/imaging";
     fetch = {
       type = "git";
       url = "https://github.com/disintegration/imaging";
-      rev = "v1.5.0";
-      sha256 = "1laxccmzi7q51zxn81ringmdwp8iaipivrl375yc3gq56d70sp0r";
+      rev = "9458da53d1e65e098d48467a4317c403327e4424";
+      sha256 = "1b0ma9if8s892qfx5b1vjinxn00ah9vsyxijs8knkilrhf5vqcx4";
     };
   }
-
   {
     goPackagePath = "github.com/dlclark/regexp2";
     fetch = {
       type = "git";
       url = "https://github.com/dlclark/regexp2";
-      rev = "v1.1.6";
-      sha256 = "144s81ndviwhyy20ipxvvfvap8phv5p762glxrz6aqxprkxfarj5";
+      rev = "7632a260cbaf5e7594fc1544a503456ecd0827f1";
+      sha256 = "0vhp5r0ywv9p1c74fm8xzclnwx2mg9f0764b3id7a9nwh0plisx2";
     };
   }
-
   {
     goPackagePath = "github.com/eknkc/amber";
     fetch = {
       type = "git";
       url = "https://github.com/eknkc/amber";
-      rev = "cdade1c07385";
+      rev = "cdade1c073850f4ffc70a829e31235ea6892853b";
       sha256 = "152w97yckwncgw7lwjvgd8d00wy6y0nxzlvx72kl7nqqxs9vhxd9";
     };
   }
-
-  {
-    goPackagePath = "github.com/fortytw2/leaktest";
-    fetch = {
-      type = "git";
-      url = "https://github.com/fortytw2/leaktest";
-      rev = "v1.2.0";
-      sha256 = "1lf9l6zgzjbcc7hmcjhhg3blx0y8icyxvjmjqqwfbwdk502803ra";
-    };
-  }
-
   {
     goPackagePath = "github.com/fsnotify/fsnotify";
     fetch = {
       type = "git";
       url = "https://github.com/fsnotify/fsnotify";
-      rev = "v1.4.7";
-      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+      rev = "ccc981bf80385c528a65fbfdd49bf2d8da22aa23";
+      sha256 = "0hcrfmiyx27izac3v0ii0qq2kfjvhr9ma1i79hrl6a6y2ayagzz7";
     };
   }
-
+  {
+    goPackagePath = "github.com/gobuffalo/envy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobuffalo/envy";
+      rev = "e0b181c424e7ca1a36f6f2db4bdfd25ef3421e77";
+      sha256 = "1yawgabdzdvf8nbkk1n7pd4sxrjjbc10qpm30p6q3v3pnp73a0l1";
+    };
+  }
   {
     goPackagePath = "github.com/gobwas/glob";
     fetch = {
       type = "git";
       url = "https://github.com/gobwas/glob";
-      rev = "v0.2.3";
-      sha256 = "0jxk1x806zn5x86342s72dq2qy64ksb3zrvrlgir2avjhwb18n6z";
+      rev = "e7a84e9525fe90abcda167b604e483cc959ad4aa";
+      sha256 = "1v6vjklq06wqddv46ihajahaj1slv0imgaivlxr8bsx59i90js5q";
     };
   }
-
   {
     goPackagePath = "github.com/gorilla/websocket";
     fetch = {
       type = "git";
       url = "https://github.com/gorilla/websocket";
-      rev = "v1.4.0";
-      sha256 = "00i4vb31nsfkzzk7swvx3i75r2d960js3dri1875vypk3v2s0pzk";
+      rev = "483fb8d7c32fcb4b5636cd293a92e3935932e2f4";
+      sha256 = "18alxv3mjg5s6jp6yq08q89djmj9dz3d31a0fyp9zznlsqrw0va9";
     };
   }
-
   {
     goPackagePath = "github.com/hashicorp/go-immutable-radix";
     fetch = {
       type = "git";
       url = "https://github.com/hashicorp/go-immutable-radix";
-      rev = "v1.0.0";
+      rev = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5";
       sha256 = "1v3nmsnk1s8bzpclrhirz7iq0g5xxbw9q5gvrg9ss6w9crs72qr6";
     };
   }
-
-  {
-    goPackagePath = "github.com/hashicorp/go-uuid";
-    fetch = {
-      type = "git";
-      url = "https://github.com/hashicorp/go-uuid";
-      rev = "v1.0.0";
-      sha256 = "1jflywlani7583qm4ysph40hsgx3n66n5zr2k84i057fmwa1ypfy";
-    };
-  }
-
   {
     goPackagePath = "github.com/hashicorp/golang-lru";
     fetch = {
       type = "git";
       url = "https://github.com/hashicorp/golang-lru";
-      rev = "v0.5.0";
+      rev = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768";
       sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
     };
   }
-
   {
     goPackagePath = "github.com/hashicorp/hcl";
     fetch = {
       type = "git";
       url = "https://github.com/hashicorp/hcl";
-      rev = "v1.0.0";
-      sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
+      rev = "65a6292f0157eff210d03ed1bf6c59b190b8b906";
+      sha256 = "00qgmygfa4vgf9v3lpz4vp1ca1hcfcxnjqjrvp6z4jjklc8x4mqf";
     };
   }
-
-  {
-    goPackagePath = "github.com/inconshreveable/mousetrap";
-    fetch = {
-      type = "git";
-      url = "https://github.com/inconshreveable/mousetrap";
-      rev = "v1.0.0";
-      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
-    };
-  }
-
   {
     goPackagePath = "github.com/jdkato/prose";
     fetch = {
       type = "git";
       url = "https://github.com/jdkato/prose";
-      rev = "v1.1.0";
-      sha256 = "1gjqgrpc7wbqvnhgwyfhxng24qvx37qjy0x2mbikiw1vaygxqsmy";
+      rev = "a179b97cfa6fc3949fe1bcd21e01011bc17f4c2f";
+      sha256 = "0darw70dfik8sivlqakxbidcbd174g797xy9xqzp265xqh69m9a5";
     };
   }
-
   {
-    goPackagePath = "github.com/kr/pretty";
+    goPackagePath = "github.com/joho/godotenv";
     fetch = {
       type = "git";
-      url = "https://github.com/kr/pretty";
-      rev = "v0.1.0";
-      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+      url = "https://github.com/joho/godotenv";
+      rev = "c0b86d615e06d6fa5f869364d68f774ba49a86e3";
+      sha256 = "1gakzd6d73366fyw3rdnw2ldffgd8iq7vlxdkxzj5vcibz397y8b";
     };
   }
-
-  {
-    goPackagePath = "github.com/kr/pty";
-    fetch = {
-      type = "git";
-      url = "https://github.com/kr/pty";
-      rev = "v1.1.1";
-      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
-    };
-  }
-
-  {
-    goPackagePath = "github.com/kr/text";
-    fetch = {
-      type = "git";
-      url = "https://github.com/kr/text";
-      rev = "v0.1.0";
-      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
-    };
-  }
-
   {
     goPackagePath = "github.com/kyokomi/emoji";
     fetch = {
       type = "git";
       url = "https://github.com/kyokomi/emoji";
-      rev = "v1.5.1";
+      rev = "2e9a9507333f3ee28f3fab88c2c3aba34455d734";
       sha256 = "005rxyxlqcd2sfjn686xb52l11wn2w0g5jv042ka6pnsx24r812a";
     };
   }
-
-  {
-    goPackagePath = "github.com/magefile/mage";
-    fetch = {
-      type = "git";
-      url = "https://github.com/magefile/mage";
-      rev = "v1.4.0";
-      sha256 = "177hzmmzhk7bcm3jj2cj6d5l9h5ql3cikvndhk4agkslrhwr3xka";
-    };
-  }
-
   {
     goPackagePath = "github.com/magiconair/properties";
     fetch = {
       type = "git";
       url = "https://github.com/magiconair/properties";
-      rev = "v1.8.0";
+      rev = "c2353362d570a7bfa228149c62842019201cfb71";
       sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
     };
   }
-
   {
     goPackagePath = "github.com/markbates/inflect";
     fetch = {
       type = "git";
       url = "https://github.com/markbates/inflect";
-      rev = "a12c3aec81a6";
-      sha256 = "0mawr6z9nav4f5j0nmjdxg9lbfhr7wz8zi34g7b6wndmzyf8jbsd";
+      rev = "d582c680dc4d29c2279628ae00e743005bfcd4fe";
+      sha256 = "13447c10kia0nlvijwqkd0f74jcydprjqc5l88k5j963hm7k8n22";
     };
   }
-
   {
     goPackagePath = "github.com/mattn/go-isatty";
     fetch = {
       type = "git";
       url = "https://github.com/mattn/go-isatty";
-      rev = "v0.0.4";
-      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+      rev = "3fb116b820352b7f0c281308a4d6250c22d94e27";
+      sha256 = "084hplr4n4g5nvp70clljk428hc963460xz0ggcj3xdi4w7hhsvv";
     };
   }
-
   {
     goPackagePath = "github.com/mattn/go-runewidth";
     fetch = {
       type = "git";
       url = "https://github.com/mattn/go-runewidth";
-      rev = "v0.0.3";
-      sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
+      rev = "b20a3daf6a39840c202fd42cc23d53607162b045";
+      sha256 = "0crivpncmh22696d5cy7k15ll5yqfjcigk0xy73wb6g1q6vnfxs7";
     };
   }
-
   {
     goPackagePath = "github.com/miekg/mmark";
     fetch = {
       type = "git";
       url = "https://github.com/miekg/mmark";
-      rev = "v1.3.6";
-      sha256 = "0q2zrwa2vwk7a0zhmi000zpqrc01zssrj9c5n3573rg68fksg77m";
+      rev = "4a113919b52e731d8886e79b19292535937b8ce2";
+      sha256 = "1390svrqz3h052ds0jgj9bn9ll8nrriamkahrl80hdgpw0pd0b42";
     };
   }
-
   {
     goPackagePath = "github.com/mitchellh/hashstructure";
     fetch = {
       type = "git";
       url = "https://github.com/mitchellh/hashstructure";
-      rev = "v1.0.0";
+      rev = "a38c50148365edc8df43c1580c48fb2b3a1e9cd7";
       sha256 = "0zgl5c03ip2yzkb9b7fq9ml08i7j8prgd46ha1fcg8c6r7k9xl3i";
     };
   }
-
   {
     goPackagePath = "github.com/mitchellh/mapstructure";
     fetch = {
       type = "git";
       url = "https://github.com/mitchellh/mapstructure";
-      rev = "v1.0.0";
-      sha256 = "0f06q4fpzg0c370cvmpsl0iq2apl5nkbz5cd3nba5x5ysmshv1lm";
+      rev = "3536a929edddb9a5b34bd6861dc4a9647cb459fe";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
     };
   }
-
   {
     goPackagePath = "github.com/muesli/smartcrop";
     fetch = {
       type = "git";
       url = "https://github.com/muesli/smartcrop";
-      rev = "f6ebaa786a12";
-      sha256 = "0xbv5wbn0z36nkw9ay3ly6z23lpsrs0khryl1w54fz85lvwh66gp";
+      rev = "548bbf0c0965feac4997e1b51c96764f30dba677";
+      sha256 = "10ns8nvxjpykgh1rapg1pn0p3r9qvrjifw2p23yha85d9wnk8i1x";
     };
   }
-
-  {
-    goPackagePath = "github.com/nfnt/resize";
-    fetch = {
-      type = "git";
-      url = "https://github.com/nfnt/resize";
-      rev = "83c6a9932646";
-      sha256 = "005cpiwq28krbjf0zjwpfh63rp4s4is58700idn24fs3g7wdbwya";
-    };
-  }
-
   {
     goPackagePath = "github.com/nicksnyder/go-i18n";
     fetch = {
       type = "git";
       url = "https://github.com/nicksnyder/go-i18n";
-      rev = "v1.10.0";
-      sha256 = "1nlvq85c232z5yjs86pxpmkv7hk6gb5pa6j4hhzgdz85adk2ma04";
+      rev = "fc57a7d765ba8b271515d588acd2f891bdc3d070";
+      sha256 = "0fp2d9g1k67v2iznrc1n1ycafx07qxiv2f0hwll50baaw0i02q09";
     };
   }
-
   {
     goPackagePath = "github.com/olekukonko/tablewriter";
     fetch = {
       type = "git";
       url = "https://github.com/olekukonko/tablewriter";
-      rev = "d4647c9c7a84";
-      sha256 = "1274k5r9ardh1f6gsmadxmdds7zy8rkr55fb9swvnm0vazr3y01l";
+      rev = "e6d60cf7ba1f42d86d54cdf5508611c4aafb3970";
+      sha256 = "0hh95glg7d2md185r03wn52j2r33jc4zil0qvcrs66ka7bdxi7vj";
     };
   }
-
   {
     goPackagePath = "github.com/pelletier/go-toml";
     fetch = {
       type = "git";
       url = "https://github.com/pelletier/go-toml";
-      rev = "v1.2.0";
-      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
+      rev = "81a861c69d25a841d0c4394f0e6f84bc8c5afae0";
+      sha256 = "1sk301rm7rm5hfcx7z7vgask5i80wx3mhyxjr3xnm5q1rvdj6vsl";
     };
   }
-
   {
     goPackagePath = "github.com/pkg/errors";
     fetch = {
       type = "git";
       url = "https://github.com/pkg/errors";
-      rev = "v0.8.0";
-      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+      rev = "059132a15dd08d6704c67711dae0cf35ab991756";
+      sha256 = "0bxkbh2rq40kdk8i05am5np77cnskx3571v2k300j5mmj1rl1ijg";
     };
   }
-
-  {
-    goPackagePath = "github.com/pmezard/go-difflib";
-    fetch = {
-      type = "git";
-      url = "https://github.com/pmezard/go-difflib";
-      rev = "v1.0.0";
-      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
-    };
-  }
-
   {
     goPackagePath = "github.com/russross/blackfriday";
     fetch = {
       type = "git";
       url = "https://github.com/russross/blackfriday";
-      rev = "46c73eb196ba";
-      sha256 = "01z1jsdkac09cw95lqq4pahkw9xnini2mb956lvb772bby2x3dmj";
+      rev = "05f3235734ad95d0016f6a23902f06461fcf567a";
+      sha256 = "0jzbfzcywqcrnym4gxlz6nphmm1grg6wsl4f0r9x384rn83wkj7c";
     };
   }
-
-  {
-    goPackagePath = "github.com/sanity-io/litter";
-    fetch = {
-      type = "git";
-      url = "https://github.com/sanity-io/litter";
-      rev = "v1.1.0";
-      sha256 = "09nywwxxd6rmhxc7rsvs96ynjszmnvmhwr7dvh1n35hb6h9y7s2r";
-    };
-  }
-
-  {
-    goPackagePath = "github.com/sergi/go-diff";
-    fetch = {
-      type = "git";
-      url = "https://github.com/sergi/go-diff";
-      rev = "v1.0.0";
-      sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
-    };
-  }
-
   {
     goPackagePath = "github.com/shurcooL/sanitized_anchor_name";
     fetch = {
       type = "git";
       url = "https://github.com/shurcooL/sanitized_anchor_name";
-      rev = "86672fcb3f95";
+      rev = "86672fcb3f950f35f2e675df2240550f2a50762f";
       sha256 = "142m507s9971cl8qdmbcw7sqxnkgi3xqd8wzvfq15p0w7w8i4a3h";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/afero";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/afero";
-      rev = "v1.1.2";
+      rev = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd";
       sha256 = "0miv4faf5ihjfifb1zv6aia6f6ik7h1s4954kcb8n6ixzhx9ck6k";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/cast";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/cast";
-      rev = "v1.3.0";
+      rev = "8c9545af88b134710ab1cd196795e7f2388358d7";
       sha256 = "0xq1ffqj8y8h7dcnm0m9lfrh0ga7pssnn2c1dnr09chqbpn4bdc5";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/cobra";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/cobra";
-      rev = "v0.0.3";
-      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+      rev = "fe5e611709b0c57fa4a89136deaa8e1d4004d053";
+      sha256 = "1pn7g9jmhqc9yg6x02dgp4phiggnnxz8a11pv5y4vxhrvkjm6h71";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/fsync";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/fsync";
-      rev = "12a01e648f05";
+      rev = "12a01e648f05a938100a26858d2d59a120307a18";
       sha256 = "1vvbgxbbsc4mvi1axgqgn9pzjz1p495dsmwpc7mr8qxh8f6s0nhv";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/jwalterweatherman";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/jwalterweatherman";
-      rev = "94f6ae3ed3bc";
+      rev = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1";
       sha256 = "1ywmkwci5zyd88ijym6f30fj5c0k2yayxarkmnazf5ybljv50q7b";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/nitro";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/nitro";
-      rev = "24d7ef30a12d";
+      rev = "24d7ef30a12da0bdc5e2eb370a79c659ddccf0e8";
       sha256 = "143sbpx0jdgf8f8ayv51x6l4jg6cnv6nps6n60qxhx4vd90s6mib";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/pflag";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/pflag";
-      rev = "v1.0.2";
-      sha256 = "005598piihl3l83a71ahj10cpq9pbhjck4xishx1b4dzc02r9xr2";
+      rev = "082b515c9490f4eccc758469c3152b77d139f868";
+      sha256 = "03jil8szw5hsp0x4pgzdxas2njqij2466p20q1ag18lmgncjl50m";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/viper";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/viper";
-      rev = "v1.2.0";
-      sha256 = "0klv7dyllvv9jkyspy4ww5nrz24ngb3adlh884cbdjn7562bhi47";
+      rev = "62edee319679b6ceaec16de03b966102d2dea709";
+      sha256 = "182b64rih8khhh2znpfp6ka398q2hh4kc1726mm8817qrqpa0fiz";
     };
   }
-
-  {
-    goPackagePath = "github.com/stretchr/testify";
-    fetch = {
-      type = "git";
-      url = "https://github.com/stretchr/testify";
-      rev = "f2347ac6c9c9";
-      sha256 = "0ns8zc2n8gpcsd1fdaqbq7a8d939lnaxraqx5nr2fi2zdxqyh7hm";
-    };
-  }
-
   {
     goPackagePath = "github.com/tdewolff/minify";
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/minify";
-      rev = "v2.3.6";
-      sha256 = "0p4v4ab49lm5y438k5aks06fpiagbjw2j2x7i8jaa273mkgicrbb";
+      rev = "d41cfa13943e0aa7b08c15178c5e53686256e1d2";
+      sha256 = "1rwhzw61xibxmw8v91vdwdg7a8qx8cyhp34c8zhfh6rbl8jzczx2";
     };
   }
-
   {
     goPackagePath = "github.com/tdewolff/parse";
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/parse";
-      rev = "fced451e0bed";
+      rev = "fced451e0bedc5b641b8dcae76b07859e3b4adfd";
       sha256 = "1n6wcapk8xbck2zjxd4l5cgfn1v12rr7znrdpd5y2xp1nc3739c3";
     };
   }
-
-  {
-    goPackagePath = "github.com/tdewolff/test";
-    fetch = {
-      type = "git";
-      url = "https://github.com/tdewolff/test";
-      rev = "v1.0.0";
-      sha256 = "10vyp4bhanzg3yl9k8zqfdrxpsmx8yc53xv4lqxfymd7jjyqgssj";
-    };
-  }
-
   {
     goPackagePath = "github.com/wellington/go-libsass";
     fetch = {
       type = "git";
       url = "https://github.com/wellington/go-libsass";
-      rev = "615eaa47ef79";
+      rev = "615eaa47ef794d037c1906a0eb7bf85375a5decf";
       sha256 = "0imjiskn4vq7nml5jwb1scgl61jg53cfpkjnb9rsc6m8gsd8s16s";
     };
   }
-
   {
     goPackagePath = "github.com/yosssi/ace";
     fetch = {
       type = "git";
       url = "https://github.com/yosssi/ace";
-      rev = "v0.0.5";
-      sha256 = "1kbvbc56grrpnl65grygd23gyn3nkkhxdg8awhzkjmd0cvki8w1f";
+      rev = "2b21b56204aee785bf8d500c3f9dcbe3ed7d4515";
+      sha256 = "0cgpq1zdnh8l8zsn9w63asc9k7cm6k4qvjgrb4hr1106h8fjwfma";
     };
   }
-
   {
     goPackagePath = "golang.org/x/image";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/image";
-      rev = "c73c2afc3b81";
-      sha256 = "1kkafy29vz5xf6r29ghbvvbwrgjxwxvzk6dsa2qhyp1ddk6l2vkz";
+      rev = "69cc3646b96e61de0b417f4815b86c36e65783ee";
+      sha256 = "0nkywb3r0qvwkmykpswnf0svxi463ycn293y5jjididzxv9qxdp9";
     };
   }
-
   {
     goPackagePath = "golang.org/x/net";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "161cd47e91fd";
-      sha256 = "0254ld010iijygbzykib2vags1dc0wlmcmhgh4jl8iny159lhbcv";
+      rev = "c44066c5c816ec500d459a2a324a753f78531ae0";
+      sha256 = "0mgww74bl15d0jvsh4f3qr1ckjzb8icb8hn0mgs5ppa0b2fgpc4f";
     };
   }
-
   {
     goPackagePath = "golang.org/x/sync";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sync";
-      rev = "1d60e4601c6f";
+      rev = "1d60e4601c6fd243af51cc01ddf169918a5407ca";
       sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
     };
   }
-
   {
     goPackagePath = "golang.org/x/sys";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev = "d0be0721c37e";
-      sha256 = "081wyvfnlf842dqg03raxfz6lldlxpmyh1prix9lmrrm65arxb12";
+      rev = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89";
+      sha256 = "07v3l7q7y59cwvw0mc85i39v7qjcc1jh4svwi789rmrqqm5nq7q6";
     };
   }
-
   {
     goPackagePath = "golang.org/x/text";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev = "v0.3.0";
-      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+      rev = "6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2";
+      sha256 = "00mwzxly5isgf0glz7k3k2dkyqkjfc4z55qxajx4lgcp3h8xn9xj";
     };
   }
-
-  {
-    goPackagePath = "gopkg.in/check.v1";
-    fetch = {
-      type = "git";
-      url = "https://gopkg.in/check.v1";
-      rev = "788fd7840127";
-      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
-    };
-  }
-
   {
     goPackagePath = "gopkg.in/yaml.v2";
     fetch = {
       type = "git";
       url = "https://gopkg.in/yaml.v2";
-      rev = "v2.2.1";
+      rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
       sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
     };
   }


### PR DESCRIPTION
###### Motivation for this change

Hugo v0.50 was released 2 days ago. I also added myself to the maintainer list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @schneefux 
