### PR TITLE
CODEOWNERS: add mboes and Profpatsch for bazel packaging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,3 +123,6 @@
 
 # Idris
 /pkgs/development/idris-modules @Infinisil
+
+# Bazel
+/pkgs/development/tools/build-managers/bazel @mboes @Profpatsch


### PR DESCRIPTION
There is an elevated commercial interest of keeping the bazel
ecosystem up-to-date, Tweag I/O takes on maintainership.

cc @mboes 