### PR TITLE
[WIP] Implement RFC0035 II: Electric Boogaloo

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -236,6 +236,26 @@ rec {
     in lenContent >= lenSuffix &&
        substring (lenContent - lenSuffix) lenContent content == suffix;
 
+  /* Determine whether a string contains the given infix
+
+    Type: hasInfix :: string -> string -> bool
+
+    Example:
+      hasInfix "bc" "abcd"
+      => true
+      hasInfix "ab" "abcd"
+      => true
+      hasInfix "cd" "abcd"
+      => true
+      hasInfix "foo" "abcd"
+      => false
+  */
+  hasInfix = infix: content:
+    let
+      drop = x: substring 1 (stringLength x) x;
+    in hasPrefix infix content
+      || content != "" && hasInfix infix (drop content);
+
   /* Convert a string to a list of characters (i.e. singleton strings).
      This allows you to, e.g., map a function over each character.  However,
      note that this will likely be horribly inefficient; Nix is not a

--- a/pkgs/applications/altcoins/mist.nix
+++ b/pkgs/applications/altcoins/mist.nix
@@ -2,7 +2,7 @@
 
 let
   version = "0.11.1";
-  name = "mist";
+  pname = "mist";
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
@@ -26,7 +26,7 @@ let
   };
 
   mist = stdenv.lib.appendToName "unwrapped" (stdenv.mkDerivation {
-    inherit name version meta;
+    inherit pname version meta;
 
     src = {
       i686-linux = fetchurl {

--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -10,7 +10,7 @@
 
  stdenv.mkDerivation rec {
   version = "0.9.0";
-  name = "cadence";
+  pname = "cadence";
 
   src = fetchurl {
     url = "https://github.com/falkTX/Cadence/archive/v${version}.tar.gz";

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -3,8 +3,9 @@
 , libzip, rtaudio, rtmidi, speex }:
 
 let
-  glfw-git = glfw.overrideAttrs (oldAttrs: {
-    name = "glfw-git-20180529";
+  glfw-git = glfw.overrideAttrs (oldAttrs: rec {
+    name = "glfw-git-${version}";
+    version = "unstable-2018-05-29";
     src = fetchFromGitHub {
       owner = "glfw";
       repo = "glfw";

--- a/pkgs/applications/graphics/vimiv/default.nix
+++ b/pkgs/applications/graphics/vimiv/default.nix
@@ -6,7 +6,7 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  name = "vimiv";
+  pname = "vimiv";
   version = "0.7.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   let
     mupdf_modded = mupdf.overrideAttrs (attrs: {
       name = "mupdf-1.10a";
+      version = "1.10a";
       src = fetchurl {
         url = "https://mupdf.com/downloads/archive/mupdf-1.10a-source.tar.gz";
         sha256 = "0dm8wcs8i29aibzkqkrn8kcnk4q0kd1v66pg48h5c3qqp4v1zk5a";

--- a/pkgs/applications/misc/omegat.nix
+++ b/pkgs/applications/misc/omegat.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "4.1.5.2";
-  name = "omegat";
+  pname = "omegat";
 
   src = fetchurl {  # their zip has repeated files or something, so no fetchzip
     url = mirror://sourceforge/project/omegat/OmegaT%20-%20Latest/OmegaT%204.1.5%20update%202/OmegaT_4.1.5_02_Beta_Without_JRE.zip;

--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, xorg, xlibsWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.sakura.5";
-  vname = "1.2.5";
-  name = "oneko-${vname}";
+  version_name = "1.2.sakura.5";
+  version = "1.2.5";
+  name = "oneko-${version}";
   src = fetchurl {
-    url = "http://www.daidouji.com/oneko/distfiles/oneko-${version}.tar.gz";
+    url = "http://www.daidouji.com/oneko/distfiles/oneko-${version_name}.tar.gz";
     sha256 = "2c2e05f1241e9b76f54475b5577cd4fb6670de058218d04a741a04ebd4a2b22f";
   };
   buildInputs = [ xorg.imake xorg.gccmakedep xlibsWrapper ];

--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -69,7 +69,7 @@ let rpath = lib.makeLibraryPath [
 
 
 in stdenv.mkDerivation rec {
-    name = "brave";
+    pname = "brave";
     version = "0.25.2";
 
     src = fetchurl {

--- a/pkgs/applications/networking/enhanced-ctorrent/default.nix
+++ b/pkgs/applications/networking/enhanced-ctorrent/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  version = "dnh3.3.2";
-  name = "enhanced-ctorrent";
+  version = "3.3.2";
+  pname = "enhanced-ctorrent-dhn";
 
   src = fetchurl {
     url = "http://www.rahul.net/dholmes/ctorrent/ctorrent-dnh3.3.2.tar.gz";

--- a/pkgs/applications/networking/flent/http-getter.nix
+++ b/pkgs/applications/networking/flent/http-getter.nix
@@ -2,8 +2,8 @@
 , curl, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "http-getter";
-  version = "20180606";
+  pname = "http-getter";
+  version = "unstable-2018-06-06";
 
   src = fetchFromGitHub {
     owner = "tohojo";

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
@@ -9,12 +9,11 @@ let
 
 in
   stdenv.mkDerivation rec {
-    name = "salut-a-toi-${version}";
+    pname = "salut-a-toi";
     version = "0.6.1";
-    pname = "sat-${version}";
 
     src = fetchurl {
-      url = "ftp://ftp.goffi.org/sat/${pname}.tar.bz2";
+      url = "ftp://ftp.goffi.org/sat/sat-${version}.tar.bz2";
       sha256 = "0kn9403n8fpzl0hsb9kkzicsmzq2fjl627l31yykbqzc4nsr780d";
     };
 

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -12,7 +12,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "remmina-${version}";
+  pname = "remmina";
   version = "1.2.32";
 
   src = fetchFromGitLab {

--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "babluboy";
     repo = pname;
-    rev = version;
+    rev = "4f7b118281667d22f1b3205edf0b775341fa49cb";
     sha256 = "0bcyim87zk4b4xmgfs158lnds3y8jg7ppzw54kjpc9rh66fpn3b9";
   };
 

--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -3,9 +3,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bookworm";
-  version = "4f7b118281667d22f1b3205edf0b775341fa49cb";
-
-  name = "${pname}-2018-10-21";
+  version = "unstable-2018-10-21";
 
   src = fetchFromGitHub {
     owner = "babluboy";

--- a/pkgs/applications/science/misc/sasview/xhtml2pdf.nix
+++ b/pkgs/applications/science/misc/sasview/xhtml2pdf.nix
@@ -3,6 +3,7 @@
 let
   #xhtml2pdf specifically requires version "1.0b10" of html5lib
   html5 = html5lib.overrideAttrs( oldAttrs: rec{
+    name = "${oldAttrs.pname}-${version}";
     version = "1.0b10";
     src = oldAttrs.src.override {
       inherit version;

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -16,7 +16,8 @@ rec {
     } :
   let
     docker-runc = runc.overrideAttrs (oldAttrs: rec {
-      name = "docker-runc";
+      name = "docker-runc-${version}";
+      inherit version;
       src = fetchFromGitHub {
         owner = "docker";
         repo = "runc";
@@ -28,7 +29,8 @@ rec {
     });
 
     docker-containerd = (containerd.override { inherit go; }).overrideAttrs (oldAttrs: rec {
-      name = "docker-containerd";
+      name = "docker-containerd-${version}";
+      inherit version;
       src = fetchFromGitHub {
         owner = "docker";
         repo = "containerd";
@@ -42,7 +44,8 @@ rec {
     });
 
     docker-tini = tini.overrideAttrs  (oldAttrs: rec {
-      name = "docker-init";
+      name = "docker-init-${version}";
+      inherit version;
       src = fetchFromGitHub {
         owner = "krallin";
         repo = "tini";

--- a/pkgs/build-support/fetchegg/default.nix
+++ b/pkgs/build-support/fetchegg/default.nix
@@ -8,7 +8,7 @@ if md5 != "" then
   throw "fetchegg does not support md5 anymore, please use sha256"
 else
 stdenvNoCC.mkDerivation {
-  name = "chicken-${name}-export";
+  name = "chicken-${name}-export-${version}";
   builder = ./builder.sh;
   nativeBuildInputs = [ chicken ];
 

--- a/pkgs/development/beam-modules/hex-registry-snapshot.nix
+++ b/pkgs/development/beam-modules/hex-registry-snapshot.nix
@@ -1,9 +1,9 @@
 {stdenv, writeText, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-    name = "hex-registry";
+    pname = "hex-registry";
     rev = "11d7a24e9f53f52490ce255a6248e71128e73aa1";
-    version = "20180712.${rev}";
+    version = "unstable-2018-07-12";
 
     src = fetchFromGitHub {
         inherit rev;

--- a/pkgs/development/beam-modules/hex/default.nix
+++ b/pkgs/development/beam-modules/hex/default.nix
@@ -7,13 +7,13 @@ let
   };
 
   pkg = self: stdenv.mkDerivation rec {
-    name = "hex";
-    version = "v0.17.1";
+    pname = "hex";
+    version = "0.17.1";
 
     src = fetchFromGitHub {
         owner = "hexpm";
         repo = "hex";
-        rev = "${version}";
+        rev = "v${version}";
         sha256 = "1s4asar1mcavzj3w37jcz243ka0z5jm0r42yws3h4aagawxxg02z";
     };
 

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -65,7 +65,7 @@ in rec {
 
   mx = stdenv.mkDerivation rec {
     version = "5.192.0";
-    name = "mx";
+    pname = "mx";
     src = fetchFromGitHub {
       owner  = "graalvm";
       repo   = "mx";

--- a/pkgs/development/libraries/elf-header/default.nix
+++ b/pkgs/development/libraries/elf-header/default.nix
@@ -12,7 +12,7 @@ let
 in
 
 stdenvNoCC.mkDerivation {
-  name = "elf-header";
+  pname = "elf-header";
   inherit (libc) version;
 
   src = null;

--- a/pkgs/development/libraries/gsignond/default.nix
+++ b/pkgs/development/libraries/gsignond/default.nix
@@ -6,16 +6,15 @@
 let
 unwrapped = stdenv.mkDerivation rec {
   pname = "gsignond";
-  version = "39022c86ddb5062a10fb0503ad9d81a8e532d527";
+  version = "unstable-2018-10-04";
 
-  name = "${pname}-2018-10-04";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
     owner = "accounts-sso";
     repo = pname;
-    rev = version;
+    rev = "39022c86ddb5062a10fb0503ad9d81a8e532d527";
     sha256 = "1gw8vbj3j6wxqy759z97arm8lnqhmraw9s2frv3ar6crnfhlidff";
   };
 

--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -3,12 +3,12 @@
   flex, yacc, zlib, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "igraph";
+  pname = "igraph";
   version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "igraph";
-    repo = name;
+    repo = pname;
     rev = version;
     sha256 = "1wsy0r511gk069il6iqjs27q8cjvqz20gf0a7inybx1bw84845z8";
   };

--- a/pkgs/development/libraries/libsignal-protocol-c/default.nix
+++ b/pkgs/development/libraries/libsignal-protocol-c/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "libsignal-protocol-c";
+  pname = "libsignal-protocol-c";
   version = "2.3.2";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/libsignon-glib/default.nix
+++ b/pkgs/development/libraries/libsignon-glib/default.nix
@@ -2,15 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libsignon-glib";
-  version = "3639a2e90447e4640a03a44972560afe8f61aa48";
-
-  name = "${pname}-2018-10-24";
+  version = "unstable-2018-10-24";
 
   outputs = [ "out" "dev" "devdoc" "py" ];
 
   src = fetchgit {
     url = "https://gitlab.com/accounts-sso/${pname}";
-    rev = version;
+    rev = "3639a2e90447e4640a03a44972560afe8f61aa48";
     fetchSubmodules = true;
     sha256 = "1cq19zbsx4c57dc5gp3shp8lzcr1hw2ynylpn1nkvfyyrx80m60w";
   };

--- a/pkgs/development/libraries/libxl/default.nix
+++ b/pkgs/development/libraries/libxl/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libxl";
+  pname = "libxl";
   version = "3.8.1";
 
   src = fetchurl {
-    url = "http://www.libxl.com/download/${name}-lin-${version}.tar.gz";
+    url = "http://www.libxl.com/download/${pname}-lin-${version}.tar.gz";
     sha256 = "1zdbahhyhr70s8hygwp43j9z4zmglyrr782hkcm1078yvkr2f2fm";
   };
 

--- a/pkgs/development/libraries/yojimbo/default.nix
+++ b/pkgs/development/libraries/yojimbo/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, premake5, doxygen, libsodium, mbedtls }:
 
 stdenv.mkDerivation rec {
-  name = "yojimbo";
+  pname = "yojimbo";
   version = "1.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/metaphone/default.nix
+++ b/pkgs/development/python-modules/metaphone/default.nix
@@ -1,9 +1,8 @@
 { stdenv, buildPythonPackage, isPy3k, fetchPypi, nose }:
 
 buildPythonPackage rec {
-  pname = "Metaphone";
+  pname = "metaphone";
   version = "0.6";
-  name  = "metaphone-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./setup.patch;
-      version = "3${stdenv.lib.versions.minor python.version}";
+      version_ = "3${stdenv.lib.versions.minor python.version}";
     })
   ];
 

--- a/pkgs/development/python-modules/py3exiv2/setup.patch
+++ b/pkgs/development/python-modules/py3exiv2/setup.patch
@@ -3,9 +3,9 @@
 @@ -39,7 +39,7 @@
                  if '3' in l[2:]:
                      return l.replace('libboost', 'boost')
- 
+
 -libboost = get_libboost_name()
-+libboost = 'boost_python@version@'
- 
++libboost = 'boost_python@version_@'
+
  setup(
      name='py3exiv2',

--- a/pkgs/development/python-modules/pyinputevent/default.nix
+++ b/pkgs/development/python-modules/pyinputevent/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "pyinputevent";
+  pname = "pyinputevent";
   version = "2016-10-18";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/pymaging/default.nix
+++ b/pkgs/development/python-modules/pymaging/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "pymaging";
+  pname = "pymaging";
   version = "unstable-2016-11-16";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/pymaging_png/default.nix
+++ b/pkgs/development/python-modules/pymaging_png/default.nix
@@ -5,7 +5,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "pymaging-png";
+  pname = "pymaging-png";
   version = "unstable-2016-11-16";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -11,11 +11,11 @@
 }:
 
 buildPythonPackage rec {
-  name = "qutip";
+  pname = "qutip";
   version = "2.2.0";
 
   src = fetchurl {
-    url = "https://qutip.googlecode.com/files/QuTiP-2.2.0.tar.gz";
+    url = "https://qutip.googlecode.com/files/QuTiP-${version}.tar.gz";
     sha256 = "a26a639d74b2754b3a1e329d91300e587e8c399d8a81d8f18a4a74c6d6f02ba3";
   };
 

--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -7,7 +7,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "rbtools";
+  pname = "rbtools";
   version = "0.7.2";
   disabled = isPy3k;
 

--- a/pkgs/development/python-modules/repocheck/default.nix
+++ b/pkgs/development/python-modules/repocheck/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "repocheck";
+  pname = "repocheck";
   version = "2015-08-05";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/snappergui/default.nix
+++ b/pkgs/development/python-modules/snappergui/default.nix
@@ -6,7 +6,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "Snapper-GUI";
+  pname = "Snapper-GUI";
   version = "0.1";
 
   src = fetchgit {

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -25,7 +25,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "Sphinx";
+  pname = "sphinx";
   version = "1.7.9";
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/svg2tikz/default.nix
+++ b/pkgs/development/python-modules/svg2tikz/default.nix
@@ -6,7 +6,7 @@
 }:
 
 buildPythonPackage {
-  name = "svg2tikz";
+  pname = "svg2tikz";
   version = "1.0.0";
   disabled = ! isPy27;
 

--- a/pkgs/development/python-modules/urwidtrees/default.nix
+++ b/pkgs/development/python-modules/urwidtrees/default.nix
@@ -5,7 +5,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "urwidtrees";
+  pname = "urwidtrees";
   version  = "1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/waitress-django/default.nix
+++ b/pkgs/development/python-modules/waitress-django/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "waitress-django";
   version = "0.0.0";
-  name = pname;
 
   src = ./.;
   pythonPath = [ django_1_8 waitress ];

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -29,7 +29,7 @@ let
   v8 = v8_3_16_14;
 
   rainbow_rake = buildRubyGem {
-    name = "rake";
+    pname = "rake";
     gemName = "rake";
     source.sha256 = "01j8fc9bqjnrsxbppncai05h43315vmz9fwg28qdsgcjw9ck1d7n";
     type = "gem";

--- a/pkgs/development/tools/icr/default.nix
+++ b/pkgs/development/tools/icr/default.nix
@@ -2,7 +2,7 @@
 , openssl, readline }:
 
 stdenv.mkDerivation rec {
-  name = "icr";
+  pname = "icr";
   version = "0.5.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/kubectx/default.nix
+++ b/pkgs/development/tools/kubectx/default.nix
@@ -3,12 +3,12 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "kubectx";
+  pname = "kubectx";
   version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "ahmetb";
-    repo = "${name}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1507g8sm73mqfsxl3fabmj37pk9l4jddsdi4qlpf0ixhk3z1lfkg";
   };

--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -82,7 +82,7 @@ let
   };
 };
 typeshed = stdenv.mkDerivation {
-  name = "typeshed";
+  pname = "typeshed";
   version = pyre-version;
   src = fetchFromGitHub {
     owner = "python";

--- a/pkgs/development/tools/scry/default.nix
+++ b/pkgs/development/tools/scry/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, crystal, shards, which }:
 
 stdenv.mkDerivation rec {
-  name = "scry";
+  pname = "scry";
   # 0.7.1 doesn't work with crystal > 0.25
   version = "0.7.1.20180919";
 

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -6,11 +6,12 @@ let
             , platform
             , extraMakeFlags ? []
             , extraMeta ? {}
+            , version ? "1.5"
             , ... } @ args:
            stdenv.mkDerivation (rec {
 
     name = "arm-trusted-firmware-${platform}-${version}";
-    version = "1.5";
+    inherit version;
 
     src = fetchFromGitHub {
       owner = "ARM-software";

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -26,7 +26,7 @@ in
 
 let plugins = {
   x770 =   stdenv.mkDerivation rec {
-    name = "iscan-gt-x770-bundle";
+    pname = "iscan-gt-x770-bundle";
     version = "1.0.1";
     pluginVersion = "2.1.2-1";
 
@@ -58,7 +58,7 @@ let plugins = {
     meta = common_meta // { description = "iscan esci x770 plugin for "+passthru.hw; };
     };
   f720 = stdenv.mkDerivation rec {
-    name = "iscan-gt-f720-bundle";
+    pname = "iscan-gt-f720-bundle";
     version = "1.0.1";
     pluginVersion = "0.1.1-2";
 

--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -23,7 +23,7 @@ let
   };
 
   hplipState = substituteAll {
-    inherit version;
+    version_ = version;
     src = ./hplip.state;
   };
 

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -25,7 +25,7 @@ let
   };
 
   hplipState = substituteAll {
-    inherit version;
+    version_ = version;
     src = ./hplip.state;
   };
 

--- a/pkgs/misc/drivers/hplip/hplip.state
+++ b/pkgs/misc/drivers/hplip/hplip.state
@@ -1,4 +1,4 @@
 [plugin]
 installed=1
 eula=1
-version=@version@
+version=@version_@

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -67,7 +67,7 @@ in with stdenv.lib.licenses;
     buildPhase = "make";
   };
 
-  beetle-pce-fast = (mkLibRetroCore rec {
+  beetle-pce-fast = let der = (mkLibRetroCore rec {
     core = "mednafen-pce-fast";
     src = fetchRetro {
       repo = "beetle-pce-fast-libretro";
@@ -76,12 +76,12 @@ in with stdenv.lib.licenses;
     };
     description = "Port of Mednafen's PC Engine core to libretro";
     license = gpl2;
-  }).override {
+  }); in der.override {
     buildPhase = "make";
-    name = "beetle-pce-fast";
+    name = "beetle-pce-fast-${der.version}";
   };
 
-  beetle-psx = (mkLibRetroCore rec {
+  beetle-psx = let der = (mkLibRetroCore rec {
     core = "mednafen-psx";
     src = fetchRetro {
       repo = "beetle-psx-libretro";
@@ -90,12 +90,12 @@ in with stdenv.lib.licenses;
     };
     description = "Port of Mednafen's PSX Engine core to libretro";
     license = gpl2;
-  }).override {
+  }); in der.override {
     buildPhase = "make";
-    name = "beetle-psx";
+    name = "beetle-psx-${der.version}";
   };
 
-  beetle-saturn = (mkLibRetroCore rec {
+  beetle-saturn = let der = (mkLibRetroCore rec {
     core = "mednafen-saturn";
     src = fetchRetro {
       repo = "beetle-saturn-libretro";
@@ -104,9 +104,9 @@ in with stdenv.lib.licenses;
     };
     description = "Port of Mednafen's Saturn core to libretro";
     license = gpl2;
-  }).override {
+  }); in der.override {
     buildPhase = "make";
-    name = "beetle-saturn";
+    name = "beetle-saturn-${der.version}";
     meta.platforms = [ "x86_64-linux" ];
   };
 

--- a/pkgs/servers/web-apps/fileshelter/default.nix
+++ b/pkgs/servers/web-apps/fileshelter/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, libzip, boost, wt3, libconfig, pkgconfig } :
 
 stdenv.mkDerivation rec {
-  name = "fileshelter";
+  pname = "fileshelter";
   version = "3.0.0";
 
   src = fetchFromGitHub {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -65,6 +65,8 @@ rec {
     , pos ? # position used in error messages and for meta.position
         (if attrs.meta.description or null != null
           then builtins.unsafeGetAttrPos "description" attrs.meta
+          else if attrs.version or null != null
+          then builtins.unsafeGetAttrPos "version" attrs
           else builtins.unsafeGetAttrPos "name" attrs)
     , separateDebugInfo ? false
     , outputs ? [ "out" ]
@@ -79,6 +81,15 @@ rec {
     , ... } @ attrs:
 
     let
+      # Check that the name is consistent with pname and version:
+      selfConsistent = (with attrs; attrs ? "name" ->
+        (lib.assertMsg (attrs ? "version" -> lib.strings.hasInfix version name)
+          "version ${version} does not appear in name ${name}" &&
+        lib.assertMsg (attrs ? "pname" -> lib.strings.hasInfix pname name)
+          "pname ${pname} does not appear in name ${name}"));
+
+      computedName = if name != "" then name else "${attrs.pname}-${attrs.version}";
+
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
       # no package has `doCheck = true`.
       doCheck' = doCheck && stdenv.hostPlatform == stdenv.buildPlatform;
@@ -175,7 +186,7 @@ rec {
         // {
           # A hack to make `nix-env -qa` and `nix search` ignore broken packages.
           # TODO(@oxij): remove this assert when something like NixOS/nix#1771 gets merged into nix.
-          name = assert validity.handled && (separateDebugInfo -> stdenv.hostPlatform.isLinux); name + lib.optionalString
+          name = assert selfConsistent && validity.handled && (separateDebugInfo -> stdenv.hostPlatform.isLinux); computedName + lib.optionalString
             # Fixed-output derivations like source tarballs shouldn't get a host
             # suffix. But we have some weird ones with run-time deps that are
             # just used for their side-affects. Those might as well since the
@@ -287,7 +298,7 @@ rec {
       meta = {
           # `name` above includes cross-compilation cruft (and is under assert),
           # lets have a clean always accessible version here.
-          inherit name;
+          name = computedName;
 
           # If the packager hasn't specified `outputsToInstall`, choose a default,
           # which is the name of `p.bin or p.out or p`;

--- a/pkgs/tools/misc/hid-listen/default.nix
+++ b/pkgs/tools/misc/hid-listen/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip }:
 stdenv.mkDerivation rec {
-  name = "hid-listen";
+  pname = "hid-listen";
   version = "1.01";
 
   src = fetchzip {

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "modem-manager-${version}";
-  pname = "ModemManager";
   version = "1.7.990";
 
+  package = "ModemManager";
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/${pname}/${pname}-${version}.tar.xz";
+    url = "https://www.freedesktop.org/software/${package}/${package}-${version}.tar.xz";
     sha256 = "1v4hixmghlrw7w4ajq2x4k62js0594h223d0yma365zwqr7hjrfl";
   };
 

--- a/pkgs/tools/networking/quickserve/default.nix
+++ b/pkgs/tools/networking/quickserve/default.nix
@@ -12,7 +12,7 @@ let
   };
   wrappedPython = python3.withPackages (_: [ threaded_servers ]);
 in stdenv.mkDerivation {
-  name = "quickserve";
+  pname = "quickserve";
   version = "2018";
 
   unpackPhase = ":";

--- a/pkgs/tools/system/lshw/default.nix
+++ b/pkgs/tools/system/lshw/default.nix
@@ -6,10 +6,10 @@ let numVersion = "02.18"; # :(
 in
 stdenv.mkDerivation rec {
   name = "lshw-${numVersion}b";
-  version = "B.${numVersion}";
+  version = "${numVersion}";
 
   src = fetchurl {
-    url = "https://ezix.org/software/files/lshw-${version}.tar.gz";
+    url = "https://ezix.org/software/files/lshw-B.${version}.tar.gz";
     sha256 = "0brwra4jld0d53d7jsgca415ljglmmx1l2iazpj4ndilr48yy8mf";
   };
 

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -20,6 +20,7 @@ let
       });
 
       pathspec = super.pathspec.overridePythonAttrs (oldAttrs: rec {
+        name = "${oldAttrs.pname}-${version}";
         version = "0.5.5";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10553,6 +10553,7 @@ with pkgs;
   in
     (gap.override { keepAllPackages = false; }).overrideAttrs (oldAttrs: {
       name = "libgap-${oldAttrs.pname}-${version}";
+      inherit version;
       src = fetchurl {
         url = "https://www.gap-system.org/pub/gap/gap48/tar.bz2/gap${version}_${pkgVer}.tar.bz2";
         sha256 = "19n2p1mdg33s2x9rs51iak7rgndc1cwr56jyqnah0g1ydgg1yh6b";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3727,6 +3727,7 @@ in {
 
   sphinx_1_2 = self.sphinx.overridePythonAttrs rec {
     name = "sphinx-1.2.3";
+    version = "1.2.3";
     src = pkgs.fetchurl {
       url = "mirror://pypi/s/sphinx/sphinx-1.2.3.tar.gz";
       sha256 = "94933b64e2fe0807da0612c574a021c0dac28c7bd3c4a23723ae5a39ea8f3d04";


### PR DESCRIPTION
###### Motivation for this change

Follow-up for https://github.com/NixOS/nixpkgs/pull/49398

##### TODO:

Should I split this up in two PR's? Part of this is good to go and should just go in the working tree straight away.

- [x] The basic change
- [x] Consistency check
- [x] Check the entire tree is consistent (it is now!)
- [ ] Document the new check
- [x] Docs for the new `hasInfix` library function
- [x] Currently interacts really weirdly with Coq, and I have no idea why.
- [x] Check everything still works.

cc @dtzWill 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

