### PR TITLE
vulkan-tools: 1.1.85 -> 1.1.85.0

### DIFF
--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   name = "vulkan-tools-${version}";
-  version = "1.1.85";
+  version = "1.1.85.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0f4dfr8g0vy7y1hvs6z9lw52kissailzisby4qnz4akv0zz5y5s5";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake python3 vulkan-loader xlibsWrapper libxcb libXrandr wayland ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ python3 vulkan-loader xlibsWrapper libxcb libXrandr wayland ];
   enableParallelBuilding = true;
 
   cmakeFlags = [ "-DBUILD_ICD=OFF" "-DGLSLANG_INSTALL_DIR=${glslang}" ];


### PR DESCRIPTION
###### Motivation for this change

sdk-1.1.85 is a branch and not the stable release tag
Follow-up to #48861

Also moved cmake to nativeBuildInputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

