### PR TITLE
nginx: init ngx_aws_auth at 2.1.1

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -17,9 +17,7 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-
-  buildInputs =
-    [ openssl zlib pcre libxml2 libxslt gd geoip ]
+  buildInputs = [ openssl zlib pcre libxml2 libxslt gd geoip ]
     ++ concatMap (mod: mod.inputs or []) modules;
 
   configureFlags = [

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -131,6 +131,15 @@
     };
   };
 
+  ngx_aws_auth = {
+    src = fetchFromGitHub {
+      owner = "anomalizer";
+      repo = "ngx_aws_auth";
+      rev = "2.1.1";
+      sha256 = "10z67g40w7wpd13fwxyknkbg3p6hn61i4v8xw6lh27br29v1y6h9";
+    };
+  };
+
   opentracing = {
     src =
       let src' = fetchFromGitHub {
@@ -226,7 +235,7 @@
       rev = "7778f0125974befbc83751d0e1cadb2dcea57601";
       sha256 = "1x5hm6r0dkm02ffny8kjd7mmq8przyd9amg2qvy5700x6lb63pbs";
     };
-  }; 
+  };
 
   statsd = {
     src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Adds nginx module for s3 authentication.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

