### PR TITLE
Allow cloud-init to support creating btrfs partitions

### DIFF
--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -3,7 +3,16 @@
 with lib;
 
 let cfg = config.services.cloud-init;
-    path = with pkgs; [ cloud-init nettools utillinux e2fsprogs shadow openssh iproute ];
+    path = with pkgs; [
+      cloud-init
+      iproute
+      nettools
+      openssh
+      shadow
+      utillinux
+    ] ++ optional config.services.cloud-init.btrfs btrfs-progs
+      ++ optional config.services.cloud-init.ext4 e2fsprogs
+    ;
 in
 {
   options = {
@@ -26,6 +35,22 @@ in
           public key provisioning, and cloud-init is useful for that
           parts. Thus, be wary that using cloud-init in NixOS might
           come as some cost.
+        '';
+      };
+
+      btrfs = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Allow the cloud-init service to operate `btrfs` filesystem.
+        '';
+      };
+
+      ext4 = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Allow the cloud-init service to operate `ext4` filesystem.
         '';
       };
 

--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -10,15 +10,13 @@ let cfg = config.services.cloud-init;
       openssh
       shadow
       utillinux
-    ] ++ optional config.services.cloud-init.btrfs btrfs-progs
-      ++ optional config.services.cloud-init.ext4 e2fsprogs
+    ] ++ optional cfg.btrfs.enable btrfs-progs
+      ++ optional cfg.ext4.enable e2fsprogs
     ;
 in
 {
   options = {
-
     services.cloud-init = {
-
       enable = mkOption {
         type = types.bool;
         default = false;
@@ -38,7 +36,7 @@ in
         '';
       };
 
-      btrfs = mkOption {
+      btrfs.enable = mkOption {
         type = types.bool;
         default = false;
         description = ''
@@ -46,7 +44,7 @@ in
         '';
       };
 
-      ext4 = mkOption {
+      ext4.enable = mkOption {
         type = types.bool;
         default = true;
         description = ''


### PR DESCRIPTION
###### Motivation for this change
`cloud-init` does not know where is `btrfs` programmes. It makes `btrfs` partition creation fails sometimes. This PR includes `btrfs-progs` into the `PATH` environment variable.

Request for comment: should we: 1. survey the all possible configurations and add in other missing runtime dependencies of `cloud-init`; 2. or, we add one option to allow users to supply additional runtime dependencies?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

