### PR TITLE
stern: Include bash & zsh completion support

### DIFF
--- a/pkgs/applications/networking/cluster/stern/default.nix
+++ b/pkgs/applications/networking/cluster/stern/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "stern-${version}";
@@ -15,11 +15,20 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-   meta = with lib; {
-      description      = "Multi pod and container log tailing for Kubernetes";
-      homepage         = "https://github.com/wercker/stern";
-      license          = licenses.asl20;
-      maintainers      = with maintainers; [ mbode ];
-      platforms        = platforms.unix;
-    };
+  # Only build shell completion if we're _not_ cross compiling,
+  # because it requires executing the compiled stern binary.
+  postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+    mkdir -p $bin/share/bash-completion/completions
+    $bin/bin/stern --completion bash > $bin/share/bash-completion/completions/stern
+    mkdir -p $bin/share/zsh/site-functions
+    $bin/bin/stern --completion zsh > $bin/share/zsh/site-functions/_stern
+  '';
+
+  meta = with lib; {
+    description      = "Multi pod and container log tailing for Kubernetes";
+    homepage         = "https://github.com/wercker/stern";
+    license          = licenses.asl20;
+    maintainers      = with maintainers; [ mbode ];
+    platforms        = platforms.unix;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
I want tab completion

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
