### PR TITLE
uftrace: 0.9 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/uftrace/default.nix
+++ b/pkgs/development/tools/uftrace/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "namhyung";
     repo = "uftrace";
-    rev = "5766876f56b1bfcad76370d20f9f8b002a01e57d";
+    rev = "v${version}";
     sha256 = "1jb4dp6crvfzxzmi5iflc7p13b7p2v1djyj6smbf9ns4wr515y6b";
   };
 

--- a/pkgs/development/tools/uftrace/default.nix
+++ b/pkgs/development/tools/uftrace/default.nix
@@ -1,14 +1,14 @@
-{stdenv, fetchFromGitHub }:
+{stdenv, fetchFromGitHub}:
 
 stdenv.mkDerivation rec {
   name = "uftrace-${version}";
-  version = "0.9";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "namhyung";
     repo = "uftrace";
-    rev = "f0fed0b24a9727ffed04673b62f66baad21a1f99";
-    sha256 = "0rn2xwd87qy5ihn5zq9pwq8cs1vfmcqqz0wl70wskkgp2ccsd9x8";
+    rev = "5766876f56b1bfcad76370d20f9f8b002a01e57d";
+    sha256 = "1jb4dp6crvfzxzmi5iflc7p13b7p2v1djyj6smbf9ns4wr515y6b";
   };
 
   postUnpack = ''
@@ -23,4 +23,3 @@ stdenv.mkDerivation rec {
     maintainers = [stdenv.lib.maintainers.nthorne];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
Update uftrace to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

