### PR TITLE
pythonPackages.xapian: init -> 1.4.8

### DIFF
--- a/pkgs/development/libraries/xapian/bindings/python.nix
+++ b/pkgs/development/libraries/xapian/bindings/python.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchurl, pkgconfig, xapian, python, pythonPackages, isPy3k
+, zlib, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "xapian-bindings";
+  inherit (xapian) version;
+
+  src = fetchurl {
+    url = "https://oligarchy.co.uk/xapian/${version}/${pname}-${version}.tar.xz";
+    sha256 = "0ll3z3418r7bzxs4kyini2cbci5xl8i5scl3wyx88s2v4ak56bcz";
+  };
+
+  buildInputs = [ xapian pythonPackages.sphinx zlib ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  configurePhase = ''./configure PYTHON${lib.optionalString (!isPy3k) "2"}${lib.optionalString (isPy3k) "3"}=${python}/bin/${python.executable} --prefix=$out PYTHON_LIB="$out/lib/${python.libPrefix}"'';
+
+  buildPhase = ''
+    mkdir -p $out/lib/${python.libPrefix}
+    make
+  '';
+
+  installPhase = ''
+    make install
+  '';
+
+  doCheck = (!isPy3k);
+
+  checkPhase = ''
+    cd python${lib.optionalString (isPy3k) "3"}$ 
+    export PYTHONPATH=$PYTHONPATH:$out/lib/${python.libPrefix}
+    ${python}/bin/${python.executable} smoketest.py
+    ${python}/bin/${python.executable} pythontest.py
+  '';
+
+  meta = with lib; {
+    description = "Python Bindings for Xapian";
+    homepage = https://xapian.org/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2828,6 +2828,8 @@ in {
 
   colored = callPackage ../development/python-modules/colored { };
 
+  xapian-bindings = callPackage ../development/libraries/xapian/bindings/python.nix { };
+
   xdis = callPackage ../development/python-modules/xdis { };
 
   xnd = callPackage ../development/python-modules/xnd { };


### PR DESCRIPTION
###### Motivation for this change

Python bindings for Xapian, which is a dependency for a larger project I'm packaging.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

