### PR TITLE
smem: 1.4 -> 1.5

### DIFF
--- a/pkgs/os-specific/linux/smem/default.nix
+++ b/pkgs/os-specific/linux/smem/default.nix
@@ -1,31 +1,26 @@
 { lib, stdenv, fetchurl, python }:
 
 stdenv.mkDerivation rec {
-  name = "smem-1.4";
+  name = "smem-${version}";
+  version = "1.5";
 
   src = fetchurl {
-    url = "https://www.selenic.com/smem/download/${name}.tar.gz";
-    sha256 = "1v31vy23s7szl6vdrllq9zbg58bp36jf5xy3fikjfg6gyiwgia9f";
+    url = "https://selenic.com/repo/smem/archive/${version}.tar.bz2";
+    sha256 = "19ibv1byxf2b68186ysrgrhy5shkc5mc69abark1h18yigp3j34m";
   };
 
   buildInputs = [ python ];
 
-  buildPhase =
-    ''
-      gcc -O2 smemcap.c -o smemcap
-    '';
+  makeFlags = [ "smemcap" ];
 
   installPhase =
     ''
-      mkdir -p $out/bin
-      cp smem smemcap $out/bin/
-
-      mkdir -p $out/share/man/man8
-      cp smem.8 $out/share/man/man8/
+      install -Dm555 -t $out/bin/ smem smemcap
+      install -Dm444 -t $out/share/man/man8/ smem.8
     '';
 
   meta = {
-    homepage = http://www.selenic.com/smem/;
+    homepage = https://www.selenic.com/smem/;
     description = "A memory usage reporting tool that takes shared memory into account";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.eelco ];


### PR DESCRIPTION
###### Motivation for this change

Update
and now compatible with Python3 so it won't break when we change the default Python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

