### PR TITLE
pythonPackages.gym: init at 0.9.6

### DIFF
--- a/pkgs/development/python-modules/gym/default.nix
+++ b/pkgs/development/python-modules/gym/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "A toolkit by OpenAI for developing and comparing your reinforcement learning agents.";
+    description = "A toolkit by OpenAI for developing and comparing your reinforcement learning agents";
     homepage = https://gym.openai.com/;
     license = licenses.mit;
     maintainers = with maintainers; [ hyphon81 ];

--- a/pkgs/development/python-modules/gym/default.nix
+++ b/pkgs/development/python-modules/gym/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage, fetchPypi
+, numpy, requests, six, pyglet, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "gym";
+  version = "0.9.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0llbhn3zdlsz2crd5grd1yygg8zp2shsclc24iqix5gw5f65clx5";
+  };
+
+  propagatedBuildInputs = [
+    numpy requests six pyglet scipy
+  ];
+
+  # The test needs MuJoCo that is not free library.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A toolkit by OpenAI for developing and comparing your reinforcement learning agents.";
+    homepage = https://gym.openai.com/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2448,6 +2448,8 @@ in {
 
   gspread = callPackage ../development/python-modules/gspread { };
 
+  gym = callPackage ../development/python-modules/gym { };
+
   gyp = callPackage ../development/python-modules/gyp { };
 
   guessit = callPackage ../development/python-modules/guessit { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

