### PR TITLE
expand nspawn unit file validation logic to allow all currently supported fields

### DIFF
--- a/nixos/modules/system/boot/systemd-nspawn.nix
+++ b/nixos/modules/system/boot/systemd-nspawn.nix
@@ -10,8 +10,13 @@ let
   checkExec = checkUnitConfig "Exec" [
     (assertOnlyFields [
       "Boot" "ProcessTwo" "Parameters" "Environment" "User" "WorkingDirectory"
-      "Capability" "DropCapability" "KillSignal" "Personality" "MachineId"
-      "PrivateUsers" "NotifyReady"
+      "PivotRoot" "Capability" "DropCapability" "NoNewPrivileges" "KillSignal"
+      "Personality" "MachineId" "PrivateUsers" "NotifyReady" "SystemCallFilter"
+      "LimitCPU" "LimitFSIZE" "LimitDATA" "LimitSTACK" "LimitCORE" "LimitRSS"
+      "LimitNOFILE" "LimitAS" "LimitNPROC" "LimitMEMLOCK" "LimitLOCKS"
+      "LimitSIGPENDING" "LimitMSGQUEUE" "LimitNICE" "LimitRTPRIO" "LimitRTTIME"
+      "OOMScoreAdjust" "CPUAffinity" "Hostname" "ResolvConf" "Timezone"
+      "LinkJournal"
     ])
     (assertValueOneOf "Boot" boolValues)
     (assertValueOneOf "ProcessTwo" boolValues)


### PR DESCRIPTION
###### Motivation for this change
I tried to set `systemd.nspawn.ubuntu.execConfig.LimitNOFILE`, but as it turns out the nspawn module does a whole lot of validation (which is imho unnecessary beyond a simple sanity check) and rejects that property, even though it's supported:
[https://www.freedesktop.org/software/systemd/man/systemd.nspawn.html](https://www.freedesktop.org/software/systemd/man/systemd.nspawn.html)

###### Things done
I've added all (?) missing fields to the list of allowed ones. ~~But nspawn seems to be part of a bigger closure which a lot of packages depend on, so I can't really test this.~~ It's just a few additions to a list though .. what could go wrong?


Could this change be applied to the stable branch, too? As it is now nspawn is somewhat limited. Or is there some easy hack possible to circumvent the validation?

cc @Mic92 because you've been active around here 