### PR TITLE
simgrid: 3.20 -> 3.21

### DIFF
--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -18,13 +18,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "simgrid-${version}";
-  version = "3.20";
+  version = "3.21";
 
   src = fetchFromGitHub {
     owner = "simgrid";
     repo = "simgrid";
-    rev = "v${version}";
-    sha256 = "0xb20qhvsah2dz2hvn850i3w9a5ghsbcx8vka2ap6xsdkxf593gy";
+    rev = "v${replaceChars ["."] ["_"] version}";
+    sha256 = "1v0dwlww2wl56ms8lvg5zwffzbmz3sjzpkqc73f714mrc9g02bxs";
   };
 
   nativeBuildInputs = [ cmake perl python3 boost valgrind ]
@@ -107,6 +107,6 @@ stdenv.mkDerivation rec {
     homepage = http://simgrid.gforge.inria.fr/;
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ mickours ];
-    platforms = platforms.x86_64;
+    platforms = ["x86_64-linux"];
   };
 }


### PR DESCRIPTION
They changed the format of the git tags to use `_` instead of `.`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

