### PR TITLE
getdp: init at 3.0.4

### DIFF
--- a/pkgs/applications/science/math/getdp/default.nix
+++ b/pkgs/applications/science/math/getdp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake, gfortran, openblas, openmpi, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "getdp-${version}";
+  version = "3.0.4";
+  src = fetchurl {
+    url = "http://getdp.info/src/getdp-${version}-source.tgz";
+    sha256 = "0v3hg03lzw4hz28hm45hpv0gyydqz0wav7xvb5n0v0jrm47mrspv";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ gfortran openblas openmpi python3 ];
+
+  meta = with stdenv.lib; {
+    description = "A General Environment for the Treatment of Discrete Problems";
+    longDescription = ''
+      GetDP is a free finite element solver using mixed elements to discretize de Rham-type complexes in one, two and three dimensions.
+      The main feature of GetDP is the closeness between the input data defining discrete problems (written by the user in ASCII data files) and the symbolic mathematical expressions of these problems.
+    '';
+    homepage = http://getdp.info/;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with maintainers; [ wucke13 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21523,6 +21523,8 @@ in
 
   flintqs = callPackage ../development/libraries/science/math/flintqs { };
 
+  getdp = callPackage ../applications/science/math/getdp { };
+
   gurobi = callPackage ../applications/science/math/gurobi { };
 
   jags = callPackage ../applications/science/math/jags { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

