### PR TITLE
pythonPackages.autologging: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/autologging/default.nix
+++ b/pkgs/development/python-modules/autologging/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "Autologging";
+  version = "1.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16v2k16m433fxlvl7f0081n67rpxhs2hyn1ivkx1xs5qjxpv5n3k";
+    extension = "zip";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://ninthtest.info/python-autologging/;
+    description = "Easier logging and tracing for Python classes";
+    license = licenses.mit;
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -202,6 +202,8 @@ in {
 
   autograd = callPackage ../development/python-modules/autograd { };
 
+  autologging = callPackage ../development/python-modules/autologging { };
+
   automat = callPackage ../development/python-modules/automat { };
 
   awkward = callPackage ../development/python-modules/awkward { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

