### PR TITLE
docs: Remove redundancy

### DIFF
--- a/doc/quick-start.xml
+++ b/doc/quick-start.xml
@@ -147,8 +147,8 @@ $ git add pkgs/development/libraries/libfoo/default.nix</screen>
       </listitem>
       <listitem>
        <para>
-        You can use <command>nix-prefetch-url</command> (or similar
-        nix-prefetch-git, etc) <replaceable>url</replaceable> to get the
+        You can use <command>nix-prefetch-url</command>
+        <replaceable>url</replaceable> to get the
         SHA-256 hash of source distributions. There are similar commands as
         <command>nix-prefetch-git</command> and
         <command>nix-prefetch-hg</command> available in


### PR DESCRIPTION
In that paragraph the existence of nix-prefetch-git and co is mentioned twice.