### PR TITLE
raspberrypiWirelessFirmware: 2018-05-30 -> 2018-08-20

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -1,52 +1,51 @@
-{ stdenv, fetchurl, dpkg }:
+{ stdenv, fetchurl, fetchFromGitHub, dpkg }:
 
 stdenv.mkDerivation rec {
   name = "raspberrypi-wireless-firmware-${version}";
-  version = "2018-05-30";
+  version = "2018-08-20";
 
   srcs = [
-    (fetchurl {
-      url = "https://archive.raspberrypi.org/debian/pool/main/b/bluez-firmware/bluez-firmware_1.2-3+rpt5.debian.tar.xz";
-      sha256 = "06zpyrz6frkgjy26hr3998klnhjdqxwashgjgvj9rgbcqy70nkxg";
+    (fetchFromGitHub {
+      name = "bluez-firmware";
+      owner = "RPi-Distro";
+      repo = "bluez-firmware";
+      rev = "ade2bae1aaaebede09abb8fb546f767a0e4c7804";
+      sha256 = "07gm76gxp5anv6paryvxcp34a86fkny8kdlzqhzcpfczzglkp6ag";
     })
-    (fetchurl {
-      url = "https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20161130-3+rpt3_all.deb";
-      sha256 = "10l74ac28baprnsiylf2vy4pkxgb3crixid90ngs6si9smm7rn6z";
+    (fetchFromGitHub {
+      name = "firmware-nonfree";
+      owner = "RPi-Distro";
+      repo = "firmware-nonfree";
+      rev = "b518de45ced519e8f7a499f4778100173402ae43";
+      sha256 = "1d5026ic9awji6c67irpwsxpxgsc0dhn11d3abkxi2vvra1pir4g";
     })
   ];
 
   sourceRoot = ".";
+
   dontBuild = true;
   # Firmware blobs do not need fixing and should not be modified
   dontFixup = true;
-
-
-  # Unpack the debian package
-  nativeBuildInputs = [ dpkg ];
-  unpackCmd = ''
-    if ! [[ "$curSrc" =~ \.deb$ ]]; then return 1; fi
-    dpkg -x "$curSrc" .
-  '';
 
   installPhase = ''
     mkdir -p "$out/lib/firmware/brcm"
 
     # Wifi firmware
-    for filename in lib/firmware/brcm/brcmfmac434??-sdio.*; do
+    for filename in firmware-nonfree/brcm/brcmfmac434??-sdio.*; do
       cp "$filename" "$out/lib/firmware/brcm"
     done
 
     # Bluetooth firmware
-    cp broadcom/*.hcd "$out/lib/firmware/brcm"
+    cp bluez-firmware/broadcom/*.hcd "$out/lib/firmware/brcm"
   '';
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "1gwzasl5w5nc0awqv3w2081ns63wd1yds0xh0dg95dc6brnqhhf8";
+  outputHash = "1s5gb00v42s5izbaw8irs1fwvhh7z9wl07czc0nkw6p91871ivb7";
 
   meta = with stdenv.lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3 and Zero W";
-    homepage = https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/;
+    homepage = https://github.com/RPi-Distro/firmware-nonfree;
     license = licenses.unfreeRedistributableFirmware;
     platforms = platforms.linux;
     maintainers = with maintainers; [ lopsided98 ];


### PR DESCRIPTION
###### Motivation for this change

Update the Raspberry Pi wireless firmware to the latest version. This update apparently fixes some issues with simultaneous usage of Bluetooth and wifi.

###### Things done

I switch from unpacking the debian packages to using the upstream repos. When I first made this package, I didn't realize that [RPi-Distro](https://github.com/RPi-Distro) was an official Raspberry Pi account. The downside of this is that we have to download the entire linux-firmware repo when we only need a few files, but I felt this was cleaner than using the debian packages.

Wifi still works correctly with this update on my Raspberry Pi 3.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

