### PR TITLE
iwd: 0.9 -> 0.11

### DIFF
--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,23 +1,24 @@
-{ stdenv, fetchgit, autoreconfHook, coreutils, readline, python3Packages }:
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, coreutils, readline, python3Packages }:
 
 let
   ell = fetchgit {
      url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
-     rev = "0.11";
-     sha256 = "0nifa5w6fxy7cagyas2a0zhcppi83yrcsnnp70ls2rc90x4r1ip8";
+     rev = "0.14";
+     sha256 = "13jlmdk47pscmfs3c12awfwr3m6ka4fh6fyr9cl1bmqdpwqmmmk6";
   };
 in stdenv.mkDerivation rec {
   name = "iwd-${version}";
-  version = "0.9";
+  version = "0.11";
 
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
     rev = version;
-    sha256 = "1l1jbwsshjbz32s4rf0zfcn3fd16si4y9qa0zaxp00bfzflnpcd4";
+    sha256 = "0q79rdj3h16xdf0g2jdsvb2141z36z89vgzq0qn31pxzhgxdgf7j";
   };
 
   nativeBuildInputs = [
     autoreconfHook
+    pkgconfig
     python3Packages.wrapPython
   ];
 


### PR DESCRIPTION
> ver 0.11:
> 	Fix issue with handling EAP-TTLS and redundant L flags.
> 	Fix issue with handling EAP-TLS upper limit on request size.
>	Fix issue with handling handshake complete after setting keys.
>	Fix issue with handling access points with too many rates.
>	Fix issue with requiring PSK if passphrase is present.
>	Add support for retrieving list of hidden access points.
>	Add support for tunneled MS-CHAP.
>
> ver 0.10:
>	Fix issue with Ethernet authentication packet handling.
>	Fix issue with ad-hoc network scan results in station mode.
>	Fix issue with cancellation of ongoing rekey offload.
>	Add support for setting per-mac GTK credentials.
>	Add support for using external Embedded Linux library.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

