### PR TITLE
inkscape: add scour as optional dependency

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -3,10 +3,12 @@
 , glibmm, libsigcxx, lcms, boost, gettext, makeWrapper
 , gsl, python2, poppler, imagemagick, libwpg, librevenge
 , libvisio, libcdr, libexif, potrace, cmake, hicolor-icon-theme
+, scourSupport ? true
 }:
 
 let
-  python2Env = python2.withPackages(ps: with ps; [ numpy lxml ]);
+  python2Env = python2.withPackages(ps: with ps;
+    [ numpy lxml ] ++ stdenv.lib.optional scourSupport scour);
 in
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

Inkscape has an option to export to an optimised svg. To do this it requires [scour](http://www.codedread.com/scour/). This PR adds scour as an optional dependency.

###### Things done

Added:

- `pythonPackages.scour`
- scour to `python-packages.nix`
- `scourSupport` option to `inkscape/default.nix` arguments
- Myself to `maintainers-list.nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

