### PR TITLE
fix FHSUserEnv blacklists

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/chrootenv/chrootenv.c
+++ b/pkgs/build-support/build-fhs-userenv/chrootenv/chrootenv.c
@@ -19,7 +19,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-const gchar *bind_blacklist[] = {"bin", "etc", "host", "usr", NULL};
+const gchar *bind_blacklist[] = {"bin", "etc", "host", "usr", "lib", "lib64", "lib32", "sbin", NULL};
 
 void bind_mount(const gchar *source, const gchar *target) {
   fail_if(g_mkdir(target, 0755));


### PR DESCRIPTION
###### Motivation for this change

While attempting to package [yocto](https://www.yoctoproject.org/), which is a source based tool chain to build embedded Linux OSes I found it was downloading binaries to bootstrap compilation of Rust and other langs. I then switched to FHSUserEnv but my host `/lib` was still available within the chroot so binaries kept breaking because, I believe, a mismatch of glibc versions across chroot and host.

To make the chroot more pure, I have added `"lib", "lib64", "lib32", "sbin"` to the chroot blacklist.
I believe that Steam makes heavy use of this so I need to test that before merging.

Maybe it would be better to have a custom set of blacklists (or even whitelists) when creating this chroot? If that is preferable let me know and I'll try to implement.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

