### PR TITLE
subversion_1_11: init at 1.11.0

### DIFF
--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -125,4 +125,10 @@ in {
     sha256 = "1z6r3n91a4znsh68rl3jisfr7k4faymhbpalmmvsmvsap34al3cz";
     extraBuildInputs = [ lz4 utf8proc ];
   };
+
+  subversion_1_11 = common {
+    version = "1.11.0";
+    sha256 = "0miyz3xsxxp56iczxv6yqd8p06av3vxpb5nasyg2xb3ln1247i47";
+    extraBuildInputs = [ lz4 utf8proc ];
+  };
 }

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -110,11 +110,6 @@ let
   });
 
 in {
-  subversion18 = common {
-    version = "1.8.19";
-    sha256 = "1gp6426gkdza6ni2whgifjcmjb4nq34ljy07yxkrhlarvfq6ks2n";
-  };
-
   subversion19 = common {
     version = "1.9.7";
     sha256 = "08qn94zaqcclam2spb4h742lvhxw8w5bnrlya0fm0bp17hriicf3";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19091,7 +19091,7 @@ with pkgs;
       saslSupport = false;
       sasl = cyrus_sasl;
     })
-    subversion18 subversion19 subversion_1_10 subversion_1_11;
+    subversion19 subversion_1_10 subversion_1_11;
 
   subversion = subversion_1_10;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19091,7 +19091,7 @@ with pkgs;
       saslSupport = false;
       sasl = cyrus_sasl;
     })
-    subversion18 subversion19 subversion_1_10;
+    subversion18 subversion19 subversion_1_10 subversion_1_11;
 
   subversion = subversion_1_10;
 


### PR DESCRIPTION
[Apache Subversion 1.11 Release Notes](https://subversion.apache.org/docs/release-notes/1.11.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

