### PR TITLE
linux: enable CGROUP_HUGETLB, CGROUP_PERF, CGROUP_RDMA

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -370,9 +370,12 @@ let
     };
 
     container = {
-      NAMESPACES     = option yes; #  Required by 'unshare' used by 'nixos-install'
+      NAMESPACES     = yes; #  Required by 'unshare' used by 'nixos-install'
       RT_GROUP_SCHED = no;
-      CGROUP_DEVICE  = option yes;
+      CGROUP_DEVICE  = yes;
+      CGROUP_HUGETLB = yes;
+      CGROUP_PERF    = yes;
+      CGROUP_RDMA    = whenAtLeast "4.11" yes;
 
       MEMCG                    = yes;
       MEMCG_SWAP               = yes;


### PR DESCRIPTION
###### Motivation for this change

CGROUP_PERF is needed for gVisor with Docker: #50218

Affected options were added in these Linux releases:

NAMESPACES 2.6.25
CGROUP_DEVICE 2.6.26
CGROUP_HUGETLB 3.6
CGROUP_PERF 2.6.39
CGROUP_RDMA 4.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @andrew-d