### PR TITLE
pgmetrics: init at 1.5.0

### DIFF
--- a/pkgs/tools/misc/pgmetrics/default.nix
+++ b/pkgs/tools/misc/pgmetrics/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "pgmetrics-${version}";
+  version = "1.5.0";
+
+  goPackagePath = "github.com/rapidloop/pgmetrics";
+
+  src = fetchFromGitHub {
+    owner  = "rapidloop";
+    repo   = "pgmetrics";
+    rev    = "refs/tags/v${version}";
+    sha256 = "1l3vd1lvp4a6irx0zpjb5bkskkb9krx9j7pwii8jy9dcjy4gj24f";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    homepage = https://pgmetrics.io/;
+    description = "Collect and display information and stats from a running PostgreSQL server";
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/tools/misc/pgmetrics/deps.nix
+++ b/pkgs/tools/misc/pgmetrics/deps.nix
@@ -1,0 +1,84 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev =  "bb3d318650d48840a39aa21a027c6630e198e626";
+      sha256 = "1lqd8ix3cb164j5iazjby2jpa6bdsflhy0h9mi4yldvvcvrc194c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/howeyc/gopass";
+    fetch = {
+      type = "git";
+      url = "https://github.com/howeyc/gopass";
+      rev =  "bf9dde6d0d2c004a008c27aaee91170c786f6db8";
+      sha256 = "1jxzyfnqi0h1fzlsvlkn10bncic803bfhslyijcxk55mgh297g45";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev =  "88edab0803230a3898347e77b474f8c1820a1f20";
+      sha256 = "02y7c8xy33x5q4167x2drzrys41nfi7wxxp9hy4vpazfws88al9p";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pborman/getopt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pborman/getopt";
+      rev =  "7148bc3a4c3008adfcab60cbebfd0576018f330b";
+      sha256 = "0zhvvmv671r1fbdd5hbv3flx8k2rb60giqx115w0553c56qkqfpj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/rapidloop/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rapidloop/pq";
+      rev =  "f379fd34d14f11337c3945aa665f7718c0213317";
+      sha256 = "0svhissh6v1qdj9zypvj6jpjrx9g56gq8sf1pila41mczglmni05";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xdg-go/stringprep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xdg-go/stringprep";
+      rev =  "bd625b8dc1e3b0f57412280ccbcc317f0c69d8db";
+      sha256 = "03nard51zgzbaq64p6gsvrz8fps3yazl3ydd115y0bppkdx2i4ji";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "432090b8f568c018896cd8a0fb0345872bbac6ce";
+      sha256 = "1i8616qqwih6g5nx8c1hfqhp0kb110ml3xkgsn6qvc36q04amjmq";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "37707fdb30a5b38865cfb95e5aab41707daec7fd";
+      sha256 = "1abrr2507a737hdqv4q7pw7hv6ls9pdiq9crhdi52r3gcz6hvizg";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4778,6 +4778,8 @@ with pkgs;
 
   pg_top = callPackage ../tools/misc/pg_top { };
 
+  pgmetrics = callPackage ../tools/misc/pgmetrics { };
+
   pdsh = callPackage ../tools/networking/pdsh {
     rsh = true;          # enable internal rsh implementation
     ssh = openssh;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

