### PR TITLE
qt5.qtbase: add cf-private on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation {
       if stdenv.isDarwin
       then with darwin.apple_sdk.frameworks;
         [
+          # TODO: move to buildInputs, this should not be propagated.
           AGL AppKit ApplicationServices Carbon Cocoa CoreAudio CoreBluetooth
           CoreLocation CoreServices DiskArbitration Foundation OpenGL
           darwin.libobjc libiconv
@@ -77,6 +78,9 @@ stdenv.mkDerivation {
       [ libinput ]
       ++ lib.optional withGtk3 gtk3
     )
+    ++ lib.optional stdenv.isDarwin
+      # Needed for OBJC_CLASS_$_NSDate symbols.
+      [ darwin.cf-private ]
     ++ lib.optional developerBuild gdb
     ++ lib.optional (cups != null) cups
     ++ lib.optional (mysql != null) mysql.connector-c


### PR DESCRIPTION
###### Motivation for this change

Follow up for #49768

    Undefined symbols for architecture x86_64:
      "_OBJC_CLASS_$_NSDate", referenced from:
          objc-class-ref in qcore_foundation.o
      "_OBJC_CLASS_$_NSURL", referenced from:
          objc-class-ref in qcore_foundation.o
      "_OBJC_CLASS_$_NSData", referenced from:
          objc-class-ref in qcore_foundation.o
      "_CFURLCopyResourcePropertyForKey", referenced from:
          hasResourcePropertyFlag(QFileSystemMetaData const&, QFileSystemEntry const&, __CFString const*) in qfilesystemengine_unix.o
      "_CFURLCreateBookmarkDataFromFile", referenced from:
          QFileSystemEngine::getLinkTarget(QFileSystemEntry const&, QFileSystemMetaData&) in qfilesystemengine_unix.o
      "_kCFURLIsAliasFileKey", referenced from:
          QFileSystemEngine::fillMetaData(QFileSystemEntry const&, QFileSystemMetaData&, QFlags<QFileSystemMetaData::MetaDataFlag>) in qfilesystemengine_unix.o
      "_kCFURLIsHiddenKey", referenced from:
          QFileSystemEngine::fillMetaData(QFileSystemEntry const&, QFileSystemMetaData&, QFlags<QFileSystemMetaData::MetaDataFlag>) in qfilesystemengine_unix.o
      "_kCFURLIsPackageKey", referenced from:
          QFileSystemEngine::fillMetaData(QFileSystemEntry const&, QFileSystemMetaData&, QFlags<QFileSystemMetaData::MetaDataFlag>) in qfilesystemengine_unix.o
      "_CFURLCreateByResolvingBookmarkData", referenced from:
          QFileSystemEngine::getLinkTarget(QFileSystemEntry const&, QFileSystemMetaData&) in qfilesystemengine_unix.o
    ld: symbol(s) not found for architecture x86_64

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

