### PR TITLE
leveldb: 1.18 -> 1.20

### DIFF
--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "leveldb-${version}";
-  version = "1.18";
+  version = "1.20";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "leveldb";
     rev = "v${version}";
-    sha256 = "1bnsii47vbyqnbah42qgq6pbmmcg4k3fynjnw7whqfv6lpdgmb8d";
+    sha256 = "01kxga1hv4wp94agx5vl3ybxfw5klqrdsrb6p6ywvnjmjxm8322y";
   };
 
   buildPhase = ''
-    make all leveldbutil libmemenv.a
+    make all
   '';
 
   installPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
-    for file in *.dylib*; do
+    for file in out-shared/*.dylib*; do
       install_name_tool -id $out/lib/$file $file
     done
   '') + # XXX consider removing above after transition to cmake in the next release
@@ -27,9 +27,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/include/leveldb/helpers
     cp helpers/memenv/memenv.h $out/include/leveldb/helpers
 
-    cp lib* $out/lib
+    cp out-shared/lib* $out/lib
+    cp out-static/lib* $out/lib
 
-    cp leveldbutil $out/bin
+    cp out-static/leveldbutil $out/bin
   ";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Changelog:

1.20: https://github.com/google/leveldb/releases/tag/v1.20
1.19: https://github.com/google/leveldb/releases/tag/v1.19

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

