### PR TITLE
rack: 1.6.* -> 1.6.11, 2.0.* -> 2.0.6 (CVE-2018-16470, CVE-2018-16471)

### DIFF
--- a/pkgs/applications/misc/gollum/Gemfile.lock
+++ b/pkgs/applications/misc/gollum/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     posix-spawn (0.3.13)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-protection (1.5.5)
       rack
     rouge (2.2.1)
@@ -65,4 +65,4 @@ DEPENDENCIES
   gollum
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/pkgs/applications/misc/gollum/gemset.nix
+++ b/pkgs/applications/misc/gollum/gemset.nix
@@ -137,10 +137,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0in0amn0kwvzmi8h5zg6ijrx5wpsf8h96zrfmnk1kwh2ql4sxs2q";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.10";
+    version = "1.6.11";
   };
   rack-protection = {
     dependencies = ["rack"];

--- a/pkgs/applications/office/ledger-web/Gemfile.lock
+++ b/pkgs/applications/office/ledger-web/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       sinatra-session
     multi_json (1.12.1)
     pg (0.18.4)
-    rack (1.6.4)
+    rack (1.6.11)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -55,7 +55,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ledger_web (= 1.5.2)
+  ledger_web
 
 BUNDLED WITH
-   1.12.5
+   1.16.4

--- a/pkgs/applications/office/ledger-web/gemset.nix
+++ b/pkgs/applications/office/ledger-web/gemset.nix
@@ -32,6 +32,7 @@
     version = "1.5.1";
   };
   ledger_web = {
+    dependencies = ["database_cleaner" "directory_watcher" "pg" "rack" "rspec" "sequel" "sinatra" "sinatra-contrib" "sinatra-session"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0i4vagaiyayymlr41rsy4lg2cl1r011ib0ql9dgjadfy6imb4kqh";
@@ -58,10 +59,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.4";
+    version = "1.6.11";
   };
   rack-protection = {
     dependencies = ["rack"];
@@ -82,6 +83,7 @@
     version = "0.6.3";
   };
   rspec = {
+    dependencies = ["rspec-core" "rspec-expectations" "rspec-mocks"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "16g3mmih999f0b6vcz2c3qsc7ks5zy4lj1rzjh8hf6wk531nvc6s";
@@ -90,6 +92,7 @@
     version = "3.5.0";
   };
   rspec-core = {
+    dependencies = ["rspec-support"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "12yndf7y6g3s1306bv1aycsmd0gjy5m172spdhx54svca2fcpzy1";
@@ -98,6 +101,7 @@
     version = "3.5.2";
   };
   rspec-expectations = {
+    dependencies = ["diff-lcs" "rspec-support"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0bbqfrb1x8gmwf8x2xhhwvvlhwbbafq4isbvlibxi6jk602f09gs";
@@ -106,6 +110,7 @@
     version = "3.5.0";
   };
   rspec-mocks = {
+    dependencies = ["diff-lcs" "rspec-support"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0nl3ksivh9wwrjjd47z5dggrwx40v6gpb3a0gzbp1gs06a5dmk24";
@@ -130,6 +135,7 @@
     version = "4.37.0";
   };
   sinatra = {
+    dependencies = ["rack" "rack-protection" "tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1b81kbr65mmcl9cdq2r6yc16wklyp798rxkgmm5pr9fvsj7jwmxp";
@@ -138,6 +144,7 @@
     version = "1.4.7";
   };
   sinatra-contrib = {
+    dependencies = ["backports" "multi_json" "rack-protection" "rack-test" "sinatra" "tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0vi3i0icbi2figiayxpvxbqpbn1syma7w4p4zw5mav1ln4c7jnfr";
@@ -146,6 +153,7 @@
     version = "1.4.7";
   };
   sinatra-session = {
+    dependencies = ["sinatra"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "183xl8i4d2hc03afd1i52gwn2xi3vzrv02g22llhfy5wkmm44gmq";

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile.lock
@@ -630,7 +630,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.3)
     pyu-ruby-sasl (0.0.3.3)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (4.4.1)

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/gemset.nix
@@ -2320,10 +2320,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0in0amn0kwvzmi8h5zg6ijrx5wpsf8h96zrfmnk1kwh2ql4sxs2q";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.10";
+    version = "1.6.11";
   };
   rack-accept = {
     dependencies = ["rack"];

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile.lock
@@ -659,7 +659,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.3)
     pyu-ruby-sasl (0.0.3.3)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (4.4.1)

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/gemset.nix
@@ -2441,10 +2441,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0in0amn0kwvzmi8h5zg6ijrx5wpsf8h96zrfmnk1kwh2ql4sxs2q";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.10";
+    version = "1.6.11";
   };
   rack-accept = {
     dependencies = ["rack"];

--- a/pkgs/applications/version-management/redmine/Gemfile.lock
+++ b/pkgs/applications/version-management/redmine/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     protected_attributes (1.1.4)
       activemodel (>= 4.0.1, < 5.0)
     public_suffix (3.0.3)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
@@ -201,4 +201,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/pkgs/applications/version-management/redmine/gemset.nix
+++ b/pkgs/applications/version-management/redmine/gemset.nix
@@ -350,10 +350,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0in0amn0kwvzmi8h5zg6ijrx5wpsf8h96zrfmnk1kwh2ql4sxs2q";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.10";
+    version = "1.6.11";
   };
   rack-openid = {
     dependencies = ["rack" "ruby-openid"];

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -226,6 +226,12 @@ in
     '';
   };
 
+  metasploit-framework = attrs: {
+    preInstall = ''
+      export HOME=$TMPDIR
+    '';
+  };
+
   msgpack = attrs: {
     buildInputs = [ msgpack ];
   };

--- a/pkgs/development/tools/chefdk/Gemfile.lock
+++ b/pkgs/development/tools/chefdk/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
-    rack (2.0.3)
+    rack (2.0.6)
     rainbow (2.2.2)
       rake
     rake (12.3.0)
@@ -397,4 +397,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.14.6
+   1.16.4

--- a/pkgs/development/tools/chefdk/gemset.nix
+++ b/pkgs/development/tools/chefdk/gemset.nix
@@ -791,10 +791,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kczgp2zwcrvp257dl8j4y3mnyqflxr7rn4vl9w1rwblznx9n74c";
+      sha256 = "1pcgv8dv4vkaczzlix8q3j68capwhk420cddzijwqgi2qb4lm1zm";
       type = "gem";
     };
-    version = "2.0.3";
+    version = "2.0.6";
   };
   rainbow = {
     dependencies = ["rake"];

--- a/pkgs/development/web/mailcatcher/Gemfile.lock
+++ b/pkgs/development/web/mailcatcher/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    rack (1.6.8)
+    rack (1.6.11)
     rack-protection (1.5.3)
       rack
     sinatra (1.4.8)
@@ -40,4 +40,4 @@ DEPENDENCIES
   mailcatcher
 
 BUNDLED WITH
-   1.14.4
+   1.16.4

--- a/pkgs/development/web/mailcatcher/gemset.nix
+++ b/pkgs/development/web/mailcatcher/gemset.nix
@@ -16,6 +16,7 @@
     version = "1.0.9.1";
   };
   mail = {
+    dependencies = ["mime-types"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0d7lhj2dw52ycls6xigkfz6zvfhc6qggply9iycjmcyj9760yvz9";
@@ -24,6 +25,7 @@
     version = "2.6.6";
   };
   mailcatcher = {
+    dependencies = ["eventmachine" "mail" "rack" "sinatra" "skinny" "sqlite3" "thin"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h6gk8n18i5f651f244al1hscjzl27fpma4vqw0qhszqqpd5p3bx";
@@ -32,6 +34,7 @@
     version = "0.6.5";
   };
   mime-types = {
+    dependencies = ["mime-types-data"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
@@ -50,12 +53,13 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "19m7aixb2ri7p1n0iqaqx8ldi97xdhvbxijbyrrcdcl6fv5prqza";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.8";
+    version = "1.6.11";
   };
   rack-protection = {
+    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0cvb21zz7p9wy23wdav63z5qzfn4nialik22yqp6gihkgfqqrh5r";
@@ -64,6 +68,7 @@
     version = "1.5.3";
   };
   sinatra = {
+    dependencies = ["rack" "rack-protection" "tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0byxzl7rx3ki0xd7aiv1x8mbah7hzd8f81l65nq8857kmgzj1jqq";
@@ -72,6 +77,7 @@
     version = "1.4.8";
   };
   skinny = {
+    dependencies = ["eventmachine" "thin"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1y3yvx88ylgz4d2s1wskjk5rkmrcr15q3ibzp1q88qwzr5y493a9";
@@ -88,6 +94,7 @@
     version = "1.3.13";
   };
   thin = {
+    dependencies = ["daemons" "eventmachine" "rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0hrq9m3hb6pm8yrqshhg0gafkphdpvwcqmr7k722kgdisp3w91ga";

--- a/pkgs/servers/monitoring/riemann-dash/Gemfile.lock
+++ b/pkgs/servers/monitoring/riemann-dash/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     erubis (2.7.0)
     multi_json (1.3.6)
-    rack (1.6.4)
+    rack (1.6.11)
     rack-protection (1.5.3)
       rack
     riemann-dash (0.2.12)
@@ -27,4 +27,4 @@ DEPENDENCIES
   riemann-dash (= 0.2.12)
 
 BUNDLED WITH
-   1.11.2
+   1.16.4

--- a/pkgs/servers/monitoring/riemann-dash/gemset.nix
+++ b/pkgs/servers/monitoring/riemann-dash/gemset.nix
@@ -16,10 +16,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.4";
+    version = "1.6.11";
   };
   rack-protection = {
     dependencies = ["rack"];
@@ -30,6 +30,7 @@
     version = "1.5.3";
   };
   riemann-dash = {
+    dependencies = ["erubis" "multi_json" "sass" "sinatra" "webrick"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1y2vh9vcl21b6k2wqgz1y8bbcrl07r43s6q2vkgp35z1b28xcszy";
@@ -46,6 +47,7 @@
     version = "3.4.22";
   };
   sinatra = {
+    dependencies = ["rack" "rack-protection" "tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1b81kbr65mmcl9cdq2r6yc16wklyp798rxkgmm5pr9fvsj7jwmxp";

--- a/pkgs/servers/web-apps/frab/Gemfile.lock
+++ b/pkgs/servers/web-apps/frab/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (3.9.1)
-    rack (1.6.4)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)

--- a/pkgs/servers/web-apps/frab/gemset.nix
+++ b/pkgs/servers/web-apps/frab/gemset.nix
@@ -1,5 +1,6 @@
 {
   actionmailer = {
+    dependencies = ["actionpack" "actionview" "activejob" "mail" "rails-dom-testing"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0lw1pss1mrjm7x7qcg9pvxv55rz3d994yf3mwmlfg1y12fxq00n3";
@@ -8,6 +9,7 @@
     version = "4.2.7.1";
   };
   actionpack = {
+    dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1ray5bvlmkimjax011zsw0mz9llfkqrfm7q1avjlp4i0kpcz8zlh";
@@ -16,6 +18,7 @@
     version = "4.2.7.1";
   };
   actionview = {
+    dependencies = ["activesupport" "builder" "erubis" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "11m2x5nlbqrw79fh6h7m444lrka7wwy32b0dvgqg7ilbzih43k0c";
@@ -24,6 +27,7 @@
     version = "4.2.7.1";
   };
   activejob = {
+    dependencies = ["activesupport" "globalid"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0ish5wd8nvmj7f6x1i22aw5ycizy5n1z1c7f3kyxmqwhw7lb0gaz";
@@ -32,6 +36,7 @@
     version = "4.2.7.1";
   };
   activemodel = {
+    dependencies = ["activesupport" "builder"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0acz0mbmahsc9mn41275fpfnrqwig5k09m3xhz3455kv90fn79v5";
@@ -40,6 +45,7 @@
     version = "4.2.7.1";
   };
   activerecord = {
+    dependencies = ["activemodel" "activesupport" "arel"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1lk8l6i9p7qfl0pg261v5yph0w0sc0vysrdzc6bm5i5rxgi68flj";
@@ -48,6 +54,7 @@
     version = "4.2.7.1";
   };
   activeresource = {
+    dependencies = ["activemodel" "activesupport" "rails-observers"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0nr5is20cx18s7vg8bdrdc996s2abl3h7fsi1q6mqsrzw7nrv2fa";
@@ -56,6 +63,7 @@
     version = "4.1.0";
   };
   activesupport = {
+    dependencies = ["i18n" "json" "minitest" "thread_safe" "tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1gds12k7nxrcc09b727a458ndidy1nfcllj9x22jcaj7pppvq6r4";
@@ -80,6 +88,7 @@
     version = "2.4.0";
   };
   airbrussh = {
+    dependencies = ["sshkit"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0pv22d2kjdbsg9q45jca3f5gsylr2r1wfpn58g58xj4s4q4r95nx";
@@ -112,6 +121,7 @@
     version = "3.2.2";
   };
   bullet = {
+    dependencies = ["activesupport" "uniform_notifier"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "06pba7bdjnazbl0yhhvlina08nkawnm76zihkaam4k7fm0yrq1k0";
@@ -136,6 +146,7 @@
     version = "1.15.0";
   };
   capistrano = {
+    dependencies = ["i18n" "rake" "sshkit"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0f73w6gpml0ickmwky1cn6d8392q075zy10a323f3vmyvxyhr0jb";
@@ -144,6 +155,7 @@
     version = "3.4.1";
   };
   capistrano-bundler = {
+    dependencies = ["capistrano" "sshkit"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1f4iikm7pn0li2lj6p53wl0d6y7svn0h76z9c6c582mmwxa9c72p";
@@ -152,6 +164,7 @@
     version = "1.1.4";
   };
   capistrano-rails = {
+    dependencies = ["capistrano" "capistrano-bundler"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "03lzihrq72rwcqq7jiqak79wy0xbdnymn5gxj0bfgfjlg5kpgssw";
@@ -160,6 +173,7 @@
     version = "1.1.8";
   };
   capistrano-rvm = {
+    dependencies = ["capistrano" "sshkit"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "15sy8zcal041yy5kb7fcdqnxvndgdhg3w1kvb5dk7hfjk3ypznsa";
@@ -168,6 +182,7 @@
     version = "0.1.2";
   };
   capistrano3-puma = {
+    dependencies = ["capistrano" "puma"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0ynz1arnr07kcl0vsaa1znhp2ywhhs4fwndnkw8sasr9bydksln8";
@@ -184,6 +199,7 @@
     version = "1.3.7";
   };
   climate_control = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0krknwk6b8lwv1j9kjbxib6kf5zh4pxkf3y2vcyycx5d6nci1s55";
@@ -192,6 +208,7 @@
     version = "0.0.3";
   };
   cocaine = {
+    dependencies = ["climate_control"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "01kk5xd7lspbkdvn6nyj0y51zhvia3z6r4nalbdcqw5fbsywwi7d";
@@ -216,6 +233,7 @@
     version = "1.1.1";
   };
   coffee-rails = {
+    dependencies = ["coffee-script" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1mv1kaw3z4ry6cm51w8pfrbby40gqwxanrqyqr0nvs8j1bscc1gw";
@@ -224,6 +242,7 @@
     version = "4.1.1";
   };
   coffee-script = {
+    dependencies = ["coffee-script-source" "execjs"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0rc7scyk7mnpfxqv5yy4y5q1hx3i7q3ahplcp4bq2g5r24g2izl2";
@@ -264,6 +283,7 @@
     version = "2.1.1";
   };
   dotenv-rails = {
+    dependencies = ["dotenv" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "17s6c0yqaz01xd5wywjscbvv0pa3grak2lhwby91j84qm6h95vxz";
@@ -280,6 +300,7 @@
     version = "2.7.0";
   };
   exception_notification = {
+    dependencies = ["actionmailer" "activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1vclsr0rjfy1khvqyj67lgpa0v14nb542vvjkyaswn367nnmijhw";
@@ -296,6 +317,7 @@
     version = "2.7.0";
   };
   factory_girl = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1xzl4z9z390fsnyxp10c9if2n46zan3n6zwwpfnwc33crv4s410i";
@@ -304,6 +326,7 @@
     version = "4.7.0";
   };
   factory_girl_rails = {
+    dependencies = ["factory_girl" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0hzpirb33xdqaz44i1mbcfv0icjrghhgaz747llcfsflljd4pa4r";
@@ -312,6 +335,7 @@
     version = "4.7.0";
   };
   faker = {
+    dependencies = ["i18n"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "09amnh5d0m3q2gpb0vr9spbfa8l2nc0kl3s79y6sx7a16hrl4vvc";
@@ -328,6 +352,7 @@
     version = "0.6.9";
   };
   globalid = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "11plkgyl3w9k4y2scc1igvpgwyz4fnmsr63h2q4j8wkb48nlnhak";
@@ -336,6 +361,7 @@
     version = "0.3.7";
   };
   haml = {
+    dependencies = ["tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0mrzjgkygvfii66bbylj2j93na8i89998yi01fin3whwqbvx0m1p";
@@ -344,6 +370,7 @@
     version = "4.0.7";
   };
   httparty = {
+    dependencies = ["multi_xml"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1msa213hclsv14ijh49i1wggf9avhnj2j4xr58m9jx6fixlbggw6";
@@ -360,6 +387,7 @@
     version = "0.7.0";
   };
   jbuilder = {
+    dependencies = ["activesupport" "multi_json"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1jbh1296imd0arc9nl1m71yfd7kg505p8srr1ijpsqv4hhbz5qci";
@@ -376,6 +404,7 @@
     version = "1.2.1";
   };
   jquery-rails = {
+    dependencies = ["rails-dom-testing" "railties" "thor"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0prqyixv7j2qlq67qdr3miwcyvi27b9a82j51gbpb6vcl0ig2rik";
@@ -384,6 +413,7 @@
     version = "4.2.1";
   };
   jquery-ui-rails = {
+    dependencies = ["railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1gfygrv4bjpjd2c377lw7xzk1b77rxjyy3w6wl4bq1gkqvyrkx77";
@@ -400,6 +430,7 @@
     version = "1.8.3";
   };
   launchy = {
+    dependencies = ["addressable"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "190lfbiy1vwxhbgn4nl4dcbzxvm049jwc158r2x7kq3g5khjrxa2";
@@ -408,6 +439,7 @@
     version = "2.4.3";
   };
   letter_opener = {
+    dependencies = ["launchy"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1pcrdbxvp2x5six8fqn8gf09bn9rd3jga76ds205yph5m8fsda21";
@@ -416,6 +448,7 @@
     version = "1.4.1";
   };
   localized_language_select = {
+    dependencies = ["rails"];
     source = {
       fetchSubmodules = false;
       rev = "85df6b97789de6e29c630808b630e56a1b76f80c";
@@ -426,6 +459,7 @@
     version = "0.3.0";
   };
   loofah = {
+    dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "109ps521p0sr3kgc460d58b4pr1z4mqggan2jbsf0aajy9s6xis8";
@@ -434,6 +468,7 @@
     version = "2.0.3";
   };
   mail = {
+    dependencies = ["mime-types"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0c9vqfy0na9b5096i5i4qvrvhwamjnmajhgqi3kdsdfl8l6agmkp";
@@ -450,6 +485,7 @@
     version = "0.8.2";
   };
   mime-types = {
+    dependencies = ["mime-types-data"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
@@ -514,6 +550,7 @@
     version = "0.4.4";
   };
   net-scp = {
+    dependencies = ["net-ssh"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0b0jqrcsp4bbi4n4mzyf70cp2ysyp6x07j8k8cqgxnvb4i3a134j";
@@ -530,6 +567,7 @@
     version = "3.2.0";
   };
   nokogiri = {
+    dependencies = ["mini_portile2" "pkg-config"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "11sbmpy60ynak6s3794q32lc99hs448msjy8rkp84ay7mq7zqspv";
@@ -538,6 +576,7 @@
     version = "1.6.7.2";
   };
   paper_trail = {
+    dependencies = ["activerecord" "request_store"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1w3y2h1w0kml2fmzx4sdcrhnbj273npwrs0cx91xdgy2qfjj6hmr";
@@ -546,6 +585,7 @@
     version = "5.2.2";
   };
   paperclip = {
+    dependencies = ["activemodel" "activesupport" "cocaine" "mime-types" "mimemagic"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0r8krh5xg790845wzlc2r7l0jwskw4c4wk9xh4bpprqykwaghg0r";
@@ -578,6 +618,7 @@
     version = "1.1.7";
   };
   polyamorous = {
+    dependencies = ["activerecord"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1501y9l81b2lwb93fkycq8dr1bi6qcdhia3qv4fddnmrdihkl3pv";
@@ -586,6 +627,7 @@
     version = "1.3.1";
   };
   prawn = {
+    dependencies = ["pdf-core" "ttfunk"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "04pxzfmmy8a6bv3zvh1mmyy5zi4bj994kq1v6qnlq2xlhvg4cxjc";
@@ -594,6 +636,7 @@
     version = "0.15.0";
   };
   prawn_rails = {
+    dependencies = ["prawn" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "19m1pv2rsl3rf9rni78l8137dy2sq1r2443biv19wi9nis2pvgdg";
@@ -602,6 +645,7 @@
     version = "0.0.11";
   };
   pry = {
+    dependencies = ["coderay" "method_source" "slop"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "05xbzyin63aj2prrv8fbq2d5df2mid93m81hz5bvf2v4hnzs42ar";
@@ -610,6 +654,7 @@
     version = "0.10.4";
   };
   pry-byebug = {
+    dependencies = ["byebug" "pry"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0pvc94kgxd33p6iz41ghyadq8zfbjhkk07nvz2mbh3yhrc8w7gmw";
@@ -618,6 +663,7 @@
     version = "3.4.0";
   };
   pry-rails = {
+    dependencies = ["pry"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0a2iinvabis2xmv0z7z7jmh7bbkkngxj2qixfdg5m6qj9x8k1kx6";
@@ -636,12 +682,13 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09bs295yq6csjnkzj7ncj50i6chfxrhmzg1pk6p0vd2lb9ac8pj5";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.4";
+    version = "1.6.11";
   };
   rack-test = {
+    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
@@ -650,6 +697,7 @@
     version = "0.6.3";
   };
   rails = {
+    dependencies = ["actionmailer" "actionpack" "actionview" "activejob" "activemodel" "activerecord" "activesupport" "railties" "sprockets-rails"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1avd16ir7qx23dcnz1b3cafq1lja6rq0w222bs658p9n33rbw54l";
@@ -658,6 +706,7 @@
     version = "4.2.7.1";
   };
   rails-deprecated_sanitizer = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0qxymchzdxww8bjsxj05kbf86hsmrjx40r41ksj0xsixr2gmhbbj";
@@ -666,6 +715,7 @@
     version = "1.0.3";
   };
   rails-dom-testing = {
+    dependencies = ["activesupport" "nokogiri" "rails-deprecated_sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1v8jl6803mbqpxh4hn0szj081q1a3ap0nb8ni0qswi7z4la844v8";
@@ -674,6 +724,7 @@
     version = "1.0.7";
   };
   rails-html-sanitizer = {
+    dependencies = ["loofah"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "138fd86kv073zqfx0xifm646w6bgw2lr8snk16lknrrfrss8xnm7";
@@ -682,6 +733,7 @@
     version = "1.0.3";
   };
   rails-observers = {
+    dependencies = ["activemodel"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1lsw19jzmvipvrfy2z04hi7r29dvkfc43h43vs67x6lsj9rxwwcy";
@@ -690,6 +742,7 @@
     version = "0.1.2";
   };
   railties = {
+    dependencies = ["actionpack" "activesupport" "rake" "thor"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "04rz7cn64zzvq7lnhc9zqmaqmqkq84q25v0ym9lcw75j1cj1mrq4";
@@ -706,6 +759,7 @@
     version = "11.3.0";
   };
   ransack = {
+    dependencies = ["actionpack" "activerecord" "activesupport" "i18n" "polyamorous"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0cya3wygwjhj8rckckkl387bmva4nyfvqcl0qhp9hk3zv8y6wxjc";
@@ -738,6 +792,7 @@
     version = "0.8.8";
   };
   roust = {
+    dependencies = ["activesupport" "httparty" "mail"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1zdnwxxh34psv0iybcdnk9w4dpgpr07j3w1fvigkpccgz5vs82qk";
@@ -746,6 +801,7 @@
     version = "1.8.9";
   };
   rqrcode = {
+    dependencies = ["chunky_png"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h1pnnydgs032psakvg3l779w3ghbn08ajhhhw19hpmnfhrs8k0a";
@@ -762,6 +818,7 @@
     version = "3.4.22";
   };
   sass-rails = {
+    dependencies = ["railties" "sass" "sprockets" "sprockets-rails" "tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0iji20hb8crncz14piss1b29bfb6l89sz3ai5fny3iw39vnxkdcb";
@@ -770,6 +827,7 @@
     version = "5.0.6";
   };
   shoulda = {
+    dependencies = ["shoulda-context" "shoulda-matchers"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0csmf15a7mcinfq54lfa4arp0f4b2jmwva55m0p94hdf3pxnjymy";
@@ -786,6 +844,7 @@
     version = "1.2.1";
   };
   shoulda-matchers = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0d3ryqcsk1n9y35bx5wxnqbgw4m8b3c79isazdjnnbg8crdp72d0";
@@ -794,6 +853,7 @@
     version = "2.8.0";
   };
   simple_form = {
+    dependencies = ["actionpack" "activemodel"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0ii3rkkbj5cc10f5rdiny18ncdh36kijr25cah0ybbr7kigh3v3b";
@@ -810,6 +870,7 @@
     version = "3.6.0";
   };
   sprockets = {
+    dependencies = ["concurrent-ruby" "rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0jzsfiladswnzbrwqfiaj1xip68y58rwx0lpmj907vvq47k87gj1";
@@ -818,6 +879,7 @@
     version = "3.7.0";
   };
   sprockets-rails = {
+    dependencies = ["actionpack" "activesupport" "sprockets"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1zr9vk2vn44wcn4265hhnnnsciwlmqzqc6bnx78if1xcssxj6x44";
@@ -834,6 +896,7 @@
     version = "1.3.11";
   };
   sshkit = {
+    dependencies = ["net-scp" "net-ssh"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0wpqvr2dyxwp3shwh0221i1ahyg8vd2hyilmjvdi026l00gk2j4l";
@@ -842,6 +905,7 @@
     version = "1.11.3";
   };
   sucker_punch = {
+    dependencies = ["concurrent-ruby"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0l8b53mlzl568kdl4la8kcjjcnawmbl0q6hq9c3kkyippa5c0x55";
@@ -890,6 +954,7 @@
     version = "1.1.1";
   };
   tzinfo = {
+    dependencies = ["thread_safe"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1c01p3kg6xvy1cgjnzdfq45fggbwish8krd0h864jvbpybyx7cgx";
@@ -898,6 +963,7 @@
     version = "1.2.2";
   };
   uglifier = {
+    dependencies = ["execjs"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0f30s1631k03x4wm7xyc79g92pppzvyysa773zsaq2kcry1pmifc";

--- a/pkgs/tools/admin/oxidized/Gemfile.lock
+++ b/pkgs/tools/admin/oxidized/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       sinatra (~> 1.4, >= 1.4.6)
       sinatra-contrib (~> 1.4, >= 1.4.6)
     puma (3.11.3)
-    rack (1.6.9)
+    rack (1.6.11)
     rack-protection (1.5.5)
       rack
     rack-test (1.0.0)
@@ -66,4 +66,4 @@ DEPENDENCIES
   oxidized-web
 
 BUNDLED WITH
-   1.14.6
+   1.16.4

--- a/pkgs/tools/admin/oxidized/gemset.nix
+++ b/pkgs/tools/admin/oxidized/gemset.nix
@@ -103,10 +103,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "03w1ri5l91q800f1bdcdl5rbagy7s4kml136b42s2lmxmznxhr07";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.9";
+    version = "1.6.11";
   };
   rack-protection = {
     dependencies = ["rack"];

--- a/pkgs/tools/security/metasploit/Gemfile.lock
+++ b/pkgs/tools/security/metasploit/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
       arel (>= 4.0.1)
       pg_array_parser (~> 0.0.9)
     public_suffix (2.0.5)
-    rack (1.6.8)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
@@ -292,4 +292,4 @@ DEPENDENCIES
   metasploit-framework!
 
 BUNDLED WITH
-   1.15.0
+   1.16.4

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -1,5 +1,6 @@
 {
   actionpack = {
+    dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1kgrq74gp2czzxr0f2sqrc98llz03lgq498300z2z5n4khgznwc4";
@@ -8,6 +9,7 @@
     version = "4.2.9";
   };
   actionview = {
+    dependencies = ["activesupport" "builder" "erubis" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "04kgp4gmahw31miz8xdq1pns14qmvvzd14fgfv7fg9klkw3bxyyp";
@@ -16,6 +18,7 @@
     version = "4.2.9";
   };
   activemodel = {
+    dependencies = ["activesupport" "builder"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1qxmivny0ka5s3iyap08sn9bp2bd9wrhqp2njfw26hr9wsjk5kfv";
@@ -24,6 +27,7 @@
     version = "4.2.9";
   };
   activerecord = {
+    dependencies = ["activemodel" "activesupport" "arel"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "18i790dfhi4ndypd1pj9pv08knpxr2sayvvwfq7axj5jfwgpmrqb";
@@ -32,6 +36,7 @@
     version = "4.2.9";
   };
   activesupport = {
+    dependencies = ["i18n" "minitest" "thread_safe" "tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1d0a362p3m2m2kljichar2pwq0qm4vblc3njy1rdzm09ckzd45sp";
@@ -40,6 +45,7 @@
     version = "4.2.9";
   };
   addressable = {
+    dependencies = ["public_suffix"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1i8q32a4gr0zghxylpyy7jfqwxvwrivsxflg9mks6kx92frh75mh";
@@ -64,6 +70,7 @@
     version = "6.0.4";
   };
   arel-helpers = {
+    dependencies = ["activerecord"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1sx4qbzhld3a99175p2krz3hv1npc42rv3sd8x4awzkgplg3zy9c";
@@ -144,6 +151,7 @@
     version = "2.7.0";
   };
   faraday = {
+    dependencies = ["multipart-post"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1gyqsj7vlqynwvivf9485zwmcj04v1z7gq362z0b8zw2zf4ag0hw";
@@ -184,6 +192,7 @@
     version = "0.8.6";
   };
   jsobfu = {
+    dependencies = ["rkelly-remix"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1hchns89cfj0gggm2zbr7ghb630imxm2x2d21ffx2jlasn9xbkyk";
@@ -200,6 +209,7 @@
     version = "2.1.0";
   };
   loofah = {
+    dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "109ps521p0sr3kgc460d58b4pr1z4mqggan2jbsf0aajy9s6xis8";
@@ -216,6 +226,7 @@
     version = "1.0.3";
   };
   metasploit-concern = {
+    dependencies = ["activemodel" "activesupport" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0v9lm225fhzhnbjcc0vwb38ybikxwzlv8116rrrkndzs8qy79297";
@@ -224,6 +235,7 @@
     version = "2.0.5";
   };
   metasploit-credential = {
+    dependencies = ["metasploit-concern" "metasploit-model" "metasploit_data_models" "pg" "railties" "rex-socket" "rubyntlm" "rubyzip"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1flahrcl5hf4bncqs40mry6pkffvmir85kqzkad22x3dh6crw50i";
@@ -232,6 +244,7 @@
     version = "2.0.12";
   };
   metasploit-framework = {
+    dependencies = ["actionpack" "activerecord" "activesupport" "backports" "bcrypt" "bcrypt_pbkdf" "bit-struct" "dnsruby" "filesize" "jsobfu" "json" "metasm" "metasploit-concern" "metasploit-credential" "metasploit-model" "metasploit-payloads" "metasploit_data_models" "metasploit_payloads-mettle" "msgpack" "nessus_rest" "net-ssh" "network_interface" "nexpose" "nokogiri" "octokit" "openssl-ccm" "openvas-omp" "packetfu" "patch_finder" "pcaprub" "pdf-reader" "pg" "railties" "rb-readline" "rbnacl" "rbnacl-libsodium" "recog" "redcarpet" "rex-arch" "rex-bin_tools" "rex-core" "rex-encoder" "rex-exploitation" "rex-java" "rex-mime" "rex-nop" "rex-ole" "rex-powershell" "rex-random_identifier" "rex-registry" "rex-rop_builder" "rex-socket" "rex-sslscan" "rex-struct2" "rex-text" "rex-zip" "robots" "ruby_smb" "rubyntlm" "rubyzip" "sqlite3" "sshkey" "tzinfo" "tzinfo-data" "windows_error" "xdr" "xmlrpc"];
     source = {
       fetchSubmodules = false;
       rev = "dbec1c2d2ae4bd77276cbfb3c6ee2902048b9453";
@@ -242,6 +255,7 @@
     version = "4.16.1";
   };
   metasploit-model = {
+    dependencies = ["activemodel" "activesupport" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "05pnai1cv00xw87rrz38dz4s3ss45s90290d0knsy1mq6rp8yvmw";
@@ -258,6 +272,7 @@
     version = "1.3.1";
   };
   metasploit_data_models = {
+    dependencies = ["activerecord" "activesupport" "arel-helpers" "metasploit-concern" "metasploit-model" "pg" "postgres_ext" "railties" "recog"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0j3ijxn6n3ack9572a74cwknijymy41c8rx34njyhg25lx4hbvah";
@@ -338,6 +353,7 @@
     version = "6.1.1";
   };
   nokogiri = {
+    dependencies = ["mini_portile2"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1nffsyx1xjg6v5n9rrbi8y1arrcx2i5f21cp6clgh9iwiqkr7rnn";
@@ -346,6 +362,7 @@
     version = "1.8.0";
   };
   octokit = {
+    dependencies = ["sawyer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h6cm7bi0y7ysjgwws3paaipqdld6c0m0niazrjahhpz88qqq1g4";
@@ -370,6 +387,7 @@
     version = "0.0.4";
   };
   packetfu = {
+    dependencies = ["pcaprub"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "16ppq9wfxq4x2hss61l5brs3s6fmi8gb50mnp1nnnzb1asq4g8ll";
@@ -394,6 +412,7 @@
     version = "0.12.4";
   };
   pdf-reader = {
+    dependencies = ["Ascii85" "afm" "hashery" "ruby-rc4" "ttfunk"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0nlammdpjy3padmzxhsql7mw31jyqp88n6bdffiarv5kzl4s3y7p";
@@ -418,6 +437,7 @@
     version = "0.0.9";
   };
   postgres_ext = {
+    dependencies = ["activerecord" "arel" "pg_array_parser"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1lbp1qf5s1addhznm7d4bzks9adh7jpilgcsr8k7mbd0a1ailcgc";
@@ -436,12 +456,13 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "19m7aixb2ri7p1n0iqaqx8ldi97xdhvbxijbyrrcdcl6fv5prqza";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.8";
+    version = "1.6.11";
   };
   rack-test = {
+    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
@@ -450,6 +471,7 @@
     version = "0.6.3";
   };
   rails-deprecated_sanitizer = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0qxymchzdxww8bjsxj05kbf86hsmrjx40r41ksj0xsixr2gmhbbj";
@@ -458,6 +480,7 @@
     version = "1.0.3";
   };
   rails-dom-testing = {
+    dependencies = ["activesupport" "nokogiri" "rails-deprecated_sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1ny7mbjxhq20rzg4pivvyvk14irmc7cn20kxfk3vc0z2r2c49p8r";
@@ -466,6 +489,7 @@
     version = "1.0.8";
   };
   rails-html-sanitizer = {
+    dependencies = ["loofah"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "138fd86kv073zqfx0xifm646w6bgw2lr8snk16lknrrfrss8xnm7";
@@ -474,6 +498,7 @@
     version = "1.0.3";
   };
   railties = {
+    dependencies = ["actionpack" "activesupport" "rake" "thor"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1g5jnk1zllm2fr06lixq7gv8l2cwqc99akv7886gz6lshijpfyxd";
@@ -498,6 +523,7 @@
     version = "0.5.5";
   };
   rbnacl = {
+    dependencies = ["ffi"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "08dkigw8wdx53hviw1zqrs7rcrzqcwh9jd3dvwr72013z9fmyp48";
@@ -506,6 +532,7 @@
     version = "4.0.2";
   };
   rbnacl-libsodium = {
+    dependencies = ["rbnacl"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1323fli41m01af13xz5xvabsjnz09si1b9l4qd2p802kq0dr61gd";
@@ -514,6 +541,7 @@
     version = "1.0.13";
   };
   recog = {
+    dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h023ykrrra74bpbibkyg083kafaswvraw4naw9p1ghcjzn9ggj3";
@@ -530,6 +558,7 @@
     version = "3.4.0";
   };
   rex-arch = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1izzalmjwdyib8y0xlgys8qb60di6xyjk485ylgh14p47wkyc6yp";
@@ -538,6 +567,7 @@
     version = "0.1.11";
   };
   rex-bin_tools = {
+    dependencies = ["metasm" "rex-arch" "rex-core" "rex-struct2" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "01hi1cjr68adp47nxbjfprvn0r3b72r4ib82x9j33bf2pny6nvaw";
@@ -554,6 +584,7 @@
     version = "0.1.12";
   };
   rex-encoder = {
+    dependencies = ["metasm" "rex-arch" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1zm5jdxgyyp8pkfqwin34izpxdrmglx6vmk20ifnvcsm55c9m70z";
@@ -562,6 +593,7 @@
     version = "0.1.4";
   };
   rex-exploitation = {
+    dependencies = ["jsobfu" "metasm" "rex-arch" "rex-encoder" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0gbj28jqaaldpk4qzysgcl6m0wcqx3gcldarqdk55p5z9zasrk19";
@@ -578,6 +610,7 @@
     version = "0.1.5";
   };
   rex-mime = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "15a14kz429h7pn81ysa6av3qijxjmxagjff6dyss5v394fxzxf4a";
@@ -586,6 +619,7 @@
     version = "0.1.5";
   };
   rex-nop = {
+    dependencies = ["rex-arch"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0aigf9qsqsmiraa6zvfy1a7cyvf7zc3iyhzxi6fjv5sb8f64d6ny";
@@ -594,6 +628,7 @@
     version = "0.1.1";
   };
   rex-ole = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1pnzbqfnvbs0vc0z0ryszk3fxhgxrjd6gzwqa937rhlphwp5jpww";
@@ -602,6 +637,7 @@
     version = "0.1.6";
   };
   rex-powershell = {
+    dependencies = ["rex-random_identifier" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0nl60fdd1rlckk95d3s3y873w84vb0sgwvwxdzv414qxz8icpjnm";
@@ -610,6 +646,7 @@
     version = "0.1.72";
   };
   rex-random_identifier = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0cksrljaw61mdjvbmj9vqqhd8nra7jv466w5nim47n73rj72jc19";
@@ -626,6 +663,7 @@
     version = "0.1.3";
   };
   rex-rop_builder = {
+    dependencies = ["metasm" "rex-core" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0xjd3d6wnbq4ym0d0m268md8fb16f2hbwrahvxnl14q63fj9i3wy";
@@ -634,6 +672,7 @@
     version = "0.1.3";
   };
   rex-socket = {
+    dependencies = ["rex-core"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0bkr64qrfy2mcv6cpp2z2rn9npgn9s0yyagzjh7kawbm80ldwf2h";
@@ -642,6 +681,7 @@
     version = "0.1.8";
   };
   rex-sslscan = {
+    dependencies = ["rex-core" "rex-socket" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "06gbx45q653ajcx099p0yxdqqxazfznbrqshd4nwiwg1p498lmyx";
@@ -666,6 +706,7 @@
     version = "0.2.15";
   };
   rex-zip = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1mbfryyhcw47i7jb8cs8vilbyqgyiyjkfl1ngl6wdbf7d87dwdw7";
@@ -698,6 +739,7 @@
     version = "0.1.5";
   };
   ruby_smb = {
+    dependencies = ["bindata" "rubyntlm" "windows_error"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1jby5wlppxhc2jlqldic05aqd5l57171lsxqv86702grk665n612";
@@ -722,6 +764,7 @@
     version = "1.2.1";
   };
   sawyer = {
+    dependencies = ["addressable" "faraday"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0sv1463r7bqzvx4drqdmd36m7rrv6sf1v3c6vswpnq3k6vdw2dvd";
@@ -770,6 +813,7 @@
     version = "1.5.1";
   };
   tzinfo = {
+    dependencies = ["thread_safe"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "05r81lk7q7275rdq7xipfm0yxgqyd2ggh73xpc98ypngcclqcscl";
@@ -778,6 +822,7 @@
     version = "1.2.3";
   };
   tzinfo-data = {
+    dependencies = ["tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1n83rmy476d4qmzq74qx0j7lbcpskbvrj1bmy3np4d5pydyw2yky";
@@ -794,6 +839,7 @@
     version = "0.1.2";
   };
   xdr = {
+    dependencies = ["activemodel" "activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0c5cp1k4ij3xq1q6fb0f6xv5b65wy18y7bhwvsdx8wd0zyg3x96m";

--- a/pkgs/tools/text/bcat/Gemfile.lock
+++ b/pkgs/tools/text/bcat/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     bcat (0.6.2)
       rack (~> 1.0)
-    rack (1.6.8)
+    rack (1.6.11)
 
 PLATFORMS
   ruby
@@ -12,4 +12,4 @@ DEPENDENCIES
   bcat
 
 BUNDLED WITH
-   1.15.4
+   1.16.4

--- a/pkgs/tools/text/bcat/gemset.nix
+++ b/pkgs/tools/text/bcat/gemset.nix
@@ -11,9 +11,9 @@
   rack = {
     source = {
       remotes = ["http://rubygems.org"];
-      sha256 = "19m7aixb2ri7p1n0iqaqx8ldi97xdhvbxijbyrrcdcl6fv5prqza";
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };
-    version = "1.6.8";
+    version = "1.6.11";
   };
 }

--- a/pkgs/tools/typesetting/asciidoctor/Gemfile.lock
+++ b/pkgs/tools/typesetting/asciidoctor/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     public_suffix (3.0.3)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
-    rack (2.0.5)
+    rack (2.0.6)
     ruby-enum (0.7.2)
       i18n
     ruby-rc4 (0.1.5)
@@ -103,4 +103,4 @@ DEPENDENCIES
   pygments.rb
 
 BUNDLED WITH
-   1.14.6
+   1.16.4

--- a/pkgs/tools/typesetting/asciidoctor/gemset.nix
+++ b/pkgs/tools/typesetting/asciidoctor/gemset.nix
@@ -307,14 +307,12 @@
     version = "1.2.1";
   };
   rack = {
-    groups = ["default"];
-    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "158hbn7rlc3czp2vivvam44dv6vmzz16qrh5dbzhfxbfsgiyrqw1";
+      sha256 = "1pcgv8dv4vkaczzlix8q3j68capwhk420cddzijwqgi2qb4lm1zm";
       type = "gem";
     };
-    version = "2.0.5";
+    version = "2.0.6";
   };
   ruby-enum = {
     dependencies = ["i18n"];


### PR DESCRIPTION
##### Motivation for changes

- [CVE-2018-16470](https://seclists.org/oss-sec/2018/q4/128)
- [CVE-2018-16471](https://seclists.org/oss-sec/2018/q4/129)

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---