### PR TITLE
neovim wrapper: build with nodejs support

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, makeWrapper
 , vimUtils
 , bundlerEnv, ruby
+, nodejs
+, nodePackages
 , pythonPackages
 , python3Packages
 }:
@@ -12,6 +14,7 @@ let
   wrapper = {
       withPython ? true,  extraPythonPackages ? (_: []) /* the function you would have passed to python.withPackages */
     , withPython3 ? true,  extraPython3Packages ? (_: []) /* the function you would have passed to python.withPackages */
+    , withNodeJs? false
     , withRuby ? true
     , withPyGUI ? false
     , vimAlias ? false
@@ -50,6 +53,8 @@ let
         ++ (extraPython3PackagesFun ps)
         ++ (concatMap (f: f ps) pluginPython3Packages));
 
+  binPath = makeBinPath (optionals withRuby [rubyEnv] ++ optionals withNodeJs [nodejs]);
+
   in
   stdenv.mkDerivation {
       name = "neovim-${stdenv.lib.getVersion neovim}";
@@ -62,10 +67,12 @@ let
 
         makeWrapper "$(readlink -v --canonicalize-existing "${bin}")" \
           "$out/bin/nvim" --add-flags " \
+        --cmd \"${if withNodeJs then "let g:node_host_prog='${nodePackages.neovim}/bin/neovim-node-host'" else "let g:loaded_node_provider=1"}\" \
         --cmd \"${if withPython then "let g:python_host_prog='$out/bin/nvim-python'" else "let g:loaded_python_provider = 1"}\" \
         --cmd \"${if withPython3 then "let g:python3_host_prog='$out/bin/nvim-python3'" else "let g:loaded_python3_provider = 1"}\" \
         --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
-         ${optionalString withRuby '' --suffix PATH : ${rubyEnv}/bin --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
+        --suffix PATH : ${binPath} \
+        ${optionalString withRuby '' --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
 
       ''
       + optionalString (!stdenv.isDarwin) ''

--- a/pkgs/development/node-packages/node-packages-v8.json
+++ b/pkgs/development/node-packages/node-packages-v8.json
@@ -69,6 +69,7 @@
 , "meguca"
 , "mocha"
 , "multi-file-swagger"
+, "neovim"
 , "nijs"
 , "node2nix"
 , "node-gyp"

--- a/pkgs/development/node-packages/node-packages-v8.nix
+++ b/pkgs/development/node-packages/node-packages-v8.nix
@@ -12309,6 +12309,15 @@ let
         sha1 = "df8c69eef1647923c7157b9ce83840610b02cc39";
       };
     };
+    "event-lite-0.1.2" = {
+      name = "event-lite";
+      packageName = "event-lite";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/event-lite/-/event-lite-0.1.2.tgz";
+        sha512 = "HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==";
+      };
+    };
     "event-pubsub-4.3.0" = {
       name = "event-pubsub";
       packageName = "event-pubsub";
@@ -22696,6 +22705,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/msgpack/-/msgpack-1.0.2.tgz";
         sha1 = "923e2c5cffa65c8418e9b228d1124793969c429c";
+      };
+    };
+    "msgpack-lite-0.1.26" = {
+      name = "msgpack-lite";
+      packageName = "msgpack-lite";
+      version = "0.1.26";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz";
+        sha1 = "dd3c50b26f059f25e7edee3644418358e2a9ad89";
       };
     };
     "msgpack5-3.6.0" = {
@@ -50871,6 +50889,39 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Multi-file Swagger example";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+  };
+  neovim = nodeEnv.buildNodePackage {
+    name = "neovim";
+    packageName = "neovim";
+    version = "4.2.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/neovim/-/neovim-4.2.1.tgz";
+      sha512 = "2Kto3HlBsFFtgyAmV8ecNtBBUrydoXp2EfIHwIvuhOIiVinCuKJaUmp1+1u5eGGu1TDZHUiHwvFv0T05eG8T+w==";
+    };
+    dependencies = [
+      sources."async-1.0.0"
+      sources."colors-1.0.3"
+      sources."cycle-1.0.3"
+      sources."event-lite-0.1.2"
+      sources."eyes-0.1.8"
+      sources."ieee754-1.1.12"
+      sources."int64-buffer-0.1.10"
+      sources."isarray-1.0.0"
+      sources."isstream-0.1.2"
+      sources."lodash-4.17.11"
+      sources."msgpack-lite-0.1.26"
+      sources."stack-trace-0.0.10"
+      sources."traverse-0.6.6"
+      sources."winston-2.4.4"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Neovim client API and neovim remote plugin provider";
+      homepage = https://github.com/neovim/node-client;
       license = "MIT";
     };
     production = true;


### PR DESCRIPTION
###### Motivation for this change

I use NeoVim to develop nodejs projects but my editor does not work well because it's missing the NodeJS neovim provider.

I have tested this by running `nix-shell -I nixpkgs=. --pure -p 'with import <nixpkgs> {}; neovim.override { withNodeJs=true; }' --run nvim`

When I run `:checkhealth`, I see it reporting nodejs as functional.

```
## Node.js provider (optional)
  - INFO: Node.js: v8.12.0
  - INFO: Neovim node.js host: /nix/store/fhmp7164mf7pmvin72z3qxiwv6p8ps9p-node-neovim-4.2.1/bin/neovim-node-host
  - OK: Latest "neovim" npm/yarn package is installed: 4.2.1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

