### PR TITLE
[18.09] ntp: fix ntpd shutdown by using upstream patch

### DIFF
--- a/pkgs/tools/networking/ntp/seccomp.patch
+++ b/pkgs/tools/networking/ntp/seccomp.patch
@@ -1,7 +1,18 @@
-diff -urN ntp-4.2.8p10.orig/ntpd/ntpd.c ntp-4.2.8p10/ntpd/ntpd.c
---- ntp-4.2.8p10.orig/ntpd/ntpd.c	2017-04-02 20:21:17.371319663 +0200
-+++ ntp-4.2.8p10/ntpd/ntpd.c	2017-04-02 21:26:02.766178723 +0200
-@@ -1157,10 +1157,12 @@
+From 881e427f3236046466bdb8235edf86e6dfa34391 Mon Sep 17 00:00:00 2001
+From: Michael Bishop <cleverca22@gmail.com>
+Date: Mon, 11 Jun 2018 08:30:48 -0300
+Subject: [PATCH] fix the seccomp filter to include a few previously missed
+ syscalls
+
+---
+ ntpd/ntpd.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/ntpd/ntpd.c b/ntpd/ntpd.c
+index 2c7f02ec5..4c59dc2ba 100644
+--- a/ntpd/ntpd.c
++++ b/ntpd/ntpd.c
+@@ -1140,10 +1140,12 @@ int scmp_sc[] = {
  	SCMP_SYS(close),
  	SCMP_SYS(connect),
  	SCMP_SYS(exit_group),
@@ -14,15 +25,16 @@ diff -urN ntp-4.2.8p10.orig/ntpd/ntpd.c ntp-4.2.8p10/ntpd/ntpd.c
  	SCMP_SYS(getsockname),
  	SCMP_SYS(ioctl),
  	SCMP_SYS(lseek),
-@@ -1179,6 +1181,7 @@
+@@ -1162,6 +1164,8 @@ int scmp_sc[] = {
  	SCMP_SYS(sendto),
  	SCMP_SYS(setitimer),
  	SCMP_SYS(setsid),
-+        SCMP_SYS(setsockopt),
++	SCMP_SYS(setsockopt),
++	SCMP_SYS(openat),
  	SCMP_SYS(socket),
  	SCMP_SYS(stat),
  	SCMP_SYS(time),
-@@ -1195,9 +1198,11 @@
+@@ -1178,9 +1182,11 @@ int scmp_sc[] = {
  	SCMP_SYS(clock_settime),
  	SCMP_SYS(close),
  	SCMP_SYS(exit_group),
@@ -34,12 +46,12 @@ diff -urN ntp-4.2.8p10.orig/ntpd/ntpd.c ntp-4.2.8p10/ntpd/ntpd.c
  	SCMP_SYS(madvise),
  	SCMP_SYS(mmap),
  	SCMP_SYS(mmap2),
-@@ -1211,6 +1216,8 @@
+@@ -1194,6 +1200,8 @@ int scmp_sc[] = {
  	SCMP_SYS(select),
  	SCMP_SYS(setitimer),
  	SCMP_SYS(setsid),
-+        SCMP_SYS(setsockopt),
-+        SCMP_SYS(openat),
++	SCMP_SYS(setsockopt),
++	SCMP_SYS(openat),
  	SCMP_SYS(sigprocmask),
  	SCMP_SYS(sigreturn),
  	SCMP_SYS(socketcall),


### PR DESCRIPTION
After a series of amendments the seccomp.patch made ntpd work properly
but only on 32-bit systems.
This commit replaces that patch with the one submitted upstream by
cleverca22 and that fixes the issue also on 64-bit systems.

(cherry picked from commit 6759b7900eac5782f511a8161bd680ffd263b996)

###### Motivation for this change

Backport of #49562 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

