### PR TITLE
libid3tag: patch CVE-2017-11550 and CVE-2017-11551

### DIFF
--- a/pkgs/development/libraries/libid3tag/CVE-2017-11550-and-CVE-2017-11551.patch
+++ b/pkgs/development/libraries/libid3tag/CVE-2017-11550-and-CVE-2017-11551.patch
@@ -1,0 +1,13 @@
+Common subdirectories: libid3tag-0.15.1b/msvc++ and libid3tag-0.15.1b-patched/msvc++
+diff -uwp libid3tag-0.15.1b/utf16.c libid3tag-0.15.1b-patched/utf16.c
+--- libid3tag-0.15.1b/utf16.c	2004-01-23 10:41:32.000000000 +0100
++++ libid3tag-0.15.1b-patched/utf16.c	2018-11-01 13:12:00.866050641 +0100
+@@ -250,6 +250,8 @@ id3_ucs4_t *id3_utf16_deserialize(id3_by
+   id3_ucs4_t *ucs4;
+ 
+   end = *ptr + (length & ~1);
++  if (end == *ptr)
++    return 0;
+ 
+   utf16 = malloc((length / 2 + 1) * sizeof(*utf16));
+   if (utf16 == 0)

--- a/pkgs/development/libraries/libid3tag/default.nix
+++ b/pkgs/development/libraries/libid3tag/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ zlib gperf ];
 
-  patches = [ ./debian-patches.patch ];
+  patches = [
+    ./debian-patches.patch
+    ./CVE-2017-11550-and-CVE-2017-11551.patch
+  ];
 
   preConfigure = ''
     configureFlagsArray+=(


### PR DESCRIPTION
###### Motivation for this change
cc #47122 

Fixes:
- CVE-2017-11550 
- CVE-2017-11551

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

