### PR TITLE
openshift: 3.10 -> 3.11

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go_1_10, go-bindata, makeWrapper, rsync, utillinux
+{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go, go-bindata, makeWrapper, rsync, utillinux
 , coreutils, kerberos, clang
 , components ? [
   "cmd/oc"
@@ -32,8 +32,8 @@ in stdenv.mkDerivation rec {
 };
 
   # go > 1.10
-  # [FATAL] [14:44:02+0000] Please install Go version go1.10 or use PERMISSIVE_GO=y to bypass this check.
-  buildInputs = [ removeReferencesTo makeWrapper which go_1_10 rsync go-bindata kerberos clang ];
+  # [FATAL] [14:44:02+0000] Please install Go version go or use PERMISSIVE_GO=y to bypass this check.
+  buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata kerberos clang ];
 
   outputs = [ "out" ];
 
@@ -78,7 +78,7 @@ in stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    find $out/bin -type f -exec remove-references-to -t ${go_1_10} '{}' +
+    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go_1_9, go-bindata, makeWrapper, rsync, utillinux
+{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go_1_10, go-bindata, makeWrapper, rsync, utillinux
 , coreutils, kerberos, clang
 , components ? [
   "cmd/oc"
@@ -9,15 +9,15 @@
 with lib;
 
 let
-  version = "3.10.0";
+  version = "3.11.0";
   ver = stdenv.lib.elemAt (stdenv.lib.splitString "." version);
   versionMajor = ver 0;
   versionMinor = ver 1;
   versionPatch = ver 2;
-  gitCommit = "dd10d17";
+  gitCommit = "0cbc58b";
   # version is in vendor/k8s.io/kubernetes/pkg/version/base.go
-  k8sversion = "v1.10.0";
-  k8sgitcommit = "b81c8f8";
+  k8sversion = "v1.11.1";
+  k8sgitcommit = "b1b2997";
   k8sgitMajor = "0";
   k8sgitMinor = "1";
 in stdenv.mkDerivation rec {
@@ -28,12 +28,12 @@ in stdenv.mkDerivation rec {
     owner = "openshift";
     repo = "origin";
     rev = "v${version}";
-    sha256 = "13aglz005jl48z17vnggkvr39l5h6jcqgkfyvkaz4c3jakms1hi9";
+    sha256 = "06q4v2a1mm6c659ab0rzkqz6b66vx4avqfg0s9xckwhq420lzgka";
 };
 
   # go > 1.10
-  # [FATAL] [14:44:02+0000] Please install Go version go1.9 or use PERMISSIVE_GO=y to bypass this check.
-  buildInputs = [ removeReferencesTo makeWrapper which go_1_9 rsync go-bindata kerberos clang ];
+  # [FATAL] [14:44:02+0000] Please install Go version go1.10 or use PERMISSIVE_GO=y to bypass this check.
+  buildInputs = [ removeReferencesTo makeWrapper which go_1_10 rsync go-bindata kerberos clang ];
 
   outputs = [ "out" ];
 
@@ -78,7 +78,7 @@ in stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    find $out/bin -type f -exec remove-references-to -t ${go_1_9} '{}' +
+    find $out/bin -type f -exec remove-references-to -t ${go_1_10} '{}' +
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest openshift version. Using go 1.10 instead of 1.9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

