### PR TITLE
polybar: nuke reference to stdenv.cc, small clean up

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -64,10 +64,15 @@ stdenv.mkDerivation rec {
       (if i3Support || i3GapsSupport then makeWrapper else null)
     ];
 
-    fixupPhase = if (i3Support || i3GapsSupport) then ''
-    wrapProgram $out/bin/polybar \
-      --prefix PATH : "${if i3Support then i3 else i3-gaps}/bin"
-  '' else null;
+    postConfigure = ''
+      substituteInPlace ../include/settings.hpp --replace \
+        "${stdenv.cc}" "${stdenv.cc.name}"
+    '';
+
+    postInstall = if (i3Support || i3GapsSupport) then ''
+      wrapProgram $out/bin/polybar \
+        --prefix PATH : "${if i3Support then i3 else i3-gaps}/bin"
+    '' else "";
 
     nativeBuildInputs = [
       cmake pkgconfig


### PR DESCRIPTION
###### Motivation for this change

1. Get rid of cc-wrapper, binutils and friends from the runtime closure. Only used to show what compiler was used to build the package, not actually needed at runtime.
2. Ensure the standard fixup phase is executed. Could have changed `fixupPhase` to `preFixup` / `postFixup` but `postInstall` felt more appropriate. Can amend / drop this part if needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Only started using the package so tested very briefly.

/cc maintainer @afldcr