### PR TITLE
glusterfs: 3.12.12 -> 4.0.0

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -198,6 +198,9 @@ in
         install -m 0755 -d /var/log/glusterfs
       '';
 
+      # glustereventsd uses the `gluster` executable
+      path = [ glusterfs ];
+
       serviceConfig = {
         Type="simple";
         Environment="PYTHONPATH=${glusterfs}/usr/lib/python2.7/site-packages";

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,10 +15,10 @@ let
     #       The command
     #         find /nix/store/...-glusterfs-.../ -name '*.py' -executable
     #       can help with finding new Python scripts.
-    version = "3.12.12";
+    version = "4.0.0";
     name="${baseName}-${version}";
     url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
-    sha256 = "1q6rcf9y98w3kvgwdlbhl65phkdl0mfil6y7i3gnpf3d21gfb6nw";
+    sha256 = "0af3fwiixddds6gdwhkyq3l214mmjl2wpjc2qayp5rpz79lnclq3";
   };
   buildInputs = [
     fuse bison flex_2_5_35 openssl ncurses readline
@@ -70,10 +70,13 @@ rec {
   '';
 
   patches = [
+    # Remove when https://bugzilla.redhat.com/show_bug.cgi?id=1450546 is fixed
     ./glusterfs-use-PATH-instead-of-hardcodes.patch
+    # Remove when https://bugzilla.redhat.com/show_bug.cgi?id=1450593 is fixed
     ./glusterfs-python-remove-find_library.patch
     # Remove when https://bugzilla.redhat.com/show_bug.cgi?id=1489610 is fixed
     ./glusterfs-fix-bug-1489610-glusterfind-var-data-under-prefix.patch
+    # Remove when https://bugzilla.redhat.com/show_bug.cgi?id=1559130 is fixed
     ./glusterfs-glusterfind-log-remote-node_cmd-error.patch
   ];
 

--- a/pkgs/tools/filesystems/glusterfs/glusterfs-python-remove-find_library.patch
+++ b/pkgs/tools/filesystems/glusterfs/glusterfs-python-remove-find_library.patch
@@ -1,21 +1,23 @@
-From d321df349d10f038f0c89b9c11f8059572264f1b Mon Sep 17 00:00:00 2001
+From e6293e367f56833457291e32a4df7b21a52365a7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Niklas=20Hamb=C3=BCchen?= <mail@nh2.me>
 Date: Sat, 13 May 2017 18:54:36 +0200
 Subject: [PATCH] python: Remove all uses of find_library. Fixes #1450593
 
 `find_library()` doesn't consider LD_LIBRARY_PATH on Python < 3.6.
+
+Change-Id: Iee26085cb5d14061001f19f032c2664d69a378a8
 ---
  api/examples/getvolfile.py                                     |  2 +-
  geo-replication/syncdaemon/libcxattr.py                        |  3 +--
- geo-replication/syncdaemon/libgfchangelog.py                   |  3 +--
+ geo-replication/syncdaemon/libgfchangelog.py                   |  6 ++----
  tests/features/ipctest.py                                      | 10 ++--------
  tests/utils/libcxattr.py                                       |  5 ++---
  tools/glusterfind/src/libgfchangelog.py                        |  3 +--
  .../features/changelog/lib/examples/python/libgfchangelog.py   |  3 +--
- 7 files changed, 9 insertions(+), 20 deletions(-)
+ 7 files changed, 10 insertions(+), 22 deletions(-)
 
 diff --git a/api/examples/getvolfile.py b/api/examples/getvolfile.py
-index 0c95213..32c2268 100755
+index 0c95213f0..32c2268b3 100755
 --- a/api/examples/getvolfile.py
 +++ b/api/examples/getvolfile.py
 @@ -3,7 +3,7 @@
@@ -28,7 +30,7 @@ index 0c95213..32c2268 100755
                                   ctypes.c_void_p,
                                   ctypes.c_ulong]
 diff --git a/geo-replication/syncdaemon/libcxattr.py b/geo-replication/syncdaemon/libcxattr.py
-index 3671e10..f576648 100644
+index 3671e102c..f576648b7 100644
 --- a/geo-replication/syncdaemon/libcxattr.py
 +++ b/geo-replication/syncdaemon/libcxattr.py
 @@ -10,7 +10,6 @@
@@ -49,25 +51,28 @@ index 3671e10..f576648 100644
      @classmethod
      def geterrno(cls):
 diff --git a/geo-replication/syncdaemon/libgfchangelog.py b/geo-replication/syncdaemon/libgfchangelog.py
-index d87b56c..003c28c 100644
+index 334f5e9ea..093ae157a 100644
 --- a/geo-replication/syncdaemon/libgfchangelog.py
 +++ b/geo-replication/syncdaemon/libgfchangelog.py
-@@ -10,12 +10,11 @@
+@@ -9,14 +9,12 @@
+ #
  
  import os
- from ctypes import CDLL, RTLD_GLOBAL, create_string_buffer, get_errno, byref, c_ulong
+-from ctypes import CDLL, RTLD_GLOBAL, create_string_buffer, \
+-    get_errno, byref, c_ulong
 -from ctypes.util import find_library
++from ctypes import CDLL, RTLD_GLOBAL, create_string_buffer, get_errno, byref, c_ulong
  from syncdutils import ChangelogException, ChangelogHistoryNotAvailable
  
  
  class Changes(object):
--    libgfc = CDLL(find_library("gfchangelog"), mode=RTLD_GLOBAL, use_errno=True)
-+    libgfc = CDLL("libgfchangelog.so", mode=RTLD_GLOBAL, use_errno=True)
+-    libgfc = CDLL(find_library("gfchangelog"), mode=RTLD_GLOBAL,
++    libgfc = CDLL("libgfchangelog.so", mode=RTLD_GLOBAL,
+                   use_errno=True)
  
      @classmethod
-     def geterrno(cls):
 diff --git a/tests/features/ipctest.py b/tests/features/ipctest.py
-index 5aff319..9339248 100755
+index 5aff319b8..933924861 100755
 --- a/tests/features/ipctest.py
 +++ b/tests/features/ipctest.py
 @@ -1,14 +1,8 @@
@@ -88,7 +93,7 @@ index 5aff319..9339248 100755
  api.glfs_ipc.argtypes = [ ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p ]
  api.glfs_ipc.restype = ctypes.c_int
 diff --git a/tests/utils/libcxattr.py b/tests/utils/libcxattr.py
-index 149db72..4e6e6c4 100644
+index 149db72e6..4e6e6c46d 100644
 --- a/tests/utils/libcxattr.py
 +++ b/tests/utils/libcxattr.py
 @@ -11,7 +11,6 @@
@@ -112,10 +117,10 @@ index 149db72..4e6e6c4 100644
      @classmethod
      def geterrno(cls):
 diff --git a/tools/glusterfind/src/libgfchangelog.py b/tools/glusterfind/src/libgfchangelog.py
-index dd8153e..da822cf 100644
+index 0f6b40d6c..9ca3f326b 100644
 --- a/tools/glusterfind/src/libgfchangelog.py
 +++ b/tools/glusterfind/src/libgfchangelog.py
-@@ -12,14 +12,13 @@
+@@ -11,14 +11,13 @@
  import os
  from ctypes import CDLL, get_errno, create_string_buffer, c_ulong, byref
  from ctypes import RTLD_GLOBAL
@@ -132,7 +137,7 @@ index dd8153e..da822cf 100644
  
  def raise_oserr():
 diff --git a/xlators/features/changelog/lib/examples/python/libgfchangelog.py b/xlators/features/changelog/lib/examples/python/libgfchangelog.py
-index 10e73c0..2cdbf11 100644
+index 10e73c02b..2cdbf1152 100644
 --- a/xlators/features/changelog/lib/examples/python/libgfchangelog.py
 +++ b/xlators/features/changelog/lib/examples/python/libgfchangelog.py
 @@ -1,9 +1,8 @@
@@ -147,5 +152,5 @@ index 10e73c0..2cdbf11 100644
      @classmethod
      def geterrno(cls):
 -- 
-2.7.4
+2.12.0
 


### PR DESCRIPTION
###### Motivation for this change

Upgrade to new major release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bachp

I have tested this for a long time on my Gluster cluster.

Now I'm moved to ceph, but I still want to upstream the improvements to NixOS.

Note that the 4.0.0 point release is older (in date) than the current 3.12.12 point release. Thus it may not have the same level of security patches.

Note both 4.0.* and 3.* are already EOL according to https://www.gluster.org/release-schedule/, so we have to upgrade further anyway for NixOS 19.03. I hope that this PR, especially the upgrading of the NixOS specific patches, helps with that.