### PR TITLE
calibre: remove references to podofo to reduce closure size

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, poppler_utils, pkgconfig, libpng
 , imagemagick, libjpeg, fontconfig, podofo, qtbase, qmake, icu, sqlite
 , makeWrapper, unrarSupport ? false, chmlib, python2Packages, libusb1, libmtp
-, xdg_utils, makeDesktopItem, wrapGAppsHook
+, xdg_utils, makeDesktopItem, wrapGAppsHook, removeReferencesTo
 }:
 
 stdenv.mkDerivation rec {
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ makeWrapper pkgconfig qmake ];
+  nativeBuildInputs = [ makeWrapper pkgconfig qmake removeReferencesTo ];
 
   buildInputs = [
     poppler_utils libpng imagemagick libjpeg
@@ -58,8 +58,8 @@ stdenv.mkDerivation rec {
     export MAGICK_LIB=${imagemagick.out}/lib
     export FC_INC_DIR=${fontconfig.dev}/include/fontconfig
     export FC_LIB_DIR=${fontconfig.lib}/lib
-    export PODOFO_INC_DIR=${podofo}/include/podofo
-    export PODOFO_LIB_DIR=${podofo}/lib
+    export PODOFO_INC_DIR=${podofo.dev}/include/podofo
+    export PODOFO_LIB_DIR=${podofo.lib}/lib
     export SIP_BIN=${python2Packages.sip}/bin/sip
     ${python2Packages.python.interpreter} setup.py install --prefix=$out
 
@@ -87,6 +87,15 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  # Remove some references to shrink the closure size. This reference (as of
+  # 2018-11-06) was a single string like the following:
+  #   /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-podofo-0.9.6-dev/include/podofo/base/PdfVariant.h
+  preFixup = ''
+    remove-references-to -t ${podofo.dev} $out/lib/calibre/calibre/plugins/podofo.so
+  '';
+
+  disallowedReferences = [ podofo.dev ];
 
   calibreDesktopItem = makeDesktopItem {
     name = "calibre";

--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "dev" "lib" ];
+
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [ zlib freetype libjpeg libtiff fontconfig openssl libpng
@@ -31,6 +33,11 @@ stdenv.mkDerivation rec {
     "-DPODOFO_BUILD_STATIC=OFF"
     "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
   ];
+
+  postInstall = ''
+    moveToOutput lib "$lib"
+  '';
+
   meta = with stdenv.lib; {
     homepage = http://podofo.sourceforge.net;
     description = "A library to work with the PDF file format";


### PR DESCRIPTION
###### Motivation for this change
This reduces the closure size (on 18.09) from ~841 to ~833 MiB; not a _huge_ win, but given that every other library in Calibre has a `lib`/`dev` output, probably worth doing?

```
$ nix path-info -S /nix/store/k3mhm3a85r6x7xml9aab261mfxw8kgiv-calibre-3.30.0
/nix/store/k3mhm3a85r6x7xml9aab261mfxw8kgiv-calibre-3.30.0	  882307120
$ nix path-info -S /nix/store/gqpz53zbc90v70x8kq9smng61nh18q6a-calibre-3.30.0              
/nix/store/gqpz53zbc90v70x8kq9smng61nh18q6a-calibre-3.30.0	  874079880
```

In order to do this, we split `podofo` into multiple outputs (since `podofo.dev` has references to a bunch of `-dev` libraries itself, we need to split it into its' own output).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @domenkozar @pSub @AndersonTorres (maintainers of calibre)