### PR TITLE
timescaledb: (0.11.0 -> 1.0.0)

### DIFF
--- a/pkgs/servers/sql/postgresql/timescaledb/default.nix
+++ b/pkgs/servers/sql/postgresql/timescaledb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, postgresql }:
+{ stdenv, fetchFromGitHub, cmake, postgresql, openssl }:
 
 # # To enable on NixOS:
 # config.services.postgresql = {
@@ -8,16 +8,16 @@
 
 stdenv.mkDerivation rec {
   name = "timescaledb-${version}";
-  version = "0.11.0";
+  version = "1.0.0";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ postgresql ];
+  buildInputs = [ postgresql openssl ];
 
   src = fetchFromGitHub {
     owner  = "timescale";
     repo   = "timescaledb";
     rev    = "refs/tags/${version}";
-    sha256 = "06xysf45r0c2sjfl6vgdbrm7pn7nxx2n0k29bm88q0ipyyp9fr0v";
+    sha256 = "1359jc0dw8q3f0iipqfadzs8lvri9qa5w59ziz00x1d09ppw2q40";
   };
 
   # Fix the install phase which tries to install into the pgsql extension dir,
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     homepage    = https://www.timescale.com/;
     maintainers = with maintainers; [ volth ];
     platforms   = platforms.linux;
-    license     = licenses.postgresql;
+    license     = stdenv.lib.licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

