### PR TITLE
humanize: remove platform restriction

### DIFF
--- a/pkgs/development/python-modules/humanize/default.nix
+++ b/pkgs/development/python-modules/humanize/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     homepage = https://github.com/jmoiron/humanize;
     license = licenses.mit;
     maintainers = with maintainers; [ ];
-    platforms = platforms.linux; # can only test on linux
+    platforms = platforms.unix;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
This change allows humanize (and by extension, pgcli) to be built/used on OSX.

###### Things done
Removed platform restriction - it's nonsensical, as we disable execution of tests on line 18 anyway.
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
