### PR TITLE
Chromium build optimizations

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -11,7 +11,7 @@
 , nspr, systemd, kerberos
 , utillinux, alsaLib
 , bison, gperf
-, glib, gtk2, gtk3, dbus-glib
+, glib, gtk3, dbus-glib
 , libXScrnSaver, libXcursor, libXtst, libGLU_combined
 , protobuf, speechd, libXdamage, cups
 , ffmpeg, libxslt, libxml2, at-spi2-core
@@ -119,7 +119,7 @@ let
       nspr nss systemd
       utillinux alsaLib
       bison gperf kerberos
-      glib gtk2 gtk3 dbus-glib
+      glib gtk3 dbus-glib
       libXScrnSaver libXcursor libXtst libGLU_combined
       pciutils protobuf speechd libXdamage
     ] ++ optional gnomeKeyringSupport libgnome-keyring3

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -133,6 +133,7 @@ let
       ./patches/nix_plugin_paths_68.patch
       ./patches/remove-webp-include-69.patch
       ./patches/jumbo-sorted.patch
+      ./patches/no-build-timestamps.patch
 
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -103,7 +103,7 @@ let
        else result;
 
   base = rec {
-    name = "${packageName}-${version}";
+    name = "${packageName}-unwrapped-${version}";
     inherit (upstream-info) version;
     inherit packageName buildType buildPath;
 

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -132,6 +132,7 @@ let
     patches = optional enableWideVine ./patches/widevine.patch ++ [
       ./patches/nix_plugin_paths_68.patch
       ./patches/remove-webp-include-69.patch
+      ./patches/jumbo-sorted.patch
 
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.

--- a/pkgs/applications/networking/browsers/chromium/patches/jumbo-sorted.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/jumbo-sorted.patch
@@ -1,0 +1,11 @@
+--- chromium-70.0.3538.67/build/config/merge_for_jumbo.py.old	2018-10-25 19:15:54.578222230 +0300
++++ chromium-70.0.3538.67/build/config/merge_for_jumbo.py	2018-10-25 19:20:44.397613032 +0300
+@@ -132,6 +132,8 @@
+       assert not inputs
+       continue
+ 
++    inputs.sort()
++    outputs.sort()
+     write_jumbo_files(inputs, outputs, written_input_set, written_output_set)
+ 
+   assert set(args.outputs) == written_output_set, "Did not fill all outputs"

--- a/pkgs/applications/networking/browsers/chromium/patches/no-build-timestamps.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/no-build-timestamps.patch
@@ -1,0 +1,15 @@
+--- chromium-70.0.3538.67/build/compute_build_timestamp.py.orig	2018-11-02 16:00:34.368933077 +0200
++++ chromium-70.0.3538.67/build/compute_build_timestamp.py	2018-11-03 18:35:20.542943107 +0200
+@@ -94,6 +94,12 @@
+       'build_type', help='The type of build', choices=('official', 'default'))
+   args = argument_parser.parse_args()
+ 
++  # I don't trust LASTCHANGE magic, and I definelly want something deterministic here
++  SOURCE_DATE_EPOCH = os.getenv("SOURCE_DATE_EPOCH", None)
++  if SOURCE_DATE_EPOCH is not None:
++      print SOURCE_DATE_EPOCH
++      return 0
++
+   # The mtime of the revision in build/util/LASTCHANGE is stored in a file
+   # next to it. Read it, to get a deterministic time close to "now".
+   # That date is then modified as described at the top of the file so that

--- a/pkgs/applications/networking/browsers/chromium/patches/no-build-timestamps.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/no-build-timestamps.patch
@@ -1,14 +1,16 @@
 --- chromium-70.0.3538.67/build/compute_build_timestamp.py.orig	2018-11-02 16:00:34.368933077 +0200
-+++ chromium-70.0.3538.67/build/compute_build_timestamp.py	2018-11-03 18:35:20.542943107 +0200
-@@ -94,6 +94,12 @@
++++ chromium-70.0.3538.67/build/compute_build_timestamp.py	2018-11-08 04:06:21.658105129 +0200
+@@ -94,6 +94,14 @@
        'build_type', help='The type of build', choices=('official', 'default'))
    args = argument_parser.parse_args()
  
 +  # I don't trust LASTCHANGE magic, and I definelly want something deterministic here
 +  SOURCE_DATE_EPOCH = os.getenv("SOURCE_DATE_EPOCH", None)
 +  if SOURCE_DATE_EPOCH is not None:
-+      print SOURCE_DATE_EPOCH
-+      return 0
++    print SOURCE_DATE_EPOCH
++    return 0
++  else:
++    raise RuntimeError("SOURCE_DATE_EPOCH not set")
 +
    # The mtime of the revision in build/util/LASTCHANGE is stored in a file
    # next to it. Read it, to get a deterministic time close to "now".


### PR DESCRIPTION
###### Motivation for this change

Drop dependency on gtk2 (chromium itself now require gtk3 for theming)
Use SOURCE_DATE_EPOCH to build timestamp generation (I believe it more stable, than built-in magic based on LASTCOMMIT file and rounded to 5:00 of first monday on month).
Sort files when merge them for jumbo -- I not sure, if they feed to script in predictable order, so sorting forced in merger script)

/cc @domenkozar @volth 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

