### PR TITLE
vscode-extensions.ms-python: 2018.9.1 -> 2018.9.2

### DIFF
--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.9.1";
-    sha256 = "050r1rb0xyfikfa6iq741s368xz600pqdk74w6cxszxpy8kl2hng";
+    version = "2018.9.2";
+    sha256 = "11fg6dfs3f7yhzw393hi7gd7p1bvz9bnxnchmi4w2a5drj4hcs1n";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Vscode indicated a new version of the python extension was available.

Tested in vscode with:

```nix
let
  overlay = self: super: {
    vscode-with-extensions = super.vscode-with-extensions.override {
      vscodeExtensions = with super.vscode-extensions; [ ms-python.python ];
    };
  };
in
{
  nixpkgs.overlays = [ overlay ];
  environment.systemPackages = with pkgs; [ vscode-with-extensions ];
}
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

