### PR TITLE
Fix help2man.postInstall syntax error under cygwin.

### DIFF
--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     #! $SHELL -e
     export PERL5LIB=\''${PERL5LIB:+:}$gettext_perl
     ${stdenv.lib.optionalString stdenv.hostPlatform.isCygwin
-        "export PATH=\''${PATH:+:}${gettext}/bin"}
+        ''export PATH=\''${PATH:+:}${gettext}/bin''}
     exec -a \$0 $out/bin/.help2man-wrapped "\$@"
     EOF
     chmod +x $out/bin/help2man


### PR DESCRIPTION
###### Motivation for this change

currently fails with 
```
error: syntax error, unexpected '+', at /nix/store/20dlh2idhmcfrcd5b45w75jhi9wjszyp-nixpkgs-ce68b2/pkgs/development/tools/misc/help2man/default.nix:27:32
```
if `isCygwin` is true.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

