### PR TITLE
dropwatch: init at 1.5

### DIFF
--- a/pkgs/os-specific/linux/dropwatch/default.nix
+++ b/pkgs/os-specific/linux/dropwatch/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, libnl, readline, libbfd, ncurses, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "dropwatch";
+  version = "1.5";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "nhorman";
+    repo = pname;
+    rev = version;
+    sha256 = "085hyyl28v0vpxfnmzchl97fjfnzj46ynhkg6y4i6h194y0d99m7";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ libbfd libnl ncurses readline zlib ];
+
+  # To avoid running into https://sourceware.org/bugzilla/show_bug.cgi?id=14243 we need to define:
+  NIX_CFLAGS_COMPILE = [
+    "-DPACKAGE=${pname}"
+    "-DPACKAGE_VERSION=${version}"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Kernel dropped packet monitor";
+    homepage = https://github.com/nhorman/dropwatch;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.c0bw3b ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14021,6 +14021,8 @@ with pkgs;
 
   drbd = callPackage ../os-specific/linux/drbd { };
 
+  dropwatch = callPackage ../os-specific/linux/dropwatch { };
+
   dstat = callPackage ../os-specific/linux/dstat { };
 
   # unstable until the first 1.x release


### PR DESCRIPTION
###### Motivation for this change

Closes #38135

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```shell
$ nix path-info -S ./result/
/nix/store/2jihsxcvphkfxydgf6a8hdyzjgwq7fyk-dropwatch-1.5          39180320
```

```shell
$ sudo ./result/bin/dropwatch -l kas
Initalizing kallsyms db
dropwatch> start
Enabling monitoring...
Kernel monitoring activated.
Issue Ctrl-C to stop monitoring
2 drops at icmp_rcv+12a (0xffffffffac34410a)
2 drops at icmp_rcv+12a (0xffffffffac34410a)
2 drops at icmp_rcv+12a (0xffffffffac34410a)
1 drops at icmp_rcv+12a (0xffffffffac34410a)
2 drops at icmp_rcv+12a (0xffffffffac34410a)
1 drops at icmp_rcv+12a (0xffffffffac34410a)
1 drops at icmp_rcv+12a (0xffffffffac34410a)
2 drops at icmp_rcv+12a (0xffffffffac34410a)
1 drops at icmp_rcv+12a (0xffffffffac34410a)
13 drops at skb_release_data+9f (0xffffffffac2b4f8f)
2 drops at tcp_v4_rcv+160 (0xffffffffac332a30)
1 drops at nf_hook_slow+99 (0xffffffffac3046b9)
3 drops at tcp_v4_rcv+160 (0xffffffffac332a30)
```


---