### PR TITLE
glusterfs service: Switch to simple unit instead of forking

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -176,10 +176,8 @@ in
       '';
 
       serviceConfig = {
-        Type="forking";
-        PIDFile="/run/glusterd.pid";
         LimitNOFILE=65536;
-        ExecStart="${glusterfs}/sbin/glusterd -p /run/glusterd.pid --log-level=${cfg.logLevel} ${toString cfg.extraFlags}";
+        ExecStart="${glusterfs}/sbin/glusterd --no-daemon --log-level=${cfg.logLevel} ${toString cfg.extraFlags}";
         KillMode=cfg.killMode;
         TimeoutStopSec=cfg.stopKillTimeout;
       };


### PR DESCRIPTION
###### Motivation for this change

Gluster's pidfile handling is bug-ridden.

I have fixed https://bugzilla.redhat.com/show_bug.cgi?id=1509340
in an attempt to improve it but that is far from enough.

The gluster developers describe another pidfile issue as
"our brick-process management is a total nightmare", see
https://github.com/gluster/glusterfs/blob/f1071f17e02502c24375c0b480d369d37f4e4054/xlators/mgmt/glusterd/src/glusterd-utils.c#L5907-L5924

I have observed multiple cases where glusterd doesn't start correctly
and systemd doesn't notice because of the erroneous pidfile handling.

To improve the situation, we don't let glusterd daemonize itself any more
and instead use `--no-daemon` and the `Simple` service type.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bachp 

I have tested this for a long time on my Gluster cluster.

Now I'm moved to ceph, but I still want to upstream the improvements to NixOS.