### PR TITLE
vscode-with-extensions: fix insiders build

### DIFF
--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -51,7 +51,7 @@ let
     paths = vscodeExtensions;
   };
 
-  wrappedExeName = "code";
+  wrappedExeName = builtins.substring 2 (builtins.stringLength wrappedPkgName) wrappedPkgName;
   exeName = wrappedExeName;
 
   wrapperExeFile = writeScript "${exeName}" ''
@@ -75,7 +75,7 @@ runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}" {
   mkdir -p "$out/share/applications"
   mkdir -p "$out/share/pixmaps"
 
-  ln -sT "${vscode}/share/applications/code.desktop" "$out/share/applications/code.desktop"
+  ln -sT "${vscode}/share/applications/${wrappedExeName}.desktop" "$out/share/applications/${exeName}.desktop"
   ln -sT "${vscode}/share/pixmaps/code.png" "$out/share/pixmaps/code.png"
   ${if [] == vscodeExtensions
     then ''


### PR DESCRIPTION
###### Motivation for this change
Probably not the correct way to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

