### PR TITLE
bazel-deps: 2018-08-16 -> 2018-11-01

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel-deps/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-deps/default.nix
@@ -2,7 +2,7 @@
 
 buildBazelPackage rec {
   name = "bazel-deps-${version}";
-  version = "2018-08-16";
+  version = "2018-11-01";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/johnynek/bazel-deps";
@@ -15,8 +15,8 @@ buildBazelPackage rec {
   src = fetchFromGitHub {
     owner = "johnynek";
     repo = "bazel-deps";
-    rev = "942a0b03cbf159dd6e0f0f40787d6d8e4e832d81";
-    sha256 = "0ls2jvz9cxa169a8pbbykv2d4dik4ipf7dj1lkqx5g0ss7lgs6q5";
+    rev = "1af8921d52f053fad575f26762533a3823b4a847";
+    sha256 = "0srz0sbz4bq9n7cp4g1n3kd3j6rcjqfi25sq8aa64l27yqzbk53x";
   };
 
   bazelTarget = "//src/scala/com/github/johnynek/bazel_deps:parseproject_deploy.jar";
@@ -66,12 +66,13 @@ buildBazelPackage rec {
       find . -type d -empty -delete
     '';
 
-    sha256 = "0jkzf1hay0h8ksk9lhfvdliac6c5d7nih934i1xjbrn6zqlivy19";
+    sha256 = "1gvl4a9z8p4ch2gmcj3lpp0imrkrvy8wng949p3wlkibi14hc6ww";
   };
 
   buildAttrs = {
     installPhase = ''
       mkdir -p $out/bin/bazel-bin/src/scala/com/github/johnynek/bazel_deps
+
       cp gen_maven_deps.sh $out/bin
       wrapProgram "$out/bin/gen_maven_deps.sh" --set JAVA_HOME "${jre}" --prefix PATH : ${lib.makeBinPath [ jre ]}
       cp bazel-bin/src/scala/com/github/johnynek/bazel_deps/parseproject_deploy.jar $out/bin/bazel-bin/src/scala/com/github/johnynek/bazel_deps


### PR DESCRIPTION
###### Motivation for this change

Fixes #49640.

This broke when I updated `bazel`, I guess something changed with how `bazel fetch` works. The new version of `bazel-deps` has dependencies declared in a way that interacts correctly with `bazel fetch` in the current version of `bazel`, so I updated it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---