### PR TITLE
lightdm-mini-greeter: v0.3.2 -> v0.3.3

### DIFF
--- a/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "lightdm-mini-greeter-${version}";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "prikhi";
     repo = "lightdm-mini-greeter";
     rev = version;
-    sha256 = "1g3lrh034w38hiq96b0xmghmlf87hcycwdh06dwkdksr0hl08wxy";
+    sha256 = "1xlj5wqagp765rqw40ci4wir21qwyszasynk82x8308k5d3asvwb";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "A minimal, configurable, single-user GTK3 LightDM greeter";
     homepage = https://github.com/prikhi/lightdm-mini-greeter;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ mnacamura ];
+    maintainers = with maintainers; [ mnacamura prikhi ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

