### PR TITLE
ibm-plex: 1.1.6 -> 1.2.1

### DIFF
--- a/pkgs/data/fonts/ibm-plex/default.nix
+++ b/pkgs/data/fonts/ibm-plex/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "1.1.6";
+  version = "1.2.1";
 in fetchzip rec {
   name = "ibm-plex-${version}";
   url = "https://github.com/IBM/plex/releases/download/v${version}/OpenType.zip";
@@ -9,7 +9,7 @@ in fetchzip rec {
     mkdir -p $out/share/fonts
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
-  sha256 = "0n9qmh6v7gvrl1mfb0knygxlbkb78hvkdrppssx64m3pk4pxw85a";
+  sha256 = "1mwlw39nbqrk08crvgm77l98yyyabwhcgsng89c9s67gq4mlxmxa";
 
   meta = with lib; {
     description = "IBM Plex Typeface";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

