### PR TITLE
Catch2 version2 4 2

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, makeWrapper, fetchurl, requireFile, perl, ncurses, expat, python27, zlib
-, gcc48, gcc49, gcc5, gcc6
+, gcc48, gcc49, gcc5, gcc6, gcc7
 , xorg, gtk2, glib, fontconfig, freetype, unixODBC, alsaLib, glibc
 }:
 
@@ -229,7 +229,7 @@ in rec {
         sha256 = "1kx6l4yzsamk6q1f4vllcpywhbfr2j5wfl4h5zx8v6dgfpsjm2lw";
       })
     ];
-    gcc = gcc6;
+    gcc = gcc7;
   };
 
   cudatoolkit_9 = cudatoolkit_9_2;
@@ -239,7 +239,7 @@ in rec {
     url = "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux";
     sha256 = "16p3bv1lwmyqpxil8r951h385sy9asc578afrc7lssa68c71ydcj";
 
-    gcc = gcc6;
+    gcc = gcc7;
   };
 
   cudatoolkit_10 = cudatoolkit_10_0;

--- a/pkgs/development/libraries/catch2/default.nix
+++ b/pkgs/development/libraries/catch2/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, python }:
+
+stdenv.mkDerivation rec {
+  name = "catch-${version}";
+  version = "2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "catchorg";
+    repo = "Catch2";
+    rev = "v${version}";
+    sha256="1105bxbvh1xxl4yxjjp6l6w6hgsh8xbdiwlnga9di5y2x92b9bjd";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+	  "-H.."
+	  "-DBUILD_TESTING=OFF"];
+
+  meta = with stdenv.lib; {
+    description = "A multi-paradigm automated test framework for C++ and Objective-C (and, maybe, C)";
+    homepage = http://catch-lib.net;
+    license = licenses.boost;
+    maintainers = with maintainers; [ edwtjo knedlsepp ];
+    platforms = with platforms; unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1107,6 +1107,8 @@ with pkgs;
 
   catch = callPackage ../development/libraries/catch { };
 
+  catch2 = callPackage ../development/libraries/catch2 { };
+
   catdoc = callPackage ../tools/text/catdoc { };
 
   catdocx = callPackage ../tools/text/catdocx { };


### PR DESCRIPTION
###### Motivation for this change
There is a new version of catch.

I put catch2 in a separate package then catch, because catch2 doesn't support cpp 2003

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

