### PR TITLE
dvtm-unstable: init at 2018-03-31

### DIFF
--- a/pkgs/tools/misc/dvtm/default.nix
+++ b/pkgs/tools/misc/dvtm/default.nix
@@ -1,11 +1,9 @@
-{ stdenv, fetchurl, ncurses, customConfig ? null }:
-
-stdenv.mkDerivation rec {
-
+{callPackage, fetchurl}:
+callPackage ./dvtm.nix rec {
   name = "dvtm-0.15";
 
   src = fetchurl {
-    url = "${meta.homepage}/${name}.tar.gz";
+    url = "http://www.brain-dump.org/projects/dvtm/${name}.tar.gz";
     sha256 = "0475w514b7i3gxk6khy8pfj2gx9l7lv2pwacmq92zn1abv01a84g";
   };
 
@@ -17,29 +15,5 @@ stdenv.mkDerivation rec {
       sha256 = "1cby8x3ckvhzqa8yxlfrwzgm8wk7yz84kr9psdjr7xwpnca1cqrd";
     })
   ];
-
-  CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
-
-  postPatch = stdenv.lib.optionalString (customConfig != null) ''
-    cp ${builtins.toFile "config.h" customConfig} ./config.h
-  '';
-
-  buildInputs = [ ncurses ];
-
-  prePatch = ''
-    substituteInPlace Makefile \
-      --replace /usr/share/terminfo $out/share/terminfo
-  '';
-
-  installPhase = ''
-    make PREFIX=$out install
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Dynamic virtual terminal manager";
-    homepage = http://www.brain-dump.org/projects/dvtm;
-    license = licenses.mit;
-    maintainers = [ maintainers.vrthra ];
-    platforms = platforms.unix;
-  };
 }
+    

--- a/pkgs/tools/misc/dvtm/dvtm.nix
+++ b/pkgs/tools/misc/dvtm/dvtm.nix
@@ -1,0 +1,30 @@
+{ stdenv, ncurses, customConfig ? null, name, src, patches ? [] }:
+stdenv.mkDerivation rec {
+
+  inherit name src patches;
+
+  CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
+
+  postPatch = stdenv.lib.optionalString (customConfig != null) ''
+    cp ${builtins.toFile "config.h" customConfig} ./config.h
+  '';
+
+  buildInputs = [ ncurses ];
+
+  prePatch = ''
+    substituteInPlace Makefile \
+      --replace /usr/share/terminfo $out/share/terminfo
+  '';
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Dynamic virtual terminal manager";
+    homepage = http://www.brain-dump.org/projects/dvtm;
+    license = licenses.mit;
+    maintainers = [ maintainers.vrthra ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/dvtm/unstable.nix
+++ b/pkgs/tools/misc/dvtm/unstable.nix
@@ -1,0 +1,29 @@
+{callPackage, fetchFromGitHub, fetchpatch}:
+callPackage ./dvtm.nix {
+  name = "dvtm-unstable-2018-03-31";
+
+  src = fetchFromGitHub {
+    owner = "martanne";
+    repo = "dvtm";
+    rev = "311a8c0c28296f8f87fb63349e0f3254c7481e14";
+    sha256 = "0pyxjkaxh8n97kccnmd3p98vi9h8mcfy5lswzqiplsxmxxmlbpx2";
+  };
+
+  patches = [
+    # https://github.com/martanne/dvtm/pull/69
+    # Use self-pipe instead of signal blocking fixes issues on darwin.
+    (fetchpatch {
+      name = "use-self-pipe-fix-darwin";
+      url = "https://github.com/martanne/dvtm/commit/1f1ed664d64603f3f1ce1388571227dc723901b2.patch";
+      sha256 = "14j3kks7b1v6qq12442v1da3h7khp02rp0vi0qrz0rfgkg1zilpb";
+    })
+
+    # https://github.com/martanne/dvtm/pull/86
+    # Fix buffer corruption when title is updated
+    (fetchpatch {
+      name = "fix-buffer-corruption-on-title-update";
+      url = "https://github.com/martanne/dvtm/commit/be6c3f8f615daeab214d484e6fff22e19631a0d1.patch";
+      sha256 = "1wdrl3sg815lhs22fwbc4w5dn4ifpdgl7v1kqfnhg752av4im7h7";
+    })
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2367,6 +2367,8 @@ with pkgs;
     # customConfig = builtins.readFile ./dvtm.config.h;
   };
 
+  dvtm-unstable = callPackage ../tools/misc/dvtm/unstable.nix {};
+
   ecmtools = callPackage ../tools/cd-dvd/ecm-tools { };
 
   e2tools = callPackage ../tools/filesystems/e2tools { };


### PR DESCRIPTION
###### Motivation for this change

While the project is still seeing commits coming in, there has not been a release in a while.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

