### PR TITLE
opensmtpd-extras: 5.7.1 -> 6.4.0

### DIFF
--- a/pkgs/servers/mail/opensmtpd/extras.nix
+++ b/pkgs/servers/mail/opensmtpd/extras.nix
@@ -1,13 +1,21 @@
 { stdenv, fetchurl, openssl, libevent, libasr,
-  python2, pkgconfig, lua5, perl, mysql, postgresql, sqlite, hiredis }:
+  python2, pkgconfig, lua5, perl, mysql, postgresql, sqlite, hiredis,
+  enablePython ? true,
+  enableLua ? true,
+  enablePerl ? true,
+  enableMysql ? true,
+  enablePostgres ? true,
+  enableSqlite ? true,
+  enableRedis ? true,
+}:
 
 stdenv.mkDerivation rec {
   name = "opensmtpd-extras-${version}";
-  version = "5.7.1";
+  version = "6.4.0";
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "1kld4hxgz792s0cb2gl7m2n618ikzqkj88w5dhaxdrxg4x2c4vdm";
+    sha256 = "09k25l7zy5ch3fk6qphni2h0rxdp8wacmfag1whi608dgimrhrnb";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -40,42 +48,45 @@ stdenv.mkDerivation rec {
     "--with-scheduler-ram"
     "--with-scheduler-stub"
 
-  ] ++ stdenv.lib.optional (python2 != null) [
+  ] ++ stdenv.lib.optional enablePython [
     "--with-python=${python2}"
     "--with-filter-python"
     "--with-queue-python"
     "--with-table-python"
     "--with-scheduler-python"
 
-  ] ++ stdenv.lib.optional (lua5 != null) [
+  ] ++ stdenv.lib.optional enableLua [
     "--with-lua=${pkgconfig}"
     "--with-filter-lua"
 
-  ] ++ stdenv.lib.optional (perl != null) [
+  ] ++ stdenv.lib.optional enablePerl [
     "--with-perl=${perl}"
     "--with-filter-perl"
 
-  ] ++ stdenv.lib.optional (mysql != null) [
+  ] ++ stdenv.lib.optional enableMysql [
     "--with-table-mysql"
 
-  ] ++ stdenv.lib.optional (postgresql != null) [
+  ] ++ stdenv.lib.optional enablePostgres [
     "--with-table-postgres"
 
-  ] ++ stdenv.lib.optional (sqlite != null) [
+  ] ++ stdenv.lib.optional enableSqlite [
     "--with-table-sqlite"
 
-  ] ++ stdenv.lib.optional (hiredis != null) [
+  ] ++ stdenv.lib.optional enableRedis [
     "--with-table-redis"
   ];
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optional (hiredis != null) "-I${hiredis}/include/hiredis" ++
-    stdenv.lib.optional (mysql != null) "-L${mysql.connector-c}/lib/mysql";
+  NIX_CFLAGS_COMPILE =
+    stdenv.lib.optional enableRedis
+      "-I${hiredis}/include/hiredis -lhiredis"
+    ++ stdenv.lib.optional enableMysql
+      "-L${mysql.connector-c}/lib/mysql";
 
   meta = with stdenv.lib; {
     homepage = https://www.opensmtpd.org/;
     description = "Extra plugins for the OpenSMTPD mail server";
     license = licenses.isc;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner ekleog ];
   };
 }


### PR DESCRIPTION
Also use `enable*` flags instead of the impossible-to-discover trick of
setting to `null` the dependencies.

Note: I don't use these myself, so only checked that the binaries didn't fail due to linker issues: they still failed due to not being run in their expected environment / with expected flags, but I don't have a configuration using it and AFAIK we don't have any test that tests those.

Also adding myself as maintainer as I'm following OpenSMTPD closely anyway, so might as well keep OpenSMTPD-extras up-to-date and help people who have issues with it :)

cc @gebner 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

