### PR TITLE
coqPackages.ssreflect: refactor choice of source version

### DIFF
--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -18,8 +18,11 @@ let param =
 
 in
 
-stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-mathcomp-${param.version}";
+stdenv.mkDerivation rec {
+  name = "coq${coq.coq-version}-mathcomp-${version}";
+
+  # used in ssreflect
+  inherit (param) version;
 
   src = fetchFromGitHub {
     owner = "math-comp";
@@ -35,10 +38,11 @@ stdenv.mkDerivation {
 
   buildFlags = stdenv.lib.optionalString withDoc "doc";
 
+  COQBIN = "${coq}/bin/";
+
   preBuild = ''
     patchShebangs etc/utils/ssrcoqdep || true
     cd mathcomp
-    export COQBIN=${coq}/bin/
   '';
 
   installPhase = ''

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -2,26 +2,20 @@
 , graphviz, withDoc ? false
 }:
 
-let params =
+let param =
 
-  let param_1_7 = {
-      version = "1.7.0";
-      sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
-  }; in
-
+  if stdenv.lib.versionAtLeast coq.coq-version "8.6" then
   {
-    "8.5" =  {
-      version = "1.6.1";
-      sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
-    };
+    version = "1.7.0";
+    sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
+  }
+  else if stdenv.lib.versionAtLeast coq.coq-version "8.5" then
+  {
+    version = "1.6.1";
+    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
+  }
+  else throw "No version of math-comp is available for Coq ${coq.coq-version}";
 
-    "8.6" = param_1_7;
-    "8.7" = param_1_7;
-    "8.8" = param_1_7;
-    "8.9" = param_1_7;
-
-  };
-  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation {
@@ -59,7 +53,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.hasAttr v params;
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.5";
   };
 
 }

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coq, ncurses, which
+{ stdenv, fetchFromGitHub, coq, ncurses, which
 , graphviz, withDoc ? false
 }:
 
@@ -7,12 +7,12 @@ let param =
   if stdenv.lib.versionAtLeast coq.coq-version "8.6" then
   {
     version = "1.7.0";
-    sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
+    sha256 = "0wnhj9nqpx2bw6n1l4i8jgrw3pjajvckvj3lr4vzjb3my2lbxdd1";
   }
   else if stdenv.lib.versionAtLeast coq.coq-version "8.5" then
   {
     version = "1.6.1";
-    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
+    sha256 = "1ilw6vm4dlsdv9cd7kmf0vfrh2kkzr45wrqr8m37miy0byzr4p9i";
   }
   else throw "No version of math-comp is available for Coq ${coq.coq-version}";
 
@@ -21,8 +21,10 @@ in
 stdenv.mkDerivation {
   name = "coq${coq.coq-version}-mathcomp-${param.version}";
 
-  src = fetchurl {
-    url = "https://github.com/math-comp/math-comp/archive/mathcomp-${param.version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "math-comp";
+    repo = "math-comp";
+    rev = "mathcomp-${param.version}";
     inherit (param) sha256;
   };
 

--- a/pkgs/development/coq-modules/ssreflect/default.nix
+++ b/pkgs/development/coq-modules/ssreflect/default.nix
@@ -2,26 +2,20 @@
 , graphviz, withDoc ? false
 }:
 
-let params =
+let param =
 
-  let param_1_7 = {
+  if stdenv.lib.versionAtLeast coq.coq-version "8.6" then
+  {
     version = "1.7.0";
     sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
-  }; in
-
+  }
+  else if stdenv.lib.versionAtLeast coq.coq-version "8.5" then
   {
-    "8.5" =  {
-      version = "1.6.1";
-      sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
-    };
+    version = "1.6.1";
+    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
+  }
+  else throw "No version of SSReflect is available for Coq ${coq.coq-version}";
 
-    "8.6" = param_1_7;
-    "8.7" = param_1_7;
-    "8.8" = param_1_7;
-    "8.9" = param_1_7;
-
-  };
-  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation {
@@ -60,7 +54,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.hasAttr v params;
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.5";
   };
 
 }

--- a/pkgs/development/coq-modules/ssreflect/default.nix
+++ b/pkgs/development/coq-modules/ssreflect/default.nix
@@ -1,40 +1,22 @@
-{ stdenv, fetchurl, coq, ncurses, which
-, graphviz, withDoc ? false
+{ stdenv, fetchFromGitHub, coq, ncurses, which
+, graphviz, mathcomp, withDoc ? false
 }:
 
-let param =
+stdenv.mkDerivation rec {
+  name = "coq${coq.coq-version}-ssreflect-${version}";
 
-  if stdenv.lib.versionAtLeast coq.coq-version "8.6" then
-  {
-    version = "1.7.0";
-    sha256 = "05zgyi4wmasi1rcyn5jq42w0bi9713q9m8dl1fdgl66nmacixh39";
-  }
-  else if stdenv.lib.versionAtLeast coq.coq-version "8.5" then
-  {
-    version = "1.6.1";
-    sha256 = "1j9ylggjzrxz1i2hdl2yhsvmvy5z6l4rprwx7604401080p5sgjw";
-  }
-  else throw "No version of SSReflect is available for Coq ${coq.coq-version}";
-
-in
-
-stdenv.mkDerivation {
-
-  name = "coq${coq.coq-version}-ssreflect-${param.version}";
-  src = fetchurl {
-    url = "https://github.com/math-comp/math-comp/archive/mathcomp-${param.version}.tar.gz";
-    inherit (param) sha256;
-  };
+  inherit (mathcomp) src version meta;
 
   nativeBuildInputs = stdenv.lib.optionals withDoc [ graphviz ];
   buildInputs = [ coq ncurses which ] ++ (with coq.ocamlPackages; [ ocaml findlib camlp5 ]);
 
   enableParallelBuilding = true;
 
+  COQBIN = "${coq}/bin/";
+
   preBuild = ''
     patchShebangs etc/utils/ssrcoqdep || true
     cd mathcomp/ssreflect
-    export COQBIN=${coq}/bin/
   '';
 
   installPhase = ''
@@ -46,15 +28,5 @@ stdenv.mkDerivation {
     cp -r html $out/share/doc/coq/${coq.coq-version}/user-contrib/mathcomp/ssreflect/
   '';
 
-  meta = with stdenv.lib; {
-    homepage = http://ssr.msr-inria.inria.fr/;
-    license = licenses.cecill-b;
-    maintainers = with maintainers; [ vbgl jwiegley ];
-    inherit (coq.meta) platforms;
-  };
-
-  passthru = {
-    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.5";
-  };
-
+  passthru.compatibleCoqVersions = mathcomp.compatibleCoqVersions;
 }


### PR DESCRIPTION
###### Motivation for this change

Define a default version for SSReflect package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

