### PR TITLE
pythonPackages.libmr: init at 0.1.9

### DIFF
--- a/pkgs/development/python-modules/libmr/default.nix
+++ b/pkgs/development/python-modules/libmr/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, cython }:
+
+buildPythonPackage rec {
+  pname = "libmr";
+  version = "0.1.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "43ccd86693b725fa3abe648c8cdcef17ba5fa46b5528168829e5f9b968dfeb70";
+  };
+
+  propagatedBuildInputs = [ numpy cython ];
+
+  # No tests in the pypi tarball
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "libMR provides core MetaRecognition and Weibull fitting functionality";
+    homepage = https://github.com/Vastlab/libMR;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -374,6 +374,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  libmr = callPackage ../development/python-modules/libmr { };
+
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
   logster = callPackage ../development/python-modules/logster { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

