### PR TITLE
openconnect-globalprotect: init at 7.08

### DIFF
--- a/pkgs/tools/networking/openconnect-globalprotect/default.nix
+++ b/pkgs/tools/networking/openconnect-globalprotect/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, autoconf, automake, pkgconfig, libtool, vpnc, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib } :
+
+assert (openssl != null) == (gnutls == null);
+
+stdenv.mkDerivation rec {
+  name = "openconnect-globalprotect-7.08";
+
+  src = fetchGit {
+    url = "https://github.com/dlenski/openconnect.git";
+    rev = "2d2da4771acb5acad31102c343372cb1390bbec3";
+    ref = "globalprotect";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [
+    "--with-vpnc-script=${vpnc}/etc/vpnc/vpnc-script"
+    "--disable-nls"
+    "--without-openssl-version-check"
+  ];
+
+  nativeBuildInputs = [ autoconf automake pkgconfig libtool ];
+  propagatedBuildInputs = [ vpnc openssl gnutls gmp libxml2 stoken zlib ];
+
+  meta = {
+    description = "VPN Client for Cisco's AnyConnect SSL VPN";
+    homepage = http://www.infradead.org/openconnect/;
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ pradeepchhetri ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5980,6 +5980,16 @@ with pkgs;
     openssl = null;
   };
 
+  openconnect-globalprotect = openconnect-globalprotect_gnutls;
+
+  openconnect-globalprotect_openssl = callPackage ../tools/networking/openconnect-globalprotect {
+    gnutls = null;
+  };
+
+  openconnect-globalprotect_gnutls = callPackage ../tools/networking/openconnect-globalprotect {
+    openssl = null;
+  };
+
   ding-libs = callPackage ../tools/misc/ding-libs { };
 
   sssd = callPackage ../os-specific/linux/sssd {


### PR DESCRIPTION
###### Motivation for this change

`openconnect` doesn't support GlobalProtect out of the box, the fork of [dlenski](https://github.com/dlenski/openconnect) does.

Note that AUR also has this package, under the name [openconnect-palo](https://repology.org/metapackages/?search=openconnect).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
