### PR TITLE
Disable Rust doctests on Darwin.

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -80,10 +80,14 @@ in stdenv.mkDerivation (args // {
     runHook postBuild
   '';
 
-  checkPhase = args.checkPhase or ''
+  checkPhase = let
+    # Temporary work around for failing doc tests on Darwin:
+    # https://github.com/NixOS/nixpkgs/issues/49693#issuecomment-435617384
+    cargoTest = if stdenv.isDarwin then "cargo test --lib" else "cargo test";
+  in args.checkPhase or ''
     runHook preCheck
     echo "Running cargo test"
-    cargo test
+    ${cargoTest}
     runHook postCheck
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Since Rust 1.30 (?) some Rust crates do not build, see e.g. #49693 and #49708
and fail with:

```
dyld: Symbol not found: __ZTIN4llvm2cl18GenericOptionValueE
```

So far, the common pattern seems to be that the linking fails in doctests. This
change is a temporary workaround that disables doctests for Rust crates on
Darwin. This avoids the need to patch individual derivations and still runs
library tests.

Tested: building alacritty and nix-index on Darwin with tests enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

