### PR TITLE
haskellPackages.*.env: Fixed shellHook being ignored

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -443,6 +443,7 @@ stdenv.mkDerivation ({
 
     env = shellFor {
       packages = p: [ drv ];
+      inherit shellHook;
     };
 
   };


### PR DESCRIPTION
###### Motivation for this change
The problem was introduced in 2bafa93b75464eee5744653319d8046e05cf141a. Shellhook was being ignored entirely. 

Pinging @Infinisil and @ElvishJerricco, as they might want to review the change. I'm not well acquainted 
with `shellFor`, so the addition might not be the right way to do it. Also, maybe other stuff should be in there?

If this PR is merged, could it be backported to `release-18.09`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` -> `Nothing changed`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

