### PR TITLE
virtmanager: 1.5.1 -> 2.0.0

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python2Packages, intltool, file
+{ stdenv, fetchurl, python3Packages, intltool, file
 , wrapGAppsHook, gtk-vnc, vte, avahi, dconf
 , gobjectIntrospection, libvirt-glib, system-libvirt
 , gsettings-desktop-schemas, glib, libosinfo, gnome3, gtk3
@@ -8,14 +8,14 @@
 
 with stdenv.lib;
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "virt-manager-${version}";
-  version = "1.5.1";
+  version = "2.0.0";
   namePrefix = "";
 
   src = fetchurl {
     url = "http://virt-manager.org/download/sources/virt-manager/${name}.tar.gz";
-    sha256 = "1ardmd4sxdmd57y7qpka44gf09c1yq2g0xs074d3k1h925crv27f";
+    sha256 = "1b48xbrx99mfiv80c60k3ydzkpcpbq57c8h8dl0gnffmnzbs8vzb";
   };
 
   nativeBuildInputs = [
@@ -28,9 +28,9 @@ python2Packages.buildPythonApplication rec {
       gsettings-desktop-schemas libosinfo gtk3
     ] ++ optional spiceSupport spice-gtk;
 
-  propagatedBuildInputs = with python2Packages;
+  propagatedBuildInputs = with python3Packages;
     [
-      pygobject3 ipaddr libvirt libxml2 requests
+      pygobject3 ipaddress libvirt libxml2 requests
     ];
 
   patchPhase = ''
@@ -39,7 +39,7 @@ python2Packages.buildPythonApplication rec {
   '';
 
   postConfigure = ''
-    ${python2Packages.python.interpreter} setup.py configure --prefix=$out
+    ${python3Packages.python.interpreter} setup.py configure --prefix=$out
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Now uses python 3.  Will merge tomorrow.

cc @qknight @offlinehacker @fpletz

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

