### PR TITLE
dosbox: 0.74 -> 0.74-2

### DIFF
--- a/pkgs/development/libraries/SDL_sound/default.nix
+++ b/pkgs/development/libraries/SDL_sound/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL, libvorbis, flac, libmikmod }:
+{ stdenv, lib, fetchurl, SDL, libvorbis, flac, libmikmod }:
 
 stdenv.mkDerivation rec {
   name = "SDL_sound-${version}";
@@ -11,9 +11,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL libvorbis flac libmikmod ];
 
-  meta = with stdenv.lib; {
+  configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
+
+  meta = with lib; {
     description = "SDL sound library";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.lgpl21;
     homepage = https://www.icculus.org/SDL_sound/;
   };

--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -1,31 +1,16 @@
-{ stdenv, lib, fetchurl, SDL, makeDesktopItem, libGLU_combined }:
+{ stdenv, lib, fetchurl, makeDesktopItem, SDL, SDL_net, SDL_sound, libGLU_combined, libpng }:
 
 stdenv.mkDerivation rec {
-  name = "dosbox-0.74";
+  name = "dosbox-0.74-2";
 
   src = fetchurl {
     url = "mirror://sourceforge/dosbox/${name}.tar.gz";
-    sha256 = "01cfjc5bs08m4w79nbxyv7rnvzq2yckmgrbq36njn06lw8b4kxqk";
+    sha256 = "1ksp1b5szi0vy4x55rm3j1y9wq5mlslpy8llpg87rpdyjlsk0xvh";
   };
-
-  patches =
-    [ # Fix building with GCC 4.6.
-      (fetchurl {
-        url = "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/games-emulation/dosbox/files/dosbox-0.74-gcc46.patch?revision=1.1";
-        sha256 = "03iv1ph7fccfw327ngnhvzwyiix7fsbdb5mmpxivzkidhlrssxq9";
-      })
-      (fetchurl {
-        url = "https://svnweb.freebsd.org/ports/head/emulators/dosbox/files/patch-src_gui_sdlmain.cpp?revision=435580&view=co&pathrev=435580";
-        sha256 = "1mbj5wrn53k0zds2adys34949vzsbfgm0pmsyx14v9j0cxi7drca";
-        name = "patch-src_gui_sdlmain.cpp";
-      })
-    ];
-
-  patchFlags = "-p0";
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ SDL libGLU_combined ];
+  buildInputs = [ SDL SDL_net SDL_sound libGLU_combined libpng ];
 
   configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
 
@@ -42,6 +27,8 @@ stdenv.mkDerivation rec {
      mkdir -p $out/share/applications
      cp ${desktopItem}/share/applications/* $out/share/applications
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = http://www.dosbox.com/;


### PR DESCRIPTION
###### Motivation for this change

Changelog: https://sourceforge.net/projects/dosbox/files/dosbox/0.74-2/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).