### PR TITLE
swift: 4.1.3 -> 4.2.1

### DIFF
--- a/pkgs/development/compilers/swift/patches/0001-build-presets-linux-don-t-require-using-Ninja.patch
+++ b/pkgs/development/compilers/swift/patches/0001-build-presets-linux-don-t-require-using-Ninja.patch
@@ -11,7 +11,7 @@ diff --git a/utils/build-presets.ini b/utils/build-presets.ini
 index 7ee57ad2df..e6b0af3581 100644
 --- a/utils/build-presets.ini
 +++ b/utils/build-presets.ini
-@@ -686,7 +686,7 @@ swiftpm
+@@ -717,7 +717,7 @@ swiftpm
  xctest
  dash-dash
  

--- a/pkgs/development/compilers/swift/patches/0002-build-presets-linux-allow-custom-install-prefix.patch
+++ b/pkgs/development/compilers/swift/patches/0002-build-presets-linux-allow-custom-install-prefix.patch
@@ -11,7 +11,7 @@ diff --git a/utils/build-presets.ini b/utils/build-presets.ini
 index e6b0af3581..1095cbaab7 100644
 --- a/utils/build-presets.ini
 +++ b/utils/build-presets.ini
-@@ -708,7 +708,7 @@ install-lldb
+@@ -723,7 +723,7 @@ install-lldb
  install-llbuild
  install-swiftpm
  install-xctest

--- a/pkgs/development/compilers/swift/patches/0004-build-presets-linux-plumb-extra-cmake-options.patch
+++ b/pkgs/development/compilers/swift/patches/0004-build-presets-linux-plumb-extra-cmake-options.patch
@@ -11,7 +11,7 @@ diff --git a/utils/build-presets.ini b/utils/build-presets.ini
 index 1739e91dc2..0608fed9c1 100644
 --- a/utils/build-presets.ini
 +++ b/utils/build-presets.ini
-@@ -708,6 +708,8 @@ install-destdir=%(install_destdir)s
+@@ -740,6 +740,8 @@ install-destdir=%(install_destdir)s
  # Path to the .tar.gz package we would create.
  installable-package=%(installable_package)s
  

--- a/pkgs/development/compilers/swift/patches/build-script-pax.patch
+++ b/pkgs/development/compilers/swift/patches/build-script-pax.patch
@@ -1,6 +1,6 @@
 --- swift/utils/build-script-impl	2017-01-23 12:47:20.401326309 -0600
 +++ swift-pax/utils/build-script-impl	2017-01-23 13:24:10.339366996 -0600
-@@ -1823,6 +1823,17 @@ function set_lldb_xcodebuild_options() {
+@@ -1837,6 +1837,17 @@ function set_lldb_xcodebuild_options() {
      fi
  }
  
@@ -18,7 +18,7 @@
  #
  # Configure and build each product
  #
-@@ -2624,6 +2634,12 @@ for host in "${ALL_HOSTS[@]}"; do
+@@ -2735,6 +2746,12 @@ for host in "${ALL_HOSTS[@]}"; do
              fi
  
              call "${CMAKE_BUILD[@]}" "${build_dir}" $(cmake_config_opt ${product}) -- "${BUILD_ARGS[@]}" ${build_targets[@]}

--- a/pkgs/development/compilers/swift/patches/glibc-arch-headers.patch
+++ b/pkgs/development/compilers/swift/patches/glibc-arch-headers.patch
@@ -1,0 +1,13 @@
+The Nix glibc headers do not use include/x86_64-linux-gnu subdirectories.
+
+--- swift/stdlib/public/Platform/CMakeLists.txt	2018-09-30 17:51:51.581766303 +0200
++++ swift/stdlib/public/Platform/CMakeLists.txt	2018-09-30 18:40:04.118956708 +0200
+@@ -65,7 +65,7 @@
+     endif()
+ 
+     set(GLIBC_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
+-    set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}")
++    set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
+ 
+     if(NOT "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}" STREQUAL "/")
+       set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_INCLUDE_PATH}")

--- a/pkgs/development/compilers/swift/patches/llvm-include-dirs.patch
+++ b/pkgs/development/compilers/swift/patches/llvm-include-dirs.patch
@@ -1,0 +1,13 @@
+Only use the Nix include dirs when no sysroot is configured.
+
+--- clang/lib/Driver/ToolChains/Linux.cpp	2018-10-05 18:01:15.731109551 +0200
++++ clang/lib/Driver/ToolChains/Linux.cpp	2018-10-05 18:00:27.959509924 +0200
+@@ -565,7 +565,7 @@
+ 
+   // Check for configure-time C include directories.
+   StringRef CIncludeDirs(C_INCLUDE_DIRS);
+-  if (CIncludeDirs != "") {
++  if (CIncludeDirs != "" && (SysRoot.empty() || SysRoot == "/")) {
+     SmallVector<StringRef, 5> dirs;
+     CIncludeDirs.split(dirs, ":");
+     for (StringRef dir : dirs) {

--- a/pkgs/development/compilers/swift/purity.patch
+++ b/pkgs/development/compilers/swift/purity.patch
@@ -11,7 +11,7 @@ diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
 index fe3c0191bb..c6a482bece 100644
 --- a/lib/Driver/ToolChains/Gnu.cpp
 +++ b/lib/Driver/ToolChains/Gnu.cpp
-@@ -494,13 +494,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+@@ -398,13 +398,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
    if (!Args.hasArg(options::OPT_static)) {
      if (Args.hasArg(options::OPT_rdynamic))
        CmdArgs.push_back("-export-dynamic");


### PR DESCRIPTION
I updated Swift to the current version 4.2.1. This involved some additional patching to get things to build correctly.

I am especially unsure about disabling the two test phases `stress-test` and `test-optimized`. They had minor failures related to the tests not finding tools like `find`. I already found other tests disabled in a similar fashion, so I just added these test phases there.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).