### PR TITLE
openh264: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/libraries/openh264/default.nix
+++ b/pkgs/development/libraries/openh264/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "openh264-${version}";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "cisco";
     repo = "openh264";
     rev = "v${version}";
-    sha256 = "0ywrqni05bh925ws5fmd24bm6h9n6z2wp1q19v545v06biiwr46a";
+    sha256 = "1pl7hpk25nh7lcx1lbbv984gvnim0d6hxf4qfmrjjfjf6w37sjw4";
   };
 
   buildInputs = [ nasm ];


### PR DESCRIPTION
encoder fixes, clang compilation error for ARM

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (WSL)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - no tests present
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` - nox not compatible with WSL
- [ ] Tested execution of all binary files (usually in `./result/bin/`) - no binary
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

