### PR TITLE
brave: 0.25.2 -> 0.56.12

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -30,7 +30,8 @@
   pango,
   udev,
   xorg,
-  zlib
+  zlib,
+  xdg_utils
 }:
 
 let rpath = lib.makeLibraryPath [
@@ -65,32 +66,67 @@ let rpath = lib.makeLibraryPath [
     udev
     xorg.libxcb
     zlib
+    xdg_utils
 ];
 
 
 in stdenv.mkDerivation rec {
     name = "brave";
-    version = "0.25.2";
+    version = "0.56.12";
 
     src = fetchurl {
-        url = "https://github.com/brave/browser-laptop/releases/download/v${version}dev/brave_${version}_amd64.deb";
-        sha256 = "1r3rsa6szps7mvvpqyw0mg16zn36x451dxq4nmn2l5ds5cp1f017";
+        url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
+        sha256 = "1pvablwchpsm1fdhfp9kr2912yv4812r8prv5fn799qpflzxvyai";
     };
 
-    phases = [ "unpackPhase" "installPhase" ];
+    dontConfigure = true;
+    dontBuild = true;
+    dontPatchELF = true;
 
     nativeBuildInputs = [ dpkg ];
 
-    unpackPhase = "dpkg-deb -x $src .";
+    unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
 
     installPhase = ''
         mkdir -p $out
 
         cp -R usr/* $out
+        cp -R opt/ $out/opt
+
+        export BINARYWRAPPER=$out/opt/brave.com/brave/brave-browser
+
+        # Fix path to bash in $BINARYWRAPPER
+        substituteInPlace $BINARYWRAPPER \
+            --replace /bin/bash ${stdenv.shell}
+
+        ln -sf $BINARYWRAPPER $out/bin/brave
 
         patchelf \
             --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-            --set-rpath "${rpath}" $out/bin/brave
+            --set-rpath "${rpath}" $out/opt/brave.com/brave/brave
+
+        # Fix paths
+        substituteInPlace $out/share/applications/brave-browser.desktop \
+            --replace /usr/bin/brave-browser $out/bin/brave
+        substituteInPlace $out/share/gnome-control-center/default-apps/brave-browser.xml \
+            --replace /opt/brave.com $out/opt/brave.com
+        substituteInPlace $out/share/menu/brave-browser.menu \
+            --replace /opt/brave.com $out/opt/brave.com
+        substituteInPlace $out/opt/brave.com/brave/default-app-block \
+            --replace /opt/brave.com $out/opt/brave.com
+
+        # Correct icons location
+        icon_sizes=("16" "22" "24" "32" "48" "64" "128" "256")
+
+        for icon in ''${icon_sizes[*]}
+        do
+            mkdir -p $out/share/icons/hicolor/$icon\x$icon/apps
+            ln -s $out/opt/brave.com/brave/product_logo_$icon.png $out/share/icons/hicolor/$icon\x$icon/apps/brave-browser.png
+        done
+
+        # Replace xdg-settings and xdg-mime
+        ln -sf ${xdg_utils}/bin/xdg-settings $out/opt/brave.com/brave/xdg-settings
+        ln -sf ${xdg_utils}/bin/xdg-mime $out/opt/brave.com/brave/xdg-mime
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

This switches to a chromium-based browser from a muon-based one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

