### PR TITLE
pelican: markdown is needed at runtime

### DIFF
--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -30,13 +30,12 @@ buildPythonPackage rec {
     git
     mock
     nose
-    markdown
     typogrify
   ];
 
   propagatedBuildInputs = [
     jinja2 pygments docutils pytz unidecode six dateutil feedgenerator
-    blinker pillow beautifulsoup4 markupsafe lxml
+    blinker pillow beautifulsoup4 markupsafe lxml markdown
   ];
 
   postPatch= ''


### PR DESCRIPTION
###### Motivation for this change
Without markdown at runtime pelican will ignore all markdown
articles/pages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

