### PR TITLE
oidentd: 2.2.2 -> 2.3.1

### DIFF
--- a/nixos/modules/services/networking/oidentd.nix
+++ b/nixos/modules/services/networking/oidentd.nix
@@ -28,8 +28,7 @@ with lib;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig.Type = "forking";
-      script = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup" +
-          optionalString config.networking.enableIPv6 " -a ::";
+      script = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup";
     };
 
     users.users.oidentd = {

--- a/pkgs/servers/identd/oidentd/default.nix
+++ b/pkgs/servers/identd/oidentd/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, bison, flex }:
 
 stdenv.mkDerivation rec {
   name = "oidentd-${version}";
-  version = "2.2.2";
-
-  CFLAGS = [ "--std=gnu89" ];
+  version = "2.3.1";
+  nativeBuildInputs = [ bison flex ];
 
   src = fetchurl {
-    url = "https://ftp.janikrabe.com/pub/oidentd/releases/${version}/${name}.tar.gz";
-    sha256 = "1svj7ymljp4s17d7jlx6602n9081714qsj5yymmv1s9wagzjqyn9";
+    url = "https://files.janikrabe.com/pub/oidentd/releases/${version}/${name}.tar.gz";
+    sha256 = "1sljid4jyz9gjyx8wy3xd6bq4624dxs422nqd3mcxnsvgxr6d6zd";
   };
 
-  meta = {
-    homepage = http://ojnk.sourceforge.net/;
-    description = "An implementation of the IDENT protocol";
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    description = "Configurable Ident protocol server";
+    homepage = https://oidentd.janikrabe.com/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This updates oidentd to version 2.3.1.

* Added license: GPLv2.
* Updated homepage and description.
* CFLAGS are no longer necessary as of version 2.2.0.
* Option '-a ::' is no longer necessary as of version 2.2.0.

###### Motivation for this change

Several issues have been fixed since version 2.2.0. [See the changes](https://github.com/janikrabe/oidentd/blob/v2.3.1/NEWS).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

