### PR TITLE
fetchgit: extraConfig, allowing extra git configuration.

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -20,6 +20,8 @@ in
   # successfully. This can do things like check or transform the file.
   postFetch ? ""
 , preferLocalBuild ? true
+, # Extra configuration appended to the repo's local configuration file.
+  extraConfig ? ""
 }:
 
 /* NOTE:
@@ -59,7 +61,7 @@ stdenvNoCC.mkDerivation {
   outputHashMode = "recursive";
   outputHash = sha256;
 
-  inherit url rev leaveDotGit fetchSubmodules deepClone branchName postFetch;
+  inherit url rev leaveDotGit fetchSubmodules deepClone branchName postFetch extraConfig;
 
   GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -207,6 +207,9 @@ clone(){
     # Initialize the repository.
     init_remote "$url"
 
+    # Append extra config.
+    echo "${extraConfig}" >> .git/config
+
     # Download data from the repository.
     checkout_ref "$hash" "$ref" ||
     checkout_hash "$hash" "$ref" || (


### PR DESCRIPTION
###### Motivation for this change
This adds an extra parameter `extraConfig` to `fetchgit`, allowing extra contents to be appended to `.git/config` before fetching. This is useful in some circumstances; in particular I added this because I'm using an upstream repo that requires `[url "..."]` sections in my local git config for submodules to be cloned correctly.

This shouldn't impact any of the existing `fetchgit` call sites, but is something others may find useful.

I'm no expert on the caveats of bash, so I'm not sure if there's a safer/better way to append to the config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

