### PR TITLE
Fixes weird mismatch with libreoffice and libreoffice-unwrapped.

### DIFF
--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -13,4 +13,7 @@ in
   for i in $(ls "${libreoffice}/bin/"); do
     test "$i" = "soffice" || ln -s soffice "$out/bin/$(basename "$i")"
   done
-'') // { inherit libreoffice dbus; }
+'') // {
+  inherit libreoffice dbus;
+  meta = libreoffice.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17652,6 +17652,7 @@ with pkgs;
   librecad = callPackage ../applications/misc/librecad { };
 
   libreoffice = hiPrio libreoffice-still;
+  libreoffice-unwrapped = libreoffice.libreoffice;
 
   libreoffice-args = {
     inherit (perlPackages) ArchiveZip IOCompress;
@@ -17673,21 +17674,20 @@ with pkgs;
     };
   };
 
-  libreoffice-unwrapped = callPackage ../applications/office/libreoffice
-  (libreoffice-args // {
-  });
-  libreoffice-still-unwrapped = callPackage ../applications/office/libreoffice/still.nix
-  (libreoffice-args // {
-      poppler = poppler_0_61;
-  });
-
   libreoffice-fresh = lowPrio (callPackage ../applications/office/libreoffice/wrapper.nix {
-    libreoffice = libreoffice-unwrapped;
+    libreoffice = callPackage ../applications/office/libreoffice
+      (libreoffice-args // {
+      });
   });
+  libreoffice-fresh-unwrapped = libreoffice-fresh.libreoffice;
 
   libreoffice-still = lowPrio (callPackage ../applications/office/libreoffice/wrapper.nix {
-    libreoffice = libreoffice-still-unwrapped;
+    libreoffice = callPackage ../applications/office/libreoffice/still.nix
+      (libreoffice-args // {
+          poppler = poppler_0_61;
+      });
   });
+  libreoffice-still-unwrapped = libreoffice-still.libreoffice;
 
   libvmi = callPackage ../development/libraries/libvmi { };
 


### PR DESCRIPTION
Additionally fixes description on wrapped packages.

###### Motivation for this change

As far as the attributes are concerned, I believe it's confusing how `libreoffice-unwrapped` doesn't point to the same version than `libreoffice` would (even though it's not really to be used!).

I'm not 100% confident on the implementation, is there any reasons for the previous implementation compared to the current implementation? Furthermore, it's more about all the `unwrapped` than specifically libreoffice, but would it make sense to make a move to make them less accessible so new users are less confused by an internal thing? Unless I misunderstood something about `libreoffice-*-unwrapped`, they are mostly there as an internal thing, right?

This bring an incompatible change where a user using `libreoffice-unwrapped` hoping to use `fresh` would now be inadvertently be using `still`.

* * *

And for the description, well, that's an obvious net gain, whether the other change is desired or not.

From:
> ![image](https://user-images.githubusercontent.com/132835/48282321-5f634980-e427-11e8-99cf-0cc2f2cb43d5.png)

To:
> ![image](https://user-images.githubusercontent.com/132835/48282324-61c5a380-e427-11e8-9161-ce459825f05f.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

cc @7c6f434c as maintainer of libreoffice.