### PR TITLE
libaccounts-glib: 1.23 -> 1.24

### DIFF
--- a/pkgs/development/libraries/libaccounts-glib/py-override.patch
+++ b/pkgs/development/libraries/libaccounts-glib/py-override.patch
@@ -1,0 +1,38 @@
+diff --git a/libaccounts-glib/pygobject/meson.build b/libaccounts-glib/pygobject/meson.build
+index fa1f4a0..588c4ce 100644
+--- a/libaccounts-glib/pygobject/meson.build
++++ b/libaccounts-glib/pygobject/meson.build
+@@ -1,11 +1,19 @@
+-python3 = import('python3')
+-python_exec = python3.find_python()
+-python_exec_result = run_command(python_exec, ['-c', 'import gi; from os.path import abspath; print(abspath(gi._overridesdir))'])
++py_override = get_option('py-overrides-dir')
+ 
+-if python_exec_result.returncode() != 0
+-    error('Failed to retreive the python GObject override directory')
++if py_override == ''
++    python3 = import('python3')
++    python_exec = python3.find_python()
++    
++    python_exec_result = run_command(python_exec, ['-c', 'import gi; from os.path import abspath; print(abspath(gi._overridesdir))'])
++
++    if python_exec_result.returncode() != 0
++        error('Failed to retreive the python GObject override directory')
++    endif
++
++    py_override = python_exec_result.stdout().strip()
+ endif
+ 
+-install_data('Accounts.py',
+-    install_dir: join_paths(python_exec_result.stdout().strip())
++install_data(
++    'Accounts.py',
++    install_dir: py_override
+ )
+diff --git a/meson_options.txt  b/meson_options.txt 
+new file mode 100644
+index 0000000..2c33804
+--- /dev/null
++++ b/meson_options.txt 	
+@@ -0,0 +1 @@
++option('py-overrides-dir', type : 'string', value : '', description: 'Path to pygobject overrides directory')


### PR DESCRIPTION
###### Motivation for this change
They are now using meson here too.

Also added multiple outputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jtojnar 