### PR TITLE
vimPlugins: add jedi-vim plugin

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -3414,6 +3414,19 @@ self = rec {
 
   };
 
+  jedi-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "jedi-vim-2018-10-14";
+    src = fetchgit {
+      url = "https://github.com/davidhalter/jedi-vim";
+      rev = "b6dfc5fd49c26d4dbe9f54c814956567a7a9b3a8";
+      sha256 = "11wvynjl1m23vdp4wvirhmm7vnpji5affbyhwz67yjkvh6c42xqa";
+    };
+    dependencies = [];
+    # it'd be nice to check for python3 support in vim, but nobody else seems to care
+    buildInputs = [python3Packages.jedi];
+
+  };
+
 } // lib.optionalAttrs (config.allowAliases or true) (with self; {
 
   # aliasess

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -30,6 +30,7 @@
 "github:ctrlpvim/ctrlp.vim"
 "github:dag/vim2hs"
 "github:dannyob/quickfixstatus"
+"github:davidhalter/jedi-vim"
 "github:derekelkins/agda-vim"
 "github:derekwyatt/vim-scala"
 "github:dhruvasagar/vim-table-mode"


### PR DESCRIPTION
###### Motivation for this change

I need the jedi-vim vim plugin. As the vim-plugins/defaultnix differ heavily between master and release-18.09, I'll do 2 different PRs for each branch.

###### Things done

This plugin needs python3 support in vim, but no other addon seems to
care about verifying that vim is built accordingly, so I don't do that
as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] successfully used the packaged plug-in in my nixpkgs.vim_configurable
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

