### PR TITLE
 fetchFromGitHub: add goPackagePath similar to meta.homepage

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "go-ethereum-${version}";
   version = "1.8.20";
-  goPackagePath = "github.com/ethereum/go-ethereum";
 
   # Fix for usb-related segmentation faults on darwin
   propagatedBuildInputs =

--- a/pkgs/applications/editors/micro/default.nix
+++ b/pkgs/applications/editors/micro/default.nix
@@ -4,7 +4,6 @@ buildGoPackage  rec {
   name = "micro-${version}";
   version = "1.4.1";
 
-  goPackagePath = "github.com/zyedidia/micro";
 
   src = fetchFromGitHub {
     owner = "zyedidia";

--- a/pkgs/applications/graphics/meme/default.nix
+++ b/pkgs/applications/graphics/meme/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
 
   owner = "nomad-software";
   repo = "meme";
-  goPackagePath = "github.com/${owner}/${repo}";
 
   src = fetchFromGitHub {
     inherit owner repo;

--- a/pkgs/applications/misc/archiver/default.nix
+++ b/pkgs/applications/misc/archiver/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   name = "archiver-${version}";
   version = "3.0.0";
 
-  goPackagePath = "github.com/mholt/archiver";
 
   src = fetchFromGitHub {
     owner = "mholt";

--- a/pkgs/applications/misc/autospotting/default.nix
+++ b/pkgs/applications/misc/autospotting/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "autospotting-${version}";
   version = "unstable-2018-11-17";
-  goPackagePath = "github.com/AutoSpotting/AutoSpotting";
 
   src = fetchFromGitHub {
     owner = "AutoSpotting";

--- a/pkgs/applications/misc/exercism/default.nix
+++ b/pkgs/applications/misc/exercism/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name    = "exercism-${version}";
   version = "3.0.9";
 
-  goPackagePath = "github.com/exercism/cli";
 
   src = fetchFromGitHub {
     owner  = "exercism";

--- a/pkgs/applications/misc/hivemind/default.nix
+++ b/pkgs/applications/misc/hivemind/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "hivemind-${version}";
   version = "1.0.4";
-  goPackagePath = "github.com/DarthSim/hivemind";
 
   src = fetchFromGitHub {
     owner = "DarthSim";

--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "hugo-${version}";
   version = "0.50";
 
-  goPackagePath = "github.com/gohugoio/hugo";
 
   src = fetchFromGitHub {
     owner  = "gohugoio";

--- a/pkgs/applications/misc/mqtt-bench/default.nix
+++ b/pkgs/applications/misc/mqtt-bench/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.3.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/takanorig/mqtt-bench";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/applications/misc/overmind/default.nix
+++ b/pkgs/applications/misc/overmind/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "overmind-${version}";
   version = "1.2.1";
-  goPackagePath = "github.com/DarthSim/overmind";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/misc/syncthing-tray/default.nix
+++ b/pkgs/applications/misc/syncthing-tray/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "syncthing-tray-${version}";
   version = "0.7";
 
-  goPackagePath = "github.com/alex2108/syncthing-tray";
 
   src = fetchFromGitHub {
     owner = "alex2108";

--- a/pkgs/applications/misc/terminal-parrot/default.nix
+++ b/pkgs/applications/misc/terminal-parrot/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
     name = "terminal-parrot-1.1.0";
     version = "1.1.0";
-    goPackagePath = "github.com/jmhobbs/terminal-parrot";
 
     src = fetchFromGitHub {
         owner = "jmhobbs";

--- a/pkgs/applications/misc/todolist/default.nix
+++ b/pkgs/applications/misc/todolist/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "todolist-${version}";
   version = "v0.8.1";
 
-  goPackagePath = "github.com/gammons/todolist";
 
   src = fetchFromGitHub {
     owner = "gammons";

--- a/pkgs/applications/misc/wtf/default.nix
+++ b/pkgs/applications/misc/wtf/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   name = "wtf-${version}";
   version = "0.4.0";
 
-  goPackagePath = "github.com/senorprogrammer/wtf";
 
   src = fetchFromGitHub {
     owner = "senorprogrammer";

--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "c14-cli-${version}";
   version = "0.3";
 
-  goPackagePath = "github.com/online-net/c14-cli";
 
   src = fetchFromGitHub {
     owner = "online-net";

--- a/pkgs/applications/networking/cloudflared/default.nix
+++ b/pkgs/applications/networking/cloudflared/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name    = "cloudflared-${version}";
   version = "2018.10.3";
 
-  goPackagePath = "github.com/cloudflare/cloudflared";
 
   src = fetchFromGitHub {
     owner  = "cloudflare";

--- a/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/xhyve.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "docker-machine-xhyve-${version}";
   version = "0.3.3";
 
-  goPackagePath = "github.com/zchee/docker-machine-driver-xhyve";
   goDeps = ./xhyve-deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -12,7 +12,6 @@ buildGoPackage {
     sha256 = "02ir10070rpayv9s53anldwjy5ggl268shgf085d188wl6vshaiv";
   };
 
-  goPackagePath = "github.com/roboll/helmfile";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/networking/cluster/heptio-ark/default.nix
+++ b/pkgs/applications/networking/cluster/heptio-ark/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "heptio-ark-${version}";
   version = "0.9.6";
 
-  goPackagePath = "github.com/heptio/ark";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -12,7 +12,6 @@ buildGoPackage {
     sha256 = "1xldh1ca8ym8cg3w5cxizmhqxwi5kmiin28f320mxdr28fzljc2w";
   };
 
-  goPackagePath = "github.com/xetys/hetzner-kube";
 
   meta = {
     description = "A CLI tool for provisioning Kubernetes clusters on Hetzner Cloud";

--- a/pkgs/applications/networking/cluster/kompose/default.nix
+++ b/pkgs/applications/networking/cluster/kompose/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "kompose-${version}";
   version = "1.9.0";
 
-  goPackagePath = "github.com/kubernetes/kompose";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/applications/networking/cluster/kontemplate/default.nix
+++ b/pkgs/applications/networking/cluster/kontemplate/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name          = "kontemplate-${version}";
   version       = "1.7.0";
-  goPackagePath = "github.com/tazjin/kontemplate";
   goDeps        = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/ksonnet/default.nix
+++ b/pkgs/applications/networking/cluster/ksonnet/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "0z7gkgcsiclm72bznmzv5jcgx5rblndcsiqc0r2mwhxhmv19bs04";
   };
 
-  goPackagePath = "github.com/ksonnet/ksonnet";
 
   meta = {
     description = "A CLI-supported framework that streamlines writing and deployment of Kubernetes configurations to multiple clusters";

--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -12,7 +12,6 @@ buildGoPackage {
     sha256 = "12kv1p707kdxjx5l8rcikd1gjwp5xjxdmmyvlpnvyagrphgrwpsf";
   };
 
-  goPackagePath = "github.com/ksonnet/kubecfg";
 
   meta = {
     description = "A tool for managing Kubernetes resources as code";

--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -25,7 +25,6 @@ buildGoPackage rec {
   name = "kubeval-${version}";
   version = "0.7.3";
 
-  goPackagePath = "github.com/garethr/kubeval";
   src = fetchFromGitHub {
     owner = "garethr";
     repo = "kubeval";

--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.8.6";
   rev = "v${version}";
 
-  goPackagePath = "github.com/hashicorp/nomad";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/pachyderm/default.nix
+++ b/pkgs/applications/networking/cluster/pachyderm/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.4.6";
   rev = "v${version}";
 
-  goPackagePath = "github.com/pachyderm/pachyderm";
   subPackages = [ "src/server/cmd/pachctl" ];
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/stern/default.nix
+++ b/pkgs/applications/networking/cluster/stern/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "stern-${version}";
   version = "1.10.0";
 
-  goPackagePath = "github.com/wercker/stern";
 
   src = fetchFromGitHub {
     owner = "wercker";

--- a/pkgs/applications/networking/cluster/terraform-docs/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-docs/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   pname = "terraform-docs";
   version = "0.5.0";
 
-  goPackagePath = "github.com/segmentio/${pname}";
 
   src = fetchFromGitHub {
     owner  = "segmentio";

--- a/pkgs/applications/networking/cluster/terraform-inventory/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-inventory/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.7-pre";
   rev = "v${version}";
 
-  goPackagePath = "github.com/adammck/terraform-inventory";
 
   subPackages = [ "./" ];
 

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -10,7 +10,6 @@ let
     buildGoPackage rec {
       inherit (data) owner repo version sha256;
       name = "${repo}-${version}";
-      goPackagePath = "github.com/${owner}/${repo}";
       src = fetchFromGitHub {
         inherit owner repo sha256;
         rev = "v${version}";

--- a/pkgs/applications/networking/cluster/terraform-providers/gandi/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/gandi/default.nix
@@ -3,7 +3,6 @@ buildGoPackage rec {
   name = "terraform-provider-gandi-${version}";
   version = "1.0.0";
 
-  goPackagePath = "github.com/tiramiseb/terraform-provider-gandi";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/terraform-providers/ibm/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/ibm/default.nix
@@ -14,7 +14,6 @@ buildGoPackage rec {
   name = "terraform-provider-ibm-${version}";
   version = "0.11.1";
 
-  goPackagePath = "github.com/terraform-providers/terraform-provider-ibm";
   subPackages = [ "./" ];
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -21,7 +21,6 @@ buildGoPackage rec {
   name = "terraform-provider-libvirt-${version}";
   version = "0.4";
 
-  goPackagePath = "github.com/dmacvicar/terraform-provider-libvirt";
 
   src = fetchFromGitHub {
     owner = "dmacvicar";

--- a/pkgs/applications/networking/cluster/terragrunt/default.nix
+++ b/pkgs/applications/networking/cluster/terragrunt/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "terragrunt-${version}";
   version = "0.17.4";
 
-  goPackagePath = "github.com/gruntwork-io/terragrunt";
 
   src = fetchFromGitHub {
     owner  = "gruntwork-io";

--- a/pkgs/applications/networking/drive/default.nix
+++ b/pkgs/applications/networking/drive/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "drive-${version}";
   version = "0.3.8.1";
 
-  goPackagePath = "github.com/odeke-em/drive";
   subPackages = [ "cmd/drive" ];
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/gdrive/default.nix
+++ b/pkgs/applications/networking/gdrive/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2.1.0";
   rev     = "${version}";
 
-  goPackagePath = "github.com/prasmussen/gdrive";
 
   src = fetchFromGitHub {
     owner  = "prasmussen";

--- a/pkgs/applications/networking/instant-messengers/coyim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/coyim/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   name = "coyim-${version}";
   version = "0.3.7_1";
 
-  goPackagePath = "github.com/twstrike/coyim";
 
   src = fetchFromGitHub {
     owner = "twstrike";

--- a/pkgs/applications/networking/instant-messengers/slack-term/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack-term/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   name = "slack-term-${version}";
   version = "0.4.1";
 
-  goPackagePath = "github.com/erroneousboat/slack-term";
 
   src = fetchFromGitHub {
     owner = "erroneousboat";

--- a/pkgs/applications/networking/instant-messengers/xmpp-client/default.nix
+++ b/pkgs/applications/networking/instant-messengers/xmpp-client/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "20160916-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "abbf9020393e8caae3e8996a16ce48446e31cf0e";
 
-  goPackagePath = "github.com/agl/xmpp-client";
 
   src = fetchFromGitHub {
     owner = "agl";

--- a/pkgs/applications/networking/ipfs-migrator/default.nix
+++ b/pkgs/applications/networking/ipfs-migrator/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "ipfs-migrator-${version}";
   version = "7";
 
-  goPackagePath = "github.com/ipfs/fs-repo-migrations";
 
   goDeps = ./deps.nix;
 

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.4.18";
   rev = "v${version}";
 
-  goPackagePath = "github.com/ipfs/go-ipfs";
 
   extraSrcPaths = [
     (fetchgx {

--- a/pkgs/applications/networking/ipget/default.nix
+++ b/pkgs/applications/networking/ipget/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.2.5";
   rev = "v${version}";
 
-  goPackagePath = "github.com/ipfs/ipget";
   
   extraSrcPaths = [
     (fetchgx {

--- a/pkgs/applications/networking/sync/desync/default.nix
+++ b/pkgs/applications/networking/sync/desync/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.4.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/folbricht/desync";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "rclone-${version}";
   version = "1.45";
 
-  goPackagePath = "github.com/ncw/rclone";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/applications/version-management/git-and-tools/ghq/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghq/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "ghq-${version}";
   version = "0.8.0";
 
-  goPackagePath = "github.com/motemen/ghq";
 
   src = fetchFromGitHub {
     owner = "motemen";

--- a/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-02-26";
   rev = "2414523905939525559e4b2498c5597f86193b61";
 
-  goPackagePath = "github.com/google/git-appraise";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/applications/version-management/git-and-tools/lab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "lab-${version}";
   version = "0.14.0";
 
-  goPackagePath = "github.com/zaquestion/lab";
 
   src = fetchFromGitHub {
     owner = "zaquestion";

--- a/pkgs/applications/version-management/git-lfs/1.nix
+++ b/pkgs/applications/version-management/git-lfs/1.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.5.6";
   rev = "0d02fb7d9a1c599bbf8c55e146e2845a908e04e0";
   
-  goPackagePath = "github.com/git-lfs/git-lfs";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "git-lfs-${version}";
   version = "2.5.2";
 
-  goPackagePath = "github.com/git-lfs/git-lfs";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/applications/version-management/git-sizer/default.nix
+++ b/pkgs/applications/version-management/git-sizer/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   name = "${pname}-${version}";
   version = "1.0.0";
 
-  goPackagePath = "github.com/github/git-sizer";
 
   src = fetchFromGitHub {
     owner = "github";

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -37,7 +37,6 @@ buildGoPackage rec {
       --prefix PATH : ${makeBinPath [ bash git gzip openssh ]}
   '';
 
-  goPackagePath = "github.com/gogs/gogs";
 
   meta = {
     description = "A painless self-hosted Git service";

--- a/pkgs/applications/virtualization/docker/distribution.nix
+++ b/pkgs/applications/virtualization/docker/distribution.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2.6.2";
   rev = "v${version}";
 
-  goPackagePath = "github.com/docker/distribution";
 
   src = fetchFromGitHub {
     owner = "docker";

--- a/pkgs/applications/virtualization/docker/proxy.nix
+++ b/pkgs/applications/virtualization/docker/proxy.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "1ng577k11cyv207bp0vaz5jjfcn2igd6w95zn4izcq1nldzp5935";
   };
 
-  goPackagePath = "github.com/docker/libnetwork";
 
   goDeps = null;
 

--- a/pkgs/applications/virtualization/ecs-agent/default.nix
+++ b/pkgs/applications/virtualization/ecs-agent/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   pname   = "amazon-ecs-agent";
   version = "1.18.0";
 
-  goPackagePath = "github.com/aws/${pname}";
   subPackages   = [ "agent" ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -13,9 +13,6 @@
 # Disabled flag
 , disabled ? false
 
-# Go import path of the package
-, goPackagePath
-
 # Go package aliases
 , goPackageAliases ? [ ]
 
@@ -41,7 +38,9 @@
 with builtins;
 
 let
-  args = lib.filterAttrs (name: _: name != "extraSrcs") args';
+  goPackagePath = args'.goPackagePath or args'.src.nakedUrl;
+
+  args = lib.filterAttrs (name: _: name != "extraSrcs") args' // { inherit goPackagePath; };
 
   removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
 

--- a/pkgs/development/interpreters/joker/default.nix
+++ b/pkgs/development/interpreters/joker/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "joker-${version}";
   version = "0.10.1";
 
-  goPackagePath = "github.com/candid82/joker";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/development/tools/asmfmt/default.nix
+++ b/pkgs/development/tools/asmfmt/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   name = "asmfmt-${version}";
   version = "1.1";
 
-  goPackagePath = "github.com/klauspost/asmfmt";
 
   src = fetchFromGitHub {
     owner = "klauspost";

--- a/pkgs/development/tools/azcopy/default.nix
+++ b/pkgs/development/tools/azcopy/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "azure-storage-azcopy-${version}";
   version = "10.0.1-pre";
   revision = "10.0.1";
-  goPackagePath = "github.com/Azure/azure-storage-azcopy";
 
   goDeps= ./deps.nix;
 

--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "bazel-buildtools-unstable-${version}";
   version = "2018-10-11";
 
-  goPackagePath = "github.com/bazelbuild/buildtools";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";

--- a/pkgs/development/tools/build-managers/mage/default.nix
+++ b/pkgs/development/tools/build-managers/mage/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "mage-${version}";
   version = "1.7.1";
 
-  goPackagePath = "github.com/magefile/mage";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/compile-daemon/default.nix
+++ b/pkgs/development/tools/compile-daemon/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2017-03-08";
   rev = "d447e567232bcb84cedd3b2be012c7127f31f469";
 
-  goPackagePath = "github.com/githubnemo/CompileDaemon";
 
   src = fetchFromGitHub {
     owner = "githubnemo";

--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   name = "drone-cli-${version}";
   version = "0.8.6";
   revision = "v${version}";
-  goPackagePath = "github.com/drone/drone-cli";
 
   goDeps= ./deps.nix;
 

--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "drone.io-${version}";
   version = "0.8.6-20180727-${stdenv.lib.strings.substring 0 7 revision}";
   revision = "c48150767c2700d35dcc29b110a81c8b5969175e";
-  goPackagePath = "github.com/drone/drone";
 
   # These dependencies pulled (in `drone` buildprocess) via Makefile,
   # so I extracted them here, all revisions pinned by same date, as ${version}

--- a/pkgs/development/tools/corgi/default.nix
+++ b/pkgs/development/tools/corgi/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "corgi-${rev}";
   rev = "v0.2.4";
 
-  goPackagePath = "github.com/DrakeW/corgi";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/database/dbmate/default.nix
+++ b/pkgs/development/tools/database/dbmate/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "dbmate-${version}";
   version = "1.4.1";
 
-  goPackagePath = "github.com/amacneil/dbmate";
 
   src = fetchFromGitHub {
     owner = "amacneil";

--- a/pkgs/development/tools/deadcode/default.nix
+++ b/pkgs/development/tools/deadcode/default.nix
@@ -10,7 +10,6 @@ buildGoPackage rec {
   version = "2016-07-24";
   rev = "210d2dc333e90c7e3eedf4f2242507a8e83ed4ab";
 
-  goPackagePath = "github.com/tsenart/deadcode";
   excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "delve-${version}";
   version = "1.1.0";
 
-  goPackagePath = "github.com/derekparker/delve";
   excludedPackages = "\\(_fixtures\\|scripts\\|service/test\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/dep/default.nix
+++ b/pkgs/development/tools/dep/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.5.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/golang/dep";
   subPackages = [ "cmd/dep" ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/dep2nix/default.nix
+++ b/pkgs/development/tools/dep2nix/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   name = "dep2nix-${version}";
   version = "0.0.2";
 
-  goPackagePath = "github.com/nixcloud/dep2nix";
 
   src = fetchFromGitHub {
     owner = "nixcloud";

--- a/pkgs/development/tools/easyjson/default.nix
+++ b/pkgs/development/tools/easyjson/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "easyjson-unstable-${version}";
   version = "2018-08-23";
-  goPackagePath = "github.com/mailru/easyjson";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/ejson/default.nix
+++ b/pkgs/development/tools/ejson/default.nix
@@ -13,7 +13,6 @@ in buildGoPackage rec {
 
   nativeBuildInputs = [ gems ];
 
-  goPackagePath = "github.com/Shopify/ejson";
   subPackages = [ "cmd/ejson" ];
 
   goDeps = ./deps.nix;

--- a/pkgs/development/tools/errcheck/default.nix
+++ b/pkgs/development/tools/errcheck/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   name = "errcheck-${version}";
   version = "1.1.0";
 
-  goPackagePath = "github.com/kisielk/errcheck";
   excludedPackages = "\\(testdata\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gauge-${version}";
   version = "1.0.3";
 
-  goPackagePath = "github.com/getgauge/gauge";
   excludedPackages = ''\(build\|man\)'';
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gdm/default.nix
+++ b/pkgs/development/tools/gdm/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gdm-${version}";
   version = "1.4";
 
-  goPackagePath = "github.com/sparrc/gdm";
 
   src = fetchFromGitHub {
     owner = "sparrc";

--- a/pkgs/development/tools/glide/default.nix
+++ b/pkgs/development/tools/glide/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "glide-${version}";
   version = "0.12.3";
 
-  goPackagePath = "github.com/Masterminds/glide";
 
    buildFlagsArray = ''
    -ldflags=

--- a/pkgs/development/tools/gllvm/default.nix
+++ b/pkgs/development/tools/gllvm/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gllvm-${version}";
   version = "1.2.3";
 
-  goPackagePath = "github.com/SRI-CSL/gllvm";
 
   src = fetchFromGitHub {
     owner = "SRI-CSL";

--- a/pkgs/development/tools/glock/default.nix
+++ b/pkgs/development/tools/glock/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "20160816-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "b8c84ff5ade15a6238ca61c20d3afc70d2e41276";
 
-  goPackagePath = "github.com/robfig/glock";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/go-bindata-assetfs/default.nix
+++ b/pkgs/development/tools/go-bindata-assetfs/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "go-bindata-assetfs-${version}";
   version = "20160814-${rev}";
   rev = "e1a2a7e";
-  goPackagePath = "github.com/elazarl/go-bindata-assetfs";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/go-junit-report/default.nix
+++ b/pkgs/development/tools/go-junit-report/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-06-14";
   rev = "385fac0ced9acaae6dc5b39144194008ded00697";
 
-  goPackagePath = "github.com/jstemmer/go-junit-report";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/go-langserver/default.nix
+++ b/pkgs/development/tools/go-langserver/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "unstable-2018-03-05";
   rev = "5d7a5dd74738978d635f709669241f164c120ebd";
 
-  goPackagePath = "github.com/sourcegraph/go-langserver";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/go-motion/default.nix
+++ b/pkgs/development/tools/go-motion/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-04-09";
   rev = "218875ebe23806e7af82f3b5b14bb3355534f679";
 
-  goPackagePath = "github.com/fatih/motion";
   excludedPackages = ''testdata'';
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/go-outline/default.nix
+++ b/pkgs/development/tools/go-outline/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "unstable-2017-08-04";
   rev = "9e9d089bb61a5ce4f8e0c8d8dc5b4e41b0e02a48";
 
-  goPackagePath = "github.com/ramya-rao-a/go-outline";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/go-protobuf/default.nix
+++ b/pkgs/development/tools/go-protobuf/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-01-04";
   rev = "1e59b77b52bf8e4b449a57e6f79f21226d571845";
 
-  goPackagePath = "github.com/golang/protobuf";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/go-symbols/default.nix
+++ b/pkgs/development/tools/go-symbols/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "unstable-2018-05-23";
   rev = "953befd75e223f514580fcb698aead0dd6ad3421";
 
-  goPackagePath = "github.com/acroca/go-symbols";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/goa/default.nix
+++ b/pkgs/development/tools/goa/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "goa-${version}";
   version = "1.4.0";
 
-  goPackagePath = "github.com/goadesign/goa";
   subPackages = [ "goagen" ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gocode-gomod/default.nix
+++ b/pkgs/development/tools/gocode-gomod/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-10-16";
   rev = "12640289f65065d652cc942ffa01a52bece1dd53";
 
-  goPackagePath = "github.com/stamblerre/gocode";
 
   # we must allow references to the original `go` package,
   # because `gocode` needs to dig into $GOROOT to provide completions for the

--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-11-05";
   rev = "0af7a86943a6e0237c90f8aeb74a882e1862c898";
 
-  goPackagePath = "github.com/mdempsky/gocode";
   excludedPackages = ''internal/suggest/testdata'';
 
   # we must allow references to the original `go` package,

--- a/pkgs/development/tools/goconst/default.nix
+++ b/pkgs/development/tools/goconst/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   name = "goconst-${version}";
   version = "1.1.0";
 
-  goPackagePath = "github.com/jgautheron/goconst";
   excludedPackages = ''testdata'';
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/goconvey/default.nix
+++ b/pkgs/development/tools/goconvey/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "goconvey-${version}";
   version = "1.6.3";
 
-  goPackagePath = "github.com/smartystreets/goconvey";
   excludedPackages = "web/server/watch/integration_testing";
 
   goDeps = ./deps.nix;

--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2015-02-08";
   rev = "aa8f8b160214d8dfccfe3e17e578dd0fcc6fede7";
 
-  goPackagePath = "github.com/alecthomas/gocyclo";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/gogetdoc/default.nix
+++ b/pkgs/development/tools/gogetdoc/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-10-25";
   rev = "9098cf5fc236a5e25060730544af2ba6d65cd968";
 
-  goPackagePath = "github.com/zmb3/gogetdoc";
   excludedPackages = "\\(testdata\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/golangci-lint/default.nix
+++ b/pkgs/development/tools/golangci-lint/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "golangci-lint-${version}";
   version = "1.9.2";
-  goPackagePath = "github.com/golangci/golangci-lint";
 
   subPackages = [ "cmd/golangci-lint" ];
 

--- a/pkgs/development/tools/gometalinter/default.nix
+++ b/pkgs/development/tools/gometalinter/default.nix
@@ -42,7 +42,6 @@ in buildGoPackage rec {
   name = "gometalinter-${version}";
   version = "2.0.11";
 
-  goPackagePath = "github.com/alecthomas/gometalinter";
   excludedPackages = "\\(regressiontests\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gomodifytags/default.nix
+++ b/pkgs/development/tools/gomodifytags/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-09-14";
   rev = "141225bf62b6e5c9c0c9554a2e993e8c30aebb1d";
 
-  goPackagePath = "github.com/fatih/gomodifytags";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/gopkgs/default.nix
+++ b/pkgs/development/tools/gopkgs/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gopkgs-${version}";
   version = "2.0.1";
 
-  goPackagePath = "github.com/uudashr/gopkgs";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gosec/default.nix
+++ b/pkgs/development/tools/gosec/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   name = "gosec-${version}";
   version = "1.2.0";
 
-  goPackagePath = "github.com/securego/gosec";
   excludedPackages = ''cmd/tlsconfig'';
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/gotests/default.nix
+++ b/pkgs/development/tools/gotests/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.5.2";
   rev = "v${version}";
 
-  goPackagePath = "github.com/cweill/gotests";
   excludedPackages = "testdata";
   goDeps = ./deps.nix;
 

--- a/pkgs/development/tools/govendor/default.nix
+++ b/pkgs/development/tools/govendor/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "govendor-${version}";
   version = "1.0.9";
 
-  goPackagePath = "github.com/kardianos/govendor";
 
   src = fetchFromGitHub {
     owner = "kardianos";

--- a/pkgs/development/tools/gox/default.nix
+++ b/pkgs/development/tools/gox/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gox-${version}";
   version = "20181025";
 
-  goPackagePath = "github.com/mitchellh/gox";
 
   src = fetchFromGitHub {
     owner = "mitchellh";

--- a/pkgs/development/tools/gron/default.nix
+++ b/pkgs/development/tools/gron/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
 
   owner = "tomnomnom";
   repo = "gron";
-  goPackagePath = "github.com/${owner}/${repo}";
 
   src = fetchFromGitHub {
     inherit owner repo;

--- a/pkgs/development/tools/hcloud/default.nix
+++ b/pkgs/development/tools/hcloud/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "hcloud-${version}";
   version = "1.11.0";
   
-  goPackagePath = "github.com/hetznercloud/cli";
 
   src = fetchFromGitHub {
     owner = "hetznercloud";

--- a/pkgs/development/tools/iferr/default.nix
+++ b/pkgs/development/tools/iferr/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-06-15";
   rev = "bb332a3b1d9129b6486c7ddcb7030c11b05cfc88";
 
-  goPackagePath = "github.com/koron/iferr";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/impl/default.nix
+++ b/pkgs/development/tools/impl/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-02-27";
   rev = "3d0f908298c49598b6aa84f101c69670e15d1d03";
 
-  goPackagePath = "github.com/josharian/impl";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/ineffassign/default.nix
+++ b/pkgs/development/tools/ineffassign/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-09-09";
 	rev = "1003c8bd00dc2869cb5ca5282e6ce33834fed514";
 
-  goPackagePath = "github.com/gordonklaus/ineffassign";
   excludedPackages = ''testdata'';
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/jid/default.nix
+++ b/pkgs/development/tools/jid/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "jid-${version}";
   version = "0.7.2";
 
-  goPackagePath = "github.com/simeji/jid";
 
   src = fetchFromGitHub {
     owner = "simeji";

--- a/pkgs/development/tools/jmespath/default.nix
+++ b/pkgs/development/tools/jmespath/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.2.2";
   rev = "${version}";
 
-  goPackagePath = "github.com/jmespath/go-jmespath";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/jp/default.nix
+++ b/pkgs/development/tools/jp/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.1.2";
   rev = "${version}";
 
-  goPackagePath = "github.com/jmespath/jp";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/json2hcl/default.nix
+++ b/pkgs/development/tools/json2hcl/default.nix
@@ -13,7 +13,6 @@ buildGoPackage rec {
   };
 
   owner = "kvz";
-  goPackagePath = "github.com/${owner}/${pname}";
   goDeps = ./deps.nix;
 
   meta = with lib; {

--- a/pkgs/development/tools/kexpand/default.nix
+++ b/pkgs/development/tools/kexpand/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "kexpand-unstable-2017-05-12";
 
-  goPackagePath = "github.com/kopeio/kexpand";
 
   subPackages = [ "." ];
 

--- a/pkgs/development/tools/kube-prompt/default.nix
+++ b/pkgs/development/tools/kube-prompt/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.0.5";
   rev = "v${version}";
 
-  goPackagePath = "github.com/c-bata/kube-prompt";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/kubicorn/default.nix
+++ b/pkgs/development/tools/kubicorn/default.nix
@@ -15,7 +15,6 @@ buildGoPackage rec {
   };
 
   subPackages = ["."];
-  goPackagePath = "github.com/kubicorn/kubicorn";
 
   meta = {
     description = "Simple, cloud native infrastructure for Kubernetes";

--- a/pkgs/development/tools/lazygit/default.nix
+++ b/pkgs/development/tools/lazygit/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "lazygit-${version}";
   version = "0.5";
 
-  goPackagePath = "github.com/jesseduffield/lazygit";
 
   src = fetchFromGitHub {
     owner = "jesseduffield";

--- a/pkgs/development/tools/leaps/default.nix
+++ b/pkgs/development/tools/leaps/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "leaps-${version}";
   version = "0.9.0";
 
-  goPackagePath = "github.com/Jeffail/leaps";
 
   src = fetchFromGitHub {
     owner = "Jeffail";

--- a/pkgs/development/tools/librarian-puppet-go/default.nix
+++ b/pkgs/development/tools/librarian-puppet-go/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "librarian-puppet-go-${version}";
   version = "0.3.9";
 
-  goPackagePath = "github.com/tmtk75/librarian-puppet-go";
 
   src = fetchFromGitHub {
     owner = "tmtk75";

--- a/pkgs/development/tools/maligned/default.nix
+++ b/pkgs/development/tools/maligned/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-07-07";
   rev = "6e39bd26a8c8b58c5a22129593044655a9e25959";
 
-  goPackagePath = "github.com/mdempsky/maligned";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/manul/default.nix
+++ b/pkgs/development/tools/manul/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "manul-unstable-2016-09-30";
 
-  goPackagePath = "github.com/kovetskiy/manul";
   excludedPackages = "tests";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/misc/circleci-cli/default.nix
+++ b/pkgs/development/tools/misc/circleci-cli/default.nix
@@ -2,12 +2,10 @@
 
 let
   owner = "CircleCI-Public";
-  pname = "circleci-cli";
-  version = "0.1.2569";
 in
 buildGoPackage rec {
-  name = "${pname}-${version}";
-  inherit version;
+  pname = "circleci-cli";
+  version = "0.1.5245";
 
   src =  fetchFromGitHub {
     inherit owner;
@@ -15,8 +13,6 @@ buildGoPackage rec {
     rev = "v${version}";
     sha256 = "0ixiqx8rmia02r44zbhw149p5x9r9cv1fsnlhl8p2x5zd2bdr18x";
   };
-
-  goPackagePath = "github.com/${owner}/${pname}";
 
   meta = with stdenv.lib; {
     # Box blurb edited from the AUR package circleci-cli

--- a/pkgs/development/tools/misc/elfinfo/default.nix
+++ b/pkgs/development/tools/misc/elfinfo/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "elfinfo-${version}";
   version = "0.7.5";
 
-  goPackagePath = "github.com/xyproto/elfinfo";
   src = fetchFromGitHub {
     rev = version;
     owner = "xyproto";

--- a/pkgs/development/tools/misc/hound/default.nix
+++ b/pkgs/development/tools/misc/hound/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-11-02";
   rev = "74ec7448a234d8d09e800b92e52c92e378c07742";
 
-  goPackagePath = "github.com/etsy/hound";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/misc/linuxkit/default.nix
+++ b/pkgs/development/tools/misc/linuxkit/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2017-07-08";
   rev = "8ca19a84d5281b1b15c7a48c21e5786943b47f1c";
 
-  goPackagePath = "github.com/linuxkit/linuxkit";
 
   src = fetchFromGitHub {
     owner = "linuxkit";

--- a/pkgs/development/tools/misc/md2man/default.nix
+++ b/pkgs/development/tools/misc/md2man/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "go-md2man-${version}";
   version = "1.0.6";
 
-  goPackagePath = "github.com/cpuguy83/go-md2man";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/development/tools/misc/moby/default.nix
+++ b/pkgs/development/tools/misc/moby/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2017-07-06";
   rev = "d87a3f9990ed24ebbb51695879cd640cb07a4b40";
 
-  goPackagePath = "github.com/moby/tool";
 
   src = fetchFromGitHub {
     owner = "moby";

--- a/pkgs/development/tools/mustache-go/default.nix
+++ b/pkgs/development/tools/mustache-go/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "mustache-go-${version}";
   version = "1.0.1";
 
-  goPackagePath = "github.com/cbroglie/mustache";
 
   src = fetchFromGitHub {
     owner = "cbroglie";

--- a/pkgs/development/tools/packer/default.nix
+++ b/pkgs/development/tools/packer/default.nix
@@ -3,7 +3,6 @@ buildGoPackage rec {
   name = "packer-${version}";
   version = "1.3.1";
 
-  goPackagePath = "github.com/hashicorp/packer";
 
   subPackages = [ "." ];
 

--- a/pkgs/development/tools/pet/default.nix
+++ b/pkgs/development/tools/pet/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "pet-${version}";
   version = "0.3.2";
 
-  goPackagePath = "github.com/knqyf263/pet";
 
   src = fetchFromGitHub {
     owner = "knqyf263";

--- a/pkgs/development/tools/quicktemplate/default.nix
+++ b/pkgs/development/tools/quicktemplate/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "quicktemplate-unstable-${version}";
   version = "2018-11-26";
-  goPackagePath = "github.com/valyala/quicktemplate";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/reflex/default.nix
+++ b/pkgs/development/tools/reflex/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   name = "reflex-${version}";
   version = "0.2.0";
 
-  goPackagePath = "github.com/cespare/reflex";
 
   src = fetchFromGitHub {
     owner = "cespare";

--- a/pkgs/development/tools/reftools/default.nix
+++ b/pkgs/development/tools/reftools/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   version = "2018-09-14";
   rev = "654d0ba4f96d62286ca33cd46f7674b84f76d399";
 
-  goPackagePath = "github.com/davidrjenni/reftools";
   excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/richgo/default.nix
+++ b/pkgs/development/tools/richgo/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "richgo-${version}";
   version = "0.2.8";
-  goPackagePath = "github.com/kyoh86/richgo";
 
   src = fetchFromGitHub {
     owner = "kyoh86";

--- a/pkgs/development/tools/textql/default.nix
+++ b/pkgs/development/tools/textql/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "textql-${version}";
   version = "2.0.3";
 
-  goPackagePath = "github.com/dinedal/textql";
 
   src = fetchFromGitHub {
     owner  = "dinedal";

--- a/pkgs/development/tools/toxiproxy/default.nix
+++ b/pkgs/development/tools/toxiproxy/default.nix
@@ -10,7 +10,6 @@ buildGoPackage rec {
     sha256 = "1a7yry846iwi9cs9xam2vjbw73fjy45agjrwk214k0n1ziaawz2f";
   };
 
-  goPackagePath = "github.com/Shopify/toxiproxy";
   subPackages = ["cmd" "cli"];
   buildFlagsArray = "-ldflags=-X github.com/Shopify/toxiproxy.Version=v${version}";
 

--- a/pkgs/development/tools/tychus/default.nix
+++ b/pkgs/development/tools/tychus/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "tychus-${version}";
   version = "0.6.3";
 
-  goPackagePath = "github.com/devlocker/tychus";
   goDeps = ./deps.nix;
   subPackages = [];
 

--- a/pkgs/development/tools/unconvert/default.nix
+++ b/pkgs/development/tools/unconvert/default.nix
@@ -9,7 +9,6 @@ buildGoPackage rec {
   version = "2018-07-03";
   rev = "1a9a0a0a3594e9363e49545fb6a4e24ac4c68b7b";
 
-  goPackagePath = "github.com/mdempsky/unconvert";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/vndr/default.nix
+++ b/pkgs/development/tools/vndr/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2018-06-23";
   rev = "81cb8916aad3c8d06193f008dba3e16f82851f52";
 
-  goPackagePath = "github.com/LK4D4/vndr";
   excludedPackages = "test";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/vultr/default.nix
+++ b/pkgs/development/tools/vultr/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "vultr-${version}";
   version = "1.15.0";
-  goPackagePath = "github.com/JamesClonk/vultr";
 
   src = fetchFromGitHub {
     owner = "JamesClonk";

--- a/pkgs/development/tools/yaml2json/default.nix
+++ b/pkgs/development/tools/yaml2json/default.nix
@@ -4,7 +4,6 @@
 buildGoPackage rec {
   name = "yaml2json-${version}";
   version = "unstable-2017-05-03";
-  goPackagePath = "github.com/bronze1man/yaml2json";
 
   goDeps = ./deps.nix;
 

--- a/pkgs/development/web/minify/default.nix
+++ b/pkgs/development/web/minify/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "v2.0.0";
   rev = "41f3effd65817bac8acea89d49b3982211803a4d";
 
-  goPackagePath = "github.com/tdewolff/minify";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/misc/logging/beats/5.x.nix
+++ b/pkgs/misc/logging/beats/5.x.nix
@@ -11,7 +11,6 @@ let beat = package : extraArgs : buildGoPackage (rec {
         sha256 = "00g90i58c6gnyzszsx7y75vn1350hrkzrsb50xx700jqg9ii8yin";
       };
 
-      goPackagePath = "github.com/elastic/beats";
 
       subPackages = [ package ];
 

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -11,7 +11,6 @@ let beat = package : extraArgs : buildGoPackage (rec {
         sha256 = "1qnrq9bhk7csgcxycb8c7975lq0p7cxw29i6sji777zv4hn7442m";
       };
 
-      goPackagePath = "github.com/elastic/beats";
 
       subPackages = [ package ];
 

--- a/pkgs/os-specific/linux/fscrypt/default.nix
+++ b/pkgs/os-specific/linux/fscrypt/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "fscrypt-${version}";
   version = "0.2.4";
 
-  goPackagePath = "github.com/google/fscrypt";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "caddy-${version}";
   version = "0.11.1";
 
-  goPackagePath = "github.com/mholt/caddy";
 
   subPackages = [ "caddy" ];
 

--- a/pkgs/servers/cayley/default.nix
+++ b/pkgs/servers/cayley/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "cayley-${version}";
   version = "0.6.1";
 
-  goPackagePath = "github.com/cayleygraph/cayley";
 
   src = fetchFromGitHub {
     owner = "cayleygraph";

--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.3.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/hashicorp/consul";
 
   # Note: Currently only release tags are supported, because they have the Consul UI
   # vendored. See

--- a/pkgs/servers/dgraph/default.nix
+++ b/pkgs/servers/dgraph/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "dgraph-${version}";
   version = "0.8.2";
 
-  goPackagePath = "github.com/dgraph-io/dgraph";
 
   src = fetchFromGitHub {
     owner = "dgraph-io";

--- a/pkgs/servers/dns/coredns/default.nix
+++ b/pkgs/servers/dns/coredns/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "coredns-${version}";
   version = "005";
 
-  goPackagePath = "github.com/miekg/coredns";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/servers/echoip/default.nix
+++ b/pkgs/servers/echoip/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "echoip-${version}";
   version = "unstable-2018-11-20";
 
-  goPackagePath = "github.com/mpolden/echoip";
 
   src = fetchFromGitHub {
     owner = "mpolden";

--- a/pkgs/servers/etcd/default.nix
+++ b/pkgs/servers/etcd/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "3.3.1"; # After updating check that nixos tests pass
   rev = "v${version}";
 
-  goPackagePath = "github.com/coreos/etcd";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/gnatsd/default.nix
+++ b/pkgs/servers/gnatsd/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "1.2.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/nats-io/gnatsd";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/gotty/default.nix
+++ b/pkgs/servers/gotty/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.0.13";
   rev = "v${version}";
 
-  goPackagePath = "github.com/yudai/gotty";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/holochain-go/default.nix
+++ b/pkgs/servers/holochain-go/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.1.0-alpha";
   rev = "a17510b910a7a377441c152b8dccdbae1999f63f";
 
-  goPackagePath = "github.com/holochain/holochain-proto";
 
 
   src = fetchFromGitHub {

--- a/pkgs/servers/http/webhook/default.nix
+++ b/pkgs/servers/http/webhook/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "webhook-${version}";
   version = "2.6.8";
 
-  goPackagePath = "github.com/adnanh/webhook";
   excludedPackages = [ "test" ];
 
   src = fetchFromGitHub {

--- a/pkgs/servers/hydron/default.nix
+++ b/pkgs/servers/hydron/default.nix
@@ -4,7 +4,6 @@
 buildGoPackage rec {
   name = "hydron-unstable-${version}";
   version = "2018-10-08";
-  goPackagePath = "github.com/bakape/hydron";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/servers/interlock/default.nix
+++ b/pkgs/servers/interlock/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "2016.04.13";
   rev = "v${version}";
 
-  goPackagePath = "github.com/inversepath/interlock";
 
   subPackages = [ "./cmd/interlock" ];
 

--- a/pkgs/servers/livepeer/default.nix
+++ b/pkgs/servers/livepeer/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "livepeer-${version}";
   version = "0.2.4";
 
-  goPackagePath = "github.com/livepeer/go-livepeer";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/servers/mail/mailhog/default.nix
+++ b/pkgs/servers/mail/mailhog/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.0.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/mailhog/MailHog";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/mattermost/matterircd.nix
+++ b/pkgs/servers/mattermost/matterircd.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "0g57g91v7208yynf758k9v73jdhz4fbc1v23p97rzrl97aq0rd5r";
   };
 
-  goPackagePath = "github.com/42wim/matterircd";
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/servers/meguca/default.nix
+++ b/pkgs/servers/meguca/default.nix
@@ -4,7 +4,6 @@
 buildGoPackage rec {
   name = "meguca-unstable-${version}";
   version = "2018-12-06";
-  goPackagePath = "github.com/bakape/meguca";
   goDeps = ./server_deps.nix;
 
   src = fetchFromGitHub {

--- a/pkgs/servers/mesos-dns/default.nix
+++ b/pkgs/servers/mesos-dns/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.1.2";
   rev = "v${version}";
   
-  goPackagePath = "github.com/mesosphere/mesos-dns";
 
   # Avoid including the benchmarking test helper in the output:
   subPackages = [ "." ];

--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -12,7 +12,6 @@ buildGoPackage rec {
     sha256 = "076m4w6z2adl8pi9x7in8s2pa51vj4qlk3m32ibh6yhqfzpbfgd2";
   };
 
-  goPackagePath = "github.com/minio/minio";
 
   buildFlagsArray = [''-ldflags=
     -X github.com/minio/minio/cmd.Version=${version}

--- a/pkgs/servers/mirrorbits/default.nix
+++ b/pkgs/servers/mirrorbits/default.nix
@@ -24,7 +24,6 @@ buildGoPackage rec {
     rm -rf testing
   '';
 
-  goPackagePath = "github.com/etix/mirrorbits";
   goDeps = ./deps.nix;
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/monitoring/consul-alerts/default.nix
+++ b/pkgs/servers/monitoring/consul-alerts/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.5.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/AcalephStorage/consul-alerts";
 
   goDeps = ./deps.nix;
 

--- a/pkgs/servers/monitoring/grafana-reporter/default.nix
+++ b/pkgs/servers/monitoring/grafana-reporter/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "2.0.1";
   rev = "v${version}";
 
-  goPackagePath = "github.com/IzakMarais/reporter";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/servers/monitoring/kapacitor/default.nix
+++ b/pkgs/servers/monitoring/kapacitor/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "kapacitor-${version}";
   version = "1.5.1";
 
-  goPackagePath = "github.com/influxdata/kapacitor";
 
   src = fetchFromGitHub {
     owner = "influxdata";

--- a/pkgs/servers/monitoring/mtail/default.nix
+++ b/pkgs/servers/monitoring/mtail/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "mtail-${version}";
   version = "3.0.0-rc4";
-  goPackagePath = "github.com/google/mtail";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/servers/monitoring/prometheus/bind-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/bind-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "20161221-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "4e1717c7cd5f31c47d0c37274464cbaabdd462ba";
 
-  goPackagePath = "github.com/digitalocean/bind_exporter";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.12.0";
   rev = version;
 
-  goPackagePath = "github.com/prometheus/blackbox_exporter";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/servers/monitoring/prometheus/consul-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/consul-exporter.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "consul_exporter-${version}";
   version = "0.3.0";
 
-  goPackagePath = "github.com/prometheus/consul_exporter";
 
   src = fetchFromGitHub {
     owner = "prometheus";

--- a/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "dnsmasq_exporter-${version}";
   version = "0.1.0";
 
-  goPackagePath = "github.com/google/dnsmasq_exporter";
 
   src = fetchFromGitHub {
     owner = "google";

--- a/pkgs/servers/monitoring/prometheus/dovecot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dovecot-exporter.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "dovecot_exporter-${version}";
   version = "0.1.3";
 
-  goPackagePath = "github.com/kumina/dovecot_exporter";
 
   src = fetchFromGitHub {
     owner = "kumina";

--- a/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.8.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/prometheus/haproxy_exporter";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/mesos-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mesos-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.1.0";
   rev = version;
 
-  goPackagePath = "github.com/prometheus/mesos_exporter";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.10.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/prometheus/mysqld_exporter";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/nginx-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nginx-exporter.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "nginx_exporter-${version}";
   version = "0.1.0";
 
-  goPackagePath = "github.com/discordianfish/nginx_exporter";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.17.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/prometheus/node_exporter";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/openvpn-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/openvpn-exporter.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2017-05-15";
   rev = "a2a179a222144fa9a10030367045f075375a2803";
 
-  goPackagePath = "github.com/kumina/openvpn_exporter";
 
   src = fetchFromGitHub {
     owner = "kumina";

--- a/pkgs/servers/monitoring/prometheus/prom2json.nix
+++ b/pkgs/servers/monitoring/prometheus/prom2json.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.1.0";
   rev = "${version}";
 
-  goPackagePath = "github.com/prometheus/prom2json";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.4.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/prometheus/pushgateway";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "snmp_exporter-${version}";
   version = "0.13.0";
 
-  goPackagePath = "github.com/prometheus/snmp_exporter";
 
   src = fetchFromGitHub {
     owner = "prometheus";

--- a/pkgs/servers/monitoring/prometheus/statsd-bridge.nix
+++ b/pkgs/servers/monitoring/prometheus/statsd-bridge.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.4.0";
   rev = version;
 
-  goPackagePath = "github.com/prometheus/statsd_bridge";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/servers/monitoring/prometheus/surfboard-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/surfboard-exporter.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "surfboard_exporter-${version}";
   version = "2.0.0";
 
-  goPackagePath = "github.com/ipstatic/surfboard_exporter";
 
   src = fetchFromGitHub {
     rev = version;

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "telegraf-${version}";
   version = "1.7.0";
 
-  goPackagePath = "github.com/influxdata/telegraf";
 
   excludedPackages = "test";
 

--- a/pkgs/servers/monitoring/uchiwa/default.nix
+++ b/pkgs/servers/monitoring/uchiwa/default.nix
@@ -12,7 +12,6 @@ let
 
   backend = buildGoPackage {
     name = "uchiwa-backend-${version}";
-    goPackagePath = "github.com/${owner}/${repo}";
     inherit src;
     postInstall = ''
       mkdir $out

--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "0.11.2";
   rev = "v${version}";
 
-  goPackagePath = "github.com/nats-io/nats-streaming-server";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -15,7 +15,6 @@ buildGoPackage rec {
     -X main.version=${version}
   '' ];
 
-  goPackagePath = "github.com/influxdata/influxdb";
 
   excludedPackages = "test";
 

--- a/pkgs/servers/nsq/default.nix
+++ b/pkgs/servers/nsq/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.3.5";
   rev = "v${version}";
 
-  goPackagePath = "github.com/bitly/nsq";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/oauth2_proxy/default.nix
+++ b/pkgs/servers/oauth2_proxy/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "20180325-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "a94b0a8b25e553f7333f7b84aeb89d9d18ec259b";
   
-  goPackagePath = "github.com/bitly/oauth2_proxy";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/serf/default.nix
+++ b/pkgs/servers/serf/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.8.1";
   rev = "v${version}";
 
-  goPackagePath = "github.com/hashicorp/serf";
 
   src = fetchFromGitHub {
     owner = "hashicorp";

--- a/pkgs/servers/simplehttp2server/default.nix
+++ b/pkgs/servers/simplehttp2server/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "simplehttp2server-${version}";
   version = "3.1.3";
 
-  goPackagePath = "github.com/GoogleChromeLabs/simplehttp2server";
 
   src = fetchFromGitHub {
      owner = "GoogleChromeLabs";

--- a/pkgs/servers/skydns/default.nix
+++ b/pkgs/servers/skydns/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2.5.3a";
   rev = "${version}";
   
-  goPackagePath = "github.com/skynetservices/skydns";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "traefik-${version}";
   version = "1.7.4";
 
-  goPackagePath = "github.com/containous/traefik";
 
   src = fetchFromGitHub {
     owner = "containous";

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
   hardeningDisable = [ "fortify" ];
 
-  goPackagePath = "github.com/trezor/trezord-go";
 
   src = fetchFromGitHub {
     owner  = "trezor";

--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "antibody-${version}";
   version = "4.0.2";
 
-  goPackagePath = "github.com/getantibody/antibody";
 
   src = fetchFromGitHub {
     owner  = "getantibody";

--- a/pkgs/tools/X11/go-sct/default.nix
+++ b/pkgs/tools/X11/go-sct/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "20180605-${stdenv.lib.strings.substring 0 7 rev}";
   rev = "eb1e851f2d5017038d2b8e3653645c36d3a279f4";
 
-  goPackagePath = "github.com/d4l3k/go-sct";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/X11/grobi/default.nix
+++ b/pkgs/tools/X11/grobi/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   version = "0.5.1";
   name = "grobi-${version}";
 
-  goPackagePath = "github.com/fd0/grobi";
 
   src = fetchFromGitHub {
     rev = "5ddc167b9e4f84755a515828360abda15c54b7de";

--- a/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
+++ b/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "amazon-ecr-credential-helper-${version}";
   version = "0.1.0";
 
-  goPackagePath = "github.com/awslabs/amazon-ecr-credential-helper";
 
   src = fetchFromGitHub {
     owner = "awslabs";

--- a/pkgs/tools/admin/aws-env/default.nix
+++ b/pkgs/tools/admin/aws-env/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "${pname}-${version}";
   rev = "v${version}";
 
-  goPackagePath = "github.com/Droplr/aws-env";
 
   src = fetchFromGitHub {
     owner = "Droplr";

--- a/pkgs/tools/admin/aws-rotate-key/default.nix
+++ b/pkgs/tools/admin/aws-rotate-key/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "aws-rotate-key-${version}";
   version = "1.0.4";
 
-  goPackagePath = "github.com/Fullscreen/aws-rotate-key";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/tools/admin/aws-vault/default.nix
+++ b/pkgs/tools/admin/aws-vault/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   pname = "aws-vault";
   version = "4.3.0";
 
-  goPackagePath = "github.com/99designs/${pname}";
 
   src = fetchFromGitHub {
     owner = "99designs";

--- a/pkgs/tools/admin/clair/default.nix
+++ b/pkgs/tools/admin/clair/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   pname = "clair";
   version = "2.0.7";
 
-  goPackagePath = "github.com/coreos/clair";
 
   src = fetchFromGitHub {
     owner = "coreos";

--- a/pkgs/tools/admin/docker-credential-gcr/default.nix
+++ b/pkgs/tools/admin/docker-credential-gcr/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "docker-credential-gcr-${version}";
   version = "1.4.3";
 
-  goPackagePath = "github.com/GoogleCloudPlatform/docker-credential-gcr";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";

--- a/pkgs/tools/admin/iamy/default.nix
+++ b/pkgs/tools/admin/iamy/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "iamy-${version}";
   version = "2.1.1";
 
-  goPackagePath = "github.com/99designs/iamy";
 
   src = fetchFromGitHub {
     owner = "99designs";

--- a/pkgs/tools/admin/lego/default.nix
+++ b/pkgs/tools/admin/lego/default.nix
@@ -12,7 +12,6 @@ buildGoPackage rec {
     sha256 = "1b2cv78v54afflz3gfyidkwzq7r2h5j45rmz0ybps03pr0hs4gk3";
   };
 
-  goPackagePath = "github.com/xenolf/lego";
   goDeps = ./deps.nix;
 
   meta = with lib; {

--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec{
   name = "scaleway-cli-${version}";
   version = "1.17";
 
-  goPackagePath = "github.com/scaleway/scaleway-cli";
 
   src = fetchFromGitHub {
     owner = "scaleway";

--- a/pkgs/tools/backup/diskrsync/default.nix
+++ b/pkgs/tools/backup/diskrsync/default.nix
@@ -13,7 +13,6 @@ buildGoPackage rec {
     sha256 = "1rpfk7ds4lpff30aq4d8rw7g9j4bl2hd1bvcwd1pfxalp222zkxn";
   };
 
-  goPackagePath = "github.com/dop251/diskrsync";
   goDeps = ./deps.nix;
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/backup/wal-g/default.nix
+++ b/pkgs/tools/backup/wal-g/default.nix
@@ -15,7 +15,6 @@ buildGoPackage rec {
 
   doCheck = true;
 
-  goPackagePath = "github.com/wal-g/wal-g";
   meta = {
     inherit (src.meta) homepage;
     license = stdenv.lib.licenses.asl20;

--- a/pkgs/tools/misc/blsd/default.nix
+++ b/pkgs/tools/misc/blsd/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "blsd-${version}";
   version = "2017-07-27";
 
-  goPackagePath = "github.com/junegunn/blsd";
 
   src = fetchFromGitHub {
     owner = "junegunn";

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -3,7 +3,6 @@
 buildGoPackage rec {
   name = "direnv-${version}";
   version = "2.19.0";
-  goPackagePath = "github.com/direnv/direnv";
 
   src = fetchFromGitHub {
     owner = "direnv";

--- a/pkgs/tools/misc/docker-ls/default.nix
+++ b/pkgs/tools/misc/docker-ls/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "1dhadi1s3nm3r8q5a0m59fy4jdya8p7zvm22ci7ifm3mmw960xly";
   };
 
-  goPackagePath = "github.com/mayflower/docker-ls";
 
   meta = with stdenv.lib; {
     description = "Tools for browsing and manipulating docker registries";

--- a/pkgs/tools/misc/envsubst/default.nix
+++ b/pkgs/tools/misc/envsubst/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "envsubst-${version}";
   version = "1.1.0";
 
-  goPackagePath = "github.com/a8m/envsubst";
   src = fetchFromGitHub {
     owner = "a8m";
     repo = "envsubst";

--- a/pkgs/tools/misc/fsql/default.nix
+++ b/pkgs/tools/misc/fsql/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "fsql-${version}";
   version = "0.3.1";
 
-  goPackagePath = "github.com/kshvmdn/fsql";
 
   src = fetchFromGitHub {
     owner = "kshvmdn";

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.17.5";
   rev = "${version}";
 
-  goPackagePath = "github.com/junegunn/fzf";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/misc/hyperledger-fabric/default.nix
+++ b/pkgs/tools/misc/hyperledger-fabric/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   pname = "hyperledger-fabric";
   version = "1.3.0";
 
-  goPackagePath = "github.com/hyperledger/fabric";
 
   # taken from https://github.com/hyperledger/fabric/blob/v1.3.0/Makefile#L108
   subPackages = [

--- a/pkgs/tools/misc/ical2org/default.nix
+++ b/pkgs/tools/misc/ical2org/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "ical2org-${version}";
   version="1.1.5";
 
-  goPackagePath = "github.com/rjhorniii/ical2org";
 
   src = fetchFromGitHub {
     owner = "rjhorniii";

--- a/pkgs/tools/misc/kt/default.nix
+++ b/pkgs/tools/misc/kt/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "014q39bg88vg1xdq1bz6wj982zb148sip3a42hbrinh8qj41y4yg";
   };
 
-  goPackagePath = "github.com/fgeller/kt";
 
   meta = with stdenv.lib; {
     description = "Kafka command line tool";

--- a/pkgs/tools/misc/massren/default.nix
+++ b/pkgs/tools/misc/massren/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "1bn6qy30kpxi3rkr3bplsc80xnhj0hgfl0qaczbg3zmykfmsl3bl";
   };
 
-  goPackagePath = "github.com/laurent22/massren";
 
   meta = with lib; {
     description = "Easily rename multiple files using your text editor";

--- a/pkgs/tools/misc/mmake/default.nix
+++ b/pkgs/tools/misc/mmake/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "mmake-${version}";
   version = "1.2.0";
 
-  goPackagePath = "github.com/tj/mmake";
 
   src = fetchFromGitHub {
     owner = "tj";

--- a/pkgs/tools/misc/mongodb-tools/default.nix
+++ b/pkgs/tools/misc/mongodb-tools/default.nix
@@ -14,7 +14,6 @@ buildGoPackage rec {
   version = "3.7.2";
   rev = "r${version}";
 
-  goPackagePath = "github.com/mongodb/mongo-tools";
   subPackages = map (t: t + "/main") tools;
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/pgcenter/default.nix
+++ b/pkgs/tools/misc/pgcenter/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "pgcenter-${version}";
   version = "0.5.0";
 
-  goPackagePath = "github.com/lesovsky/pgcenter";
 
   src = fetchFromGitHub {
     owner  = "lesovsky";

--- a/pkgs/tools/misc/pgmetrics/default.nix
+++ b/pkgs/tools/misc/pgmetrics/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "pgmetrics-${version}";
   version = "1.5.0";
 
-  goPackagePath = "github.com/rapidloop/pgmetrics";
 
   src = fetchFromGitHub {
     owner  = "rapidloop";

--- a/pkgs/tools/misc/phraseapp-client/default.nix
+++ b/pkgs/tools/misc/phraseapp-client/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "phraseapp-client-${version}";
   version = "1.11.0";
 
-  goPackagePath = "github.com/phrase/phraseapp-client";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/powerline-go/default.nix
+++ b/pkgs/tools/misc/powerline-go/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   name = "${pname}-${version}";
   rev = "v${version}";
 
-  goPackagePath = "github.com/justjanne/powerline-go";
 
   src = fetchFromGitHub {
     owner = "justjanne";

--- a/pkgs/tools/misc/systrayhelper/default.nix
+++ b/pkgs/tools/misc/systrayhelper/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.0.4";
   rev = "ded1f2ed4d30f6ca2c89a13db0bd3046c6d6d0f9";
 
-  goPackagePath = "github.com/ssbc/systrayhelper";
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/tools/misc/teleconsole/default.nix
+++ b/pkgs/tools/misc/teleconsole/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "teleconsole-${version}";
   version = "0.4.0";
 
-  goPackagePath = "github.com/gravitational/teleconsole";
 
   src = fetchFromGitHub {
     owner = "gravitational";

--- a/pkgs/tools/misc/up/default.nix
+++ b/pkgs/tools/misc/up/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "171bwbk2c7jbi51xdawzv7qy71492mfs9z5j0a5j52qmnr4vjjgs";
   };
 
-  goPackagePath = "github.com/akavel/up";
   goDeps = ./deps.nix;
 
   meta = with lib; {

--- a/pkgs/tools/misc/xmonad-log/default.nix
+++ b/pkgs/tools/misc/xmonad-log/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "xmonad-log-${version}";
   version = "0.1.0";
 
-  goPackagePath = "github.com/xintron/xmonad-log";
 
   src = fetchFromGitHub {
     owner = "xintron";

--- a/pkgs/tools/networking/amass/default.nix
+++ b/pkgs/tools/networking/amass/default.nix
@@ -8,7 +8,6 @@ buildGoPackage rec {
   name = "amass-${version}";
   version = "2.8.5";
 
-  goPackagePath = "github.com/OWASP/Amass";
 
   src = fetchFromGitHub {
     owner = "OWASP";

--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "assh-${version}";
   version = "2.7.0";
 
-  goPackagePath = "github.com/moul/advanced-ssh-config";
   subPackages = [ "cmd/assh" ];
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
@@ -14,7 +14,6 @@ buildGoPackage rec {
   };
 
   goDeps = ./datadog-process-agent-deps.nix;
-  goPackagePath = "github.com/${owner}/${repo}";
 
   meta = with stdenv.lib; {
     description = "Live process collector for the DataDog Agent v6";

--- a/pkgs/tools/networking/dd-agent/datadog-trace-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-trace-agent.nix
@@ -13,7 +13,6 @@ buildGoPackage rec {
   };
 
   goDeps = ./datadog-trace-agent-deps.nix;
-  goPackagePath = "github.com/${owner}/${repo}";
 
   meta = with stdenv.lib; {
     description = "Live trace collector for the DataDog Agent v6";

--- a/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "dnscrypt-proxy2-${version}";
   version = "2.0.15";
 
-  goPackagePath = "github.com/jedisct1/dnscrypt-proxy";
 
   src = fetchFromGitHub {
     owner = "jedisct1";

--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "0.6.2";
   rev = "v${version}";
 
-  goPackagePath = "github.com/coreos/flannel";
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/tools/networking/goklp/default.nix
+++ b/pkgs/tools/networking/goklp/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "goklp-${version}";
   version = "1.6";
 
-  goPackagePath = "github.com/AppliedTrust/goklp";
 
   src = fetchFromGitHub {
     owner = "AppliedTrust";

--- a/pkgs/tools/networking/httplab/default.nix
+++ b/pkgs/tools/networking/httplab/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.3.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/gchaincl/httplab";
 
   src = fetchFromGitHub {
     owner = "gchaincl";

--- a/pkgs/tools/networking/kail/default.nix
+++ b/pkgs/tools/networking/kail/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "kail-${version}";
   version = "0.7.0";
 
-  goPackagePath = "github.com/boz/kail";
 
   src = fetchFromGitHub {
     owner = "boz";

--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -12,7 +12,6 @@ buildGoPackage rec {
     sha256 = "1hbw3yam5lc9414f3f8yh32ycj0wz2xc934ksvjnrhkk4xzyal6h";
   };
 
-  goPackagePath = "github.com/minio/mc";
 
   buildFlagsArray = [''-ldflags=
     -X github.com/minio/mc/cmd.Version=${version}

--- a/pkgs/tools/networking/qr-filetransfer/default.nix
+++ b/pkgs/tools/networking/qr-filetransfer/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "qr-filetransfer-unstable-${version}";
   version = "2018-10-22";
 
-  goPackagePath = "github.com/claudiodangelis/qr-filetransfer";
 
   src = fetchFromGitHub {
     rev = "b1e5b91aa2aa469f870c62074e879d46e353edae";

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "07695hba72q722d18q75pwa45azg9jibj6vqnhwb7mnwz2i7hkkc";
   };
 
-  goPackagePath = "github.com/SrKomodo/shadowfox-updater";
   goDeps = ./deps.nix;
 
   buildFlags = "--tags release";

--- a/pkgs/tools/networking/skydive/default.nix
+++ b/pkgs/tools/networking/skydive/default.nix
@@ -4,7 +4,6 @@
 buildGoPackage rec {
   name = "skydive-${version}";
   version = "0.17.0";
-  goPackagePath = "github.com/skydive-project/skydive";
 
   src = fetchFromGitHub {
     owner = "skydive-project";

--- a/pkgs/tools/networking/subfinder/default.nix
+++ b/pkgs/tools/networking/subfinder/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "subfinder-git-${version}";
   version = "2018-07-15";
 
-  goPackagePath = "github.com/subfinder/subfinder";
 
   src = fetchFromGitHub {
     owner = "subfinder";

--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "0pixm48is9if9d2b4qc5mwwa4lzma6snkib6z2a1d4pmdx1lmpmm";
   };
 
-  goPackagePath = "github.com/dbcdk/morph";
   goDeps = ./deps.nix;
 
   buildInputs = [ go-bindata ];

--- a/pkgs/tools/package-management/nixops/nixops-dns.nix
+++ b/pkgs/tools/package-management/nixops/nixops-dns.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   version = "1.0";
 
   goDeps = ./deps.nix;
-  goPackagePath = "github.com/kamilchm/nixops-dns";
 
   src = fetchFromGitHub {
     owner = "kamilchm";

--- a/pkgs/tools/security/aws-okta/default.nix
+++ b/pkgs/tools/security/aws-okta/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "aws-okta-${version}";
   version = "0.19.0";
 
-  goPackagePath = "github.com/segmentio/aws-okta";
 
   src = fetchFromGitHub {
     owner = "segmentio";

--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "bettercap-${version}";
   version = "2.11";
 
-  goPackagePath = "github.com/bettercap/bettercap";
 
   src = fetchFromGitHub {
     owner = "bettercap";

--- a/pkgs/tools/security/certmgr/default.nix
+++ b/pkgs/tools/security/certmgr/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   version = "1.6.1";
   name = "certmgr-${version}";
 
-  goPackagePath = "github.com/cloudflare/certmgr/";
 
   src = fetchFromGitHub {
     owner = "cloudflare";

--- a/pkgs/tools/security/certstrap/default.nix
+++ b/pkgs/tools/security/certstrap/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "certstrap-${version}";
   version = "1.1.1";
 
-  goPackagePath = "github.com/square/certstrap";
 
   src = fetchFromGitHub {
     owner = "square";

--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "cfssl-${version}";
   version = "1.3.2";
 
-  goPackagePath = "github.com/cloudflare/cfssl";
 
   src = fetchFromGitHub {
     owner = "cloudflare";

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   version = "1.8.4";
   name = "gopass-${version}";
 
-  goPackagePath = "github.com/gopasspw/gopass";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/hologram/default.nix
+++ b/pkgs/tools/security/hologram/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
     sha256 = "00scryz8js6gbw8lp2y23qikbazz2dd992r97rqh0l1q4baa0ckn";
   };
 
-  goPackagePath = "github.com/AdRoll/hologram";
 
   goDeps = ./deps.nix;
 

--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "kbfs-${version}";
   version = "2.11.0";
 
-  goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" "kbfsgit/git-remote-keybase" ];
 
   dontRenameImports = true;

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -7,7 +7,6 @@ buildGoPackage rec {
   name = "keybase-${version}";
   version = "2.11.0";
 
-  goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
 
   dontRenameImports = true;

--- a/pkgs/tools/security/notary/default.nix
+++ b/pkgs/tools/security/notary/default.nix
@@ -22,7 +22,6 @@ buildGoPackage rec {
     runHook postBuild
   '';
 
-  goPackagePath = "github.com/theupdateframework/notary";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "saml2aws-${version}";
   version = "2.10.0";
 
-  goPackagePath = "github.com/versent/saml2aws";
   goDeps = ./deps.nix;
 
   buildFlagsArray = ''

--- a/pkgs/tools/system/confd/default.nix
+++ b/pkgs/tools/system/confd/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.9.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/kelseyhightower/confd";
   subPackages = [ "./" ];
 
   src = fetchFromGitHub {

--- a/pkgs/tools/system/consul-template/default.nix
+++ b/pkgs/tools/system/consul-template/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.19.4";
   rev = "v${version}";
 
-  goPackagePath = "github.com/hashicorp/consul-template";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/system/ctop/default.nix
+++ b/pkgs/tools/system/ctop/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2017-05-28";
   rev = "b4e1fbf29073625ec803025158636bdbcf2357f4";
 
-  goPackagePath = "github.com/bcicen/ctop";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/system/envconsul/default.nix
+++ b/pkgs/tools/system/envconsul/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.7.3";
   rev = "v${version}";
 
-  goPackagePath = "github.com/hashicorp/envconsul";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/system/gotop/default.nix
+++ b/pkgs/tools/system/gotop/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gotop-${version}";
   version = "1.7.1";
 
-  goPackagePath = "github.com/cjbassi/gotop";
 
   src = fetchFromGitHub {
     repo = "gotop";

--- a/pkgs/tools/system/journalbeat/default.nix
+++ b/pkgs/tools/system/journalbeat/default.nix
@@ -9,7 +9,6 @@ in buildGoPackage rec {
   name = "journalbeat-${version}";
   version = "5.6.8";
 
-  goPackagePath = "github.com/mheese/journalbeat";
 
   buildInputs = [ makeWrapper pkgs.systemd ];
 

--- a/pkgs/tools/system/pcstat/default.nix
+++ b/pkgs/tools/system/pcstat/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "pcstat-unstable-${version}";
   version = "2017-05-28";
 
-  goPackagePath = "github.com/tobert/pcstat";
 
   src = fetchFromGitHub {
     rev    = "91a7346e5b462a61e876c0574cb1ba331a6a5ac5";

--- a/pkgs/tools/system/systemd-journal2gelf/default.nix
+++ b/pkgs/tools/system/systemd-journal2gelf/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "SystemdJournal2Gelf-${version}";
   version = "20170413";
 
-  goPackagePath = "github.com/parse-nl/SystemdJournal2Gelf";
 
   src = fetchFromGitHub {
     rev = "862b1d60d2ba12cd8480304ca95041066cc8bdd0";

--- a/pkgs/tools/text/gucci/default.nix
+++ b/pkgs/tools/text/gucci/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "gucci-${version}";
   version = "0.1.0";
 
-  goPackagePath = "github.com/noqcks/gucci";
 
   src = fetchFromGitHub {
     owner = "noqcks";

--- a/pkgs/tools/text/peco/default.nix
+++ b/pkgs/tools/text/peco/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "peco-${version}";
   version = "0.5.3";
 
-  goPackagePath = "github.com/peco/peco";
   subPackages = [ "cmd/peco" ];
 
   src = fetchFromGitHub {

--- a/pkgs/tools/text/platinum-searcher/default.nix
+++ b/pkgs/tools/text/platinum-searcher/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "2.1.5";
   rev = "v${version}";
 
-  goPackagePath = "github.com/monochromegane/the_platinum_searcher";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/text/shfmt/default.nix
+++ b/pkgs/tools/text/shfmt/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.1.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/mvdan/sh";
 
   src = fetchFromGitHub {
     owner = "mvdan";

--- a/pkgs/tools/text/sift/default.nix
+++ b/pkgs/tools/text/sift/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "0.9.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/svent/sift";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "vale-${version}";
   version = "1.3.0";
 
-  goPackagePath = "github.com/errata-ai/vale";
 
   src = fetchFromGitHub {
     owner  = "errata-ai";

--- a/pkgs/tools/typesetting/mmark/default.nix
+++ b/pkgs/tools/typesetting/mmark/default.nix
@@ -5,7 +5,6 @@ buildGoPackage rec {
   version = "1.3.6";
   rev = "v${version}";
 
-  goPackagePath = "github.com/miekg/mmark";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/virtualization/awless/default.nix
+++ b/pkgs/tools/virtualization/awless/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "awless-${version}";
   version = "0.0.14";
 
-  goPackagePath = "github.com/wallix/awless";
 
   src = fetchFromGitHub {
     owner  = "wallix";

--- a/pkgs/tools/virtualization/distrobuilder/default.nix
+++ b/pkgs/tools/virtualization/distrobuilder/default.nix
@@ -11,7 +11,6 @@ buildGoPackage rec {
   version = "2018_10_04";
   rev = "d2329be9569d45028a38836186d2353b8ddfe1ca";
 
-  goPackagePath = "github.com/lxc/distrobuilder";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/virtualization/govc/default.nix
+++ b/pkgs/tools/virtualization/govc/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "govc-${version}";
   version = "0.16.0";
 
-  goPackagePath = "github.com/vmware/govmomi";
 
   subPackages = [ "govc" ];
 

--- a/pkgs/tools/virtualization/marathonctl/default.nix
+++ b/pkgs/tools/virtualization/marathonctl/default.nix
@@ -4,7 +4,6 @@ buildGoPackage rec {
   name = "marathonctl-unstable-${version}";
   version = "2017-03-06";
 
-  goPackagePath = "github.com/shoenig/marathonctl";
   subPackages = [ "." ];
   goDeps = ./deps.nix;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -266,7 +266,8 @@ in
     ... # For hash agility
   }@args: assert private -> !fetchSubmodules;
   let
-    baseUrl = "https://${githubBase}/${owner}/${repo}";
+    nakedUrl = "${githubBase}/${owner}/${repo}";
+    baseUrl = "https://${nakedUrl}";
     passthruAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "private" "githubBase" "varPrefix" ];
     varBase = "NIX${if varPrefix == null then "" else "_${varPrefix}"}_GITHUB_PRIVATE_";
     # We prefer fetchzip in cases we don't need submodules as the hash
@@ -290,7 +291,7 @@ in
         then { inherit rev fetchSubmodules; url = "${baseUrl}.git"; }
         else ({ url = "${baseUrl}/archive/${rev}.tar.gz"; } // privateAttrs)
       ) // passthruAttrs // { inherit name; };
-  in fetcher fetcherArgs // { meta.homepage = baseUrl; inherit rev; };
+  in fetcher fetcherArgs // { meta.homepage = baseUrl; inherit nakedUrl rev; };
 
   fetchFromBitbucket = {
     owner, repo, rev, name ? "source",


### PR DESCRIPTION
###### Motivation for this change

Also updating circleci-cli as an example of how to use this. This would potentially be useful in 284 files: 

```
$ ag --nix -l . ./pkgs | xargs grep --files-with-match "goPackagePath = \"github.com" | xargs grep --files-with-match "fetchFromGitHub" | wc -l
284
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

