### PR TITLE
 pythonPackages.python-gitlab: init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/httmock/default.nix
+++ b/pkgs/development/python-modules/httmock/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, requests }:
+
+buildPythonPackage rec {
+  pname   = "httmock";
+  version = "1.2.6";
+
+  src = fetchFromGitHub {
+    owner = "patrys";
+    repo = "httmock";
+    rev = version;
+    sha256 = "0iya8qsb2jm03s9p6sf1yzgm1irxl3dcq0k0a9ygl0skzjz5pvab";
+  };
+
+  checkInputs = [ requests ];
+
+  meta = with stdenv.lib; {
+    description = "A mocking library for requests";
+    homepage    = https://github.com/patrys/httmock;
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/development/python-modules/python-gitlab/default.nix
+++ b/pkgs/development/python-modules/python-gitlab/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests, six, mock, httmock }:
+
+buildPythonPackage rec {
+  pname   = "python-gitlab";
+  version = "1.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "20ceb9232f9a412ce6554056a6b5039013d0755261d57b5c8ada7035773de795";
+  };
+
+  propagatedBuildInputs = [ requests six ];
+
+  checkInputs = [ mock httmock ];
+
+  meta = with stdenv.lib; {
+    description = "Interact with GitLab API";
+    homepage    = https://github.com/python-gitlab/python-gitlab;
+    license     = licenses.lgpl3;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2438,6 +2438,8 @@ in {
 
   html5lib = callPackage ../development/python-modules/html5lib { };
 
+  httmock = callPackage ../development/python-modules/httmock { };
+
   http_signature = callPackage ../development/python-modules/http_signature { };
 
   httpbin = callPackage ../development/python-modules/httpbin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1626,6 +1626,8 @@ in {
     inherit (pkgs.gitAndTools) git-annex;
   };
 
+  python-gitlab = callPackage ../development/python-modules/python-gitlab { };
+
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };
   google-cloud-sdk-gce = callPackage ../tools/admin/google-cloud-sdk { with-gce=true; };
 


### PR DESCRIPTION
###### Motivation for this change

Python lib to access GitLab API

I had to pull httmock from GitHub because the tests where not included on PyPi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

