### PR TITLE
ly: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4003,6 +4003,11 @@
     github = "spacefrogg";
     name = "Michael Raitza";
   };
+  spacekookie = {
+    email = "kookie@spacekookie.de";
+    github = "spacekookie";
+    name = "Katharina Fey";
+  };
   spencerjanssen = {
     email = "spencerjanssen@gmail.com";
     github = "spencerjanssen";

--- a/pkgs/applications/display-managers/ly/default.nix
+++ b/pkgs/applications/display-managers/ly/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, linux-pam }:
+
+stdenv.mkDerivation rec { 
+  name = "ly-${version}";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "cylgom";
+    repo = "ly";
+    rev = version;
+    sha256 = "16gjcrd4a6i4x8q8iwlgdildm7cpdsja8z22pf2izdm6rwfki97d";
+    fetchSubmodules = true;
+  }; 
+
+  buildInputs = [ linux-pam ];
+  makeFlags = [ "FLAGS=-Wno-error" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/ly $out/bin 
+  '';
+
+  meta = with lib; {
+    description = "TUI display manager";
+    license = licenses.wtfpl;
+    homepage = https://github.com/cylgom/ly;
+    maintainers = [ maintainers.spacekookie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19014,6 +19014,8 @@ with pkgs;
 
   lightdm-mini-greeter = callPackage ../applications/display-managers/lightdm-mini-greeter { };
 
+  ly = callPackage ../applications/display-managers/ly { }; 
+
   slic3r = callPackage ../applications/misc/slic3r { };
 
   slic3r-prusa3d = callPackage ../applications/misc/slic3r/prusa3d.nix { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

