### PR TITLE
nixos/rspamd: Fix enable for locals and overrides

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -153,9 +153,10 @@ let
       ${cfg.extraConfig}
    '';
 
+  filterFiles = files: filterAttrs (n: v: v.enable) files;
   rspamdDir = pkgs.linkFarm "etc-rspamd-dir" (
-    (mapAttrsToList (name: file: { name = "local.d/${name}"; path = file.source; }) cfg.locals) ++
-    (mapAttrsToList (name: file: { name = "override.d/${name}"; path = file.source; }) cfg.overrides) ++
+    (mapAttrsToList (name: file: { name = "local.d/${name}"; path = file.source; }) (filterFiles cfg.locals)) ++
+    (mapAttrsToList (name: file: { name = "override.d/${name}"; path = file.source; }) (filterFiles cfg.overrides)) ++
     (optional (cfg.localLuaRules != null) { name = "rspamd.local.lua"; path = cfg.localLuaRules; }) ++
     [ { name = "rspamd.conf"; path = rspamdConfFile; } ]
   );
@@ -207,7 +208,7 @@ in
       };
 
       locals = mkOption {
-        type = with types; loaOf (submodule (configFileModule "locals"));
+        type = with types; attrsOf (submodule (configFileModule "locals"));
         default = {};
         description = ''
           Local configuration files, written into <filename>/etc/rspamd/local.d/{name}</filename>.
@@ -220,7 +221,7 @@ in
       };
 
       overrides = mkOption {
-        type = with types; loaOf (submodule (configFileModule "overrides"));
+        type = with types; attrsOf (submodule (configFileModule "overrides"));
         default = {};
         description = ''
           Overridden configuration files, written into <filename>/etc/rspamd/override.d/{name}</filename>.


### PR DESCRIPTION
###### Motivation for this change

When implementing #49620 I included an `enable` option for both the
`locals` and `overrides` options but the code writing the files didn't
actually look at `enable` and so would write the file regardless of its
value. I also set the type to `loaOf` which should have been `attrsOf`
since the code was not written to handle the options being lists.

This fixes both of those issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

