### PR TITLE
metrics.nix: add a metrick for the current number of packages as seen by nix-env

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -49,6 +49,9 @@ runCommand "nixpkgs-metrics"
     run nix-env.qa nix-env -f ${nixpkgs} -qa
     run nix-env.qaDrv nix-env -f ${nixpkgs} -qa --drv-path --meta --xml
 
+    num=$(nix-env -f ${nixpkgs} -qa | wc -l)
+    echo "nix-env.qaCount $num" >> $out/nix-support/hydra-metrics
+
     export GC_INITIAL_HEAP_SIZE=128k
     run nix-env.qaAggressive nix-env -f ${nixpkgs} -qa
     run nix-env.qaDrvAggressive nix-env -f ${nixpkgs} -qa --drv-path --meta --xml


### PR DESCRIPTION
###### Motivation for this change

A tiny piece of #45841 I would like to be applied anyway.

###### Things done

It is a bit hacky, but

- [X] I using this for quite a while and I'm very happy about it.