### PR TITLE
handbrake: 1.1.0 -> 1.1.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -88,6 +88,7 @@ in
   graphite = handleTest ./graphite.nix {};
   hadoop.hdfs = handleTestOn [ "x86_64-linux" ] ./hadoop/hdfs.nix {};
   hadoop.yarn = handleTestOn [ "x86_64-linux" ] ./hadoop/yarn.nix {};
+  handbrake = handleTestOn ["x86_64-linux"] ./handbrake.nix {};
   haproxy = handleTest ./haproxy.nix {};
   #hardened = handleTest ./hardened.nix {}; # broken due useSandbox = true
   hibernate = handleTest ./hibernate.nix {};

--- a/nixos/tests/handbrake.nix
+++ b/nixos/tests/handbrake.nix
@@ -1,0 +1,25 @@
+import ./make-test.nix ({ pkgs, ... }:
+let
+  # Download Big Buck Bunny example, licensed under CC Attribution 3.0.
+  testMkv = pkgs.fetchurl {
+    url = "https://github.com/Matroska-Org/matroska-test-files/blob/cf0792be144ac470c4b8052cfe19bb691993e3a2/test_files/test1.mkv?raw=true";
+    sha256 = "1hfxbbgxwfkzv85pvpvx55a72qsd0hxjbm9hkl5r3590zw4s75h9";
+  };
+in {
+  name = "handbrake";
+
+  meta = {
+    maintainers = with pkgs.stdenv.lib.maintainers; [ danieldk ];
+  };
+
+  machine = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ handbrake ];
+  };
+
+  testScript = ''
+    # Test MP4 and MKV transcoding. Since this is a short clip, transcoding typically
+    # only takes a few seconds.
+    $machine->succeed("HandBrakeCLI -i ${testMkv} -o test.mp4 -e x264 -q 20 -B 160");
+    $machine->succeed("HandBrakeCLI -i ${testMkv} -o test.mkv -e x264 -q 20 -B 160");
+  '';
+})

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -20,20 +20,33 @@
 
 stdenv.mkDerivation rec {
   # TODO: Release 1.2.0 would switch LibAV to FFmpeg.
-  version = "1.1.0";
+  version = "1.1.2";
   name = "handbrake-${version}";
 
   src = fetchurl {
     url = ''https://download2.handbrake.fr/${version}/HandBrake-${version}-source.tar.bz2'';
-    sha256 = "1nj0ihflisxcfkmsk7fm3b5cn7cpnpg66dk2lkp2ip6qidppqbm0";
+    sha256 = "0bny0hwlr55g2c69rsamv0xvwmfh1s4a582b9vq20xv5ly84m6ms";
   };
 
   patched_libav_12 = libav_12.overrideAttrs (super: {
-    # NOTE: 2018-04-26: HandBrake compilation (1.1.0) requires a patch of LibAV (12.3) from HandBrake team. This patch not went LibAV upstream.
     patches = (super.patches or []) ++ [(
+      # NOTE: 2018-04-26: HandBrake compilation (1.1.0) requires
+      # a patch of LibAV (12.3) from HandBrake team. This patch
+      # not went LibAV upstream.
       fetchurl {
         url = ''https://raw.githubusercontent.com/HandBrake/HandBrake/9e1f245708a157231c427c0ef9b91729d59a30e1/contrib/ffmpeg/A21-mp4-sdtp.patch'';
         sha256 = "14grzyvb1qbb90k31ibabnwmwnrc48ml6h2z0rjamdv83q45jq4g";
+      })
+      # NOTE: 2018-11-11: Transcoding to MP4 can fail with:
+      #
+      # Tag avc1/0x31637661 incompatible with output codec id '28'
+      # muxavformat: avformat_write_header failed!
+      #
+      # Fix using Handbrake patch that is not upstream in libav.
+      (
+      fetchurl {
+        url = ''https://raw.githubusercontent.com/HandBrake/HandBrake/df6c26fa261423237ee2bec0bf784c32cbfda3fa/contrib/ffmpeg/A20-avc3-hvc1-override.patch'';
+        sha256 = "1vijd7bmkzp3sb6zhpcpdni8fz4h13wgglnml6cz9f44j41w2c3v";
       })
     ];
   });


### PR DESCRIPTION
###### Motivation for this change

Changes:

https://github.com/HandBrake/HandBrake/releases/tag/1.1.2
https://github.com/HandBrake/HandBrake/releases/tag/1.1.1

Derivation changes:

- Retrieve A21-mp4-sdtp.patch from the Handbrake repository rather
  than a gist.
- Transcoding to to MP4 was broken, failing with:

  Tag avc1/0x31637661 incompatible with output codec id '28'
  muxavformat: avformat_write_header failed!

  Fix this using A20-avc3-hvc1-override.patch provided by upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

