### PR TITLE
slack-term: init at 0.4.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack-term/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack-term/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  # https://github.com/erroneousboat/slack-term
+  name = "slack-term-${version}";
+  version = "0.4.1";
+
+  goPackagePath = "github.com/erroneousboat/slack-term";
+
+  src = fetchFromGitHub {
+    owner = "erroneousboat";
+    repo = "slack-term";
+    rev = "v${version}";
+    sha256 = "1340bq7h31fxykxbxpn6hv7n2hmjf20f8vg5gan9pjf5jaa6kfza";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Slack client for your terminal";
+    homepage = https://github.com/erroneousboat/slack-term;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17240,6 +17240,8 @@ with pkgs;
 
   slack-cli = callPackage ../tools/networking/slack-cli { };
 
+  slack-term = callPackage ../applications/networking/instant-messengers/slack-term { };
+
   singularity = callPackage ../applications/virtualization/singularity { };
 
   spectmorph = callPackage ../applications/audio/spectmorph { };


### PR DESCRIPTION
###### Motivation for this change

See slack-term wiki for using "non-legacy" token.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---