### PR TITLE
bazel: support tools/bazel workspace bootstrap scripts

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -192,9 +192,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
+
+    # official wrapper scripts that searches for $WORKSPACE_ROOT/tools/bazel
+    # if it can’t find something in tools, it calls $out/bin/bazel-real
     cp scripts/packages/bazel.sh $out/bin/bazel
     mv output/bazel $out/bin/bazel-real
+
     wrapProgram "$out/bin/bazel" --set JAVA_HOME "${runJdk}"
+
+    # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
     mv output/bazel-complete.bash $out/share/bash-completion/completions/bazel
     cp scripts/zsh_completion/_bazel $out/share/zsh/site-functions/
@@ -204,23 +210,31 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     export TEST_TMPDIR=$(pwd)
 
+    hello_test () {
+      $out/bin/bazel test --test_output=errors \
+        examples/cpp:hello-success_test \
+        examples/java-native/src/test/java/com/example/myproject:hello
+    }
+
+    # test whether $WORKSPACE_ROOT/tools/bazel works
+
     mkdir -p tools
-    touch tools/bazel
+    cat > tools/bazel <<"EOF"
+    #!${stdenv.shell} -e
+    exit 1
+    EOF
     chmod +x tools/bazel
 
-    echo "#!/bin/bash -e" > tools/bazel
-    echo "exit 1" >> tools/bazel
+    # first call should fail if tools/bazel is used
+    ! hello_test
 
-    ! $out/bin/bazel test --test_output=errors \
-        examples/cpp:hello-success_test \
-        examples/java-native/src/test/java/com/example/myproject:hello
+    cat > tools/bazel <<"EOF"
+    #!${stdenv.shell} -e
+    exec "$BAZEL_REAL" "$@"
+    EOF
 
-    echo "#!/bin/bash -e" > tools/bazel
-    echo "exec \"\$BAZEL_REAL\" \"\$@\"" >> tools/bazel
-
-    $out/bin/bazel test --test_output=errors \
-        examples/cpp:hello-success_test \
-        examples/java-native/src/test/java/com/example/myproject:hello
+    # second call succeeds because it defers to $out/bin/bazel-real
+    hello_test
   '';
 
   # Save paths to hardcoded dependencies so Nix can detect them.

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -192,7 +192,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    mv output/bazel $out/bin
+    cp scripts/packages/bazel.sh $out/bin/bazel
+    mv output/bazel $out/bin/bazel-real
     wrapProgram "$out/bin/bazel" --set JAVA_HOME "${runJdk}"
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
     mv output/bazel-complete.bash $out/share/bash-completion/completions/bazel


### PR DESCRIPTION
###### Motivation for this change
The standard (non-Nix) Bazel installations support a Bazel preloader file in `$WORKSPACE_ROOT/tools/bazel`. This file is required to build many Bazel projects (OSS and private), so this PR adds support by copying over the missing bootstrap script from the Bazel repo.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

