### PR TITLE
virtualgl: revert PR #49185

### DIFF
--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -19,12 +19,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  postPatch = ''
-    # script calls exec, which fails with plain sh
-    substituteInPlace ./server/vglrun.in \
-      --replace '#!/bin/sh' '#!/usr/bin/env bash'
-  '';
-
   meta = with stdenv.lib; {
     homepage = http://www.virtualgl.org/;
     description = "X11 GL rendering in a remote computer with full 3D hw acceleration";


### PR DESCRIPTION
###### Motivation for this change
/bin/sh was replaced with bash in vglrun (https://github.com/NixOS/nixpkgs/pull/49185)
It turns out this this was unnecessary.

CC @Mic92 

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

