### PR TITLE
nixosTests: use hostPlatform.system instead of builtins.currentSystem

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5,7 +5,7 @@
  * to merges. Please use the full-text search of your editor. ;)
  * Hint: ### starts category names.
  */
-{ lib, noSysDirs, config}:
+{ lib, noSysDirs, config }:
 self: pkgs:
 
 with pkgs;
@@ -75,8 +75,7 @@ with pkgs;
 
   nixosTests =
     let
-      # TODO(Ericson2314,ekleog): Check this will work correctly with cross-
-      system = builtins.currentSystem;
+      system = hostPlatform.system;
       rawTests = (import ../../nixos/release.nix {
         nixpkgs = pkgs;
       }).tests;


### PR DESCRIPTION
###### Motivation for this change

This should (hopefully) fix the invalid use of `builtins.currentSystem` in https://github.com/NixOS/nixpkgs/pull/44439.

I have tested on normal non-cross NixOS only, unfortunately. Also, I must say I don't really get the meaning of the `system` argument in tests (thought it was the platform on which the test was supposed to run, and hence should default to `builtins.currentSystem`, but I guess I was wrong), so this is likely not the correct system to pick :/

cc @Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

