### PR TITLE
networkmanager-l2tp: hoist pname attribute

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp/default.nix
+++ b/pkgs/tools/networking/network-manager/l2tp/default.nix
@@ -2,9 +2,10 @@
 , networkmanager, ppp, xl2tpd, strongswan, libsecret
 , withGnome ? true, gnome3, networkmanagerapplet }:
 
-stdenv.mkDerivation rec {
-  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+let
   pname = "NetworkManager-l2tp";
+in stdenv.mkDerivation rec {
+  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   version = "1.2.10";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Since #49398 was merged, name should have pname as a suffix, however
this derivation adds '-gnome' as a suffix when it is built with GNOME
support. This change makes the derivation more similar to some other
Network Manager plugins, where pname is not an attribute.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

