### PR TITLE
nixos/fontconfig/make-fonts-cache: don't fail to clean the cache

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -3,6 +3,7 @@
 runCommand "fc-cache"
   rec {
     buildInputs = [ fontconfig.bin ];
+    preferLocalBuild = true;
     passAsFile = [ "fontDirs" ];
     fontDirs = ''
       <!-- Font directories -->
@@ -27,5 +28,5 @@ runCommand "fc-cache"
 
     # This is not a cache dir in the normal sense -- it won't be automatically
     # recreated.
-    rm "$out/CACHEDIR.TAG"
+    rm -f "$out/CACHEDIR.TAG"
   ''


### PR DESCRIPTION
###### Motivation for this change

Today I couldn't rebuild because of:
[...]
/nix/store/lxkrsrlqplz2n75hvpq6vr0gam0gfgrl-font-cursor-misc-1.0.3/lib/X11/fonts/misc: skipping, existing cache is valid: 1 fonts, 0 dirs
/var/cache/fontconfig: cleaning cache directory
/nix/store/xq3c44ha15pfa5a9mv1z9mni3cfghsna-fc-cache: cleaning cache directory
fc-cache: succeeded
rm: cannot remove '/nix/store/xq3c44ha15pfa5a9mv1z9mni3cfghsna-fc-cache/CACHEDIR.TAG': No such file or directory
builder for '/nix/store/zxfmil40n79vhn5hb4flqc76j99a3l7b-fc-cache.drv' failed with exit code 1

Strangely, when fixing this it seems the file really exists. No clue.
Anyway this is a good pretext to add `preferLocalBuild=true`.

I guess that it's worth backporting, since I experienced this bug on 18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

