### PR TITLE
Make `fetch*` source derivation names (optionally) more descriptive and homogenize them across fetchers

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,20 +1,11 @@
 {
   lib,
+  repoRevToNameMaybe,
   stdenvNoCC,
   git,
   git-lfs,
   cacert,
 }:
-
-let
-  urlToName =
-    url: rev:
-    let
-      shortRev = lib.sources.shortRev rev;
-      appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${shortRev}";
-    in
-    "${lib.sources.urlToName url}${appendShort}";
-in
 
 lib.makeOverridable (
   lib.fetchers.withNormalizedHash { } (
@@ -24,7 +15,7 @@ lib.makeOverridable (
       url,
       tag ? null,
       rev ? null,
-      name ? urlToName url (lib.revOrTag rev tag),
+      name ? repoRevToNameMaybe url (lib.revOrTag rev tag) "git",
       leaveDotGit ? deepClone || fetchTags,
       outputHash ? lib.fakeHash,
       outputHashAlgo ? null,

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -1,12 +1,13 @@
 {
   lib,
+  repoRevToNameMaybe,
   stdenvNoCC,
   mercurial,
 }:
 {
-  name ? null,
   url,
   rev ? null,
+  name ? repoRevToNameMaybe url rev "hg",
   sha256 ? null,
   hash ? null,
   fetchSubrepos ? false,
@@ -18,7 +19,7 @@ if hash != null && sha256 != null then
 else
   # TODO: statically check if mercurial as the https support if the url starts with https.
   stdenvNoCC.mkDerivation {
-    name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
+    inherit name;
     builder = ./builder.sh;
     nativeBuildInputs = [ mercurial ];
 

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  config,
   stdenvNoCC,
   buildPackages,
   cacert,
@@ -36,8 +37,10 @@ let
         # ../repo (no trunk) -> repo
         else
           head path;
+      kind = config.fetchedSourceNameDefault;
+      suffix = lib.optionalString (kind == "full") "-svn";
     in
-    "${repoName}-r${toString rev}";
+    if kind == "source" then "source" else "${repoName}-r${toString rev}${suffix}-source";
 in
 
 {


### PR DESCRIPTION
###### Description of changes

This patch adds `lib.repoRevToName` function that generalizes away most of the code used for derivation name generation by `fetch*` (`fetchzip`, `fetchFromGitHub`, etc) functions.

It's first argument controls how the resulting name will look (see below).

Since `lib` has no equivalent of Nixpkgs' `config`, this patch adds `config.fetchedSourceNameDefault` option to Nixpkgs and then re-exposes `lib.repoRevToName config.fetchedSourceNameDefault` expression as `pkgs.repoRevToNameMaybe` which is then used in `fetch*` derivations.

The result is that different values of `config.fetchedSourceNameDefault` now control how the `src` derivations produced by `fetch*` functions are to be named, e.g.:

-   `fetchedSourceNameDefault = "source"` (the default):

        $ nix-instantiate -A fuse.src
        /nix/store/<hash>-source.drv

-   `fetchedSourceNameDefault = "versioned"`:

        $ nix-instantiate -A fuse.src
        /nix/store/<hash>-libfuse-2.9.9-source.drv

-   `fetchedSourceNameDefault = "full"`:

        $ nix-instantiate -A fuse.src
        /nix/store/<hash>-libfuse-2.9.9-github-source.drv

See documentation of `config.fetchedSourceNameDefault` for more info.

In effect, this patch also homogenizes derivation names produced by `fetch*` functions so that switching from e.g. `fetchFromGitHub` to `fetchgit` would be a noop (assuming the content hash does not change, which is not always the case for `fetchFromGitHub` since GitHub uses `git archive` internally and `fetchgit` does not).
