### PR TITLE
bashdb: 4.4-0.94 -> 4.4-1.0.0

### DIFF
--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, python36Packages }:
 
 stdenv.mkDerivation rec {
   name = "bashdb-${version}";
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     url =  "mirror://sourceforge/bashdb/${name}.tar.bz2";
     sha256 = "0p7i7bpzs6q1i7swnkr89kxqgzr146xw8d2acmqwqbslzm9dqlml";
   };
+
+  propagatedBuildInputs = [ python36Packages.pygments ];
 
   meta = {
     description = "Bash script debugger";

--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "bashdb-4.4-0.94";
+  name = "bashdb-${version}";
+  version = "4.4-1.0.0";
+
 
   src = fetchurl {
     url =  "mirror://sourceforge/bashdb/${name}.tar.bz2";
-    sha256 = "01n0dml866sacls7q8h1c6mm4nc47lq3vrar9idmkajky71aycar";
+    sha256 = "0p7i7bpzs6q1i7swnkr89kxqgzr146xw8d2acmqwqbslzm9dqlml";
   };
 
   meta = {

--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python36Packages }:
+{ stdenv, fetchurl, python3Packages }:
 
 stdenv.mkDerivation rec {
   name = "bashdb-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0p7i7bpzs6q1i7swnkr89kxqgzr146xw8d2acmqwqbslzm9dqlml";
   };
 
-  propagatedBuildInputs = [ python36Packages.pygments ];
+  ropagatedBuildInputs = [ python3Packages.pygments ];
 
   meta = {
     description = "Bash script debugger";

--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -1,16 +1,21 @@
-{ stdenv, fetchurl, python3Packages }:
+{ stdenv, fetchurl, makeWrapper, python3Packages }:
 
 stdenv.mkDerivation rec {
   name = "bashdb-${version}";
   version = "4.4-1.0.0";
-
 
   src = fetchurl {
     url =  "mirror://sourceforge/bashdb/${name}.tar.bz2";
     sha256 = "0p7i7bpzs6q1i7swnkr89kxqgzr146xw8d2acmqwqbslzm9dqlml";
   };
 
-  ropagatedBuildInputs = [ python3Packages.pygments ];
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/bashdb --prefix PYTHONPATH ":" "$(toPythonPath ${python3Packages.pygments})"
+  '';
 
   meta = {
     description = "Bash script debugger";


### PR DESCRIPTION
Updated to latest version.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

