### PR TITLE
WIP: pgFormatter: init at 3.2

### DIFF
--- a/pkgs/development/tools/pgFormatter/default.nix
+++ b/pkgs/development/tools/pgFormatter/default.nix
@@ -1,0 +1,39 @@
+{ buildPerlPackage, fetchFromGitHub, glibcLocales, lib, ... }:
+
+# original implementation stolen from https://github.com/ariutta/nixpkgs-custom/blob/aa72a115a71bb248a2a7f0deac55132e68b54365/perl-packages.nix#L13
+
+buildPerlPackage rec {
+  name = "pgFormatter-${version}";
+  version = "v3.2";
+
+  src = fetchFromGitHub {
+    owner  = "darold";
+    repo   = "pgFormatter";
+    rev    = "${version}";
+    sha256 = "1rvamvgymm4b60bq0s46mdxhqavl628vcqp7f7j1slrs4wm62ykc";
+  };
+
+  # glibcLocales is needed to fix a locale issue. See this comment:
+  # https://github.com/NixOS/nixpkgs/issues/8398#issuecomment-186832814
+  # TODO: is buildInputs the right way to specify this dependency?
+  buildInputs = [ glibcLocales ];
+
+  outputs = [ "out" ];
+
+  makeMakerFlags = [ "INSTALLDIRS=vendor" ];
+
+  # Makefile.PL only accepts DESTDIR and INSTALLDIRS, but we need to set more to make this work for NixOS.
+  patchPhase = ''
+    sed -i "s#'DESTDIR'      => \$DESTDIR,#'DESTDIR'      => '$out/',#" Makefile.PL
+    sed -i "s#'INSTALLDIRS'  => \$INSTALLDIRS,#'INSTALLDIRS'  => \$INSTALLDIRS, 'INSTALLVENDORLIB'  => 'bin/lib', 'INSTALLVENDORBIN'  => 'bin', 'INSTALLVENDORSCRIPT'  => 'bin', 'INSTALLVENDORMAN1DIR'  => 'share/man/man1', 'INSTALLVENDORMAN3DIR'  => 'share/man/man3',#" Makefile.PL
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A PostgreSQL SQL syntax beautifier that can work as a console program or as a CGI.";
+    homepage = https://github.com/darold/pgFormatter;
+    maintainers = with lib.maintainers; [ ariutta srghma ];
+    license = with lib.licenses; [ postgresql artistic2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3131,6 +3131,8 @@ with pkgs;
 
   pgf_graphics = callPackage ../tools/graphics/pgf { };
 
+  pgFormatter = callPackage ../development/tools/pgFormatter { };
+
   pgjwt = callPackage ../servers/sql/postgresql/pgjwt {};
 
   cstore_fdw = callPackage ../servers/sql/postgresql/cstore_fdw {};


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

