### PR TITLE
rspamd: add hyperscan, drop obsoleted dependencies

### DIFF
--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -1,0 +1,69 @@
+{ lib, stdenv, fetchFromGitHub, cmake, ragel, python27
+, boost
+}:
+
+# NOTICE: pkgconfig, pcap and pcre intentionally omitted from build inputs
+#         pcap used only in examples, pkgconfig used only to check for pcre
+#         which is fixed 8.41 version requirement (nixpkgs have 8.42+, and
+#         I not see any reason (for now) to backport 8.41.
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "hyperscan";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "hyperscan";
+    sha256 = "017dxg0n3gn9i4j27rcvpnp4rkqgycqni6x5d15dqpidl7zg7059";
+    rev = "v${version}";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = [ boost ];
+  nativeBuildInputs = [ cmake ragel python27 ];
+
+  cmakeFlags = [
+    "-DFAT_RUNTIME=ON"
+    "-DBUILD_AVX512=ON"
+    "-DBUILD_STATIC_AND_SHARED=ON"
+  ];
+
+  prePatch = ''
+    sed -i '/examples/d' CMakeLists.txt
+  '';
+
+  postInstall = ''
+    mkdir -p $dev/lib
+    mv $out/lib/*.a $dev/lib/
+    ln -sf $out/lib/libhs.so $dev/lib/
+    ln -sf $out/lib/libhs_runtime.so $dev/lib/
+  '';
+
+  postFixup = ''
+    sed -i "s,$out/include,$dev/include," $dev/lib/pkgconfig/libhs.pc
+    sed -i "s,$out/lib,$dev/lib," $dev/lib/pkgconfig/libhs.pc
+  '';
+
+  meta = {
+    description = "High-performance multiple regex matching library";
+    longDescription = ''
+      Hyperscan is a high-performance multiple regex matching library.
+      It follows the regular expression syntax of the commonly-used
+      libpcre library, but is a standalone library with its own C API.
+
+      Hyperscan uses hybrid automata techniques to allow simultaneous
+      matching of large numbers (up to tens of thousands) of regular
+      expressions and for the matching of regular expressions across 
+      streams of data.
+
+      Hyperscan is typically used in a DPI library stack.
+    '';
+
+    homepage = https://www.hyperscan.io/;
+    maintainers = with lib.maintainers; [ avnik ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,8 +1,9 @@
 { stdenv, lib, fetchFromGitHub, cmake, perl
 , file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu
-, libfann, gd, jemalloc
+, libfann, gd, jemalloc, openblas
 , withFann ? true
 , withGd ? false
+, withBlas ? true
 }:
 
 let libmagic = file;  # libmagic provided by file package ATM
@@ -22,7 +23,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig perl ];
   buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu jemalloc ]
     ++ lib.optional withFann libfann
-    ++ lib.optional withGd gd;
+    ++ lib.optional withGd gd
+    ++ lib.optional withBlas openblas;
 
   cmakeFlags = [
     "-DDEBIAN_BUILD=ON"

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, perl
-, file, glib, gmime, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu, libfann }:
+, file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu, libfann }:
 
 let libmagic = file;  # libmagic provided by file package ATM
 in
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ glib gmime libevent libmagic luajit openssl pcre sqlite ragel icu libfann ];
+  buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu libfann ];
 
   cmakeFlags = [
     "-DDEBIAN_BUILD=ON"

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchFromGitHub, cmake, perl
-, file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu, libfann }:
+{ stdenv, lib, fetchFromGitHub, cmake, perl
+, file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu
+, libfann, gd
+, withFann ? true
+, withGd ? false
+}:
 
 let libmagic = file;  # libmagic provided by file package ATM
 in
@@ -16,7 +20,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu libfann ];
+  buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu ]
+    ++ lib.optional withFann libfann
+    ++ lib.optional withGd gd;
 
   cmakeFlags = [
     "-DDEBIAN_BUILD=ON"
@@ -24,7 +30,8 @@ stdenv.mkDerivation rec {
     "-DDBDIR=/var/lib/rspamd"
     "-DLOGDIR=/var/log/rspamd"
     "-DLOCAL_CONFDIR=/etc/rspamd"
-  ];
+  ] ++ lib.optional withFann "-DENABLE_FANN=ON"
+    ++ lib.optional withGd "-DENABLE_GD=ON";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/vstakhov/rspamd;

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, cmake, perl
 , file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu
-, libfann, gd
+, libfann, gd, jemalloc
 , withFann ? true
 , withGd ? false
 }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu ]
+  buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu jemalloc ]
     ++ lib.optional withFann libfann
     ++ lib.optional withGd gd;
 
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     "-DDBDIR=/var/lib/rspamd"
     "-DLOGDIR=/var/log/rspamd"
     "-DLOCAL_CONFDIR=/etc/rspamd"
+    "-DENABLE_JEMALLOC=ON"
   ] ++ lib.optional withFann "-DENABLE_FANN=ON"
     ++ lib.optional withGd "-DENABLE_GD=ON";
 

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,10 +1,13 @@
 { stdenv, lib, fetchFromGitHub, cmake, perl
 , file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu
-, libfann, gd, jemalloc, openblas
+, hyperscan, libfann, gd, jemalloc, openblas
 , withFann ? true
 , withGd ? false
 , withBlas ? true
+, withHyperscan ? stdenv.isx86_64
 }:
+
+assert withHyperscan -> stdenv.isx86_64;
 
 let libmagic = file;  # libmagic provided by file package ATM
 in
@@ -24,6 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu jemalloc ]
     ++ lib.optional withFann libfann
     ++ lib.optional withGd gd
+    ++ lib.optional withHyperscan hyperscan
     ++ lib.optional withBlas openblas;
 
   cmakeFlags = [
@@ -34,6 +38,7 @@ stdenv.mkDerivation rec {
     "-DLOCAL_CONFDIR=/etc/rspamd"
     "-DENABLE_JEMALLOC=ON"
   ] ++ lib.optional withFann "-DENABLE_FANN=ON"
+    ++ lib.optional withHyperscan "-DENABLE_HYPERSCAN=ON"
     ++ lib.optional withGd "-DENABLE_GD=ON";
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -14,13 +14,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "rspamd-${version}";
-  version = "1.8.1";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
-    owner = "vstakhov";
+    owner = "rspamd";
     repo = "rspamd";
     rev = version;
-    sha256 = "1cgnychv8yz7a6mjg3b12nzs4gl0xqg9agl7m6faihnh7gqx4xld";
+    sha256 = "0al4d8h3ssxcx191d4crywz7dsp61lklc9m5z36a90a8w97v76bv";
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withGd "-DENABLE_GD=ON";
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/vstakhov/rspamd;
+    homepage = https://rspamd.com;
     license = licenses.asl20;
     description = "Advanced spam filtering system";
     maintainers = with maintainers; [ avnik fpletz ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10201,6 +10201,8 @@ with pkgs;
 
   hyena = callPackage ../development/libraries/hyena { mono = mono4; };
 
+  hyperscan = callPackage ../development/libraries/hyperscan { };
+
   icu58 = callPackage (import ../development/libraries/icu/58.nix fetchurl) ({
     nativeBuildRoot = buildPackages.icu58.override { buildRootOnly = true; };
   } //


### PR DESCRIPTION
###### Motivation for this change

Add hyperscan support on x86_64 (and package hyperscan as well)
Drop obsoleted gmime dependency
Add options to enable fann/gd/openblas

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

