### PR TITLE
chrootenv: strip the binary

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/chrootenv/default.nix
@@ -1,19 +1,15 @@
-{ stdenv, pkgconfig, glib }:
+{ stdenv, meson, ninja, pkgconfig, glib }:
 
 stdenv.mkDerivation {
   name = "chrootenv";
+  src = ./.;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = [ glib ];
-
-  buildCommand = ''
-    cc ${./chrootenv.c} $(pkg-config --cflags --libs glib-2.0) -o $out
-    ${stdenv.cc.bintools.bintools}/bin/strip $out
-  '';
 
   meta = with stdenv.lib; {
     description = "Setup mount/user namespace for FHS emulation";
-    license = licenses.free;
+    license = licenses.mit;
     maintainers = with maintainers; [ yegortimoshenko ];
     platforms = platforms.linux;
   };

--- a/pkgs/build-support/build-fhs-userenv/chrootenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/chrootenv/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation {
 
   buildCommand = ''
     cc ${./chrootenv.c} $(pkg-config --cflags --libs glib-2.0) -o $out
+    ${stdenv.cc.bintools.bintools}/bin/strip $out
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/build-support/build-fhs-userenv/chrootenv/meson.build
+++ b/pkgs/build-support/build-fhs-userenv/chrootenv/meson.build
@@ -1,0 +1,5 @@
+project('chrootenv', 'c')
+
+glib = dependency('glib-2.0')
+
+executable('chrootenv', 'chrootenv.c', dependencies: [glib], install: true)

--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -28,7 +28,7 @@ in runCommand name {
   passthru = passthru // {
     env = runCommand "${name}-shell-env" {
       shellHook = ''
-        exec ${chrootenv} ${init runScript} "$(pwd)"
+        exec ${chrootenv}/bin/chrootenv ${init runScript} "$(pwd)"
       '';
     } ''
       echo >&2 ""
@@ -41,7 +41,7 @@ in runCommand name {
   mkdir -p $out/bin
   cat <<EOF >$out/bin/${name}
   #! ${stdenv.shell}
-  exec ${chrootenv} ${init runScript} "\$(pwd)" "\$@"
+  exec ${chrootenv}/bin/chrootenv ${init runScript} "\$(pwd)" "\$@"
   EOF
   chmod +x $out/bin/${name}
   ${extraInstallCommands}


### PR DESCRIPTION
###### Motivation for this change

Get rid of references to the full compiler package from the runtime closure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not sure how to test this directly as `chrootenv` is not publicly exposed AFAIK. Tested indirectly as part of `steam`.

/cc maintainer @yegortimoshenko