### PR TITLE
granite: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchFromGitHub, perl, cmake, ninja, vala_0_40, pkgconfig, gobjectIntrospection, glib, gtk3, gnome3, gettext }:
+{ stdenv, fetchFromGitHub, cmake, ninja, vala_0_40, pkgconfig, gobjectIntrospection, gnome3, gtk3, glib, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "granite-${version}";
-  version = "5.1.0";
+  pname = "granite";
+  version = "5.2.0";
+
+  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = "granite";
+    repo = pname;
     rev = version;
     sha256 = "1v1yhz6rp616xi417m9r8072s6mpz5i8vkdyj264b73p0lgjwh40";
   };
@@ -21,10 +23,10 @@ stdenv.mkDerivation rec {
     gettext
     gobjectIntrospection
     ninja
-    perl
     pkgconfig
-    vala_0_40
+    vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
   ];
+
   buildInputs = [
     glib
     gnome3.libgee
@@ -33,9 +35,12 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An extension to GTK+ used by elementary OS";
-    longDescription = "An extension to GTK+ that provides several useful widgets and classes to ease application development. Designed for elementary OS.";
+    longDescription = ''
+      Granite is a companion library for GTK+ and GLib. Among other things, it provides complex widgets and convenience functions
+      designed for use in apps built for elementary OS.
+    '';
     homepage = https://github.com/elementary/granite;
-    license = licenses.lgpl3;
+    license = licenses.lgpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ vozz worldofpeace ];
   };


### PR DESCRIPTION
###### Motivation for this change
An update.

#### [Release Notes](https://github.com/elementary/granite/releases/tag/5.2.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

