### PR TITLE
Add Prometheus 2 service in parallel with 1.x version

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -339,6 +339,7 @@
       rss2email = 312;
       cockroachdb = 313;
       zoneminder = 314;
+      prometheus2 = 315;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -638,6 +639,7 @@
       rss2email = 312;
       cockroachdb = 313;
       zoneminder = 314;
+      prometheus2 = 315;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -4,31 +4,33 @@ with lib;
 
 let
   cfg = config.services.prometheus.alertmanager;
-  mkConfigFile = pkgs.writeText "alertmanager.yml" (builtins.toJSON cfg.configuration);
+  cfg2 = config.services.prometheus2.alertmanager;
+  mkConfigFile = amCfg:
+    pkgs.writeText "alertmanager.yml" (builtins.toJSON amCfg.configuration);
 
-  checkedConfig = file: pkgs.runCommand "checked-config" { buildInputs = [ cfg.package ]; } ''
-    ln -s ${file} $out
-    amtool check-config $out
-  '';
+  mkAlertmanagerYml = amCfg: let
+      checkedConfig = file:
+        pkgs.runCommand "checked-config" { buildInputs = [ amCfg.package ]; } ''
+        ln -s ${file} $out
+        amtool check-config $out
+      '';
+      yml = if amCfg.configText != null then
+        pkgs.writeText "alertmanager.yml" amCfg.configText
+        else mkConfigFile amCfg;
+    in
+      checkedConfig yml;
 
-  alertmanagerYml = let
-    yml = if cfg.configText != null then
-        pkgs.writeText "alertmanager.yml" cfg.configText
-        else mkConfigFile;
-    in checkedConfig yml;
-
-  cmdlineArgs = cfg.extraFlags ++ [
-    "--config.file ${alertmanagerYml}"
-    "--web.listen-address ${cfg.listenAddress}:${toString cfg.port}"
-    "--log.level ${cfg.logLevel}"
-    ] ++ (optional (cfg.webExternalUrl != null)
-      "--web.external-url ${cfg.webExternalUrl}"
-    ) ++ (optional (cfg.logFormat != null)
-      "--log.format ${cfg.logFormat}"
-  );
-in {
-  options = {
-    services.prometheus.alertmanager = {
+  mkCmdlineArgs = amCfg:
+    amCfg.extraFlags ++ [
+    "--config.file ${mkAlertmanagerYml amCfg}"
+    "--web.listen-address ${amCfg.listenAddress}:${toString amCfg.port}"
+    "--log.level ${amCfg.logLevel}"
+    ] ++ (optional (amCfg.webExternalUrl != null)
+      "--web.external-url ${amCfg.webExternalUrl}"
+    ) ++ (optional (amCfg.logFormat != null)
+      "--log.format ${amCfg.logFormat}"
+    );
+    amOptions = {
       enable = mkEnableOption "Prometheus Alertmanager";
 
       package = mkOption {
@@ -134,36 +136,44 @@ in {
         '';
       };
     };
+    mkAMConfig = amCfg: amVersion:
+      config = mkMerge [
+        (mkIf amCfg.enable {
+          assertions = singleton {
+            assertion = amCfg.configuration != null || amCfg.configText != null;
+            message = "Can not enable alertmanager without a configuration. "
+             + "Set either the `configuration` or `configText` attribute.";
+          };
+        })
+        (mkIf amCfg.enable {
+          networking.firewall.allowedTCPPorts = optional amCfg.openFirewall amCfg.port;
+
+          systemd.services."alertmanager${amVersion}" = {
+            wantedBy = [ "multi-user.target" ];
+            after    = [ "network.target" ];
+            script = ''
+              ${amCfg.package}/bin/alertmanager \
+                ${concatStringsSep " \\\n  " cmdlineArgs}
+            '';
+            serviceConfig = {
+              User = amCfg.user;
+              Group = amCfg.group;
+              Restart  = "always";
+              PrivateTmp = true;
+              WorkingDirectory = "/tmp";
+              ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+            };
+          };
+        })
+      ];
+in {
+  options = {
+    services.prometheus.alertmanager = amOptions;
+    services.prometheus2.alertmanager = amOptions;
   };
 
   config = mkMerge [
-    (mkIf cfg.enable {
-      assertions = singleton {
-        assertion = cfg.configuration != null || cfg.configText != null;
-        message = "Can not enable alertmanager without a configuration. "
-         + "Set either the `configuration` or `configText` attribute.";
-      };
-    })
-    (mkIf cfg.enable {
-      networking.firewall.allowedTCPPorts = optional cfg.openFirewall cfg.port;
-
-      systemd.services.alertmanager = {
-        wantedBy = [ "multi-user.target" ];
-        after    = [ "network.target" ];
-        script = ''
-          ${cfg.package}/bin/alertmanager \
-            ${concatStringsSep " \\\n  " cmdlineArgs}
-        '';
-
-        serviceConfig = {
-          User = cfg.user;
-          Group = cfg.group;
-          Restart  = "always";
-          PrivateTmp = true;
-          WorkingDirectory = "/tmp";
-          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        };
-      };
-    })
+    (mkAMConfig cfg "")
+    (mkAMConfig cfg2 "2")
   ];
 }

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -152,7 +152,7 @@ let
           after    = [ "network.target" ];
           script = ''
             ${amCfg.package}/bin/alertmanager \
-              ${concatStringsSep " \\\n  " cmdlineArgs}
+              ${concatStringsSep " \\\n  " (mkCmdlineArgs amCfg)}
           '';
           serviceConfig = {
             User = amCfg.user;

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -4,8 +4,11 @@ with lib;
 
 let
   cfg = config.services.prometheus;
+  cfg2 = config.services.prometheus2;
   promUser = "prometheus";
   promGroup = "prometheus";
+  prom2User = "prometheus2";
+  prom2Group = "prometheus2";
 
   # Get a submodule without any embedded metadata:
   _filter = x: filterAttrs (k: v: k != "_module") x;
@@ -17,13 +20,21 @@ let
     promtool ${what} $out
   '';
 
+  # a wrapper that verifies that the configuration is valid for
+  # prometheus 2
+  prom2toolCheck = what: name: file: pkgs.runCommand "${name}-${what}-checked"
+    { buildInputs = [ cfg2.package ]; } ''
+    ln -s ${file} $out
+    promtool ${what} $out
+  '';
+
   # Pretty-print JSON to a file
   writePrettyJSON = name: x:
     pkgs.runCommand name { } ''
       echo '${builtins.toJSON x}' | ${pkgs.jq}/bin/jq . > $out
     '';
 
-  # This becomes the main config file
+  # This becomes the main config file for Prometheus 1
   promConfig = {
     global = cfg.globalConfig;
     rule_files = map (promtoolCheck "check-rules" "rules") (cfg.ruleFiles ++ [
@@ -35,7 +46,7 @@ let
   generatedPrometheusYml = writePrettyJSON "prometheus.yml" promConfig;
 
   prometheusYml = let
-    yml =  if cfg.configText != null then
+    yml = if cfg.configText != null then
       pkgs.writeText "prometheus.yml" cfg.configText
       else generatedPrometheusYml;
     in promtoolCheck "check-config" "prometheus.yml" yml;
@@ -48,6 +59,39 @@ let
     "-alertmanager.timeout=${toString cfg.alertmanagerTimeout}s"
     (optionalString (cfg.alertmanagerURL != []) "-alertmanager.url=${concatStringsSep "," cfg.alertmanagerURL}")
     (optionalString (cfg.webExternalUrl != null) "-web.external-url=${cfg.webExternalUrl}")
+  ];
+
+  # This becomes the main config file for Prometheus 2
+  promConfig2 = {
+    global = cfg2.globalConfig;
+    rule_files = map (prom2toolCheck "check-rules" "rules") (cfg2.ruleFiles ++ [
+      (pkgs.writeText "prometheus.rules" (concatStringsSep "\n" cfg2.rules))
+    ]);
+    scrape_configs = cfg2.scrapeConfigs;
+    alerting = optionalAttrs (cfg2.alertmanagerURL != []) {
+      alertmanagers = [{
+        static_configs = [{
+          targets = cfg2.alertmanagerURL;
+        }];
+      }];
+    };
+  };
+
+  generatedPrometheus2Yml = writePrettyJSON "prometheus.yml" promConfig2;
+
+  prometheus2Yml = let
+    yml = if cfg2.configText != null then
+      pkgs.writeText "prometheus.yml" cfg2.configText
+      else generatedPrometheus2Yml;
+    in promtoo2lCheck "check-config" "prometheus.yml" yml;
+
+  cmdlineArgs2 = cfg2.extraFlags ++ [
+    "--storage.tsdb.path=${cfg2.dataDir}/data/"
+    "--config.file=${prometheus2Yml}"
+    "--web.listen-address=${cfg2.listenAddress}"
+    "--alertmanager.notification-queue-capacity=${toString cfg2.alertmanagerNotificationQueueCapacity}"
+    "--alertmanager.timeout=${toString cfg2.alertmanagerTimeout}s"
+    (optionalString (cfg2.webExternalUrl != null) "-web.external-url=${cfg2.webExternalUrl}")
   ];
 
   promTypes.globalConfig = types.submodule {
@@ -497,30 +541,178 @@ in {
         '';
       };
     };
-  };
+    services.prometheus2 = {
 
-  config = mkIf cfg.enable {
-    users.groups.${promGroup}.gid = config.ids.gids.prometheus;
-    users.users.${promUser} = {
-      description = "Prometheus daemon user";
-      uid = config.ids.uids.prometheus;
-      group = promGroup;
-      home = cfg.dataDir;
-      createHome = true;
-    };
-    systemd.services.prometheus = {
-      wantedBy = [ "multi-user.target" ];
-      after    = [ "network.target" ];
-      script = ''
-        #!/bin/sh
-        exec ${cfg.package}/bin/prometheus \
-          ${concatStringsSep " \\\n  " cmdlineArgs}
-      '';
-      serviceConfig = {
-        User = promUser;
-        Restart  = "always";
-        WorkingDirectory = cfg.dataDir;
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the Prometheus 2 monitoring daemon.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.prometheus_2;
+        defaultText = "pkgs.prometheus_2";
+        description = ''
+          The prometheus2 package that should be used.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0:9090";
+        description = ''
+          Address to listen on for the web interface, API, and telemetry.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/prometheus2";
+        description = ''
+          Directory to store Prometheus 2 metrics data.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Extra commandline options when launching Prometheus 2.
+        '';
+      };
+
+      configText = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          If non-null, this option defines the text that is written to
+          prometheus.yml. If null, the contents of prometheus.yml is generated
+          from the structured config options.
+        '';
+      };
+
+      globalConfig = mkOption {
+        type = promTypes.globalConfig;
+        default = {};
+        apply = _filter;
+        description = ''
+          Parameters that are valid in all  configuration contexts. They
+          also serve as defaults for other configuration sections
+        '';
+      };
+
+      rules = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Alerting and/or Recording rules to evaluate at runtime.
+        '';
+      };
+
+      ruleFiles = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          Any additional rules files to include in this configuration.
+        '';
+      };
+
+      scrapeConfigs = mkOption {
+        type = types.listOf promTypes.scrape_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          A list of scrape configurations.
+        '';
+      };
+
+      alertmanagerURL = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          List of Alertmanager URLs to send notifications to.
+        '';
+      };
+
+      alertmanagerNotificationQueueCapacity = mkOption {
+        type = types.int;
+        default = 10000;
+        description = ''
+          The capacity of the queue for pending alert manager notifications.
+        '';
+      };
+
+      alertmanagerTimeout = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+          Alert manager HTTP API timeout (in seconds).
+        '';
+      };
+
+      webExternalUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "https://example.com/";
+        description = ''
+          The URL under which Prometheus is externally reachable (for example,
+          if Prometheus is served via a reverse proxy).
+        '';
       };
     };
-  };
+   };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      users.groups.${promGroup}.gid = config.ids.gids.prometheus;
+      users.users.${promUser} = {
+        description = "Prometheus daemon user";
+        uid = config.ids.uids.prometheus;
+        group = promGroup;
+        home = cfg.dataDir;
+        createHome = true;
+      };
+      systemd.services.prometheus = {
+        wantedBy = [ "multi-user.target" ];
+        after    = [ "network.target" ];
+        script = ''
+          #!/bin/sh
+          exec ${cfg.package}/bin/prometheus \
+            ${concatStringsSep " \\\n  " cmdlineArgs}
+        '';
+        serviceConfig = {
+          User = promUser;
+          Restart  = "always";
+          WorkingDirectory = cfg.dataDir;
+        };
+      };
+    })
+    (mkIf cfg2.enable {
+      users.groups.${prom2Group}.gid = config.ids.gids.prometheus2;
+      users.users.${prom2User} = {
+        description = "Prometheus2 daemon user";
+        uid = config.ids.uids.prometheus2;
+        group = prom2Group;
+        home = cfg2.dataDir;
+        createHome = true;
+      };
+      systemd.services.prometheus2 = {
+        wantedBy = [ "multi-user.target" ];
+        after    = [ "network.target" ];
+        script = ''
+          #!/bin/sh
+          exec ${cfg.package}/bin/prometheus \
+            ${concatStringsSep " \\\n  " cmdlineArgs2}
+        '';
+        serviceConfig = {
+          User = prom2User;
+          Restart  = "always";
+          WorkingDirectory = cfg2.dataDir;
+        };
+      };
+    })
+  ];
 }

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -4,8 +4,10 @@ with lib;
 
 let
   cfg = config.services.prometheus.exporters;
+  cfg2 = config.services.prometheus2.exporters;
 
-  # each attribute in `exporterOpts` is expected to have specified:
+  # each attribute in `exporterOpts` is a function that when executed
+  # with `cfg` or `cfg2` as parameter is expected to have specified:
   #   - port        (types.int):   port on which the exporter listens
   #   - serviceOpts (types.attrs): config that is merged with the
   #                                default definition of the exporter's
@@ -108,13 +110,18 @@ let
     };
   };
 
-  mkSubModules = (foldl' (a: b: a//b) {}
-    (mapAttrsToList (name: opts: mkSubModule {
-      inherit name;
-      inherit (opts) port serviceOpts;
-      extraOpts = opts.extraOpts or {};
-    }) exporterOpts)
-  );
+  mkSubModules = exCfg:
+    (foldl' (a: b: a//b) {}
+      (mapAttrsToList (name: confGen:
+        let
+          conf = (confGen exCfg);
+        in
+          mkSubModule {
+            inherit name;
+            inherit (conf) port serviceOpts;
+            extraOpts = conf.extraOpts or {};
+          }) exporterOpts)
+    );
 
   mkExporterConf = { name, conf, serviceOpts }:
     mkIf conf.enable {
@@ -133,11 +140,36 @@ let
         serviceConfig.Group = conf.group;
       });
   };
+  mkExportersConfig = exCfg: promVersion:
+    ([{
+      assertions = [{
+        assertion = (exCfg.snmp.configurationPath == null) != (exCfg.snmp.configuration == null);
+        message = ''
+          Please ensure you have either `services.prometheus.exporters.snmp.configuration'
+          or `services.prometheus${promVersion}.exporters.snmp.configurationPath' set!
+        '';
+      }];
+    }] ++ [(mkIf config.services.minio.enable {
+      services."prometheus${promVersion}".exporters.minio = {
+        minioAddress  = mkDefault "http://localhost:9000";
+        minioAccessKey = mkDefault config.services.minio.accessKey;
+        minioAccessSecret = mkDefault config.services.minio.secretKey;
+      };
+    })] ++ (mapAttrsToList (name: confGen:
+      let
+        conf = (confGen exCfg);
+      in
+      mkExporterConf {
+        inherit name;
+        inherit (conf) serviceOpts;
+        conf = exCfg.${name};
+      }) exporterOpts)
+    );
 in
 {
   options.services.prometheus.exporters = mkOption {
     type = types.submodule {
-      options = (mkSubModules);
+      options = (mkSubModules cfg);
     };
     description = "Prometheus exporter configuration";
     default = {};
@@ -152,25 +184,24 @@ in
     '';
   };
 
-  config = mkMerge ([{
-    assertions = [{
-      assertion = (cfg.snmp.configurationPath == null) != (cfg.snmp.configuration == null);
-      message = ''
-        Please ensure you have either `services.prometheus.exporters.snmp.configuration'
-          or `services.prometheus.exporters.snmp.configurationPath' set!
-      '';
-    }];
-  }] ++ [(mkIf config.services.minio.enable {
-    services.prometheus.exporters.minio.minioAddress  = mkDefault "http://localhost:9000";
-    services.prometheus.exporters.minio.minioAccessKey = mkDefault config.services.minio.accessKey;
-    services.prometheus.exporters.minio.minioAccessSecret = mkDefault config.services.minio.secretKey;
-  })] ++ (mapAttrsToList (name: conf:
-    mkExporterConf {
-      inherit name;
-      inherit (conf) serviceOpts;
-      conf = cfg.${name};
-    }) exporterOpts)
-  );
+  options.services.prometheus2.exporters = mkOption {
+    type = types.submodule {
+      options = (mkSubModules cfg2);
+    };
+    description = "Prometheus 2 exporter configuration";
+    default = {};
+    example = literalExample ''
+      {
+        node = {
+          enable = true;
+          enabledCollectors = [ "systemd" ];
+        };
+        varnish.enable = true;
+      }
+    '';
+  };
+
+  config = mkMerge ((mkExportersConfig cfg "") ++ (mkExportersConfig cfg2 "2"));
 
   meta = {
     doc = ./exporters.xml;

--- a/nixos/modules/services/monitoring/prometheus/exporters/bind.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/bind.nix
@@ -2,54 +2,55 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.bind;
-in
-{
-  port = 9119;
-  extraOpts = {
-    bindURI = mkOption {
-      type = types.str;
-      default = "http://localhost:8053/";
-      description = ''
-        HTTP XML API address of an Bind server.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.bind;
+  in
+  {
+    port = 9119;
+    extraOpts = {
+      bindURI = mkOption {
+        type = types.str;
+        default = "http://localhost:8053/";
+        description = ''
+          HTTP XML API address of an Bind server.
+        '';
+      };
+      bindTimeout = mkOption {
+        type = types.str;
+        default = "10s";
+        description = ''
+          Timeout for trying to get stats from Bind.
+        '';
+      };
+      bindVersion = mkOption {
+        type = types.enum [ "xml.v2" "xml.v3" "auto" ];
+        default = "auto";
+        description = ''
+          BIND statistics version. Can be detected automatically.
+        '';
+      };
+      bindGroups = mkOption {
+        type = types.listOf (types.enum [ "server" "view" "tasks" ]);
+        default = [ "server" "view" ];
+        description = ''
+          List of statistics to collect. Available: [server, view, tasks]
+        '';
+      };
     };
-    bindTimeout = mkOption {
-      type = types.str;
-      default = "10s";
-      description = ''
-        Timeout for trying to get stats from Bind.
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-bind-exporter}/bin/bind_exporter \
+            -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            -bind.pid-file /var/run/named/named.pid \
+            -bind.timeout ${toString cfg.bindTimeout} \
+            -bind.stats-url ${cfg.bindURI} \
+            -bind.stats-version ${cfg.bindVersion} \
+            -bind.stats-groups ${concatStringsSep "," cfg.bindGroups} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-    bindVersion = mkOption {
-      type = types.enum [ "xml.v2" "xml.v3" "auto" ];
-      default = "auto";
-      description = ''
-        BIND statistics version. Can be detected automatically.
-      '';
-    };
-    bindGroups = mkOption {
-      type = types.listOf (types.enum [ "server" "view" "tasks" ]);
-      default = [ "server" "view" ];
-      description = ''
-        List of statistics to collect. Available: [server, view, tasks]
-      '';
-    };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-bind-exporter}/bin/bind_exporter \
-          -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          -bind.pid-file /var/run/named/named.pid \
-          -bind.timeout ${toString cfg.bindTimeout} \
-          -bind.stats-url ${cfg.bindURI} \
-          -bind.stats-version ${cfg.bindVersion} \
-          -bind.stats-groups ${concatStringsSep "," cfg.bindGroups} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
@@ -2,30 +2,31 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.blackbox;
-in
-{
-  port = 9115;
-  extraOpts = {
-    configFile = mkOption {
-      type = types.path;
-      description = ''
-        Path to configuration file.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.blackbox;
+  in
+  {
+    port = 9115;
+    extraOpts = {
+      configFile = mkOption {
+        type = types.path;
+        description = ''
+          Path to configuration file.
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      AmbientCapabilities = [ "CAP_NET_RAW" ]; # for ping probes
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-blackbox-exporter}/bin/blackbox_exporter \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --config.file ${cfg.configFile} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-      ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+    serviceOpts = {
+      serviceConfig = {
+        AmbientCapabilities = [ "CAP_NET_RAW" ]; # for ping probes
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-blackbox-exporter}/bin/blackbox_exporter \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            --config.file ${cfg.configFile} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      };
     };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
@@ -2,77 +2,78 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.collectd;
-in
-{
-  port = 9103;
-  extraOpts = {
-    collectdBinary = {
-      enable = mkEnableOption "collectd binary protocol receiver";
+baseCfg:
+  let
+    cfg = baseCfg.collectd;
+  in
+  {
+    port = 9103;
+    extraOpts = {
+      collectdBinary = {
+        enable = mkEnableOption "collectd binary protocol receiver";
 
-      authFile = mkOption {
-        default = null;
-        type = types.nullOr types.path;
-        description = "File mapping user names to pre-shared keys (passwords).";
-      };
+        authFile = mkOption {
+          default = null;
+          type = types.nullOr types.path;
+          description = "File mapping user names to pre-shared keys (passwords).";
+        };
 
-      port = mkOption {
-        type = types.int;
-        default = 25826;
-        description = ''Network address on which to accept collectd binary network packets.'';
-      };
+        port = mkOption {
+          type = types.int;
+          default = 25826;
+          description = ''Network address on which to accept collectd binary network packets.'';
+        };
 
-      listenAddress = mkOption {
-        type = types.str;
-        default = "0.0.0.0";
-        description = ''
-          Address to listen on for binary network packets.
+        listenAddress = mkOption {
+          type = types.str;
+          default = "0.0.0.0";
+          description = ''
+            Address to listen on for binary network packets.
+            '';
+        };
+
+        securityLevel = mkOption {
+          type = types.enum ["None" "Sign" "Encrypt"];
+          default = "None";
+          description = ''
+            Minimum required security level for accepted packets.
           '';
+        };
       };
 
-      securityLevel = mkOption {
-        type = types.enum ["None" "Sign" "Encrypt"];
-        default = "None";
+      logFormat = mkOption {
+        type = types.str;
+        default = "logger:stderr";
+        example = "logger:syslog?appname=bob&local=7 or logger:stdout?json=true";
         description = ''
-          Minimum required security level for accepted packets.
+          Set the log target and format.
+        '';
+      };
+
+      logLevel = mkOption {
+        type = types.enum ["debug" "info" "warn" "error" "fatal"];
+        default = "info";
+        description = ''
+          Only log messages with the given severity or above.
         '';
       };
     };
-
-    logFormat = mkOption {
-      type = types.str;
-      default = "logger:stderr";
-      example = "logger:syslog?appname=bob&local=7 or logger:stdout?json=true";
-      description = ''
-        Set the log target and format.
-      '';
+    serviceOpts = let
+      collectSettingsArgs = if (cfg.collectdBinary.enable) then ''
+        -collectd.listen-address ${cfg.collectdBinary.listenAddress}:${toString cfg.collectdBinary.port} \
+        -collectd.security-level ${cfg.collectdBinary.securityLevel} \
+      '' else "";
+    in {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-collectd-exporter}/bin/collectd_exporter \
+            -log.format ${cfg.logFormat} \
+            -log.level ${cfg.logLevel} \
+            -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            ${collectSettingsArgs} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-
-    logLevel = mkOption {
-      type = types.enum ["debug" "info" "warn" "error" "fatal"];
-      default = "info";
-      description = ''
-        Only log messages with the given severity or above.
-      '';
-    };
-  };
-  serviceOpts = let
-    collectSettingsArgs = if (cfg.collectdBinary.enable) then ''
-      -collectd.listen-address ${cfg.collectdBinary.listenAddress}:${toString cfg.collectdBinary.port} \
-      -collectd.security-level ${cfg.collectdBinary.securityLevel} \
-    '' else "";
-  in {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-collectd-exporter}/bin/collectd_exporter \
-          -log.format ${cfg.logFormat} \
-          -log.level ${cfg.logLevel} \
-          -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          ${collectSettingsArgs} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/dnsmasq.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dnsmasq.nix
@@ -2,38 +2,39 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.dnsmasq;
-in
-{
-  port = 9153;
-  extraOpts = {
-    dnsmasqListenAddress = mkOption {
-      type = types.str;
-      default = "localhost:53";
-      description = ''
-        Address on which dnsmasq listens.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.dnsmasq;
+  in
+  {
+    port = 9153;
+    extraOpts = {
+      dnsmasqListenAddress = mkOption {
+        type = types.str;
+        default = "localhost:53";
+        description = ''
+          Address on which dnsmasq listens.
+        '';
+      };
+      leasesPath = mkOption {
+        type = types.path;
+        default = "/var/lib/misc/dnsmasq.leases";
+        example = "/var/lib/dnsmasq/dnsmasq.leases";
+        description = ''
+          Path to the <literal>dnsmasq.leases</literal> file.
+        '';
+      };
     };
-    leasesPath = mkOption {
-      type = types.path;
-      default = "/var/lib/misc/dnsmasq.leases";
-      example = "/var/lib/dnsmasq/dnsmasq.leases";
-      description = ''
-        Path to the <literal>dnsmasq.leases</literal> file.
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-dnsmasq-exporter}/bin/dnsmasq_exporter \
+            --listen ${cfg.listenAddress}:${toString cfg.port} \
+            --dnsmasq ${cfg.dnsmasqListenAddress} \
+            --leases_path ${cfg.leasesPath} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-dnsmasq-exporter}/bin/dnsmasq_exporter \
-          --listen ${cfg.listenAddress}:${toString cfg.port} \
-          --dnsmasq ${cfg.dnsmasqListenAddress} \
-          --leases_path ${cfg.leasesPath} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dovecot.nix
@@ -2,71 +2,72 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.dovecot;
-in
-{
-  port = 9166;
-  extraOpts = {
-    telemetryPath = mkOption {
-      type = types.str;
-      default = "/metrics";
-      description = ''
-        Path under which to expose metrics.
-      '';
-    };
-    socketPath = mkOption {
-      type = types.path;
-      default = "/var/run/dovecot/stats";
-      example = "/var/run/dovecot2/old-stats";
-      description = ''
-        Path under which the stats socket is placed.
-        The user/group under which the exporter runs,
-        should be able to access the socket in order
-        to scrape the metrics successfully.
+baseCfg:
+  let
+    cfg = baseCfg.dovecot;
+  in
+  {
+    port = 9166;
+    extraOpts = {
+      telemetryPath = mkOption {
+        type = types.str;
+        default = "/metrics";
+        description = ''
+          Path under which to expose metrics.
+        '';
+      };
+      socketPath = mkOption {
+        type = types.path;
+        default = "/var/run/dovecot/stats";
+        example = "/var/run/dovecot2/old-stats";
+        description = ''
+          Path under which the stats socket is placed.
+          The user/group under which the exporter runs,
+          should be able to access the socket in order
+          to scrape the metrics successfully.
 
-        Please keep in mind that the stats module has changed in
-        <link xlink:href="https://wiki2.dovecot.org/Upgrading/2.3">Dovecot 2.3+</link> which
-        is not <link xlink:href="https://github.com/kumina/dovecot_exporter/issues/8">compatible with this exporter</link>.
+          Please keep in mind that the stats module has changed in
+          <link xlink:href="https://wiki2.dovecot.org/Upgrading/2.3">Dovecot 2.3+</link> which
+          is not <link xlink:href="https://github.com/kumina/dovecot_exporter/issues/8">compatible with this exporter</link>.
 
-        The following extra config has to be passed to Dovecot to ensure that recent versions
-        work with this exporter:
-        <programlisting>
-        {
-          <xref linkend="opt-services.prometheus.exporters.dovecot.enable" /> = true;
-          <xref linkend="opt-services.prometheus.exporters.dovecot.socketPath" /> = "/var/run/dovecot2/old-stats";
-          <xref linkend="opt-services.dovecot2.extraConfig" /> = '''
-            mail_plugins = $mail_plugins old_stats
-            service old-stats {
-              unix_listener old-stats {
-                user = nobody
-                group = nobody
+          The following extra config has to be passed to Dovecot to ensure that recent versions
+          work with this exporter:
+          <programlisting>
+          {
+            <xref linkend="opt-services.prometheus.exporters.dovecot.enable" /> = true;
+            <xref linkend="opt-services.prometheus.exporters.dovecot.socketPath" /> = "/var/run/dovecot2/old-stats";
+            <xref linkend="opt-services.dovecot2.extraConfig" /> = '''
+              mail_plugins = $mail_plugins old_stats
+              service old-stats {
+                unix_listener old-stats {
+                  user = nobody
+                  group = nobody
+                }
               }
-            }
-          ''';
-        }
-        </programlisting>
-      '';
+            ''';
+          }
+          </programlisting>
+        '';
+      };
+      scopes = mkOption {
+        type = types.listOf types.str;
+        default = [ "user" ];
+        example = [ "user" "global" ];
+        description = ''
+          Stats scopes to query.
+        '';
+      };
     };
-    scopes = mkOption {
-      type = types.listOf types.str;
-      default = [ "user" ];
-      example = [ "user" "global" ];
-      description = ''
-        Stats scopes to query.
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.prometheus-dovecot-exporter}/bin/dovecot_exporter \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            --web.telemetry-path ${cfg.telemetryPath} \
+            --dovecot.socket-path ${cfg.socketPath} \
+            --dovecot.scopes ${concatStringsSep "," cfg.scopes} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      ExecStart = ''
-        ${pkgs.prometheus-dovecot-exporter}/bin/dovecot_exporter \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --web.telemetry-path ${cfg.telemetryPath} \
-          --dovecot.socket-path ${cfg.socketPath} \
-          --dovecot.scopes ${concatStringsSep "," cfg.scopes} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/fritzbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fritzbox.nix
@@ -2,38 +2,39 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.fritzbox;
-in
-{
-  port = 9133;
-  extraOpts = {
-    gatewayAddress = mkOption {
-      type = types.str;
-      default = "fritz.box";
-      description = ''
-        The hostname or IP of the FRITZ!Box.
-      '';
-    };
+baseCfg:
+  let
+    cfg = baseCfg.fritzbox;
+  in
+  {
+    port = 9133;
+    extraOpts = {
+      gatewayAddress = mkOption {
+        type = types.str;
+        default = "fritz.box";
+        description = ''
+          The hostname or IP of the FRITZ!Box.
+        '';
+      };
 
-    gatewayPort = mkOption {
-      type = types.int;
-      default = 49000;
-      description = ''
-        The port of the FRITZ!Box UPnP service.
-      '';
+      gatewayPort = mkOption {
+        type = types.int;
+        default = 49000;
+        description = ''
+          The port of the FRITZ!Box UPnP service.
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-fritzbox-exporter}/bin/fritzbox_exporter \
-          -listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          -gateway-address ${cfg.gatewayAddress} \
-          -gateway-port ${toString cfg.gatewayPort} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-fritzbox-exporter}/bin/fritzbox_exporter \
+            -listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            -gateway-address ${cfg.gatewayAddress} \
+            -gateway-port ${toString cfg.gatewayPort} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/json.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/json.nix
@@ -2,35 +2,36 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.json;
-in
-{
-  port = 7979;
-  extraOpts = {
-    url = mkOption {
-      type = types.str;
-      description = ''
-        URL to scrape JSON from.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.json;
+  in
+  {
+    port = 7979;
+    extraOpts = {
+      url = mkOption {
+        type = types.str;
+        description = ''
+          URL to scrape JSON from.
+        '';
+      };
+      configFile = mkOption {
+        type = types.path;
+        description = ''
+          Path to configuration file.
+        '';
+      };
+      listenAddress = {}; # not used
     };
-    configFile = mkOption {
-      type = types.path;
-      description = ''
-        Path to configuration file.
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-json-exporter}/bin/prometheus-json-exporter \
+            --port ${toString cfg.port} \
+            ${cfg.url} ${cfg.configFile} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-    listenAddress = {}; # not used
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-json-exporter}/bin/prometheus-json-exporter \
-          --port ${toString cfg.port} \
-          ${cfg.url} ${cfg.configFile} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/minio.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/minio.nix
@@ -2,64 +2,65 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.minio;
-in
-{
-  port = 9290;
-  extraOpts = {
-    minioAddress = mkOption {
-      type = types.str;
-      example = "https://10.0.0.1:9000";
-      description = ''
-        The URL of the minio server.
-        Use HTTPS if Minio accepts secure connections only.
-        By default this connects to the local minio server if enabled.
-      '';
-    };
+baseCfg:
+  let
+    cfg = baseCfg.minio;
+  in
+  {
+    port = 9290;
+    extraOpts = {
+      minioAddress = mkOption {
+        type = types.str;
+        example = "https://10.0.0.1:9000";
+        description = ''
+          The URL of the minio server.
+          Use HTTPS if Minio accepts secure connections only.
+          By default this connects to the local minio server if enabled.
+        '';
+      };
 
-    minioAccessKey = mkOption {
-      type = types.str;
-      example = "yourMinioAccessKey";
-      description = ''
-        The value of the Minio access key.
-        It is required in order to connect to the server.
-        By default this uses the one from the local minio server if enabled
-        and <literal>config.services.minio.accessKey</literal>.
-      '';
-    };
+      minioAccessKey = mkOption {
+        type = types.str;
+        example = "yourMinioAccessKey";
+        description = ''
+          The value of the Minio access key.
+          It is required in order to connect to the server.
+          By default this uses the one from the local minio server if enabled
+          and <literal>config.services.minio.accessKey</literal>.
+        '';
+      };
 
-    minioAccessSecret = mkOption {
-      type = types.str;
-      description = ''
-        The value of the Minio access secret.
-        It is required in order to connect to the server.
-        By default this uses the one from the local minio server if enabled
-        and <literal>config.services.minio.secretKey</literal>.
-      '';
-    };
+      minioAccessSecret = mkOption {
+        type = types.str;
+        description = ''
+          The value of the Minio access secret.
+          It is required in order to connect to the server.
+          By default this uses the one from the local minio server if enabled
+          and <literal>config.services.minio.secretKey</literal>.
+        '';
+      };
 
-    minioBucketStats = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Collect statistics about the buckets and files in buckets.
-        It requires more computation, use it carefully in case of large buckets..
-      '';
+      minioBucketStats = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Collect statistics about the buckets and files in buckets.
+          It requires more computation, use it carefully in case of large buckets..
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-minio-exporter}/bin/minio-exporter \
-          -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          -minio.server ${cfg.minioAddress} \
-          -minio.access-key ${cfg.minioAccessKey} \
-          -minio.access-secret ${cfg.minioAccessSecret} \
-          ${optionalString cfg.minioBucketStats "-minio.bucket-stats"} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-minio-exporter}/bin/minio-exporter \
+            -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            -minio.server ${cfg.minioAddress} \
+            -minio.access-key ${cfg.minioAccessKey} \
+            -minio.access-secret ${cfg.minioAccessSecret} \
+            ${optionalString cfg.minioBucketStats "-minio.bucket-stats"} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/nginx.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nginx.nix
@@ -2,46 +2,47 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.nginx;
-in
-{
-  port = 9113;
-  extraOpts = {
-    scrapeUri = mkOption {
-      type = types.str;
-      default = "http://localhost/nginx_status";
-      description = ''
-        Address to access the nginx status page.
-        Can be enabled with services.nginx.statusPage = true.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.nginx;
+  in
+  {
+    port = 9113;
+    extraOpts = {
+      scrapeUri = mkOption {
+        type = types.str;
+        default = "http://localhost/nginx_status";
+        description = ''
+          Address to access the nginx status page.
+          Can be enabled with services.nginx.statusPage = true.
+        '';
+      };
+      telemetryEndpoint = mkOption {
+        type = types.str;
+        default = "/metrics";
+        description = ''
+          Path under which to expose metrics.
+        '';
+      };
+      insecure = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Ignore server certificate if using https.
+        '';
+      };
     };
-    telemetryEndpoint = mkOption {
-      type = types.str;
-      default = "/metrics";
-      description = ''
-        Path under which to expose metrics.
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-nginx-exporter}/bin/nginx_exporter \
+            --nginx.scrape_uri '${cfg.scrapeUri}' \
+            --telemetry.address ${cfg.listenAddress}:${toString cfg.port} \
+            --telemetry.endpoint ${cfg.telemetryEndpoint} \
+            --insecure ${toString cfg.insecure} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-    insecure = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Ignore server certificate if using https.
-      '';
-    };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-nginx-exporter}/bin/nginx_exporter \
-          --nginx.scrape_uri '${cfg.scrapeUri}' \
-          --telemetry.address ${cfg.listenAddress}:${toString cfg.port} \
-          --telemetry.endpoint ${cfg.telemetryEndpoint} \
-          --insecure ${toString cfg.insecure} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -2,39 +2,40 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.node;
-in
-{
-  port = 9100;
-  extraOpts = {
-    enabledCollectors = mkOption {
-      type = types.listOf types.string;
-      default = [];
-      example = ''[ "systemd" ]'';
-      description = ''
-        Collectors to enable. The collectors listed here are enabled in addition to the default ones.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.node;
+  in
+  {
+    port = 9100;
+    extraOpts = {
+      enabledCollectors = mkOption {
+        type = types.listOf types.string;
+        default = [];
+        example = ''[ "systemd" ]'';
+        description = ''
+          Collectors to enable. The collectors listed here are enabled in addition to the default ones.
+        '';
+      };
+      disabledCollectors = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ''[ "timex" ]'';
+        description = ''
+          Collectors to disable which are enabled by default.
+        '';
+      };
     };
-    disabledCollectors = mkOption {
-      type = types.listOf types.str;
-      default = [];
-      example = ''[ "timex" ]'';
-      description = ''
-        Collectors to disable which are enabled by default.
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        RuntimeDirectory = "prometheus-node-exporter";
+        ExecStart = ''
+          ${pkgs.prometheus-node-exporter}/bin/node_exporter \
+            ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
+            ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      RuntimeDirectory = "prometheus-node-exporter";
-      ExecStart = ''
-        ${pkgs.prometheus-node-exporter}/bin/node_exporter \
-          ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
-          ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
@@ -2,80 +2,81 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.postfix;
-in
-{
-  port = 9154;
-  extraOpts = {
-    telemetryPath = mkOption {
-      type = types.str;
-      default = "/metrics";
-      description = ''
-        Path under which to expose metrics.
-      '';
-    };
-    logfilePath = mkOption {
-      type = types.path;
-      default = "/var/log/postfix_exporter_input.log";
-      example = "/var/log/mail.log";
-      description = ''
-        Path where Postfix writes log entries.
-        This file will be truncated by this exporter!
-      '';
-    };
-    showqPath = mkOption {
-      type = types.path;
-      default = "/var/spool/postfix/public/showq";
-      example = "/var/lib/postfix/queue/public/showq";
-      description = ''
-        Path where Postfix places it's showq socket.
-      '';
-    };
-    systemd = {
-      enable = mkEnableOption ''
-        reading metrics from the systemd-journal instead of from a logfile
-      '';
-      unit = mkOption {
+baseCfg:
+  let
+    cfg = baseCfg.postfix;
+  in
+  {
+    port = 9154;
+    extraOpts = {
+      telemetryPath = mkOption {
         type = types.str;
-        default = "postfix.service";
+        default = "/metrics";
         description = ''
-          Name of the postfix systemd unit.
+          Path under which to expose metrics.
         '';
       };
-      slice = mkOption {
-        type = types.nullOr types.str;
-        default = null;
+      logfilePath = mkOption {
+        type = types.path;
+        default = "/var/log/postfix_exporter_input.log";
+        example = "/var/log/mail.log";
         description = ''
-          Name of the postfix systemd slice.
-          This overrides the <option>systemd.unit</option>.
+          Path where Postfix writes log entries.
+          This file will be truncated by this exporter!
         '';
       };
-      journalPath = mkOption {
-        type = types.nullOr types.path;
-        default = null;
+      showqPath = mkOption {
+        type = types.path;
+        default = "/var/spool/postfix/public/showq";
+        example = "/var/lib/postfix/queue/public/showq";
         description = ''
-          Path to the systemd journal.
+          Path where Postfix places it's showq socket.
+        '';
+      };
+      systemd = {
+        enable = mkEnableOption ''
+          reading metrics from the systemd-journal instead of from a logfile
+        '';
+        unit = mkOption {
+          type = types.str;
+          default = "postfix.service";
+          description = ''
+            Name of the postfix systemd unit.
+          '';
+        };
+        slice = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            Name of the postfix systemd slice.
+            This overrides the <option>systemd.unit</option>.
+          '';
+        };
+        journalPath = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            Path to the systemd journal.
+          '';
+        };
+      };
+    };
+    serviceOpts = {
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.prometheus-postfix-exporter}/bin/postfix_exporter \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            --web.telemetry-path ${cfg.telemetryPath} \
+            --postfix.showq_path ${cfg.showqPath} \
+            ${concatStringsSep " \\\n  " (cfg.extraFlags
+            ++ optional cfg.systemd.enable "--systemd.enable"
+            ++ optional cfg.systemd.enable (if cfg.systemd.slice != null
+                                            then "--systemd.slice ${cfg.systemd.slice}"
+                                            else "--systemd.unit ${cfg.systemd.unit}")
+            ++ optional (cfg.systemd.enable && (cfg.systemd.journalPath != null))
+                         "--systemd.jounal_path ${cfg.systemd.journalPath}"
+            ++ optional (!cfg.systemd.enable) "--postfix.logfile_path ${cfg.logfilePath}")}
         '';
       };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      ExecStart = ''
-        ${pkgs.prometheus-postfix-exporter}/bin/postfix_exporter \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --web.telemetry-path ${cfg.telemetryPath} \
-          --postfix.showq_path ${cfg.showqPath} \
-          ${concatStringsSep " \\\n  " (cfg.extraFlags
-          ++ optional cfg.systemd.enable "--systemd.enable"
-          ++ optional cfg.systemd.enable (if cfg.systemd.slice != null
-                                          then "--systemd.slice ${cfg.systemd.slice}"
-                                          else "--systemd.unit ${cfg.systemd.unit}")
-          ++ optional (cfg.systemd.enable && (cfg.systemd.journalPath != null))
-                       "--systemd.jounal_path ${cfg.systemd.journalPath}"
-          ++ optional (!cfg.systemd.enable) "--postfix.logfile_path ${cfg.logfilePath}")}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -2,70 +2,71 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.snmp;
-in
-{
-  port = 9116;
-  extraOpts = {
-    configurationPath = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      description = ''
-        Path to a snmp exporter configuration file. Mutually exclusive with 'configuration' option.
-      '';
-      example = "./snmp.yml";
-    };
+baseCfg:
+  let
+    cfg = baseCfg.snmp;
+  in
+  {
+    port = 9116;
+    extraOpts = {
+      configurationPath = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Path to a snmp exporter configuration file. Mutually exclusive with 'configuration' option.
+        '';
+        example = "./snmp.yml";
+      };
 
-    configuration = mkOption {
-      type = types.nullOr types.attrs;
-      default = {};
-      description = ''
-        Snmp exporter configuration as nix attribute set. Mutually exclusive with 'configurationPath' option.
-      '';
-      example = ''
-        {
-          "default" = {
-            "version" = 2;
-            "auth" = {
-              "community" = "public";
+      configuration = mkOption {
+        type = types.nullOr types.attrs;
+        default = {};
+        description = ''
+          Snmp exporter configuration as nix attribute set. Mutually exclusive with 'configurationPath' option.
+        '';
+        example = ''
+          {
+            "default" = {
+              "version" = 2;
+              "auth" = {
+                "community" = "public";
+              };
             };
           };
-        };
-      '';
-    };
+        '';
+      };
 
-    logFormat = mkOption {
-      type = types.str;
-      default = "logger:stderr";
-      description = ''
-        Set the log target and format.
-      '';
-    };
+      logFormat = mkOption {
+        type = types.str;
+        default = "logger:stderr";
+        description = ''
+          Set the log target and format.
+        '';
+      };
 
-    logLevel = mkOption {
-      type = types.enum ["debug" "info" "warn" "error" "fatal"];
-      default = "info";
-      description = ''
-        Only log messages with the given severity or above.
-      '';
+      logLevel = mkOption {
+        type = types.enum ["debug" "info" "warn" "error" "fatal"];
+        default = "info";
+        description = ''
+          Only log messages with the given severity or above.
+        '';
+      };
     };
-  };
-  serviceOpts = let
-    configFile = if cfg.configurationPath != null
-                 then cfg.configurationPath
-                 else "${pkgs.writeText "snmp-eporter-conf.yml" (builtins.toJSON cfg.configuration)}";
-    in {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-snmp-exporter.bin}/bin/snmp_exporter \
-          --config.file=${configFile} \
-          --log.format=${cfg.logFormat} \
-          --log.level=${cfg.logLevel} \
-          --web.listen-address=${cfg.listenAddress}:${toString cfg.port} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
+    serviceOpts = let
+      configFile = if cfg.configurationPath != null
+                   then cfg.configurationPath
+                   else "${pkgs.writeText "snmp-eporter-conf.yml" (builtins.toJSON cfg.configuration)}";
+      in {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-snmp-exporter.bin}/bin/snmp_exporter \
+            --config.file ${configFile} \
+            --log.format ${cfg.logFormat} \
+            --log.level ${cfg.logLevel} \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/surfboard.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/surfboard.nix
@@ -2,31 +2,32 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.surfboard;
-in
-{
-  port = 9239;
-  extraOpts = {
-    modemAddress = mkOption {
-      type = types.str;
-      default = "192.168.100.1";
-      description = ''
-        The hostname or IP of the cable modem.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.surfboard;
+  in
+  {
+    port = 9239;
+    extraOpts = {
+      modemAddress = mkOption {
+        type = types.str;
+        default = "192.168.100.1";
+        description = ''
+          The hostname or IP of the cable modem.
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    description = "Prometheus exporter for surfboard cable modem";
-    unitConfig.Documentation = "https://github.com/ipstatic/surfboard_exporter";
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-surfboard-exporter}/bin/surfboard_exporter \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --modem-address ${cfg.modemAddress} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
+    serviceOpts = {
+      description = "Prometheus exporter for surfboard cable modem";
+      unitConfig.Documentation = "https://github.com/ipstatic/surfboard_exporter";
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-surfboard-exporter}/bin/surfboard_exporter \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            --modem-address ${cfg.modemAddress} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/tor.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/tor.nix
@@ -2,44 +2,45 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.tor;
-in
-{
-  port = 9130;
-  extraOpts = {
-    torControlAddress = mkOption {
-      type = types.str;
-      default = "127.0.0.1";
-      description = ''
-        Tor control IP address or hostname.
-      '';
-    };
+baseCfg:
+  let
+    cfg = baseCfg.tor;
+  in
+  {
+    port = 9130;
+    extraOpts = {
+      torControlAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = ''
+          Tor control IP address or hostname.
+        '';
+      };
 
-    torControlPort = mkOption {
-      type = types.int;
-      default = 9051;
-      description = ''
-        Tor control port.
-      '';
+      torControlPort = mkOption {
+        type = types.int;
+        default = 9051;
+        description = ''
+          Tor control port.
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-tor-exporter}/bin/prometheus-tor-exporter \
-          -b ${cfg.listenAddress} \
-          -p ${toString cfg.port} \
-          -a ${cfg.torControlAddress} \
-          -c ${toString cfg.torControlPort} \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
-    };
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-tor-exporter}/bin/prometheus-tor-exporter \
+            -b ${cfg.listenAddress} \
+            -p ${toString cfg.port} \
+            -a ${cfg.torControlAddress} \
+            -c ${toString cfg.torControlPort} \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
 
-    # CPython requires a process to either have $HOME defined or run as a UID
-    # defined in /etc/passwd. The latter is false with DynamicUser, so define a
-    # dummy $HOME. https://bugs.python.org/issue10496
-    environment = { HOME = "/var/empty"; };
-  };
-}
+      # CPython requires a process to either have $HOME defined or run as a UID
+      # defined in /etc/passwd. The latter is false with DynamicUser, so define a
+      # dummy $HOME. https://bugs.python.org/issue10496
+      environment = { HOME = "/var/empty"; };
+    };
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/unifi.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/unifi.nix
@@ -2,66 +2,67 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.unifi;
-in
-{
-  port = 9130;
-  extraOpts = {
-    unifiAddress = mkOption {
-      type = types.str;
-      example = "https://10.0.0.1:8443";
-      description = ''
-        URL of the UniFi Controller API.
-      '';
-    };
+baseCfg:
+  let
+    cfg = baseCfg.unifi;
+  in
+  {
+    port = 9130;
+    extraOpts = {
+      unifiAddress = mkOption {
+        type = types.str;
+        example = "https://10.0.0.1:8443";
+        description = ''
+          URL of the UniFi Controller API.
+        '';
+      };
 
-    unifiInsecure = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        If enabled skip the verification of the TLS certificate of the UniFi Controller API.
-        Use with caution.
-      '';
-    };
+      unifiInsecure = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If enabled skip the verification of the TLS certificate of the UniFi Controller API.
+          Use with caution.
+        '';
+      };
 
-    unifiUsername = mkOption {
-      type = types.str;
-      example = "ReadOnlyUser";
-      description = ''
-        username for authentication against UniFi Controller API.
-      '';
-    };
+      unifiUsername = mkOption {
+        type = types.str;
+        example = "ReadOnlyUser";
+        description = ''
+          username for authentication against UniFi Controller API.
+        '';
+      };
 
-    unifiPassword = mkOption {
-      type = types.str;
-      description = ''
-        Password for authentication against UniFi Controller API.
-      '';
-    };
+      unifiPassword = mkOption {
+        type = types.str;
+        description = ''
+          Password for authentication against UniFi Controller API.
+        '';
+      };
 
-    unifiTimeout = mkOption {
-      type = types.str;
-      default = "5s";
-      example = "2m";
-      description = ''
-        Timeout including unit for UniFi Controller API requests.
-      '';
+      unifiTimeout = mkOption {
+        type = types.str;
+        default = "5s";
+        example = "2m";
+        description = ''
+          Timeout including unit for UniFi Controller API requests.
+        '';
+      };
     };
-  };
-  serviceOpts = {
-    serviceConfig = {
-      DynamicUser = true;
-      ExecStart = ''
-        ${pkgs.prometheus-unifi-exporter}/bin/unifi_exporter \
-          -telemetry.addr ${cfg.listenAddress}:${toString cfg.port} \
-          -unifi.addr ${cfg.unifiAddress} \
-          -unifi.username ${cfg.unifiUsername} \
-          -unifi.password ${cfg.unifiPassword} \
-          -unifi.timeout ${cfg.unifiTimeout} \
-          ${optionalString cfg.unifiInsecure "-unifi.insecure" } \
-          ${concatStringsSep " \\\n  " cfg.extraFlags}
-      '';
+    serviceOpts = {
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = ''
+          ${pkgs.prometheus-unifi-exporter}/bin/unifi_exporter \
+            -telemetry.addr ${cfg.listenAddress}:${toString cfg.port} \
+            -unifi.addr ${cfg.unifiAddress} \
+            -unifi.username ${cfg.unifiUsername} \
+            -unifi.password ${cfg.unifiPassword} \
+            -unifi.timeout ${cfg.unifiTimeout} \
+            ${optionalString cfg.unifiInsecure "-unifi.insecure" } \
+            ${concatStringsSep " \\\n  " cfg.extraFlags}
+        '';
+      };
     };
-  };
-}
+  }

--- a/nixos/modules/services/monitoring/prometheus/exporters/varnish.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/varnish.nix
@@ -2,87 +2,88 @@
 
 with lib;
 
-let
-  cfg = config.services.prometheus.exporters.varnish;
-in
-{
-  port = 9131;
-  extraOpts = {
-    noExit = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Do not exit server on Varnish scrape errors.
-      '';
+baseCfg:
+  let
+    cfg = baseCfg.varnish;
+  in
+  {
+    port = 9131;
+    extraOpts = {
+      noExit = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Do not exit server on Varnish scrape errors.
+        '';
+      };
+      withGoMetrics = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Export go runtime and http handler metrics.
+        '';
+      };
+      verbose = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable verbose logging.
+        '';
+      };
+      raw = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable raw stdout logging without timestamps.
+        '';
+      };
+      varnishStatPath = mkOption {
+        type = types.str;
+        default = "varnishstat";
+        description = ''
+          Path to varnishstat.
+        '';
+      };
+      instance = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          varnishstat -n value.
+        '';
+      };
+      healthPath = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Path under which to expose healthcheck. Disabled unless configured.
+        '';
+      };
+      telemetryPath = mkOption {
+        type = types.str;
+        default = "/metrics";
+        description = ''
+          Path under which to expose metrics.
+        '';
+      };
     };
-    withGoMetrics = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Export go runtime and http handler metrics.
-      '';
+    serviceOpts = {
+      path = [ pkgs.varnish ];
+      serviceConfig = {
+        DynamicUser = true;
+        RestartSec = mkDefault 1;
+        ExecStart = ''
+          ${pkgs.prometheus-varnish-exporter}/bin/prometheus_varnish_exporter \
+            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+            --web.telemetry-path ${cfg.telemetryPath} \
+            --varnishstat-path ${cfg.varnishStatPath} \
+            ${concatStringsSep " \\\n  " (cfg.extraFlags
+              ++ optional (cfg.healthPath != null) "--web.health-path ${cfg.healthPath}"
+              ++ optional (cfg.instance != null) "-n ${cfg.instance}"
+              ++ optional cfg.noExit "--no-exit"
+              ++ optional cfg.withGoMetrics "--with-go-metrics"
+              ++ optional cfg.verbose "--verbose"
+              ++ optional cfg.raw "--raw")}
+        '';
+      };
     };
-    verbose = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enable verbose logging.
-      '';
-    };
-    raw = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Enable raw stdout logging without timestamps.
-      '';
-    };
-    varnishStatPath = mkOption {
-      type = types.str;
-      default = "varnishstat";
-      description = ''
-        Path to varnishstat.
-      '';
-    };
-    instance = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = ''
-        varnishstat -n value.
-      '';
-    };
-    healthPath = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = ''
-        Path under which to expose healthcheck. Disabled unless configured.
-      '';
-    };
-    telemetryPath = mkOption {
-      type = types.str;
-      default = "/metrics";
-      description = ''
-        Path under which to expose metrics.
-      '';
-    };
-  };
-  serviceOpts = {
-    path = [ pkgs.varnish ];
-    serviceConfig = {
-      DynamicUser = true;
-      RestartSec = mkDefault 1;
-      ExecStart = ''
-        ${pkgs.prometheus-varnish-exporter}/bin/prometheus_varnish_exporter \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --web.telemetry-path ${cfg.telemetryPath} \
-          --varnishstat-path ${cfg.varnishStatPath} \
-          ${concatStringsSep " \\\n  " (cfg.extraFlags
-            ++ optional (cfg.healthPath != null) "--web.health-path ${cfg.healthPath}"
-            ++ optional (cfg.instance != null) "-n ${cfg.instance}"
-            ++ optional cfg.noExit "--no-exit"
-            ++ optional cfg.withGoMetrics "--with-go-metrics"
-            ++ optional cfg.verbose "--verbose"
-            ++ optional cfg.raw "--raw")}
-      '';
-    };
-  };
-}
+  }

--- a/nixos/tests/prometheus-2.nix
+++ b/nixos/tests/prometheus-2.nix
@@ -1,0 +1,34 @@
+import ./make-test.nix {
+  name = "prometheus-2";
+
+  nodes = {
+    one = { pkgs, ... }: {
+      services.prometheus2 = {
+        enable = true;
+        scrapeConfigs = [{
+          job_name = "prometheus";
+          static_configs = [{
+            targets = [ "127.0.0.1:9090" ];
+            labels = { instance = "localhost"; };
+          }];
+        }];
+        rules = [
+          ''
+            groups:
+              - name: test
+                rules:
+                  - record: testrule
+                    expr: count(up{job="prometheus"})
+          ''
+        ];
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+    $one->waitForUnit("prometheus2.service");
+    $one->waitForOpenPort(9090);
+    $one->succeed("curl -s http://127.0.0.1:9090/metrics");
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change

Cleaned up version of  #46069.  The reason for this is that there's no clean upgrade path from 1.x to 2.x, the suggested solution by the Prometheus team is that of let them run in parallel an use the 1.x instance as source for the 2.x.

in the original PR someone suggested a more copy and paste approach. I don't know, I don't really need Prometheus 1.x. So is up to you to decide

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

