### PR TITLE
nixos/incron: added nixos test to ensure expected behaviour

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -336,6 +336,7 @@ in rec {
   tests.plasma5 = callTest tests/plasma5.nix {};
   tests.plotinus = callTest tests/plotinus.nix {};
   tests.keymap = callSubTests tests/keymap.nix {};
+  tests.incron = callTest tests/incron.nix {};
   tests.initrdNetwork = callTest tests/initrd-network.nix {};
   tests.kafka = callSubTests tests/kafka.nix {};
   tests.kernel-latest = callTest tests/kernel-latest.nix {};

--- a/nixos/tests/incron.nix
+++ b/nixos/tests/incron.nix
@@ -1,0 +1,52 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+{
+  name = "incron";
+  meta.maintainers = [ lib.maintainers.aanderse ];
+
+  machine =
+    { ... }:
+    { services.incron.enable = true;
+      services.incron.extraPackages = [ pkgs.coreutils ];
+      services.incron.systab = ''
+        /test IN_CREATE,IN_MODIFY,IN_CLOSE_WRITE,IN_MOVED_FROM,IN_MOVED_TO echo "$@/$# $%" >> /root/incron.log
+      '';
+
+      # ensure the directory to be monitored exists before incron is started
+      system.activationScripts.incronTest = ''
+        mkdir /test
+      '';
+    };
+
+  testScript = ''
+    startAll;
+
+    $machine->waitForUnit("multi-user.target");
+    $machine->waitForUnit("incron.service");
+
+    $machine->succeed("test -d /test");
+    # create some activity for incron to monitor
+    $machine->succeed("touch /test/file");
+    $machine->succeed("echo foo >> /test/file");
+    $machine->succeed("mv /test/file /root");
+    $machine->succeed("mv /root/file /test");
+
+    $machine->sleep(1);
+
+    # touch /test/file
+    $machine->succeed("grep '/test/file IN_CREATE' /root/incron.log");
+
+    # echo foo >> /test/file
+    $machine->succeed("grep '/test/file IN_MODIFY' /root/incron.log");
+    $machine->succeed("grep '/test/file IN_CLOSE_WRITE' /root/incron.log");
+
+    # mv /test/file /root
+    $machine->succeed("grep '/test/file IN_MOVED_FROM' /root/incron.log");
+
+    # mv /root/file /test
+    $machine->succeed("grep '/test/file IN_MOVED_TO' /root/incron.log");
+
+    # ensure something unexpected is not present
+    $machine->fail("grep 'IN_OPEN' /root/incron.log");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
Finally got around to writing NixOS test for this module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

