### PR TITLE
matrix-synapse: 0.33.6 -> 0.33.8

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, python2Packages, fetchurl, fetchFromGitHub }:
+{ lib, stdenv, python2Packages, fetchurl, fetchFromGitHub
+, enableSystemd ? true
+}:
 let
   matrix-angular-sdk = python2Packages.buildPythonPackage rec {
     name = "matrix-angular-sdk-${version}";
@@ -26,13 +28,13 @@ let
   };
 in python2Packages.buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.33.6";
+  version = "0.33.8";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "0c1dr09f1msv6xvpmdlncx7yyj6qxnpihd93lqckd115fds12g5h";
+    sha256 = "122ba09xkc1x35qaajcynkjikg342259rgy81m8abz0l8mcg4mkm";
   };
 
   patches = [
@@ -40,16 +42,41 @@ in python2Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python2Packages; [
-    blist canonicaljson daemonize dateutil frozendict pillow pyasn1
-    pydenticon pymacaroons-pynacl pynacl pyopenssl pysaml2 pytz requests
-    signedjson systemd twisted ujson unpaddedbase64 pyyaml prometheus_client
-    matrix-angular-sdk bleach netaddr jinja2 psycopg2
-    psutil msgpack-python lxml matrix-synapse-ldap3
-    phonenumbers jsonschema affinity bcrypt sortedcontainers treq
-  ];
+    bcrypt
+    bleach
+    canonicaljson
+    daemonize
+    dateutil
+    frozendict
+    jinja2
+    jsonschema
+    lxml
+    matrix-angular-sdk
+    matrix-synapse-ldap3
+    msgpack-python
+    netaddr
+    phonenumbers
+    pillow
+    prometheus_client
+    psutil
+    psycopg2
+    pyasn1
+    pydenticon
+    pymacaroons-pynacl
+    pynacl
+    pyopenssl
+    pysaml2
+    pyyaml
+    requests
+    signedjson
+    sortedcontainers
+    treq
+    twisted
+    unpaddedbase64
+  ] ++ lib.optional enableSystemd systemd;
 
-  # Checks fail because of Tox.
-  doCheck = false;
+  doCheck = true;
+  checkPhase = "python -m twisted.trial test";
 
   buildInputs = with python2Packages; [
     mock setuptoolsTrial


### PR DESCRIPTION
Also reworked dependencies:
 * blist and ujson are marked as no longer needed
 * pytz has no mention throughout `git log -p` on synapse's repository
 * systemd and affinity are optional (but turned on by default)

cc @roblabla @Ralith 

@GrahamcOfBorg test matrix-synapse

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

