### PR TITLE
 pythonPackages.snapcast: init at 2.0.9 

### DIFF
--- a/pkgs/development/python-modules/snapcast/default.nix
+++ b/pkgs/development/python-modules/snapcast/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, pytest
+, construct }:
+
+buildPythonPackage rec {
+  pname = "snapcast";
+  version = "2.0.9";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hlfcg0qdfavjzhxz4v2spjkj6440a1254wrncfkfkyff6rv9x3s";
+  };
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [ construct ];
+
+  # no checks from Pypi - https://github.com/happyleavesaoc/python-snapcast/issues/23
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Control Snapcast, a multi-room synchronous audio solution";
+    homepage = https://github.com/happyleavesaoc/python-snapcast/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -664,7 +664,7 @@
     "media_player.russound_rnet" = ps: with ps; [  ];
     "media_player.samsungtv" = ps: with ps; [ wakeonlan ];
     "media_player.sisyphus" = ps: with ps; [  ];
-    "media_player.snapcast" = ps: with ps; [  ];
+    "media_player.snapcast" = ps: with ps; [ snapcast ];
     "media_player.songpal" = ps: with ps; [  ];
     "media_player.sonos" = ps: with ps; [  ];
     "media_player.soundtouch" = ps: with ps; [ libsoundtouch ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -642,6 +642,8 @@ in {
 
   slicerator = callPackage ../development/python-modules/slicerator { };
 
+  snapcast = callPackage ../development/python-modules/snapcast { };
+
   spglib = callPackage ../development/python-modules/spglib { };
 
   statistics = callPackage ../development/python-modules/statistics { };


### PR DESCRIPTION
###### Motivation for this change

HA supports snapcast!

Cc @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

