### PR TITLE
pyjwt: fix tests to work with pytest >= 3.9.0

### DIFF
--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -15,6 +15,13 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestrunner pytestcov pytest ];
 
+  # pytest 3.9.0 changed behavior of deprecated_call, see release notes
+  postPatch = ''
+    for x in tests/test_api_*py; do
+      substituteInPlace "$x" --replace AssertionError pytest.fail.Exception
+    done
+  '';
+
   meta = with lib; {
     description = "JSON Web Token implementation in Python";
     homepage = https://github.com/jpadilla/pyjwt;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---