### PR TITLE
bamf: 2018-02-07 -> 0.5.4

### DIFF
--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -3,14 +3,15 @@
 , xorgserver, dbus, python2 }:
 
 stdenv.mkDerivation rec {
-  name = "bamf-2018-02-07";
+  name = "bamf-${version}";
+  version = "0.5.4";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchgit {
     url = https://git.launchpad.net/~unity-team/bamf;
-    rev = "0.5.3+18.04.20180207.2-0ubuntu1";
-    sha256 = "0hvbgzi0mzzzvcamd9mi1ykbk2l6zxffspyk5fpik8bij56nhzym";
+    rev = version;
+    sha256 = "1klvij1wyhdj5d8sr3b16pfixc1yk8ihglpjykg7zrr1f50jfgsz";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
A stable bamf release has been made.

##### Breakdown of changes can be seen at the [ChangeLog](https://git.launchpad.net/bamf/commit/?id=054fbdf625c4c559f74673662e7b595b144ce468).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jtojnar 
