### PR TITLE
phototonic: 1.7.1 -> 2.1

### DIFF
--- a/pkgs/applications/graphics/phototonic/default.nix
+++ b/pkgs/applications/graphics/phototonic/default.nix
@@ -2,15 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "phototonic-${version}";
-  version = "1.7.1";
+  version = "2.1";
 
   src = fetchFromGitHub {
     repo = "phototonic";
     owner = "oferkv";
-    # There is currently no tag for 1.7.1 see
-    # https://github.com/oferkv/phototonic/issues/214
-    rev = "c37070e4a068570d34ece8de1e48aa0882c80c5b";
-    sha256 = "1agd3bsrpljd019qrjvlbim5l0bhpx53dhpc0gvyn0wmcdzn92gj";
+    rev = "v${version}";
+    sha256 = "0csidmxl1sfmn6gq81vn9f9jckb4swz3sgngnwqa4f75lr6604h7";
   };
 
   buildInputs = [ qtbase exiv2 ];


### PR DESCRIPTION
###### Motivation for this change
update with bug fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainer @pSub 
