### PR TITLE
wire-desktop: don't explicitly set phases

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -72,7 +72,10 @@ in
       categories = "Network;InstantMessaging;Chat;VideoConference";
     };
 
-    phases = [ "unpackPhase" "installPhase" ];
+    dontBuild = true;
+    dontPatchELF = true;
+    dontConfigure = true;
+
     nativeBuildInputs = [ dpkg ];
     unpackPhase = "dpkg-deb -x $src .";
     installPhase = ''
@@ -93,7 +96,7 @@ in
 
       # Desktop file
       mkdir -p "$out/share/applications"
-      cp ${desktopItem}/share/applications/* "$out/share/applications"
+      cp "${desktopItem}/share/applications/"* "$out/share/applications"
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
part of #28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

