### PR TITLE
matplotlib: 2.2.3 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/matplotlib/2.2.3.nix
+++ b/pkgs/development/python-modules/matplotlib/2.2.3.nix
@@ -1,0 +1,92 @@
+{ stdenv, fetchPypi, python, buildPythonPackage, pycairo, backports_functools_lru_cache
+, which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
+, freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
+, enableGhostscript ? false, ghostscript ? null, gtk3
+, enableGtk2 ? false, pygtk ? null, gobjectIntrospection
+, enableGtk3 ? false, cairo
+, enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
+, enableQt ? false, pyqt4
+, libcxx
+, Cocoa
+, pythonOlder
+}:
+
+assert enableGhostscript -> ghostscript != null;
+assert enableGtk2 -> pygtk != null;
+assert enableTk -> (tcl != null)
+                && (tk != null)
+                && (tkinter != null)
+                && (libX11 != null)
+                ;
+assert enableQt -> pyqt4 != null;
+
+buildPythonPackage rec {
+  version = "2.2.3";
+  pname = "matplotlib";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7355bf757ecacd5f0ac9dd9523c8e1a1103faadf8d33c22664178e17533f8ce5";
+  };
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
+
+  XDG_RUNTIME_DIR = "/tmp";
+
+  buildInputs = [ python which sphinx stdenv ]
+    ++ stdenv.lib.optional enableGhostscript ghostscript
+    ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
+
+  propagatedBuildInputs =
+    [ cycler dateutil nose numpy pyparsing tornado freetype kiwisolver
+      libpng pkgconfig mock pytz ]
+    ++ stdenv.lib.optional (pythonOlder "3.3") backports_functools_lru_cache
+    ++ stdenv.lib.optional enableGtk2 pygtk
+    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
+    ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
+    ++ stdenv.lib.optionals enableQt [ pyqt4 ]
+    ++ stdenv.lib.optionals (builtins.hasAttr "isPy2" python) [ functools32 subprocess32 ];
+
+  patches =
+    [ ./basedirlist.patch ] ++
+    stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv-2.2.3.patch ];
+
+  # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
+  # corresponding interpreter object for its library paths. This fails if
+  # `$DISPLAY` is not set. The fallback option assumes that Tcl/Tk are both
+  # installed under the same path which is not true in Nix.
+  # With the following patch we just hard-code these paths into the install
+  # script.
+  postPatch =
+    let
+      inherit (stdenv.lib.strings) substring;
+      tcl_tk_cache = ''"${tk}/lib", "${tcl}/lib", "${substring 0 3 tk.version}"'';
+    in
+    stdenv.lib.optionalString enableTk
+      "sed -i '/self.tcl_tk_cache = None/s|None|${tcl_tk_cache}|' setupext.py";
+
+  checkPhase = ''
+    ${python.interpreter} tests.py
+  '';
+
+  # Test data is not included in the distribution (the `tests` folder
+  # is missing)
+  doCheck = false;
+
+  prePatch = ''
+    # Failing test: ERROR: matplotlib.tests.test_style.test_use_url
+    sed -i 's/test_use_url/fails/' lib/matplotlib/tests/test_style.py
+    # Failing test: ERROR: test suite for <class 'matplotlib.sphinxext.tests.test_tinypages.TestTinyPages'>
+    sed -i 's/TestTinyPages/fails/' lib/matplotlib/sphinxext/tests/test_tinypages.py
+    # Transient errors
+    sed -i 's/test_invisible_Line_rendering/noop/' lib/matplotlib/tests/test_lines.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python plotting library, making publication quality plots";
+    homepage    = "http://matplotlib.sourceforge.net/";
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.unix;
+  };
+
+}

--- a/pkgs/development/python-modules/matplotlib/darwin-stdenv-2.2.3.patch
+++ b/pkgs/development/python-modules/matplotlib/darwin-stdenv-2.2.3.patch
@@ -1,0 +1,10 @@
+--- a/src/_macosx.m	2015-10-30 00:46:20.000000000 +0200
++++ b/src/_macosx.m	2015-11-01 14:52:25.000000000 +0200
+@@ -6264,6 +6264,7 @@
+ 
+ static bool verify_framework(void)
+ {
++    return true;  /* nixpkgs darwin stdenv */
+ #ifdef COMPILING_FOR_10_6
+     NSRunningApplication* app = [NSRunningApplication currentApplication];
+     NSApplicationActivationPolicy activationPolicy = [app activationPolicy];

--- a/pkgs/development/python-modules/matplotlib/darwin-stdenv.patch
+++ b/pkgs/development/python-modules/matplotlib/darwin-stdenv.patch
@@ -1,10 +1,12 @@
---- a/src/_macosx.m	2015-10-30 00:46:20.000000000 +0200
-+++ b/src/_macosx.m	2015-11-01 14:52:25.000000000 +0200
-@@ -6264,6 +6264,7 @@
+diff -ruN matplotlib-3.0.0/src/_macosx.m matplotlib-3.0.0.patched/src/_macosx.m
+--- matplotlib-3.0.0/src/_macosx.m	2018-09-16 00:35:21.000000000 +0200
++++ matplotlib-3.0.0.patched/src/_macosx.m	2018-11-03 13:14:33.000000000 +0100
+@@ -2577,6 +2577,7 @@
  
  static bool verify_framework(void)
  {
 +    return true;  /* nixpkgs darwin stdenv */
- #ifdef COMPILING_FOR_10_6
-     NSRunningApplication* app = [NSRunningApplication currentApplication];
-     NSApplicationActivationPolicy activationPolicy = [app activationPolicy];
+     ProcessSerialNumber psn;
+     /* These methods are deprecated, but they don't require the app to
+        have started  */
+

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, python, buildPythonPackage, pycairo, backports_functools_lru_cache
+{ stdenv, fetchPypi, python, buildPythonPackage, isPy3k, pycairo, backports_functools_lru_cache
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
 , enableGhostscript ? false, ghostscript ? null, gtk3
@@ -21,12 +21,14 @@ assert enableTk -> (tcl != null)
 assert enableQt -> pyqt4 != null;
 
 buildPythonPackage rec {
-  version = "2.2.3";
+  version = "3.0.0";
   pname = "matplotlib";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7355bf757ecacd5f0ac9dd9523c8e1a1103faadf8d33c22664178e17533f8ce5";
+    sha256 = "1yb5dvv34sq90a409i9pakg1if6lawmwsc5rdvzw3hm7k0y37qml";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
@@ -44,8 +46,7 @@ buildPythonPackage rec {
     ++ stdenv.lib.optional enableGtk2 pygtk
     ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
-    ++ stdenv.lib.optionals enableQt [ pyqt4 ]
-    ++ stdenv.lib.optionals (builtins.hasAttr "isPy2" python) [ functools32 subprocess32 ];
+    ++ stdenv.lib.optionals enableQt [ pyqt4 ];
 
   patches =
     [ ./basedirlist.patch ] ++

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2726,11 +2726,18 @@ in {
 
   mathics = callPackage ../development/python-modules/mathics { };
 
-  matplotlib = callPackage ../development/python-modules/matplotlib {
-    stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
-    enableGhostscript = true;
-    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
-  };
+  matplotlib =
+    if isPy3k then
+      callPackage ../development/python-modules/matplotlib {
+        stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
+        enableGhostscript = true;
+        inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa; }
+    else
+      # matplotlib >= 3.0.0 does not support Python2k
+      callPackage ../development/python-modules/matplotlib/2.2.3.nix {
+        stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
+        enableGhostscript = true;
+        inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa; };
 
   matrix-client = callPackage ../development/python-modules/matrix-client { };
 


### PR DESCRIPTION
###### Motivation for this change

Update matplotlib to the latest upstream version (3.0.0). This version does not support Python 2. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

