### PR TITLE
c-ares: 1.14.0 -> 1.15.0

### DIFF
--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -2,23 +2,14 @@
 
 let self =
 stdenv.mkDerivation rec {
-  name = "c-ares-1.14.0";
+  name = "c-ares-1.15.0";
 
   src = fetchurl {
     url = "https://c-ares.haxx.se/download/${name}.tar.gz";
-    sha256 = "0vnwmbvymw677k780kpb6sb8i3szdp89rzy8mz1fwg1657yw3ls5";
+    sha256 = "0lk8knip4xk6qzksdkn7085mmgm4ixfczdyyjw656c193y3rgnvc";
   };
 
-  configureFlags = if stdenv.hostPlatform.isWindows then [ "--disable-shared" "--enable-static" ] else null;
-
-  # ares_android.h header is missing
-  # see issue https://github.com/c-ares/c-ares/issues/216
-  postPatch = if stdenv.hostPlatform.isAndroid then ''
-    cp ${fetchurl {
-      url = "https://raw.githubusercontent.com/c-ares/c-ares/cares-1_14_0/ares_android.h";
-      sha256 = "1aw8y6r5c8zq6grjwf4mcm2jj35r5kgdklrp296214s1f1827ps8";
-    }} ares_android.h
-  '' else null;
+  configureFlags = stdenv.lib.optionals stdenv.hostPlatform.isWindows [ "--disable-shared" "--enable-static" ];
 
   meta = with stdenv.lib; {
     description = "A C library for asynchronous DNS requests";


### PR DESCRIPTION
###### Motivation for this change

https://c-ares.haxx.se/changelog.html#1_15_0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---