### PR TITLE
libtiff: 4.0.9 -> 2018-11-04

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,35 +1,37 @@
-{ stdenv, fetchurl, pkgconfig, zlib, libjpeg, xz }:
+{ stdenv
+, fetchFromGitLab
 
-let
-  version = "4.0.9";
-in
+, pkgconfig
+, autogen
+, autoconf
+, automake
+, libtool
+
+, zlib
+, libjpeg
+, xz
+}:
+
 stdenv.mkDerivation rec {
-  name = "libtiff-${version}";
+  version = "2018-11-04";
+  name = "libtiff-unstable-${version}";
 
-  src = fetchurl {
-    url = "https://download.osgeo.org/libtiff/tiff-${version}.tar.gz";
-    sha256 = "1kfg4q01r4mqn7dj63ifhi6pmqzbf4xax6ni6kkk81ri5kndwyvf";
+  src = fetchFromGitLab {
+    owner = "libtiff";
+    repo = "libtiff";
+    rev = "779e54ca32b09155c10d398227a70038de399d7d";
+    sha256 = "029fmn0rdmb5gxhg83ff9j2zx3qk6wsiaiv554jq26pdc23achsp";
   };
-
-  prePatch = let
-      debian = fetchurl {
-        # When the URL disappears, it typically means that Debian has new patches
-        # (probably security) and updating to new tarball will apply them as well.
-        url = http://http.debian.net/debian/pool/main/t/tiff/tiff_4.0.9-6.debian.tar.xz;
-        sha256 = "10yk5npchxscgsnd7ihd3bbbw2fxkl7ni0plm43c9q4nwp6ms52f";
-      };
-    in ''
-      tar xf ${debian}
-      patches="$patches $(sed 's|^|debian/patches/|' < debian/patches/series)"
-    '';
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autogen autoconf automake libtool ];
 
   propagatedBuildInputs = [ zlib libjpeg xz ]; #TODO: opengl support (bogus configure detection)
 
   enableParallelBuilding = true;
+
+  preConfigure = "./autogen.sh";
 
   doCheck = true; # not cross;
 


### PR DESCRIPTION
###### Motivation for this change
This includes a bunch of security fixes (#49786), and mimics [what Debian has done][1] in moving to a git snapshot instead of a released version + backported security patches.

[1]: https://metadata.ftp-master.debian.org/changelogs//main/t/tiff/tiff_4.0.9+git181026-1_changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(there don't appear to be any maintainers for `libtiff` to cc)