### PR TITLE
lib/system: More Types of CPUs Added

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -112,11 +112,26 @@ rec {
     config = "aarch64-none-elf";
     libc = "newlib";
   };
+  
+  aarch64be-embedded = {
+    config = "aarch64_be-none-elf";
+    libc = "newlib";
+  }
 
   ppc-embedded = {
     config = "powerpc-none-eabi";
     libc = "newlib";
   };
+  
+  ppcle-embedded = {
+    config = "powerpcle-none-eabi";
+    libc = "newlib";
+  };
+  
+  alpha-embedded = {
+    config = "alpha-elf";
+    libc = "newlib";
+  }
 
   i686-embedded = {
     config = "i686-elf";

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -116,7 +116,7 @@ rec {
   aarch64be-embedded = {
     config = "aarch64_be-none-elf";
     libc = "newlib";
-  }
+  };
 
   ppc-embedded = {
     config = "powerpc-none-eabi";
@@ -131,7 +131,7 @@ rec {
   alpha-embedded = {
     config = "alpha-elf";
     libc = "newlib";
-  }
+  };
 
   i686-embedded = {
     config = "i686-elf";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -104,7 +104,7 @@ rec {
     wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
     wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
     
-    alpha    = { bits = 64; significantBye = littleEndian; family = "alpha"; };
+    alpha    = { bits = 64; significantByte = littleEndian; family = "alpha"; };
 
     avr      = { bits = 8; family = "avr"; };
   };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -80,7 +80,7 @@ rec {
     armv8r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
     armv8m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
     aarch64  = { bits = 64; significantByte = littleEndian; family = "arm"; version = "8"; };
-    aarch64_be = { bits = 64; significantByte = bigEndian; family = "arm" version = "8"; };
+    aarch64_be = { bits = 64; significantByte = bigEndian; family = "arm"; version = "8"; };
 
     i686     = { bits = 32; significantByte = littleEndian; family = "x86"; };
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -80,6 +80,7 @@ rec {
     armv8r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
     armv8m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
     aarch64  = { bits = 64; significantByte = littleEndian; family = "arm"; version = "8"; };
+    aarch64_be = { bits = 64; significantByte = bigEndian; family = "arm" version = "8"; };
 
     i686     = { bits = 32; significantByte = littleEndian; family = "x86"; };
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };
@@ -92,6 +93,7 @@ rec {
     powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
     powerpc64 = { bits = 64; significantByte = bigEndian; family = "power"; };
     powerpc64le = { bits = 64; significantByte = littleEndian; family = "power"; };
+    powerpcle = { bits = 32; significantByte = littleEndian; family = "power"; };
 
     riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; };
     riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };
@@ -101,6 +103,8 @@ rec {
 
     wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
     wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
+    
+    alpha    = { bits = 64; significantBye = littleEndian; family = "alpha"; };
 
     avr      = { bits = 8; family = "avr"; };
   };


### PR DESCRIPTION
I have added more types of CPUs to try to support.

These could be useful for porting Nix packages to more platforms.