### PR TITLE
brightnessctl: fix udev and clean unnecessary make flags

### DIFF
--- a/pkgs/misc/brightnessctl/default.nix
+++ b/pkgs/misc/brightnessctl/default.nix
@@ -11,20 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "1n1gb8ldgqv3vs565yhk1w4jfvrviczp94r8wqlkv5q6ab43c8w9";
   };
 
-  makeFlags = [ "MODE=0755" "PREFIX=" "DESTDIR=$(out)" ];
-  installTargets = [ "install" "install_udev_rules" ];
+  makeFlags = [ "PREFIX=" "DESTDIR=$(out)" ];
 
   postPatch = ''
     substituteInPlace 90-brightnessctl.rules --replace /bin/ ${coreutils}/bin/
-    substituteInPlace 90-brightnessctl.rules --replace %k '*'
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://github.com/Hummer12007/brightnessctl";
-    maintainers = [ stdenv.lib.maintainers.Dje4321 ];
-    license = stdenv.lib.licenses.mit;
     description = "This program allows you read and control device brightness";
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ megheaiulian ];
+    platforms = platforms.linux;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
The Makefile of the package now installs udev rules file correctly by default and so additional flags are not needed.  Also the `--replace %k '*'` breaks the udev permissions.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

