### PR TITLE
ocamlPackages.*: remove unnecessary unpackCmd

### DIFF
--- a/doc/languages-frameworks/ocaml.xml
+++ b/doc/languages-frameworks/ocaml.xml
@@ -67,9 +67,9 @@ buildDunePackage rec {
 
  <para>
    Here is a second example, this time using a source archive generated with
-   <literal>dune-release</literal>. The <literal>unpackCmd</literal>
-   redefinition is necessary to be able to unpack the kind of tarball that
-   <literal>dune-release</literal> generates. This library does not depend
+   <literal>dune-release</literal>. It is a good idea to use this archive when
+   it is available as it will usually contain substituted variables such as a
+   <literal>%%VERSION%%</literal> field. This library does not depend
    on any other OCaml library and no tests are run after building it.
  </para>
 
@@ -86,8 +86,6 @@ buildDunePackage rec {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
     sha256 = "1msg3vycd3k8qqj61sc23qks541cxpb97vrnrvrhjnqxsqnh6ygq";
   };
-
-  unpackCmd = "tar xjf $src";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/flowtype/ocaml-wtf8;

--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "0ixjwc3plrljvj24za3l9gy0w30lsbggp8yh02lwrzw61ls4cri0";
   };
 
-  unpackCmd = "tar -xf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/bos/default.nix
+++ b/pkgs/development/ocaml-modules/bos/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
 		sha256 = "1s10iqx8rgnxr5n93lf4blwirjf8nlm272yg5sipr7lsr35v49wc";
 	};
 
-	unpackCmd = "tar xjf $src";
-
 	buildInputs = [ ocaml findlib ocamlbuild topkg ];
 	propagatedBuildInputs = [ astring fmt fpath logs rresult ];
 

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
     sha256 = "18jqphjiifljlh9jg8zpl6310p3iwyaqphdkmf89acyaix0s4kj1";
   };
 
-  unpackCmd = "tar xjf $src";
-
   nativeBuildInputs = [ ocamlbuild topkg ];
   buildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ result ];

--- a/pkgs/development/ocaml-modules/cpuid/default.nix
+++ b/pkgs/development/ocaml-modules/cpuid/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation {
     sha256 = "08k2558a3dnxn8msgpz8c93sfn0y027ganfdi2yvql0fp1ixv97p";
   };
 
-  unpackCmd = "tar xjf $src";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ocb-stubblr ];
 
   inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -9,8 +9,6 @@ buildDunePackage rec {
     sha256 = "1x4jxsvd1lrfibnjdjrkfl7hqsc48rljnwbap6faanj9qhwwa6v2";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   propagatedBuildInputs = [ sexplib ocplib-endian ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
 	pname = "cstruct-lwt";
-	inherit (cstruct) version src unpackCmd meta;
+	inherit (cstruct) version src meta;
 
   minimumOCamlVersion = "4.02";
 

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
 	pname = "ppx_cstruct";
-	inherit (cstruct) version src unpackCmd meta;
+	inherit (cstruct) version src meta;
 
   minimumOCamlVersion = "4.02";
 

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
 	pname = "cstruct-unix";
-	inherit (cstruct) version src unpackCmd meta;
+	inherit (cstruct) version src meta;
 
   minimumOCamlVersion = "4.02";
 

--- a/pkgs/development/ocaml-modules/csv/default.nix
+++ b/pkgs/development/ocaml-modules/csv/default.nix
@@ -9,8 +9,6 @@ buildDunePackage rec {
 		sha256 = "0cgfb6cwhwy7ypc1i3jyfz6sdnykp75aqi6kk0g1a2d81yjwzbcg";
 	};
 
-	unpackCmd = "tar -xjf $src";
-
 	meta = {
 		description = "A pure OCaml library to read and write CSV files";
 		license = stdenv.lib.licenses.lgpl21;

--- a/pkgs/development/ocaml-modules/digestif/default.nix
+++ b/pkgs/development/ocaml-modules/digestif/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
     sha256 = "0fsyfi5ps17j3wjav5176gf6z3a5xcw9aqhcr1gml9n9ayfbkhrd";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -11,8 +11,6 @@ buildDunePackage rec {
     sha256 = "0rzysj07z2q6gk0yhjxnjnba01vmdb9x32wwna10qk3rrb8r2pnn";
   };
 
-  unpackCmd = "tar xjf $src";
-
   hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/farfadet/default.nix
+++ b/pkgs/development/ocaml-modules/farfadet/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
     sha256 = "06wvd57c8khpq0c2hvm15zng269zvabsw1lcaqphqdcckl67nsxr";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   propagatedBuildInputs = [ faraday ];
@@ -31,4 +29,3 @@ stdenv.mkDerivation rec {
     inherit (ocaml.meta) platforms;
   };
 }
-

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation {
     sha256 = "1zj9azcxcn6skmb69ykgmi9z8c50yskwg03wqgh87lypgjdcz060";
   };
 
-  unpackCmd = "tar xjf $src";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg cmdliner ];
   propagatedBuildInputs = [ result uchar ];
 

--- a/pkgs/development/ocaml-modules/fpath/default.nix
+++ b/pkgs/development/ocaml-modules/fpath/default.nix
@@ -7,8 +7,6 @@ stdenv.mkDerivation {
     sha256 = "1hr05d8bpqmqcfdavn4rjk9rxr7v2zl84866f5knjifrm60sxqic";
   };
 
-  unpackCmd = "tar xjf $src";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   propagatedBuildInputs = [ astring ];

--- a/pkgs/development/ocaml-modules/functoria/default.nix
+++ b/pkgs/development/ocaml-modules/functoria/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 		sha256 = "019rl4rir4lwgjyqj2wq3ylw4daih1kxxgbc6ld6kzcq66mwr747";
 	};
 
-	unpackCmd = "tar xjf $src";
-
 	buildInputs = [ ocaml findlib ocamlbuild topkg ];
 	propagatedBuildInputs = [ bos cmdliner ocamlgraph ];
 

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  unpackCmd = "tar xjf $src";
-
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
 
   installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -11,8 +11,6 @@ buildDunePackage rec {
     sha256 = "17hqf7z5afp2z2c55fk5myxkm7cm74259rqm94hcxkqlpdaqhm8h";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   propagatedBuildInputs = [ cstruct ];
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/integers/default.nix
+++ b/pkgs/development/ocaml-modules/integers/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation {
 		sha256 = "08b1ljw88ny3l0mdq6xmffjk8anfc77igryva5jz1p6f4f746ywk";
 	};
 
-	unpackCmd = "tar xjf $src";
-
 	buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
 	inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
   propagatedBuildInputs = [ uutf ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   meta = {

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "1khbn7jqpid83zn8rvyh1x1sirls7zc878zj4fz985m5xlsfy853";
   };
 
-  unpackCmd = "tar xjf $src";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg fmt cmdliner lwt ];
   propagatedBuildInputs = [ result ];
 

--- a/pkgs/development/ocaml-modules/lru/default.nix
+++ b/pkgs/development/ocaml-modules/lru/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "0bd7js9rrma1fjjjjc3fgr9l5fjbhgihx2nsaf96g2b35iiaimd0";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   propagatedBuildInputs = [ psq ];

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
-  unpackCmd = "tar xjf $src";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ]
   ++ stdenv.lib.optional jsooSupport js_of_ocaml;
 

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "0zshi9hlhcz61n5z1k6fx6rsi0pl4xgahsyl2jp0crqkaf3hqwlg";
   };
 
-  unpackCmd = "tar xjf $curSrc";
-
   patches = [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0001-add-missing-runtime-dependencies-in-_tags.patch";

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     sha256 = "0wdfmgx1mz77s7m451vy8r9i4iqwn7s7b39kpbpckf3w9417riq0";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ocb-stubblr ];
   propagatedBuildInputs = [ result uucp uuseg uutf ] ++
                           optional withLwt lwt;

--- a/pkgs/development/ocaml-modules/octavius/default.nix
+++ b/pkgs/development/ocaml-modules/octavius/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation {
 		sha256 = "02milzzlr4xk5aymg2fjz27f528d5pyscqvld3q0dm41zcpkz5ml";
 	};
 
-	unpackCmd = "tar xjf $src";
-
 	buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
 	inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ uutf result ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/ppx_blob/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_blob/default.nix
@@ -9,8 +9,6 @@ buildDunePackage rec {
     sha256 = "1xmslk1mwdzhy1bydgsjlcb7h544c39hvxa8lywp8w72gaggjl16";
   };
 
-  unpackCmd = "tar xjf $curSrc";
-
   buildInputs = [ alcotest ocaml-migrate-parsetree ];
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
@@ -11,8 +11,6 @@ buildDunePackage rec {
     sha256 = "0qy0wa3rd5yh1612jijadi1yddfslpsmmmf69phi2dhr3vmkhza7";
   };
 
-  unpackCmd = "tar xjf $src";
-
   buildInputs = [ ocaml-migrate-parsetree ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/psq/default.nix
+++ b/pkgs/development/ocaml-modules/psq/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
     sha256 = "08ghgdivbjrxnaqc3hsb69mr9s2ql5ds0fb97b7z6zimzqibz6lp";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "0z2snhda8bg136xkw2msw6k2dz84vb49p8bgzrxfs8mawdlk0kkg";
   };
 
-  unpackCmd = "tar -xf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg js_of_ocaml ];
 
   propagatedBuildInputs = [ result ];

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -8,7 +8,6 @@ stdenv.mkDerivation {
     sha256 = "1aj8w79gdd9xnrbz7s5p8glcb4pmimi8jp9f439dqnf6ih3mqb3v";
   };
 
-  unpackCmd = "tar xjf $src";
   buildInputs = [ ocaml findlib topkg ocamlbuild ];
 
   inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -8,7 +8,6 @@ let param =
     sha256 = "06pkbnkad2ck50jn59ggwv154yd9vb01abblihvam6p27m4za1pc";
     buildInputs = [ dune ];
     extra = {
-      unpackCmd = "tar -xjf $curSrc";
       buildPhase = "dune build -p rope";
       inherit (dune) installPhase;
     };

--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation rec {
 		sha256 = "1k69a3gvrk7f2cshwjzvk7818f0bwxhacgd14wxy6d4gmrggci86";
 	};
 
-	unpackCmd = "tar xjf $src";
-
 	buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
 	inherit (topkg) buildPhase installPhase;

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ result ];
 
-  unpackCmd = "tar xjf ${src}";
   buildPhase = "${run} build";
   createFindlibDestdir = true;
   installPhase = "${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild topkg result ocb-stubblr ];
   propagatedBuildInputs = [ SDL2 ctypes ];
 
-  unpackCmd = "tar xjf $src";
-
   preConfigure = ''
     # The following is done to avoid an additional dependency (ncurses)
     # due to linking in the custom bytecode runtime. Instead, just

--- a/pkgs/development/ocaml-modules/uchar/default.nix
+++ b/pkgs/development/ocaml-modules/uchar/default.nix
@@ -8,7 +8,6 @@ stdenv.mkDerivation {
     sha256 = "1w2saw7zanf9m9ffvz2lvcxvlm118pws2x1wym526xmydhqpyfa7";
   };
 
-  unpackCmd = "tar xjf $src";
   buildInputs = [ ocaml ocamlbuild findlib opaline ];
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
   installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -11,8 +11,6 @@ buildDunePackage rec {
     sha256 = "1m845rwd70wi4iijkrigyz939m1x84ba70hvv0d9sgk6971w4kz0";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ounit ];
   propagatedBuildInputs = [ ppx_sexp_conv re sexplib stringext ];
   doCheck = true;

--- a/pkgs/development/ocaml-modules/uucd/default.nix
+++ b/pkgs/development/ocaml-modules/uucd/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   propagatedBuildInputs = [ xmlm ];

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ uchar ];
 
-  unpackCmd = "tar xjf $src";
-
   buildPhase = "${topkg.buildPhase} --with-cmdliner false";
 
   inherit (topkg) installPhase;

--- a/pkgs/development/ocaml-modules/uuidm/default.nix
+++ b/pkgs/development/ocaml-modules/uuidm/default.nix
@@ -2,13 +2,11 @@
 
 stdenv.mkDerivation rec {
   version = "0.9.6";
-  name = "uuidm-${version}"; 
+  name = "uuidm-${version}";
   src = fetchurl {
     url = "http://erratique.ch/software/uuidm/releases/uuidm-${version}.tbz";
     sha256 = "0hz4fdx0x16k0pw9995vkz5d1hmzz6b16wck9li399rcbfnv5jlc";
   };
-
-  unpackCmd = "tar -xf $curSrc";
 
   buildInputs = [ ocaml findlib ocamlbuild topkg cmdliner ];
 

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ uchar ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild cmdliner topkg uutf ];
   propagatedBuildInputs = [ uucp uchar ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild topkg cmdliner ];
   propagatedBuildInputs = [ uchar ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation rec {
                           ++ optionals pdfBackend [ uutf otfm ]
                           ++ optionals htmlcBackend [ js_of_ocaml js_of_ocaml-ocamlbuild js_of_ocaml-ppx ];
 
-  unpackCmd = "tar xjf $src";
-
   buildPhase = topkg.buildPhase
     + " --with-uutf ${boolToString pdfBackend}"
     + " --with-otfm ${boolToString pdfBackend}"

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -11,8 +11,6 @@ buildDunePackage rec {
     sha256 = "1msg3vycd3k8qqj61sc23qks541cxpb97vrnrvrhjnqxsqnh6ygq";
   };
 
-  unpackCmd = "tar xjf $src";
-
   meta = with stdenv.lib; {
     homepage = https://github.com/flowtype/ocaml-wtf8;
     description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "1c62mw9rnzq0rs3ihbhfs18nv4mdzwag7893hlqgji3wmaai70pk";
   };
 
-  unpackCmd = "tar -xjf $curSrc";
-
   buildInputs = [ ocaml findlib ocamlbuild topkg ppx_sexp_conv ounit cstruct-unix ];
   propagatedBuildInputs = [ asn1-combinators astring nocrypto ];
 

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
-  unpackCmd = "tar xjf $src";
-
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

It turns out that the default unpacking command was perfectly able to handle `.tbz` tarballs.

cc @Mic92 @vbgl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

