### PR TITLE
Add test links

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -249,8 +249,9 @@ in rec {
   # Run the tests for each platform.  You can run a test by doing
   # e.g. ‘nix-build -A tests.login.x86_64-linux’, or equivalently,
   # ‘nix-build tests/login.nix -A result’.
-  tests.atd = callTest tests/atd.nix {};
   tests.acme = callTest tests/acme.nix {};
+  tests.ammonite = callTest tests/ammonite.nix {};
+  tests.atd = callTest tests/atd.nix {};
   tests.avahi = callTest tests/avahi.nix {};
   tests.beegfs = callTest tests/beegfs.nix {};
   tests.upnp = callTest tests/upnp.nix {};

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -36,4 +36,6 @@ in import ./make-test.nix {
     $client->waitForUnit("default.target");
     $client->succeed('curl https://example.com/ | grep -qF "hello world"');
   '';
+
+  meta.timeout = 120;
 }

--- a/nixos/tests/ammonite.nix
+++ b/nixos/tests/ammonite.nix
@@ -2,6 +2,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   name = "ammonite";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];
+    timeout = 40;
   };
 
   nodes = {

--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -4,6 +4,7 @@ import ./make-test.nix ({ pkgs, ... }:
   name = "atd";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ bjornfor ];
+    timeout = 200;
   };
 
   machine =

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, jre, gnused
+{ stdenv, lib, fetchurl, makeWrapper, jre, gnused, nixosTests
 , disableRemoteLogging ? true
 }:
 
@@ -39,5 +39,8 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.nequissimus ];
+    tests = {
+      smoke-test = nixosTests.ammonite;
+    };
   };
 }

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, openssl, zlib, pcre, libxml2, libxslt
 , gd, geoip
+, nixosTests
 , withDebug ? false
 , withStream ? true
 , withMail ? false
@@ -76,5 +77,8 @@ stdenv.mkDerivation {
     license     = licenses.bsd2;
     platforms   = platforms.all;
     maintainers = with maintainers; [ thoughtpolice raskin fpletz ];
+    tests = {
+      acme = nixosTests.acme;
+    };
   };
 }

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3Packages, bash }:
+{ stdenv, python3Packages, bash, nixosTests }:
 
 python3Packages.buildPythonApplication rec {
   pname = "simp_le-client";
@@ -30,5 +30,8 @@ python3Packages.buildPythonApplication rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ gebner makefu ];
     platforms = platforms.linux;
+    tests = {
+      acme = nixosTests.acme;
+    };
   };
 }

--- a/pkgs/tools/system/at/default.nix
+++ b/pkgs/tools/system/at/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, bison, flex, pam
+{ stdenv, fetchurl, fetchpatch, bison, flex, pam, nixosTests
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 , atWrapperPath ? "/run/wrappers/bin/at"
 }:
@@ -55,5 +55,8 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2Plus;
     homepage = https://packages.qa.debian.org/at;
     platforms = stdenv.lib.platforms.linux;
+    tests = {
+      nixos-module = nixosTests.atd;
+    };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

First batch of adding test links as per #44439. The timeouts computed here are coherent with the only pre-existing timeout for the `opensmtpd`, ie. 2x the time the test takes to run on my computer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

