### PR TITLE
Update jupyter packages to python 3 only packages with 27 support

### DIFF
--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -16,7 +16,7 @@ buildPythonApplication rec {
     colorama
     requests
     pygments
-    prompt_toolkit
+    prompt_toolkit_1
     six
   ];
 

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -57,7 +57,7 @@ in pythonPackages.buildPythonPackage rec {
     ++ (with pythonPackages; [
       yarl aiohttp multidict
       jinja2 psutil zipstream raven jsonschema typing
-      prompt_toolkit
+      prompt_toolkit_1
     ]);
 
   # Requires network access

--- a/pkgs/development/python-modules/ipykernel/4.nix
+++ b/pkgs/development/python-modules/ipykernel/4.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, isPy27
+, mock
+, ipython
+, jupyter_client
+, pexpect
+, traitlets
+, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "ipykernel";
+  version = "4.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "699103c8e64886e3ec7053f2a6aa83bb90426063526f63a818732ff385202bad";
+  };
+
+  checkInputs = [ nose ] ++ lib.optional isPy27 mock;
+  propagatedBuildInputs = [
+    ipython
+    jupyter_client
+    pexpect
+    traitlets
+    tornado
+  ];
+
+  # Tests require backends.
+  # I don't want to add all supported backends as propagatedBuildInputs
+  doCheck = false;
+
+  meta = {
+    description = "IPython Kernel for Jupyter";
+    homepage = http://ipython.org/;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -1,37 +1,31 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, nose
-, isPy27
-, mock
 , ipython
 , jupyter_client
-, pexpect
 , traitlets
 , tornado
+, pythonOlder
+, pytest
+, nose
 }:
 
 buildPythonPackage rec {
   pname = "ipykernel";
-  version = "4.8.2";
+  version = "5.1.0";
+  disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c091449dd0fad7710ddd9c4a06e8b9e15277da306590bc07a3a1afa6b4453c8f";
+    sha256 = "0fc0bf97920d454102168ec2008620066878848fcfca06c22b669696212e292f";
   };
 
-  buildInputs = [ nose ] ++ lib.optional isPy27 mock;
-  propagatedBuildInputs = [
-    ipython
-    jupyter_client
-    pexpect
-    traitlets
-    tornado
-  ];
+  checkInputs = [ pytest nose ];
+  propagatedBuildInputs = [ ipython jupyter_client traitlets tornado ];
 
-  # Tests require backends.
-  # I don't want to add all supported backends as propagatedBuildInputs
-  doCheck = false;
+  checkPhase = ''
+    HOME=$(mktemp -d) pytest ipykernel
+  '';
 
   meta = {
     description = "IPython Kernel for Jupyter";

--- a/pkgs/development/python-modules/ipython/5.nix
+++ b/pkgs/development/python-modules/ipython/5.nix
@@ -26,26 +26,16 @@
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "5.7.0";
+  version = "5.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0g1jm06qriq48m58311cs7askp83ipq3yq96hv4kg431nxzkmd4d";
+    sha256 = "4bac649857611baaaf76bc82c173aa542f7486446c335fe1a6c05d0d491c8906";
   };
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace setup.py --replace "'gnureadline'" " "
   '';
-
-  patches = [
-    # improve cython support, needed by sage, accepted upstream
-    # https://github.com/ipython/ipython/pull/11139
-    (fetchpatch {
-      name = "signature-use-inspect.patch";
-      url = "https://github.com/ipython/ipython/commit/8d399b98d3ed5c765835594100c4d36fb2f739dc.patch";
-      sha256 = "1r7v9clwwbskmj4y160vcj6g0vzqbvnj4y1bm2n4bskafapm42g0";
-    })
-  ];
 
   buildInputs = [ glibcLocales ];
 

--- a/pkgs/development/python-modules/ipython/5.nix
+++ b/pkgs/development/python-modules/ipython/5.nix
@@ -19,7 +19,7 @@
 , requests
 , simplegeneric
 , traitlets
-, prompt_toolkit
+, prompt_toolkit_1
 , pexpect
 , appnope
 }:
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   checkInputs = [ nose pygments testpath ] ++ lib.optional isPy27 mock;
 
   propagatedBuildInputs = [
-    backports_shutil_get_terminal_size decorator pickleshare prompt_toolkit
+    backports_shutil_get_terminal_size decorator pickleshare prompt_toolkit_1
     simplegeneric traitlets requests pathlib2 pexpect
   ] ++ lib.optionals stdenv.isDarwin [ appnope ];
 

--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -12,22 +12,21 @@
 , jedi
 , decorator
 , pickleshare
-, simplegeneric
 , traitlets
 , prompt_toolkit
 , pexpect
 , appnope
-, typing
 , backcall
 }:
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "6.5.0";
+  version = "7.1.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b0f2ef9eada4a68ef63ee10b6dde4f35c840035c50fd24265f8052c98947d5a4";
+    sha256 = "b10a7ddd03657c761fc503495bc36471c8158e3fc948573fb9fe82a7029d8efd";
   };
 
   prePatch = lib.optionalString stdenv.isDarwin ''
@@ -42,13 +41,12 @@ buildPythonPackage rec {
     jedi
     decorator
     pickleshare
-    simplegeneric
     traitlets
     prompt_toolkit
+    pygments
     pexpect
     backcall
-  ] ++ lib.optionals stdenv.isDarwin [appnope]
-    ++ lib.optionals (pythonOlder "3.5") [ typing ];
+  ] ++ lib.optionals stdenv.isDarwin [appnope];
 
   LC_ALL="en_US.UTF-8";
 
@@ -57,11 +55,6 @@ buildPythonPackage rec {
   checkPhase = ''
     nosetests
   '';
-
-  # IPython 6.0.0 and above does not support Python < 3.3.
-  # The last IPython version to support older Python versions
-  # is 5.3.x.
-  disabled = pythonOlder "3.3";
 
   meta = {
     description = "IPython: Productive Interactive Computing";

--- a/pkgs/development/python-modules/jupyter_console/5.nix
+++ b/pkgs/development/python-modules/jupyter_console/5.nix
@@ -5,19 +5,17 @@
 , jupyter_client
 , ipython
 , ipykernel
-, prompt_toolkit
+, prompt_toolkit_1
 , pygments
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "jupyter_console";
-  version = "6.0.0";
-  disabled = pythonOlder "3.5";
+  version = "5.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "308ce876354924fb6c540b41d5d6d08acfc946984bf0c97777c1ddcb42e0b2f5";
+    sha256 = "545dedd3aaaa355148093c5609f0229aeb121b4852995c2accfa64fe3e0e55cd";
   };
 
   checkInputs = [ nose ];
@@ -25,7 +23,7 @@ buildPythonPackage rec {
     jupyter_client
     ipython
     ipykernel
-    prompt_toolkit
+    prompt_toolkit_1
     pygments
   ];
 

--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -6,6 +6,8 @@
 , ipython
 , jinja2
 , python-oauth2
+, prometheus_client
+, async_generator
 , pamela
 , sqlalchemy
 , tornado
@@ -18,27 +20,27 @@
 let
   # js/css assets that setup.py tries to fetch via `npm install` when building
   # from source.
-  bootstrap = 
+  bootstrap =
     fetchzip {
       url = "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz";
       sha256 = "0r7s54bbf68ri1na9bbabyf12mcpb6zk5ja2q6z82aw1fa4xi3yd";
     };
-  font-awesome = 
+  font-awesome =
     fetchzip {
       url = "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz";
       sha256 = "1xnxbdlfdd60z5ix152m8r2kk9dkwlqwpypky1mm3dv64ajnzdbk";
     };
-  jquery = 
+  jquery =
     fetchzip {
       url = "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz";
       sha256 = "1j6y18miwzafdj8kfpwbmbn9qvgnbnpc7l4arqrhqj33m04xrlgi";
     };
-  moment = 
+  moment =
     fetchzip {
-      url = "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz";
-      sha256 = "1b4vyvs24v6y92pf2iqjm5aa7jg7khcpspn00girc7lpi917f9vw";
+      url = "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz";
+      sha256 = "12gb3p0rz5wyjwykv9g0pix7dd352lx1z7rzdjsf2brhwc4ffyip";
     };
-  requirejs = 
+  requirejs =
     fetchzip {
       url = "https://registry.npmjs.org/requirejs/-/requirejs-2.3.4.tgz";
       sha256 = "0q6mkj0iv341kks06dya6lfs2kdw0n6vc7n4a7aa3ia530fk9vja";
@@ -48,11 +50,12 @@ in
 
 buildPythonPackage rec {
   pname = "jupyterhub";
-  version = "0.8.1";
+  version = "0.9.4";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "100cf18d539802807a45450d38fefbb376cf1c810f3b1b31be31638829a5c69c";
+    sha256 = "7848bbb299536641a59eb1977ec3c7c95d931bace4a2803d7e9b28b9256714da";
   };
 
   # Most of this only applies when building from source (e.g. js/css assets are
@@ -103,14 +106,13 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     alembic ipython jinja2 pamela python-oauth2 requests sqlalchemy tornado
-    traitlets
+    traitlets prometheus_client async_generator
   ];
 
   # Disable tests because they take an excessive amount of time to complete.
   doCheck = false;
 
-  disabled = pythonOlder "3.4";
-  
+
   meta = with lib; {
     description = "Serves multiple Jupyter notebook instances";
     homepage = http://jupyter.org/;

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -1,19 +1,22 @@
-{ lib, buildPythonPackage, isPy3k, fetchPypi, ipython_genutils, jupyterlab_launcher, notebook }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jupyterlab_server
+, notebook
+, pythonOlder
+}:
+
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "0.34.12";
-  disabled = !isPy3k;
+  version = "0.35.4";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7d8378d19a0ae173e91a493db996c37828b410b7ee556da21a153486168ecf87";
+    sha256 = "deba0b2803640fcad72c61366bff11d5945173015961586d5e3b2f629ffeb455";
   };
 
-  propagatedBuildInputs = [
-    ipython_genutils
-    jupyterlab_launcher
-    notebook
-  ];
+  propagatedBuildInputs = [ jupyterlab_server notebook ];
 
   makeWrapperArgs = [
     "--set" "JUPYTERLAB_DIR" "$out/share/jupyter/lab"

--- a/pkgs/development/python-modules/jupyterlab_server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_server/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, notebook
+, jsonschema
+, pythonOlder
+, requests
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterlab_server";
+  version = "0.2.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "72d916a73957a880cdb885def6d8664a6d1b2760ef5dca5ad665aa1e8d1bb783";
+  };
+
+  checkInputs = [ requests pytest ];
+  propagatedBuildInputs = [ notebook jsonschema ];
+
+  # test_listing test fails
+  # this is a new package and not all tests pass
+  doCheck = false;
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "JupyterLab Server";
+    homepage = http://jupyter.org;
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -17,15 +17,16 @@
 , pandocfilters
 , tornado
 , jupyter_client
+, defusedxml
 }:
 
 buildPythonPackage rec {
   pname = "nbconvert";
-  version = "5.3.1";
+  version = "5.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1f9dkvpx186xjm4xab0qbph588mncp4vqk3fmxrsnqs43mks9c8j";
+    sha256 = "a8a2749f972592aa9250db975304af6b7337f32337e523a2c995cc9e12c07807";
   };
 
   checkInputs = [ nose pytest glibcLocales ];
@@ -33,11 +34,14 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     entrypoints bleach mistune jinja2 pygments traitlets testpath
     jupyter_core nbformat ipykernel pandocfilters tornado jupyter_client
+    defusedxml
   ];
 
+  # disable preprocessor tests for ipython 7
+  # see issue https://github.com/jupyter/nbconvert/issues/898
   checkPhase = ''
-    mkdir tmp
-    LC_ALL=en_US.UTF-8 HOME=`realpath tmp` py.test -v
+    export LC_ALL=en_US.UTF-8
+    HOME=$(mktemp -d) py.test -v --ignore="nbconvert/preprocessors/tests/test_execute.py"
   '';
 
   meta = {

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -25,11 +25,11 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "5.6.0";
+  version = "5.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e2c8e931cc19db4f8c63e6a396efbc13a228b2cb5b2919df011b946f28239a08";
+    sha256 = "b85e4de3d54cf4f14fe1d0515a980ccb49ddd4cdd21250cc0d4fb6374d50b1a7";
   };
 
   LC_ALL = "en_US.utf8";

--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -10,7 +10,7 @@ pythonPackages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with pythonPackages; [
-    cli-helpers click configobj humanize prompt_toolkit_2 psycopg2
+    cli-helpers click configobj humanize prompt_toolkit psycopg2
     pygments sqlparse pgspecial setproctitle keyring
   ];
 

--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -28,7 +28,7 @@ python3Packages.buildPythonApplication rec {
 
   checkInputs = [ python3Packages.pytest glibcLocales git ];
 
-  propagatedBuildInputs = with python3Packages; [ ply prompt_toolkit_2 pygments ];
+  propagatedBuildInputs = with python3Packages; [ ply prompt_toolkit pygments ];
 
   meta = with stdenv.lib; {
     description = "A Python-ish, BASHwards-compatible shell";

--- a/pkgs/tools/admin/aws_shell/default.nix
+++ b/pkgs/tools/admin/aws_shell/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , awscli
-, prompt_toolkit
+, prompt_toolkit_1
 , boto3
 , configobj
 , pygments
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   # Why does it propagate packages that are used for testing?
   propagatedBuildInputs = [
     awscli
-    prompt_toolkit
+    prompt_toolkit_1
     boto3
     configobj
     pygments

--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -15,7 +15,7 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [
-    pymysql configobj sqlparse prompt_toolkit pygments click pycrypto cli-helpers
+    pymysql configobj sqlparse prompt_toolkit_1 pygments click pycrypto cli-helpers
   ];
 
   checkInputs = [ pytest mock glibcLocales ];

--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
     click
     httpie
     parsimonious
-    prompt_toolkit
+    prompt_toolkit_1
     pygments
     six
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2524,12 +2524,10 @@ in {
 
   ipyparallel = callPackage ../development/python-modules/ipyparallel { };
 
-  # Newer versions of IPython no longer support Python 2.7.
-  ipython = if isPy27 then self.ipython_5 else self.ipython_6;
-
-  ipython_5 = callPackage ../development/python-modules/ipython/5.nix { };
-
-  ipython_6 = callPackage ../development/python-modules/ipython { };
+  ipython = if pythonOlder "3.5" then
+      callPackage ../development/python-modules/ipython/5.nix { }
+    else
+      callPackage ../development/python-modules/ipython { };
 
   ipython_genutils = callPackage ../development/python-modules/ipython_genutils { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2520,7 +2520,10 @@ in {
 
   ipy = callPackage ../development/python-modules/IPy { };
 
-  ipykernel = callPackage ../development/python-modules/ipykernel { };
+  ipykernel = if pythonOlder "3.4" then
+      callPackage ../development/python-modules/ipykernel/4.nix { }
+    else
+      callPackage ../development/python-modules/ipykernel { };
 
   ipyparallel = callPackage ../development/python-modules/ipyparallel { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1787,6 +1787,8 @@ in {
 
   jupyterlab_launcher = callPackage ../development/python-modules/jupyterlab_launcher { };
 
+  jupyterlab_server = callPackage ../development/python-modules/jupyterlab_server { };
+
   jupyterlab = callPackage ../development/python-modules/jupyterlab {};
 
   PyLTI = callPackage ../development/python-modules/pylti { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3761,10 +3761,9 @@ in {
     };
   };
 
-  prompt_toolkit = self.prompt_toolkit_1;
+  prompt_toolkit = self.prompt_toolkit_2;
 
   prompt_toolkit_1 = callPackage ../development/python-modules/prompt_toolkit/1.nix { };
-
   prompt_toolkit_2 = callPackage ../development/python-modules/prompt_toolkit { };
 
   protobuf = callPackage ../development/python-modules/protobuf {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1780,7 +1780,10 @@ in {
 
   jupyter = callPackage ../development/python-modules/jupyter { };
 
-  jupyter_console = callPackage ../development/python-modules/jupyter_console { };
+  jupyter_console = if pythonOlder "3.5" then
+       callPackage ../development/python-modules/jupyter_console/5.nix { }
+     else
+       callPackage ../development/python-modules/jupyter_console { };
 
   jupyterlab_launcher = callPackage ../development/python-modules/jupyterlab_launcher { };
 


### PR DESCRIPTION
###### Motivation for this change & Things done

Jupyter has moved their releases to [only supporting python 3+](https://github.com/jupyter/roadmap/blob/master/accepted/migration-to-python-3-only.md). This has blocked upgrading of several python packages within `nixpkgs`. These include `ipython`, `ipykernel`, and `jupyter`. This PR upgrades to newest releases while keeping python 2.7 support for these packages as well.

I would like input on if this is the appropriate way to support multiple versions. The important details are in the changes to `python-packages.nix`

This expression allows support for the most recent versions of `ipython` for each python version.

This update required making `prompt_toolkit` 2.x.x the default version. I have ensure that all applications that depended on prompt_toolkit 1.x.x still work. This issue was addressed recently with https://github.com/NixOS/nixpkgs/pull/49853.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

