### PR TITLE
gvisor: init at 2018-11-10

### DIFF
--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -1,0 +1,79 @@
+{
+  stdenv
+, pkgs
+, lib
+, fetchFromGitHub
+, cacert
+, symlinks
+, writeScript
+, callPackage
+
+, coreutils
+, bash
+, bazel
+, git
+, go
+, python
+, removeReferencesTo
+}:
+
+let
+
+  # Bazel command we run.
+  bazelCmd = "USER=nix bazel";
+
+  # All dependency repositories that we fetch through Nix.
+  repos = import ./repositories.nix {
+    inherit (pkgs) fetchFromGitHub fetchgit fetchurl fetchzip buildGoPackage unzip;
+  };
+
+  # Command-line args to use above repositories.
+  reposArgs = lib.mapAttrsToList (name: value: "--override_repository=${name}=${value}") repos;
+
+in
+
+stdenv.mkDerivation rec {
+  name = "gvisor-${version}";
+  version = "2018-11-10";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo  = "gvisor";
+    rev   = "d97ccfa346d23d99dcbe634a10fa5d81b089100d";
+    sha256 = "1x921qjxg041vghk4ypklqvcbpw2xs42bfah1k80g4ids29l1qyi";
+  };
+
+  nativeBuildInputs = [ bazel go python ];
+
+  patchPhase = ''
+    sed -i \
+      's|go_register_toolchains(go_version="1.11.2")|go_register_toolchains(go_version="host")|g' \
+      WORKSPACE
+    find . -name '*.sh' -exec \
+      sed -i 's|#!/bin/bash|#!/bin/sh|g' {} \;
+  '';
+
+  buildPhase = ''
+    export TEST_TMPDIR=$PWD/bazel_root_dir
+    mkdir -p "$TEST_TMPDIR"
+
+    # Actually run the build
+    ${bazelCmd} build \
+      ${lib.escapeShellArgs reposArgs} \
+      //runsc:runsc
+  '';
+
+  # TODO: use build event protocol(?) in order to find the right output file,
+  # if we expand the set of supported platforms
+  installPhase = ''
+    install -Dm755 ./bazel-bin/runsc/linux_amd64_pure_stripped/runsc $out/bin/runsc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Container Runtime Sandbox";
+    homepage = https://github.com/google/gvisor;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ andrew-d ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/virtualization/gvisor/gazelle-deps.nix
+++ b/pkgs/applications/virtualization/gvisor/gazelle-deps.nix
@@ -1,0 +1,57 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/bazelbuild/buildtools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bazelbuild/buildtools";
+      rev =  "0b76442a60b61abbff02239620b493f25d6d9867";
+      sha256 = "09svc30cb3c4jqw9kprvrbzvch6xw05pxdg3awjhbbr4lqcw92k6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev =  "c01d1270ff3e442a8a57cddc1c92dc1138598194";
+      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "2a47403f2ae58167c4d75973960ccc62b28cb0d8";
+      sha256 = "0ww1iz1zcw995957h32289yascl37pkvfj3qcvyghvnzf7xg9v6z";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev =  "4c874b978acba4ecd4a257d3bb8829dd5de17be8";
+      sha256 = "1r1hqiasbpkpp66p29i2a2xi06gdzw532wf63wnpqzd5543hf5zx";
+    };
+  }
+]

--- a/pkgs/applications/virtualization/gvisor/repositories.nix
+++ b/pkgs/applications/virtualization/gvisor/repositories.nix
@@ -1,0 +1,219 @@
+# This file contains all Bazel repositories, manually translated to Nix code so
+# that we can perform a build without any network access.
+#
+# When changing this file, it's helpful to run a gvisor build using the
+# following command, which generates a "resolved.bzl" file containing all
+# dependencies:
+#   bazel sync --experimental_repository_cache=$PWD/my_cache --experimental_repository_resolved_file=./resolved.bzl
+#
+
+{
+# From stdenv
+  fetchFromGitHub
+, fetchgit
+, fetchurl
+, fetchzip
+, buildGoPackage
+, unzip
+}:
+
+let
+
+  # Actual Bazel dependencies.
+  deps = rec {
+    io_bazel_rules_go = fetchzip {
+      url       = "https://github.com/bazelbuild/rules_go/releases/download/0.16.2/rules_go-0.16.2.tar.gz";
+      sha256    = "05a8ya3qqxziz92f9srcfy7a1nv4a2vahx1mh8mjr0p01b2r4f8c";
+      stripRoot = false;
+    };
+
+    bazel_gazelle = fetchzip {
+      url       = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz";
+      sha256    = "1w99splkwxggjai66aar1lx5rsmcayrvh6v4id4gliww2daqqq1k";
+      stripRoot = false;
+    };
+
+    com_github_google_subcommands = fetchFromGitHubAndGazelle {
+      owner  = "google";
+      repo   = "subcommands";
+      rev    = "ce3d4cfc062faac7115d44e5befec8b5a08c3faa";
+      sha256 = "046hwy73nlrlh7k0ar6zqmb9c1zvclc701a7q6mhbzsisc1cnb1m";
+    };
+
+    com_github_cenkalti_backoff = fetchFromGitHubAndGazelle {
+      owner  = "cenkalti";
+      repo   = "backoff";
+      rev    = "66e726b43552c0bab0539b28e640b89fd6862115";
+      sha256 = "0ng3dhng23n8anj19fn264l7f59i3916rxzvzmc7fg271nprpshq";
+    };
+
+    com_github_syndtr_gocapability = fetchFromGitHubAndGazelle {
+      owner  = "syndtr";
+      repo   = "gocapability";
+      rev    = "d98352740cb2c55f81556b63d4a1ec64c5a319c2";
+      sha256 = "04jb3hyxq4h4ak9l0dpgfq5lzzipakrk31fw6902fziz6lp29sxg";
+    };
+
+    com_github_opencontainers_runtime-spec = fetchFromGitHubAndGazelle {
+      owner  = "opencontainers";
+      repo   = "runtime-spec";
+      rev    = "b2d941ef6a780da2d9982c1fb28d77ad97f54fc7";
+      sha256 = "1swpwva2vzlmna2r02bdxzb54ggpcjis5faaaqx29g1jv1k8k2h7";
+    };
+
+    org_golang_x_tools = fetchurl {
+      urls   = ["https://codeload.github.com/golang/tools/zip/3e7aa9e59977626dc60433e9aeadf1bb63d28295"];
+      sha256 = "0s7c1sfqb6xvhwcs0s1q8byw62fzdn0r0dw561sk6qhiwcs8xp3c";
+
+      recursiveHash = true;
+      downloadToTemp = true;
+
+      postFetch = ''
+        set -ex
+        unpackDir="$TMPDIR/unpacked"
+        mkdir "$unpackDir" && cd "$unpackDir"
+
+        ${unzip}/bin/unzip -qq "$downloadedFile"
+
+        cd "$TMPDIR"
+        mkdir unpacked-stripped
+
+        shopt -s dotglob
+        mv "$unpackDir/tools-3e7aa9e59977626dc60433e9aeadf1bb63d28295"/* unpacked-stripped/
+        shopt -u dotglob
+
+        unpackDir="$TMPDIR/unpacked-stripped"
+
+        touch "$unpackDir/WORKSPACE"
+        cd "$unpackDir"
+        patch -p1 < ${io_bazel_rules_go}/third_party/org_golang_x_tools-gazelle.patch
+        patch -p1 < ${io_bazel_rules_go}/third_party/org_golang_x_tools-extras.patch
+
+
+        cd "$TMPDIR"
+        mv "$unpackDir" "$out"
+      '';
+    };
+
+    org_golang_x_sys = fetchgit {
+      url    = "https://github.com/golang/sys";
+      rev    = "e4b3c5e9061176387e7cea65e4dc5853801f3fb7";
+      sha256 = "0r6nff5dd5ypqaq1d4vjkfdgainj090i3h88j13369jfzwsnvcjv";
+
+      postFetch = ''
+        set -ex
+        cd "$out"
+        touch "$out/WORKSPACE"
+        cd "$unpackDir"
+        patch -p1 < ${io_bazel_rules_go}/third_party/org_golang_x_sys-gazelle.patch
+      '';
+    };
+
+    com_github_golang_protobuf = fetchgit {
+      url    = "https://github.com/golang/protobuf";
+      rev    = "aa810b61a9c79d51363740d207bb46cf8e620ed5";
+      sha256 = "1f20bk7y27wwzq56pdajkpkk2bw9krw2yz7h1xqyv9nr9pszsk0x";
+
+      postFetch = ''
+        set -ex
+        cd "$out"
+        touch "$out/WORKSPACE"
+        cd "$unpackDir"
+        patch -p1 < ${io_bazel_rules_go}/third_party/com_github_golang_protobuf-gazelle.patch
+        patch -p1 < ${io_bazel_rules_go}/third_party/com_github_golang_protobuf-extras.patch
+      '';
+    };
+
+    com_google_protobuf = fetchurl {
+      urls   = ["https://codeload.github.com/google/protobuf/zip/48cb18e5c419ddd23d9badcfe4e9df7bde1979b2"];
+      sha256 = "1bg40miylzpy2wgbd7l7zjgmk43l12q38fq0zkn0vzy1lsj457sq";
+
+      recursiveHash = true;
+      downloadToTemp = true;
+
+      postFetch = ''
+        set -ex
+        unpackDir="$TMPDIR/unpacked"
+        mkdir "$unpackDir" && cd "$unpackDir"
+
+        ${unzip}/bin/unzip -qq "$downloadedFile"
+
+        cd "$TMPDIR"
+        mkdir unpacked-stripped
+
+        shopt -s dotglob
+        mv "$unpackDir/protobuf-48cb18e5c419ddd23d9badcfe4e9df7bde1979b2"/* unpacked-stripped/
+        shopt -u dotglob
+
+        unpackDir="$TMPDIR/unpacked-stripped"
+
+        touch "$unpackDir/WORKSPACE"
+        # no patches
+
+        cd "$TMPDIR"
+        mv "$unpackDir" "$out"
+      '';
+    };
+
+    com_github_google_btree = fetchFromGitHubAndGazelle {
+      owner  = "google";
+      repo   = "btree";
+      rev    = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306";
+      sha256 = "10lgk3wwvp9li3v6nhl0ibw09fbh8nk10ymg3f6kqsdaparbxhk8";
+    };
+
+    com_github_gofrs_flock = fetchFromGitHubAndGazelle {
+      owner  = "gofrs";
+      repo   = "flock";
+      rev    = "886344bea0798d02ff3fae16a922be5f6b26cee0";
+      sha256 = "0pa9glnhzmv0pmd25hv5qhkxfqjq14swmrrgr612f67vzg0g4acy";
+    };
+
+    com_github_kr_pty = fetchFromGitHubAndGazelle {
+      owner  = "kr";
+      repo   = "pty";
+      rev    = "282ce0e5322c82529687d609ee670fac7c7d917c";
+      sha256 = "0g8873xnb5nc00d5d39jnp3k63rblxl501dmyxsxp684whv9spa9";
+    };
+
+    com_github_vishvananda_netlink = fetchFromGitHubAndGazelle {
+      owner  = "vishvananda";
+      repo   = "netlink";
+      rev    = "d35d6b58e1cb692b27b94fc403170bf44058ac3e";
+      sha256 = "1hhw86m40xfslr2fjn8vmlv11d449n7ipgdiv7ayiclqfmlxvp2b";
+    };
+
+    com_github_vishvananda_netns = fetchFromGitHubAndGazelle {
+      owner  = "vishvananda";
+      repo   = "netns";
+      rev    = "be1fbeda19366dea804f00efff2dd73a1642fdcc";
+      sha256 = "0kfgg366klig1xyjbd1yzj99yzqw4r5ylpq3ilr6sh0bi1jizpz8";
+    };
+  };
+
+  # Build gazelle using the same dependencies.
+  gazelle = buildGoPackage rec {
+    name = "bazel-gazelle-${version}";
+    version = "2018-11-10";
+
+    goPackagePath = "github.com/bazelbuild/bazel-gazelle";
+    goDeps = ./gazelle-deps.nix;
+    subPackages = [ "cmd/gazelle" ];
+
+    src = deps.bazel_gazelle;
+  };
+
+  # Wrapper around `fetchFromGitHub` that calls `gazelle` on the fetched
+  # repository.
+  # TODO(andrew-d): make this work on non-GitHub dependencies
+  fetchFromGitHubAndGazelle = args @ { owner, repo, ... }: fetchFromGitHub (args // {
+    extraPostFetch = ''
+      cd $out
+      ${gazelle}/bin/gazelle \
+        -go_prefix "github.com/${owner}/${repo}" \
+        -repo_root "$PWD"
+      touch WORKSPACE
+    '' + (if args ? "extraPostFetch" then args.extraPostFetch else "");
+  });
+
+in deps

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17244,6 +17244,8 @@ with pkgs;
 
   gv = callPackage ../applications/misc/gv { };
 
+  gvisor = callPackage ../applications/virtualization/gvisor { };
+
   guvcview = callPackage ../os-specific/linux/guvcview {
     pulseaudioSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;


### PR DESCRIPTION
###### Motivation for this change
Add a package for the `gvisor` container runtime sandbox.  This was requested in #39889, but there were some problems with Bazel at the time.  I've managed to get this working, but I'd appreciate feedback on how I've done so.  In short: there's two derivations here; one that is a fixed-output derivation produced by running `bazel sync` to download all dependencies and making them deterministic, and a second that uses the above derivation along with the source in order to build the actual output binary.  At the end of the whole process, `gvisor` is runnable:

```
$ /nix/store/iag5vgl51alqmirabvz5ij9yfp6kwmby-gvisor-2018-11-10/bin/runsc --help
Usage: runsc <flags> <subcommand> <subcommand args>

Subcommands:
	checkpoint       checkpoint current state of container (experimental)
	create           create a secure container
	delete           delete resources held by a container
	events           display container events such as OOM notifications, cpu, memory, and IO usage statistics
```

I haven't yet tested this with Docker, so I'll try to do that shortly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dtzWill and @q3k (on the original issue)
cc @mboes (Bazel maintainer - feedback appreciated!)