### PR TITLE
gst_all_1: make extensible

### DIFF
--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,29 +1,29 @@
-{ callPackage }:
+{ lib, newScope, ffmpeg }:
 
-rec {
+lib.makeExtensible (self: with self; {
+  callPackage = newScope (self // { libav = ffmpeg; });
+
   gstreamer = callPackage ./core { };
 
   gstreamermm = callPackage ./gstreamermm { };
 
-  gst-plugins-base = callPackage ./base { inherit gstreamer; };
+  gst-plugins-base = callPackage ./base { };
 
-  gst-plugins-good = callPackage ./good { inherit gst-plugins-base; };
+  gst-plugins-good = callPackage ./good { };
 
-  gst-plugins-bad = callPackage ./bad { inherit gst-plugins-base; };
+  gst-plugins-bad = callPackage ./bad { };
 
-  gst-plugins-ugly = callPackage ./ugly { inherit gst-plugins-base; };
+  gst-plugins-ugly = callPackage ./ugly { };
 
-  gst-rtsp-server = callPackage ./rtsp-server { inherit gst-plugins-base; };
+  gst-rtsp-server = callPackage ./rtsp-server { };
 
-  gst-libav = callPackage ./libav { inherit gst-plugins-base; };
+  gst-libav = callPackage ./libav { };
 
-  gst-editing-services = callPackage ./ges { inherit gst-plugins-base; };
+  gst-editing-services = callPackage ./ges { };
 
-  gst-vaapi = callPackage ./vaapi {
-    inherit gst-plugins-base gstreamer gst-plugins-bad;
-  };
+  gst-vaapi = callPackage ./vaapi { };
 
-  gst-validate = callPackage ./validate { inherit gst-plugins-base; };
+  gst-validate = callPackage ./validate { };
 
   # note: gst-python is in ./python/default.nix - called under pythonPackages
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9811,9 +9811,7 @@ with pkgs;
 
   gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
 
-  gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
-    callPackage = pkgs.newScope (pkgs // { libav = pkgs.ffmpeg; });
-  });
+  gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer { });
 
   gstreamer = callPackage ../development/libraries/gstreamer/legacy/gstreamer {
     bison = bison2;


### PR DESCRIPTION
It was previously difficult to override a single gstreamer package and cause it to be used by other gstreamer packages. This PR converts `gst_all_1` to an extensible attrset, which fixes this problem. I'm not sure that this is perfect implementation, I just based it off other examples I found in nixpkgs.

It is now possible to override a gstreamer package using something like this:
```
gst_all_1.extend (self: super: {
  gst-plugins-bad = (super.gst-plugins-bad.overrideAttrs (old: rec {
    buildInputs = old.buildInputs ++ [ self.rtmpdump ];
  }));
});
```

This PR only directly causes one rebuild, because `gst-validate` used to have gstreamer 0.10 passed as a dependency, which was inherited from the top level package set, rather than from `gst_all_1`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

