### PR TITLE
nixos/rspamd: Multiple workers, extraConfig priority & postfix integration

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -139,7 +139,7 @@ let
       }
 
       ${concatStringsSep "\n" (mapAttrsToList (name: value: ''
-        worker ${optionalString (value.name != "normal" && value.name != "controller") "${value.name}"} {
+        worker "${value.type}" {
           type = "${value.type}";
           ${optionalString (value.enable != null)
             "enabled = ${if value.enable != false then "yes" else "no"};"}

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -102,7 +102,8 @@ in
       $machine->log($machine->succeed("cat /etc/rspamd/rspamd.conf"));
       $machine->log($machine->succeed("grep 'CONFDIR/worker-controller.inc' /etc/rspamd/rspamd.conf"));
       $machine->log($machine->succeed("grep 'CONFDIR/worker-normal.inc' /etc/rspamd/rspamd.conf"));
-      $machine->log($machine->succeed("grep 'verysecretpassword' /etc/rspamd/rspamd.conf"));
+      $machine->log($machine->succeed("grep 'LOCAL_CONFDIR/override.d/worker-controller2.inc' /etc/rspamd/rspamd.conf"));
+      $machine->log($machine->succeed("grep 'verysecretpassword' /etc/rspamd/override.d/worker-controller2.inc"));
       $machine->waitUntilSucceeds("journalctl -u rspamd | grep -i 'starting controller process' >&2");
       $machine->log($machine->succeed("rspamc -h /run/rspamd-worker.sock stat"));
       $machine->log($machine->succeed("curl --unix-socket /run/rspamd-worker.sock http://localhost/ping"));


### PR DESCRIPTION
##### Motivation for this change

###### Multiple workers

When the workers option for rspamd was originally implemented it was based on a flawed understanding of how workers are configured in rspamd. This meant that while rspamd supports configuring multiple workers of the same type, so that different controller workers could have different passwords, the NixOS module did not support this because it would write an invalid configuration file if you tried.

Specifically a configuration like the one below:

```
workers.controller = {};
workers.controller2 = {
  type = "controller";
};
```

Would result in a rspamd configuration of:

```
worker {
  type = "controller";
  count = 1;
  .include "$CONFDIR/worker-controller.inc"
}
worker "controller2" {
  type = "controller";
  count = 1;
}
```

While to get multiple controller workers it should instead be:

```
worker "controller" {
  type = "controller";
  count = 1;
  .include "$CONFDIR/worker-controller.inc"
}
worker "controller" {
  type = "controller";
  count = 1;
}
```

###### extraConfig priority

The lines stored in `extraConfig` and `worker.<name?>.extraConfig` should take precedent over values from included files but in order to do this in rspamd UCL they need to be stored in a file that then gets included with a high priority. This commit uses the `overrides` option to store the value of the two `extraConfig` options in `extra-config.inc` and `worker-<name?>.inc` respectively.

###### postfix integration

The `rmilter` module has options for configuring `postfix` to use it but since that module is deprecated because rspamd now has a builtin worker that supports the milter protocol this PR adds similar `postfix` integration options directly to the `rspamd` module.

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
