### PR TITLE
plymouth: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "plymouth-${version}";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/plymouth/releases/${name}.tar.xz";
-    sha256 = "0x2a9s5jdvfcrdnwbdhm5x4ck3zimmcpghnqvhl65byfj25d13cz";
+    sha256 = "0l8kg7b2vfxgz9gnrn0v2w4jvysj2cirp0nxads5sy05397pl6aa";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

https://cgit.freedesktop.org/plymouth/tag/?h=0.9.4

Note: I haven't tested this personally (other than build testing).
Since proper integration is what makes or breaks this,
someone should at least check a boot or two?

But thought I'd get it ready for our tester ;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---