### PR TITLE
nixos/manual: move syncthing notice in the right position

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -97,17 +97,17 @@
        start org.nixos.nix-daemon</command>.
       </para>
      </listitem>
-     <listitem>
-      <para>
-        The Syncthing state and configuration data has been moved from
-        <varname>services.syncthing.dataDir</varname> to the newly defined
-        <varname>services.syncthing.configDir</varname>, which default to
-        <literal>/var/lib/syncthing/.config/syncthing</literal>.
-        This change makes possible to share synced directories using ACLs
-        without Syncthing resetting the permission on every start.
-      </para>
-     </listitem>
     </itemizedlist>
+   </listitem>
+   <listitem>
+    <para>
+      The Syncthing state and configuration data has been moved from
+      <varname>services.syncthing.dataDir</varname> to the newly defined
+      <varname>services.syncthing.configDir</varname>, which default to
+      <literal>/var/lib/syncthing/.config/syncthing</literal>.
+      This change makes possible to share synced directories using ACLs
+      without Syncthing resetting the permission on every start.
+    </para>
    </listitem>
    <listitem>
     <para>


### PR DESCRIPTION
###### Motivation for this change
Fixup of #47526 

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Built manual
---

