### PR TITLE
gawk: add windows build

### DIFF
--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -17,41 +17,12 @@ assert (doCheck && stdenv.isLinux) -> glibcLocales != null;
 
 let
   inherit (stdenv.lib) optional;
-in
-stdenv.mkDerivation rec {
+
   name = "gawk-4.2.1";
 
   src = fetchurl {
     url = "mirror://gnu/gawk/${name}.tar.xz";
     sha256 = "0lam2zf3n7ak4pig8w46lhx9hzx50kj2v2yj1616mm26wy2rf4fi";
-  };
-
-  # When we do build separate interactive version, it makes sense to always include man.
-  outputs = [ "out" "info" ] ++ optional (!interactive) "man";
-
-  nativeBuildInputs = optional (doCheck && stdenv.isLinux) glibcLocales;
-
-  buildInputs =
-       optional withSigsegv libsigsegv
-    ++ optional interactive readline
-    ++ optional stdenv.isDarwin locale;
-
-  configureFlags = [
-    (if withSigsegv then "--with-libsigsegv-prefix=${libsigsegv}" else "--without-libsigsegv")
-    (if interactive then "--with-readline=${readline.dev}" else "--without-readline")
-  ];
-
-  makeFlags = "AR=${stdenv.cc.targetPrefix}ar";
-
-  inherit doCheck;
-
-  postInstall = ''
-    rm "$out"/bin/gawk-*
-    ln -s gawk.1 "''${!outputMan}"/share/man/man1/awk.1
-  '';
-
-  passthru = {
-    libsigsegv = if withSigsegv then libsigsegv else null; # for stdenv bootstrap
   };
 
   meta = with stdenv.lib; {
@@ -74,9 +45,66 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl3Plus;
 
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
 
     maintainers = [ ];
   };
-}
+in
 
+if stdenv.hostPlatform.isWindows then
+  stdenv.mkDerivation rec {
+    inherit src name meta;
+
+    # $src/pc has pre-configured makefiles for Windows
+    configurePhase = ''
+      substituteInPlace pc/gawkmisc.pc    --replace 'int execvp(const char *file, const char *const *argv)' 'int execvp(const char *file, char *const *argv)'
+      substituteInPlace pc/Makefile       --replace CC=gcc               CC=${stdenv.cc.targetPrefix}cc
+      substituteInPlace pc/Makefile       --replace 'prefix = c:/gnu'    "prefix = $out"
+      substituteInPlace pc/Makefile.ext   --replace 'prefix = c:/gnu'    "prefix = $out"
+      sed -i -r 's,\tgcc ,\t${stdenv.cc.targetPrefix}cc ,g' pc/Makefile.ext
+
+      mv pc/Makefile.ext ./extension/Makefile
+      mv pc/{Makefile,config.h,popen.h,socket.h,dlfcn.h,in.h,getid.c,popen.c} ./
+      mv support/{dfa.h,random.h,getopt.h,regex.h,getopt_int.h,xalloc.h,regex_internal.h,localeinfo.h,regcomp.c,regexec.c,regex_internal.c,localeinfo.c,dfa.c,getopt.c,random.c,regex.c,getopt1.c} ./
+    '';
+
+    buildPhase = ''
+      make mingw32
+      ( cd extension; make extensions MPFR= MPFR_LIBS= )
+    '';
+
+    preInstall = ''mkdir -p $out/lib'';
+  }
+else
+  stdenv.mkDerivation rec {
+    inherit src name meta;
+
+    # When we do build separate interactive version, it makes sense to always include man.
+    outputs = [ "out" "info" ] ++ optional (!interactive) "man";
+
+    nativeBuildInputs = optional (doCheck && stdenv.isLinux) glibcLocales;
+
+    buildInputs =
+         optional withSigsegv libsigsegv
+      ++ optional interactive readline
+      ++ optional stdenv.isDarwin locale;
+
+    configureFlags = [
+      (if withSigsegv then "--with-libsigsegv-prefix=${libsigsegv}" else "--without-libsigsegv")
+      (if interactive then "--with-readline=${readline.dev}" else "--without-readline")
+    ];
+
+    makeFlags = "AR=${stdenv.cc.targetPrefix}ar";
+
+    inherit doCheck;
+
+    postInstall = ''
+      rm "$out"/bin/gawk-*
+      ln -s gawk.1 "''${!outputMan}"/share/man/man1/awk.1
+    '';
+
+    passthru = {
+      libsigsegv = if withSigsegv then libsigsegv else null; # for stdenv bootstrap
+    };
+
+  }


### PR DESCRIPTION
###### Motivation for this change

```gawk``` upstream supports windows natively and the source tarball contains manually pre-```./configured``` Makefiles in ```pc/``` directory

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

