### PR TITLE
git-big-picture: 0.9.0 -> 0.10.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -2,7 +2,7 @@
 
 python2Packages.buildPythonApplication rec {
   pname = "git-big-picture";
-  version = "0.9.0";
+  version = "0.10.1";
 
   name = "${pname}-${version}";
 
@@ -10,7 +10,7 @@ python2Packages.buildPythonApplication rec {
     owner = "esc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1h283gzs4nx8lrarmr454zza52cilmnbdrqn1n33v3cn1rayl3c9";
+    sha256 = "0b0zdq7d7k7f6p3wwc799347fraphbr20rxd1ysnc4xi1cj4wpmi";
   };
 
   buildInputs = [ git graphviz ];
@@ -21,7 +21,7 @@ python2Packages.buildPythonApplication rec {
     '';
 
   meta = {
-    description = "Tool for visualization of Git repositories.";
+    description = "Tool for visualization of Git repositories";
     homepage = https://github.com/esc/git-big-picture;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
https://github.com/esc/git-big-picture/blob/master/README.rst#Changelog

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

