### PR TITLE
archiver: init at 3.0.0

### DIFF
--- a/pkgs/applications/misc/archiver/default.nix
+++ b/pkgs/applications/misc/archiver/default.nix
@@ -1,0 +1,28 @@
+{ buildGoPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildGoPackage rec {
+  name = "archiver-${version}";
+  version = "3.0.0";
+
+  goPackagePath = "github.com/mholt/archiver";
+
+  src = fetchFromGitHub {
+    owner = "mholt";
+    repo = "archiver";
+    rev = "v${version}";
+    sha256 = "1wngv51333h907mp6nbzd9dq6r0x06mag2cij92912jcbzy0q8bk";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Easily create and extract .zip, .tar, .tar.gz, .tar.bz2, .tar.xz, .tar.lz4, .tar.sz, and .rar (extract-only) files with Go";
+    homepage = https://github.com/mholt/archiver;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/archiver/deps.nix
+++ b/pkgs/applications/misc/archiver/deps.nix
@@ -1,0 +1,56 @@
+[
+  {
+    goPackagePath = "github.com/dsnet/compress";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dsnet/compress";
+      rev = "cc9eb1d7ad760af14e8f918698f745e80377af4f";
+      sha256 = "159liclywmyb6zx88ga5gn42hfl4cpk1660zss87fkx31hdq9fgx";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "2e65f85255dbc3072edf28d6b5b8efc472979f5a";
+      sha256 = "05w6mpc4qcy0pv8a2bzng8nf4s5rf5phfang4jwy9rgf808q0nxf";
+    };
+  }
+  {
+    goPackagePath = "github.com/nwaples/rardecode";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nwaples/rardecode";
+      rev = "197ef08ef68c4454ae5970a9c2692d6056ceb8d7";
+      sha256 = "0vvijw7va283dbdvnf4bgkn7bjngxqzk1rzdpy8sl343r62bmh4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/pierrec/lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/lz4";
+      rev = "623b5a2f4d2a41e411730dcdfbfdaeb5c0c4564e";
+      sha256 = "1hhf7vyz5irrqs7ixdmvsvzmy9izv3ha8jbyy0cs486h61nzqkki";
+    };
+  }
+  {
+    goPackagePath = "github.com/ulikunitz/xz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ulikunitz/xz";
+      rev = "590df8077fbcb06ad62d7714da06c00e5dd2316d";
+      sha256 = "07mivr4aiw3b8qzwajsxyjlpbkf3my4xx23lv0yryc4pciam5lhy";
+    };
+  }
+  {
+    goPackagePath = "github.com/xi2/xz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xi2/xz";
+      rev = "48954b6210f8d154cb5f8484d3a3e1f83489309e";
+      sha256 = "178r0fa2dpzxf0sabs7dn0c8fa7vs87zlxk6spkn374ls9pir7nq";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -148,6 +148,8 @@ with pkgs;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;
 
+  archiver = callPackage ../applications/misc/archiver { };
+
   digitalbitbox = libsForQt5.callPackage ../applications/misc/digitalbitbox { };
 
   dockerTools = callPackage ../build-support/docker { };


### PR DESCRIPTION
###### Motivation for this change

Archiver is a pretty useful tool with no dependencies for creating and extracting many types of archives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

