### PR TITLE
Docs: Add chapter on Profiles

### DIFF
--- a/nixos/doc/manual/configuration/configuration.xml
+++ b/nixos/doc/manual/configuration/configuration.xml
@@ -22,5 +22,6 @@
  <xi:include href="networking.xml" />
  <xi:include href="linux-kernel.xml" />
  <xi:include href="../generated/modules.xml" xpointer="xpointer(//section[@id='modules']/*)" />
+ <xi:include href="profiles.xml" />
 <!-- Apache; libvirtd virtualisation -->
 </part>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -33,4 +33,5 @@
  <xi:include href="profiles/graphical.xml" />
  <xi:include href="profiles/hardened.xml" />
  <xi:include href="profiles/headless.xml" />
+ <xi:include href="profiles/installation-device.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -31,4 +31,5 @@
  <xi:include href="profiles/demo.xml" />
  <xi:include href="profiles/docker-container.xml" />
  <xi:include href="profiles/graphical.xml" />
+ <xi:include href="profiles/hardened.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -27,4 +27,5 @@
  </para>
  <xi:include href="profiles/all-hardware.xml" />
  <xi:include href="profiles/base.xml" />
+ <xi:include href="profiles/clone-config.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -32,4 +32,5 @@
  <xi:include href="profiles/docker-container.xml" />
  <xi:include href="profiles/graphical.xml" />
  <xi:include href="profiles/hardened.xml" />
+ <xi:include href="profiles/headless.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -34,4 +34,5 @@
  <xi:include href="profiles/hardened.xml" />
  <xi:include href="profiles/headless.xml" />
  <xi:include href="profiles/installation-device.xml" />
+ <xi:include href="profiles/minimal.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -26,4 +26,5 @@
   profile. Detailing each option configured by each one is out of scope.
  </para>
  <xi:include href="profiles/all-hardware.xml" />
+ <xi:include href="profiles/base.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -35,4 +35,5 @@
  <xi:include href="profiles/headless.xml" />
  <xi:include href="profiles/installation-device.xml" />
  <xi:include href="profiles/minimal.xml" />
+ <xi:include href="profiles/qemu-guest.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -30,4 +30,5 @@
  <xi:include href="profiles/clone-config.xml" />
  <xi:include href="profiles/demo.xml" />
  <xi:include href="profiles/docker-container.xml" />
+ <xi:include href="profiles/graphical.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -1,0 +1,29 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="ch-profiles">
+ <title>Profiles</title>
+ <para>
+  In some cases, it may be desirable to take advantage of commonly-used,
+  predefined configurations provided by nixpkgs, but different from those that
+  come as default. This is a role fulfilled by NixOS's Profiles, which come as
+  files living in <filename>&lt;nixpkgs/nixos/modules/profiles&gt;</filename>.
+  That is to say, expected usage is to add them to the imports list of your
+  <filename>/etc/configuration.nix</filename> as such:
+ </para>
+ <programlisting>
+  imports = [
+   &lt;nixpkgs/nixos/modules/profiles/profile-name.nix&gt;
+  ];
+ </programlisting>
+ <para>
+  Even if some of these profiles seem only useful in the context of
+  install media, many are actually intended to be used in real installs.
+ </para>
+ <para>
+  What follows is a brief explanation on the purpose and use-case for each
+  profile. Detailing each option configured by each one is out of scope.
+ </para>
+ <xi:include href="profiles/all-hardware.xml" />
+</chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -28,4 +28,5 @@
  <xi:include href="profiles/all-hardware.xml" />
  <xi:include href="profiles/base.xml" />
  <xi:include href="profiles/clone-config.xml" />
+ <xi:include href="profiles/demo.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles.xml
+++ b/nixos/doc/manual/configuration/profiles.xml
@@ -29,4 +29,5 @@
  <xi:include href="profiles/base.xml" />
  <xi:include href="profiles/clone-config.xml" />
  <xi:include href="profiles/demo.xml" />
+ <xi:include href="profiles/docker-container.xml" />
 </chapter>

--- a/nixos/doc/manual/configuration/profiles/all-hardware.xml
+++ b/nixos/doc/manual/configuration/profiles/all-hardware.xml
@@ -1,0 +1,20 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-all-hardware">
+ <title>All Hardware</title>
+ <para>
+  Enables all hardware supported by NixOS: i.e., all firmware is
+  included, and all devices from which one may boot are enabled in the initrd.
+  Its primary use is in the NixOS installation CDs.
+ </para>
+ <para>
+  The enabled kernel modules include support for SATA and PATA, SCSI
+  (partially), USB, Firewire (untested), Virtio (QEMU, KVM, etc.), VMware, and
+  Hyper-V. Additionally, <xref linkend="opt-hardware.enableAllFirmware"/> is
+  enabled, and the firmware for the ZyDAS ZD1211 chipset is specifically
+  installed.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/base.xml
+++ b/nixos/doc/manual/configuration/profiles/base.xml
@@ -1,0 +1,15 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-base">
+ <title>Base</title>
+ <para>
+  Defines the software packages included in the "minimal"
+  installation CD. It installs several utilities useful in a simple recovery or
+  install media, such as a text-mode web browser, and tools for manipulating
+  block devices, networking, hardware diagnostics, and filesystems (with their
+  respective kernel modules).
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/clone-config.xml
+++ b/nixos/doc/manual/configuration/profiles/clone-config.xml
@@ -9,6 +9,6 @@
   This profile is used in installer images.
   It provides an editable configuration.nix that imports all the modules that
   were also used when creating the image in the first place.
-  As a result it allow users to edit and rebuild the live-system.
+  As a result it allows users to edit and rebuild the live-system.
  </para>
 </section>

--- a/nixos/doc/manual/configuration/profiles/clone-config.xml
+++ b/nixos/doc/manual/configuration/profiles/clone-config.xml
@@ -1,0 +1,11 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-clone-config">
+ <title>Clone Config</title>
+ <para>
+  <emphasis>TBD</emphasis>
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/clone-config.xml
+++ b/nixos/doc/manual/configuration/profiles/clone-config.xml
@@ -6,6 +6,9 @@
          xml:id="sec-profile-clone-config">
  <title>Clone Config</title>
  <para>
-  <emphasis>TBD</emphasis>
+  This profile is used in installer images.
+  It provides an editable configuration.nix that imports all the modules that
+  were also used when creating the image in the first place.
+  As a result it allow users to edit and rebuild the live-system.
  </para>
 </section>

--- a/nixos/doc/manual/configuration/profiles/demo.xml
+++ b/nixos/doc/manual/configuration/profiles/demo.xml
@@ -1,0 +1,13 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-demo">
+ <title>Demo</title>
+ <para>
+  This profile just enables a "demo" user, with password "demo", uid 1000, wheel
+  group and <link linkend="opt-services.xserver.displayManager.sddm.autoLogin">
+   autologin in the SDDM display manager</link>.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/demo.xml
+++ b/nixos/doc/manual/configuration/profiles/demo.xml
@@ -6,7 +6,7 @@
          xml:id="sec-profile-demo">
  <title>Demo</title>
  <para>
-  This profile just enables a "demo" user, with password "demo", uid 1000, wheel
+  This profile just enables a <systemitem class="username">demo</systemitem> user, with password <literal>demo</literal>, uid <literal>1000</literal>, <systemitem class="groupname">wheel</systemitem>
   group and <link linkend="opt-services.xserver.displayManager.sddm.autoLogin">
    autologin in the SDDM display manager</link>.
  </para>

--- a/nixos/doc/manual/configuration/profiles/docker-container.xml
+++ b/nixos/doc/manual/configuration/profiles/docker-container.xml
@@ -8,7 +8,7 @@
  <para>
   This is the profile from which the Docker images are generated. It prepares a
   working system by importing the <link linkend="sec-profile-minimal">Minimal</link> and
-  <link linkend="sec-profile-clone-config">Clone Config</link> profiles, and setting appropiate
+  <link linkend="sec-profile-clone-config">Clone Config</link> profiles, and setting appropriate
   configutation options that are useful inside a container context, like
   <xref linkend="opt-boot.isContainer"/>.
  </para>

--- a/nixos/doc/manual/configuration/profiles/docker-container.xml
+++ b/nixos/doc/manual/configuration/profiles/docker-container.xml
@@ -9,7 +9,7 @@
   This is the profile from which the Docker images are generated. It prepares a
   working system by importing the <link linkend="sec-profile-minimal">Minimal</link> and
   <link linkend="sec-profile-clone-config">Clone Config</link> profiles, and setting appropriate
-  configutation options that are useful inside a container context, like
+  configuration options that are useful inside a container context, like
   <xref linkend="opt-boot.isContainer"/>.
  </para>
 </section>

--- a/nixos/doc/manual/configuration/profiles/docker-container.xml
+++ b/nixos/doc/manual/configuration/profiles/docker-container.xml
@@ -1,0 +1,15 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-docker-container">
+ <title>Docker Container</title>
+ <para>
+  This is the profile from which the Docker images are generated. It prepares a
+  working system by importing the <link linkend="sec-profile-minimal">Minimal</link> and
+  <link linkend="sec-profile-clone-config">Clone Config</link> profiles, and setting appropiate
+  configutation options that are useful inside a container context, like
+  <xref linkend="opt-boot.isContainer"/>.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/graphical.xml
+++ b/nixos/doc/manual/configuration/profiles/graphical.xml
@@ -1,0 +1,21 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-graphical">
+ <title>Graphical</title>
+ <para>
+  Defines a NixOS configuration with the Plasma 5 desktop. It's used by the
+  graphical installation CD.
+ </para>
+ <para>
+  It sets <xref linkend="opt-services.xserver.enable"/>,
+  <xref linkend="opt-services.xserver.displayManager.sddm.enable"/>,
+  <xref linkend="opt-services.xserver.desktopManager.plasma5.enable"/> (
+  <link linkend="opt-services.xserver.desktopManager.plasma5.enableQt4Support">
+   without Qt4 Support</link>), and
+  <xref linkend="opt-services.xserver.libinput.enable"/> to true. It also
+  includes glxinfo and firefox in the system packages list.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/hardened.xml
+++ b/nixos/doc/manual/configuration/profiles/hardened.xml
@@ -11,7 +11,7 @@
  </para>
  <para>
   This includes a hardened kernel, and limiting the system information
-  available to procesess via de <filename>/sys</filename> and
+  available to processes through the <filename>/sys</filename> and
   <filename>/proc</filename> filesystems. It also disables the User Namespaces
   feature of the kernel, which stops Nix from being able to build anything
   (this particular setting can be overriden via

--- a/nixos/doc/manual/configuration/profiles/hardened.xml
+++ b/nixos/doc/manual/configuration/profiles/hardened.xml
@@ -1,0 +1,22 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-hardened">
+ <title>Hardened</title>
+ <para>
+  A profile with most (vanilla) hardening options enabled by default,
+  potentially at the cost of features and performance.
+ </para>
+ <para>
+  This includes a hardened kernel, and limiting the system information
+  available to procesess via de <filename>/sys</filename> and
+  <filename>/proc</filename> filesystems. It also disables the User Namespaces
+  feature of the kernel, which stops Nix from being able to build anything
+  (this particular setting can be overriden via
+  <xref linkend="opt-security.allowUserNamespaces"/>). See the <literal
+   xlink:href="https://github.com/nixos/nixpkgs/tree/master/nixos/modules/profiles/hardened.nix">
+   profile source</literal> for further detail on which settings are altered.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/headless.xml
+++ b/nixos/doc/manual/configuration/profiles/headless.xml
@@ -1,0 +1,18 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-headless">
+ <title>Headless</title>
+ <para>
+  Common configuration for headless machines (e.g., Amazon EC2 instances).
+ </para>
+ <para>
+  Disables <link linkend="opt-sound.enable">sound</link>,
+  <link linkend="opt-boot.vesa">vesa</link>, serial consoles,
+  <link linkend="opt-systemd.enableEmergencyMode">emergency mode</link>,
+  <link linkend="opt-boot.loader.grub.splashImage">grub splash images</link> and
+  configures the kernel to reboot automatically on panic.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/installation-device.xml
+++ b/nixos/doc/manual/configuration/profiles/installation-device.xml
@@ -1,0 +1,35 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-installation-device">
+ <title>Installation Device</title>
+ <para>
+  Provides a basic configuration for installation devices like CDs. This means
+  enabling hardware scans, using the <link linkend="sec-profile-clone-config">
+   Clone Config profile</link> to guarantee
+  <filename>/etc/nixos/configuration.nix</filename> exists (for
+  <command>nixos-rebuild</command> to work), a copy of the Nixpkgs channel
+  snapshot used to create the install media.
+ </para>
+ <para>
+  Additionally, documentation for <link linkend="opt-documentation.enable">
+   Nixpkgs</link> and <link linkend="opt-documentation.nixos.enable">NixOS
+   </link> are forcefully enabled (to override the
+   <link linkend="sec-profile-minimal">Minimal profile</link> preference); the
+   NixOS manual is shown automatically on TTY 8, sudo and udisks are disabled.
+   Autologin is enabled as root.
+ </para>
+ <para>
+  A message is shown to the user to start a display manager if needed,
+  ssh with <xref linkend="opt-services.openssh.permitRootLogin"/> are enabled (but
+  doesn't autostart). WPA Supplicant is also enabled without autostart.
+ </para>
+ <para>
+  Finally, vim is installed, root is set to not have a password, the kernel is
+  made more silent for remote public IP installs, and several settings are
+  tweaked so that the installer has a better chance of succeeding under
+  low-memory environments.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/minimal.xml
+++ b/nixos/doc/manual/configuration/profiles/minimal.xml
@@ -1,0 +1,17 @@
+
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-minimal">
+ <title>Minimal</title>
+ <para>
+  This profile defines a small NixOS configuration. It does not contain any
+  graphical stuff. It's a very short file that enables
+  <link linkend="opt-environment.noXlibs">noXlibs</link>, sets
+  <link linkend="opt-i18n.supportedLocales">i18n.supportedLocales</link>
+  to only support the user-selected locale,
+  <link linkend="opt-documentation.enable">disables packages' documentation
+  </link>, and <link linkend="opt-sound.enable">disables sound</link>.
+ </para>
+</section>

--- a/nixos/doc/manual/configuration/profiles/qemu-guest.xml
+++ b/nixos/doc/manual/configuration/profiles/qemu-guest.xml
@@ -1,0 +1,16 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-profile-qemu-guest">
+ <title>QEMU Guest</title>
+ <para>
+  This profile contains common configuration for virtual machines running under
+  QEMU (using virtio).
+ </para>
+ <para>
+  It makes virtio modules available on the initrd, sets the system time from
+  the hardware clock to work around a bug in qemu-kvm, and
+  <link linkend="opt-security.rngd.enable">enables rngd</link>.
+ </para>
+</section>


### PR DESCRIPTION
###### Motivation for this change

Profiles lack discovery and documentation. Hopefully this is the beginning of a fix. **Clone-config is empty** because I haven't had the time to understand what it does, so someone should provide at least a short summary.

In fact, I'd like to have insight on why most options are set in each profile, I just resorted to state what is set, without a reason why.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

