### PR TITLE
openarena: fix loading libGL.so with libglvnd

### DIFF
--- a/pkgs/games/openarena/default.nix
+++ b/pkgs/games/openarena/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, makeWrapper, patchelf, pkgs, stdenv, SDL, libogg, libvorbis, curl }:
+{ fetchurl, makeWrapper, patchelf, pkgs, stdenv, SDL, libglvnd, libogg, libvorbis, curl }:
 
 stdenv.mkDerivation rec {
   name = "openarena-${version}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   installPhase = let
     gameDir = "$out/openarena-$version";
     interpreter = "$(< \"$NIX_CC/nix-support/dynamic-linker\")";
-    libPath = stdenv.lib.makeLibraryPath [ SDL libogg libvorbis curl ];
+    libPath = stdenv.lib.makeLibraryPath [ SDL libglvnd libogg libvorbis curl ];
   in ''
     mkdir -pv $out/bin
     cd $out


### PR DESCRIPTION
###### Motivation for this change

openarena broken by libglvnd transition (https://github.com/NixOS/nixpkgs/pull/37369#issuecomment-435664238 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

