### PR TITLE
.github/CODEOWNERS: Add infinisil to idris-modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,3 +117,6 @@
 # Dhall
 /pkgs/development/dhall-modules      @Gabriel439 @Profpatsch
 /pkgs/development/interpreters/dhall @Gabriel439 @Profpatsch
+
+# Idris
+/pkgs/development/idris-modules @Infinisil


### PR DESCRIPTION
###### Motivation for this change
Am often involved with idris packages.

- https://github.com/NixOS/nixpkgs/pull/50182
- https://github.com/NixOS/nixpkgs/pull/49143
- https://github.com/NixOS/nixpkgs/pull/46410
- https://github.com/NixOS/nixpkgs/pull/43735#pullrequestreview-138303050
- https://github.com/NixOS/nixpkgs/pull/43444
- https://github.com/NixOS/nixpkgs/pull/42861
- https://github.com/NixOS/nixpkgs/pull/42855
- https://github.com/NixOS/nixpkgs/pull/42647
- https://github.com/NixOS/nixpkgs/pull/42621

Also maybe @brainrape and @mpickering are interested in having their names there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

