### PR TITLE
keepass-keepassrpc: v1.7.3 -> v.1.8.0

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keepassrpc/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keepassrpc/default.nix
@@ -1,12 +1,12 @@
 { stdenv, buildEnv, fetchurl, mono }:
 
 let
-  version = "1.7.3.1";
+  version = "1.8.0";
   drv = stdenv.mkDerivation {
     name = "keepassrpc-${version}";
     src = fetchurl {
       url    = "https://github.com/kee-org/keepassrpc/releases/download/v${version}/KeePassRPC.plgx";
-      sha256 = "1y9b35qg27caj3pbaqqzrqpk61hbbd8617ziwdc9vl799i786m9k";
+      sha256 = "1dclfpia559cqf78qw29zz235h1df5md4kgjv3bbi8y41wwmx7cd";
     };
 
     meta = with stdenv.lib; {
@@ -14,7 +14,7 @@ let
       homepage    = https://github.com/kee-org/keepassrpc;
       platforms   = [ "x86_64-linux" ];
       license     = licenses.gpl2;
-      maintainers = with maintainers; [ mjanczyk svsdep ];
+      maintainers = with maintainers; [ mjanczyk svsdep mgregoire ];
     };
 
     pluginFilename = "KeePassRPC.plgx";


### PR DESCRIPTION
###### Motivation for this change
Following #47042 keepassrpc needs to be updated or it can lead to incompatibility issue.

###### Things done

Update keepassrpc plugin to latest version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

