### PR TITLE
ssh-agents: init at 1.0.1

### DIFF
--- a/pkgs/tools/networking/ssh-agents/default.nix
+++ b/pkgs/tools/networking/ssh-agents/default.nix
@@ -1,0 +1,43 @@
+{ fetchFromGitHub
+, lib
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation rec {
+  name = "ssh-agents-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "kalbasit";
+    repo = "ssh-agents";
+    rev = "v${version}";
+    sha256 = "1l09zy87033v7hd17lhkxikwikqz5nj9x6c2w80rqpad4lp9ihwz";
+  };
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "ssh-agents capable of spawning and maintaining multiple ssh-agents across terminals";
+    longDescription = ''
+      The SSH agent is usually spawned by running eval $(ssh-agent), however this
+      spawns a new SSH agent at every invocation. This project provides an
+      ssh-agent wrapper called ssh-agents that is capable of spawning an SSH
+      agent and caching the environment variables for later invocation.
+
+      Features
+      - One SSH agent across all terminals
+      - Add all un-encrypted SSH keys to the agent upon spawning. Please note
+        that encrypted SSH keys can only be added via ssh-add after having
+        started the agent.
+      - Ability to have different keys in different agents for security purposes.
+      - Multiple SSH agents
+      - To use multi-SSH agents, start ssh agent with the --name flag. The
+        given name is expected to be a folder under ~/.ssh/name containing the
+        keys to include in the agent.
+    '';
+    homepage = https://github.com/kalbasit/ssh-agents;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -786,6 +786,8 @@ with pkgs;
 
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
+  ssh-agents = callPackage ../tools/networking/ssh-agents { };
+
   titaniumenv = callPackage ../development/mobile/titaniumenv { };
 
   abootimg = callPackage ../development/mobile/abootimg {};


### PR DESCRIPTION
###### Motivation for this change

I have created this script many years ago, and I finally managed to extract it as a separate project. I'm hoping it'll help someone as frustrated as I was trying to use multiple SSH agents across many terminal sessions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

