### PR TITLE
pulumi: init at 0.16.2

### DIFF
--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl }:
+
+let
+
+  version = "0.16.2";
+
+  # switch the dropdown to “manual” on https://pulumi.io/quickstart/install.html # TODO: update script
+  pulumiArchPackage = {
+    "x86_64-linux" = {
+      url = "https://get.pulumi.com/releases/sdk/pulumi-v${version}-linux-x64.tar.gz";
+      sha256 = "16qgy2pj3xkf1adi3882fpsl99jwsm19111fi5vzh1xqf39sg549";
+    };
+    "x86_64-darwin" = {
+      url = "https://get.pulumi.com/releases/sdk/pulumi-v${version}-darwin-x64.tar.gz";
+      sha256 = "18ck9khspa0x798bdlwk8dzylbsq7s35xmla8yasd9qqlab1yy1a";
+    };
+  };
+
+in stdenv.mkDerivation rec {
+  inherit version;
+  name = "pulumi-${version}";
+
+  src = fetchurl pulumiArchPackage.${stdenv.hostPlatform.system};
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp * $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://pulumi.io/;
+    description = "Pulumi is a cloud development platform that makes creating cloud programs easy and productive";
+    license = with licenses; [ asl20 ];
+    platforms = builtins.attrNames pulumiArchPackage;
+    maintainers = with maintainers; [
+      peterromfeldhk
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4663,6 +4663,8 @@ with pkgs;
       };
   };
 
+  pulumi-bin = callPackage ../tools/admin/pulumi { };
+
   p0f = callPackage ../tools/security/p0f { };
 
   pngout = callPackage ../tools/graphics/pngout { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

