### PR TITLE
uriparser: 0.9.0 backport to 18.09

### DIFF
--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -1,13 +1,13 @@
 { stdenv, cmake, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   name = "gtest-${version}";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "googletest";
     rev = "release-${version}";
-    sha256 = "0bjlljmbf8glnd9qjabx73w6pd7ibv43yiyngqvmvgxsabzr8399";
+    sha256 = "0270msj6n7mggh4xqqjp54kswbl7mkcc8px1p5dqdpmw5ngh9fzk";
   };
 
   buildInputs = [ cmake ];

--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchFromGitHub }:
+{ stdenv, cmake, ninja, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   name = "gtest-${version}";
   version = "1.8.1";
@@ -10,24 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0270msj6n7mggh4xqqjp54kswbl7mkcc8px1p5dqdpmw5ngh9fzk";
   };
 
-  buildInputs = [ cmake ];
-
-  configurePhase = ''
-    mkdir build
-    cd build
-    cmake ../ -DCMAKE_INSTALL_PREFIX=$out
-  '';
-
-  installPhase = ''
-    mkdir -p $out/lib
-    cp -v googlemock/gtest/libgtest.a googlemock/gtest/libgtest_main.a googlemock/libgmock.a googlemock/libgmock_main.a $out/lib
-    ln -s $out/lib/libgmock.a $out/lib/libgoogletest.a
-    mkdir -p $out/include
-    cp -v -r ../googlemock/include/gmock $out/include
-    cp -v -r ../googletest/include/gtest $out/include
-    mkdir -p $out/src
-    cp -v -r ../googlemock/src/* ../googletest/src/* $out/src
-  '';
+  nativeBuildInputs = [ cmake ninja ];
 
   meta = with stdenv.lib; {
     description = "Google's framework for writing C++ tests";

--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, cpptest, pkgconfig, doxygen, graphviz }:
+{ stdenv, fetchurl, gtest, pkgconfig, doxygen, graphviz }:
 
 stdenv.mkDerivation rec {
   name = "uriparser-${version}";
-  version = "0.8.6";
+  version = "0.9.0";
 
   # Release tarball differs from source tarball
   src = fetchurl {
     url = "https://github.com/uriparser/uriparser/releases/download/${name}/${name}.tar.bz2";
-    sha256 = "0m2a5bf5b00ybagxmsa8mdj9mhc62vcm0qimy1ivfza1fbjsf287";
+    sha256 = "0b2yagxzhq9ghpszci6a9xlqg0yl7vq9j5r8dwbar3nszqsfnrzc";
   };
 
-  nativeBuildInputs = [ pkgconfig cpptest doxygen graphviz ];
+  nativeBuildInputs = [ pkgconfig gtest doxygen graphviz ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change
Backport request for #49274 

cc @jtojnar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

