### PR TITLE
bump: pythonPackages.simanneal, fastjet, herwig

### DIFF
--- a/pkgs/development/libraries/physics/fastjet/default.nix
+++ b/pkgs/development/libraries/physics/fastjet/default.nix
@@ -2,20 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "fastjet-${version}";
-  version = "3.3.1";
+  version = "3.3.2";
 
   src = fetchurl {
     url = "http://fastjet.fr/repo/fastjet-${version}.tar.gz";
-    sha256 = "0lvchyh9q2p8lb10isazw0wbwzs24yg7gxyhpj9xpvz5hydyvgvn";
+    sha256 = "1hk3k7dyik640dzg21filpywc2dl862nl2hbpg384hf5pw9syn9z";
   };
 
   buildInputs = [ python2 ];
-
-  postPatch = ''
-    substituteInPlace plugins/SISCone/SISConeBasePlugin.cc \
-      --replace 'structure_of<UserScaleBase::StructureType>()' \
-                'structure_of<UserScaleBase>()'
-  '';
 
   configureFlags = [
     "--enable-allcxxplugins"

--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     homepage    = https://herwig.hepforge.org/;
     platforms   = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ veprbl ];
+    broken      = stdenv.isAarch64; # doesn't compile: ignoring return value of 'FILE* freopen...
   };
 }

--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "herwig-${version}";
-  version = "7.1.3";
+  version = "7.1.4";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/herwig/Herwig-${version}.tar.bz2";
-    sha256 = "1iq1h5ap86729c4pfkswzfh0l2v20fyvqsb15c35g0407l54wfqm";
+    sha256 = "1awr1jz0q873x8bgwiilzklhk1zkgm6slvpychpnvsf9vk05mmdx";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];

--- a/pkgs/development/libraries/physics/thepeg/default.nix
+++ b/pkgs/development/libraries/physics/thepeg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "thepeg-${version}";
-  version = "2.1.3";
+  version = "2.1.4";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/thepeg/ThePEG-${version}.tar.bz2";
-    sha256 = "030wpk78mwb56iph5iqmblsxgzpydsa25bbkv07bihihfm8gds0n";
+    sha256 = "1x9dfxmsbmzmsxrv3cczfyrnqkxjcpy89v6v7ycysrx9k8qkf320";
   };
 
   buildInputs = [ boost fastjet gsl hepmc lhapdf rivet zlib ];

--- a/pkgs/development/python-modules/simanneal/default.nix
+++ b/pkgs/development/python-modules/simanneal/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "simanneal";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "perrygeo";
     repo = "simanneal";
     rev = version;
-    sha256 = "12499wvf7ii7cy8z2f1d472p7q9napg1lj0h9xx8l1mbr1hjlp3q";
+    sha256 = "0p75da4nbk6iy16aahl0ilqg605jrr6aa1pzfyd9hc7ak2vs6840";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change

Bump some of the packages I maintain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

