### PR TITLE
Renames stateVersion to stateEpoch

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -29,5 +29,5 @@ with lib;
   # Add Memtest86+ to the CD.
   boot.loader.grub.memtest86.enable = true;
 
-  system.stateVersion = mkDefault "18.03";
+  system.stateEpoch = mkDefault "18.03";
 }

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -638,7 +638,7 @@ $bootLoaderConfig
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "${\(qw(@release@))}"; # Did you read the comment?
+  system.stateEpoch = "${\(qw(@release@))}"; # Did you read the comment?
 
 }
 EOF

--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -21,7 +21,7 @@ with lib;
   services.xserver.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" "modesetting" ];
 
   powerManagement.enable = false;
-  system.stateVersion = mkDefault "18.03";
+  system.stateEpoch = mkDefault "18.03";
 
   installer.cloneConfigExtra = ''
   # Let demo build as a trusted user.
@@ -58,6 +58,6 @@ with lib;
   # Enable the OpenSSH daemon.
   # services.openssh.enable = true;
 
-  system.stateVersion = mkDefault "18.03";
+  system.stateEpoch = mkDefault "18.03";
   '';
 }

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -46,7 +46,7 @@ in
       description = "The NixOS release code name (e.g. <literal>Emu</literal>).";
     };
 
-    stateVersion = mkOption {
+    stateEpoch = mkOption {
       type = types.str;
       default = cfg.release;
       description = ''

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -7,6 +7,10 @@ let
 
   gitRepo      = "${toString pkgs.path}/.git";
   gitCommitId  = lib.substring 0 7 (commitIdFromGitRepo gitRepo);
+
+  # Monotonically increasing number, representing the current
+  # "epoch" for configuration files for a freshly installed system.
+  stateEpoch = 100;
 in
 
 {
@@ -48,17 +52,18 @@ in
 
     stateEpoch = mkOption {
       type = types.str;
-      default = cfg.release;
+      default = stateEpoch;
       description = ''
         Every once in a while, a new NixOS release may change
         configuration defaults in a way incompatible with stateful
         data. For instance, if the default version of PostgreSQL
         changes, the new version will probably be unable to read your
-        existing databases. To prevent such breakage, you can set the
-        value of this option to the NixOS release with which you want
-        to be compatible. The effect is that NixOS will option
-        defaults corresponding to the specified release (such as using
-        an older version of PostgreSQL).
+        existing databases. To prevent such breakage, when generating
+        the system configuration, the current value is saved in the
+        configuration to prevent such changes from happening.
+        The effect is that NixOS will use defaults corresponding
+        to the specified moment in time (such as using a specific
+        version of PostgreSQL, or stateful data directories).
       '';
     };
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -231,6 +231,8 @@ with lib;
     (mkRenamedOptionModule [ "system" "nixosRevision" ] [ "system" "nixos" "revision" ])
     (mkRenamedOptionModule [ "system" "nixosLabel" ] [ "system" "nixos" "label" ])
 
+    (mkRenamedOptionModule [ "system" "stateVersion" ] [ "system" "stateEpoch" ])
+
     # Users
     (mkAliasOptionModule [ "users" "extraUsers" ] [ "users" "users" ])
     (mkAliasOptionModule [ "users" "extraGroups" ] [ "users" "groups" ])

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -218,7 +218,7 @@ in
   config = mkIf config.services.mysql.enable {
 
     services.mysql.dataDir =
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/mysql"
+      mkDefault (if versionAtLeast config.system.stateEpoch "17.09" then "/var/lib/mysql"
                  else "/var/mysql");
 
     users.users.mysql = {

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -146,7 +146,7 @@ in
       };
       superUser = mkOption {
         type = types.str;
-        default= if versionAtLeast config.system.stateVersion "17.09" then "postgres" else "root";
+        default= if versionAtLeast config.system.stateEpoch "17.09" then "postgres" else "root";
         internal = true;
         description = ''
           NixOS traditionally used 'root' as superuser, most other distros use 'postgres'.
@@ -165,14 +165,14 @@ in
 
     services.postgresql.package =
       # Note: when changing the default, make it conditional on
-      # ‘system.stateVersion’ to maintain compatibility with existing
+      # ‘system.stateEpoch’ to maintain compatibility with existing
       # systems!
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then pkgs.postgresql_9_6
-            else if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql_9_5
+      mkDefault (if versionAtLeast config.system.stateEpoch "17.09" then pkgs.postgresql_9_6
+            else if versionAtLeast config.system.stateEpoch "16.03" then pkgs.postgresql_9_5
             else pkgs.postgresql_9_4);
 
     services.postgresql.dataDir =
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
+      mkDefault (if versionAtLeast config.system.stateEpoch "17.09" then "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
                  else "/var/db/postgresql");
 
     services.postgresql.authentication = mkAfter

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -342,7 +342,7 @@ in {
       };
       database_type = mkOption {
         type = types.enum [ "sqlite3" "psycopg2" ];
-        default = if versionAtLeast config.system.stateVersion "18.03"
+        default = if versionAtLeast config.system.stateEpoch "18.03"
           then "psycopg2"
           else "sqlite3";
         description = ''

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -14,7 +14,7 @@ let
     (optionalString (cfg.defaultMode == "norouting") "--routing=none")
   ] ++ cfg.extraFlags);
 
-  defaultDataDir = if versionAtLeast config.system.stateVersion "17.09" then
+  defaultDataDir = if versionAtLeast config.system.stateEpoch "17.09" then
     "/var/lib/ipfs" else
     "/var/lib/ipfs/.ipfs";
 

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -9,7 +9,7 @@ let
   confFile = pkgs.writeText "radicale.conf" cfg.config;
 
   # This enables us to default to version 2 while still not breaking configurations of people with version 1
-  defaultPackage = if versionAtLeast config.system.stateVersion "17.09" then {
+  defaultPackage = if versionAtLeast config.system.stateEpoch "17.09" then {
     pkg = pkgs.radicale2;
     text = "pkgs.radicale2";
   } else {
@@ -35,7 +35,7 @@ in
       defaultText = defaultPackage.text;
       description = ''
         Radicale package to use. This defaults to version 1.x if
-        <literal>system.stateVersion &lt; 17.09</literal> and version 2.x
+        <literal>system.stateEpoch &lt; 17.09</literal> and version 2.x
         otherwise.
       '';
     };

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -74,7 +74,7 @@ in {
         '';
         default =
           let
-            nixos = config.system.stateVersion;
+            nixos = config.system.stateEpoch;
             cond  = versionAtLeast nixos "19.03";
           in cfg.dataDir + (optionalString cond "/.config/syncthing");
       };

--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -66,7 +66,7 @@ in {
       description = "Caddy web server";
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = mkIf (versionAtLeast config.system.stateVersion "17.09")
+      environment = mkIf (versionAtLeast config.system.stateEpoch "17.09")
         { CADDYPATH = cfg.dataDir; };
       serviceConfig = {
         ExecStart = ''

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -131,8 +131,8 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
 
     services.xserver.displayManager.job.logToJournal = true;
 
-    # set default stateVersion to avoid warnings during eval
-    system.stateVersion = mkDefault "18.03";
+    # set default stateEpoch to avoid warnings during eval
+    system.stateEpoch = mkDefault "18.03";
   };
 
 }

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -3,7 +3,7 @@
   options = {
     ec2 = {
       hvm = lib.mkOption {
-        default = lib.versionAtLeast config.system.stateVersion "17.03";
+        default = lib.versionAtLeast config.system.stateEpoch "17.03";
         internal = true;
         description = ''
           Whether the EC2 instance is a HVM instance.

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -611,7 +611,7 @@ in
                   { services.postgresql.enable = true;
                     services.postgresql.package = pkgs.postgresql_9_6;
 
-                    system.stateVersion = "17.03";
+                    system.stateEpoch = "17.03";
                   };
               };
           }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -201,7 +201,7 @@ in rec {
         modules = singleton ({ ... }:
           { fileSystems."/".device  = mkDefault "/dev/sda1";
             boot.loader.grub.device = mkDefault "/dev/sda";
-            system.stateVersion = mkDefault "18.03";
+            system.stateEpoch = mkDefault "18.03";
           });
       }).config.system.build.toplevel;
       preferLocalBuild = true;

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -24,7 +24,7 @@ import ./make-test.nix ({ pkgs, ...} : {
           inherit (config.nixpkgs.localSystem) system;
           modules = lib.singleton {
             containers.foo.config = {
-              system.stateVersion = "18.03";
+              system.stateEpoch = "18.03";
             };
           };
         };

--- a/nixos/tests/containers-ipv4.nix
+++ b/nixos/tests/containers-ipv4.nix
@@ -20,7 +20,7 @@ import ./make-test.nix ({ pkgs, ...} : {
             { services.httpd.enable = true;
               services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
-              system.stateVersion = "18.03";
+              system.stateEpoch = "18.03";
             };
         };
 

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -43,7 +43,7 @@ in
             });
           })
         ];
-        system.stateVersion = "17.03";
+        system.stateEpoch = "17.03";
       };
       radicale1_export = lib.recursiveUpdate radicale1 {
         services.radicale.extraArgs = [
@@ -54,7 +54,7 @@ in
         services.radicale.extraArgs = [ "--verify-storage" ];
       };
       radicale2 = lib.recursiveUpdate (common args) {
-        system.stateVersion = "17.09";
+        system.stateEpoch = "17.09";
       };
     };
 


### PR DESCRIPTION
###### Motivation for this change

Initially thrown on the wall [2018-10-07](https://logs.nix.samueldr.com/nixos/2018-10-07#1538875683-1538875214;).

This change is to reduce the support questions like this:

> I changed `stateVersion` in my `configuration.nix` and NixOS hasn't been upgraded to the next release. What gives?

Using the release version as a marker to decide between stateful schemas is in itself a good idea, but might not be the best interface to present to the end-users.

Having a monotonically incrementing opaque number will reduce confusion.

The number `100` has been chosen as:

  * It is bigger than 18.09 when compared as a version
  * Allows us to start "at zero" in a new range.

The number would have been `1` if possible, but existing `stateVersion = xx.yy;` makes it harder to implemented in such a way.

Additionally, decoupling the release version makes it so it is possible to have concurrent incompatible changes in `unstable`, while staying compatible, making for a better rolling-release approximation.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Expectations

A bit of bikeshedding. A bit of criticism about the implementation.

Please consider the idea and propose better implementations, but don't hang yourself up on details of the implementation. I'm more interested in the big picture than corner case things. Once the big picture is better unveiled, and everything falls in place, the details can be worked out. Thanks.