### PR TITLE
Ansible py3

### DIFF
--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -4,13 +4,12 @@
 , ansible
 , pytest
 , mock
-, isPy3k
+, python3Packages
 }:
 
-buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   version = "2.0.1";
   pname = "pytest-ansible";
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
@@ -24,7 +23,7 @@ buildPythonPackage rec {
   # requires pandoc < 2.0
   # buildInputs = [ setuptools-markdown ];
   checkInputs =  [ mock ];
-  propagatedBuildInputs = [ ansible pytest ];
+  propagatedBuildInputs = [ python3Packages.pytest ansible ];
 
   # tests not included with release
   doCheck = false;

--- a/pkgs/development/tools/ansible-lint/default.nix
+++ b/pkgs/development/tools/ansible-lint/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, ansible }:
+{ stdenv, fetchFromGitHub, python3Packages, ansible }:
 
-pythonPackages.buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "ansible-lint";
   version = "3.4.23";
 
@@ -11,9 +11,9 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "0cnfgxh5m7alzm811hc95jigbca5vc1pf8fjazmsakmhdjyfbpb7";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ pyyaml six ] ++ [ ansible ];
+  propagatedBuildInputs = with python3Packages; [ pyyaml six ] ++ [ ansible ];
 
-  checkInputs = [ pythonPackages.nose ];
+  checkInputs = [ python3Packages.nose ];
 
   postPatch = ''
     patchShebangs bin/ansible-lint

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -47,11 +47,6 @@ let
 in rec {
   # We will carry all the supported versions
 
-  ansible_2_4 = generic {
-    version = "2.4.4.0";
-    sha256  = "0n1k6h0h6av74nw8vq98fmh6q4pq6brpwmx45282vh3bkdmpa0ib";
-  };
-
   ansible_2_5 = generic {
     version = "2.5.11";
     sha256  = "07rhgkl3a2ba59rqh9pyz1p661gc389shlwa2sw1m6wwifg4lm24";

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, python2
+{ stdenv, fetchurl, python3
 , windowsSupport ? false
 }:
 
 let
-  generic = { version, sha256, py ? python2 }: py.pkgs.buildPythonPackage rec {
+  generic = { version, sha256, py ? python3 }: py.pkgs.buildPythonPackage rec {
     pname = "ansible";
     inherit version;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8066,7 +8066,6 @@ with pkgs;
   augeas = callPackage ../tools/system/augeas { };
 
   inherit (callPackages ../tools/admin/ansible {})
-    ansible_2_4
     ansible_2_5
     ansible_2_6
     ansible_2_7


### PR DESCRIPTION
###### Motivation for this change

- Switch to python3 for ansible and related packages
- Remove ansible 2.4 as it [does not support python 3](https://github.com/NixOS/nixpkgs/pull/40277#discussion_r187281450) and is already [out of support](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#id14)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This PR should make #44413 obsolete.
closes #44413

I guess I need to provide an update to the release notes for 19.03, but I would first like to get some feedback it this change has the chance to get merged.

cc @jgeerds @joamaki @c0bw3b 