### PR TITLE
pam_mount: do not re-prompt for password

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -378,7 +378,7 @@ let
               ${optionalString config.security.pam.enableEcryptfs
                 "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}
               ${optionalString cfg.pamMount
-                "auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
+                "auth optional ${pkgs.pam_mount}/lib/security/pam_mount.so disable_interactive"}
               ${optionalString cfg.enableKwallet
                 ("auth optional ${pkgs.plasma5.kwallet-pam}/lib/security/pam_kwallet5.so" +
                  " kwalletd=${pkgs.libsForQt5.kwallet.bin}/bin/kwalletd5")}
@@ -437,7 +437,7 @@ let
           ${optionalString config.security.pam.enableEcryptfs
               "session optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"}
           ${optionalString cfg.pamMount
-              "session optional ${pkgs.pam_mount}/lib/security/pam_mount.so"}
+              "session optional ${pkgs.pam_mount}/lib/security/pam_mount.so disable_interactive"}
           ${optionalString use_ldap
               "session optional ${pam_ldap}/lib/security/pam_ldap.so"}
           ${optionalString config.services.sssd.enable


### PR DESCRIPTION
###### Motivation for this change

nixos-rebuild test causes pam_mount to prompt for a password when running with
an encrypted home:

```
building '/nix/store/p6bflh7n5zy2dql8l45mix9qnzq65hbk-nixos-system-mildred-18.09.git.98592c5da79M.drv'...
activating the configuration...
setting up /etc...
reenter password for pam_mount:
(mount.c:68): Messages from underlying mount program:
(mount.c:72): crypt_activate_by_passphrase: File exists
(pam_mount.c:522): mount of /dev/mapper/vg0-lv_home_peter failed
kbuildsycoca5 running...
```

This change makes pam_mount not prompt. It still tries to remount (and fails in
the process) but that message can be ignored.

Fixes: #44586

Reference: https://unix.stackexchange.com/a/273894

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

