### PR TITLE
pythonPackages.click-repl: init at 0.1.6

### DIFF
--- a/pkgs/development/python-modules/click-repl/default.nix
+++ b/pkgs/development/python-modules/click-repl/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, click, prompt_toolkit }:
+
+buildPythonPackage rec {
+  pname = "click-repl";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mcmz95595nrp4r58spy1ac993db26hk4q97isghbmn4md99vwmr";
+  };
+
+  propagatedBuildInputs = [ click prompt_toolkit ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/click-contrib/click-repl;
+    description = "Subcommand REPL for click apps";
+    license = licenses.mit;
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1140,6 +1140,8 @@ in {
 
   click-plugins = callPackage ../development/python-modules/click-plugins {};
 
+  click-repl = callPackage ../development/python-modules/click-repl { };
+
   click-threading = callPackage ../development/python-modules/click-threading {};
 
   cligj = callPackage ../development/python-modules/cligj { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

