### PR TITLE
doc: Fixes default python interpreter.

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -487,7 +487,7 @@ and in this case the `python35` interpreter is automatically used.
 Versions 2.7, 3.4, 3.5, 3.6 and 3.7 of the CPython interpreter are available as
 respectively `python27`, `python34`, `python35` and `python36`. The PyPy interpreter
 is available as `pypy`. The aliases `python2` and `python3` correspond to respectively `python27` and
-`python35`. The default interpreter, `python`, maps to `python2`.
+`python36`. The default interpreter, `python`, maps to `python2`.
 The Nix expressions for the interpreters can be found in
 `pkgs/development/interpreters/python`.
 


### PR DESCRIPTION
This is equivalent to the change in
a649f1c0cdb7b618ab64c6bf33a66fbbc1507116, which cannot apply cleanly as
cherry-picked. The stable (18.09) nixpkgs still has python34.

###### Motivation for this change

#50201

cc @bhipple, @Infinisil (merger)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
