### PR TITLE
nixos/dockd: add new service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -927,6 +927,11 @@
     github = "cwoac";
     name = "Oliver Matthews";
   };
+  cyraxjoe = {
+    email = "rivera@joel.mx";
+    github = "cyraxjoe";
+    name = "Joel Rivera";
+  };
   DamienCassou = {
     email = "damien@cassou.me";
     github = "DamienCassou";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -270,6 +270,7 @@
   ./services/hardware/actkbd.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/brltty.nix
+  ./services/hardware/dockd.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix
   ./services/hardware/illum.nix

--- a/nixos/modules/services/hardware/dockd.nix
+++ b/nixos/modules/services/hardware/dockd.nix
@@ -1,0 +1,103 @@
+{ config, lib, pkgs, ...}:
+with lib;
+let
+  cfg = config.services.dockd;
+in
+{
+  ###############################################
+  options.services.dockd = {
+
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, run dockd as a systemd user service.
+      '';
+    };
+
+    dockedConfPath = mkOption {
+      type = types.str;
+      default = "/etc/dockd/docked.conf";
+      description = ''
+        Path to the file that will store the configuration of the
+        environment when the ThinkPad is placed on the dock.
+      '';
+    };
+
+    undockedConfPath = mkOption {
+      type = types.str;
+      default = "/etc/dockd/undocked.conf";
+      description = ''
+        Path to the file that will store the configuration of the
+         environment when the ThinkPad is removed from the dock.
+      '';
+    };
+
+    dockHookPath = mkOption {
+      type = types.str;
+      default = "/etc/dockd/dock.hook";
+      description = ''
+        Path to the executable to execute when the ThinkPad is placed
+        on the dock.
+        Ignored if the "dockHook" option is set.
+      '';
+    };
+
+    dockHook = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Script to be executed when the ThinkPad is placed on the dock.
+        If defined, the "dockHookPath" option will be ignored.
+      '';
+    };
+
+    undockHookPath = mkOption {
+      type = types.str;
+      default = "/etc/dockd/undock.hook";
+      description = ''
+        Path to the executable to trigger when the ThinkPad is removed
+        from the dock.
+        Ignored if the "undockHook" option is set.
+      '';
+    };
+
+    undockHook = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Script to be executed when the ThinkPad is removed from the dock.
+        If defined, the "undockHookPath" option will be ignored.
+      '';
+    };
+
+  };
+  ##################################################
+  config =
+  let
+    # override the paths on which the dockd executable
+    # should lookup for the configuration and hook scripts
+    dockd =
+     pkgs.dockd.override {
+       inherit (cfg) dockedConfPath undockedConfPath;
+       dockHookPath = (if cfg.dockHook != ""
+                       then pkgs.writeScript "dock.hook"
+                       else cfg.dockHookPath);
+       undockHookPath = (if cfg.undockHook != ""
+                         then pkgs.writeScript "undock.hook" cfg.undockHook
+                         else cfg.undockHookPath);
+     };
+  in mkIf cfg.enable {
+    services.acpid.enable = true; # required for libthinkpad
+    environment.systemPackages = [ dockd ];
+    systemd.user.services.dockd = {
+      description = "Lenovo ThinkPad Dock Daemon";
+      after = [ "acpid.service" ];
+      path = [ dockd ];
+      environment = { DISPLAY = ":0"; };
+      script = ''
+        dockd --daemon
+      '';
+    };
+  };
+}

--- a/nixos/modules/services/hardware/dockd.nix
+++ b/nixos/modules/services/hardware/dockd.nix
@@ -21,6 +21,8 @@ in
       description = ''
         Path to the file that will store the configuration of the
         environment when the ThinkPad is placed on the dock.
+
+        Make sure the file exists and is writable by the user of the session.
       '';
     };
 
@@ -29,65 +31,131 @@ in
       default = "/etc/dockd/undocked.conf";
       description = ''
         Path to the file that will store the configuration of the
-         environment when the ThinkPad is removed from the dock.
+        environment when the ThinkPad is removed from the dock.
+
+        Make sure the file exists and is writable by the user of the session.
       '';
     };
 
     dockHookPath = mkOption {
       type = types.str;
-      default = "/etc/dockd/dock.hook";
+      default = "";
       description = ''
-        Path to the executable to execute when the ThinkPad is placed
-        on the dock.
-        Ignored if the "dockHook" option is set.
+        Path to the executable to run when the ThinkPad is placed on the dock.
+        If set, make sure the file exists and is executable by the user of the session.
+
+        Example: "/etc/dockd/dock.hook"
+
+        This option is mutually exclusive the "dockHook" option.
       '';
     };
 
     dockHook = mkOption {
-      type = types.str;
-      default = "";
+      type = with types; nullOr str;
+      default = null;
       description = ''
         Script to be executed when the ThinkPad is placed on the dock.
-        If defined, the "dockHookPath" option will be ignored.
+        If is set to null (the default) then create dummy script to
+        fulfill the expectations of dockd.
+
+        Example:  "echo docked"
+
+        This option is mutually exclusive to the "dockHookPath" option.
       '';
     };
 
     undockHookPath = mkOption {
       type = types.str;
-      default = "/etc/dockd/undock.hook";
+      default = "";
       description = ''
-        Path to the executable to trigger when the ThinkPad is removed
-        from the dock.
-        Ignored if the "undockHook" option is set.
+        Path to the executable to run when the ThinkPad is removed from the dock.
+
+        Example: "/etc/dockd/undock.hook"
+
+        If set, make sure the file exists and is executable by the user of the session.
+
+        This option is mutually exclusive to the "undockHook" option.
       '';
     };
 
     undockHook = mkOption {
-      type = types.str;
-      default = "";
+      type = with types; nullOr str;
+      default = null;
       description = ''
         Script to be executed when the ThinkPad is removed from the dock.
-        If defined, the "undockHookPath" option will be ignored.
+        If is set to null (the default) then create dummy script to
+        fulfill the expectations of dockd.
+
+        Example:  "echo undocked"
+
+        This option is mutually exclusive to the "undockHookPath" option.
       '';
     };
 
   };
   ##################################################
   config =
-  let
-    # override the paths on which the dockd executable
-    # should lookup for the configuration and hook scripts
-    dockd =
-     pkgs.dockd.override {
-       inherit (cfg) dockedConfPath undockedConfPath;
-       dockHookPath = (if cfg.dockHook != ""
-                       then pkgs.writeScript "dock.hook"
-                       else cfg.dockHookPath);
-       undockHookPath = (if cfg.undockHook != ""
-                         then pkgs.writeScript "undock.hook" cfg.undockHook
-                         else cfg.undockHookPath);
-     };
-  in mkIf cfg.enable {
+    let
+       # override the paths on which the dockd executable
+       # should lookup for the configuration and hook scripts
+       dockd =
+        # configure a default script content if the dockHook or undockHook hook is
+        # set to null, specified that the user is not interested on doing nothing
+        # with the hooks
+        let
+          dockHook = if cfg.dockHook == null then "exit 0" else cfg.dockHook;
+          undockHook = if cfg.undockHook == null then "exit 0" else cfg.undockHook;
+          inherit(pkgs) writeScript;
+        in
+        pkgs.dockd.override {
+          inherit (cfg) dockedConfPath undockedConfPath;
+          dockHookPath = (if dockHook  != ""
+                          then writeScript "dock.hook" dockHook
+                          else cfg.dockHookPath);
+          undockHookPath = (if undockHook  != ""
+                            then writeScript "undock.hook" undockHook
+                            else cfg.undockHookPath);
+        };
+    in
+    mkIf cfg.enable {
+    assertions = [
+      # verify that only one of (dockHook | dockHookPath) is defined
+      {
+        assertion =
+         if ((cfg.dockHook != null && cfg.dockHook != "") && (cfg.dockHookPath != ""))
+         then false else true;
+        message = ''
+        You have to define ONLY one of "dockHook" or "dockHookPath"
+        '';
+      }
+      # verify that only one of (undockHook | undockHookPath) is defined
+      {
+        assertion =
+          if ((cfg.undockHook != null && cfg.undockHook != "") && (cfg.undockHookPath != ""))
+          then false else true;
+        message = ''
+        You have to define ONLY one of "undockHook" or "undockHookPath"
+        '';
+      }
+      # if the dockHookPath is used, verify the path exists
+      {
+        assertion =
+          if cfg.dockHookPath != "" then
+          (builtins.pathExists cfg.dockHookPath) else true;
+        message = ''
+          The path in "dockHookPath" does not exists.
+        '';
+      }
+      # if the undockHookPath is used, verify the path exists
+      {
+        assertion =
+         if cfg.undockHookPath != "" then
+         (builtins.pathExists cfg.undockHookPath) else true;
+        message = ''
+          The path in "undockHookPath" does not exists.
+        '';
+      }
+    ];
     services.acpid.enable = true; # required for libthinkpad
     environment.systemPackages = [ dockd ];
     systemd.user.services.dockd = {

--- a/pkgs/applications/misc/dockd/CMakeLists.patch
+++ b/pkgs/applications/misc/dockd/CMakeLists.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 58756e2..df07ccc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,9 +23,9 @@ target_link_libraries(${PROJECT_NAME} X11 Xrandr thinkpad)
+ install(TARGETS ${PROJECT_NAME}
+         RUNTIME DESTINATION bin)
+ 
+-install(FILES dockd.desktop DESTINATION /etc/xdg/autostart)
+-install(FILES dock.hook DESTINATION /etc/dockd)
+-install(FILES undock.hook DESTINATION /etc/dockd)
++install(FILES dockd.desktop DESTINATION $ENV{out}/etc/xdg/autostart)
++install(FILES dock.hook DESTINATION $ENV{out}/etc/dockd)
++install(FILES undock.hook DESTINATION $ENV{out}/etc/dockd)
+ 
+ set(CPACK_PACKAGE_VENDOR "Ognjen Galic")
+ set(CPACK_PACKAGE_VERSION_MAJOR 1)

--- a/pkgs/applications/misc/dockd/crtc_h.patch
+++ b/pkgs/applications/misc/dockd/crtc_h.patch
@@ -1,0 +1,15 @@
+diff --git a/crtc.h b/crtc.h
+index 2c56ad3..17782aa 100644
+--- a/crtc.h
++++ b/crtc.h
+@@ -8,8 +8,8 @@ using ThinkPad::Utilities::Ini::Ini;
+ using ThinkPad::Utilities::Ini::IniKeypair;
+ using ThinkPad::Utilities::Ini::IniSection;
+ 
+-#define CONFIG_LOCATION_DOCKED "/etc/dockd/docked.conf"
+-#define CONFIG_LOCATION_UNDOCKED "/etc/dockd/undocked.conf"
++#define CONFIG_LOCATION_DOCKED "@DOCKED_CONF_PATH@"
++#define CONFIG_LOCATION_UNDOCKED "@UNDOCKED_CONF_PATH@"
+ 
+ typedef struct _crtc {
+ 

--- a/pkgs/applications/misc/dockd/default.nix
+++ b/pkgs/applications/misc/dockd/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, fetchurl
+, cmake
+, libXrandr
+, libthinkpad
+, dockedConfPath ? "/etc/dockd/docked.conf"
+, undockedConfPath ? "/etc/dockd/undocked.conf"
+, dockHookPath ? "/etc/dockd/dock.hook"
+, undockHookPath ? "/etc/dockd/undock.hook"
+}:
+let
+  version = "1.21";
+in
+stdenv.mkDerivation rec {
+   name = "dockd-${ version }";
+   src = fetchurl {
+      url = "https://github.com/libthinkpad/dockd/archive/${ version }.tar.gz";
+      sha256 = "1r2h77zv4r52sdnv977ay3j9lljsd0sgzd0cxp4j3pynr276lspx";
+   };
+   buildInputs = [ libXrandr libthinkpad ];
+   nativeBuildInputs = [ cmake ];
+   # the current implementation has the location of the paths hard-coded
+   # in the source code, apply the patches to make be able to modify
+   # those paths when we build the package
+   patches = [ ./CMakeLists.patch ./crtc_h.patch ./hooks_cpp.patch ];
+   postPatch = ''
+     echo "Replacing DOCKED_CONF_PATH to ${ dockedConfPath }"
+     echo "Replacing UNDOCKED_CONF_PATH to ${ undockedConfPath }"
+     echo "Replacing DOCK_HOOK_PATH  to ${ dockHookPath }"
+     echo "Replacing UNDOCK_HOOK_PATH  to ${ undockHookPath }"
+     substituteInPlace crtc.h \
+       --subst-var-by DOCKED_CONF_PATH '${ dockedConfPath }' \
+       --subst-var-by UNDOCKED_CONF_PATH '${ undockedConfPath }'
+     substituteInPlace hooks.cpp \
+       --subst-var-by DOCK_HOOK_PATH '${ dockHookPath }' \
+       --subst-var-by UNDOCK_HOOK_PATH '${ undockHookPath }'
+   '';
+   postInstall = ''
+     rm -rf $out/etc/
+   '';
+   meta = with stdenv.lib; {
+     description = "A program that detects when your ThinkPad is added or removed from a dock";
+     longDescription = ''
+       A program that runs in the background and detects when your ThinkPad is added
+       or removed from a dock and it automatically switches output mode profiles
+       that you have configured before.
+     '';
+     homepage = https://github.com/libthinkpad/dockd;
+     license = [ licenses.bsd2 ];
+     maintainers = with maintainers; [ cyraxjoe ];
+     platforms = platforms.linux;
+   };
+}

--- a/pkgs/applications/misc/dockd/hooks_cpp.patch
+++ b/pkgs/applications/misc/dockd/hooks_cpp.patch
@@ -1,0 +1,22 @@
+diff --git a/hooks.cpp b/hooks.cpp
+index 2fddb6c..d137ad3 100644
+--- a/hooks.cpp
++++ b/hooks.cpp
+@@ -5,7 +5,7 @@
+ 
+ void Hooks::executeDockHook()
+ {
+-	int ret = system("/etc/dockd/dock.hook");
++	int ret = system("@DOCK_HOOK_PATH@");
+ 
+ 	if (ret == -1)
+ 		syslog(LOG_ERR, "Failed to execute dock hook");
+@@ -15,7 +15,7 @@ void Hooks::executeDockHook()
+ 
+ void Hooks::executeUndockHook()
+ {
+-	int ret = system("/etc/dockd/undock.hook");
++	int ret = system("@UNDOCK_HOOK_PATH@");
+ 
+ 	if (ret == -1)
+ 		syslog(LOG_ERR, "Failed to execute undock hook");

--- a/pkgs/development/libraries/libthinkpad/default.nix
+++ b/pkgs/development/libraries/libthinkpad/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchurl
+, cmake
+, systemd
+, libudev
+, acpid }:
+let
+  version = "2.6";
+in
+stdenv.mkDerivation {
+  name = "libthinkpad-${ version }";
+
+  src = fetchurl {
+    url = "https://github.com/libthinkpad/libthinkpad/archive/${ version }.tar.gz";
+    sha256 = "1yxaj063h68s3phka05fphpsnwp0iwgjnwdn8mg4a8chqc2zb5cq";
+  };
+
+  buildInputs = [ cmake systemd.dev libudev.dev acpid ];
+
+  meta = with stdenv.lib; {
+    description = "Library to change configuration and manage hardware events for ThinkPads";
+    homepage = https://github.com/libthinkpad/libthinkpad;
+    longDescription = ''
+      libthinkpad is a userspace general purpose library to change
+      hardware configuration and manage hardware events in the userspace
+      for Lenovo/IBM ThinkPad laptops.
+
+      The library unifies ACPI dispatchers, hardware information systems
+      and hardware configuration interfaces into a single userspace library.
+    '';
+    license = [ licenses.bsd2 ];
+    maintainers = with maintainers; [ cyraxjoe ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -134,6 +134,8 @@ with pkgs;
 
   docker-ls = callPackage ../tools/misc/docker-ls { };
 
+  dockd = callPackage ../applications/misc/dockd { };
+
   dotfiles = callPackage ../applications/misc/dotfiles { };
 
   dotnetenv = callPackage ../build-support/dotnetenv {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1459,6 +1459,8 @@ with pkgs;
 
   libndtypes = callPackage ../development/libraries/libndtypes { };
 
+  libthinkpad = callPackage ../development/libraries/libthinkpad { };
+
   libxnd = callPackage ../development/libraries/libxnd { };
 
   link-grammar = callPackage ../tools/text/link-grammar { };


### PR DESCRIPTION
###### Motivation for this change
 Adds the dockd service for nixos and all the dependencies, libthinkpad and the daemon itself "dockd".

Dockd is a dock management daemon for the Lenovo Thinkpads, very helpful if you are running minimal wm, like i3. It allows you to configure for example, a set of multiple monitors when you dock you laptop.

https://github.com/libthinkpad/dockd 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

