### PR TITLE
go: make compiler usable for cross compiles

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -131,13 +131,16 @@ stdenv.mkDerivation rec {
     substituteInPlace "src/cmd/link/internal/ld/lib.go" --replace dsymutil ${llvm}/bin/llvm-dsymutil
   '';
 
-  GOOS = if stdenv.isDarwin then "darwin" else "linux";
-  GOARCH = if stdenv.isDarwin then "amd64"
-           else if stdenv.hostPlatform.isi686 then "386"
-           else if stdenv.hostPlatform.isx86_64 then "amd64"
-           else if stdenv.hostPlatform.isAarch32 then "arm"
-           else if stdenv.hostPlatform.isAarch64 then "arm64"
-           else throw "Unsupported system";
+  GOOS = stdenv.hostPlatform.parsed.kernel.name;
+  GOARCH = {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+  }.${stdenv.hostPlatform.parsed.cpu.name} or (throw "Unsupported system");
   GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
   GO386 = 387; # from Arch: don't assume sse2 on i686
   CGO_ENABLED = 1;

--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -133,12 +133,12 @@ stdenv.mkDerivation rec {
 
   GOOS = if stdenv.isDarwin then "darwin" else "linux";
   GOARCH = if stdenv.isDarwin then "amd64"
-           else if stdenv.targetPlatform.isi686 then "386"
-           else if stdenv.targetPlatform.isx86_64 then "amd64"
-           else if stdenv.targetPlatform.isAarch32 then "arm"
-           else if stdenv.targetPlatform.isAarch64 then "arm64"
+           else if stdenv.hostPlatform.isi686 then "386"
+           else if stdenv.hostPlatform.isx86_64 then "amd64"
+           else if stdenv.hostPlatform.isAarch32 then "arm"
+           else if stdenv.hostPlatform.isAarch64 then "arm64"
            else throw "Unsupported system";
-  GOARM = toString (stdenv.lib.intersectLists [(stdenv.targetPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+  GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
   GO386 = 387; # from Arch: don't assume sse2 on i686
   CGO_ENABLED = 1;
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";


### PR DESCRIPTION
###### Motivation for this change

Allow go compiler to be used in cross compiles

This makes the go compiler usable for cross compiles. Previously, specifying go as `nativeBuildsInputs` or `depsBuildBuild` dependencies resulted in a go compiler built for the wrong platform. Now it pulls in the appropriate build platform version.

I don't think `buildGoPackage` supports cross compiles, so existing go packages like `terraform` will still not cross compile. But one could now manually set up a go build that cross compiles without using `buildGoPackage`.

And go itself currently doesn't seem to cross compile; this PR doesn't change that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions - gentoo with Nix 2.0.4
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

