### PR TITLE
numpy: fix high cpu count bug

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchPypi, python, buildPythonPackage, isPyPy, gfortran, pytest, blas }:
+{ stdenv, lib, fetchPypi, fetchpatch, python, buildPythonPackage, isPyPy, gfortran, pytest, blas }:
 
 buildPythonPackage rec {
   pname = "numpy";
@@ -14,7 +14,14 @@ buildPythonPackage rec {
   nativeBuildInputs = [ gfortran pytest ];
   buildInputs = [ blas ];
 
-  patches = lib.optionals (python.hasDistutilsCxxPatch or false) [
+  patches = [
+    # fix a bug with high cpu count (https://github.com/numpy/numpy/issues/12087)
+    (fetchpatch {
+      name = "limit-default-for-get_num_build_jobs-to-8.patch";
+      url = "https://github.com/numpy/numpy/commit/4c05fed01c68a305abf62135695bc61606746683.patch";
+      sha256 = "1j2jlaibbx1fjszxzkgxrz7k8id34kg3gbc2fh4ib6y7hfnbqqz5";
+    })
+  ] ++ lib.optionals (python.hasDistutilsCxxPatch or false) [
     # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
     # Patching of numpy.distutils is needed to prevent it from undoing the
     # patch to distutils.


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/numpy/numpy/issues/12087, which shows itself when testing sage on hydra.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

