### PR TITLE
 pythonPackages.broadlink: init at 0.9 

### DIFF
--- a/pkgs/development/python-modules/broadlink/default.nix
+++ b/pkgs/development/python-modules/broadlink/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchPypi, buildPythonPackage
+, pyaes, pycrc }:
+
+buildPythonPackage rec {
+  pname = "broadlink";
+  version = "0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10dnd859yjh1h6qrxhvkslbsj5fh5g654xsq2yqblkkv3xd711rs";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace pyaes==1.6.0 pyaes
+    '';
+
+  propagatedBuildInputs = [ pyaes pycrc ];
+
+  # no tests available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python API for controlling Broadlink IR controllers";
+    homepage =  http://github.com/mjg59/python-broadlink;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -851,7 +851,7 @@
     "sensor.bme680" = ps: with ps; [  ];
     "sensor.bmw_connected_drive" = ps: with ps; [  ];
     "sensor.bom" = ps: with ps; [  ];
-    "sensor.broadlink" = ps: with ps; [  ];
+    "sensor.broadlink" = ps: with ps; [ broadlink ];
     "sensor.buienradar" = ps: with ps; [  ];
     "sensor.canary" = ps: with ps; [  ];
     "sensor.cert_expiry" = ps: with ps; [  ];
@@ -1139,7 +1139,7 @@
     "switch.arduino" = ps: with ps; [  ];
     "switch.arest" = ps: with ps; [  ];
     "switch.bbb_gpio" = ps: with ps; [  ];
-    "switch.broadlink" = ps: with ps; [  ];
+    "switch.broadlink" = ps: with ps; [ broadlink ];
     "switch.command_line" = ps: with ps; [  ];
     "switch.deconz" = ps: with ps; [  ];
     "switch.deluge" = ps: with ps; [ deluge-client ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -260,6 +260,8 @@ in {
 
   brotli = callPackage ../development/python-modules/brotli { };
 
+  broadlink = callPackage ../development/python-modules/broadlink { };
+
   browser-cookie3 = callPackage ../development/python-modules/browser-cookie3 { };
 
   browsermob-proxy = disabledIf isPy3k (callPackage ../development/python-modules/browsermob-proxy {});


### PR DESCRIPTION
###### Motivation for this change

Broadlink support for HA!

Cc: @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

