### PR TITLE
buildDunePackage: add support function and use it in a few packages

### DIFF
--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -19,6 +19,7 @@
  <xi:include href="java.xml" />
  <xi:include href="lua.xml" />
  <xi:include href="node.section.xml" />
+ <xi:include href="ocaml.xml" />
  <xi:include href="perl.xml" />
  <xi:include href="python.section.xml" />
  <xi:include href="qt.xml" />

--- a/doc/languages-frameworks/ocaml.xml
+++ b/doc/languages-frameworks/ocaml.xml
@@ -1,0 +1,101 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="sec-language-ocaml">
+ <title>OCaml</title>
+
+ <para>
+   OCaml libraries should be installed in
+   <literal>$(out)/lib/ocaml/${ocaml.version}/site-lib/</literal>. Such
+   directories are automatically added to the <literal>$OCAMLPATH</literal>
+   environment variable when building another package that depends on them
+   or when opening a <literal>nix-shell</literal>.
+ </para>
+
+ <para>
+   Given that most of the OCaml ecosystem is now built with dune,
+   nixpkgs includes a convenience build support function called
+   <literal>buildDunePackage</literal> that will build an OCaml package
+   using dune, OCaml and findlib and any additional dependencies provided
+   as <literal>buildInputs</literal> or <literal>propagatedBuildInputs</literal>.
+ </para>
+
+ <para>
+   Here is a simple package example. It defines an (optional) attribute
+   <literal>minimumOCamlVersion</literal> that will be used to throw a
+   descriptive evaluation error if building with an older OCaml is attempted.
+   It uses the <literal>fetchFromGitHub</literal> fetcher to get its source.
+   It sets the <literal>doCheck</literal> (optional) attribute to
+   <literal>true</literal> which means that tests will be run with
+   <literal>dune runtest -p angstrom</literal> after the build
+   (<literal>dune build -p angstrom</literal>) is complete.
+   It uses <literal>alcotest</literal> as a build input (because it is needed
+   to run the tests) and <literal>bigstringaf</literal> and
+   <literal>result</literal> as propagated build inputs (thus they will also
+   be available to libraries depending on this library).
+   The library will be installed using the <literal>angstrom.install</literal>
+   file that dune generates.
+ </para>
+
+ <programlisting>
+{ stdenv, fetchFromGitHub, buildDunePackage, alcotest, result, bigstringaf }:
+
+buildDunePackage rec {
+  pname = "angstrom";
+  version = "0.10.0";
+
+  minimumOCamlVersion = "4.03";
+
+  src = fetchFromGitHub {
+    owner  = "inhabitedtype";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0lh6024yf9ds0nh9i93r9m6p5psi8nvrqxl5x7jwl13zb0r9xfpw";
+  };
+
+  buildInputs = [ alcotest ];
+  propagatedBuildInputs = [ bigstringaf result ];
+  doCheck = true;
+
+  meta = {
+    homepage = https://github.com/inhabitedtype/angstrom;
+    description = "OCaml parser combinators built for speed and memory efficiency";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}
+ </programlisting>
+
+ <para>
+   Here is a second example, this time using a source archive generated with
+   <literal>dune-release</literal>. The <literal>unpackCmd</literal>
+   redefinition is necessary to be able to unpack the kind of tarball that
+   <literal>dune-release</literal> generates. This library does not depend
+   on any other OCaml library and no tests are run after building it.
+ </para>
+
+ <programlisting>
+{ stdenv, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "wtf8";
+  version = "1.0.1";
+
+  minimumOCamlVersion = "4.01";
+
+  src = fetchurl {
+    url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "1msg3vycd3k8qqj61sc23qks541cxpb97vrnrvrhjnqxsqnh6ygq";
+  };
+
+  unpackCmd = "tar xjf $src";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/flowtype/ocaml-wtf8;
+    description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";
+    license = licenses.mit;
+    maintainers = [ maintainers.eqyiel ];
+  };
+}
+ </programlisting>
+
+</section>

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, ocaml, findlib, dune }:
+
+{ pname, version, buildInputs ? [], ... }@args:
+
+if args ? minimumOCamlVersion &&
+   ! stdenv.lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation ({
+
+  buildPhase = "dune build -p ${pname}";
+  checkPhase = "dune runtest -p ${pname}";
+  inherit (dune) installPhase;
+
+  meta.platform = ocaml.meta.platform;
+
+} // args // {
+
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+
+  buildInputs = [ ocaml dune findlib ] ++ buildInputs;
+
+})

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -9,9 +9,21 @@ else
 
 stdenv.mkDerivation ({
 
-  buildPhase = "dune build -p ${pname}";
-  checkPhase = "dune runtest -p ${pname}";
-  inherit (dune) installPhase;
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname}
+    runHook postBuild
+  '';
+  checkPhase = ''
+    runHook preCheck
+    dune runtest -p ${pname}
+    runHook postCheck
+  '';
+  installPhase = ''
+    runHook preInstall
+    ${dune.installPhase}
+    runHook postInstall
+  '';
 
   meta.platform = ocaml.meta.platform;
 

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, dune }:
+{ stdenv, fetchurl, ocaml, findlib, dune, opaline }:
 
 { pname, version, buildInputs ? [], ... }@args:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation ({
   '';
   installPhase = ''
     runHook preInstall
-    ${dune.installPhase}
+    ${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR
     runHook postInstall
   '';
 

--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -1,37 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, alcotest, result
-, bigstringaf
-}:
+{ stdenv, fetchFromGitHub, buildDunePackage, alcotest, result, bigstringaf }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
-then throw "angstrom is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "angstrom";
   version = "0.10.0";
-  name = "ocaml${ocaml.version}-angstrom-${version}";
+
+  minimumOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner  = "inhabitedtype";
-    repo   = "angstrom";
-    rev    = "${version}";
+    repo   = pname;
+    rev    = version;
     sha256 = "0lh6024yf9ds0nh9i93r9m6p5psi8nvrqxl5x7jwl13zb0r9xfpw";
   };
 
-  buildInputs = [ ocaml findlib dune alcotest ];
+  buildInputs = [ alcotest ];
   propagatedBuildInputs = [ bigstringaf result ];
-
-  buildPhase = "dune build -p angstrom";
-
   doCheck = true;
-  checkPhase = "dune runtest -p angstrom";
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = https://github.com/inhabitedtype/angstrom;
     description = "OCaml parser combinators built for speed and memory efficiency";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -1,24 +1,20 @@
-{ stdenv, menhir, easy-format, ocaml, findlib, fetchFromGitHub, dune, which, biniou, yojson }:
+{ stdenv, menhir, easy-format, fetchFromGitHub, buildDunePackage, which, biniou, yojson }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "atd";
   version = "2.0.0";
-
-  name = "ocaml${ocaml.version}-atd-${version}";
 
   src = fetchFromGitHub {
     owner = "mjambon";
-    repo = "atd";
+    repo = pname;
     rev = version;
     sha256 = "0alzmk97rxg7s6irs9lvf89dy9n3r769my5n4j9p9qyigcdgjaia";
   };
 
   createFindlibDestdir = true;
 
-  buildInputs = [ which dune ocaml findlib menhir ];
+  buildInputs = [ which menhir ];
   propagatedBuildInputs = [ easy-format biniou yojson ];
-
-  buildPhase = "jbuilder build";
-  inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mjambon/atd;

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -1,32 +1,25 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, alcotest }:
+{ stdenv, fetchFromGitHub, buildDunePackage, alcotest }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
-then throw "bigstringaf is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "bigstringaf";
   version = "0.3.0";
-  name = "ocaml${ocaml.version}-bigstringaf-${version}";
+
+  minimumOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
-    repo = "bigstringaf";
+    repo = pname;
     rev = version;
     sha256 = "1yx6hv8rk0ldz1h6kk00rwg8abpfc376z00aifl9f5rn7xavpscs";
   };
 
-  buildInputs = [ ocaml findlib dune alcotest ];
-
+  buildInputs = [ alcotest ];
   doCheck = true;
-  checkPhase = "dune runtest";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Bigstring intrinsics and fast blits based on memcpy/memmove";
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -1,16 +1,15 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, easy-format }:
+{ stdenv, fetchFromGitHub, buildDunePackage, easy-format }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "biniou";
   version = "1.2.0";
-  name = "ocaml${ocaml.version}-biniou-${version}";
+
   src = fetchFromGitHub {
     owner = "mjambon";
-    repo = "biniou";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0mjpgwyfq2b2izjw0flmlpvdjgqpq8shs89hxj1np2r50csr8dcb";
   };
-
-  buildInputs = [ ocaml findlib dune ];
 
   propagatedBuildInputs = [ easy-format ];
 
@@ -18,11 +17,8 @@ stdenv.mkDerivation rec {
    patchShebangs .
   '';
 
-  inherit (dune) installPhase;
-
   meta = {
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
     description = "Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve";
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -1,31 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
-, ppx_tools_versioned
-, ounit
-}:
+{ stdenv, fetchFromGitHub, buildDunePackage, ppx_tools_versioned, ounit }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-bitstring-${version}";
+buildDunePackage rec {
+  pname = "bitstring";
   version = "3.0.0";
+
   src = fetchFromGitHub {
     owner = "xguerin";
-    repo = "bitstring";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0r49qax7as48jgknzaq6p9rbpmrvnmlic713wzz5bj60j5h0396f";
   };
 
-  buildInputs = [ ocaml findlib dune ppx_tools_versioned ounit ];
-
-  buildPhase = "jbuilder build";
-
+  buildInputs = [ ppx_tools_versioned ounit ];
   doCheck = true;
-  checkPhase = "jbuilder runtest";
-
-  inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
     description = "This library adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml";
     homepage = https://github.com/xguerin/bitstring;
-    inherit (ocaml.meta) platforms;
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.maurer ];
   };

--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchzip, findlib, dune, ocaml, configurator, cppo, lablgtk }:
-stdenv.mkDerivation rec {
-  name = "camlimages-${version}";
+{ stdenv, fetchzip, buildDunePackage, configurator, cppo, lablgtk }:
+
+buildDunePackage rec {
+  pname = "camlimages";
   version = "5.0.0";
+
   src = fetchzip {
-    url = "https://bitbucket.org/camlspotter/camlimages/get/${version}.tar.gz";
+    url = "https://bitbucket.org/camlspotter/${pname}/get/${version}.tar.gz";
     sha256 = "00qvwxkfnhv93yi1iq7vy3p5lxyi9xigxcq464s4ii6bmp32d998";
   };
-  buildInputs = [ findlib dune ocaml configurator cppo lablgtk ];
-  buildPhase = "dune build -p camlimages";
-  inherit (dune) installPhase;
-  
+
+  buildInputs = [ configurator cppo lablgtk ];
+
   meta = with stdenv.lib; {
     branch = "5.0";
     homepage = https://bitbucket.org/camlspotter/camlimages;

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,24 +1,21 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, cppo }:
+{ stdenv, fetchFromGitHub, buildDunePackage, cppo }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "camomile";
 	version = "1.0.1";
-	name = "ocaml${ocaml.version}-camomile-${version}";
 
 	src = fetchFromGitHub {
 		owner = "yoriyuki";
-		repo = "camomile";
-		rev = "${version}";
+		repo = pname;
+		rev = version;
 		sha256 = "1pfxr9kzkpd5bsdqrpxasfxkawwkg4cpx3m1h6203sxi7qv1z3fn";
 	};
 
-	buildInputs = [ ocaml findlib dune cppo ];
+	buildInputs = [ cppo ];
 
 	configurePhase = "ocaml configure.ml --share $out/share/camomile";
 
-	inherit (dune) installPhase;
-
 	meta = {
-		inherit (ocaml.meta) platforms;
 		inherit (src.meta) homepage;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		license = stdenv.lib.licenses.lgpl21;

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
+{ stdenv, fetchFromGitHub, buildDunePackage
 , ppx_fields_conv, ppx_sexp_conv, ppx_deriving
 , base64, fieldslib, jsonm, re, stringext, uri
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "cohttp";
 	version = "1.1.1";
-	name = "ocaml${ocaml.version}-cohttp-${version}";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
@@ -14,19 +14,14 @@ stdenv.mkDerivation rec {
 		sha256 = "1dzd6vy43b7p9xplzg2whylz5br59zxaqywa14b4l377f31gnwq1";
 	};
 
-	buildInputs = [ ocaml findlib dune jsonm ppx_fields_conv ppx_sexp_conv ];
+	buildInputs = [ jsonm ppx_fields_conv ppx_sexp_conv ];
 
 	propagatedBuildInputs = [ ppx_deriving base64 fieldslib re stringext uri ];
-
-	buildPhase = "dune build -p cohttp";
-
-	inherit (dune) installPhase;
 
 	meta = {
 		description = "HTTP(S) library for Lwt, Async and Mirage";
 		license = stdenv.lib.licenses.isc;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, cohttp-lwt
+{ stdenv, buildDunePackage, cohttp-lwt
 , conduit-lwt-unix, ppx_sexp_conv
 , cmdliner, fmt, magic-mime
 }:
@@ -7,13 +7,11 @@ if !stdenv.lib.versionAtLeast cohttp-lwt.version "0.99"
 then cohttp-lwt
 else
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-cohttp-lwt-unix-${version}";
-	inherit (cohttp-lwt) version src installPhase meta;
+buildDunePackage rec {
+	pname = "cohttp-lwt-unix";
+	inherit (cohttp-lwt) version src meta;
 
-	buildInputs = [ ocaml findlib dune cmdliner ppx_sexp_conv ];
+	buildInputs = [ cmdliner ppx_sexp_conv ];
 
 	propagatedBuildInputs = [ cohttp-lwt conduit-lwt-unix fmt magic-mime ];
-
-	buildPhase = "dune build -p cohttp-lwt-unix";
 }

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -1,16 +1,14 @@
-{ stdenv, ocaml, findlib, dune, cohttp, ocaml_lwt, uri, ppx_sexp_conv }:
+{ stdenv, buildDunePackage, cohttp, ocaml_lwt, uri, ppx_sexp_conv }:
 
 if !stdenv.lib.versionAtLeast cohttp.version "0.99"
 then cohttp
 else
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-cohttp-lwt-${version}";
-	inherit (cohttp) version src installPhase meta;
+buildDunePackage rec {
+	pname = "cohttp-lwt";
+	inherit (cohttp) version src meta;
 
-	buildInputs = [ ocaml findlib dune uri ppx_sexp_conv ];
+	buildInputs = [ uri ppx_sexp_conv ];
 
 	propagatedBuildInputs = [ cohttp ocaml_lwt ];
-
-	buildPhase = "dune build -p cohttp-lwt";
 }

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
+{ stdenv, fetchFromGitHub, buildDunePackage
 , ppx_sexp_conv
 , astring, ipaddr, uri
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "conduit";
 	version = "1.0.0";
-	name = "ocaml${ocaml.version}-conduit-${version}";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
@@ -14,18 +14,13 @@ stdenv.mkDerivation rec {
 		sha256 = "1ryigzh7sfif1mly624fpm87aw5h60n5wzdlrvqsf71qcpxc6iiz";
 	};
 
-	buildInputs = [ ocaml findlib dune ppx_sexp_conv ];
+	buildInputs = [ ppx_sexp_conv ];
 	propagatedBuildInputs = [ astring ipaddr uri ];
-
-	buildPhase = "dune build -p conduit";
-
-	inherit (dune) installPhase;
 
 	meta = {
 		description = "Network connection library for TCP and SSL";
 		license = stdenv.lib.licenses.isc;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml, findlib, dune, conduit-lwt
+{ stdenv, buildDunePackage, conduit-lwt
 , logs, ppx_sexp_conv, lwt_ssl
 }:
 
@@ -6,13 +6,11 @@ if !stdenv.lib.versionAtLeast conduit-lwt.version "1.0"
 then conduit-lwt
 else
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-conduit-lwt-unix-${version}";
-	inherit (conduit-lwt) version src installPhase meta;
+buildDunePackage rec {
+	pname = "conduit-lwt-unix";
+	inherit (conduit-lwt) version src meta;
 
-	buildInputs = [ ocaml findlib dune ppx_sexp_conv ];
+	buildInputs = [ ppx_sexp_conv ];
 
 	propagatedBuildInputs = [ conduit-lwt logs lwt_ssl ];
-
-	buildPhase = "dune build -p conduit-lwt-unix";
 }

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,16 +1,14 @@
-{ stdenv, ocaml, findlib, dune, ppx_sexp_conv, conduit, ocaml_lwt }:
+{ stdenv, buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt }:
 
 if !stdenv.lib.versionAtLeast conduit.version "1.0"
 then conduit
 else
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-conduit-lwt-${version}";
-	inherit (conduit) version src installPhase meta;
+buildDunePackage rec {
+	pname = "conduit-lwt";
+	inherit (conduit) version src meta;
 
-	buildInputs = [ ocaml findlib dune ppx_sexp_conv ];
+	buildInputs = [ ppx_sexp_conv ];
 
 	propagatedBuildInputs = [ conduit ocaml_lwt ];
-
-	buildPhase = "dune build -p conduit-lwt";
 }

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchurl, ocaml, dune, findlib, sexplib, ocplib-endian }:
+{ stdenv, fetchurl, buildDunePackage, sexplib, ocplib-endian }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-cstruct-${version}";
+buildDunePackage rec {
+  pname = "cstruct";
   version = "3.1.1";
+
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-${version}.tbz";
     sha256 = "1x4jxsvd1lrfibnjdjrkfl7hqsc48rljnwbap6faanj9qhwwa6v2";
@@ -10,19 +11,12 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "tar -xjf $curSrc";
 
-  buildInputs = [ ocaml dune findlib ];
-
   propagatedBuildInputs = [ sexplib ocplib-endian ];
-
-  buildPhase = "dune build -p cstruct";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Access C-like structures directly from OCaml";
     license = stdenv.lib.licenses.isc;
     homepage = "https://github.com/mirage/ocaml-cstruct";
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -1,12 +1,10 @@
-{ stdenv, ocaml, cstruct, lwt }:
+{ buildDunePackage, cstruct, lwt }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.02";
+buildDunePackage {
+	pname = "cstruct-lwt";
+	inherit (cstruct) version src unpackCmd meta;
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-cstruct-lwt-${version}";
-	inherit (cstruct) version src unpackCmd buildInputs installPhase meta;
+  minimumOCamlVersion = "4.02";
 
 	propagatedBuildInputs = [ cstruct lwt ];
-
-	buildPhase = "${cstruct.buildPhase}-lwt";
 }

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -1,13 +1,11 @@
-{ stdenv, ocaml, cstruct, ppx_tools_versioned }:
+{ buildDunePackage, cstruct, ppx_tools_versioned }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.02";
+buildDunePackage {
+	pname = "ppx_cstruct";
+	inherit (cstruct) version src unpackCmd meta;
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-ppx_cstruct-${version}";
-	inherit (cstruct) version src unpackCmd installPhase meta;
+  minimumOCamlVersion = "4.02";
 
-	buildInputs = cstruct.buildInputs ++ [ ppx_tools_versioned ];
+	buildInputs = [ ppx_tools_versioned ];
 	propagatedBuildInputs = [ cstruct ];
-
-	buildPhase = "dune build -p ppx_cstruct";
 }

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -1,12 +1,10 @@
-{ stdenv, ocaml, cstruct }:
+{ buildDunePackage, cstruct }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.02";
+buildDunePackage {
+	pname = "cstruct-unix";
+	inherit (cstruct) version src unpackCmd meta;
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-cstruct-unix-${version}";
-	inherit (cstruct) version src unpackCmd buildInputs installPhase meta;
+  minimumOCamlVersion = "4.02";
 
 	propagatedBuildInputs = [ cstruct ];
-
-	buildPhase = "${cstruct.buildPhase}-unix";
 }

--- a/pkgs/development/ocaml-modules/csv/default.nix
+++ b/pkgs/development/ocaml-modules/csv/default.nix
@@ -1,26 +1,20 @@
-{ stdenv, fetchurl, ocaml, findlib, dune }:
+{ stdenv, fetchurl, buildDunePackage }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "csv";
 	version = "2.1";
-	name = "ocaml${ocaml.version}-csv-${version}";
+
 	src = fetchurl {
-		url = "https://github.com/Chris00/ocaml-csv/releases/download/2.1/csv-2.1.tbz";
+		url = "https://github.com/Chris00/ocaml-${pname}/releases/download/${version}/csv-${version}.tbz";
 		sha256 = "0cgfb6cwhwy7ypc1i3jyfz6sdnykp75aqi6kk0g1a2d81yjwzbcg";
 	};
 
 	unpackCmd = "tar -xjf $src";
-
-	buildInputs = [ ocaml findlib dune ];
-
-	buildPhase = "dune build -p csv";
-
-	inherit (dune) installPhase;
 
 	meta = {
 		description = "A pure OCaml library to read and write CSV files";
 		license = stdenv.lib.licenses.lgpl21;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		homepage = https://github.com/Chris00/ocaml-csv;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/doc-ock-html/default.nix
+++ b/pkgs/development/ocaml-modules/doc-ock-html/default.nix
@@ -1,27 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, doc-ock, tyxml, xmlm }:
+{ stdenv, fetchFromGitHub, buildDunePackage, doc-ock, tyxml, xmlm }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-doc-ock-html-${version}";
+buildDunePackage rec {
+  pname = "doc-ock-html";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "ocaml-doc";
-    repo = "doc-ock-html";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1y620h48qrplmcm78g7c78zibpkai4j3icwmnx95zb3r8xq8554y";
   };
 
-  buildInputs = [ ocaml findlib dune ];
-
   propagatedBuildInputs = [ doc-ock tyxml xmlm ];
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "From doc-ock to HTML";
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/doc-ock-xml/default.nix
+++ b/pkgs/development/ocaml-modules/doc-ock-xml/default.nix
@@ -1,27 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, doc-ock, menhir, xmlm }:
+{ stdenv, fetchFromGitHub, buildDunePackage, doc-ock, menhir, xmlm }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-doc-ock-xml-${version}";
+buildDunePackage rec {
+  pname = "doc-ock-xml";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "ocaml-doc";
-    repo = "doc-ock-xml";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1s27ri7vj9ixi5p5ixg6g6invk96807bvxbqjrr1dm8sxgl1nd20";
   };
 
-  buildInputs = [ ocaml findlib dune ];
-
   propagatedBuildInputs = [ doc-ock menhir xmlm ];
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "XML printer and parser for Doc-Ock";
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/doc-ock/default.nix
+++ b/pkgs/development/ocaml-modules/doc-ock/default.nix
@@ -1,27 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, octavius, cppo }:
+{ stdenv, fetchFromGitHub, buildDunePackage, octavius, cppo }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-doc-ock-${version}";
+buildDunePackage rec {
+  pname = "doc-ock";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "ocaml-doc";
-    repo = "doc-ock";
+    repo = pname;
     rev = "v${version}";
     sha256 = "090vprm12jrl55yllk1hdzbsqyr107yjs2qnc49yahdhvnr4h5b7";
   };
 
-  buildInputs = [ ocaml findlib dune cppo ];
+  buildInputs = [ cppo ];
 
   propagatedBuildInputs = [ octavius ];
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Extract documentation from OCaml files";
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -1,11 +1,10 @@
-{ stdenv, fetchurl, ocaml, findlib, dune }:
+{ stdenv, fetchurl, buildDunePackage }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "dtoa";
-  name = "ocaml-${pname}-${version}";
   version = "0.3.1";
+
+  minimumOCamlVersion = "4.01";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
@@ -14,19 +13,12 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "tar xjf $src";
 
-  buildInputs = [ ocaml findlib dune ];
-
-  buildPhase = "dune build -p dtoa";
-
-  inherit (dune) installPhase;
-
   hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/flowtype/ocaml-dtoa;
     description = "Converts OCaml floats into strings (doubles to ascii, \"d to a\"), using the efficient Grisu3 algorithm.";
     license = licenses.mit;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.eqyiel ];
   };
 }

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -1,27 +1,20 @@
-{ stdenv, fetchzip, ocaml, findlib, dune, jsonm, hex, sexplib }:
+{ stdenv, fetchzip, buildDunePackage, jsonm, hex, sexplib }:
 
-let version = "0.6.0"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-ezjsonm-${version}";
+buildDunePackage rec {
+  pname = "ezjsonm";
+  version = "0.6.0";
 
   src = fetchzip {
-    url = "https://github.com/mirage/ezjsonm/archive/${version}.tar.gz";
+    url = "https://github.com/mirage/${pname}/archive/${version}.tar.gz";
     sha256 = "18g64lhai0bz65b9fil12vlgfpwa9b5apj7x6d7n4zzm18qfazvj";
   };
 
-  buildInputs = [ ocaml findlib dune ];
   propagatedBuildInputs = [ jsonm hex sexplib ];
-
-  buildPhase = "dune build -p ezjsonm";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "An easy interface on top of the Jsonm library";
     homepage = https://github.com/mirage/ezjsonm;
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/ezxmlm/default.nix
@@ -1,23 +1,17 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, xmlm }:
+{ stdenv, fetchFromGitHub, buildDunePackage, xmlm }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "ezxmlm";
   version = "1.0.2";
-  name = "ocaml${ocaml.version}-ezxmlm-${version}";
 
   src = fetchFromGitHub {
     owner = "avsm";
-    repo = "ezxmlm";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1dgr61f0hymywikn67inq908x5adrzl3fjx3v14l9k46x7kkacl9";
   };
 
   propagatedBuildInputs = [ xmlm ];
-
-  buildInputs = [ ocaml findlib dune ];
-
-  buildFlags = "build";
-
-  inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
     description = "Combinators to use with xmlm for parsing and selection";
@@ -34,7 +28,6 @@ stdenv.mkDerivation rec {
     '';
     maintainers = [ maintainers.carlosdagos ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
     license = licenses.isc;
   };
 }

--- a/pkgs/development/ocaml-modules/faraday/default.nix
+++ b/pkgs/development/ocaml-modules/faraday/default.nix
@@ -1,34 +1,25 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, alcotest }:
+{ stdenv, fetchFromGitHub, buildDunePackage, alcotest }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "faraday is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-faraday-${version}";
+buildDunePackage rec {
+  pname = "faraday";
   version = "0.5.0";
+
+  minimumOCamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
-    repo = "faraday";
+    repo = pname;
     rev = version;
     sha256 = "1kql0il1frsbx6rvwqd7ahi4m14ik6la5an6c2w4x7k00ndm4d7n";
   };
 
-  buildInputs = [ ocaml findlib dune alcotest ];
-
-  buildPhase = "dune build -p faraday";
-
+  buildInputs = [ alcotest ];
   doCheck = true;
-  checkPhase = "jbuilder runtest";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Serialization library built for speed and memory efficiency";
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -1,28 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
+{ stdenv, fetchFromGitHub, buildDunePackage, ocurl, cryptokit, ocaml_extlib, yojson, ocamlnet, xmlm }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "gapi-ocaml is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "gapi-ocaml-${version}";
+buildDunePackage rec {
+  pname = "gapi-ocaml";
   version = "0.3.6";
+
+  minimumOCamlVersion = "4.02";
+
   src = fetchFromGitHub {
     owner = "astrada";
-    repo = "gapi-ocaml";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0qgsy51bhkpfgl5rdnjw4bqs5fbh2w4vwrfbl8y3lh1wrqmnwci4";
   };
-  buildInputs = [ ocaml dune findlib ];
-  propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib yojson ocamlnet xmlm ];
 
-  inherit (dune) installPhase;
+  propagatedBuildInputs = [ ocurl cryptokit ocaml_extlib yojson ocamlnet xmlm ];
 
   meta = {
     description = "OCaml client for google services";
     homepage = http://gapi-ocaml.forge.ocamlcore.org;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ bennofs ];
-    platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/git-http/default.nix
+++ b/pkgs/development/ocaml-modules/git-http/default.nix
@@ -1,24 +1,15 @@
-{ stdenv, ocaml, findlib, dune, git, cohttp-lwt
-, alcotest, mtime, nocrypto
-}:
+{ buildDunePackage, git, cohttp-lwt, alcotest, mtime, nocrypto }:
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-git-http-${version}";
+buildDunePackage rec {
+	pname = "git-http";
 	inherit (git) version src;
 
-	buildInputs = [ ocaml findlib dune alcotest mtime nocrypto ];
-
+	buildInputs = [ alcotest mtime nocrypto ];
 	propagatedBuildInputs = [ git cohttp-lwt ];
-
-	buildPhase = "dune build -p git-http";
-
-	inherit (dune) installPhase;
-
 	doCheck = true;
-	checkPhase = "dune runtest -p git-http";
 
 	meta = {
 		description = "Client implementation of the “Smart” HTTP Git protocol in pure OCaml";
-		inherit (git.meta) homepage license maintainers platforms;
+		inherit (git.meta) homepage license maintainers;
 	};
 }

--- a/pkgs/development/ocaml-modules/git-unix/default.nix
+++ b/pkgs/development/ocaml-modules/git-unix/default.nix
@@ -1,22 +1,14 @@
-{ stdenv, ocaml, findlib, dune, git-http
-, cohttp-lwt-unix
-, tls, cmdliner, mtime
-}:
+{ buildDunePackage, git-http, cohttp-lwt-unix, tls, cmdliner, mtime }:
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-git-unix-${version}";
+buildDunePackage rec {
+	pname = "git-unix";
 	inherit (git-http) version src;
 
-	buildInputs = [ ocaml findlib dune cmdliner mtime ];
-
+	buildInputs = [ cmdliner mtime ];
 	propagatedBuildInputs = [ cohttp-lwt-unix git-http tls ];
-
-	buildPhase = "dune build -p git-unix";
-
-	inherit (dune) installPhase;
 
 	meta = {
 		description = "Unix backend for the Git protocol(s)";
-		inherit (git-http.meta) homepage license maintainers platforms;
+		inherit (git-http.meta) homepage license maintainers;
 	};
 }

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
+{ stdenv, fetchFromGitHub, buildDunePackage
 , astring, decompress, fmt, hex, logs, mstruct, ocaml_lwt, ocamlgraph, uri
 , alcotest, mtime, nocrypto
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "git";
 	version = "1.11.5";
-	name = "ocaml${ocaml.version}-git-${version}";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
@@ -14,22 +14,14 @@ stdenv.mkDerivation rec {
 		sha256 = "0r1bxpxjjnl9hh8xbabsxl7svzvd19hfy73a2y1m4kljmw64dpfh";
 	};
 
-	buildInputs = [ ocaml findlib dune alcotest mtime nocrypto ];
-
+	buildInputs = [ alcotest mtime nocrypto ];
 	propagatedBuildInputs = [ astring decompress fmt hex logs mstruct ocaml_lwt ocamlgraph uri ];
-
-	buildPhase = "dune build -p git";
-
-	inherit (dune) installPhase;
-
 	doCheck = true;
-	checkPhase = "dune runtest -p git";
 
 	meta = {
 		description = "Git format and protocol in pure OCaml";
 		license = stdenv.lib.licenses.isc;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -1,34 +1,25 @@
-{ stdenv, fetchurl, ocaml, findlib, dune, cstruct }:
+{ stdenv, fetchurl, buildDunePackage, cstruct }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "hex is not available for OCaml ${ocaml.version}"
-else
+buildDunePackage rec {
+  pname = "hex";
+  version = "1.2.0";
 
-let version = "1.2.0"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-hex-${version}";
+  minimumOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-hex/releases/download/v1.2.0/hex-1.2.0.tbz";
+    url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/hex-${version}.tbz";
     sha256 = "17hqf7z5afp2z2c55fk5myxkm7cm74259rqm94hcxkqlpdaqhm8h";
   };
 
   unpackCmd = "tar -xjf $curSrc";
 
-  buildInputs = [ ocaml findlib dune ];
   propagatedBuildInputs = [ cstruct ];
-
-  buildPhase = "dune build -p hex";
   doCheck = true;
-  checkPhase = "jbuilder runtest";
-  inherit (dune) installPhase;
 
   meta = {
     description = "Mininal OCaml library providing hexadecimal converters";
     homepage = https://github.com/mirage/ocaml-hex;
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/httpaf/default.nix
+++ b/pkgs/development/ocaml-modules/httpaf/default.nix
@@ -1,33 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
-, angstrom, faraday, alcotest
-}:
+{ stdenv, fetchFromGitHub, buildDunePackage, angstrom, faraday, alcotest }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "httpaf";
   version = "0.4.1";
-  name = "ocaml${ocaml.version}-httpaf-${version}";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
-    repo = "httpaf";
+    repo = pname;
     rev = version;
     sha256 = "0i2r004ihj00hd97475y8nhjqjln58xx087zcjl0dfp0n7q80517";
   };
 
-  buildInputs = [ ocaml findlib dune alcotest ];
+  buildInputs = [ alcotest ];
   propagatedBuildInputs = [ angstrom faraday ];
-
-  buildPhase = "dune build -p httpaf";
-
   doCheck = true;
-  checkPhase = "dune runtest -p httpaf";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "A high-performance, memory-efficient, and scalable web server for OCaml";
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -1,23 +1,19 @@
-{ stdenv, fetchzip, ocaml, findlib, dune, configurator, cstruct }:
+{ stdenv, fetchzip, buildDunePackage, configurator, cstruct }:
 
-let version = "2.0.1"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-io-page-${version}";
+buildDunePackage rec {
+  pname = "io-page";
+  version = "2.0.1";
 
   src = fetchzip {
-    url = "https://github.com/mirage/io-page/archive/${version}.tar.gz";
+    url = "https://github.com/mirage/${pname}/archive/${version}.tar.gz";
     sha256 = "1rw04dwrlx5hah5dkjf7d63iff82j9cifr8ifjis5pdwhgwcff8i";
   };
 
-  buildInputs = [ ocaml findlib dune configurator ];
+  buildInputs = [ configurator ];
   propagatedBuildInputs = [ cstruct ];
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = https://github.com/mirage/io-page;
-    inherit (ocaml.meta) platforms;
     license = stdenv.lib.licenses.isc;
     description = "IO memory page library for Mirage backends";
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,20 +1,15 @@
-{ stdenv, fetchurl, ocaml, ocamlbuild, findlib
-, dune, sexplib, ppx_sexp_conv
-}:
+{ stdenv, fetchurl, buildDunePackage, sexplib, ppx_sexp_conv }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ipaddr-${version}";
+buildDunePackage rec {
+  pname = "ipaddr";
   version = "2.8.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-ipaddr/archive/${version}.tar.gz";
+    url = "https://github.com/mirage/ocaml-${pname}/archive/${version}.tar.gz";
     sha256 = "1amb1pbm9ybpxy6190qygpj6nmbzzs2r6vx4xh5r6v89szx9rfxw";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild dune ];
   propagatedBuildInputs = [ ppx_sexp_conv sexplib ];
-
-  inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mirage/ocaml-ipaddr;

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -7,26 +7,26 @@
 rec {
 
   ocaml-compiler-libs = janePackage {
-    name = "ocaml-compiler-libs";
+    pname = "ocaml-compiler-libs";
     hash = "03jds7bszh8wwpfwxb3dg0gyr1j1872wxwx1xqhry5ir0i84bg0s";
     meta.description = "OCaml compiler libraries repackaged";
   };
 
   sexplib0 = janePackage {
-    name = "sexplib0";
+    pname = "sexplib0";
     meta.description = "Library containing the definition of S-expressions and some base converters";
     hash = "07v3ggyss7xhfv14bjk1n87sr42iqwj4cgjiv2lcdfkqk49i2bmi";
   };
 
   parsexp = janePackage {
-    name = "parsexp";
+    pname = "parsexp";
     hash = "1nyq23s5igd8cf3n4qxprjvhbmb6ighb3fy5mw7hxl0mdgsw5fvz";
     propagatedBuildInputs = [ sexplib0 ];
     meta.description = "S-expression parsing library";
   };
 
   sexplib = janePackage {
-    name = "sexplib";
+    pname = "sexplib";
     meta.description = "Library for serializing OCaml values to and from S-expressions";
     hash = "1qfl0m04rpcjvc4yw1hzh6r16jpwmap0sa9ax6zjji67dz4szpyb";
     propagatedBuildInputs = [ num parsexp ];
@@ -34,28 +34,28 @@ rec {
 
   base = janePackage {
     version = "0.11.1";
-    name = "base";
+    pname = "base";
     hash = "0j6xb4265jr41vw4fjzak6yr8s30qrnzapnc6rl1dxy8bjai0nir";
     propagatedBuildInputs = [ sexplib0 ];
     meta.description = "Full standard library replacement for OCaml";
   };
 
   stdio = janePackage {
-    name = "stdio";
+    pname = "stdio";
     hash = "1facajqhvq34g2wrg368y0ajxd6lrj5b3lyzyj0jhdmraxajjcwn";
     propagatedBuildInputs = [ base ];
     meta.description = "Standard IO library for OCaml";
   };
 
   configurator = janePackage {
-    name = "configurator";
+    pname = "configurator";
     hash = "0h686630cscav7pil8c3w0gbh6rj4b41dvbnwmicmlkc746q5bfk";
     propagatedBuildInputs = [ stdio ];
     meta.description = "Helper library for gathering system configuration";
   };
 
   ppx_compare = janePackage {
-    name = "ppx_compare";
+    pname = "ppx_compare";
     version = "0.11.1";
     hash = "06bq4m1bsm4jlx4g7wh5m99qky7xm4c2g52kaz6pv25hdn5agi2m";
     buildInputs = [ ppxlib ];
@@ -64,7 +64,7 @@ rec {
   };
 
   ppx_sexp_conv = janePackage {
-    name = "ppx_sexp_conv";
+    pname = "ppx_sexp_conv";
     version = "0.11.2";
     hash = "0pqwnqy1xp309wvdcaax4lg02yk64lq2w03mbgfvf6ps5ry4gis9";
     propagatedBuildInputs = [ sexplib0 ppxlib ppx_deriving ];
@@ -72,7 +72,7 @@ rec {
   };
 
   variantslib = janePackage {
-    name = "variantslib";
+    pname = "variantslib";
     hash = "0hbsk34ghc28h8pzbma923ma2bgnz8lzrgcqqx9bzg161jl4s4r3";
     buildInputs = [ ppxlib ];
     propagatedBuildInputs = [ base ];
@@ -80,7 +80,7 @@ rec {
   };
 
   ppx_variants_conv = janePackage {
-    name = "ppx_variants_conv";
+    pname = "ppx_variants_conv";
     version = "0.11.1";
     hash = "1yc0gsds5m2nv39zga8nnrca2n75rkqy5dz4xj1635ybz20hhbjd";
     buildInputs = [ ppxlib ];
@@ -89,48 +89,48 @@ rec {
   };
 
   fieldslib = janePackage {
-    name = "fieldslib";
+    pname = "fieldslib";
     hash = "1yvjvfax56lmn2lxbykcmhgmxypws1vp9lhnyb8bhbavsv8yc6da";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "OCaml record fields as first class values";
   };
 
   ppx_fields_conv = janePackage {
-    name = "ppx_fields_conv";
+    pname = "ppx_fields_conv";
     hash = "1bb9cmn4js7p3qh8skzyik1pcz6sj1k4xkhf12fg1bjmb5fd0jx1";
     propagatedBuildInputs = [ fieldslib ];
     meta.description = "Generation of accessor and iteration functions for OCaml records";
   };
 
   ppx_custom_printf = janePackage {
-    name = "ppx_custom_printf";
+    pname = "ppx_custom_printf";
     hash = "1dvjzvaxhx53jqwrrlxdckwl1azrhs9kvwb48mhgd0jnz65ny726";
     propagatedBuildInputs = [ ppx_sexp_conv ];
     meta.description = "Printf-style format-strings for user-defined string conversion";
   };
 
   bin_prot = janePackage {
-    name = "bin_prot";
+    pname = "bin_prot";
     hash = "1mgbyzsr8h0y4s4j9dv7hsdrxyzhhjww5khwg2spi2my7ia95m0l";
     propagatedBuildInputs = [ ppx_compare ppx_custom_printf ppx_fields_conv ppx_variants_conv ];
     meta.description = "Binary protocol generator";
   };
 
   jane-street-headers = janePackage {
-    name = "jane-street-headers";
+    pname = "jane-street-headers";
     hash = "0kij4c7qxrja787f3sm3z6mzr322486h2djrlyhnl66vp8hrv8si";
     meta.description = "Jane Street header files";
   };
 
   ppx_here = janePackage {
-    name = "ppx_here";
+    pname = "ppx_here";
     hash = "04njv8s4n54x9rg0012ymd6y6lrnqprnh0f0f6s0jcp79q7mv43i";
     buildInputs = [ ppxlib ];
     meta.description = "Expands [%here] into its location";
   };
 
   ppx_assert = janePackage {
-    name = "ppx_assert";
+    pname = "ppx_assert";
     hash = "0qbdrl0rj0midnb6sdyaz00s0d4nb8zrrdf565lcdsi1rbnyrzan";
     buildInputs = [ ppx_here ];
     propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
@@ -139,14 +139,14 @@ rec {
 
   ppx_hash = janePackage {
     version = "0.11.1";
-    name = "ppx_hash";
+    pname = "ppx_hash";
     hash = "1p0ic6aijxlrdggpmycj12q3cy9xksbq2vq727215maz4snvlf5p";
     propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
     meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
   };
 
   ppx_inline_test = janePackage {
-    name = "ppx_inline_test";
+    pname = "ppx_inline_test";
     hash = "11n94fz1asjf5vqdgriv0pvsa5lbfpqcyk525c7816w23vskcvq6";
     buildInputs = [ ppxlib ];
     propagatedBuildInputs = [ base ];
@@ -154,7 +154,7 @@ rec {
   };
 
   ppx_sexp_message = janePackage {
-    name = "ppx_sexp_message";
+    pname = "ppx_sexp_message";
     hash = "0d94pf0mrmyp905ncgj4w6cc6zpm4nlib6nclslhgs89pxpzg6a0";
     buildInputs = [ ppx_here ];
     propagatedBuildInputs = [ ppx_sexp_conv ];
@@ -162,7 +162,7 @@ rec {
   };
 
   typerep = janePackage {
-    name = "typerep";
+    pname = "typerep";
     hash = "00j4by75fl9niqvlpiyw6ymlmlmgfzysm8w25cj5wsfsh4yrgr74";
     propagatedBuildInputs = [ base ];
     meta.description = "Runtime types for OCaml";
@@ -170,7 +170,7 @@ rec {
 
   ppx_typerep_conv = janePackage {
     version = "0.11.1";
-    name = "ppx_typerep_conv";
+    pname = "ppx_typerep_conv";
     hash = "0a13dpfrrg0rsm8qni1bh7pqcda30l70z8r6yzi5a64bmwk7g5ah";
     buildInputs = [ ppxlib ];
     propagatedBuildInputs = [ ppx_deriving typerep ];
@@ -178,7 +178,7 @@ rec {
   };
 
   ppx_js_style = janePackage {
-    name = "ppx_js_style";
+    pname = "ppx_js_style";
     hash = "1cwqyrkykc8wi60grbid1w072fcvf7k0hd387jz7mxfw44qyb85g";
     propagatedBuildInputs = [ ppxlib octavius ];
     meta.description = "Code style checker for Jane Street Packages";
@@ -186,7 +186,7 @@ rec {
 
   ppx_enumerate = janePackage {
     version = "0.11.1";
-    name = "ppx_enumerate";
+    pname = "ppx_enumerate";
     hash = "0spx9k1v7vjjb6sigbfs69yndgq76v114jhxvzjmffw7q989cyhr";
     buildInputs = [ ppxlib ];
     propagatedBuildInputs = [ ppx_deriving ];
@@ -194,14 +194,14 @@ rec {
   };
 
   ppx_base = janePackage {
-    name = "ppx_base";
+    pname = "ppx_base";
     hash = "079caqjbxk1d33hy69017n3dwslqy52alvzjddwpdjb04vjadlk6";
     propagatedBuildInputs = [ ppx_compare ppx_enumerate ppx_hash ppx_js_style ];
     meta.description = "Base set of ppx rewriters";
   };
 
   ppx_bench = janePackage {
-    name = "ppx_bench";
+    pname = "ppx_bench";
     hash = "0z98r6y4lpj6dy265m771ylx126hq3v1zjsk74yqvpwwd63gx3jz";
     buildInputs = [ ppxlib ppx_inline_test ];
     meta.description = "Syntax extension for writing in-line benchmarks in OCaml code";
@@ -209,7 +209,7 @@ rec {
 
   ppx_bin_prot = janePackage {
     version = "0.11.1";
-    name = "ppx_bin_prot";
+    pname = "ppx_bin_prot";
     hash = "1h60i75bzvhna1axyn662gyrzhh441l79vl142d235i5x31dmnkz";
     buildInputs = [ ppxlib ppx_here ];
     propagatedBuildInputs = [ bin_prot ];
@@ -217,7 +217,7 @@ rec {
   };
 
   ppx_expect = janePackage {
-    name = "ppx_expect";
+    pname = "ppx_expect";
     hash = "1g0r67vfw9jr75pybiw4ysfiswlzyfpbj0gl91rx62gqdhjh1pga";
     buildInputs = [ ppx_assert ppx_custom_printf ppx_fields_conv ppx_here ppx_variants_conv re ];
     propagatedBuildInputs = [ fieldslib ppx_compare ppx_inline_test ppx_sexp_conv ];
@@ -225,21 +225,21 @@ rec {
   };
 
   ppx_fail = janePackage {
-    name = "ppx_fail";
+    pname = "ppx_fail";
     hash = "0d0xadcl7mhp81kspcd2b0nh75h34w5a6s6j9qskjjbjif87wiix";
     buildInputs = [ ppxlib ppx_here ];
     meta.description = "Add location to calls to failwiths";
   };
 
   ppx_let = janePackage {
-    name = "ppx_let";
+    pname = "ppx_let";
     hash = "1ckzwljlb78cdf6xxd24nddnmsihvjrnq75r1b255aj3xgkzsygx";
     buildInputs = [ ppxlib ];
     meta.description = "Monadic let-bindings";
   };
 
   ppx_optcomp = janePackage {
-    name = "ppx_optcomp";
+    pname = "ppx_optcomp";
     hash = "1rahkjq6vpffs7wdz1crgbxkdnlfkj1i3j12c2andy4fhj49glcm";
     buildInputs = [ ppxlib ];
     propagatedBuildInputs = [ ppx_deriving ];
@@ -247,21 +247,21 @@ rec {
   };
 
   ppx_optional = janePackage {
-    name = "ppx_optional";
+    pname = "ppx_optional";
     hash = "0aw3hvrsdjpw4ik7rf15ghak31vhdr1lgpphr18mj76rnlrhirmx";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Pattern matching on flat options";
   };
 
   ppx_pipebang = janePackage {
-    name = "ppx_pipebang";
+    pname = "ppx_pipebang";
     hash = "0smgq587amlr3hivbbg153p83dj37w30cssp9cffc0v8kg84lfhr";
     buildInputs = [ ppxlib ];
     meta.description = "A ppx rewriter that inlines reverse application operators |> and |!";
   };
 
   ppx_sexp_value = janePackage {
-    name = "ppx_sexp_value";
+    pname = "ppx_sexp_value";
     hash = "107zwb580nrmc0l03dl3y3hf12s3c1vv8b8mz6sa4k5afp3s9nkl";
     buildInputs = [ ppx_here ];
     propagatedBuildInputs = [ ppx_sexp_conv ];
@@ -269,7 +269,7 @@ rec {
   };
 
   ppx_jane = janePackage {
-    name = "ppx_jane";
+    pname = "ppx_jane";
     hash = "0l1p6llaa60mrc5p9400cqv9yy6h76x5wfq3z1cx5xawy0yz4vlb";
     buildInputs = [ ppxlib ];
     propagatedBuildInputs = [ ppx_assert ppx_base ppx_bench ppx_bin_prot ppx_expect ppx_fail ppx_here ppx_let ppx_optcomp ppx_optional ppx_pipebang ppx_sexp_message ppx_sexp_value ppx_typerep_conv ];
@@ -277,7 +277,7 @@ rec {
   };
 
   splittable_random = janePackage {
-    name = "splittable_random";
+    pname = "splittable_random";
     hash = "1yrvpm6g62f8k6ihccxhfxpvmxbqxhi7p790a8jkdmyfdd1l6z73";
     propagatedBuildInputs = [ ppx_jane ];
     meta.description = "PRNG that can be split into independent streams";
@@ -285,7 +285,7 @@ rec {
 
   core_kernel = janePackage {
     version = "0.11.1";
-    name = "core_kernel";
+    pname = "core_kernel";
     hash = "1dg7ygy7i64c5gaakb1cp1b26p9ks81vbxmb8fd7jff2q60j2z2g";
     propagatedBuildInputs = [ configurator jane-street-headers sexplib splittable_random ];
     meta.description = "Jane Street's standard library overlay (kernel)";
@@ -293,35 +293,35 @@ rec {
 
   spawn = janePackage {
     version = "0.12.0";
-    name = "spawn";
+    pname = "spawn";
     hash = "0amgj7g9sjlbjivn1mg7yjdmxd21hgp4a0ak2zrm95dmm4gi846i";
     meta.description = "Spawning sub-processes";
   };
 
   core = janePackage {
     version = "0.11.2";
-    name = "core";
+    pname = "core";
     hash = "0vpsvd75lxb09il2rnzyib9mlr51v1hzqdc9fdxgx353pb5agh8a";
     propagatedBuildInputs = [ core_kernel spawn ];
     meta.description = "Jane Street's standard library overlay";
   };
 
   textutils_kernel = janePackage {
-    name = "textutils_kernel";
+    pname = "textutils_kernel";
     hash = "0s1ps7h54vgl76pll3y5qa1bw8f4h8wxc8mg8jq6bz8vxvl0dfv4";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "The subset of textutils using only core_kernel and working in javascript";
   };
 
   textutils = janePackage {
-    name = "textutils";
+    pname = "textutils";
     hash = "1jmhpaihnndf4pr8xsk7ws70n4mvv34ry0ggqqpfs3wb2vkcdg6j";
     propagatedBuildInputs = [ core textutils_kernel ];
     meta.description = "Text output utilities";
   };
 
   re2 = janePackage {
-    name = "re2";
+    pname = "re2";
     hash = "0bl65d0nmvr7k1mkkcc4aai86l5qzgn1xxwmszshpwhaz87cqghd";
     propagatedBuildInputs = [ core_kernel ];
     meta = {
@@ -331,7 +331,7 @@ rec {
   };
 
   core_extended = janePackage {
-    name = "core_extended";
+    pname = "core_extended";
     hash = "1fvnr6zkpbl48dl7nn3j1dpsrr6bi00iqh282wg5lgdhcsjbc0dy";
     propagatedBuildInputs = [ core re re2 textutils ];
     postPatch = ''
@@ -342,28 +342,28 @@ rec {
 
   async_kernel = janePackage {
     version = "0.11.1";
-    name = "async_kernel";
+    pname = "async_kernel";
     hash = "1ssv0gqbdns6by1wdjrrs35cj1c1n1qcfkxs8hj04b7x89wzvf1q";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (core)";
   };
 
   protocol_version_header = janePackage {
-    name = "protocol_version_header";
+    pname = "protocol_version_header";
     hash = "159qmkb0dsfmr1lv2ly50aqszpm24bvrm3sw07n2zhkxgy6q613z";
     propagatedBuildInputs = [ core_kernel ocaml-migrate-parsetree ];
     meta.description = "Protocol aware version negotiation";
   };
 
   async_rpc_kernel = janePackage {
-    name = "async_rpc_kernel";
+    pname = "async_rpc_kernel";
     hash = "0wl7kp30qxkalk91q5pja9agsvvmdjvb2q7s3m79dlvwwi11l33y";
     propagatedBuildInputs = [ core_kernel async_kernel protocol_version_header ];
     meta.description = "Platform-independent core of Async RPC library";
   };
 
   async_unix = janePackage {
-    name = "async_unix";
+    pname = "async_unix";
     hash = "1y5za5fdh0x82zdjigxci9zm9jnpfd2lfgpjcq4rih3s28f16sf7";
     propagatedBuildInputs = [ core async_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (unix)";
@@ -371,91 +371,91 @@ rec {
 
   async_extra = janePackage {
     version = "0.11.1";
-    name = "async_extra";
+    pname = "async_extra";
     hash = "0dmplvqf41820rm5i0l9bx1xmmdlq8zsszi36y2rkjna8991f7s2";
     propagatedBuildInputs = [ async_rpc_kernel async_unix ];
     meta.description = "Jane Street's asynchronous execution library (extra)";
   };
 
   async = janePackage {
-    name = "async";
+    pname = "async";
     hash = "1i05hzk4mhzj1mw98b2bdbxhnq03jvhkkkw4d948i6265jzrrbv5";
     propagatedBuildInputs = [ async_extra ];
     meta.description = "Jane Street Capital's asynchronous execution library";
   };
 
   async_find = janePackage {
-    name = "async_find";
+    pname = "async_find";
     hash = "0s0qafx74ri1vr2vv3iy1j7s3p6gp7vyg0mw5g17iafk0w6lv2iq";
     propagatedBuildInputs = [ async ];
     meta.description = "Directory traversal with Async";
   };
 
   async_interactive = janePackage {
-    name = "async_interactive";
+    pname = "async_interactive";
     hash = "01rlfcylpiak6a2n6q3chp73cvkhvb65n906dj0flmxmagn7dxd1";
     propagatedBuildInputs = [ async ];
     meta.description = "Utilities for building simple command-line based user interfaces";
   };
 
   async_parallel = janePackage {
-    name = "async_parallel";
+    pname = "async_parallel";
     hash = "0hak8ba3rfzqhz5hz2annqmsv5bkqzdihhafp0f58ryrlskafwag";
     propagatedBuildInputs = [ async ];
     meta.description = "Distributed computing library";
   };
 
   async_shell = janePackage {
-    name = "async_shell";
+    pname = "async_shell";
     hash = "1jb01ygfnhabsy72xlcg11vp7rr37sg555sm0k3yxl4r5az3y2ay";
     propagatedBuildInputs = [ core_extended async ];
     meta.description = "Shell helpers for Async";
   };
 
   async_ssl = janePackage {
-    name = "async_ssl";
+    pname = "async_ssl";
     hash = "1p83fzfla4rb820irdrz3f2hp8kq5zrhw47rqmfv6qydlca1bq64";
     propagatedBuildInputs = [ async ctypes openssl ];
     meta.description = "Async wrappers for SSL";
   };
 
   sexp_pretty = janePackage {
-    name = "sexp_pretty";
+    pname = "sexp_pretty";
     hash = "0xskahjggbwvvb82fn0jp1didxbgpmgks76xhwp9s3vqkhgz6918";
     propagatedBuildInputs = [ ppx_base re sexplib ];
     meta.description = "S-expression pretty-printer";
   };
 
   expect_test_helpers_kernel = janePackage {
-    name = "expect_test_helpers_kernel";
+    pname = "expect_test_helpers_kernel";
     hash = "0m113vq4m1xm3wmwa08r6qjc7p5f0y3ss8s4i2z591ycgs2fxzlj";
     propagatedBuildInputs = [ core_kernel sexp_pretty ];
     meta.description = "Helpers for writing expectation tests";
   };
 
   expect_test_helpers = janePackage {
-    name = "expect_test_helpers";
+    pname = "expect_test_helpers";
     hash = "13n6h7mimwkbsjdix96ghfrmxjd036m4h4zgl8qag00aacqclvpi";
     propagatedBuildInputs = [ async expect_test_helpers_kernel ];
     meta.description = "Async helpers for writing expectation tests";
   };
 
   bignum = janePackage {
-    name = "bignum";
+    pname = "bignum";
     hash = "0hqd88fb90rsj1wjj4k79gigcf31c6a45msasw99zzifzppr3w3f";
     propagatedBuildInputs = [ core_kernel zarith num ];
     meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
   cinaps = janePackage {
-    name = "cinaps";
+    pname = "cinaps";
     hash = "0f8cx4xkkk4wqpcbvva8kxdndbgawljp17dwppc6zpjpkjl8s84j";
     propagatedBuildInputs = [ re ];
     meta.description = "Trivial Metaprogramming tool using the OCaml toplevel";
   };
 
   command_rpc = janePackage {
-    name = "command_rpc";
+    pname = "command_rpc";
     hash = "111v4km0ds8ixmpmwg9ck36ap97400mqzhijf57kj6wfwgzcmr2g";
     propagatedBuildInputs = [ async ];
     meta.description = "Utilities for Versioned RPC communication with a child process over stdin and stdout";
@@ -464,49 +464,49 @@ rec {
   # Deprecated libraries
 
   ppx_ast = janePackage {
-    name = "ppx_ast";
+    pname = "ppx_ast";
     hash = "125bzswcwr3nb26ss8ydh8z4218c8fi3s2kvgqp1j1fhc5wwzqgj";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
   };
 
   ppx_core = janePackage {
-    name = "ppx_core";
+    pname = "ppx_core";
     hash = "11hgm9mxig4cm3c827f6dns9mjv3pf8g6skf10x0gw9xnp1dmzmx";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
   };
 
   ppx_driver = janePackage {
-    name = "ppx_driver";
+    pname = "ppx_driver";
     hash = "00kfx6js2kxk57k4v7hiqvwk7h35whgjihnxf75m82rnaf4yzvfi";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
   };
 
   ppx_metaquot = janePackage {
-    name = "ppx_metaquot";
+    pname = "ppx_metaquot";
     hash = "1vz8bi56jsz8w0894vgbfsfvmdyh5k1dgv45l8vhkks0s7d3ldji";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
   };
 
   ppx_traverse = janePackage {
-    name = "ppx_traverse";
+    pname = "ppx_traverse";
     hash = "1p2n5da4mxh9fk4gvxlibc706bs5xwkbppxd1x0ip1vln5pabbq5";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
   };
 
   ppx_traverse_builtins = janePackage {
-    name = "ppx_traverse_builtins";
+    pname = "ppx_traverse_builtins";
     hash = "0qlf7i8h8k3a9h8nhb0ki3y1knr6wgbm24f1qaqni53fpvzv0pfb";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
   };
 
   ppx_type_conv = janePackage {
-    name = "ppx_type_conv";
+    pname = "ppx_type_conv";
     hash = "04dbrglqqhkas25cpjz8xhjcbpk141c35qggzw66bn69izczfmaf";
     propagatedBuildInputs = [ ppxlib ];
     meta.description = "Deprecated (see ppxlib)";
@@ -515,35 +515,35 @@ rec {
   # Miscellaneous Jane Street packages
 
   core_bench = janePackage {
-    name = "core_bench";
+    pname = "core_bench";
     hash = "10i28ssfdqxxhq0rvnlp581lr1cq2apkhmm8j83fksjkmbxcrasc";
     propagatedBuildInputs = [ core_extended ];
     meta.description = "Micro-benchmarking library for OCaml";
   };
 
   core_profiler = janePackage {
-    name = "core_profiler";
+    pname = "core_profiler";
     hash = "1kaaw3jp3qarbd9rgpjfb9md0dqblf2bxiqb245sqmx4c1346v1c";
     propagatedBuildInputs = [ core_extended ];
     meta.description = "Profiling library";
   };
 
   csvfields = janePackage {
-    name = "csvfields";
+    pname = "csvfields";
     hash = "10zw4fjlniivfdzzz79lnbvcjnhk5y16m1p8mn4xbs23n6mbix0f";
     propagatedBuildInputs = [ core expect_test_helpers ];
     meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
   };
 
   ecaml = janePackage {
-    name = "ecaml";
+    pname = "ecaml";
     hash = "1is5156q59s427x3q5nh9wsi8h1x77670bmyilqxasy39yway7g8";
     propagatedBuildInputs = [ async expect_test_helpers_kernel ];
     meta.description = "Writing Emacs plugin in OCaml";
   };
 
   email_message = janePackage {
-    name = "email_message";
+    pname = "email_message";
     hash = "131jd72k4s8cdbgg6gyg7w5v8mphdlvdx4fgvh8d9a1m7kkvbxfg";
     propagatedBuildInputs = [ async angstrom core_extended cryptokit magic-mime ounit ];
     meta.description = "E-mail message parser";
@@ -551,28 +551,28 @@ rec {
 
   incremental_kernel = janePackage {
     version = "0.11.1";
-    name = "incremental_kernel";
+    pname = "incremental_kernel";
     hash = "1qp9dqncx2h0np0rndqaic4dna8f1dlkqnbjfcdhcim5dp2vg4x6";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Library for incremental computations depending only on core_kernel";
   };
 
   incremental = janePackage {
-    name = "incremental";
+    pname = "incremental";
     hash = "1xchd3v4kj56wixjrsnj7m7l0374cgkzybihs2b62mn65xf6n7ki";
     propagatedBuildInputs = [ core incremental_kernel ];
     meta.description = "Library for incremental computations";
   };
 
   incr_map = janePackage {
-    name = "incr_map";
+    pname = "incr_map";
     hash = "01vx9aldxpigz5ah9h337xcw73a7r8449v8l2xbralljhs0zglx9";
     propagatedBuildInputs = [ incremental_kernel ];
     meta.description = "Helpers for incremental operations on map like data structures";
   };
 
   ocaml_plugin = janePackage {
-    name = "ocaml_plugin";
+    pname = "ocaml_plugin";
     hash = "0fal5j59qkbksg6ak1ngn92pcgg3f9gwfaglpxb7l6bck20kaigp";
     buildInputs = [ ocamlbuild ];
     propagatedBuildInputs = [ async ];
@@ -580,28 +580,28 @@ rec {
   };
 
   parsexp_io = janePackage {
-    name = "parsexp_io";
+    pname = "parsexp_io";
     hash = "0rhdl40jiirvv6fhgjk50n8wzs3jly5d8dyyyfgpjgl39mwkjjnb";
     propagatedBuildInputs = [ parsexp ppx_js_style ];
     meta.description = "S-expression parsing library (IO functions)";
   };
 
   patience_diff = janePackage {
-    name = "patience_diff";
+    pname = "patience_diff";
     hash = "0q7a64fgg97qcd6d8c45gyz63x5vq004axxqvvfg92b8f3x2plx4";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Tool and library implementing patience diff";
   };
 
   posixat = janePackage {
-    name = "posixat";
+    pname = "posixat";
     hash = "04rs4sl0r4rg9m6l9kkqkmc4n87sv4a4w9ibq4zsjk9j4n6r2df8";
     propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv sexplib ];
     meta.description = "Binding to the posix *at functions";
   };
 
   rpc_parallel = janePackage {
-    name = "rpc_parallel";
+    pname = "rpc_parallel";
     hash = "13dx59x73i8mkwv2qkh8gx6kk8arlvghj57k1jdscdmzmyqc9gvn";
     propagatedBuildInputs = [ async ];
     meta.description = "Type-safe library for building parallel applications";
@@ -609,14 +609,14 @@ rec {
 
   shexp = janePackage {
     version = "0.11.1";
-    name = "shexp";
+    pname = "shexp";
     hash = "06yssp7bsmabaxvw9bqxyrsji1gkvl7if5adba3v6h4kilqy7rqg";
     propagatedBuildInputs = [ posixat spawn ];
     meta.description = "Process library and s-expression based shell";
   };
 
   topological_sort = janePackage {
-    name = "topological_sort";
+    pname = "topological_sort";
     hash = "1qnz5b1rs45lsl1ycxd1lglpmh8444gy5khhdp5fvxy987zkzklz";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Topological sort algorithm";

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -1,28 +1,19 @@
-{ stdenv, fetchFromGitHub, ocaml, dune, findlib, defaultVersion ? "0.11.0" }:
+{ stdenv, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.11.0" }:
 
-{ name, version ? defaultVersion, buildInputs ? [], hash, meta, ...}@args:
+{ pname, version ? defaultVersion, hash, ...}@args:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.04"
-then throw "${name}-${version} is not available for OCaml ${ocaml.version}" else
-
-stdenv.mkDerivation (args // {
-  name = "ocaml${ocaml.version}-${name}-${version}";
+buildDunePackage (args // {
   inherit version;
+
+  minimumOCamlVersion = "4.04";
 
   src = fetchFromGitHub {
     owner = "janestreet";
-    repo = name;
+    repo = pname;
     rev = "v${version}";
     sha256 = hash;
   };
 
-  buildInputs = [ ocaml dune findlib ] ++ buildInputs;
-
-  inherit (dune) installPhase;
-
-  meta = {
-    license = stdenv.lib.licenses.asl20;
-    inherit (ocaml.meta) platforms;
-    homepage = "https://github.com/janestreet/${name}";
-  } // meta;
+  meta.license = stdenv.lib.licenses.asl20;
+  meta.homepage = "https://github.com/janestreet/${pname}";
 })

--- a/pkgs/development/ocaml-modules/janestreet/old.nix
+++ b/pkgs/development/ocaml-modules/janestreet/old.nix
@@ -7,7 +7,7 @@ rec {
   # Jane Street packages, up to ppx_core
 
   sexplib = janePackage {
-    name = "sexplib";
+    pname = "sexplib";
     meta.description = "Automated S-expression conversion";
     version = "0.10.0";
     hash = "1agw649n0rnf6h4y2dr1zs1970nncxgjmf90848vbxv8y9im4yy2";
@@ -15,7 +15,7 @@ rec {
   };
 
   base = janePackage {
-    name = "base";
+    pname = "base";
     version = "0.9.4";
     hash = "0x85xi66b4zwlbdwmyc99zcmawgpp75gxqbl55rr67awavw162rw";
     propagatedBuildInputs = [ sexplib ];
@@ -23,13 +23,13 @@ rec {
   };
 
   ocaml-compiler-libs = janePackage {
-    name = "ocaml-compiler-libs";
+    pname = "ocaml-compiler-libs";
     hash = "1jz3nfrb6295sj4xj1j0zld8mhfj0xy2k4vlp9yf9sh3748n090l";
     meta.description = "OCaml compiler libraries repackaged";
   };
 
   ppx_ast = janePackage ({
-    name = "ppx_ast";
+    pname = "ppx_ast";
     propagatedBuildInputs = [ ocaml-compiler-libs ocaml-migrate-parsetree ];
     meta.description = "OCaml AST used by Jane Street ppx rewriters";
   } // (if lib.versionAtLeast ocaml.version "4.06"
@@ -43,13 +43,13 @@ rec {
   ));
 
   ppx_traverse_builtins = janePackage {
-    name = "ppx_traverse_builtins";
+    pname = "ppx_traverse_builtins";
     hash = "10ajvz02ka6qimlfrq7py4ljhk8awqkga6240kn8j046b4xfyxzi";
     meta.description = "Builtins for Ppx_traverse";
   };
 
   stdio = janePackage {
-    name = "stdio";
+    pname = "stdio";
     version = "0.9.1";
     hash = "13rj3ii0rvmklfim9ild0ib44ssdadig7a9ccjbz22m0pw84a1sx";
     propagatedBuildInputs = [ base ];
@@ -57,7 +57,7 @@ rec {
   };
 
   ppx_core = janePackage {
-    name = "ppx_core";
+    pname = "ppx_core";
     hash = "15400zxxkqdimmjpdjcs36gcbxbrhylmaczlzwd6x65v1h9aydz3";
     propagatedBuildInputs = [ ppx_ast ppx_traverse_builtins stdio ];
     meta.description = "Jane Street's standard library for ppx rewriters";
@@ -66,14 +66,14 @@ rec {
   # Jane Street packages, up to ppx_base
 
   ppx_optcomp = janePackage {
-    name = "ppx_optcomp";
+    pname = "ppx_optcomp";
     hash = "1wfj6fnh92s81yncq7yyhmax7j6zpjj1sg1f3qa1f9c5kf4kkzrd";
     propagatedBuildInputs = [ ppx_core ];
     meta.description = "Optional compilation for OCaml";
   };
 
   ppx_driver = janePackage {
-    name = "ppx_driver";
+    pname = "ppx_driver";
     version = "0.9.1";
     hash = "1amz49x6v4sh1v2my6618cah0zv5i7jmsapbk9ydps6419g5asay";
     buildInputs = [ ocamlbuild ];
@@ -82,56 +82,56 @@ rec {
   };
 
   ppx_metaquot = janePackage {
-    name = "ppx_metaquot";
+    pname = "ppx_metaquot";
     hash = "15qfd3s4x2pz006nx5316laxd3gqqi472x432qg4rfx4yh3vn31k";
     propagatedBuildInputs = [ ppx_driver ];
     meta.description = "Metaquotations for ppx_ast";
   };
 
   ppx_type_conv = janePackage {
-    name = "ppx_type_conv";
+    pname = "ppx_type_conv";
     hash = "0a0gxjvjiql9vg37k0akn8xr5724nv3xb7v37xpidv7ld927ks7p";
     propagatedBuildInputs = [ ppx_metaquot ppx_deriving ];
     meta.description = "Support Library for type-driven code generators";
   };
 
   ppx_sexp_conv = janePackage {
-    name = "ppx_sexp_conv";
+    pname = "ppx_sexp_conv";
     hash = "03cg2sym0wvpd5l7q4w9bclp589z5byygwsmnnq9h1ih56cmd55l";
     propagatedBuildInputs = [ ppx_type_conv sexplib ];
     meta.description = "Generation of S-expression conversion functions from type definitions";
   };
 
   ppx_compare = janePackage {
-    name = "ppx_compare";
+    pname = "ppx_compare";
     hash = "0wrszpvn1nms5sb5rb29p7z1wmqyd15gfzdj4ax8f843p5ywx3w9";
     propagatedBuildInputs = [ ppx_type_conv ];
     meta.description = "Generation of comparison functions from types";
   };
 
   ppx_enumerate = janePackage {
-    name = "ppx_enumerate";
+    pname = "ppx_enumerate";
     hash = "1dfy86j2z12p5n9yrwaakx1ngphs5246vxy279kz6i6j34cwxm46";
     propagatedBuildInputs = [ ppx_type_conv ];
     meta.description = "Generate a list containing all values of a finite type";
   };
 
   ppx_hash = janePackage {
-    name = "ppx_hash";
+    pname = "ppx_hash";
     hash = "1w1riy2sqd9i611sc5f5z2rqqgjl2gvvkzi5xibpv309nacnl01d";
     propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
     meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
   };
 
   ppx_js_style = janePackage {
-    name = "ppx_js_style";
+    pname = "ppx_js_style";
     hash = "09k02b1l2r7svf9l3ls69h8xydsyiang2ziigxnny2i7gy7b0w59";
     propagatedBuildInputs = [ ppx_metaquot octavius ];
     meta.description = "Code style checker for Jane Street Packages";
   };
 
   ppx_base = janePackage {
-    name = "ppx_base";
+    pname = "ppx_base";
     hash = "0qikfzbkd2wyxfrvizz6rgi6vg4ykvxkivacj4gr178dbgfl5if3";
     propagatedBuildInputs = [ ppx_enumerate ppx_hash ppx_js_style ];
     meta.description = "Base set of ppx rewriters";
@@ -140,49 +140,49 @@ rec {
   # Jane Street packages, up to ppx_bin_prot
 
   fieldslib = janePackage {
-    name = "fieldslib";
+    pname = "fieldslib";
     hash = "1wxh59888l1bfz9ipnbcas58gwg744icaixzdbsg4v8f7wymc501";
     propagatedBuildInputs = [ ppx_driver ];
     meta.description = "OCaml record fields as first class values";
   };
 
   variantslib = janePackage {
-    name = "variantslib";
+    pname = "variantslib";
     hash = "0kj53n62193j58q9vip8lfhhyf6w9d25wyvxzc163hx5m68yw0fz";
     propagatedBuildInputs = [ ppx_driver ];
     meta.description = "OCaml variants as first class values";
   };
 
   ppx_traverse = janePackage {
-    name = "ppx_traverse";
+    pname = "ppx_traverse";
     hash = "1sdqgwyq0w71i03vhc5jq4jk6rsbgwhvain48fnrllpkb5kj2la2";
     propagatedBuildInputs = [ ppx_type_conv ];
     meta.description = "Automatic generation of open recursion classes";
   };
 
   ppx_custom_printf = janePackage {
-    name = "ppx_custom_printf";
+    pname = "ppx_custom_printf";
     hash = "0cjy2c2c5g3qxqvwx1yb6p7kbmmpnpb1hll55f7a44x215lg8x19";
     propagatedBuildInputs = [ ppx_sexp_conv ppx_traverse ];
     meta.description = "Printf-style format-strings for user-defined string conversion";
   };
 
   ppx_fields_conv = janePackage {
-    name = "ppx_fields_conv";
+    pname = "ppx_fields_conv";
     hash = "0qp8zgmk58iskzrkf4g06i471kg6lrh3wqpy9klrb8pp9mg0xr9z";
     propagatedBuildInputs = [ fieldslib ppx_type_conv ];
     meta.description = "Generation of accessor and iteration functions for OCaml records";
   };
 
   ppx_variants_conv = janePackage {
-    name = "ppx_variants_conv";
+    pname = "ppx_variants_conv";
     hash = "1xayhyglgbdjqvb9123kjbwjcv0a3n3302nb0j7g8gmja8w5y834";
     propagatedBuildInputs = [ ppx_type_conv variantslib ];
     meta.description = "Generation of accessor and iteration functions for OCaml variant types";
   };
 
   bin_prot = janePackage {
-    name = "bin_prot";
+    pname = "bin_prot";
     version = "0.9.1";
     hash = "1bgcmkgz6b5i522996x589zsaiy5b3h37887lwbqvpps8by2ayvk";
     propagatedBuildInputs = [ ppx_compare ppx_custom_printf ppx_fields_conv ppx_variants_conv ];
@@ -190,14 +190,14 @@ rec {
   };
 
   ppx_here = janePackage {
-    name = "ppx_here";
+    pname = "ppx_here";
     hash = "0pjscw5ydxgy4fcxakgsazpp09ka057w5n2fp2dpkv2k5gil6rzh";
     propagatedBuildInputs = [ ppx_driver ];
     meta.description = "Expands [%here] into its location";
   };
 
   ppx_bin_prot = janePackage {
-    name = "ppx_bin_prot";
+    pname = "ppx_bin_prot";
     hash = "0qw9zqrc5yngzrzpk9awnlnd68xrb7wz5lq807c80ibxk0xvnqn3";
     propagatedBuildInputs = [ ppx_here bin_prot ];
     meta.description = "Generation of bin_prot readers and writers from types";
@@ -206,14 +206,14 @@ rec {
   # Jane Street packages, up to ppx_jane
 
   ppx_assert = janePackage {
-    name = "ppx_assert";
+    pname = "ppx_assert";
     hash = "1s5c75wkc46nlcwmgic5h7f439s26ssrzrcil501c5kpib2hlv6z";
     propagatedBuildInputs = [ ppx_sexp_conv ppx_here ppx_compare ];
     meta.description = "Assert-like extension nodes that raise useful errors on failure";
   };
 
   ppx_inline_test = janePackage {
-    name = "ppx_inline_test";
+    pname = "ppx_inline_test";
     version = "0.9.2";
     hash = "17j36ihiqprbpa2bk02449k93vaidid2sly5djrk848ccjq8n5aa";
     propagatedBuildInputs = [ ppx_metaquot ];
@@ -221,77 +221,77 @@ rec {
   };
 
   typerep = janePackage {
-    name = "typerep";
+    pname = "typerep";
     hash = "0hlc0xiznli1k6azv2mhm1s4xghhxqqd957np7828bfp7r8n2jy3";
     propagatedBuildInputs = [ base ];
     meta.description = "Runtime types for OCaml";
   };
 
   ppx_bench = janePackage {
-    name = "ppx_bench";
+    pname = "ppx_bench";
     hash = "1qk4y6c2mpw7bqjppi2nam74vs2sc89wzq162j92wsqxyqsv4p93";
     propagatedBuildInputs = [ ppx_inline_test ];
     meta.description = "Syntax extension for writing in-line benchmarks in OCaml code";
   };
 
   ppx_expect = janePackage {
-    name = "ppx_expect";
+    pname = "ppx_expect";
     hash = "1bik53k51wcqv088f0h10n3ms9h51yvg6ha3g1s903i2bxr3xs6b";
     propagatedBuildInputs = [ ppx_inline_test ppx_fields_conv ppx_custom_printf ppx_assert ppx_variants_conv re ];
     meta.description = "Cram like framework for OCaml";
   };
 
   ppx_fail = janePackage {
-    name = "ppx_fail";
+    pname = "ppx_fail";
     hash = "0qz0vlazasjyg7cv3iwpzxlvsah3zmn9dzd029xxqr1bji067s32";
     propagatedBuildInputs = [ ppx_here ppx_metaquot ];
     meta.description = "Add location to calls to failwiths";
   };
 
   ppx_let = janePackage {
-    name = "ppx_let";
+    pname = "ppx_let";
     hash = "1b914a5nynwxjvfx42v61yigvjhnd548m4yqjfchf38dmqi1f4nr";
     propagatedBuildInputs = [ ppx_driver ];
     meta.description = "Monadic let-bindings";
   };
 
   ppx_optional = janePackage {
-    name = "ppx_optional";
+    pname = "ppx_optional";
     hash = "1vknsarxba0zcp5k2jb31wfpvqrv3bpanxbahfl5s2fwspsfdc82";
     propagatedBuildInputs = [ ppx_metaquot ];
     meta.description = "Pattern matching on flat options";
   };
 
   ppx_pipebang = janePackage {
-    name = "ppx_pipebang";
+    pname = "ppx_pipebang";
     hash = "1wyfyyjvyi94ds1p90l60wdr85q2v3fq1qdf3gnv9zjfy6sb0g9h";
     propagatedBuildInputs = [ ppx_metaquot ];
     meta.description = "A ppx rewriter that inlines reverse application operators |> and |!";
   };
 
   ppx_sexp_message = janePackage {
-    name = "ppx_sexp_message";
+    pname = "ppx_sexp_message";
     hash = "0r0skyr1zf2jh48xrxbs45gzywynhlivkq24xwc0qq435fmc2jqv";
     propagatedBuildInputs = [ ppx_sexp_conv ppx_here ];
     meta.description = "A ppx rewriter for easy construction of s-expressions";
   };
 
   ppx_sexp_value = janePackage {
-    name = "ppx_sexp_value";
+    pname = "ppx_sexp_value";
     hash = "0hha5mmx700m8fy9g4znb8278l09chgwlpshny83vsmmzgq2jhah";
     propagatedBuildInputs = [ ppx_sexp_conv ppx_here ];
     meta.description = "A ppx rewriter that simplifies building s-expressions from OCaml values";
   };
 
   ppx_typerep_conv = janePackage {
-    name = "ppx_typerep_conv";
+    pname = "ppx_typerep_conv";
     hash = "0bzgfpbqijwxm8x9jq1zb4xi5sbzymk17lw5rylri3hf84p60aq1";
     propagatedBuildInputs = [ ppx_type_conv typerep ];
     meta.description = "Generation of runtime types from type declarations";
   };
 
   ppx_jane = janePackage {
-    name = "ppx_jane";
+    pname = "ppx_jane";
     hash = "16m5iw0qyp452nqj83kd0g0x3rw40lrz7392hwpd4di1wi6v2qzc";
     propagatedBuildInputs = [ ppx_base ppx_bench ppx_bin_prot ppx_expect ppx_fail ppx_let ppx_optional ppx_pipebang ppx_sexp_message ppx_sexp_value ppx_typerep_conv ];
     meta.description = "Standard Jane Street ppx rewriters";
@@ -300,7 +300,7 @@ rec {
   # Jane Street packages, up to core
 
   configurator = janePackage {
-    name = "configurator";
+    pname = "configurator";
     version = "0.9.1";
     hash = "1q0s0ghcrcrxdj6zr9zr27g7sr4qr9l14kizjphwqwwvgbzawdix";
     propagatedBuildInputs = [ ppx_base ];
@@ -308,26 +308,26 @@ rec {
   };
 
   jane-street-headers = janePackage {
-    name = "jane-street-headers";
+    pname = "jane-street-headers";
     hash = "0cdab6sblsidjbwvyvmspykyhqh44rpsjzi2djbfd5m4vh2h14gy";
     meta.description = "Jane Street header files";
   };
 
   core_kernel = janePackage {
-    name = "core_kernel";
+    pname = "core_kernel";
     hash = "05iwvggx9m81x7ijgv9gcv5znf5rmsmb76dg909bm9gkr3hbh7wh";
     propagatedBuildInputs = [ configurator jane-street-headers ppx_jane ];
     meta.description = "Jane Street's standard library overlay (kernel)";
   };
 
   spawn = janePackage {
-    name = "spawn";
+    pname = "spawn";
     hash = "1w53b8ni06ajj62yaqjy0pkbm952l0m5fzr088yk15078qaxsnb5";
     meta.description = "Spawning sub-processes";
   };
 
   core = janePackage {
-    name = "core";
+    pname = "core";
     version = "0.9.1";
     hash = "1643r0namsgj8xwfr9niimcdwyyq4ddiwd02d73ipb4a8710aqi8";
     propagatedBuildInputs = [ core_kernel spawn ];
@@ -337,7 +337,7 @@ rec {
   # Jane Street packages, up to core_extended
 
   re2 = janePackage {
-    name = "re2";
+    pname = "re2";
     hash = "1qmhl3yd6y0lq401rz72b1bsbpglb0wighpxn3x8y1ixq415p4xi";
     propagatedBuildInputs = [ core_kernel ];
     meta = {
@@ -347,14 +347,14 @@ rec {
   };
 
   textutils = janePackage {
-    name = "textutils";
+    pname = "textutils";
     hash = "1y6j2qw7rc8d80343lfv1dygnfrhn2qllz57mx28pl5kan743f6d";
     propagatedBuildInputs = [ core ];
     meta.description = "Text output utilities";
   };
 
   core_extended = janePackage {
-    name = "core_extended";
+    pname = "core_extended";
     hash = "05cnzzj0kigz9c9gsmd6mfar82wmkbqm9qzrydb80sy2fz5b30rk";
     propagatedBuildInputs = [ core re2 textutils ];
     postPatch = ''
@@ -368,63 +368,63 @@ rec {
   # Jane Street async packages
 
   async_kernel = janePackage {
-    name = "async_kernel";
+    pname = "async_kernel";
     hash = "1zwxhzy7f9900rcjls2fql9cpfmwrcah3fazzdz4h2i51f41w62x";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (core)";
   };
 
   async_rpc_kernel = janePackage {
-    name = "async_rpc_kernel";
+    pname = "async_rpc_kernel";
     hash = "1xk3s6s3xkj182p10kig2cqy8md6znif3v661h9cd02n8s57c40b";
     propagatedBuildInputs = [ core_kernel async_kernel ];
     meta.description = "Platform-independent core of Async RPC library";
   };
 
   async_unix = janePackage {
-    name = "async_unix";
+    pname = "async_unix";
     hash = "0yd4z28j5vdj2zxqi0fkgh2ic1s9h740is2dk0raga0zr5a1z03d";
     propagatedBuildInputs = [ core async_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (unix)";
   };
 
   async_extra = janePackage {
-    name = "async_extra";
+    pname = "async_extra";
     hash = "0rpy5lc5dh5mir7flq1jrppd8imby8wyw191yg4nmklg28xp5sx0";
     propagatedBuildInputs = [ async_rpc_kernel async_unix ];
     meta.description = "Jane Street's asynchronous execution library (extra)";
   };
 
   async = janePackage {
-    name = "async";
+    pname = "async";
     hash = "10ykzym19srgdiikj0s74dndx5nk15hjq1r2hc61iz48f6caxkb1";
     propagatedBuildInputs = [ async_extra ];
     meta.description = "Jane Street Capital's asynchronous execution library";
   };
 
   async_find = janePackage {
-    name = "async_find";
+    pname = "async_find";
     hash = "11dmhdzgf5kn4m0cm6zr28wpwhi2kr4lak9nmgxbrxsq28bcncxq";
     propagatedBuildInputs = [ async ];
     meta.description = "Directory traversal with Async";
   };
 
   async_interactive = janePackage {
-    name = "async_interactive";
+    pname = "async_interactive";
     hash = "1mmqqp6bi2wg7bmgf0sw34jn3iyl5kbm200dax8yqq6rfprcs49j";
     propagatedBuildInputs = [ async ];
     meta.description = "Utilities for building simple command-line based user interfaces";
   };
 
   async_parallel = janePackage {
-    name = "async_parallel";
+    pname = "async_parallel";
     hash = "0mdprhr1pv4g65g10gr3gaifrzknsdgarwfdbjlvhzfs86075kyn";
     propagatedBuildInputs = [ async ];
     meta.description = "Distributed computing library";
   };
 
   async_shell = janePackage {
-    name = "async_shell";
+    pname = "async_shell";
     hash = "02clpz3xv3i5avzifwalylb9gfxzpgnr8bnlfsjixxfk2m7kvsj2";
     propagatedBuildInputs = [ core_extended async ];
     meta = {
@@ -433,7 +433,7 @@ rec {
   };
 
   async_ssl = janePackage {
-    name = "async_ssl";
+    pname = "async_ssl";
     hash = "01w3bg38q61lc3hfh8jsr0sy1ylyv0m6g6h9yvsk8ngj6qk70nss";
     propagatedBuildInputs = [ async ctypes openssl ];
     meta.description = "Async wrappers for SSL";
@@ -442,21 +442,21 @@ rec {
   # Jane Street packages, up to expect_test_helpers
 
   sexp_pretty = janePackage {
-    name = "sexp_pretty";
+    pname = "sexp_pretty";
     hash = "1bx8va468j5b813m0vsh1jzgb6h2qnnjfmjlf2hb82sarv8lllfx";
     propagatedBuildInputs = [ ppx_base re ];
     meta.description = "S-expression pretty-printer";
   };
 
   expect_test_helpers_kernel = janePackage {
-    name = "expect_test_helpers_kernel";
+    pname = "expect_test_helpers_kernel";
     hash = "1ycqir8sqgq5nialnrfg29nqn0cqg6jjpgv24drdycdhqf5r2zg6";
     propagatedBuildInputs = [ core_kernel sexp_pretty ];
     meta.description = "Helpers for writing expectation tests";
   };
 
   expect_test_helpers = janePackage {
-    name = "expect_test_helpers";
+    pname = "expect_test_helpers";
     hash = "0rsh6rwbqfcrqisk8jp7srlnicsadbzrs02ri6zyx0p3lmznw5r2";
     propagatedBuildInputs = [ async expect_test_helpers_kernel ];
     meta.description = "Async helpers for writing expectation tests";
@@ -465,28 +465,28 @@ rec {
   # Miscellaneous Jane Street packages
 
   bignum = janePackage {
-    name = "bignum";
+    pname = "bignum";
     hash = "0g80mzsi7vc1kq4mzha8y9nl95h6cd041vix3wjrqgkdvb1qd4f3";
     propagatedBuildInputs = [ core_kernel zarith ];
     meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
   cinaps = janePackage {
-    name = "cinaps";
+    pname = "cinaps";
     hash = "02fpjiwrygkpx2q4jfldhbqh0mqxmf955wizr8k4vmsq4wsis0p5";
     propagatedBuildInputs = [ re ];
     meta.description = "Trivial Metaprogramming tool using the OCaml toplevel";
   };
 
   command_rpc = janePackage {
-    name = "command_rpc";
+    pname = "command_rpc";
     hash = "0w58z9jkz5qzbvf33wrzhfshzdvnrphj6dq8dmi52ykhfvxm7824";
     propagatedBuildInputs = [ async ];
     meta.description = "Utilities for Versioned RPC communication with a child process over stdin and stdout";
   };
 
   core_bench = janePackage {
-    name = "core_bench";
+    pname = "core_bench";
     hash = "1m2q7217nmcsck29i59djkm0h6z3aj0i01niijzr5f6ilbnmyd3h";
     propagatedBuildInputs = [ core_extended ];
     meta = {
@@ -495,7 +495,7 @@ rec {
   };
 
   core_profiler = janePackage {
-    name = "core_profiler";
+    pname = "core_profiler";
     hash = "1ir2v3wdfbf5xzqcma16asc73mkx2q6dzq5y1bx6q1rpa7iznx44";
     propagatedBuildInputs = [ core_extended ];
     meta = {
@@ -504,21 +504,21 @@ rec {
   };
 
   csvfields = janePackage {
-    name = "csvfields";
+    pname = "csvfields";
     hash = "0lbvs1kwl22ryxhw6s089f6683hj2920bn518mvr22rnv7qijy0v";
     propagatedBuildInputs = [ core ];
     meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
   };
 
   ecaml = janePackage {
-    name = "ecaml";
+    pname = "ecaml";
     hash = "1a2534bzbwgpm71aj3sm71sm0lkcjdfjj1mk91p1pg9kxn8c5x4i";
     propagatedBuildInputs = [ async ];
     meta.description = "Writing Emacs plugin in OCaml";
   };
 
   email_message = janePackage {
-    name = "email_message";
+    pname = "email_message";
     hash = "0cpaf6wn5g883bxdz029bksvrfzih99m7hzbb30fhqglmpmmkniz";
     propagatedBuildInputs = [ async core_extended cryptokit magic-mime ounit ];
     meta = {
@@ -527,28 +527,28 @@ rec {
   };
 
   incremental_kernel = janePackage {
-    name = "incremental_kernel";
+    pname = "incremental_kernel";
     hash = "0zq48wbgqcflh84n10iygi8aa3f0zzmgc7r0jwvsyg7i8zccgvf5";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Library for incremental computations depending only on core_kernel";
   };
 
   incremental = janePackage {
-    name = "incremental";
+    pname = "incremental";
     hash = "05sx8ia46v4dlvzcn7xgjcwxvbd0wmvv9r2bpvniapjnwr1nvcfh";
     propagatedBuildInputs = [ core incremental_kernel ];
     meta.description = "Library for incremental computations";
   };
 
   incr_map = janePackage {
-    name = "incr_map";
+    pname = "incr_map";
     hash = "0358qg9irxbbhn18laqww3mn43mdwvlbr0h2mvg3vdbb2c5jp4fv";
     propagatedBuildInputs = [ incremental_kernel ];
     meta.description = "Helpers for incremental operations on map like data structures";
   };
 
   ocaml_plugin = janePackage {
-    name = "ocaml_plugin";
+    pname = "ocaml_plugin";
     hash = "0q33swnlx9p1gcn1aj95501kapb7cnbzbsavid69csczwmzcxr14";
     buildInputs = [ ocamlbuild ];
     propagatedBuildInputs = [ async ];
@@ -556,28 +556,28 @@ rec {
   };
 
   parsexp = janePackage {
-    name = "parsexp";
+    pname = "parsexp";
     hash = "0brrifvnfqbfk873v6y5b2jixs2d73hpispj9r440kca5cfsv23b";
     propagatedBuildInputs = [ ppx_compare ppx_fields_conv ppx_js_style ppx_sexp_value ];
     meta.description = "S-expression parsing library";
   };
 
   parsexp_io = janePackage {
-    name = "parsexp_io";
+    pname = "parsexp_io";
     hash = "0gcmh4dg48xgszladq92yhk1hf492zf0smz462xrwknzlfdkz6a5";
     propagatedBuildInputs = [ parsexp ];
     meta.description = "S-expression parsing library (IO functions)";
   };
 
   patience_diff = janePackage {
-    name = "patience_diff";
+    pname = "patience_diff";
     hash = "0vpx9xj1ich5qmj3m26vlmix3nsdj7pd1xzhqwbc7ad2kqwy3grg";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Tool and library implementing patience diff";
   };
 
   posixat = janePackage {
-    name = "posixat";
+    pname = "posixat";
     hash = "0ak93dyzi6sc6gb0j07fj85b24d8bv6g2hm7jj5xwb39kjwh51jl";
     propagatedBuildInputs = [ ppx_sexp_conv ];
     meta.description = "Binding to the posix *at functions";
@@ -585,28 +585,28 @@ rec {
   };
 
   rpc_parallel = janePackage {
-    name = "rpc_parallel";
+    pname = "rpc_parallel";
     hash = "0s72msl2p27bz0knjlpgy5qwp0w4z76cq801ps0sab35f8jjfs38";
     propagatedBuildInputs = [ async ];
     meta.description = "Type-safe library for building parallel applications";
   };
 
   shexp = janePackage {
-    name = "shexp";
+    pname = "shexp";
     hash = "1fkz4l9z4i0fz2kccd5blm2j9x2x4z6y1cn29wjmc3spqfxbq37y";
     propagatedBuildInputs = [ posixat spawn ];
     meta.description = "Process library and s-expression based shell";
   };
 
   topological_sort = janePackage {
-    name = "topological_sort";
+    pname = "topological_sort";
     hash = "1d64fyq0clsgham9p1f5rk01z8pxalglp92xmqw2iznyw0vxhvsy";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Topological sort algorithm";
   };
 
   typerep_extended = janePackage {
-    name = "typerep_extended";
+    pname = "typerep_extended";
     hash = "15gq8mrvlipd616rffr3f0wqw5d0ijnnizix610g2d5viirh0j9p";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Runtime types for OCaml (Extended)";

--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -1,25 +1,18 @@
-{ stdenv, fetchurl, libev, ocaml, findlib, dune
-, zed, lwt_log, lwt_react
-}:
+{ stdenv, fetchurl, libev, buildDunePackage, zed, lwt_log, lwt_react }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.02";
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "lambda-term";
   version = "1.13";
-  name = "ocaml${ocaml.version}-lambda-term-${version}";
+
+  minimumOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "https://github.com/diml/lambda-term/archive/${version}.tar.gz";
+    url = "https://github.com/diml/${pname}/archive/${version}.tar.gz";
     sha256 = "1hy5ryagqclgdm9lzh1qil5mrynlypv7mn6qm858hdcnmz9zzn0l";
   };
 
-  buildInputs = [ libev ocaml findlib dune ];
-
+  buildInputs = [ libev ];
   propagatedBuildInputs = [ zed lwt_log lwt_react ];
-
-  buildPhase = "dune build -p lambda-term";
-
-  inherit (dune) installPhase;
 
   hasSharedObjects = true;
 
@@ -41,7 +34,6 @@ stdenv.mkDerivation rec {
 
     homepage = https://github.com/diml/lambda-term;
     license = stdenv.lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [
       stdenv.lib.maintainers.gal_bolle
     ];

--- a/pkgs/development/ocaml-modules/linenoise/default.nix
+++ b/pkgs/development/ocaml-modules/linenoise/default.nix
@@ -1,29 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, dune, findlib, result }:
+{ stdenv, fetchFromGitHub, buildDunePackage, result }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "linenoise is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-linenoise-${version}";
+buildDunePackage rec {
+  pname = "linenoise";
   version = "1.1.0";
+
+  minimumOCamlVersion = "4.02";
+
   src = fetchFromGitHub {
     owner = "fxfactorial";
-    repo = "ocaml-linenoise";
+    repo = "ocaml-${pname}";
     rev = "v${version}";
     sha256 = "1h6rqfgmhmd7p5z8yhk6zkbrk4yzw1v2fgwas2b7g3hqs6y0xj0q";
   };
 
-  buildInputs = [ ocaml findlib dune ];
   propagatedBuildInputs = [ result ];
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "OCaml bindings to linenoise";
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/lwt/4.x.nix
+++ b/pkgs/development/ocaml-modules/lwt/4.x.nix
@@ -1,35 +1,29 @@
-{ stdenv, fetchzip, pkgconfig, ncurses, libev, dune
-, ocaml, findlib, cppo
-, ocaml-migrate-parsetree, ppx_tools_versioned, result
+{ stdenv, fetchzip, pkgconfig, ncurses, libev, buildDunePackage, ocaml
+, cppo, ocaml-migrate-parsetree, ppx_tools_versioned, result
 }:
 
 let inherit (stdenv.lib) optional versionAtLeast; in
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "lwt";
   version = "4.1.0";
-  name = "ocaml${ocaml.version}-lwt-${version}";
 
   src = fetchzip {
-    url = "https://github.com/ocsigen/lwt/archive/${version}.tar.gz";
+    url = "https://github.com/ocsigen/${pname}/archive/${version}.tar.gz";
     sha256 = "16wnc61kfj54z4q8sn9f5iik37pswz328hcz3z6rkza3kh3s6wmm";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocaml findlib dune cppo
-    ocaml-migrate-parsetree ppx_tools_versioned
-  ] ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
+  buildInputs = [ cppo ocaml-migrate-parsetree ppx_tools_versioned ]
+   ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev result ];
 
   configurePhase = "ocaml src/util/configure.ml -use-libev true";
-  buildPhase = "jbuilder build -p lwt";
-  inherit (dune) installPhase;
 
   meta = {
     homepage = "https://ocsigen.org/lwt/";
     description = "A cooperative threads library for OCaml";
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     license = stdenv.lib.licenses.lgpl21;
-    inherit (ocaml.meta) platforms;
   };
 }
-

--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -1,19 +1,15 @@
-{ stdenv, dune, ocaml, findlib, lwt, ppx_tools_versioned }:
+{ stdenv, buildDunePackage, lwt, ppx_tools_versioned }:
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-lwt_ppx-${lwt.version}";
+buildDunePackage {
+  pname = "lwt_ppx";
 
-  inherit (lwt) src;
+  inherit (lwt) src version;
 
-  buildInputs = [ dune ocaml findlib ppx_tools_versioned ];
-
+  buildInputs = [ ppx_tools_versioned ];
   propagatedBuildInputs = [ lwt ];
-
-  buildPhase = "dune build -p lwt_ppx";
-  installPhase = "${dune.installPhase} lwt_ppx.install";
 
   meta = {
     description = "Ppx syntax extension for Lwt";
-    inherit (lwt.meta) license platforms homepage maintainers;
+    inherit (lwt.meta) license homepage maintainers;
   };
 }

--- a/pkgs/development/ocaml-modules/lwt_log/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_log/default.nix
@@ -1,33 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, lwt }:
+{ stdenv, fetchFromGitHub, buildDunePackage, lwt }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "lwt_log is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "lwt_log";
   version = "1.1.0";
-  name = "ocaml${ocaml.version}-lwt_log-${version}";
+
+  minimumOCamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "aantron";
-    repo = "lwt_log";
+    repo = pname;
     rev = version;
     sha256 = "1c58gkqfvyf2j11jwj2nh4iq999wj9xpnmr80hz9d0nk9fv333pi";
   };
 
-  buildInputs = [ ocaml findlib dune ];
-
   propagatedBuildInputs = [ lwt ];
-
-  buildPhase = "dune build -p lwt_log";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Lwt logging library (deprecated)";
     homepage = "https://github.com/aantron/lwt_log";
     license = stdenv.lib.licenses.lgpl21;
-    inherit (ocaml.meta) platforms;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/lwt_react/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_react/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		description = "Helpers for using React with Lwt";
-		inherit (lwt.meta) homepage license maintainers platforms;
+		inherit (lwt.meta) homepage license maintainers;
+    inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/lwt_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_ssl/default.nix
@@ -1,28 +1,22 @@
-{ stdenv, fetchzip, ocaml, findlib, dune, ssl, lwt }:
+{ stdenv, fetchzip, buildDunePackage, ssl, lwt }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "lwt_ssl is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "lwt_ssl";
   version = "1.1.2";
-  name = "ocaml${ocaml.version}-lwt_ssl-${version}";
+
+  minimumOCamlVersion = "4.02";
 
   src = fetchzip {
-    url = "https://github.com/aantron/lwt_ssl/archive/${version}.tar.gz";
+    url = "https://github.com/aantron/${pname}/archive/${version}.tar.gz";
     sha256 = "1q0an3djqjxv83v3iswi7m81braqx93kcrcwrxwmf6jzhdm4pn15";
   };
 
-  buildInputs = [ ocaml findlib dune ];
   propagatedBuildInputs = [ ssl lwt ];
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = "https://github.com/aantron/lwt_ssl";
     description = "OpenSSL binding with concurrent I/O";
     license = stdenv.lib.licenses.lgpl21;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/mstruct/default.nix
+++ b/pkgs/development/ocaml-modules/mstruct/default.nix
@@ -1,33 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
-, cstruct
-}:
+{ stdenv, fetchFromGitHub, buildDunePackage, cstruct }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "mstruct is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+	pname = "mstruct";
 	version = "1.4.0";
-	name = "ocaml${ocaml.version}-mstruct-${version}";
+
+  minimumOCamlVersion = "4.02";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
-		repo = "ocaml-mstruct";
+		repo = "ocaml-${pname}";
 		rev = "v${version}";
 		sha256 = "1p4ygwzs3n1fj4apfib0z0sabpph21bkq1dgjk4bsa59pq4prncm";
 	};
 
-	buildInputs = [ ocaml findlib dune ];
-
 	propagatedBuildInputs = [ cstruct ];
-
-	inherit (dune) installPhase;
 
 	meta = {
 		description = "A thin mutable layer on top of cstruct";
 		license = stdenv.lib.licenses.isc;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
@@ -1,30 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, dune, result }:
+{ stdenv, fetchFromGitHub, buildDunePackage, result }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "ocaml-migrate-parsetree is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-   name = "ocaml${ocaml.version}-ocaml-migrate-parsetree-${version}";
+buildDunePackage rec {
+   pname = "ocaml-migrate-parsetree";
    version = "1.1.0";
 
    src = fetchFromGitHub {
      owner = "ocaml-ppx";
-     repo = "ocaml-migrate-parsetree";
+     repo = pname;
      rev = "v${version}";
      sha256 = "1d2n349d1cqm3dr09mwy5m9rfd4bkkqvri5i94wknpsrr35vnrr1";
    };
 
-   buildInputs = [ ocaml findlib ocamlbuild dune ];
    propagatedBuildInputs = [ result ];
-
-   inherit (dune) installPhase;
 
    meta = {
      description = "Convert OCaml parsetrees between different major versions";
      license = stdenv.lib.licenses.lgpl21;
      maintainers = [ stdenv.lib.maintainers.vbgl ];
      inherit (src.meta) homepage;
-     inherit (ocaml.meta) platforms;
    };
 }

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,26 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, cppo
-, bos, cmdliner, tyxml
-}:
+{ stdenv, fetchFromGitHub, buildDunePackage, cppo, bos, cmdliner, tyxml }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-odoc-${version}";
+buildDunePackage rec {
+  pname = "odoc";
   version = "1.3.0";
+
   src = fetchFromGitHub {
     owner = "ocaml";
-    repo = "odoc";
+    repo = pname;
     rev = version;
     sha256 = "0hjan5aj5zk8j8qyagv9r4hqm469mh207cv2m6kxwgnw0c3cz7sy";
   };
 
-  buildInputs = [ ocaml findlib dune cppo bos cmdliner tyxml ];
-
-  inherit (dune) installPhase;
+  buildInputs = [ cppo bos cmdliner tyxml ];
 
   meta = {
     description = "A documentation generator for OCaml";
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -1,26 +1,18 @@
-{ stdenv, fetchurl, ocaml, findlib, dune, alcotest
-, ocaml-migrate-parsetree
-}:
+{ stdenv, fetchurl, buildDunePackage, alcotest, ocaml-migrate-parsetree }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ppx_blob-${version}";
+buildDunePackage rec {
+  pname = "ppx_blob";
   version = "0.4.0";
 
   src = fetchurl {
-    url = "https://github.com/johnwhitington/ppx_blob/releases/download/${version}/ppx_blob-${version}.tbz";
+    url = "https://github.com/johnwhitington/${pname}/releases/download/${version}/ppx_blob-${version}.tbz";
     sha256 = "1xmslk1mwdzhy1bydgsjlcb7h544c39hvxa8lywp8w72gaggjl16";
   };
 
   unpackCmd = "tar xjf $curSrc";
 
-  buildInputs = [ ocaml findlib dune alcotest ocaml-migrate-parsetree ];
-
-  buildPhase = "dune build -p ppx_blob";
-
+  buildInputs = [ alcotest ocaml-migrate-parsetree ];
   doCheck = true;
-  checkPhase = "dune runtest -p ppx_blob";
-
-  inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/johnwhitington/ppx_blob;

--- a/pkgs/development/ocaml-modules/ppx_derivers/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_derivers/default.nix
@@ -1,29 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune }:
+{ stdenv, fetchFromGitHub, buildDunePackage }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "ppx_derivers is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-ppx_derivers-${version}";
+buildDunePackage rec {
+	pname = "ppx_derivers";
 	version = "1.2";
+
+  minimumOCamlVersion = "4.02";
 
 	src = fetchFromGitHub {
 		owner = "diml";
-		repo = "ppx_derivers";
+		repo = pname;
 		rev = version;
 		sha256 = "0bnhihl1w31as5w2czly1v3d6pbir9inmgsjg2cj6aaj9v1dzd85";
 	};
-
-	buildInputs = [ ocaml findlib dune ];
-
-	inherit (dune) installPhase;
 
 	meta = {
 		description = "Shared [@@deriving] plugin registry";
 		license = stdenv.lib.licenses.bsd3;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
@@ -1,11 +1,10 @@
-{ stdenv, fetchurl, ocaml, findlib, dune, ocaml-migrate-parsetree }:
+{ stdenv, fetchurl, buildDunePackage, ocaml-migrate-parsetree }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "ppx_gen_rec";
-  name = "ocaml${ocaml.version}-${pname}-${version}";
   version = "1.0.0";
+
+  minimumOCamlVersion = "4.01";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
@@ -14,17 +13,12 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "tar xjf $src";
 
-  buildInputs = [ ocaml findlib dune ocaml-migrate-parsetree ];
-
-  buildPhase = "dune build -p ppx_gen_rec";
-
-  inherit (dune) installPhase;
+  buildInputs = [ ocaml-migrate-parsetree ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/flowtype/ocaml-ppx_gen_rec;
     description = "ocaml preprocessor that generates a recursive module";
     license = licenses.mit;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.frontsideair ];
   };
 }

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,34 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
+{ stdenv, fetchFromGitHub, buildDunePackage
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "ppxlib";
   version = "0.3.1";
-  name = "ocaml${ocaml.version}-ppxlib-${version}";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
-    repo = "ppxlib";
+    repo = pname;
     rev = version;
     sha256 = "0qpjl84x8abq9zivifb0k8ld7fa1lrhkbajmmccvfv06ja3as1v4";
   };
 
-  buildInputs = [ ocaml findlib dune ];
-
   propagatedBuildInputs = [
     ocaml-compiler-libs ocaml-migrate-parsetree ppx_derivers stdio
   ];
-
-  buildPhase = "dune build";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Comprehensive ppx tool set";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
-
 }

--- a/pkgs/development/ocaml-modules/re/default.nix
+++ b/pkgs/development/ocaml-modules/re/default.nix
@@ -1,29 +1,22 @@
-{ stdenv, fetchzip, ocaml, findlib, dune, ounit, seq }:
+{ stdenv, fetchzip, buildDunePackage, ounit, seq }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "re is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-re-${version}";
+buildDunePackage rec {
+  pname = "re";
   version = "1.8.0";
+
+  minimumOCamlVersion = "4.02";
 
   src = fetchzip {
     url = "https://github.com/ocaml/ocaml-re/archive/${version}.tar.gz";
     sha256 = "0ch6hvmm4ym3w2vghjxf3ka5j1023a37980fqi4zcb7sx756z20i";
   };
 
-  buildInputs = [ ocaml findlib dune ounit ];
+  buildInputs = [ ounit ];
   propagatedBuildInputs = [ seq ];
-
   doCheck = true;
-  checkPhase = "jbuilder runtest";
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = https://github.com/ocaml/ocaml-re;
-    platforms = ocaml.meta.platforms or [];
     description = "Pure OCaml regular expressions, with support for Perl and POSIX-style strings";
     license = stdenv.lib.licenses.lgpl2;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/sequence/default.nix
+++ b/pkgs/development/ocaml-modules/sequence/default.nix
@@ -1,28 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, qtest, result }:
+{ stdenv, fetchFromGitHub, buildDunePackage, qtest, result }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "sequence is not available for OCaml ${ocaml.version}"
-else
+buildDunePackage rec {
+  pname = "sequence";
+  version = "1.1";
 
-let version = "1.1"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-sequence-${version}";
+  minimumOCamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "c-cube";
-    repo = "sequence";
+    repo = pname;
     rev = version;
     sha256 = "08j37nldw47syq3yw4mzhhvya43knl0d7biddp0q9hwbaxhzgi44";
   };
 
-  buildInputs = [ ocaml findlib dune qtest ];
+  buildInputs = [ qtest ];
   propagatedBuildInputs = [ result ];
 
   doCheck = true;
-  checkPhase = "dune runtest";
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = https://github.com/c-cube/sequence;
@@ -34,6 +28,5 @@ stdenv.mkDerivation {
       sequence is iterated/folded on.
     '';
     license = stdenv.lib.licenses.bsd2;
-    platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/sqlexpr/default.nix
+++ b/pkgs/development/ocaml-modules/sqlexpr/default.nix
@@ -1,32 +1,24 @@
-{ stdenv, fetchurl, ocaml, findlib, dune, ocaml_lwt
+{ stdenv, fetchurl, buildDunePackage, ocaml_lwt
 , lwt_ppx, ocaml-migrate-parsetree, ppx_tools_versioned, csv, ocaml_sqlite3
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "sqlexpr";
   version = "0.9.0";
-  name = "ocaml${ocaml.version}-sqlexpr-${version}";
 
   src = fetchurl {
   url = "https://github.com/mfp/ocaml-sqlexpr/releases/download/${version}/ocaml-sqlexpr-${version}.tar.gz";
   sha256 = "0z0bkzi1mh0m39alzr2ds7hjpfxffx6azpfsj2wpaxrg64ks8ypd";
   };
 
-  buildInputs = [ ocaml findlib dune lwt_ppx ocaml-migrate-parsetree ppx_tools_versioned ];
-
+  buildInputs = [ lwt_ppx ocaml-migrate-parsetree ppx_tools_versioned ];
   propagatedBuildInputs = [ ocaml_lwt csv ocaml_sqlite3 ];
-
-  buildPhase = "dune build -p sqlexpr";
-
   doCheck = true;
-  checkPhase = "dune runtest -p sqlexpr";
-
-  inherit (dune) installPhase;
 
   meta = {
     description = "Type-safe, convenient SQLite database access";
     homepage = "https://github.com/mfp/ocaml-sqlexpr";
     license = stdenv.lib.licenses.lgpl21;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/sqlexpr/ppx.nix
+++ b/pkgs/development/ocaml-modules/sqlexpr/ppx.nix
@@ -1,15 +1,11 @@
-{ stdenv, ocaml, findlib, dune, sqlexpr, ounit
+{ stdenv, buildDunePackage, sqlexpr, ounit
 , ppx_core, ppx_tools_versioned, re, lwt_ppx
 }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ppx_sqlexpr-${version}";
-  inherit (sqlexpr) version src installPhase meta;
+buildDunePackage {
+  pname = "ppx_sqlexpr";
+  inherit (sqlexpr) version src meta;
 
-  buildInputs = [ ocaml findlib dune sqlexpr ounit ppx_core ppx_tools_versioned re lwt_ppx ];
-
-  buildPhase = "dune build -p ppx_sqlexpr";
-
+  buildInputs = [ sqlexpr ounit ppx_core ppx_tools_versioned re lwt_ppx ];
   doCheck = true;
-  checkPhase = "dune runtest -p ppx_sqlexpr";
 }

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -1,33 +1,26 @@
-{ stdenv, fetchurl, ocaml, findlib, dune, ppx_sexp_conv, ounit
+{ stdenv, fetchurl, buildDunePackage, ppx_sexp_conv, ounit
 , re, sexplib, stringext
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
+  pname = "uri";
   version = "1.9.6";
-  name = "ocaml${ocaml.version}-uri-${version}";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-uri/releases/download/v${version}/uri-${version}.tbz";
+    url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
     sha256 = "1m845rwd70wi4iijkrigyz939m1x84ba70hvv0d9sgk6971w4kz0";
   };
 
   unpackCmd = "tar -xjf $curSrc";
 
-  buildInputs = [ ocaml findlib dune ounit ];
+  buildInputs = [ ounit ];
   propagatedBuildInputs = [ ppx_sexp_conv re sexplib stringext ];
-
-  buildPhase = "jbuilder build";
-
   doCheck = true;
-  checkPhase = "jbuilder runtest";
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = "https://github.com/mirage/ocaml-uri";
     description = "RFC3986 URI parsing library for OCaml";
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -1,11 +1,10 @@
-{ stdenv, fetchurl, ocaml, findlib, dune }:
+{ stdenv, fetchurl, buildDunePackage }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01";
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "wtf8";
-  name = "ocaml-${pname}-${version}";
   version = "1.0.1";
+
+  minimumOCamlVersion = "4.01";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
@@ -14,17 +13,10 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "tar xjf $src";
 
-  buildInputs = [ ocaml findlib dune ];
-
-  buildPhase = "dune build -p wtf8";
-
-  inherit (dune) installPhase;
-
   meta = with stdenv.lib; {
     homepage = https://github.com/flowtype/ocaml-wtf8;
     description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";
     license = licenses.mit;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.eqyiel ];
   };
 }

--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, czmq, stdint }:
+{ stdenv, fetchFromGitHub, buildDunePackage, czmq, stdint }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-zmq-${version}";
+buildDunePackage rec {
+  pname = "zmq";
   version = "20180726";
+
   src = fetchFromGitHub {
     owner = "issuu";
     repo = "ocaml-zmq";
@@ -14,19 +15,13 @@ stdenv.mkDerivation rec {
     ./ocaml-zmq-issue43.patch
   ];
 
-  buildInputs = [ ocaml findlib dune czmq ];
-
+  buildInputs = [ czmq ];
   propagatedBuildInputs = [ stdint ];
-
-  buildPhase = "dune build -p zmq";
-
-  inherit (dune) installPhase;
 
   meta = with stdenv.lib; {
     description = "ZeroMQ bindings for OCaml";
     license     = licenses.mit;
     maintainers = with maintainers; [ akavel ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/zmq/lwt.nix
+++ b/pkgs/development/ocaml-modules/zmq/lwt.nix
@@ -1,12 +1,8 @@
-{ stdenv, ocaml, findlib, dune, zmq, ocaml_lwt }:
+{ stdenv, buildDunePackage, zmq, ocaml_lwt }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-zmq-lwt-${version}";
-  inherit (zmq) version src installPhase meta;
-
-  buildInputs = [ ocaml findlib dune ];
+buildDunePackage rec {
+  pname = "zmq-lwt";
+  inherit (zmq) version src meta;
 
   propagatedBuildInputs = [ zmq ocaml_lwt ];
-
-  buildPhase = "dune build -p zmq-lwt";
 }

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -1,23 +1,17 @@
-{ stdenv, fetchzip, ocaml, findlib, dune, yojson }:
+{ stdenv, fetchzip, buildDunePackage, yojson }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.02";
-
-let
+buildDunePackage rec {
+  pname = "merlin";
   version = "3.2.2";
-in
 
-stdenv.mkDerivation {
-
-  name = "merlin-${version}";
+  minimumOCamlVersion = "4.02";
 
   src = fetchzip {
     url = "https://github.com/ocaml/merlin/archive/v${version}.tar.gz";
     sha256 = "15ssgmwdxylbwhld9p1cq8x6kadxyhll5bfyf11dddj6cldna3hb";
   };
 
-  buildInputs = [ ocaml findlib dune yojson ];
-
-  inherit (dune) installPhase;
+  buildInputs = [ yojson ];
 
   meta = with stdenv.lib; {
     description = "An editor-independent tool to ease the development of programs in OCaml";

--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -1,33 +1,25 @@
-{ stdenv, fetchzip, ncurses
-, ocamlPackages
-, dune
-}:
+{ stdenv, fetchzip, ncurses, ocamlPackages }:
 
-stdenv.mkDerivation rec {
+with ocamlPackages; buildDunePackage rec {
+  pname = "ocaml-top";
   version = "1.1.5";
-  name = "ocaml-top-${version}";
+
   src = fetchzip {
     url = "https://github.com/OCamlPro/ocaml-top/archive/${version}.tar.gz";
     sha256 = "1d4i6aanrafgrgk4mh154k6lkwk0b6mh66rykz33awlf5pfqd8yv";
   };
 
-  buildInputs = [ ncurses dune ]
-  ++ (with ocamlPackages; [ ocaml ocp-build findlib lablgtk ocp-index ]);
+  buildInputs = [ ncurses ocp-build lablgtk ocp-index ];
 
   configurePhase = ''
     export TERM=xterm
     ocp-build -init
   '';
 
-  buildPhase = "jbuilder build";
-
-  inherit (dune) installPhase;
-
   meta = {
     homepage = https://www.typerex.org/ocaml-top.html;
     license = stdenv.lib.licenses.gpl3;
     description = "A simple cross-platform OCaml code editor built for top-level evaluation";
-    platforms = ocamlPackages.ocaml.meta.platforms or [];
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,15 +1,10 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, dune }:
+{ stdenv, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages;
-
-if !stdenv.lib.versionAtLeast ocaml.version "4.05"
-then throw "ocamlformat is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  version = "0.8";
+with ocamlPackages; buildDunePackage rec {
   pname = "ocamlformat";
-  name = "${pname}-${version}";
+  version = "0.8";
+
+  minimumOCamlVersion = "4.05";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
@@ -19,9 +14,6 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    ocaml
-    dune
-    findlib
     base
     cmdliner
     fpath
@@ -34,17 +26,10 @@ stdenv.mkDerivation rec {
     tools/gen_version.sh src/Version.ml version
   '';
 
-  buildPhase = ''
-    dune build -p ocamlformat
-  '';
-
-  inherit (dune) installPhase;
-
   meta = {
-    homepage = "https://github.com/ocaml-ppx/ocamlformat";
+    inherit (src.meta) homepage;
     description = "Auto-formatter for OCaml code";
     maintainers = [ stdenv.lib.maintainers.Zimmi48 ];
     license = stdenv.lib.licenses.mit;
-    inherit (ocamlPackages.ocaml.meta) platforms;
   };
 }

--- a/pkgs/tools/misc/patdiff/default.nix
+++ b/pkgs/tools/misc/patdiff/default.nix
@@ -3,7 +3,7 @@
 with ocamlPackages;
 
 janePackage {
-  name = "patdiff";
+  pname = "patdiff";
   hash = "02cdn5j5brbp4n2rpxprzxfakjbl7n2llixg7m632bih3ppmfcq1";
   buildInputs = [ core_extended expect_test_helpers patience_diff ocaml_pcre ];
   meta = {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -17,6 +17,8 @@ let
 
     buildOcaml = callPackage ../build-support/ocaml { };
 
+    buildDunePackage = callPackage ../build-support/ocaml/dune.nix {};
+
     alcotest = callPackage ../development/ocaml-modules/alcotest {};
 
     angstrom = callPackage ../development/ocaml-modules/angstrom { };


### PR DESCRIPTION
###### Motivation for this change

This takes advantage of the uniformization of the OCaml package ecosystem around the dune build system (and often the accompanying dune-release) to simplify the way usual OCaml derivations are prepared in nixpkgs.

cc @vbgl 

###### Things done

I have ported a few packages which allowed me to refine the design of `dunePackage` but not all of them yet.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

