### PR TITLE
agda: use writeShellScriptbin instead of writeScriptBin

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -3,7 +3,7 @@
 # Contact: stdenv.lib.maintainers.fuuzetsu
 
 { stdenv, Agda, glibcLocales
-, writeScriptBin
+, writeShellScriptBin
 , extension ? (self: super: {})
 }:
 
@@ -77,7 +77,7 @@ let
         buildInputs = let
           # Makes a wrapper available to the user. Very useful in
           # nix-shell where all dependencies are -i'd.
-          agdaWrapper = writeScriptBin "agda" ''
+          agdaWrapper = writeShellScriptBin "agda" ''
             ${self.agdaWithArgs} "$@"
           '';
         in [agdaWrapper] ++ self.buildDepends;

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -78,7 +78,7 @@ let
           # Makes a wrapper available to the user. Very useful in
           # nix-shell where all dependencies are -i'd.
           agdaWrapper = writeShellScriptBin "agda" ''
-            ${self.agdaWithArgs} "$@"
+            exec ${self.agdaWithArgs} "$@"
           '';
         in [agdaWrapper] ++ self.buildDepends;
       };


### PR DESCRIPTION
This adds the shell shebang to the wrapper script. Without this,
emacs and in particular agda2-mode (but probably other applications as
well) return a format error when trying to execute agda.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

