### PR TITLE
falkon: enable qtwayland

### DIFF
--- a/pkgs/applications/networking/browsers/falkon/default.nix
+++ b/pkgs/applications/networking/browsers/falkon/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchFromGitHub, cmake, extra-cmake-modules, pkgconfig, qmake
-, libpthreadstubs, libxcb, libXdmcp, qtsvg, qttools, qtwebengine, qtx11extras, kwallet }:
+{ stdenv, lib, fetchFromGitHub, cmake, extra-cmake-modules, pkgconfig, qmake
+, libpthreadstubs, libxcb, libXdmcp
+, qtsvg, qttools, qtwebengine, qtx11extras
+, qtwayland
+, kwallet
+}:
 
 stdenv.mkDerivation rec {
   name = "falkon-${version}";
@@ -21,9 +25,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libpthreadstubs libxcb libXdmcp
+    qtsvg qttools qtwebengine qtx11extras
     kwallet
-    qtsvg qtwebengine qtx11extras
-  ];
+  ] ++ lib.optionals stdenv.isLinux [ qtwayland ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig qmake qttools ];
 


### PR DESCRIPTION
###### Motivation for this change
Enable wayland support in `falkon`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

