### PR TITLE
yacreader: init at 9.5.0, libunarr: init at 1.0.1

### DIFF
--- a/pkgs/applications/graphics/yacreader/default.nix
+++ b/pkgs/applications/graphics/yacreader/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, qmake, poppler, pkgconfig, libunarr, libGLU
+, qtdeclarative, qtgraphicaleffects, qtmultimedia, qtquickcontrols, qtscript
+}:
+
+stdenv.mkDerivation rec {
+  name = "yacreader-${version}";
+  version = "9.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/YACReader/yacreader/releases/download/${version}/${name}-src.tar.xz";
+    sha256 = "0cv5y76kjvsqsv4fp99j8np5pm4m76868i1nn40q6hy573dmxwm6";
+  };
+
+  nativeBuildInputs = [ qmake pkgconfig ];
+  buildInputs = [ poppler libunarr libGLU qtmultimedia qtscript ];
+  propagatedBuildInputs = [ qtquickcontrols qtgraphicaleffects qtdeclarative ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A comic reader for cross-platform reading and managing your digital comic collection";
+    homepage = http://www.yacreader.com;
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/development/libraries/libunarr/default.nix
+++ b/pkgs/development/libraries/libunarr/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "libunarr-${version}";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/selmf/unarr/releases/download/v${version}/unarr-${version}.tar.xz";
+    sha256 = "1db500k6w90qn6qb4j3zcczailmmv81q9lv4bwq516hbncg5p4sl";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/selmf/unarr;
+    description = "A lightweight decompression library with support for rar, tar and zip archives";
+    license = licenses.lgpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11138,6 +11138,8 @@ with pkgs;
   giflib_4_1 = callPackage ../development/libraries/giflib/4.1.nix { };
   giflib_5_1 = callPackage ../development/libraries/giflib/5.1.nix { };
 
+  libunarr = callPackage ../development/libraries/libunarr { };
+
   libungif = callPackage ../development/libraries/giflib/libungif.nix { };
 
   libunibreak = callPackage ../development/libraries/libunibreak { };
@@ -22646,6 +22648,8 @@ with pkgs;
     freeglut = null;
     openal = null;
   };
+
+  yacreader = libsForQt5.callPackage ../applications/graphics/yacreader { };
 
   yadm = callPackage ../applications/version-management/yadm { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

