### PR TITLE
nixos/postgresqlBackup: set to umask to 0077

### DIFF
--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -20,6 +20,8 @@ let
       '';
 
       script = ''
+        umask 0077 # ensure backup is only readable by postgres user
+
         if [ -e ${cfg.location}/${db}.sql.gz ]; then
           ${pkgs.coreutils}/bin/mv ${cfg.location}/${db}.sql.gz ${cfg.location}/${db}.prev.sql.gz
         fi

--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -53,6 +53,7 @@ let
       # Check backup service
       $machine->succeed("systemctl start postgresqlBackup-postgres.service");
       $machine->succeed("zcat /var/backup/postgresql/postgres.sql.gz | grep '<test>ok</test>'");
+      $machine->succeed("stat -c '%a' /var/backup/postgresql/postgres.sql.gz | grep 600");
       $machine->shutdown;
     '';
 


### PR DESCRIPTION
###### Motivation for this change
The backup file now is world readable (0644). The `mkdir` in the service file creates the backup directory with mode 0700. However, if the directory already exists the permissions are not changed and
the backup file is exposed. Setting the umask during creation of the dump to 0077 ensures
that the backup itself is not exposed and existing settings are not changed (i.e. the directory permissions).

This patch also needs a backport to 18.09

###### Things done
* Ensure that the backup file is only readable by the owner by setting umask 0077
* Add file permission test to `nixos/tests/postgresql.nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

