### PR TITLE
picard: 1.4.2 -> 2.0.4

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -1,26 +1,32 @@
-{ stdenv, python2Packages, fetchurl, gettext }:
+{ stdenv, python3Packages, fetchurl, gettext, chromaprint }:
 
 let
-  pythonPackages = python2Packages;
+  pythonPackages = python3Packages;
 in pythonPackages.buildPythonApplication rec {
   pname = "picard";
-  version = "1.4.2";
+  version = "2.0.4";
 
   src = fetchurl {
     url = "http://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-${version}.tar.gz";
-    sha256 = "0d12k40d9fbcn801gp5zdsgvjdrh4g97vda3ga16rmmvfwwfxbgh";
+    sha256 = "0ds3ylpqn717fnzcjrfn05v5xram01bj6n3hwn9igmkd1jgf8vhc";
   };
 
   buildInputs = [ gettext ];
 
   propagatedBuildInputs = with pythonPackages; [
-    pyqt4
+    pyqt5
     mutagen
+    chromaprint
     discid
   ];
 
   installPhase = ''
     python setup.py install --prefix="$out"
+  '';
+
+  prePatch = ''
+    # Pesky unicode punctuation.
+    substituteInPlace setup.cfg --replace "‘" "'"
   '';
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Changes:

https://github.com/metabrainz/picard/releases
https://blog.musicbrainz.org/2018/07/19/picard-2-0-released/

Upgrades to Python 3 and PyQt 5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

