### PR TITLE
androidenv.androidsdk: patch x64 interpreter path of emulator{,-check}

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -73,11 +73,12 @@ stdenv.mkDerivation rec {
         --prefix PATH : ${jdk}/bin \
         --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
 
-      # The emulators need additional libraries, which are dynamically loaded => let's wrap them
 
       ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
         for i in emulator emulator-check
         do
+            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
+            # The emulators need additional libraries, which are dynamically loaded => let's wrap them
             wrapProgram `pwd`/$i \
               --prefix PATH : ${stdenv.lib.makeBinPath [ file glxinfo ]} \
               --suffix LD_LIBRARY_PATH : `pwd`/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \


### PR DESCRIPTION
Currently the `emulator` and `emulator-check` binaries error with the message `No such file or directory`, due to a hard-coded interpreter path:

```
.emulator-wrapped:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.15, stripped
```



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - ~[ ] macOS~ (changes only effect x86-64 linux)
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---