### PR TITLE
Add "emulator" function to systems

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -66,6 +66,46 @@ rec {
          # uname -r
          release = null;
       };
+
+      qemuArch =
+        if final.isArm then "arm"
+        else if final.isx86_64 then "x86_64"
+        else if final.isx86 then "i386"
+        else {
+          "powerpc" = "ppc";
+          "powerpc64" = "ppc64";
+          "powerpc64le" = "ppc64";
+          "mips64" = "mips";
+          "mipsel64" = "mipsel";
+        }.${final.parsed.cpu.name} or final.parsed.cpu.name;
+
+      emulator = pkgs: let
+        qemu-user = pkgs.qemu.override {
+          smartcardSupport = false;
+          spiceSupport = false;
+          openGLSupport = false;
+          virglSupport = false;
+          vncSupport = false;
+          gtkSupport = false;
+          sdlSupport = false;
+          pulseSupport = false;
+          smbdSupport = false;
+          seccompSupport = false;
+          hostCpuTargets = ["${final.qemuArch}-linux-user"];
+        };
+        wine-name = "wine${toString final.parsed.cpu.bits}";
+        wine = (pkgs.winePackagesFor wine-name).minimal;
+      in
+        if final.parsed.kernel.name == pkgs.stdenv.hostPlatform.parsed.kernel.name &&
+           (final.parsed.cpu.name == pkgs.stdenv.hostPlatform.parsed.cpu.name ||
+            (final.platform.isi686 && pkgs.stdenv.hostPlatform.isx86_64))
+        then pkgs.runtimeShell
+        else if final.isWindows
+        then "${wine}/bin/${wine-name}"
+        else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux
+        then "${qemu-user}/bin/qemu-${final.qemuArch}"
+        else throw "Don't know how to run ${final.config} executables.";
+
     } // mapAttrs (n: v: v final.parsed) inspect.predicates
       // args;
   in assert final.useAndroidPrebuilt -> final.isAndroid;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -2,7 +2,14 @@
 # `crossSystem`. They are put here for user convenience, but also used by cross
 # tests and linux cross stdenv building, so handle with care!
 { lib }:
-let platforms = import ./platforms.nix { inherit lib; }; in
+let
+  platforms = import ./platforms.nix { inherit lib; };
+
+  riscv = bits: {
+    config = "riscv${bits}-unknown-linux-gnu";
+    platform = platforms.riscv-multiplatform bits;
+  };
+in
 
 rec {
   #
@@ -92,10 +99,6 @@ rec {
   musl64 = { config = "x86_64-unknown-linux-musl"; };
   musl32  = { config = "i686-unknown-linux-musl"; };
 
-  riscv = bits: {
-    config = "riscv${bits}-unknown-linux-gnu";
-    platform = platforms.riscv-multiplatform bits;
-  };
   riscv64 = riscv "64";
   riscv32 = riscv "32";
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -18,6 +18,10 @@
 , virglSupport ? openGLSupport, virglrenderer
 , smbdSupport ? false, samba
 , hostCpuOnly ? false
+, hostCpuTargets ? (if hostCpuOnly
+                    then (stdenv.lib.optional stdenv.isx86_64 "i386-softmmu"
+                          ++ ["${stdenv.hostPlatform.qemuArch}-softmmu"])
+                    else null)
 , nixosTestRunner ? false
 }:
 
@@ -27,11 +31,6 @@ let
     + optionalString pulseSupport "pa,"
     + optionalString sdlSupport "sdl,";
 
-  hostCpuTargets = if stdenv.isx86_64 then "i386-softmmu,x86_64-softmmu"
-                   else if stdenv.isi686 then "i386-softmmu"
-                   else if stdenv.isAarch32 then "arm-softmmu"
-                   else if stdenv.isAarch64 then "aarch64-softmmu"
-                   else throw "Don't know how to build a 'hostCpuOnly = true' QEMU";
 in
 
 stdenv.mkDerivation rec {
@@ -113,7 +112,7 @@ stdenv.mkDerivation rec {
     ++ optional smartcardSupport "--enable-smartcard"
     ++ optional spiceSupport "--enable-spice"
     ++ optional usbredirSupport "--enable-usb-redir"
-    ++ optional hostCpuOnly "--target-list=${hostCpuTargets}"
+    ++ optional (hostCpuTargets != null) "--target-list=${stdenv.lib.concatStringsSep "," hostCpuTargets}"
     ++ optional stdenv.isDarwin "--enable-cocoa"
     ++ optional stdenv.isLinux "--enable-linux-aio"
     ++ optional gtkSupport "--enable-gtk"
@@ -135,12 +134,13 @@ stdenv.mkDerivation rec {
     '';
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
-  postInstall =
-    if stdenv.isx86_64       then ''makeWrapper $out/bin/qemu-system-x86_64  $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
-    else if stdenv.isi686    then ''makeWrapper $out/bin/qemu-system-i386    $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
-    else if stdenv.isAarch32 then ''makeWrapper $out/bin/qemu-system-arm     $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
-    else if stdenv.isAarch64 then ''makeWrapper $out/bin/qemu-system-aarch64 $out/bin/qemu-kvm --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"''
-    else "";
+  postInstall = ''
+    if [ -x $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
+      makeWrapper $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} \
+                  $out/bin/qemu-kvm \
+                  --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"
+    fi
+  '';
 
   passthru = {
     qemu-system-i386 = "bin/qemu-system-i386";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12465,7 +12465,7 @@ with pkgs;
   taglib-sharp = callPackage ../development/libraries/taglib-sharp { };
 
   talloc = callPackage ../development/libraries/talloc {
-    python = python2;
+    python = buildPackages.python2;
   };
 
   tclap = callPackage ../development/libraries/tclap {};

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -54,7 +54,7 @@ rec {
   # More poor man's memoisation
   pkgsForCross = let
     examplesByConfig = lib.flip lib.mapAttrs'
-      (builtins.removeAttrs lib.systems.examples [ "riscv" ])
+      lib.systems.examples
       (_: crossSystem: nameValuePair crossSystem.config {
         inherit crossSystem;
         pkgsFor = mkPkgsFor crossSystem;


### PR DESCRIPTION
exeWrapper is based on meson's exe_wrapper idea. Basically, it will give you an emulator that can run whatever executable you want. It is useful for instance in "waf" build systems that expect a "--cross-execute" flag to run some configuration tests. We can use QEMU to emulate Linxux systems. On windows systems we can use WINE.

I am hoping this is useful in more things, for instance running, some tests in the emulator when doing cross compilation.

The QEMU system should be able to run Linux. Running ```pkgs.exeWrapper { config = "aarch64-unknown-linux-gnu"; }```, will give you a bash script to emulate an aarch64 system. I have already rewritten the Nixpkgs cross tests to use this (and can probably add them to release-cross.nix).