### PR TITLE
minishift: 1.25.0 -> 1.26.1

### DIFF
--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -4,11 +4,11 @@
 }:
 
 let
-  version = "1.25.0";
+  version = "1.26.1";
 
   # Update these on version bumps according to Makefile
   b2dIsoVersion = "v1.3.0";
-  centOsIsoVersion = "v1.12.0";
+  centOsIsoVersion = "v1.13.0";
   openshiftVersion = "v3.11.0";
 
 in buildGoPackage rec {
@@ -19,7 +19,7 @@ in buildGoPackage rec {
     owner = "minishift";
     repo = "minishift";
     rev = "v${version}";
-    sha256 = "12a1irj92lplzkr88g049blpjsdsfwfihs2xix971cq7v0w38fkf";
+    sha256 = "1nh31j58hk6rpcb25ivdi1h2skgpdzm02whcccz0wmr8z6yma1a0";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];
@@ -60,7 +60,7 @@ in buildGoPackage rec {
       or develop with it, day-to-day, on your local host.
     '';
     homepage = https://github.com/minishift/minishift;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz vdemeester ];
     platforms = platforms.linux;
     license = licenses.asl20;
   };


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump minishift to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

