### PR TITLE
flyway: 5.1.4 -> 5.2.1

### DIFF
--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -1,22 +1,23 @@
 { stdenv, fetchurl, jre_headless, makeWrapper }:
   let
-    version = "5.1.4";
+    version = "5.2.1";
   in
     stdenv.mkDerivation {
       name = "flyway-${version}";
       src = fetchurl {
-        url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.1.4/flyway-commandline-${version}.tar.gz";
-        sha256 = "1raz125k55v6xa8gp6ylcjxz77r5364xqp9di46rayx3z2282f7q";
+        url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${version}/flyway-commandline-${version}.tar.gz";
+        sha256 = "0lm536qc8pqj4s21dd47gi99nwwflk17gqzfwaflghw3fnhn7i1s";
       };
       buildInputs = [ makeWrapper ];
       dontBuild = true;
       dontStrip = true;
       installPhase = ''
         mkdir -p $out/bin $out/share/flyway
-        cp -r sql jars lib drivers $out/share/flyway
+        cp -r sql jars drivers conf $out/share/flyway
+        cp -r lib/community $out/share/flyway/lib
         makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
           --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
-          --add-flags "-cp '$out/share/flyway/lib/*:$out/share/flyway/drivers/*'" \
+          --add-flags "-classpath '$out/share/flyway/lib/*:$out/share/flyway/drivers/*'" \
           --add-flags "org.flywaydb.commandline.Main"
       '';
       meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Supersedes #48523 and make the tool actually runnable
Distribute only the community edition JARs which are the only ones under Apache 2.0 license
This also reduce closure size

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```shell
$ nix path-info -S ./result
/nix/store/mh9vpyxw8068dxzdswj1yy29i5dfq90r-flyway-5.2.1          156906096

$ ./result/bin/flyway -v
Flyway Community Edition 5.2.1 by Boxfuse
```

---
