### PR TITLE
Provide all the binaries needed by the vim-go plugin

### DIFF
--- a/pkgs/development/tools/asmfmt/default.nix
+++ b/pkgs/development/tools/asmfmt/default.nix
@@ -1,0 +1,37 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+, fetchpatch
+}:
+
+buildGoPackage rec {
+  name = "asmfmt-${version}";
+  version = "1.1";
+
+  goPackagePath = "github.com/klauspost/asmfmt";
+
+  src = fetchFromGitHub {
+    owner = "klauspost";
+    repo = "asmfmt";
+    rev = "v${version}";
+    sha256 = "08mybfizcvck460axakycz9ndzcgwqilp5mmgm4bl8hfrn36mskw";
+  };
+
+  patches = [
+    (fetchpatch {
+      excludes = ["README.md"];
+      url = "https://github.com/klauspost/asmfmt/commit/39a37c8aed8095e0fdfb07f78fc8acbd465d9627.patch";
+      sha256 = "18bc77l87mf0yvqc3adlakxz6wflyqfsc2wrmh9q0nlqghlmnw5k";
+    })
+  ];
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Go Assembler Formatter";
+    homepage = https://github.com/klauspost/asmfmt;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/asmfmt/deps.nix
+++ b/pkgs/development/tools/asmfmt/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "3a10b9bf0a52df7e992a8c3eb712a86d3c896c75";
+      sha256 = "19f3dijcc54jnd7458jab2dgpd0gzccmv2qympd9wi8cc8jpnhws";
+    };
+  }
+  {
+    goPackagePath = "sourcegraph.com/sqs/goreturns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sqs/goreturns";
+      rev = "538ac601451833c7c4449f8431d65d53c1c60e41";
+      sha256 = "0gcplch8zmcgwl6xvcffxg50g3xnf60n7dlqxgn51179qcjr354p";
+    };
+  }
+]

--- a/pkgs/development/tools/check/default.nix
+++ b/pkgs/development/tools/check/default.nix
@@ -1,0 +1,30 @@
+{ buildGoPackage
+, lib
+, fetchFromGitLab
+}:
+
+buildGoPackage rec {
+  name = "check-unstable-${version}";
+  version = "2018-09-12";
+  rev = "88db195993f8e991ad402754accd0635490769f9";
+
+  goPackagePath = "gitlab.com/opennota/check";
+
+  src = fetchFromGitLab {
+    inherit rev;
+
+    owner = "opennota";
+    repo = "check";
+    sha256 = "1983xmdkgpqda4qz8ashc6xv1zg5jl4zly3w566grxc5sfxpgf0i";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "A set of utilities for checking Go sources.";
+    homepage = https://gitlab.com/opennota/check;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/check/deps.nix
+++ b/pkgs/development/tools/check/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "677d2ff680c1";
+      sha256 = "0vp1w1haqcjd82dxd6x9xrllbfwvm957rxwkpji96cgvhsli2bq5";
+    };
+  }
+]

--- a/pkgs/development/tools/deadcode/default.nix
+++ b/pkgs/development/tools/deadcode/default.nix
@@ -1,0 +1,31 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+# TODO(yl): should we package https://github.com/remyoudompheng/go-misc instead of
+# the standalone extract of deadcode from it?
+buildGoPackage rec {
+  name = "deadcode-unstable-${version}";
+  version = "2016-07-24";
+  rev = "210d2dc333e90c7e3eedf4f2242507a8e83ed4ab";
+
+  goPackagePath = "github.com/tsenart/deadcode";
+  excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "tsenart";
+    repo = "deadcode";
+    sha256 = "05kif593f4wygnrq2fdjhn7kkcpdmgjnykcila85d0gqlb1f36g0";
+  };
+
+  meta = with lib; {
+    description = "deadcode is a very simple utility which detects unused declarations in a Go package.";
+    homepage = https://github.com/remyoudompheng/go-misc/tree/master/deadcode;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/errcheck/default.nix
+++ b/pkgs/development/tools/errcheck/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "errcheck-${version}";
+  version = "1.1.0";
+
+  goPackagePath = "github.com/kisielk/errcheck";
+  excludedPackages = "\\(testdata\\)";
+
+  src = fetchFromGitHub {
+    owner = "kisielk";
+    repo = "errcheck";
+    rev = "v${version}";
+    sha256 = "19vd4rxmqbk5lpiav3pf7df3yjlz0l0dwx9mn0gjq5f998iyhy6y";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "errcheck is a program for checking for unchecked errors in go programs.";
+    homepage = https://github.com/kisielk/errcheck;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/errcheck/deps.nix
+++ b/pkgs/development/tools/errcheck/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "80517062f582ea3340cd4baf70e86d539ae7d84d";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "3a10b9bf0a52df7e992a8c3eb712a86d3c896c75";
+      sha256 = "19f3dijcc54jnd7458jab2dgpd0gzccmv2qympd9wi8cc8jpnhws";
+    };
+  }
+]

--- a/pkgs/development/tools/go-tools/default.nix
+++ b/pkgs/development/tools/go-tools/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "go-tools-${version}";
+  version = "2017.2.2";
+
+  goPackagePath = "honnef.co/go/tools";
+  excludedPackages = ''\(simple\|ssa\|ssa/ssautil\|lint\|staticcheck\|unused\)/testdata'';
+
+  src = fetchFromGitHub {
+    owner = "dominikh";
+    repo = "go-tools";
+    rev = "${version}";
+    sha256 = "1khl6szjj0skkfqp234p9rf3icik7fw2pk2x0wbj3wa9q3f84hb7";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "A collection of tools and libraries for working with Go code, including linters and static analysis.";
+    homepage = https://staticcheck.io;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/go-tools/deps.nix
+++ b/pkgs/development/tools/go-tools/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "80517062f582ea3340cd4baf70e86d539ae7d84d";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "96e9e165b75e735822645eff82850b08c377be36";
+      sha256 = "1zj9ck5sg9b0pphxybmvxf64hhcap7v7j37fx3v5aknf18crjjdg";
+    };
+  }
+]

--- a/pkgs/development/tools/goconst/default.nix
+++ b/pkgs/development/tools/goconst/default.nix
@@ -1,0 +1,27 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "goconst-${version}";
+  version = "1.1.0";
+
+  goPackagePath = "github.com/jgautheron/goconst";
+  excludedPackages = ''testdata'';
+
+  src = fetchFromGitHub {
+    owner = "jgautheron";
+    repo = "goconst";
+    rev = version;
+    sha256 = "0zhscvv9w54q1h2vs8xx3qkz98cf36qhxjvdq0xyz3qvn4vhnyw6";
+  };
+
+  meta = with lib; {
+    description = "Find in Go repeated strings that could be replaced by a constant";
+    homepage = https://github.com/jgautheron/goconst;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -1,0 +1,28 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "gocyclo-unstable-${version}";
+  version = "2015-02-08";
+  rev = "aa8f8b160214d8dfccfe3e17e578dd0fcc6fede7";
+
+  goPackagePath = "github.com/alecthomas/gocyclo";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "alecthomas";
+    repo = "gocyclo";
+    sha256 = "094rj97q38j53lmn2scshrg8kws8c542yq5apih1ahm9wdkv8pxr";
+  };
+
+  meta = with lib; {
+    description = "Calculate cyclomatic complexities of functions in Go source code.";
+    homepage = https://github.com/alecthomas/gocyclo;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/gogetdoc/default.nix
+++ b/pkgs/development/tools/gogetdoc/default.nix
@@ -1,0 +1,31 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "gogetdoc-unstable-${version}";
+  version = "2018-10-25";
+  rev = "9098cf5fc236a5e25060730544af2ba6d65cd968";
+
+  goPackagePath = "github.com/zmb3/gogetdoc";
+  excludedPackages = "\\(testdata\\)";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "zmb3";
+    repo = "gogetdoc";
+    sha256 = "159dgkd2lz07kimbpzminli5p539l4ry0dr93r46iz3lk5q76znl";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Gets documentation for items in Go source code";
+    homepage = https://github.com/zmb3/gogetdoc;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/gogetdoc/deps.nix
+++ b/pkgs/development/tools/gogetdoc/deps.nix
@@ -1,0 +1,13 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "6adeb8aab2de";
+      sha256 = "0kylkki0ksdm12ppl37fghzbma9hmgqwph0nwngv08v4blk6li6k";
+    };
+  }
+]

--- a/pkgs/development/tools/gometalinter/default.nix
+++ b/pkgs/development/tools/gometalinter/default.nix
@@ -1,0 +1,70 @@
+{ buildGoPackage
+, deadcode
+, errcheck
+, fetchFromGitHub
+, go
+, go-check
+, go-tools
+, goconst
+, gocyclo
+, golint
+, gosec
+, gotools
+, ineffassign
+, maligned
+, interfacer
+, lib
+, makeWrapper
+, unconvert
+}:
+
+with lib;
+
+let
+  runtimeDeps = [
+    deadcode
+    errcheck
+    go
+    go-check
+    go-tools
+    goconst
+    gocyclo
+    golint
+    gosec
+    gotools
+    ineffassign
+    interfacer
+    maligned
+    unconvert
+  ];
+
+in buildGoPackage rec {
+  name = "gometalinter-${version}";
+  version = "2.0.11";
+
+  goPackagePath = "github.com/alecthomas/gometalinter";
+  excludedPackages = "\\(regressiontests\\)";
+
+  src = fetchFromGitHub {
+    owner = "alecthomas";
+    repo = "gometalinter";
+    rev = "v${version}";
+    sha256 = "08p7bwvhpgizif8qi59m8mm3mcny70x9msbk8m8vjpphsq55wha4";
+  };
+
+  postInstall = ''
+    wrapProgram $bin/bin/gometalinter --prefix PATH : "${makeBinPath runtimeDeps}"
+  '';
+
+  buildInputs = [ makeWrapper ];
+
+  allowGoReference = true;
+
+  meta = with lib; {
+    description = "Concurrently run Go lint tools and normalise their output";
+    homepage = https://github.com/alecthomas/gometalinter;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/gosec/default.nix
+++ b/pkgs/development/tools/gosec/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "gosec-${version}";
+  version = "1.1.0";
+
+  goPackagePath = "github.com/securego/gosec";
+  excludedPackages = ''cmd/tlsconfig'';
+
+  src = fetchFromGitHub {
+    owner = "securego";
+    repo = "gosec";
+    rev = "${version}";
+    sha256 = "0vjn3g6w4y4ayx0g766jp31vb78cipl90fcg0mccjr0a539qrpy6";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Golang security checker";
+    homepage = https://github.com/securego/gosec;
+    license = licenses.asl20 ;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/gosec/deps.nix
+++ b/pkgs/development/tools/gosec/deps.nix
@@ -1,0 +1,193 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.2.0";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "0de1eaf82fa3";
+      sha256 = "177af7bjq6clmkqshnmnwlpwvx80kpi2277q275iwq59lp48viq1";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/nbutton23/zxcvbn-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nbutton23/zxcvbn-go";
+      rev = "a22cb81b2ecd";
+      sha256 = "0hm16vc7xrw0cqla6xcn59bb7n2sa0j8rkniywn5dqnbrpza12cd";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "11459a886d9c";
+      sha256 = "1nswc1fnrrs792qbix05h91bilj8rr3wxmxgwi97p2gjk0r292zh";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "dcabb60a477c";
+      sha256 = "1775lv5jbsgv3ghq5v2827slqlhqdadrzc1nkpq4y0hdv2qzrgkm";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/ryanuber/go-glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ryanuber/go-glob";
+      rev = "256dc444b735";
+      sha256 = "07rsd7hranghwc68ib0r2zxd9d5djanzjvd84j9dgj3wqsyg5mi2";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.2.2";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "8351a756f30f";
+      sha256 = "0b6m579i3wrx1m69mqkdng5gjfssprxx0pg45kzrdi68sh0zr5d1";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "1d60e4601c6f";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "164713f0dfce";
+      sha256 = "1qn9vvyqsaaj0az0rbilzc4pfv9sl4vh78c2g37yya5gcdnarh3w";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "1cbadb444a80";
+      sha256 = "0ih9ysagh4ylj08393497sscf3yziybc6acg4mrh0wa7mld75j56";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "e531a2a1c15f";
+      sha256 = "0740w56nmjqdj7ld1h3gpcpi3x8n81bdx0pp267rz9hmwkrb2s1c";
+    };
+  }
+
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "eb3733d160e7";
+      sha256 = "1srhvcaa9db3a6xj29mkjr5kg33y71pclrlx4vcwz5m1lgb5c7q6";
+    };
+  }
+]

--- a/pkgs/development/tools/iferr/default.nix
+++ b/pkgs/development/tools/iferr/default.nix
@@ -1,0 +1,28 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "iferr-unstable-${version}";
+  version = "2018-06-15";
+  rev = "bb332a3b1d9129b6486c7ddcb7030c11b05cfc88";
+
+  goPackagePath = "github.com/koron/iferr";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "koron";
+    repo = "iferr";
+    sha256 = "1nyqy1sgq2afiama4wy7wap8s03c0hiwwa0f6kwq3y59097rfc0c";
+  };
+
+  meta = with lib; {
+    description = ''Generate "if err != nil {" block'';
+    homepage = https://github.com/koron/iferr;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/impl/default.nix
+++ b/pkgs/development/tools/impl/default.nix
@@ -1,0 +1,30 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "impl-unstable-${version}";
+  version = "2018-02-27";
+  rev = "3d0f908298c49598b6aa84f101c69670e15d1d03";
+
+  goPackagePath = "github.com/josharian/impl";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "josharian";
+    repo = "impl";
+    sha256 = "0xpip20x5vclrl0by1760lg73v6lj6nmkbiazlskyvpkw44h8a7c";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "impl generates method stubs for implementing an interface.";
+    homepage = https://github.com/josharian/impl;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/impl/deps.nix
+++ b/pkgs/development/tools/impl/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "96e9e165b75e735822645eff82850b08c377be36";
+      sha256 = "1zj9ck5sg9b0pphxybmvxf64hhcap7v7j37fx3v5aknf18crjjdg";
+    };
+  }
+]

--- a/pkgs/development/tools/ineffassign/default.nix
+++ b/pkgs/development/tools/ineffassign/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "ineffassign-unstable-${version}";
+  version = "2018-09-09";
+	rev = "1003c8bd00dc2869cb5ca5282e6ce33834fed514";
+
+  goPackagePath = "github.com/gordonklaus/ineffassign";
+  excludedPackages = ''testdata'';
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "gordonklaus";
+    repo = "ineffassign";
+    sha256 = "1rkzqvd3z03vq8q8qi9cghvgggsf02ammj9wq8jvpnx6b2sd16nd";
+  };
+
+  meta = with lib; {
+    description = "Detect ineffectual assignments in Go code.";
+    homepage = https://github.com/gordonklaus/ineffassign;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/interfacer/default.nix
+++ b/pkgs/development/tools/interfacer/default.nix
@@ -1,0 +1,31 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "interfacer-unstable-${version}";
+  version = "2018-08-31";
+  rev = "c20040233aedb03da82d460eca6130fcd91c629a";
+
+  goPackagePath = "mvdan.cc/interfacer";
+  excludedPackages = ''check/testdata'';
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "mvdan";
+    repo = "interfacer";
+    sha256 = "0cx4m74mvn200360pmsqxx4z0apk9fcknwwqh8r94zd3jfv4akq2";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "A linter that suggests interface types.";
+    homepage = https://github.com/mvdan/interfacer;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/interfacer/deps.nix
+++ b/pkgs/development/tools/interfacer/deps.nix
@@ -1,0 +1,29 @@
+[
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "80517062f582ea3340cd4baf70e86d539ae7d84d";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "96e9e165b75e735822645eff82850b08c377be36";
+      sha256 = "1zj9ck5sg9b0pphxybmvxf64hhcap7v7j37fx3v5aknf18crjjdg";
+    };
+  }
+  {
+    goPackagePath = "mvdan.cc/lint";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mvdan/lint";
+      rev = "adc824a0674b99099789b6188a058d485eaf61c0";
+      sha256 = "17mi2rvkg9kzv1shxcyawzcj4jj3v738d1j82fp4yygx859yvr8r";
+    };
+  }
+]

--- a/pkgs/development/tools/maligned/default.nix
+++ b/pkgs/development/tools/maligned/default.nix
@@ -1,0 +1,30 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "maligned-unstable-${version}";
+  version = "2018-07-07";
+  rev = "6e39bd26a8c8b58c5a22129593044655a9e25959";
+
+  goPackagePath = "github.com/mdempsky/maligned";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "mdempsky";
+    repo = "maligned";
+    sha256 = "08inr5xjqv9flrlyhqd8ck1q26y5xb6iilz0xkb6bqa4dl5ialhi";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Tool to detect Go structs that would take less memory if their fields were sorted.";
+    homepage = https://github.com/mdempsky/maligned;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/maligned/deps.nix
+++ b/pkgs/development/tools/maligned/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "80517062f582ea3340cd4baf70e86d539ae7d84d";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "96e9e165b75e735822645eff82850b08c377be36";
+      sha256 = "1zj9ck5sg9b0pphxybmvxf64hhcap7v7j37fx3v5aknf18crjjdg";
+    };
+  }
+]

--- a/pkgs/development/tools/reftools/default.nix
+++ b/pkgs/development/tools/reftools/default.nix
@@ -1,0 +1,29 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "reftools-unstable-${version}";
+  version = "2018-09-14";
+  rev = "654d0ba4f96d62286ca33cd46f7674b84f76d399";
+
+  goPackagePath = "github.com/davidrjenni/reftools";
+  excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "davidrjenni";
+    repo = "reftools";
+    sha256 = "12y2h1h15xadc8pa3xsj11hpdxz5dss6k7xaa4h1ifkvnasjp5w2";
+  };
+
+  meta = with lib; {
+    description = "reftools - refactoring tools for Go";
+    homepage = https://github.com/davidrjenni/reftools;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/unconvert/default.nix
+++ b/pkgs/development/tools/unconvert/default.nix
@@ -1,0 +1,31 @@
+
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "unconvert-unstable-${version}";
+  version = "2018-07-03";
+  rev = "1a9a0a0a3594e9363e49545fb6a4e24ac4c68b7b";
+
+  goPackagePath = "github.com/mdempsky/unconvert";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "mdempsky";
+    repo = "unconvert";
+    sha256 = "1ww5qk1cmdis4ig5mb0b0w7nzrf3734s51plmgdxqsr35y88q4p9";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Remove unnecessary type conversions from Go source";
+    homepage = https://github.com/mdempsky/unconvert;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/unconvert/deps.nix
+++ b/pkgs/development/tools/unconvert/deps.nix
@@ -1,0 +1,29 @@
+[
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "80517062f582ea3340cd4baf70e86d539ae7d84d";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2";
+      sha256 = "00mwzxly5isgf0glz7k3k2dkyqkjfc4z55qxajx4lgcp3h8xn9xj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "96e9e165b75e735822645eff82850b08c377be36";
+      sha256 = "1zj9ck5sg9b0pphxybmvxf64hhcap7v7j37fx3v5aknf18crjjdg";
+    };
+  }
+]

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -9,6 +9,12 @@
 , languagetool
 , Cocoa, CoreFoundation, CoreServices
 , buildVimPluginFrom2Nix
+
+# vim-go denpencies
+, asmfmt, delve, errcheck, godef, golint
+, gomodifytags, gotags, gotools, motion
+, gnused, reftools, gogetdoc, gometalinter
+, impl, iferr
 }:
 
 let
@@ -245,6 +251,34 @@ with generated;
 
   vim-easytags = vim-easytags.overrideAttrs(old: {
     dependencies = ["vim-misc"];
+  });
+
+  # change the go_bin_path to point to a path in the nix store. See the code in
+  # fatih/vim-go here
+  # https://github.com/fatih/vim-go/blob/155836d47052ea9c9bac81ba3e937f6f22c8e384/autoload/go/path.vim#L154-L159
+  vim-go = vim-go.overrideAttrs(old: let
+    binPath = lib.makeBinPath [
+      asmfmt
+      delve
+      errcheck
+      godef
+      gogetdoc
+      golint
+      gometalinter
+      gomodifytags
+      gotags
+      gotools
+      iferr
+      impl
+      motion
+      reftools
+    ];
+    in {
+    postPatch = ''
+      ${gnused}/bin/sed \
+        -Ee 's@let go_bin_path = go#path#BinPath\(\)@let go_bin_path = "${binPath}"@g' \
+        -i autoload/go/path.vim
+    '';
   });
 
   vim-grammarous = vim-grammarous.overrideAttrs(old: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14767,6 +14767,8 @@ with pkgs;
 
   gotests = callPackage ../development/tools/gotests { };
 
+  impl = callPackage ../development/tools/impl { };
+
   quicktemplate = callPackage ../development/tools/quicktemplate { };
 
   gogoclient = callPackage ../os-specific/linux/gogoclient { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14739,6 +14739,8 @@ with pkgs;
 
   govendor = callPackage ../development/tools/govendor { };
 
+  go-tools = callPackage ../development/tools/go-tools { };
+
   gotools = callPackage ../development/tools/gotools { };
 
   gotop = callPackage ../tools/system/gotop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -801,6 +801,8 @@ with pkgs;
   };
   aria = aria2;
 
+  asmfmt = callPackage ../development/tools/asmfmt { };
+
   aspcud = callPackage ../tools/misc/aspcud { };
 
   at = callPackage ../tools/system/at { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14739,6 +14739,8 @@ with pkgs;
 
   golangci-lint = callPackage ../development/tools/golangci-lint { };
 
+  gocyclo = callPackage ../development/tools/gocyclo { };
+
   godef = callPackage ../development/tools/godef { };
 
   gopkgs = callPackage ../development/tools/gopkgs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14727,6 +14727,8 @@ with pkgs;
 
   gocode = callPackage ../development/tools/gocode { };
 
+  goconst = callPackage ../development/tools/goconst { };
+
   goconvey = callPackage ../development/tools/goconvey { };
 
   gotags = callPackage ../development/tools/gotags { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14718,12 +14718,13 @@ with pkgs;
 
   easyjson = callPackage ../development/tools/easyjson { };
 
+  iferr = callPackage ../development/tools/iferr { };
+
   go-bindata = callPackage ../development/tools/go-bindata { };
 
   go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };
 
   go-protobuf = callPackage ../development/tools/go-protobuf { };
-
 
   go-symbols = callPackage ../development/tools/go-symbols { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15526,6 +15526,8 @@ with pkgs;
 
   hasklig = callPackage ../data/fonts/hasklig {};
 
+  interfacer = callPackage ../development/tools/interfacer { };
+
   inter-ui = callPackage ../data/fonts/inter-ui { };
 
   siji = callPackage ../data/fonts/siji { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10142,6 +10142,8 @@ with pkgs;
 
   imlibsetroot = callPackage ../applications/graphics/imlibsetroot { libXinerama = xorg.libXinerama; } ;
 
+  ineffassign = callPackage ../development/tools/ineffassign { };
+
   ijs = callPackage ../development/libraries/ijs { };
 
   incrtcl = callPackage ../development/libraries/incrtcl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6949,6 +6949,8 @@ with pkgs;
 
   go-junit-report = callPackage ../development/tools/go-junit-report { };
 
+  gogetdoc = callPackage ../development/tools/gogetdoc { };
+
   gox = callPackage ../development/tools/gox { };
 
   gprolog = callPackage ../development/compilers/gprolog { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5095,6 +5095,8 @@ with pkgs;
 
   recoverjpeg = callPackage ../tools/misc/recoverjpeg { };
 
+  reftools = callPackage ../development/tools/reftools { };
+
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };
 
   reptyr = callPackage ../os-specific/linux/reptyr {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1313,6 +1313,8 @@ with pkgs;
 
   envsubst = callPackage ../tools/misc/envsubst { };
 
+  errcheck = callPackage ../development/tools/errcheck { };
+
   eschalot = callPackage ../tools/security/eschalot { };
 
   esptool = callPackage ../tools/misc/esptool { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6955,6 +6955,8 @@ with pkgs;
 
   gogetdoc = callPackage ../development/tools/gogetdoc { };
 
+  gometalinter = callPackage ../development/tools/gometalinter { };
+
   gox = callPackage ../development/tools/gox { };
 
   gprolog = callPackage ../development/compilers/gprolog { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -659,6 +659,8 @@ with pkgs;
 
   cconv = callPackage ../tools/text/cconv { };
 
+  go-check = callPackage ../development/tools/check { };
+
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -122,6 +122,8 @@ with pkgs;
     inherit dhall-nix;
   };
 
+  deadcode = callPackage ../development/tools/deadcode { };
+
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12535,6 +12535,8 @@ with pkgs;
     vala = vala_0_40;
   };
 
+  unconvert = callPackage ../development/tools/unconvert { };
+
   unibilium = callPackage ../development/libraries/unibilium { };
 
   unicap = callPackage ../development/libraries/unicap {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14745,6 +14745,8 @@ with pkgs;
 
   gopkgs = callPackage ../development/tools/gopkgs { };
 
+  gosec = callPackage ../development/tools/gosec { };
+
   govers = callPackage ../development/tools/govers { };
 
   govendor = callPackage ../development/tools/govendor { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15528,6 +15528,8 @@ with pkgs;
 
   interfacer = callPackage ../development/tools/interfacer { };
 
+  maligned = callPackage ../development/tools/maligned { };
+
   inter-ui = callPackage ../data/fonts/inter-ui { };
 
   siji = callPackage ../data/fonts/siji { };


### PR DESCRIPTION
###### Motivation for this change

The vim-go plugin requires some external binaries to function properly, this change patches the plugin with the PATH that provides all the binaries it needs.

I tested the plugin with:

```shell
nix-shell -I nixpkgs=. --pure -p 'with import <nixpkgs> {}; neovim.override { configure = { vam.pluginDictionaries = [ "vim-go" ]; }; }'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

replaces #49498