### PR TITLE
rustracer: remove rustup dependency

### DIFF
--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, rustup, substituteAll }:
+{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, substituteAll }:
 
 rustPlatform.buildRustPackage rec {
   name = "racer-${version}";
@@ -13,8 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1j3fviimdxn6xa75z0l9wkgdnznp8q20jjs42mql6ql782dga5lk";
 
-  # rustup is required for test
-  buildInputs = [ makeWrapper rustup ];
+  buildInputs = [ makeWrapper ];
 
   preCheck = ''
     export RUST_SRC_PATH="${rustPlatform.rustcSrc}"


### PR DESCRIPTION
###### Motivation for this change

racer builds fine on Linux and macOS without racer as a dependency.
racer does not actually use rustup, but 'rustc --print sysroot', which
is already available through the rustc dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

