### PR TITLE
acsccid: init at 1.1.6

### DIFF
--- a/pkgs/tools/security/acsccid/default.nix
+++ b/pkgs/tools/security/acsccid/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, gettext, flex, perl, pkgconfig, pcsclite, libusb }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.6";
+  name = "acsccid-${version}";
+
+  src = fetchFromGitHub {
+    owner = "acshk";
+    repo = "acsccid";
+    rev = "26bc84c738d12701e6a7289ed578671d71cbf3cb";
+    sha256 = "09k7hvcay092wkyf0hjsvimg1h4qzss1nk7m5yanlib4ldhw5g5c";
+  };
+
+  doCheck = true;
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ pcsclite libusb autoconf automake libtool gettext flex perl ];
+
+  postPatch = ''
+    sed -e s_/bin/echo_echo_g -i src/Makefile.am
+    patchShebangs src/convert_version.pl
+    patchShebangs src/create_Info_plist.pl
+  '';
+
+  preConfigure = ''
+    libtoolize --force
+    aclocal
+    autoheader
+    automake --force-missing --add-missing
+    autoconf
+    configureFlags="$configureFlags --enable-usbdropdir=$out/pcsc/drivers"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card readers.";
+    longDescription = ''
+      acsccid is a PC/SC driver for Linux/Mac OS X and it supports ACS CCID smart card
+      readers. This library provides a PC/SC IFD handler implementation and
+      communicates with the readers through the PC/SC Lite resource manager (pcscd).
+
+      acsccid is based on ccid. See CCID free software driver for more
+      information:
+      https://ccid.apdu.fr/
+
+      It can be enabled in /etc/nixos/configuration.nix by adding:
+        services.pcscd.enable = true;
+        services.pcscd.plugins = [ pkgs.acsccid ];
+    '';
+    homepage = src.meta.homepage;
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ roberth ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9043,6 +9043,8 @@ with pkgs;
 
   acl = callPackage ../development/libraries/acl { };
 
+  acsccid = callPackage ../tools/security/acsccid { };
+
   activemq = callPackage ../development/libraries/apache-activemq { };
 
   adns = callPackage ../development/libraries/adns { };


### PR DESCRIPTION
###### Motivation for this change

This adds support for ACS CCID smart card readers, for use with the pcscd service.

(The non-CCID version is already supported by the libacr38u driver.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

