### PR TITLE
steamPackages.steam-runtime-wrapped: don't include all of gcc

### DIFF
--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -11,7 +11,7 @@ let
     libva1
     libvdpau
     vulkan-loader
-    gcc.cc
+    gcc.cc.lib
     nss
     nspr
     xorg.libxcb


### PR DESCRIPTION
###### Motivation for this change

As I understand it that override is used to provide a newer version of libstdc++ and for that the `lib` output alone should be sufficient.

/cc @abbradar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

