### PR TITLE
liquidsoap: make it find ladspa plugins

### DIFF
--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, which, pkgconfig
+{ stdenv, makeWrapper, fetchurl, which, pkgconfig
 , ocamlPackages
 , libao, portaudio, alsaLib, libpulseaudio, libjack2
 , libsamplerate, libmad, taglib, lame, libogg
@@ -31,10 +31,14 @@ stdenv.mkDerivation {
     sed ${toString packageFilters} PACKAGES.default > PACKAGES
   '';
 
+  postFixup = ''
+    wrapProgram $out/bin/liquidsoap --set LIQ_LADSPA_PATH /run/current-system/sw/lib/ladspa
+  '';
+
   configureFlags = [ "--localstatedir=/var" ];
 
   buildInputs =
-    [ which ocamlPackages.ocaml ocamlPackages.findlib pkgconfig
+    [ makeWrapper which ocamlPackages.ocaml ocamlPackages.findlib pkgconfig
       libao portaudio alsaLib libpulseaudio libjack2
       libsamplerate libmad taglib lame libogg
       libvorbis speex libtheora libopus fdk_aac

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -37,8 +37,9 @@ stdenv.mkDerivation {
 
   configureFlags = [ "--localstatedir=/var" ];
 
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs =
-    [ makeWrapper which ocamlPackages.ocaml ocamlPackages.findlib pkgconfig
+    [ which ocamlPackages.ocaml ocamlPackages.findlib
       libao portaudio alsaLib libpulseaudio libjack2
       libsamplerate libmad taglib lame libogg
       libvorbis speex libtheora libopus fdk_aac
@@ -51,7 +52,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Swiss-army knife for multimedia streaming";
-    homepage = http://liquidsoap.fm/;
+    homepage = https://www.liquidsoap.info/;
     maintainers = with maintainers; [ ehmry ];
     license = licenses.gpl2;
     platforms = ocamlPackages.ocaml.meta.platforms or [];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

