### PR TITLE
spaceship-prompt: correct homepage url

### DIFF
--- a/pkgs/shells/zsh/spaceship-prompt/default.nix
+++ b/pkgs/shells/zsh/spaceship-prompt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec{
 
   meta = with stdenv.lib; {
     description = "Zsh prompt for Astronauts";
-    homepage = https://github.com/halfo/lambda-mod-zsh-theme/;
+    homepage = https://github.com/denysdovhan/spaceship-prompt/;
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ nyanloutre ];


### PR DESCRIPTION
###### Motivation for this change

@Infinisil Sorry I missed that bit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

