### PR TITLE
ocamlPackages.checkseum: init at 0.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, ocaml, findlib, dune, alcotest, cmdliner, fmt, optint, rresult }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "checkseum is not available for OCaml ${ocaml.version}"
+else
+
+# The C implementation is not portable: x86 only
+let hasC = stdenv.isi686 || stdenv.isx86_64; in
+
+stdenv.mkDerivation rec {
+  version = "0.0.3";
+  name = "ocaml${ocaml.version}-checkseum-${version}";
+  src = fetchurl {
+    url = "https://github.com/mirage/checkseum/releases/download/v0.0.3/checkseum-v0.0.3.tbz";
+    sha256 = "12j45zsvil1ynwx1x8fbddhqacc8r1zf7f6h576y3f3yvbg7l1fm";
+  };
+
+  postPatch = stdenv.lib.optionalString (!hasC) ''
+    rm -r bin src-c
+  '';
+
+  buildInputs = [ ocaml findlib dune alcotest cmdliner fmt rresult ];
+  propagatedBuildInputs = [ optint ];
+
+  buildPhase = "dune build";
+
+  doCheck = hasC;
+  checkPhase = "dune runtest";
+
+  inherit (dune) installPhase;
+
+  meta = {
+    homepage = "https://github.com/mirage/checkseum";
+    description = "ADLER-32 and CRC32C Cyclic Redundancy Check";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/optint/default.nix
+++ b/pkgs/development/ocaml-modules/optint/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, ocaml, findlib, dune }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "optint is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.0.2";
+  name = "ocaml${ocaml.version}-optint-${version}";
+  src = fetchurl {
+    url = "https://github.com/mirage/optint/releases/download/v0.0.2/optint-v0.0.2.tbz";
+    sha256 = "1lmb7nycmkr05y93slqi98i1lcs1w4kcngjzjwz7i230qqjpw9w1";
+  };
+
+  buildInputs = [ ocaml findlib dune ];
+
+  buildPhase = "dune build";
+
+  inherit (dune) installPhase;
+
+  meta = {
+    homepage = "https://github.com/mirage/optint";
+    description = "Abstract type of integer between x64 and x86 architecture";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -138,6 +138,8 @@ let
 
     cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
+    checkseum = callPackage ../development/ocaml-modules/checkseum { };
+
     cil = callPackage ../development/ocaml-modules/cil { };
 
     cmdliner = callPackage ../development/ocaml-modules/cmdliner { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -557,6 +557,8 @@ let
 
     opti = callPackage ../development/ocaml-modules/opti { };
 
+    optint = callPackage ../development/ocaml-modules/optint { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otr = callPackage ../development/ocaml-modules/otr { };


### PR DESCRIPTION
###### Motivation for this change

Needed to update the `decompress` and `git` libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

