### PR TITLE
ghc-8.2.1-binary: Patch shebang causing failures in Centos 6

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
     # Some scripts used during the build need to have their shebangs patched
     ''
       patchShebangs ghc-${version}/utils/
+      patchShebangs ghc-${version}/configure
     '' +
 
     # Strip is harmful, see also below. It's important that this happens


### PR DESCRIPTION
###### Motivation for this change

On Centos 6, when building from source the system shell would be used causing glibc reference problems.

```
...
cannot find section .interp
cannot find section .interp
cannot find section .interp
cannot find section .interp
cannot find section .interp
not an ELF executable
not an ELF executable
missing ELF header
not an ELF executable
cannot find section .interp
file ./ghc-8.2.1/ghc/stage2/build/tmp/ghc-stage2 had a PT_GNU_STACK program header, converted
setting SOURCE_DATE_EPOCH to timestamp 1500679444 of file ghc-8.2.1/configure
patching sources
configuring
configure flags: --prefix=/share/nix/store/6gvgr6m1rclbm9q9dah623awc263qzxp-ghc-8.2.1-binary --with-gmp-libraries=/share/nix/store/c5dw1yv0jkyf2p35scnl07lipdz1y2sv-gmp-6.1.2/lib --with-gmp-includes=/share/nix/store/kmwwwq5c0b8wdq6pw5x3b7sl8xzswj1-gmp-6.1.2-dev/include
/bin/sh: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /share/nix/store/p0sdx09s2nk9js3f914660x1l9smlcbk-ncurses-6.1-abi5-compat/lib/libtinfo.so.5)
/bin/sh: /lib64/libc.so.6: version `GLIBC_2.16' not found (required by /share/nix/store/p0sdx09s2nk9js3f914660x1l9smlcbk-ncurses-6.1-abi5-compat/lib/libtinfo.so.5)
builder for ‘/share/nix/store/b4b7d0d4zfmqkqsh1ydc4cmchzqk9vy5-ghc-8.2.1-binary.drv’ failed with exit code 1
cannot build derivation ‘/share/nix/store/r9vi05vlgmbly78wvynh4mdyhyz0998w-ghc-8.4.3.drv’: 1 dependencies couldn't be built
error: build of ‘/share/nix/store/r9vi05vlgmbly78wvynh4mdyhyz0998w-ghc-8.4.3.drv’ failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

