### PR TITLE
nvidia_x11_beta: stable -> 415.13

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -36,8 +36,13 @@ rec {
     patches = lib.optional (kernel.meta.branch == "4.19") ./drm_mode_connector.patch;
   };
 
-  # No active beta right now
-  beta = stable;
+  # Should evaluate to stable when there is no active beta
+  beta = generic {
+    version = "415.13";
+    sha256_64bit = "0nk4a45a93qc98gy5lkb14v7m837p0635kpynrr2mqa8p1vnvlia";
+    settingsSha256 = "0i112bl4691s07g7lic0j83rx9672jzq108pi10vq4cxrdqcr3s9";
+    persistencedSha256 = "1ifd7vjznwvddvh4xcylk3rsf7ypxkh0x9pkwn3cv0i29zvq5rmg";
+  };
 
   legacy_340 = generic {
     version = "340.104";


### PR DESCRIPTION
###### Motivation for this change
Fails to build on 4.20.0-rc1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

