### PR TITLE
rustc: build with system llvm and jemalloc

### DIFF
--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -29,7 +29,7 @@ in rec {
       ./patches/disable-test-inherit-env.patch
     ];
 
-    forceBundledLLVM = true;
+    withBundledLLVM = false;
 
     configureFlags = [ "--release-channel=stable" ];
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,9 +1,9 @@
-{ stdenv, targetPackages
+{ stdenv, targetPackages, removeReferencesTo
 , fetchurl, fetchgit, fetchzip, file, python2, tzdata, ps
 , llvm, jemalloc, ncurses, darwin, rustPlatform, git, cmake, curl
 , which, libffi, gdb
 , version
-, forceBundledLLVM ? false
+, withBundledLLVM ? false
 , src
 , configureFlags ? []
 , patches
@@ -40,7 +40,10 @@ stdenv.mkDerivation {
   # See https://github.com/NixOS/nixpkgs/pull/34227
   stripDebugList = if stdenv.isDarwin then [ "bin" ] else null;
 
-  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${llvmShared}/lib";
+  NIX_LDFLAGS =
+       # when linking stage1 libstd: cc: undefined reference to `__cxa_begin_catch'
+       optional (stdenv.isLinux && !withBundledLLVM) "--push-state --as-needed -lstdc++ --pop-state"
+    ++ optional stdenv.isDarwin "-rpath ${llvmShared}/lib";
 
   # Enable nightly features in stable compiles (used for
   # bootstrapping, see https://github.com/rust-lang/rust/pull/37265).
@@ -54,13 +57,12 @@ stdenv.mkDerivation {
   # We need rust to build rust. If we don't provide it, configure will try to download it.
   # Reference: https://github.com/rust-lang/rust/blob/master/src/bootstrap/configure.py
   configureFlags = configureFlags
-                ++ [ "--enable-local-rust" "--local-rust-root=${rustPlatform.rust.rustc}" "--enable-rpath" ]
-                ++ [ "--enable-vendor" ]
-                # ++ [ "--jemalloc-root=${jemalloc}/lib"
-                ++ [ "--default-linker=${targetPackages.stdenv.cc}/bin/cc" ]
-                ++ optional (!forceBundledLLVM) [ "--enable-llvm-link-shared" ]
-                ++ optional (targets != []) "--target=${target}"
-                ++ optional (!forceBundledLLVM) "--llvm-root=${llvmShared}";
+                ++ [ "--enable-local-rust" "--local-rust-root=${rustPlatform.rust.rustc}" "--enable-rpath"
+                     "--enable-vendor"
+                     "--jemalloc-root=${jemalloc}/lib"
+                     "--default-linker=${targetPackages.stdenv.cc}/bin/cc" ]
+                ++ optional (!withBundledLLVM) [ "--enable-llvm-link-shared" "--llvm-root=${llvmShared}" ]
+                ++ optional (targets != []) "--target=${target}";
 
   # The bootstrap.py will generated a Makefile that then executes the build.
   # The BOOTSTRAP_ARGS used by this Makefile must include all flags to pass
@@ -79,28 +81,12 @@ stdenv.mkDerivation {
   postPatch = ''
     patchShebangs src/etc
 
-    # Fix dynamic linking against llvm
-    #${optionalString (!forceBundledLLVM) ''sed -i 's/, kind = \\"static\\"//g' src/etc/mklldeps.py''}
+    ${optionalString (!withBundledLLVM) ''rm -rf src/llvm''}
+    rm -rf src/jemalloc
 
     # Fix the configure script to not require curl as we won't use it
     sed -i configure \
       -e '/probe_need CFG_CURL curl/d'
-
-    # Fix the use of jemalloc prefixes which our jemalloc doesn't have
-    # TODO: reenable if we can figure out how to get our jemalloc to work
-    #[ -f src/liballoc_jemalloc/lib.rs ] && sed -i 's,je_,,g' src/liballoc_jemalloc/lib.rs
-    #[ -f src/liballoc/heap.rs ] && sed -i 's,je_,,g' src/liballoc/heap.rs # Remove for 1.4.0+
-
-    # Disable fragile tests.
-    rm -vr src/test/run-make-fulldeps/linker-output-non-utf8 || true
-    rm -vr src/test/run-make-fulldeps/issue-26092 || true
-
-    # Remove test targeted at LLVM 3.9 - https://github.com/rust-lang/rust/issues/36835
-    rm -vr src/test/ui/run-pass/issue-36023.rs || true
-
-    # Disable test getting stuck on hydra - possible fix:
-    # https://reviews.llvm.org/rL281650
-    rm -vr src/test/ui/run-pass/issue-36474.rs || true
 
     # On Hydra: `TcpListener::bind(&addr)`: Address already in use (os error 98)'
     sed '/^ *fn fast_rebind()/i#[ignore]' -i src/libstd/net/tcp.rs
@@ -137,14 +123,14 @@ stdenv.mkDerivation {
   # ps is needed for one of the test cases
   nativeBuildInputs =
     [ file python2 ps rustPlatform.rust.rustc git cmake
-      which libffi
+      which libffi removeReferencesTo
     ]
     # Only needed for the debuginfo tests
     ++ optional (!stdenv.isDarwin) gdb;
 
-  buildInputs = [ ncurses ] ++ targetToolchains
+  buildInputs = targetToolchains
     ++ optional stdenv.isDarwin Security
-    ++ optional (!forceBundledLLVM) llvmShared;
+    ++ optional (!withBundledLLVM) llvmShared;
 
   outputs = [ "out" "man" "doc" ];
   setOutputFlags = false;
@@ -164,6 +150,12 @@ stdenv.mkDerivation {
   '';
 
   inherit doCheck;
+
+  # remove references to llvm-config in lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/librustc_codegen_llvm-llvm.so
+  # and thus a transitive dependency on ncurses
+  postInstall = ''
+    find $out/lib -name "*.so" -type f -exec remove-references-to -t ${llvmShared} '{}' '+'
+  '';
 
   configurePlatforms = [];
 

--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -1,6 +1,13 @@
-{ stdenv, fetchurl, version, sha256, ... }@args:
+{ version, sha256 }:
+{ stdenv, fetchurl,
+# By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
+# then stops downstream builds (mariadb in particular) from detecting it. This
+# option should remove the prefix and give us a working jemalloc.
+# Causes segfaults with some software (ex. rustc), but defaults to true for backward
+# compatibility. Ignored on non OSX.
+stripPrefix ? true }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "jemalloc-${version}";
   inherit version;
 
@@ -9,10 +16,8 @@ stdenv.mkDerivation (rec {
     inherit sha256;
   };
 
-  # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
-  # then stops downstream builds (mariadb in particular) from detecting it. This
-  # option should remove the prefix and give us a working jemalloc.
-  configureFlags = stdenv.lib.optional stdenv.isDarwin "--with-jemalloc-prefix=";
+  # see the comment on stripPrefix
+  configureFlags = stdenv.lib.optional (stdenv.isDarwin && stripPrefix) "--with-jemalloc-prefix=";
   doCheck = true;
 
   enableParallelBuilding = true;
@@ -28,4 +33,4 @@ stdenv.mkDerivation (rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ wkennington ];
   };
-} // (builtins.removeAttrs args [ "stdenv" "fetchurl" "version" "sha256" ]))
+}

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchurl, fetchpatch }:
 import ./common.nix {
-  inherit stdenv fetchurl;
   version = "5.1.0";
   sha256 = "0s3jpcyhzia8d4k0xyc67is78kg416p9yc3c2f9w6fhhqqffd5jk";
 }

--- a/pkgs/development/libraries/jemalloc/jemalloc450.nix
+++ b/pkgs/development/libraries/jemalloc/jemalloc450.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchurl }:
 import ./common.nix {
-  inherit stdenv fetchurl;
   version = "4.5.0";
   sha256 = "10373xhpc10pgmai9fkc1z0rs029qlcb3c0qfnvkbwdlcibdh2cl";
-}
+} 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7324,6 +7324,7 @@ with pkgs;
   # For beta and nightly releases use the nixpkgs-mozilla overlay
   rust = callPackage ../development/compilers/rust ({
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+    llvm = llvm_7;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });


### PR DESCRIPTION
###### Motivation for this change

We can use our llvm instead of the bundled one, just like fedora does: https://src.fedoraproject.org/rpms/rust/blob/master/f/rust.spec

The closure size goes down a little: 780MB -> 740MB, but now part of this closure is llvm and can be shared. This also benefits compilation time.

The commit also includes some cleanup of tests which no longer exist and don't need to be removed.

I tested compilation of alacritty, firefox, thunderbird and ripgrep on x86_64-linux. (on top of master, 9f8828286212d8ce7b0fb3578c5f209c434dc60a)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

