### PR TITLE
RStudio 1.2 preview init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -406,6 +406,11 @@
     github = "AveryLychee";
     name = "Avery Lychee";
   };
+  averelld = {
+    email = "averell+nixos@rxd4.com";
+    github = "averelld";
+    name = "averelld";
+  };
   avnik = {
     email = "avn@avnik.info";
     github = "avnik";

--- a/pkgs/applications/editors/rstudio/clang-location.patch
+++ b/pkgs/applications/editors/rstudio/clang-location.patch
@@ -1,0 +1,25 @@
+diff --git i/src/cpp/core/libclang/LibClang.cpp w/src/cpp/core/libclang/LibClang.cpp
+index ec12a3a1ff..8c81b633ae 100644
+--- i/src/cpp/core/libclang/LibClang.cpp
++++ w/src/cpp/core/libclang/LibClang.cpp
+@@ -54,7 +54,7 @@ std::vector<std::string> defaultCompileArgs(LibraryVersion version)
+ 
+    // we need to add in the associated libclang headers as
+    // they are not discovered / used by default during compilation
+-   FilePath llvmPath = s_libraryPath.parent().parent();
++   FilePath llvmPath("@clang@");
+    boost::format fmt("%1%/lib/clang/%2%/include");
+    fmt % llvmPath.absolutePath() % version.asString();
+    std::string includePath = fmt.str();
+@@ -77,10 +77,7 @@ std::vector<std::string> systemClangVersions()
+ #elif defined(__unix__)
+    // default set of versions
+    clangVersions = {
+-      "/usr/lib/libclang.so",
+-      "/usr/lib/llvm/libclang.so",
+-      "/usr/lib64/libclang.so",
+-      "/usr/lib64/llvm/libclang.so",
++      "@libclang.so@"
+    };
+    
+    // iterate through the set of available 'llvm' directories

--- a/pkgs/applications/editors/rstudio/fix-cmake.patch
+++ b/pkgs/applications/editors/rstudio/fix-cmake.patch
@@ -1,0 +1,15 @@
+diff --git a/src/cpp/desktop/CMakeLists.txt b/src/cpp/desktop/CMakeLists.txt
+index f5701bf735..27af4148ff 100644
+--- a/src/cpp/desktop/CMakeLists.txt
++++ b/src/cpp/desktop/CMakeLists.txt
+@@ -112,6 +112,7 @@ find_package(Qt5WebEngine REQUIRED)
+ find_package(Qt5WebEngineWidgets REQUIRED)
+ find_package(Qt5PrintSupport REQUIRED)
+ find_package(Qt5Quick REQUIRED)
++find_package(Qt5QuickWidgets REQUIRED)
+ find_package(Qt5Positioning REQUIRED)
+ find_package(Qt5Sensors REQUIRED)
+ find_package(Qt5Svg REQUIRED)
+-- 
+2.17.1
+

--- a/pkgs/applications/editors/rstudio/preview.nix
+++ b/pkgs/applications/editors/rstudio/preview.nix
@@ -1,0 +1,119 @@
+{ stdenv, fetchurl, fetchFromGitHub, makeDesktopItem, cmake, boost, zlib
+, openssl, R, qtbase, qtdeclarative, qtsensors, qtwebengine, qtwebchannel
+, libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper, pandoc
+, llvmPackages
+}:
+
+let
+  rev = "f33fb2b2f1";
+  ginVer = "2.1.2";
+  gwtVer = "2.8.1";
+in
+stdenv.mkDerivation rec {
+  name = "RStudio-preview-${rev}";
+
+  nativeBuildInputs = [ cmake unzip ant jdk makeWrapper pandoc ];
+
+  buildInputs = [ boost zlib openssl R qtbase qtdeclarative qtsensors
+                  qtwebengine qtwebchannel libuuid ];
+
+  src = fetchFromGitHub {
+    owner = "rstudio";
+    repo = "rstudio";
+    inherit rev;
+    sha256 = "0v3vzqjp74c3m4h9l6w2lrdnjqaimdjzbf7vhnlxj2qa0lwsnykb";
+  };
+
+  # Hack RStudio to only use the input R and provided libclang.
+  patches = [ ./r-location.patch ./clang-location.patch ];
+  postPatch = ''
+    substituteInPlace src/cpp/core/r_util/REnvironmentPosix.cpp --replace '@R@' ${R}
+    substituteInPlace src/cpp/core/libclang/LibClang.cpp \
+      --replace '@clang@' ${llvmPackages.clang.cc} \
+      --replace '@libclang.so@' ${llvmPackages.clang.cc.lib}/lib/libclang.so
+  '';
+
+  ginSrc = fetchurl {
+    url = "https://s3.amazonaws.com/rstudio-buildtools/gin-${ginVer}.zip";
+    sha256 = "16jzmljravpz6p2rxa87k5f7ir8vs7ya75lnfybfajzmci0p13mr";
+  };
+
+  gwtSrc = fetchurl {
+    url = "https://s3.amazonaws.com/rstudio-buildtools/gwt-${gwtVer}.zip";
+    sha256 = "19x000m3jwnkqgi6ic81lkzyjvvxcfacw2j0vcfcaknvvagzhyhb";
+  };
+
+  hunspellDictionaries = with stdenv.lib; filter isDerivation (attrValues hunspellDicts);
+
+  mathJaxSrc = fetchurl {
+    url = https://s3.amazonaws.com/rstudio-buildtools/mathjax-26.zip;
+    sha256 = "0wbcqb9rbfqqvvhqr1pbqax75wp8ydqdyhp91fbqfqp26xzjv6lk";
+  };
+
+  rsconnectSrc = fetchFromGitHub {
+    owner = "rstudio";
+    repo = "rsconnect";
+    rev = "984745d8";
+    sha256 = "037z0y32k1gdda192y5qn5hi7wp8wyap44mkjlklrgcqkmlcylb9";
+  };
+
+  preConfigure =
+    ''
+      GWT_LIB_DIR=src/gwt/lib
+
+      mkdir -p $GWT_LIB_DIR/gin/${ginVer}
+      unzip ${ginSrc} -d $GWT_LIB_DIR/gin/${ginVer}
+
+      unzip ${gwtSrc}
+      mkdir -p $GWT_LIB_DIR/gwt
+      mv gwt-${gwtVer} $GWT_LIB_DIR/gwt/${gwtVer}
+
+      mkdir dependencies/common/dictionaries
+      for dict in ${builtins.concatStringsSep " " hunspellDictionaries}; do
+        for i in "$dict/share/hunspell/"*; do
+          ln -sv $i dependencies/common/dictionaries/
+        done
+      done
+
+      unzip ${mathJaxSrc} -d dependencies/common/mathjax-26
+
+      mkdir -p dependencies/common/pandoc
+      cp ${pandoc}/bin/pandoc dependencies/common/pandoc/
+
+      cp -r ${rsconnectSrc} dependencies/common/rsconnect
+      pushd dependencies/common
+      ${R}/bin/R CMD build -d --no-build-vignettes rsconnect
+      popd
+    '';
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" "-DQT_QMAKE_EXECUTABLE=$NIX_QT5_TMP/bin/qmake" ];
+
+  desktopItem = makeDesktopItem {
+    name = name;
+    exec = "rstudio %F";
+    icon = "rstudio";
+    desktopName = "RStudio Preview";
+    genericName = "IDE";
+    comment = meta.description;
+    categories = "Development;";
+    mimeType = "text/x-r-source;text/x-r;text/x-R;text/x-r-doc;text/x-r-sweave;text/x-r-markdown;text/x-r-html;text/x-r-presentation;application/x-r-data;application/x-r-project;text/x-r-history;text/x-r-profile;text/x-tex;text/x-markdown;text/html;text/css;text/javascript;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;";
+  };
+
+  postInstall = ''
+      wrapProgram $out/bin/rstudio --suffix PATH : ${gnumake}/bin
+      mkdir $out/share
+      cp -r ${desktopItem}/share/applications $out/share
+      mkdir $out/share/icons
+      ln $out/rstudio.png $out/share/icons
+  '';
+
+  meta = with stdenv.lib;
+    { description = "Set of integrated tools for the R language";
+      homepage = https://www.rstudio.com/;
+      license = licenses.agpl3;
+      maintainers = with maintainers; [ averelld ];
+      platforms = platforms.linux;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18765,6 +18765,10 @@ with pkgs;
   rstudio = libsForQt5.callPackage ../applications/editors/rstudio {
     boost = boost166;
   };
+  rstudio-preview = libsForQt5.callPackage ../applications/editors/rstudio/preview.nix {
+    boost = boost166;
+    llvmPackages = llvmPackages_7;
+  };
 
   rsync = callPackage ../applications/networking/sync/rsync {
     enableACLs = !(stdenv.isDarwin || stdenv.isSunOS || stdenv.isFreeBSD);


### PR DESCRIPTION
###### Motivation for this change
- preview hasn't been released in a long time
- working clang/completion
- could potentially be merged to default and deleted once a release happens
- there are no regular tags or available version numbers on the public repo, so this isn't technically equivalent to any preview "release" binary that could be downloaded.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

