### PR TITLE
pythonPackages.google-cloud-*: init all 37 modules 

### DIFF
--- a/pkgs/development/python-modules/google_cloud_asset/default.nix
+++ b/pkgs/development/python-modules/google_cloud_asset/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, grpc_google_iam_v1
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-asset";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cec2f44a670371e24e6140c454fdac3ed06be0a021042c6756a3284b505335c7";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Asset API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_automl/default.nix
+++ b/pkgs/development/python-modules/google_cloud_automl/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-automl";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "793d463f78d22a822196cb3e34b247fbdba07eeae15ceadb911f5ccecd843f87";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud AutoML API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_bigquery/default.nix
+++ b/pkgs/development/python-modules/google_cloud_bigquery/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_resumable_media
+, google_api_core
+, google_cloud_core
+, pandas
+, pyarrow
+, pytest
+, mock
+, ipython
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-bigquery";
+  version = "1.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d559ba1e05cf6a960e09bb5aab3aeb4d50ad9e08c77a20a17c01c9b2bd8d6cb7";
+  };
+
+  checkInputs = [ pytest mock ipython ];
+  propagatedBuildInputs = [ google_resumable_media google_api_core google_cloud_core pandas pyarrow ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google BigQuery API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_bigquery_datatransfer/default.nix
+++ b/pkgs/development/python-modules/google_cloud_bigquery_datatransfer/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-bigquery-datatransfer";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f5b5d0de43805fa9ebb620c58e1d27e6d32d2fc8e9a2f954ee170f7a026c8757";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "BigQuery Data Transfer API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_bigtable/default.nix
+++ b/pkgs/development/python-modules/google_cloud_bigtable/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, grpc_google_iam_v1
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-bigtable";
+  version = "0.31.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b6c8572697b5fdc7fcb95d88f87b8c84cea5a7aef2d57d3de0d6a9e2b0e8424f";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ grpc_google_iam_v1 google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Bigtable API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_container/default.nix
+++ b/pkgs/development/python-modules/google_cloud_container/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-container";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a89afcb1fe96bc9361c231c223c3bbe19fa3787caeb4697cd5778990e1077270";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Container Engine API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_dataproc/default.nix
+++ b/pkgs/development/python-modules/google_cloud_dataproc/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-dataproc";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "531dbd3e5862df5e67751efdcd89f00d0ded35f3a87a18fd3245e1c365080720";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Dataproc API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_datastore/default.nix
+++ b/pkgs/development/python-modules/google_cloud_datastore/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-datastore";
+  version = "1.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03c1a06b0d94ac2f801513c9255bd5fc8773d036f0e59d63ffe1152cfe4320de";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Datastore API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_dlp/default.nix
+++ b/pkgs/development/python-modules/google_cloud_dlp/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-dlp";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "408e5c6820dc53dd589a7bc378d25c2cf5817c448b7c7b1268bc745ecbe04ec3";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Data Loss Prevention (DLP) API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_dns/default.nix
+++ b/pkgs/development/python-modules/google_cloud_dns/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-dns";
+  version = "0.29.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f6ea35676c59b6bfd4a2e6aa42670c6ed3505ba46f7117cdc953094e568f404e";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud DNS API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_error_reporting/default.nix
+++ b/pkgs/development/python-modules/google_cloud_error_reporting/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_cloud_logging
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-error-reporting";
+  version = "0.30.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "768a5c3ed7a96b60f051717c1138e561493ab0ef4dd4acbcf9e2b1cc2d09e06a";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_cloud_logging ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stackdriver Error Reporting API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_firestore/default.nix
+++ b/pkgs/development/python-modules/google_cloud_firestore/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-firestore";
+  version = "0.30.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7f990572ace890867bbbc63c9d700c1d2635ba4c799e05f30b6fdca490021243";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  # tests were not included with release
+  # See issue https://github.com/googleapis/google-cloud-python/issues/6380
+  doCheck = false;
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Firestore API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_iot/default.nix
+++ b/pkgs/development/python-modules/google_cloud_iot/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, grpc_google_iam_v1
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-iot";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1502fa6d64f8f0f7c0e34e71c82c5daacc8fd8f78256cfadef5ae06c5efcc3b4";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud IoT API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    # maintainers = [ maintainers. ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_kms/default.nix
+++ b/pkgs/development/python-modules/google_cloud_kms/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, grpc_google_iam_v1
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-kms";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "add648f9185a8724f8632b3a006ee0af4847a5ab4ca085954ff1d00a8cd2d54c";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Key Management Service (KMS) API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_language/default.nix
+++ b/pkgs/development/python-modules/google_cloud_language/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-language";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2450e3265df129241cb21badb9d4ce2089d2652581df38e03c14a7ec85679ecb";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Natural Language API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_logging/default.nix
+++ b/pkgs/development/python-modules/google_cloud_logging/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+, webapp2
+, django
+, flask
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-logging";
+  version = "1.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "418ae534a8044ea5fd385fc4958763d76b8f315785d7a61f264c5a04035d02d5";
+  };
+
+  checkInputs = [ pytest mock webapp2 django flask ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stackdriver Logging API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_monitoring/default.nix
+++ b/pkgs/development/python-modules/google_cloud_monitoring/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pandas
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-monitoring";
+  version = "0.30.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6b26d659360306d51b9fb88c5b1eb77bf49967a37b6348ae9568c083e466274d";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_api_core pandas ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stackdriver Monitoring API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_pubsub/default.nix
+++ b/pkgs/development/python-modules/google_cloud_pubsub/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, grpc_google_iam_v1
+, google_api_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-pubsub";
+  version = "0.38.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b0481fa61faf8143c3cffc9d3fbe757423a200fbddddcf27feb2c49e3c35e58";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Pub/Sub API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_redis/default.nix
+++ b/pkgs/development/python-modules/google_cloud_redis/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-redis";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c0fa00cafbce3e9a0e35fb7f9d754ac70b450b6496c62c20bb3a1f500aeca9e4";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 google_api_core ];
+
+  # requires old version of google-api-core (override)
+  preBuild = ''
+    sed -i "s/'google-api-core\[grpc\] >= 0.1.0, < 0.2.0dev'/'google-api-core'/g" setup.py
+    sed -i "s/google-api-core\[grpc\]<0.2.0dev,>=0.1.0/google-api-core/g" google_cloud_redis.egg-info/requires.txt
+  '';
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Memorystore for Redis API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_resource_manager/default.nix
+++ b/pkgs/development/python-modules/google_cloud_resource_manager/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_cloud_core
+, google_api_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-resource-manager";
+  version = "0.28.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fc29c11dcbe9208261d377185a1ae5331bab43f2a592222a25c8aca9c8031308";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_cloud_core google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Resource Manager API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_runtimeconfig/default.nix
+++ b/pkgs/development/python-modules/google_cloud_runtimeconfig/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-runtimeconfig";
+  version = "0.28.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f441fbc22e2d0871ecb390854aa352cf467d2751cbc0dac7578274ead813519e";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud RuntimeConfig API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_securitycenter/default.nix
+++ b/pkgs/development/python-modules/google_cloud_securitycenter/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, grpc_google_iam_v1
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-securitycenter";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6ef386ba065a167670ad1b67f15fb7ba9e21ce33579fa6d7fafafd5b970b3e8a";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Security Command Center API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_spanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_spanner/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, grpc_google_iam_v1
+, grpcio-gcp
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-spanner";
+  version = "1.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f7140e1cb43fbf670521112f03822b63d15fbcbd2830c7cfa1b868836e04b6b4";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ grpcio-gcp grpc_google_iam_v1 google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Spanner API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_speech/default.nix
+++ b/pkgs/development/python-modules/google_cloud_speech/default.nix
@@ -13,8 +13,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ google_api_core ];
   checkInputs = [ pytest mock ];
 
-  # needs credentials
-  doCheck = false;
+  checkPhase = ''
+    pytest tests/unit
+  '';
 
   meta = with stdenv.lib; {
     description = "Cloud Speech API enables integration of Google speech recognition into applications.";

--- a/pkgs/development/python-modules/google_cloud_storage/default.nix
+++ b/pkgs/development/python-modules/google_cloud_storage/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_resumable_media
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-storage";
+  version = "1.13.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fc32b9be41a45016ba2387e3ad23e70ccba399d626ef596409316f7cee477956";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_resumable_media google_api_core google_cloud_core ];
+
+  checkPhase = ''
+   pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Storage API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_tasks/default.nix
+++ b/pkgs/development/python-modules/google_cloud_tasks/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, grpc_google_iam_v1
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-tasks";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f874a7aabad225588263c6cbcd4d67455cc682ebb6d9f00bd06c8d2d5673b4db";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ enum34 grpc_google_iam_v1 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Tasks API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_testutils/default.nix
+++ b/pkgs/development/python-modules/google_cloud_testutils/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, six
+, google_auth
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-testutils";
+  version = "unstable-36ffa923c7037e8b4fdcaa76272cb6267e908a9d";
+
+  # google-cloud-testutils is not "really"
+  # released as a python package
+  # but it is required for google-cloud-* tests
+  # so why not package it as a module
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "google-cloud-python";
+    rev = "36ffa923c7037e8b4fdcaa76272cb6267e908a9d";
+    sha256 = "1fvcnssmpgf4lfr7l9h7cz984rbc5mfr1j1br12japcib5biwzjy";
+  };
+
+  propagatedBuildInputs = [ six google_auth ];
+
+  postPatch = ''
+    cd test_utils
+  '';
+
+  meta = with stdenv.lib; {
+    description = "System test utilities for google-cloud-python";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_texttospeech/default.nix
+++ b/pkgs/development/python-modules/google_cloud_texttospeech/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-texttospeech";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6064bc6e2761694b708878ff3d5902c6ce5eb44a770a921e7a99caf6c2533ae3";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Text-to-Speech API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_trace/default.nix
+++ b/pkgs/development/python-modules/google_cloud_trace/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-trace";
+  version = "0.19.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2cb774498e90143a9565dd50e2814b6b0292242a53b8804a1a529989e18b7461";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stackdriver Trace API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_translate/default.nix
+++ b/pkgs/development/python-modules/google_cloud_translate/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, google_cloud_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-translate";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4420f5b320145bf097ca9a12b18ec27c067886e2832d181f268c46c3bcb0d2e4";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Translation API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_videointelligence/default.nix
+++ b/pkgs/development/python-modules/google_cloud_videointelligence/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-videointelligence";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bd0abc18070520fd5757b15356e8483149e1caebbe43019257ccb2c43cddbbbe";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Video Intelligence API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_vision/default.nix
+++ b/pkgs/development/python-modules/google_cloud_vision/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, enum34
+, google_api_core
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-vision";
+  version = "0.34.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "50392b2c68e40dbf725c531ba4d325bd910da6441a472ed0a3fadfd0ab8548f7";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ enum34 google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cloud Vision API API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
+++ b/pkgs/development/python-modules/google_cloud_websecurityscanner/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, google_api_core
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-cloud-websecurityscanner";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d41a9e1a093862aa1b181fa7fdc2a94e185eb4a8f290dbdb928bc9ebd253a95f";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ google_api_core ];
+
+  checkPhase = ''
+    pytest tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Web Security Scanner API client library";
+    homepage = https://github.com/GoogleCloudPlatform/google-cloud-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/google_resumable_media/default.nix
+++ b/pkgs/development/python-modules/google_resumable_media/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, six
+, requests
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "google-resumable-media";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "97de518f8166d442cc0b61fab308bcd319dbb970981e667ec8ded44f5ce49836";
+  };
+
+  checkInputs = [ pytest mock ];
+  propagatedBuildInputs = [ six requests ];
+
+  checkPhase = ''
+    py.test tests/unit
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utilities for Google Media Downloads and Resumable Uploads";
+    homepage = https://github.com/GoogleCloudPlatform/google-resumable-media-python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/grpc_google_iam_v1/default.nix
+++ b/pkgs/development/python-modules/grpc_google_iam_v1/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, grpcio
+, googleapis_common_protos
+}:
+
+buildPythonPackage rec {
+  pname = "grpc-google-iam-v1";
+  version = "0.11.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5009e831dcec22f3ff00e89405249d6a838d1449a46ac8224907aa5b0e0b1aec";
+  };
+
+  propagatedBuildInputs = [ grpcio googleapis_common_protos ];
+
+  meta = with stdenv.lib; {
+    description = "GRPC library for the google-iam-v1 service";
+    homepage = https://github.com/googleapis/googleapis;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/grpcio-gcp/default.nix
+++ b/pkgs/development/python-modules/grpcio-gcp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, grpcio
+}:
+
+buildPythonPackage rec {
+  pname = "grpcio-gcp";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e292605effc7da39b7a8734c719afb12ec4b5362add3528d8afad3aa3aa9057c";
+  };
+
+  propagatedBuildInputs = [ grpcio ];
+
+  meta = with stdenv.lib; {
+    description = "gRPC extensions for Google Cloud Platform";
+    homepage = https://grpc.io;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/webapp2/default.nix
+++ b/pkgs/development/python-modules/webapp2/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, webob
+, six
+, jinja2
+}:
+
+buildPythonPackage rec {
+  pname = "webapp2";
+  version = "2.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "997db622a266bd64eb7fcc9cfe823efb69277544aa92064030c16acbfb2733a5";
+  };
+
+  # # error in tests when running with python 3+
+  doCheck = false;
+
+  propagatedBuildInputs = [ webob six ];
+
+  meta = with stdenv.lib; {
+    description = "Taking Google App Engine's webapp to the next level";
+    homepage = http://webapp-improved.appspot.com;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2466,6 +2466,8 @@ in {
 
   grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
 
+  grpc_google_iam_v1 = callPackage ../development/python-modules/grpc_google_iam_v1 { };
+
   gspread = callPackage ../development/python-modules/gspread { };
 
   gyp = callPackage ../development/python-modules/gyp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -196,7 +196,7 @@ in {
 
   astropy = callPackage ../development/python-modules/astropy { };
 
-  astroquery = callPackage ../development/python-modules/astroquery { }; 
+  astroquery = callPackage ../development/python-modules/astroquery { };
 
   atom = callPackage ../development/python-modules/atom { };
 
@@ -2444,10 +2444,9 @@ in {
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };
 
-  gpgme = toPythonModule (pkgs.gpgme.override {
-    pythonSupport = true;
-    inherit (self) python;
-  });
+  google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
+
+  gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });
 
   gphoto2 = callPackage ../development/python-modules/gphoto2 {
     inherit (pkgs) pkgconfig;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -716,6 +716,8 @@ in {
 
   vidstab = callPackage ../development/python-modules/vidstab { };
 
+  webapp2 = callPackage ../development/python-modules/webapp2 { };
+
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };
 
   WazeRouteCalculator = callPackage ../development/python-modules/WazeRouteCalculator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2450,6 +2450,8 @@ in {
 
   google_cloud_bigquery_datatransfer = callPackage ../development/python-modules/google_cloud_bigquery_datatransfer { };
 
+  google_cloud_bigtable = callPackage ../development/python-modules/google_cloud_bigtable { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2480,6 +2480,8 @@ in {
 
   google_cloud_pubsub = callPackage ../development/python-modules/google_cloud_pubsub { };
 
+  google_cloud_redis = callPackage ../development/python-modules/google_cloud_redis { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2494,6 +2494,8 @@ in {
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };
 
+  google_cloud_tasks = callPackage ../development/python-modules/google_cloud_tasks { };
+
   google_cloud_testutils = callPackage ../development/python-modules/google_cloud_testutils { };
 
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2484,6 +2484,8 @@ in {
 
   google_cloud_resource_manager = callPackage ../development/python-modules/google_cloud_resource_manager { };
 
+  google_cloud_runtimeconfig = callPackage ../development/python-modules/google_cloud_runtimeconfig { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2466,6 +2466,8 @@ in {
 
   google_cloud_error_reporting = callPackage ../development/python-modules/google_cloud_error_reporting { };
 
+  google_cloud_firestore = callPackage ../development/python-modules/google_cloud_firestore { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_logging = callPackage ../development/python-modules/google_cloud_logging { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2464,6 +2464,8 @@ in {
 
   google_cloud_dns = callPackage ../development/python-modules/google_cloud_dns { };
 
+  google_cloud_error_reporting = callPackage ../development/python-modules/google_cloud_error_reporting { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_logging = callPackage ../development/python-modules/google_cloud_logging { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2454,6 +2454,8 @@ in {
 
   google_cloud_container = callPackage ../development/python-modules/google_cloud_container { };
 
+  google_cloud_dataproc = callPackage ../development/python-modules/google_cloud_dataproc { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2488,6 +2488,8 @@ in {
 
   google_cloud_securitycenter = callPackage ../development/python-modules/google_cloud_securitycenter { };
 
+  google_cloud_spanner = callPackage ../development/python-modules/google_cloud_spanner { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2440,6 +2440,8 @@ in {
 
   google_auth = callPackage ../development/python-modules/google_auth { };
 
+  google_cloud_asset = callPackage ../development/python-modules/google_cloud_asset { };
+
   google_cloud_core = callPackage ../development/python-modules/google_cloud_core { };
 
   google_cloud_bigquery = callPackage ../development/python-modules/google_cloud_bigquery { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2504,6 +2504,8 @@ in {
 
   google_cloud_translate = callPackage ../development/python-modules/google_cloud_translate { };
 
+  google_cloud_videointelligence = callPackage ../development/python-modules/google_cloud_videointelligence { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2486,6 +2486,8 @@ in {
 
   google_cloud_runtimeconfig = callPackage ../development/python-modules/google_cloud_runtimeconfig { };
 
+  google_cloud_securitycenter = callPackage ../development/python-modules/google_cloud_securitycenter { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2466,6 +2466,8 @@ in {
 
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
+  google_cloud_logging = callPackage ../development/python-modules/google_cloud_logging { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2508,6 +2508,8 @@ in {
 
   google_cloud_vision = callPackage ../development/python-modules/google_cloud_vision { };
 
+  google_cloud_websecurityscanner = callPackage ../development/python-modules/google_cloud_websecurityscanner { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2502,6 +2502,8 @@ in {
 
   google_cloud_trace = callPackage ../development/python-modules/google_cloud_trace { };
 
+  google_cloud_translate = callPackage ../development/python-modules/google_cloud_translate { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2476,6 +2476,8 @@ in {
 
   google_cloud_logging = callPackage ../development/python-modules/google_cloud_logging { };
 
+  google_cloud_monitoring = callPackage ../development/python-modules/google_cloud_monitoring { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2444,6 +2444,8 @@ in {
 
   google_cloud_bigquery = callPackage ../development/python-modules/google_cloud_bigquery { };
 
+  google_cloud_bigquery_datatransfer = callPackage ../development/python-modules/google_cloud_bigquery_datatransfer { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2442,6 +2442,8 @@ in {
 
   google_cloud_core = callPackage ../development/python-modules/google_cloud_core { };
 
+  google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
+
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };
 
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2452,6 +2452,8 @@ in {
 
   google_cloud_bigtable = callPackage ../development/python-modules/google_cloud_bigtable { };
 
+  google_cloud_container = callPackage ../development/python-modules/google_cloud_container { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2446,6 +2446,8 @@ in {
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };
 
+  google_cloud_testutils = callPackage ../development/python-modules/google_cloud_testutils { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2472,6 +2472,8 @@ in {
 
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
+  google_cloud_language = callPackage ../development/python-modules/google_cloud_language { };
+
   google_cloud_logging = callPackage ../development/python-modules/google_cloud_logging { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2482,6 +2482,8 @@ in {
 
   google_cloud_redis = callPackage ../development/python-modules/google_cloud_redis { };
 
+  google_cloud_resource_manager = callPackage ../development/python-modules/google_cloud_resource_manager { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2460,6 +2460,8 @@ in {
 
   google_cloud_dlp = callPackage ../development/python-modules/google_cloud_dlp { };
 
+  google_cloud_dns = callPackage ../development/python-modules/google_cloud_dns { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2442,6 +2442,8 @@ in {
 
   google_cloud_asset = callPackage ../development/python-modules/google_cloud_asset { };
 
+  google_cloud_automl = callPackage ../development/python-modules/google_cloud_automl { };
+
   google_cloud_core = callPackage ../development/python-modules/google_cloud_core { };
 
   google_cloud_bigquery = callPackage ../development/python-modules/google_cloud_bigquery { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2444,6 +2444,8 @@ in {
 
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
+  google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
+
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };
 
   google_cloud_testutils = callPackage ../development/python-modules/google_cloud_testutils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2506,6 +2506,8 @@ in {
 
   google_cloud_videointelligence = callPackage ../development/python-modules/google_cloud_videointelligence { };
 
+  google_cloud_vision = callPackage ../development/python-modules/google_cloud_vision { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2458,6 +2458,8 @@ in {
 
   google_cloud_datastore = callPackage ../development/python-modules/google_cloud_datastore { };
 
+  google_cloud_dlp = callPackage ../development/python-modules/google_cloud_dlp { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2442,6 +2442,8 @@ in {
 
   google_cloud_core = callPackage ../development/python-modules/google_cloud_core { };
 
+  google_cloud_bigquery = callPackage ../development/python-modules/google_cloud_bigquery { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2500,6 +2500,8 @@ in {
 
   google_cloud_texttospeech = callPackage ../development/python-modules/google_cloud_texttospeech { };
 
+  google_cloud_trace = callPackage ../development/python-modules/google_cloud_trace { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2456,6 +2456,8 @@ in {
 
   google_cloud_dataproc = callPackage ../development/python-modules/google_cloud_dataproc { };
 
+  google_cloud_datastore = callPackage ../development/python-modules/google_cloud_datastore { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2468,6 +2468,8 @@ in {
 
   google_cloud_firestore = callPackage ../development/python-modules/google_cloud_firestore { };
 
+  google_cloud_iot = callPackage ../development/python-modules/google_cloud_iot { };
+
   google_cloud_kms = callPackage ../development/python-modules/google_cloud_kms { };
 
   google_cloud_logging = callPackage ../development/python-modules/google_cloud_logging { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2498,6 +2498,8 @@ in {
 
   google_cloud_testutils = callPackage ../development/python-modules/google_cloud_testutils { };
 
+  google_cloud_texttospeech = callPackage ../development/python-modules/google_cloud_texttospeech { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2478,6 +2478,8 @@ in {
 
   google_cloud_monitoring = callPackage ../development/python-modules/google_cloud_monitoring { };
 
+  google_cloud_pubsub = callPackage ../development/python-modules/google_cloud_pubsub { };
+
   google_cloud_storage = callPackage ../development/python-modules/google_cloud_storage { };
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2516,6 +2516,8 @@ in {
 
   grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
 
+  grpcio-gcp = callPackage ../development/python-modules/grpcio-gcp { };
+
   grpc_google_iam_v1 = callPackage ../development/python-modules/grpc_google_iam_v1 { };
 
   gspread = callPackage ../development/python-modules/gspread { };


### PR DESCRIPTION
###### Motivation for this change

I will be doing a lot of development with google-cloud in the coming year. Wanted to make sure that all the google python modules are available. 

###### Things done

Tests are enabled for every package. All pass entirely. Compared to `azure` and `aws` python tools this is the best set of modules I have seen. No circular dependencies, `pytest` and `mock` are the only testing dependencies.

Many modules have been added. Without this python module [initialization tools I made](https://github.com/costrouc/nixpkgs-dev-tools/blob/master/python/python-package-init.py) this would have taken days.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

