### PR TITLE
nixos/rngd: do not pass --version flag

### DIFF
--- a/nixos/modules/security/rngd.nix
+++ b/nixos/modules/security/rngd.nix
@@ -29,7 +29,7 @@ with lib;
 
       description = "Hardware RNG Entropy Gatherer Daemon";
 
-      serviceConfig.ExecStart = "${pkgs.rng-tools}/sbin/rngd -f -v";
+      serviceConfig.ExecStart = "${pkgs.rng-tools}/sbin/rngd -f";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

At least for me, `rngd` immediately fails after printing the version number when started with the `-v` command line flag:
```
 1  decoysnail  ~  systemctl status rngd.service                                     Mon 05 Nov 2018 10:43:56 AM CET
● rngd.service - Hardware RNG Entropy Gatherer Daemon
   Loaded: loaded (/nix/store/a8sa4nijg2dgbhsmx8335niv3hn8nqwm-unit-rngd.service/rngd.service; linked; vendor preset: >
   Active: failed (Result: exit-code) since Mon 2018-11-05 10:36:54 CET; 8min ago
  Process: 30953 ExecStart=/nix/store/xhd1rkdc13g77c4ydzxyfpma3fgnb9w9-rng-tools-6.6/sbin/rngd -f -v (code=exited, sta>
 Main PID: 30953 (code=exited, status=1/FAILURE)

Nov 05 10:36:54 decoysnail systemd[1]: Started Hardware RNG Entropy Gatherer Daemon.
Nov 05 10:36:54 decoysnail rngd[30953]: rngd 6.6
Nov 05 10:36:54 decoysnail rngd[30953]: Copyright 2001-2004 Jeff Garzik
Nov 05 10:36:54 decoysnail rngd[30953]: Copyright 2017 Neil Horman
Nov 05 10:36:54 decoysnail rngd[30953]: Copyright (c) 2001 by Philipp Rumpf
Nov 05 10:36:54 decoysnail rngd[30953]: This is free software; see the source for copying conditions.  There is NO war>
Nov 05 10:36:54 decoysnail systemd[1]: rngd.service: Main process exited, code=exited, status=1/FAILURE
Nov 05 10:36:54 decoysnail systemd[1]: rngd.service: Failed with result 'exit-code'.
```

However it works when started without the `-v` flag:
```
 3  decoysnail  ~  sudo /nix/store/xhd1rkdc13g77c4ydzxyfpma3fgnb9w9-rng-tools-6.6/sbin/rngd -f

Initalizing available sources

Failed to init entropy source hwrng

Enabling RDRAND rng support

Initalizing entropy source rdrand
```

cc @JohnAZoidberg @c0bw3b

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

