### PR TITLE
Revert "NixOS tests: Wait for shell for 10x longer (50m)"

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -250,8 +250,7 @@ sub connect {
         $self->start;
 
         local $SIG{ALRM} = sub { die "timed out waiting for the VM to connect\n"; };
-        # 50 minutes -- increased as a test, see #49441
-        alarm 3000;
+        alarm 300;
         readline $self->{socket} or die "the VM quit before connecting\n";
         alarm 0;
 


### PR DESCRIPTION
This reverts commit 9bc10e12916979c5c620be5b521b9218a0077cba from #49441

This commit was used to debug the test failures in especially the internally restarting tests. Tests still experience the same timeout, however, with reduced frequency, which is probably due to the other recent efforts in stabilizing Hydra. Here's a recent failure from installer.zfsroot: https://hydra.nixos.org/build/83682241/nixlog/9/tail

```
machine# [   25.181616] dhcpcd[1162]: forked to background, child pid 1333
machine# [   25.187133] systemd[1]: Started DHCP Client.
machine# [   25.193277] systemd[1]: Reached target Network.
machine# [   25.197863] systemd[1]: Reached target Network is Online.
machine# [   25.327615] systemd[1]: Starting Permit User Sessions...
machine# [   25.329232] systemd[1]: Started Permit User Sessions.
machine# [   25.330600] systemd[1]: Started Getty on tty1.
machine# [   25.333924] systemd[1]: Reached target Login Prompts.
machine# [   25.337706] systemd[1]: Reached target Multi-User System.
machine# [   25.342149] systemd[1]: Startup finished in 9.169s (kernel) + 16.028s (userspace) = 25.198s.
machine# [   27.843749] dhcpcd[1333]: eth0: no IPv6 Routers available
machine# [  901.130707] systemd[1]: Starting Cleanup of Temporary Directories...
machine# [  901.149885] systemd[1]: Started Cleanup of Temporary Directories.
error: timed out waiting for the VM to connect
timed out waiting for the VM to connect
cleaning up
killing machine (pid 668)
vde_switch: EOF on stdin, cleaning up and exiting
builder for '/nix/store/7csvy3w7g99xd2ghl903zdhw08z2hyk7-vm-test-run-installer-zfs-root.drv' failed with exit code 4
```

This suggests to me that the increased timeout as suspected doesn't actually do anything, because the failure will occur regardless of how long we wait. If that turns out wrong, we can always re-revert, but I think the root cause should be sought elsewhere within the VM test framework.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

