### PR TITLE
darwin: don't include cf-private in framework dependencies

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm, Xaw3d
 , pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
-, alsaLib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf
+, alsaLib, cairo, acl, gpm, cf-private, AppKit, GSS, ImageIO, m17n_lib, libotf
 , systemd ? null
 , withX ? !stdenv.isDarwin
 , withNS ? stdenv.isDarwin
@@ -64,9 +64,12 @@ stdenv.mkDerivation rec {
     ++ lib.optional (withX && withGTK2) gtk2-x11
     ++ lib.optionals (withX && withGTK3) [ gtk3-x11 gsettings-desktop-schemas ]
     ++ lib.optional (stdenv.isDarwin && withX) cairo
-    ++ lib.optionals (withX && withXwidgets) [ webkitgtk ];
-
-  propagatedBuildInputs = lib.optionals withNS [ AppKit GSS ImageIO ];
+    ++ lib.optionals (withX && withXwidgets) [ webkitgtk ]
+    ++ lib.optionals withNS [
+      AppKit GSS ImageIO
+      # Needed for CFNotificationCenterAddObserver symbols.
+      cf-private
+    ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -6,7 +6,7 @@
     sha256 = "18ifhv5q9prd175q3vxbqf6qyvkk6bc7d2lhqdk0q78i68kv9y0c";
   }
 # apple frameworks
-, Carbon, Cocoa
+, cf-private, Carbon, Cocoa
 }:
 
 let
@@ -19,7 +19,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gettext pkgconfig ];
   buildInputs = [ ncurses ]
-    ++ stdenv.lib.optionals stdenv.hostPlatform.isDarwin [ Carbon Cocoa ];
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isDarwin [
+      Carbon Cocoa
+      # Needed for OBJC_CLASS_$_NSArray symbols.
+      cf-private
+    ];
 
   configureFlags = [
     "--enable-multibyte"

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -4,6 +4,7 @@
 , x11Support ? stdenv.hostPlatform == stdenv.buildPlatform, libXext, libICE, libXrandr
 , pulseaudioSupport ? true, libpulseaudio
 , OpenGL, CoreAudio, CoreServices, AudioUnit, Kernel, Cocoa
+, cf-private
 }:
 
 # NOTE: When editing this expression see if the same change applies to
@@ -41,7 +42,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ]
     ++ optional (!stdenv.hostPlatform.isMinGW) audiofile
-    ++ optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
+    ++ optionals stdenv.isDarwin [
+      AudioUnit CoreAudio CoreServices Kernel OpenGL
+      # Needed for NSDefaultRunLoopMode symbols.
+      cf-private
+    ];
 
   configureFlags = [
     "--disable-oss"

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, fetchurl, fetchpatch, pkgconfig, audiofile, libcap, libiconv
-, openglSupport ? false, libGL, libGLU
-, alsaSupport ? true, alsaLib
-, x11Support ? stdenv.hostPlatform == stdenv.buildPlatform, libXext, libICE, libXrandr
-, pulseaudioSupport ? true, libpulseaudio
+{ stdenv, config, libGLSupported, fetchurl, fetchpatch, pkgconfig, audiofile, libcap, libiconv
+, openglSupport ? libGLSupported, libGL, libGLU
+, alsaSupport ? stdenv.isLinux, alsaLib
+, x11Support ? !stdenv.isCygwin, libXext, libICE, libXrandr
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio
 , OpenGL, CoreAudio, CoreServices, AudioUnit, Kernel, Cocoa
 , cf-private
 }:
@@ -10,7 +10,7 @@
 # NOTE: When editing this expression see if the same change applies to
 # SDL2 expression too
 
-with lib;
+with stdenv.lib;
 
 assert !stdenv.isDarwin -> alsaSupport || pulseaudioSupport;
 assert openglSupport -> (stdenv.isDarwin || x11Support && libGL != null && libGLU != null);
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     for lib in $out/lib/*.so* ; do
       if [[ -L "$lib" ]]; then
-        patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath propagatedBuildInputs}" "$lib"
+        patchelf --set-rpath "$(patchelf --print-rpath $lib):${makeLibraryPath propagatedBuildInputs}" "$lib"
       fi
     done
   '';

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -8,7 +8,7 @@
 , ibusSupport ? false, ibus
 , pulseaudioSupport ? true, libpulseaudio
 , AudioUnit, Cocoa, CoreAudio, CoreServices, ForceFeedback, OpenGL
-, audiofile, libiconv
+, audiofile, cf-private, libiconv
 }:
 
 # NOTE: When editing this expression see if the same change applies to
@@ -54,7 +54,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ audiofile libiconv ]
     ++ dlopenBuildInputs
     ++ optional  ibusSupport ibus
-    ++ optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
+    ++ optionals stdenv.isDarwin [
+      AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL
+      # Needed for NSDefaultRunLoopMode symbols.
+      cf-private
+    ];
 
   # /build/SDL2-2.0.7/src/video/wayland/SDL_waylandevents.c:41:10: fatal error:
   #   pointer-constraints-unstable-v1-client-protocol.h: No such file or directory

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, fetchurl, pkgconfig, pruneLibtoolFiles
-, openglSupport ? false, libGL
-, alsaSupport ? true, alsaLib
-, x11Support ? true, libX11, xproto, libICE, libXi, libXScrnSaver, libXcursor, libXinerama, libXext, libXxf86vm, libXrandr
-, waylandSupport ? true, wayland, wayland-protocols, libxkbcommon
-, dbusSupport ? false, dbus
+{ stdenv, config, libGLSupported, fetchurl, pkgconfig, pruneLibtoolFiles
+, openglSupport ? libGLSupported, libGL
+, alsaSupport ? stdenv.isLinux, alsaLib
+, x11Support ? !stdenv.isCygwin, libX11, xproto, libICE, libXi, libXScrnSaver, libXcursor, libXinerama, libXext, libXxf86vm, libXrandr
+, waylandSupport ? stdenv.isLinux, wayland, wayland-protocols, libxkbcommon
+, dbusSupport ? stdenv.isLinux, dbus
 , udevSupport ? false, udev
 , ibusSupport ? false, ibus
-, pulseaudioSupport ? true, libpulseaudio
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio
 , AudioUnit, Cocoa, CoreAudio, CoreServices, ForceFeedback, OpenGL
 , audiofile, cf-private, libiconv
 }:
@@ -14,7 +14,7 @@
 # NOTE: When editing this expression see if the same change applies to
 # SDL expression too
 
-with lib;
+with stdenv.lib;
 
 assert !stdenv.isDarwin -> alsaSupport || pulseaudioSupport;
 assert openglSupport -> (stdenv.isDarwin || x11Support && libGL != null);

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -34,7 +34,7 @@ with frameworks; with libs; {
   CoreMIDIServer          = [];
   CoreMedia               = [ ApplicationServices AudioToolbox CoreAudio CF CoreGraphics CoreVideo ];
   CoreMediaIO             = [ CF CoreMedia ];
-  CoreText                = [ CF CoreGraphics cf-private ];
+  CoreText                = [ CF CoreGraphics ];
   CoreVideo               = [ ApplicationServices CF CoreGraphics IOSurface OpenGL ];
   CoreWLAN                = [ SecurityFoundation ];
   DVComponentGlue         = [ CoreServices QuickTime ];
@@ -48,8 +48,7 @@ with frameworks; with libs; {
   ExceptionHandling       = [];
   FWAUserLib              = [];
   ForceFeedback           = [ CF IOKit ];
-  # cf-private was moved first in list because of https://github.com/NixOS/nixpkgs/pull/28635
-  Foundation              = [ cf-private CF libobjc Security ApplicationServices SystemConfiguration ];
+  Foundation              = [ CF libobjc Security ApplicationServices SystemConfiguration ];
   GLKit                   = [ CF ];
   GLUT                    = [ OpenGL ];
   GSS                     = [];

--- a/pkgs/servers/x11/quartz-wm/default.nix
+++ b/pkgs/servers/x11/quartz-wm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, xorg, pixman, pkgconfig, AppKit, Xplugin, darwin }:
+{ stdenv, fetchurl, xorg, pixman, pkgconfig, AppKit, Foundation, Xplugin, cf-private }:
 
 let version = "1.3.1";
 in stdenv.mkDerivation {
@@ -19,9 +19,11 @@ in stdenv.mkDerivation {
     xorg.libXext
     pixman
     pkgconfig
-    AppKit Xplugin darwin.apple_sdk.frameworks.Foundation
+    AppKit Xplugin Foundation
+    # Needed for CFNotificationCenterAddObserver symbols.
+    cf-private
   ];
-  meta = with lib; {
+  meta = with stdenv.lib; {
     license = licenses.apsl20;
     platforms = platforms.darwin;
     maintainers = with maintainers; [ matthewbauer ];

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, lib, buildEnv, makeFontsConf, gnused, writeScript, xorg, bashInteractive, xterm, makeWrapper, ruby
+{ stdenv, buildEnv, makeFontsConf, gnused, writeScript, xorg, bashInteractive, xterm, makeWrapper, ruby
 , quartz-wm, fontconfig, xlsfonts, xfontsel
 , ttf_bitstream_vera, freefont_ttf, liberation_ttf
+, cf-private
 , shell ? "${bashInteractive}/bin/bash"
 }:
 
@@ -97,7 +98,11 @@ let
 in stdenv.mkDerivation {
   name = "xquartz-${stdenv.lib.getVersion xorg.xorgserver}";
 
-  buildInputs = [ ruby makeWrapper ];
+  buildInputs = [
+    ruby makeWrapper
+    # Needed for NSDefaultRunLoopMode symbols.
+    cf-private
+  ];
 
   unpackPhase = "sourceRoot=.";
 
@@ -134,7 +139,7 @@ in stdenv.mkDerivation {
     defaultStartX="$out/bin/startx -- $out/bin/Xquartz"
 
     ruby ${./patch_plist.rb} \
-      ${lib.escapeShellArg (builtins.toXML {
+      ${stdenv.lib.escapeShellArg (builtins.toXML {
         XQUARTZ_DEFAULT_CLIENT = "${xterm}/bin/xterm";
         XQUARTZ_DEFAULT_SHELL  = "${shell}";
         XQUARTZ_DEFAULT_STARTX = "@STARTX@";
@@ -179,7 +184,7 @@ in stdenv.mkDerivation {
       --replace "@FONTCONFIG_FILE@" "$fontsConfPath"
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     platforms   = platforms.darwin;
     maintainers = with maintainers; [ cstrahan ];
     license     = licenses.mit;

--- a/pkgs/tools/misc/contacts/default.nix
+++ b/pkgs/tools/misc/contacts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xcbuildHook, Foundation, AddressBook }:
+{ stdenv, fetchurl, xcbuildHook, cf-private, Foundation, AddressBook }:
 
 stdenv.mkDerivation rec {
   version = "1.1a-3";
@@ -10,15 +10,17 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ xcbuildHook ];
-  buildInputs = [ Foundation AddressBook ];
+
+  buildInputs = [
+    Foundation AddressBook
+    # Needed for OBJC_CLASS_$_NSArray symbols.
+    cf-private
+  ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp Products/Default/contacts $out/bin
   '';
-
-  ## FIXME: the framework setup hook isn't adding these correctly
-  NIX_LDFLAGS = " -F${Foundation}/Library/Frameworks/ -F${AddressBook}/Library/Frameworks/";
 
   meta = with stdenv.lib; {
     description = "Access contacts from the Mac address book from command-line";

--- a/pkgs/tools/security/pinentry/mac.nix
+++ b/pkgs/tools/security/pinentry/mac.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, xcbuildHook, libiconv, Cocoa, ncurses }:
+{ stdenv, fetchFromGitHub, xcbuildHook, libiconv, Cocoa, ncurses, cf-private }:
 
 stdenv.mkDerivation rec {
   name = "pinentry-mac-0.9.4";
@@ -11,7 +11,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ xcbuildHook ];
-  buildInputs = [ libiconv Cocoa ncurses ];
+
+  buildInputs = [
+    libiconv Cocoa ncurses
+    # Needed for OBJC_CLASS_$_NSArray symbols.
+    cf-private
+  ];
 
   installPhase = ''
     mkdir -p $out/Applications

--- a/pkgs/tools/video/atomicparsley/default.nix
+++ b/pkgs/tools/video/atomicparsley/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchhg, autoreconfHook, zlib, darwin }:
+{ stdenv, fetchhg, autoreconfHook, zlib, cf-private, Cocoa }:
 
 stdenv.mkDerivation rec {
   name = "atomicparsley-${version}";
@@ -9,10 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "05n4kbn91ps52h3wi1qb2jwygjsc01qzx4lgkv5mvwl5i49rj8fm";
   };
 
-  buildInputs =
-    [ autoreconfHook
-      zlib
-    ] ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ zlib ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [
+      Cocoa
+      # Needed for OBJC_CLASS_$_NSDictionary symbols.
+      cf-private
+    ];
 
   installPhase = "install -D AtomicParsley $out/bin/AtomicParsley";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12152,6 +12152,7 @@ with pkgs;
     waylandSupport = stdenv.isLinux;
     udevSupport = stdenv.isLinux;
     pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
+    inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13858,7 +13858,9 @@ with pkgs;
   # have created a cycle.
   xorg = recurseIntoAttrs ((lib.callPackageWith __splicedPackages ../servers/x11/xorg {
   }).overrideScope' (lib.callPackageWith __splicedPackages ../servers/x11/xorg/overrides.nix {
-    inherit (darwin) apple_sdk;
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa;
+    inherit (darwin.apple_sdk.libs) Xplugin;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
     python = python2; # Incompatible with Python 3x
     udev = if stdenv.isLinux then udev else null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12122,10 +12122,6 @@ with pkgs;
   schroedinger = callPackage ../development/libraries/schroedinger { };
 
   SDL = callPackage ../development/libraries/SDL {
-    openglSupport = libGLSupported;
-    alsaSupport = stdenv.isLinux;
-    x11Support = !stdenv.isCygwin;
-    pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) OpenGL CoreAudio CoreServices AudioUnit Kernel Cocoa;
   };
@@ -12147,12 +12143,6 @@ with pkgs;
   SDL_ttf = callPackage ../development/libraries/SDL_ttf { };
 
   SDL2 = callPackage ../development/libraries/SDL2 {
-    openglSupport = libGLSupported;
-    alsaSupport = stdenv.isLinux;
-    x11Support = !stdenv.isCygwin;
-    waylandSupport = stdenv.isLinux;
-    udevSupport = stdenv.isLinux;
-    pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12126,6 +12126,7 @@ with pkgs;
     alsaSupport = stdenv.isLinux;
     x11Support = !stdenv.isCygwin;
     pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
+    inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) OpenGL CoreAudio CoreServices AudioUnit Kernel Cocoa;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19378,6 +19378,7 @@ with pkgs;
   };
 
   vim = callPackage ../applications/editors/vim {
+    inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13842,7 +13842,10 @@ with pkgs;
 
   xqilla = callPackage ../development/tools/xqilla { };
 
-  xquartz = callPackage ../servers/x11/xquartz { };
+  xquartz = callPackage ../servers/x11/xquartz {
+    inherit (darwin) cf-private;
+  };
+
   quartz-wm = callPackage ../servers/x11/quartz-wm {
     stdenv = clangStdenv;
     inherit (darwin) cf-private;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4779,6 +4779,7 @@ with pkgs;
   };
 
   pinentry_mac = callPackage ../tools/security/pinentry/mac.nix {
+    inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1172,6 +1172,7 @@ with pkgs;
   codec2 = callPackage ../development/libraries/codec2 { };
 
   contacts = callPackage ../tools/misc/contacts {
+    inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Foundation AddressBook;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16313,6 +16313,7 @@ with pkgs;
     imagemagick = null;
     acl = null;
     gpm = null;
+    inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AppKit GSS ImageIO;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -571,7 +571,10 @@ with pkgs;
     gsl = gsl_1;
   };
 
-  atomicparsley = callPackage ../tools/video/atomicparsley { };
+  atomicparsley = callPackage ../tools/video/atomicparsley {
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   autoflake = callPackage ../development/tools/analysis/autoflake { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13845,7 +13845,8 @@ with pkgs;
   xquartz = callPackage ../servers/x11/xquartz { };
   quartz-wm = callPackage ../servers/x11/quartz-wm {
     stdenv = clangStdenv;
-    inherit (darwin.apple_sdk.frameworks) AppKit;
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) AppKit Foundation;
     inherit (darwin.apple_sdk.libs) Xplugin;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Using cf-private can cause problems, it's better to include it
explicitly in places where it's actually required.

Fixes #49781

NOTE: this will break some things, a bit more testing is required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
