### PR TITLE
opensmtpd: 6.4.0p1 -> 6.4.0p2

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   name = "opensmtpd-${version}";
-  version = "6.4.0p1";
+  version = "6.4.0p2";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib libressl db pam ];
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "1qxxhnlsmpfh9v4azgl0634955r085gsic1c66jdll21bd5w2mq8";
+    sha256 = "1y7snhsrcdi56vaa23iwjpybhyrnnh2f6dxrfnacn7xgy5xwzbvn";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Should fix the issues mentioned at https://github.com/NixOS/nixpkgs/pull/48901#issuecomment-435838142 and after, and on IRC.

See upstream https://github.com/OpenSMTPD/OpenSMTPD/issues/886

cc @obadz @rickynils @the-kenny @Izorkin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

