### PR TITLE
spaceship-prompt: init at 3.7.1

### DIFF
--- a/pkgs/shells/zsh/spaceship-prompt/default.nix
+++ b/pkgs/shells/zsh/spaceship-prompt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zsh }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec{
   name = "spaceship-prompt-${version}";

--- a/pkgs/shells/zsh/spaceship-prompt/default.nix
+++ b/pkgs/shells/zsh/spaceship-prompt/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, zsh }:
+
+stdenv.mkDerivation rec{
+  name = "spaceship-prompt-${version}";
+  version = "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "denysdovhan";
+    repo = "spaceship-prompt";
+    sha256 = "0laihax18bs254rm2sww5wkjbmkp4m5c8aicgqpi4diz7difxk6z";
+    rev = "aaa34aeab9ba0a99416788f627ec9aeffba392f0";
+  };
+
+  installPhase = ''
+    install -D -m644 LICENSE.md "$out/share/licenses/spaceship-prompt/LICENSE"
+    install -D -m644 README.md "$out/share/doc/spaceship-prompt/README.md"
+    find docs -type f -exec install -D -m644 {} "$out/share/doc/spaceship-prompt/{}" \;
+    find lib -type f -exec install -D -m644 {} "$out/lib/spaceship-prompt/{}" \;
+    find scripts -type f -exec install -D -m644 {} "$out/lib/spaceship-prompt/{}" \;
+    find sections -type f -exec install -D -m644 {} "$out/lib/spaceship-prompt/{}" \;
+    install -D -m644 spaceship.zsh "$out/lib/spaceship-prompt/spaceship.zsh"
+    install -d "$out/share/zsh/themes/"
+    ln -s "$out/lib/spaceship-prompt/spaceship.zsh" "$out/share/zsh/themes/spaceship.zsh-theme"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Zsh prompt for Astronauts";
+    homepage = https://github.com/halfo/lambda-mod-zsh-theme/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12323,6 +12323,8 @@ with pkgs;
 
   spandsp = callPackage ../development/libraries/spandsp {};
 
+  spaceship-prompt = callPackage ../shells/zsh/spaceship-prompt {};
+
   spatialite_tools = callPackage ../development/libraries/spatialite-tools { };
 
   spdk = callPackage ../development/libraries/spdk { };


### PR DESCRIPTION
###### Motivation for this change

ZSH prompt, can be used with `ohMyZsh.customPkgs`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

