### PR TITLE
vimPlugins: vim-go: make gocode, gocode-mod and keyify available to it

### DIFF
--- a/pkgs/development/tools/gocode-gomod/default.nix
+++ b/pkgs/development/tools/gocode-gomod/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "gocode-gomod-unstable-${version}";
+  version = "2018-10-16";
+  rev = "12640289f65065d652cc942ffa01a52bece1dd53";
+
+  goPackagePath = "github.com/stamblerre/gocode";
+
+  # we must allow references to the original `go` package,
+  # because `gocode` needs to dig into $GOROOT to provide completions for the
+  # standard packages.
+  allowGoReference = true;
+
+  excludedPackages = ''internal/suggest/testdata'';
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "stamblerre";
+    repo = "gocode";
+    sha256 = "1avv0b5p2l8pv38m5gg97k57ndr5k9yy0rfkmmwjq96pa221hs1q";
+  };
+
+  goDeps = ./deps.nix;
+
+  postInstall = ''
+    mv $bin/bin/gocode $bin/bin/gocode-gomod
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An autocompletion daemon for the Go programming language";
+    longDescription = ''
+      Gocode is a helper tool which is intended to be integrated with your
+      source code editor, like vim, neovim and emacs. It provides several
+      advanced capabilities, which currently includes:
+
+        - Context-sensitive autocompletion
+
+      It is called daemon, because it uses client/server architecture for
+      caching purposes. In particular, it makes autocompletions very fast.
+      Typical autocompletion time with warm cache is 30ms, which is barely
+      noticeable.
+    '';
+    homepage = https://github.com/stamblerre/gocode;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/tools/gocode-gomod/deps.nix
+++ b/pkgs/development/tools/gocode-gomod/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "78dc5bac0cacea7969e98b79c3b86597e0aa4e25";
+      sha256 = "16jg2x1sfm39kz4rchn0gxyq99fnkxw6v51wxriqbs76a2wrznp9";
+    };
+  }
+]

--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -2,10 +2,11 @@
 
 buildGoPackage rec {
   name = "gocode-unstable-${version}";
-  version = "2018-10-22";
-  rev = "e893215113e5f7594faa3a8eb176c2700c921276";
+  version = "2018-11-05";
+  rev = "0af7a86943a6e0237c90f8aeb74a882e1862c898";
 
   goPackagePath = "github.com/mdempsky/gocode";
+  excludedPackages = ''internal/suggest/testdata'';
 
   # we must allow references to the original `go` package,
   # because `gocode` needs to dig into $GOROOT to provide completions for the
@@ -17,16 +18,10 @@ buildGoPackage rec {
 
     owner = "mdempsky";
     repo = "gocode";
-    sha256 = "1zsll7yghv64890k7skl0g2lg9rsaiisgrfnb8kshsxrcxi1kc2l";
+    sha256 = "0fxqn0v6dbwarn444lc1xrx5vfkcidi73f4ba7l4clsb9qdqgyam";
   };
 
   goDeps = ./deps.nix;
-
-  preBuild = ''
-    # getting an error building the testdata because they contain invalid files
-    # on purpose as part of the testing.
-    rm -r go/src/$goPackagePath/internal/suggest/testdata
-  '';
 
   meta = with stdenv.lib; {
     description = "An autocompletion daemon for the Go programming language";

--- a/pkgs/development/tools/gocode/deps.nix
+++ b/pkgs/development/tools/gocode/deps.nix
@@ -4,8 +4,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/tools";
-      rev = "6fe81c087942f588f40c3f67b41ce284f2f70eee";
-      sha256 = "04yl7rk2lf94bxz74ja5snh7ava9gcnf2yx6y002pfkk538r6w5d";
+      rev = "78dc5bac0cacea7969e98b79c3b86597e0aa4e25";
+      sha256 = "16jg2x1sfm39kz4rchn0gxyq99fnkxw6v51wxriqbs76a2wrznp9";
     };
   }
 ]

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -276,8 +276,8 @@ with generated;
     in {
     postPatch = ''
       ${gnused}/bin/sed \
-        -Ee 's@let go_bin_path = go#path#BinPath\(\)@let go_bin_path = "${binPath}"@g' \
-        -i autoload/go/path.vim
+        -Ee 's@"go_bin_path", ""@"go_bin_path", "${binPath}"@g' \
+        -i autoload/go/config.vim
     '';
   });
 

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -14,7 +14,7 @@
 , asmfmt, delve, errcheck, godef, golint
 , gomodifytags, gotags, gotools, motion
 , gnused, reftools, gogetdoc, gometalinter
-, impl, iferr
+, impl, iferr, gocode, gocode-gomod, go-tools
 }:
 
 let
@@ -261,6 +261,9 @@ with generated;
       asmfmt
       delve
       errcheck
+      go-tools
+      gocode
+      gocode-gomod
       godef
       gogetdoc
       golint

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14705,6 +14705,8 @@ with pkgs;
 
   gocode = callPackage ../development/tools/gocode { };
 
+  gocode-gomod = callPackage ../development/tools/gocode-gomod { };
+
   goconst = callPackage ../development/tools/goconst { };
 
   goconvey = callPackage ../development/tools/goconvey { };


### PR DESCRIPTION
###### Motivation for this change

This is a continuation of #49669, it seems that I have missed the gocode-gomod binary and I forgot to add gocode and go-tools to the vim-go path.

With regards to the `sed` change, initially, I patched [go#path#CheckBinPath()](https://github.com/fatih/vim-go/blob/5fffae94cbb45f3f5452fe423011729499f5389b/autoload/go/path.vim#L154) which is called anytime a binary is called. However, there's also [this call](https://github.com/fatih/vim-go/blob/5fffae94cbb45f3f5452fe423011729499f5389b/plugin/go.vim#L93) left unpached that can cause confusion if the user runs `:GoInstallBinaries` as it won't see the nix-store paths. In this PR, I decided to patch [go#config#BinPath()](https://github.com/fatih/vim-go/blob/5fffae94cbb45f3f5452fe423011729499f5389b/autoload/go/config.vim#L351-L353) which is called by any call out to a binary. As an added bonus, this patch patches the default go_bin_path, so a user can simply `let g:go_bin_path="..."` from the vimrc to override it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Mic92 