### PR TITLE
haskell-opencv: fix build and #47595

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -251,6 +251,10 @@ self: super: {
   # Fails for non-obvious reasons while attempting to use doctest.
   search = dontCheck super.search;
 
+  # see https://github.com/LumiGuide/haskell-opencv/commit/cd613e200aa20887ded83256cf67d6903c207a60
+  opencv = dontCheck (removeConfigureFlag (removeConfigureFlag (appendPatch super.opencv ./patches/opencv-fix-116.patch) "--with-gcc=${pkgs.stdenv.cc}/bin/c++") "--with-ld=${pkgs.stdenv.cc}/bin/c++");
+  opencv-extra = dontCheck (removeConfigureFlag (removeConfigureFlag (appendPatch super.opencv-extra ./patches/opencv-fix-116.patch) "--with-gcc=${pkgs.stdenv.cc}/bin/c++") "--with-ld=${pkgs.stdenv.cc}/bin/c++");
+
   # https://github.com/ekmett/structures/issues/3
   structures = dontCheck super.structures;
 

--- a/pkgs/development/haskell-modules/patches/opencv-fix-116.patch
+++ b/pkgs/development/haskell-modules/patches/opencv-fix-116.patch
@@ -1,0 +1,11 @@
+diff -ur opencv-0.0.2.1.bak/Setup.hs opencv-0.0.2.1/Setup.hs
+--- opencv-0.0.2.1.bak/Setup.hs	2018-11-10 17:18:41.355731189 +0100
++++ opencv-0.0.2.1/Setup.hs	2018-11-10 17:18:56.901681162 +0100
+@@ -3,6 +3,6 @@
+ 
+ main = do
+     args <- getArgs
+-    let args' | "configure" `elem` args = args ++ ["--with-gcc","c++", "--with-ld","c++"]
++    let args' | "configure" `elem` args = args ++ ["--with-gcc","c++"]
+               | otherwise               = args
+     defaultMainArgs args'


### PR DESCRIPTION
applied patch can be removed, when
https://github.com/LumiGuide/haskell-opencv/commit/cd613e200aa20887ded83256cf67d6903c207a60
hits hackage and later nixpkgs.

###### Motivation for this change

get opencv to build again and fix #47595

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

