### PR TITLE
Add writeOnly options to the module system

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -324,7 +324,7 @@ rec {
       # Check whether the option is defined, and apply the ‘apply’
       # function to the merged value.  This allows options to yield a
       # value computed from the definitions.
-      value =
+      internalValue =
         if !res.isDefined then
           throw "The option `${showOption loc}' is used but not defined."
         else if opt ? apply then
@@ -332,8 +332,15 @@ rec {
         else
           res.mergedValue;
 
+      writeOnlyError =
+        throw "The option `${showOption loc}' is writeOnly. ${opt.writeOnlyErrorMessage or "Its value should only be used in the defining module."}";
+
+      value = if opt.writeOnly or false then writeOnlyError else internalValue;
+
     in opt //
       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
+        # Only use this in the defining module.
+        inherit internalValue;
         inherit (res.defsFinal') highestPrio;
         definitions = map (def: def.value) res.defsFinal;
         files = map (def: def.file) res.defsFinal;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -48,6 +48,12 @@ rec {
     visible ? null,
     # Whether the option can be set only once
     readOnly ? null,
+    # Whether the option value should be used in the defining module only,
+    # where it is available as options.<...>.writeOnly.
+    # This is not enforced.
+    writeOnly ? null,
+    # Optional error message to show when writeOnly option is accessed
+    writeOnlyErrorMessage ? null,
     # Obsolete, used by types.optionSet.
     options ? null
     } @ attrs:

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,6 +149,18 @@ checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-long-list.ni
 # Check loaOf with many merges of lists.
 checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-merges.nix
 
+# Check writeOnly options
+
+#  * default error
+checkConfigError "The option \`shy' is writeOnly. Its value should only be used in the defining module." config.shy ./declare-writeOnly-options.nix ./define-writeOnly-options.nix
+
+#  * custom error
+checkConfigError "The option \`notRecommended' is writeOnly. Read from the recommended option instead." config.notRecommended ./declare-writeOnly-options.nix ./define-writeOnly-options.nix
+
+#  * use internalValue
+checkConfigOutput "<silence>" options.shy.internalValue ./declare-writeOnly-options.nix ./define-writeOnly-options.nix
+
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/declare-writeOnly-options.nix
+++ b/lib/tests/modules/declare-writeOnly-options.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+{
+  options.shy = lib.mkOption {
+    writeOnly = true;
+    type = lib.types.string;
+  };
+
+  options.notRecommended = lib.mkOption {
+    writeOnly = true;
+    writeOnlyErrorMessage = "Read from the recommended option instead.";
+    type = lib.types.string;
+  };
+}

--- a/lib/tests/modules/define-writeOnly-options.nix
+++ b/lib/tests/modules/define-writeOnly-options.nix
@@ -1,0 +1,4 @@
+{
+  shy = "<silence>";
+  notRecommended = "Kind of weird value. Use something else.";
+}


### PR DESCRIPTION
###### Motivation for this change

I have found a situation, #49765 where it would really help to disallow using certain options outside the defining module.

The value will still be available only as `options.foo.bar.internalValue` and a `options.foo.bar.value` or `config.foo.bar` will yield an error.

The error message is configurable, so the module author can provide a hint of what else the module user should do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

