### PR TITLE
Fix flightgear, simgear & speed_dreams

### DIFF
--- a/pkgs/development/libraries/openscenegraph/3.4.0.nix
+++ b/pkgs/development/libraries/openscenegraph/3.4.0.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchurl, cmake, pkgconfig, doxygen, unzip
+, freetype, libjpeg, jasper, libxml2, zlib, gdal, curl, libX11
+, cairo, poppler, librsvg, libpng, libtiff, libXrandr
+, xineLib, boost
+, withApps ? false
+, withSDL ? false, SDL
+, withQt4 ? false, qt4
+}:
+
+stdenv.mkDerivation rec {
+  name = "openscenegraph-${version}";
+  version = "3.4.0";
+
+  src = fetchurl {
+    url = "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-${version}.zip";
+    sha256 = "03h4wfqqk7rf3mpz0sa99gy715cwpala7964z2npd8jxfn27swjw";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake doxygen unzip ];
+
+  buildInputs = [
+    freetype libjpeg jasper libxml2 zlib gdal curl libX11
+    cairo poppler librsvg libpng libtiff libXrandr boost
+    xineLib
+  ] ++ lib.optional withSDL SDL
+    ++ lib.optional withQt4 qt4;
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = lib.optional (!withApps) "-DBUILD_OSG_APPLICATIONS=OFF";
+
+  meta = with stdenv.lib; {
+    description = "A 3D graphics toolkit";
+    homepage = http://www.openscenegraph.org/;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
+    license = "OpenSceneGraph Public License - free LGPL-based license";
+  };
+}

--- a/pkgs/development/libraries/simgear/default.nix
+++ b/pkgs/development/libraries/simgear/default.nix
@@ -6,12 +6,12 @@
 
 stdenv.mkDerivation rec {
   name = "simgear-${version}";
-  version = "2017.3.1";
-  shortVersion = "2017.3";
+  version = "2018.2.2";
+  shortVersion = "2018.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${name}.tar.bz2";
-    sha256 = "1x71wvycs2bjgmmacswgk6091p65p46fr40mr7f4kcipnx88bq0f";
+    sha256 = "f61576bc36aae36f350154749df1cee396763604c06b8a71c4b50452d9151ce5";
   };
 
   buildInputs = [ plib freeglut xproto libX11 libXext xextproto libXi inputproto
@@ -28,4 +28,3 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2;
   };
 }
-

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -6,14 +6,14 @@
 }:
 
 let
-  version = "2017.3.1";
-  shortVersion = "2017.3";
+  version = "2018.2.2";
+  shortVersion = "2018.2";
   data = stdenv.mkDerivation rec {
     name = "flightgear-base-${version}";
 
     src = fetchurl {
       url = "mirror://sourceforge/flightgear/release-${shortVersion}/FlightGear-${version}-data.tar.bz2";
-      sha256 = "166q0fsbp17lx1l1n6i8cfk3d1i79pasz1liya09z6m2i1pb026z";
+      sha256 = "c89b94e4cf3cb7eda728daf6cca6dd051f7a47863776c99fd2f3fe0054400ac4";
     };
 
     phases = [ "installPhase" ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${name}.tar.bz2";
-    sha256 = "1kccf91vmxnzyki6grx09s10dvr4j6qrz34ikj7jn81g5scisbkg";
+    sha256 = "61f809ef0a3f6908d156f0c483ed5313d31b5a6ac74761955d0b266751718147";
   };
 
   # Of all the files in the source and data archives, there doesn't seem to be

--- a/pkgs/games/speed-dreams/default.nix
+++ b/pkgs/games/speed-dreams/default.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
     tar -xf ${wip-cars-and-tracks}
   '';
 
+  prePatch = ''
+    # https://sourceforge.net/p/speed-dreams/mailman/message/35665539/
+    sed -i "s|lastSlash = '\\\0'|lastSlash = NULL|" src/libs/tgf/params.cpp
+    sed -i "s|const char\* error = '\\\0'|const char\* error = NULL|" src/libs/tgfclient/openalmusicplayer.cpp
+  '';
+
   preBuild = ''
     make -C src/libs/portability
     make -C src/libs/portability portability.o

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11605,6 +11605,7 @@ with pkgs;
   opensaml-cpp = callPackage ../development/libraries/opensaml-cpp { };
 
   openscenegraph = callPackage ../development/libraries/openscenegraph { };
+  openscenegraph_3_4 = callPackage ../development/libraries/openscenegraph/3.4.0.nix { };
 
   openslp = callPackage ../development/libraries/openslp {};
 
@@ -12190,7 +12191,7 @@ with pkgs;
     avrlibc = pkgsCross.avr.libcCross;
   };
 
-  simgear = callPackage ../development/libraries/simgear { };
+  simgear = callPackage ../development/libraries/simgear { openscenegraph = openscenegraph_3_4; };
 
   simp_le = callPackage ../tools/admin/simp_le { };
 
@@ -20236,7 +20237,7 @@ with pkgs;
 
   fish-fillets-ng = callPackage ../games/fish-fillets-ng {};
 
-  flightgear = libsForQt5.callPackage ../games/flightgear { };
+  flightgear = libsForQt5.callPackage ../games/flightgear { openscenegraph = openscenegraph_3_4; };
 
   flock = callPackage ../development/tools/flock { };
 
@@ -20678,6 +20679,7 @@ with pkgs;
     # Torcs wants to make shared libraries linked with plib libraries (it provides static).
     # i686 is the only platform I know than can do that linking without plib built with -fPIC
     libpng = libpng12;
+    openscenegraph = openscenegraph_3_4;
   };
 
   torcs = callPackage ../games/torcs { };


### PR DESCRIPTION
###### Motivation for this change
All 3 of these packages are broken in 18.09 due to incompatibility with the version of openscenegraph in 18.09. The idea is to reintroduce the version of openscenegraph shipped with 18.03 so these applications can work again.

###### Things done
As well as adding a second version of openscenegraph I have version bumped both flightgear & simgear, and fixed a separate bug in speed_dreams.
Since all of these packages are currently broken in 18.09 my intention is that these changes are backported to 18.09.

Once again looking to @7c6f434c for some review and/or approval on this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

