### PR TITLE
syncplay: 1.5.5 -> 1.6.0

### DIFF
--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, fetchurl, python3Packages }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "syncplay-${version}";
-  version = "1.5.5";
+  version = "1.6.0";
 
   format = "other";
 
   src = fetchurl {
-    url = https://github.com/Syncplay/syncplay/archive/v1.5.5.tar.gz;
-    sha256 = "0g12hm84c48fjrmwljl0ii62f55vm6fk2mv8vna7fadabmk6dwhr";
+    url = https://github.com/Syncplay/syncplay/archive/v1.6.0.tar.gz;
+    sha256 = "19x7b694p8b3qp578qk8q4g0pybhfjd4zk8rgrggz40s1yyfnwy5";
   };
 
-  propagatedBuildInputs = with python2Packages; [ pyside twisted ];
+  propagatedBuildInputs = with python3Packages; [ pyside twisted ];
 
   makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
 


### PR DESCRIPTION
###### Motivation for this change
fixes #49928

Switched to python3 as per `syncplay-server` output

```
Traceback (most recent call last):
  File "/nix/store/zamfk74l1wn144q45k6cxyjz8famdbzv-syncplay-1.6.0/bin/.syncplay-server-wrapped", line 13, in <module>
    raise Exception("You must run Syncplay with Python 3.4 or newer!")
Exception: You must run Syncplay with Python 3.4 or newer!
```

Currently appears to work correctly now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Mic92 
