### PR TITLE
pytorch: disable distributed tests

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -72,7 +72,7 @@ in buildPythonPackage rec {
   ] ++ lib.optional (pythonOlder "3.5") typing;
 
   checkPhase = ''
-    ${cudaStubEnv}python test/run_test.py --exclude dataloader sparse torch utils
+    ${cudaStubEnv}python test/run_test.py --exclude dataloader sparse torch utils distributed
   '';
 
   meta = {


### PR DESCRIPTION
These fail with sandboxing, fixes #48158

###### Motivation for this change

Pytorch doesn't build with sandboxing enabled (`nix build nixpkgs.python3.pkgs.pytorch`) without this fix. See the bug report for specific errors.

It would be better to fix the tests, but I can't figure out how at the moment. Will open another PR if I do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

