### PR TITLE
vimPlugins.gist-vim: gist-vim depends on WebApi

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -162,6 +162,10 @@ with generated;
     dependencies = ["self"];
   });
 
+  gist-vim = gist-vim.overrideAttrs(old: {
+    dependencies = ["webapi-vim"];
+  });
+
   gitv = gitv.overrideAttrs(old: {
     dependencies = ["gitv"];
   });


### PR DESCRIPTION
###### Motivation for this change

I'm trying to use `:Gist` from NeoVim, but I get the following error:

```vimL
Gist: require 'webapi', install https://github.com/mattn/webapi-vim
Gist: require 'webapi', install https://github.com/mattn/webapi-vim
E117: Unknown function: gist#Gist
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes #43399
