### PR TITLE
Add slurp and grim

### DIFF
--- a/pkgs/applications/misc/grim/default.nix
+++ b/pkgs/applications/misc/grim/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, scdoc, cairo, libjpeg
+, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "grim-${version}";
+  version = "61df6f0a9531520c898718874c460826bc7e2b42";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "grim";
+    rev = version;
+    sha256 = "1n1fd3ash88fp33vyjndwdf77ig6mnws9jxhgjy5ag07l4xv8923";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  buildInputs = [ cairo wayland wayland-protocols libjpeg ];
+
+  meta = with stdenv.lib; {
+    description = "Grab images from a Wayland compositor";
+    homepage = https://wayland.emersion.fr/grim;
+    license = licenses.mit;
+    maintainers = with maintainers; [ koral ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/slurp/default.nix
+++ b/pkgs/applications/misc/slurp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, scdoc, cairo
+, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "slurp-${version}";
+  version = "0dbd03991462397eb92bb40af712c837c898ebf1";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "slurp";
+    rev = version;
+    sha256 = "0b89ri5h9hg0nqlcrrlyg9zglsgqabn1bs0qd4isdmsq8232davh";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  buildInputs = [ cairo wayland wayland-protocols ];
+
+  meta = with stdenv.lib; {
+    description = "Select a region in a Wayland compositor";
+    homepage = https://wayland.emersion.fr/slurp;
+    license = licenses.mit;
+    maintainers = with maintainers; [ koral ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22857,4 +22857,6 @@ with pkgs;
   newlibCross = callPackage ../development/misc/newlib {
     stdenv = crossLibcStdenv;
   };
+
+  slurp = callPackage ../applications/misc/slurp {};
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22859,4 +22859,6 @@ with pkgs;
   };
 
   slurp = callPackage ../applications/misc/slurp {};
+
+  grim = callPackage ../applications/misc/grim {};
 }


### PR DESCRIPTION
###### Motivation for this change

slurp and grim together make it possible to take screenshots on sway 1.0 (wayland compositor).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

