### PR TITLE
adoptopenjdk-openj9-bin: 11 -> 11.0.1 [Critical security fixes]

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
@@ -1,26 +1,43 @@
 let
-  version = "11";
-  buildNumber = "28";
-  baseUrl = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}";
-  makePackage = { packageType, vmType, sha256 }: import ./jdk-darwin-base.nix {
+  makePackage = { version, buildNumber, packageType, vmType, sha256 }: import ./jdk-darwin-base.nix {
     name = if packageType == "jdk"
       then
         "adoptopenjdk-${vmType}-bin-${version}"
       else
         "adoptopenjdk-${packageType}-${vmType}-bin-${version}";
-    url = "${baseUrl}/OpenJDK${version}-${packageType}_x64_mac_${vmType}_${version}_${buildNumber}.tar.gz";
+
+    url = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}/OpenJDK11-${packageType}_x64_mac_${vmType}_${version}_${buildNumber}.tar.gz";
+
     inherit sha256;
   };
 in
 {
   jdk-hotspot = makePackage {
+    version = "11";
+    buildNumber = "28";
     packageType = "jdk";
     vmType = "hotspot";
     sha256 = "ca0ec49548c626904061b491cae0a29b9b4b00fb34d8973dc217e10ab21fb0f3";
   };
   jre-hotspot = makePackage {
+    version = "11";
+    buildNumber = "28";
     packageType = "jre";
     vmType = "hotspot";
     sha256 = "ef4dbfe5aed6ab2278fcc14db6cc73abbaab56e95f6ebb023790a7ebc6d7f30c";
+  };
+  jdk-openj9 = makePackage {
+    version = "11.0.1";
+    buildNumber = "13";
+    packageType = "jdk";
+    vmType = "openj9";
+    sha256 = "c5e9b588b4ac5b0bd5b4edd69d59265d1199bb98af7ca3270e119b264ffb6e3f";
+  };
+  jre-openj9 = makePackage {
+    version = "11.0.1";
+    buildNumber = "13";
+    packageType = "jre";
+    vmType = "openj9";
+    sha256 = "0901dc5946fdf967f92f7b719ddfffdcdde5bd3fef86a83d7a3f2f39ddbef1f8";
   };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
@@ -1,36 +1,43 @@
 let
-  version = "11";
-  buildNumber = "28";
-  baseUrl = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}";
-  makePackage = { packageType, vmType, sha256 }: import ./jdk-linux-base.nix {
+  makePackage = { version, buildNumber, packageType, vmType, sha256 }: import ./jdk-linux-base.nix {
     name = if packageType == "jdk"
       then
         "adoptopenjdk-${vmType}-bin-${version}"
       else
         "adoptopenjdk-${packageType}-${vmType}-bin-${version}";
-    url = "${baseUrl}/OpenJDK${version}-${packageType}_x64_linux_${vmType}_${version}_${buildNumber}.tar.gz";
+
+    url = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}/OpenJDK11-${packageType}_x64_linux_${vmType}_${version}_${buildNumber}.tar.gz";
+
     inherit sha256;
   };
 in
 {
   jdk-hotspot = makePackage {
+    version = "11";
+    buildNumber = "28";
     packageType = "jdk";
     vmType = "hotspot";
     sha256 = "e1e18fc9ce2917473da3e0acb5a771bc651f600c0195a3cb40ef6f22f21660af";
   };
   jre-hotspot = makePackage {
+    version = "11";
+    buildNumber = "28";
     packageType = "jre";
     vmType = "hotspot";
     sha256 = "346448142d46c6e51d0fadcaadbcde31251d7678922ec3eb010fcb1b6e17804c";
   };
   jdk-openj9 = makePackage {
+    version = "11.0.1";
+    buildNumber = "13";
     packageType = "jdk";
     vmType = "openj9";
-    sha256 = "fd77f22eb74078bcf974415abd888296284d2ceb81dbaca6ff32f59416ebc57f";
+    sha256 = "765947ab9457a29d2aa9d11460a4849611343c1e0ea3b33b9c08409cd4672251";
   };
   jre-openj9 = makePackage {
+    version = "11.0.1";
+    buildNumber = "13";
     packageType = "jre";
     vmType = "openj9";
-    sha256 = "83a7c95e6b2150a739bdd5e8a6fe0315904fd13d8867c95db67c0318304a2c42";
+    sha256 = "a016413fd8415429b42e543fed7a1bee5010b1dbaf71d29a26e1c699f334c6ff";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6458,9 +6458,12 @@ with pkgs;
     then callPackage adoptopenjdk-bin-11-packages-linux.jre-hotspot {}
     else callPackage adoptopenjdk-bin-11-packages-darwin.jre-hotspot {};
 
-  # no OpenJ9 for Darwin
-  adoptopenjdk-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages-linux.jdk-openj9 {};
-  adoptopenjdk-jre-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {};
+  adoptopenjdk-openj9-bin-11 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-11-packages-linux.jdk-openj9 {}
+    else callPackage adoptopenjdk-bin-11-packages-darwin.jdk-openj9 {};
+  adoptopenjdk-jre-openj9-bin-11 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {}
+    else callPackage adoptopenjdk-bin-11-packages-darwin.jre-openj9 {};
 
   adoptopenjdk-bin = adoptopenjdk-hotspot-bin-11;
   adoptopenjdk-jre-bin = adoptopenjdk-jre-hotspot-bin-11;


### PR DESCRIPTION
###### Motivation for this change

Oracle JDK has several security fixes. I'm not sure this applicable to OpenJ9.

https://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html#AppendixJAVA

AdoptOpenJDK 11.0.1 for Hotspot is not released yet. I changed the package structure so that OpenJ9 may have different version than Hotspot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

