### PR TITLE
nixos/jupyter: wait for network.target

### DIFF
--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -145,6 +145,7 @@ in {
       systemd.services.jupyter = {
         description = "Jupyter development server";
 
+        after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
 
         # TODO: Patch notebook so we can explicitly pass in a shell


### PR DESCRIPTION
###### Motivation for this change
For me `jupyter` configured with `services.jupyter` fails to start on boot with `OSError: [Errno 99] Cannot assign requested address` (traceback below) but works just fine after restarting.

Adding an `after = [ "network.target" ];` dependency fixes this for me.

cc @aborsu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
Nov 06 09:30:27 lulus systemd[1]: Started Jupyter development server.
Nov 06 09:30:27 lulus jupyter-notebook[958]: Traceback (most recent call last):
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/1ibabrhqbjsf5w060c4hw2x7k4v0hxf3-python3.6-notebook-5.6.0/bin/.jupyter-notebook-wrapped", line 12, in <module>
Nov 06 09:30:27 lulus jupyter-notebook[958]:     sys.exit(main())
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/p0zpg8f51krcsx1gp8b7qwdhq7ynzw5f-python3.6-jupyter_core-4.4.0/lib/python3.6/site-packages/jupyter_core/application.py", line 266, in launch_instance
Nov 06 09:30:27 lulus jupyter-notebook[958]:     return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/5a6x5msd2k9x3zcjh2rqckl31c4q0vxs-python3.6-traitlets-4.3.2/lib/python3.6/site-packages/traitlets/config/application.py", line 657, in launch_instance
Nov 06 09:30:27 lulus jupyter-notebook[958]:     app.initialize(argv)
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "<decorator-gen-7>", line 2, in initialize
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/5a6x5msd2k9x3zcjh2rqckl31c4q0vxs-python3.6-traitlets-4.3.2/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
Nov 06 09:30:27 lulus jupyter-notebook[958]:     return method(app, *args, **kwargs)
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/1ibabrhqbjsf5w060c4hw2x7k4v0hxf3-python3.6-notebook-5.6.0/lib/python3.6/site-packages/notebook/notebookapp.py", line 1602, in initialize
Nov 06 09:30:27 lulus jupyter-notebook[958]:     self.init_webapp()
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/1ibabrhqbjsf5w060c4hw2x7k4v0hxf3-python3.6-notebook-5.6.0/lib/python3.6/site-packages/notebook/notebookapp.py", line 1381, in init_webapp
Nov 06 09:30:27 lulus jupyter-notebook[958]:     self.http_server.listen(port, self.ip)
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/q03rxjwp6kiaf4i4lp0dq1h6dnhn3d52-python3.6-tornado-5.1/lib/python3.6/site-packages/tornado/tcpserver.py", line 143, in listen
Nov 06 09:30:27 lulus jupyter-notebook[958]:     sockets = bind_sockets(port, address=address)
Nov 06 09:30:27 lulus jupyter-notebook[958]:   File "/nix/store/q03rxjwp6kiaf4i4lp0dq1h6dnhn3d52-python3.6-tornado-5.1/lib/python3.6/site-packages/tornado/netutil.py", line 168, in bind_sockets
Nov 06 09:30:27 lulus jupyter-notebook[958]:     sock.bind(sockaddr)
Nov 06 09:30:27 lulus jupyter-notebook[958]: OSError: [Errno 99] Cannot assign requested address
```

Jupyter service configuration
https://github.com/sveitser/nixconfig/blob/93c74a50499cd7356fa0381f1481ec777a9982c4/desktop-home.nix#L39-L61