### PR TITLE
home-assistant: 0.81.5 -> 0.82.0

### DIFF
--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook bison flex pkgconfig perl ];
   buildInputs = [ libuuid cppunit protobuf3_1 zlib avahi libmicrohttpd python3 ];
-  propagatedBuildInputs = [ python3Packages.protobuf3_1 python3Packages.numpy ];
+  propagatedBuildInputs = [
+    (python3Packages.protobuf.override { protobuf = protobuf3_1; })
+    python3Packages.numpy
+  ];
 
   configureFlags = [ "--enable-python-libs" ];
 

--- a/pkgs/development/libraries/openzwave/default.nix
+++ b/pkgs/development/libraries/openzwave/default.nix
@@ -3,16 +3,18 @@
 , systemd }:
 
 let
-  version = "2018-04-04";
+  version = "2018-11-04";
 
 in stdenv.mkDerivation rec {
   name = "openzwave-${version}";
 
+  # Use fork by Home Assistant because this package is mainly used for python.pkgs.homeassistant-pyozw.
+  # See https://github.com/OpenZWave/open-zwave/compare/master...home-assistant:hass for the difference.
   src = fetchFromGitHub {
-    owner = "OpenZWave";
+    owner = "home-assistant";
     repo = "open-zwave";
-    rev = "ab5fe966fee882bb9e8d78a91db892a60a1863d9";
-    sha256 = "0yby8ygzjn5zp5vhysxaadbzysqanwd2zakz379299qs454pr2h9";
+    rev = "2cc174ad5c935d2d17828634aca2db5a60c59237";
+    sha256 = "1d13maj93i6h792cbvqpx43ffss44dxmvbwj2777vzvvjib8m4n8";
   };
 
   nativeBuildInputs = [ doxygen fontconfig graphviz-nox libxml2 pkgconfig which ];

--- a/pkgs/development/python-modules/homeassistant-pyozw/default.nix
+++ b/pkgs/development/python-modules/homeassistant-pyozw/default.nix
@@ -1,0 +1,14 @@
+{ python_openzwave, fetchPypi }:
+
+python_openzwave.overridePythonAttrs (oldAttrs: rec {
+  pname = "homeassistant_pyozw";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "bca4062906f65db9b4668388e6755d6ea3ee9e1b02ad3ed81738bb4d32a79342";
+  };
+
+  meta.homepage = https://github.com/home-assistant/python-openzwave;
+})

--- a/pkgs/development/python-modules/ruamel_yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel_yaml/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, ruamel_base
+, typing
+, ruamel_ordereddict
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "ruamel.yaml";
+  version = "0.15.35";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xggyfaj6vprggahf7cq8kp9j79rb7hn8ndk3bxj2sxvwhhliiwd";
+  };
+
+  # Tests cannot load the module to test
+  doCheck = false;
+
+  propagatedBuildInputs = [ ruamel_base typing ]
+    ++ stdenv.lib.optional (!isPy3k) ruamel_ordereddict;
+
+  meta = with stdenv.lib; {
+    description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
+    homepage = https://bitbucket.org/ruamel/yaml;
+    license = licenses.mit;
+  };
+
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.81.5";
+  version = "0.82.0";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -137,6 +137,7 @@
     "binary_sensor.rpi_gpio" = ps: with ps; [  ];
     "binary_sensor.rpi_pfio" = ps: with ps; [  ];
     "binary_sensor.satel_integra" = ps: with ps; [  ];
+    "binary_sensor.sense" = ps: with ps; [  ];
     "binary_sensor.skybell" = ps: with ps; [  ];
     "binary_sensor.sleepiq" = ps: with ps; [  ];
     "binary_sensor.spc" = ps: with ps; [  ];
@@ -317,18 +318,20 @@
     "deconz" = ps: with ps; [  ];
     "deconz.config_flow" = ps: with ps; [  ];
     "deconz.const" = ps: with ps; [  ];
+    "deconz.gateway" = ps: with ps; [  ];
     "demo" = ps: with ps; [ aiohttp-cors ];
     "device_sun_light_trigger" = ps: with ps; [  ];
     "device_tracker" = ps: with ps; [  ];
     "device_tracker.actiontec" = ps: with ps; [  ];
     "device_tracker.aruba" = ps: with ps; [ pexpect ];
-    "device_tracker.asuswrt" = ps: with ps; [ pexpect ];
+    "device_tracker.asuswrt" = ps: with ps; [  ];
     "device_tracker.automatic" = ps: with ps; [ aiohttp-cors ];
     "device_tracker.bbox" = ps: with ps; [  ];
     "device_tracker.bluetooth_le_tracker" = ps: with ps; [  ];
     "device_tracker.bluetooth_tracker" = ps: with ps; [  ];
     "device_tracker.bmw_connected_drive" = ps: with ps; [  ];
     "device_tracker.bt_home_hub_5" = ps: with ps; [  ];
+    "device_tracker.bt_smarthub" = ps: with ps; [  ];
     "device_tracker.cisco_ios" = ps: with ps; [ pexpect ];
     "device_tracker.ddwrt" = ps: with ps; [  ];
     "device_tracker.demo" = ps: with ps; [  ];
@@ -407,6 +410,7 @@
     "fan.mqtt" = ps: with ps; [ paho-mqtt ];
     "fan.template" = ps: with ps; [  ];
     "fan.tuya" = ps: with ps; [  ];
+    "fan.wemo" = ps: with ps; [  ];
     "fan.wink" = ps: with ps; [  ];
     "fan.xiaomi_miio" = ps: with ps; [ construct ];
     "fan.zha" = ps: with ps; [  ];
@@ -417,7 +421,7 @@
     "foursquare" = ps: with ps; [ aiohttp-cors ];
     "freedns" = ps: with ps; [  ];
     "fritzbox" = ps: with ps; [  ];
-    "frontend" = ps: with ps; [ aiohttp-cors ruamel_yaml ];
+    "frontend" = ps: with ps; [ aiohttp-cors ];
     "gc100" = ps: with ps; [  ];
     "geo_location" = ps: with ps; [  ];
     "geo_location.demo" = ps: with ps; [  ];
@@ -433,6 +437,7 @@
     "google_assistant.trait" = ps: with ps; [  ];
     "google_domains" = ps: with ps; [  ];
     "graphite" = ps: with ps; [  ];
+    "greeneye_monitor" = ps: with ps; [  ];
     "group" = ps: with ps; [  ];
     "habitica" = ps: with ps; [  ];
     "hangouts" = ps: with ps; [  ];
@@ -492,6 +497,7 @@
     "image_processing.openalpr_local" = ps: with ps; [  ];
     "image_processing.opencv" = ps: with ps; [ numpy ];
     "image_processing.seven_segments" = ps: with ps; [  ];
+    "image_processing.tensorflow" = ps: with ps; [ numpy pillow protobuf ];
     "influxdb" = ps: with ps; [ influxdb ];
     "input_boolean" = ps: with ps; [  ];
     "input_datetime" = ps: with ps; [  ];
@@ -611,11 +617,11 @@
     "lock.wink" = ps: with ps; [  ];
     "lock.xiaomi_aqara" = ps: with ps; [  ];
     "lock.zwave" = ps: with ps; [  ];
-    "logbook" = ps: with ps; [ aiohttp-cors ruamel_yaml sqlalchemy ];
+    "logbook" = ps: with ps; [ aiohttp-cors sqlalchemy ];
     "logentries" = ps: with ps; [  ];
     "logger" = ps: with ps; [  ];
     "logi_circle" = ps: with ps; [  ];
-    "lovelace" = ps: with ps; [ ruamel_yaml ];
+    "lovelace" = ps: with ps; [  ];
     "lutron" = ps: with ps; [  ];
     "lutron_caseta" = ps: with ps; [  ];
     "mailbox" = ps: with ps; [ aiohttp-cors ];
@@ -740,7 +746,7 @@
     "notify.hangouts" = ps: with ps; [  ];
     "notify.hipchat" = ps: with ps; [  ];
     "notify.homematic" = ps: with ps; [ pyhomematic ];
-    "notify.html5" = ps: with ps; [ aiohttp-cors ruamel_yaml ];
+    "notify.html5" = ps: with ps; [ aiohttp-cors ];
     "notify.instapush" = ps: with ps; [  ];
     "notify.ios" = ps: with ps; [ aiohttp-cors zeroconf ];
     "notify.joaoapps_join" = ps: with ps; [  ];
@@ -789,8 +795,8 @@
     "openuv" = ps: with ps; [  ];
     "openuv.config_flow" = ps: with ps; [  ];
     "openuv.const" = ps: with ps; [  ];
-    "panel_custom" = ps: with ps; [ aiohttp-cors ruamel_yaml ];
-    "panel_iframe" = ps: with ps; [ aiohttp-cors ruamel_yaml ];
+    "panel_custom" = ps: with ps; [ aiohttp-cors ];
+    "panel_iframe" = ps: with ps; [ aiohttp-cors ];
     "persistent_notification" = ps: with ps; [  ];
     "pilight" = ps: with ps; [  ];
     "plant" = ps: with ps; [  ];
@@ -842,6 +848,7 @@
     "scene.wink" = ps: with ps; [  ];
     "script" = ps: with ps; [  ];
     "scsgate" = ps: with ps; [  ];
+    "sense" = ps: with ps; [  ];
     "sensor" = ps: with ps; [  ];
     "sensor.abode" = ps: with ps; [  ];
     "sensor.ads" = ps: with ps; [  ];
@@ -929,12 +936,13 @@
     "sensor.gearbest" = ps: with ps; [  ];
     "sensor.geizhals" = ps: with ps; [  ];
     "sensor.geo_rss_events" = ps: with ps; [  ];
-    "sensor.gitlab_ci" = ps: with ps; [  ];
+    "sensor.gitlab_ci" = ps: with ps; [ python-gitlab ];
     "sensor.gitter" = ps: with ps; [  ];
     "sensor.glances" = ps: with ps; [  ];
     "sensor.google_travel_time" = ps: with ps; [  ];
     "sensor.google_wifi" = ps: with ps; [  ];
     "sensor.gpsd" = ps: with ps; [  ];
+    "sensor.greeneye_monitor" = ps: with ps; [  ];
     "sensor.gtfs" = ps: with ps; [  ];
     "sensor.habitica" = ps: with ps; [  ];
     "sensor.haveibeenpwned" = ps: with ps; [  ];
@@ -975,6 +983,7 @@
     "sensor.lyft" = ps: with ps; [  ];
     "sensor.magicseaweed" = ps: with ps; [  ];
     "sensor.melissa" = ps: with ps; [  ];
+    "sensor.meteo_france" = ps: with ps; [  ];
     "sensor.metoffice" = ps: with ps; [  ];
     "sensor.mfi" = ps: with ps; [  ];
     "sensor.mhz19" = ps: with ps; [  ];
@@ -1017,7 +1026,7 @@
     "sensor.pilight" = ps: with ps; [  ];
     "sensor.plex" = ps: with ps; [  ];
     "sensor.pocketcasts" = ps: with ps; [  ];
-    "sensor.pollen" = ps: with ps; [  ];
+    "sensor.pollen" = ps: with ps; [ numpy ];
     "sensor.postnl" = ps: with ps; [  ];
     "sensor.pushbullet" = ps: with ps; [ pushbullet ];
     "sensor.pvoutput" = ps: with ps; [  ];
@@ -1096,7 +1105,7 @@
     "sensor.twitch" = ps: with ps; [  ];
     "sensor.uber" = ps: with ps; [  ];
     "sensor.uk_transport" = ps: with ps; [  ];
-    "sensor.upnp" = ps: with ps; [ aiohttp-cors ];
+    "sensor.upnp" = ps: with ps; [  ];
     "sensor.ups" = ps: with ps; [  ];
     "sensor.uptime" = ps: with ps; [  ];
     "sensor.uscis" = ps: with ps; [  ];
@@ -1124,7 +1133,6 @@
     "sensor.xbox_live" = ps: with ps; [  ];
     "sensor.xiaomi_aqara" = ps: with ps; [  ];
     "sensor.xiaomi_miio" = ps: with ps; [ construct ];
-    "sensor.yahoo_finance" = ps: with ps; [  ];
     "sensor.yr" = ps: with ps; [ xmltodict ];
     "sensor.yweather" = ps: with ps; [ yahooweather ];
     "sensor.zabbix" = ps: with ps; [  ];
@@ -1298,7 +1306,7 @@
     "unifi.errors" = ps: with ps; [  ];
     "upcloud" = ps: with ps; [  ];
     "updater" = ps: with ps; [ distro ];
-    "upnp" = ps: with ps; [ aiohttp-cors ];
+    "upnp" = ps: with ps; [  ];
     "upnp.config_flow" = ps: with ps; [  ];
     "upnp.const" = ps: with ps; [  ];
     "upnp.device" = ps: with ps; [  ];
@@ -1362,7 +1370,7 @@
     "zone.const" = ps: with ps; [  ];
     "zone.zone" = ps: with ps; [  ];
     "zoneminder" = ps: with ps; [  ];
-    "zwave" = ps: with ps; [ pydispatcher python_openzwave ];
+    "zwave" = ps: with ps; [ homeassistant-pyozw pydispatcher ];
     "zwave.config_flow" = ps: with ps; [  ];
     "zwave.const" = ps: with ps; [  ];
     "zwave.discovery_schemas" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -20,8 +20,8 @@ let
     # Override the version of some packages pinned in Home Assistant's setup.py
     (mkOverride "aiohttp" "3.4.4"
       "51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db3475fa")
-    (mkOverride "astral" "1.6.1"
-      "ab0c08f2467d35fcaeb7bad15274743d3ac1ad18b5391f64a0058a9cd192d37d")
+    (mkOverride "astral" "1.7.1"
+      "88086fd2006c946567285286464b2da3294a3b0cbba4410b7008ec2458f82a07")
     (mkOverride "async-timeout" "3.0.1"
       "0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f")
     (mkOverride "attrs" "18.2.0"
@@ -36,10 +36,16 @@ let
       "bf4d9b61dce69c49e830950aa36fad194706463b0b6dfe81425b9e0bc6644d46")
     (mkOverride "requests" "2.20.0"
       "99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c")
+    (mkOverride "ruamel_yaml" "0.15.72"
+      "97652b9e3a76958cf6684d5d963674adf345d8cc192ddd95e2a21b22cda29f40")
     (mkOverride "voluptuous" "0.11.5"
       "567a56286ef82a9d7ae0628c5842f65f516abcb496e74f3f59f1d7b28df314ef")
     (mkOverride "voluptuous-serialize" "2.0.0"
       "44be04d87aec34bd7d31ab539341fadc505205f2299031ed9be985112c21aa41")
+
+    # used by auth.mfa_modules.totp
+    (mkOverride "pyotp" "2.2.6"
+      "dd9130dd91a0340d89a0f06f887dbd76dd07fb95a8886dc4bc401239f2eebd69")
 
     # used by check_config script
     # can be unpinned once https://github.com/home-assistant/home-assistant/issues/11917 is resolved
@@ -79,7 +85,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.81.5";
+  hassVersion = "0.82.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -94,12 +100,12 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "1fgf9hrv7q7g8s561sir951vd27a459mh3k685xzfnhkh4si47g4";
+    sha256 = "1vvq6frzwmbnynpq6269ykifwmvm8zj5zraslsph3jidppx2bnd4";
   };
 
   propagatedBuildInputs = [
     # From setup.py
-    aiohttp astral async-timeout attrs bcrypt certifi jinja2 pyjwt cryptography pip pytz pyyaml requests voluptuous voluptuous-serialize
+    aiohttp astral async-timeout attrs bcrypt certifi jinja2 pyjwt cryptography pip pytz pyyaml requests ruamel_yaml voluptuous voluptuous-serialize
     # From http, frontend and recorder components and auth.mfa_modules.totp
     sqlalchemy aiohttp-cors hass-frontend pyotp pyqrcode
   ] ++ componentBuildInputs ++ extraBuildInputs;

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20181026.4";
+  version = "20181103.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b0610206eee06042847d89a581ecfcd71255b0e1ecff77e302237e8aa175b00d";
+    sha256 = "b1b598f637ffc4c37a3d35aa3b912216f0340cb43fa6c50f4617536669d19499";
   };
 
   propagatedBuildInputs = [ user-agents ];

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ aiohttp astral async-timeout attrs certifi jinja2 pyjwt cryptography pip pytz pyyaml requests voluptuous ])"
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ aiohttp astral async-timeout attrs certifi jinja2 pyjwt cryptography pip pytz pyyaml requests ruamel_yaml voluptuous ])"
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each component has an associated .py file,
@@ -93,7 +93,7 @@ def name_to_attr_path(req):
             except KeyError:
                 pass
     # Let's hope there's only one derivation with a matching name
-    assert(len(attr_paths) <= 1)
+    assert len(attr_paths) <= 1, "{} matches more than one derivation: {}".format(req, attr_paths)
     if len(attr_paths) == 1:
         return attr_paths.pop()
     else:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21679,14 +21679,14 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   };
 
-  caffe2 = callPackage ../development/libraries/science/math/caffe2 {
+  caffe2 = callPackage ../development/libraries/science/math/caffe2 (rec {
     eigen3 = eigen3_3;
     inherit (python3Packages) python future six numpy pydot;
     protobuf = protobuf3_1;
-    python-protobuf = python3Packages.protobuf3_1;
+    python-protobuf = python3Packages.protobuf.override { inherit protobuf; };
     # Used only for image loading.
     opencv3 = opencv3WithoutCuda;
-  };
+  });
 
   cntk = callPackage ../applications/science/math/cntk rec {
     cudaSupport = pkgs.config.cudaSupport or false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2468,6 +2468,8 @@ in {
 
   hetzner = callPackage ../development/python-modules/hetzner { };
 
+  homeassistant-pyozw = callPackage ../development/python-modules/homeassistant-pyozw { };
+
   htmllaundry = callPackage ../development/python-modules/htmllaundry { };
 
   html5lib = callPackage ../development/python-modules/html5lib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3771,12 +3771,6 @@ in {
     protobuf = pkgs.protobuf;
   };
 
-  protobuf3_1 = callPackage ../development/python-modules/protobuf {
-    disabled = isPyPy;
-    doCheck = !isPy3k;
-    protobuf = pkgs.protobuf3_1;
-  };
-
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
   psutil = callPackage ../development/python-modules/psutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5987,27 +5987,7 @@ in {
 
   typeguard = callPackage ../development/python-modules/typeguard { };
 
-  ruamel_yaml = buildPythonPackage rec {
-    name = "ruamel.yaml-${version}";
-    version = "0.15.35";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/r/ruamel.yaml/${name}.tar.gz";
-      sha256 = "0xggyfaj6vprggahf7cq8kp9j79rb7hn8ndk3bxj2sxvwhhliiwd";
-    };
-
-    # Tests cannot load the module to test
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ ruamel_base typing ] ++
-    (optional (!isPy3k) self.ruamel_ordereddict);
-
-    meta = {
-      description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
-      homepage = https://bitbucket.org/ruamel/yaml;
-      license = licenses.mit;
-    };
-  };
+  ruamel_yaml = callPackage ../development/python-modules/ruamel_yaml { };
 
   runsnakerun = buildPythonPackage rec {
     name = "runsnakerun-2.0.4";


### PR DESCRIPTION
###### Motivation for this change
~This is work in progress because the test does not run successfully. I don't have access to a real-world instance of Home Assistant right now so I'm still putting this online for review.~
Found out the problem: I had to pin `pyotp`.

`python.pkgs.protobuf3_1` needed to be removed because `parse-requirements.py` would not be able tell which version to use. That's also the reason why I improved the `assert` statement.

I cherry-picked 00209911b0cdb76b8ec53c4be595e5a0349ba472 because I want to use `fetchPypi.override`. Should I use `git cherry-pick -x` for that?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

