### PR TITLE
fusuma: init at 0.10.2

### DIFF
--- a/pkgs/tools/inputmethods/fusuma/Gemfile
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem "fusuma"

--- a/pkgs/tools/inputmethods/fusuma/Gemfile.lock
+++ b/pkgs/tools/inputmethods/fusuma/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    fusuma (0.10.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fusuma
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/tools/inputmethods/fusuma/default.nix
+++ b/pkgs/tools/inputmethods/fusuma/default.nix
@@ -1,0 +1,22 @@
+{ lib, bundlerApp, makeWrapper, libinput }:
+
+bundlerApp {
+  pname = "fusuma";
+  gemdir = ./.;
+  exes = [ "fusuma" ];
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram "$out/bin/fusuma" \
+      --prefix PATH : ${lib.makeBinPath [ libinput ]}
+  '';
+
+  meta = with lib; {
+    description = "Multitouch gestures with libinput driver on X11, Linux";
+    homepage    = https://github.com/iberianpig/fusuma;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ jfrankenau ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fusuma/gemset.nix
+++ b/pkgs/tools/inputmethods/fusuma/gemset.nix
@@ -1,0 +1,10 @@
+{
+  fusuma = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hj64kafxj29gk53vj2syhs3vdywl3h9cpiknaqqm4srjx9g04a0";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2759,6 +2759,8 @@ with pkgs;
 
   fuseiso = callPackage ../tools/filesystems/fuseiso { };
 
+  fusuma = callPackage ../tools/inputmethods/fusuma {};
+
   fdbPackages = callPackage ../servers/foundationdb {
     stdenv49 = overrideCC stdenv gcc49;
   };


### PR DESCRIPTION
###### Motivation for this change

In contrast to libinput-gestures fusuma supports repeating commands which for example makes pinch to zoom much more pleasurable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @teozkr