### PR TITLE
qtwebglplugin: init at 5.11

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -113,6 +113,7 @@ let
       qtwayland = callPackage ../modules/qtwayland.nix {};
       qtwebchannel = callPackage ../modules/qtwebchannel.nix {};
       qtwebengine = callPackage ../modules/qtwebengine.nix {};
+      qtwebglplugin = callPackage ../modules/qtwebglplugin.nix {};
       qtwebkit = callPackage ../modules/qtwebkit.nix {};
       qtwebsockets = callPackage ../modules/qtwebsockets.nix {};
       qtx11extras = callPackage ../modules/qtx11extras.nix {};

--- a/pkgs/development/libraries/qt-5/modules/qtwebglplugin.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebglplugin.nix
@@ -1,0 +1,6 @@
+{ qtModule, qtbase, qtwebsockets }:
+
+qtModule {
+  name = "qtwebglplugin";
+  qtInputs = [ qtbase qtwebsockets ];
+}


### PR DESCRIPTION
Note: As with all Qt plugins, must set QT_QPA_PLATFORM_PLUGIN_PATH=~/.nix-profile/lib/qt-5.11/plugins for it to be found.

###### Motivation for this change
qtwebglplugin wasn't packaged

###### Things done
Added a Qt module

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: To test/use this, you need to:
Set `QT_QPA_PLATFORM_PLUGIN_PATH=~/.nix-profile/lib/qt-5.11/plugins`
Run a Qt Quick application, either with the environment variable `QT_QPA_PLATFORM=webgl` or with the argument `-platform webgl`
Point a WebGL-capable browser at `<IP address>:8080`.
I tested it with a number of the examples in the qt sources in qtdeclarative/examples.