### PR TITLE
polar-bookshelf: 1.0.11 -> 1.0.13

### DIFF
--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   name = "polar-bookshelf-${version}";
-  version = "1.0.11";
+  version = "1.0.13";
 
   # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
     url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
-    sha256 = "11rrwd5cr984nhgrib12hx6k74hzgmb3cfk6qnr1l604dk9pqfqx";
+    sha256 = "0dh7pw8ncm8kr9anb6jqw7rr4lxgmq8a40c9zlrhzyswdpvnp1g7";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -70,6 +70,10 @@ stdenv.mkDerivation rec {
     mv usr/share/* $out/share/
 
     ln -s $out/share/polar-bookshelf/polar-bookshelf $out/bin/polar-bookshelf
+    
+    # Correct desktop file `Exec`
+    substituteInPlace $out/share/applications/polar-bookshelf.desktop \
+      --replace "/opt/Polar Bookshelf/polar-bookshelf" "$out/bin/polar-bookshelf"
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/burtonator/polar-bookshelf/releases/tag/v1.0.13

Changelog: 
```
# 1.0.13

 - point release to fix auto-updates in release process and upgrade 
   electron-builder and electron-updater

 - migration from typescript 3.0.3 to 3.1.6 due to incompatibility to with new 
   electron-builder

# 1.0.12

- Reduced the minimum mouse click duration required for bringing up the annotation 
  bar. 

- Fixed bug with Electron generating an error window on exit due to a conversion 
  of the wrong type to an integer.  This was/is an Electron bug.  This may not
  be fixed in all situations but it's much better than it was before.

- Feature: drag and drop for bulk PDF import works. 

- Upgrade to Electron 3.0.8

- Fixed analytics around number of documents in the repository

- Feature: The "Delete" text is now danger red.

- Feature: Implemented a confirm prompt when deleteing flashcards, comments, and
  annotations.
 
- Feature: Implemented Cancel when creating flashcards and comments 

- Feature: Reworked anki sync to run from the doc repository.

- Feature: Renamed "Copy URL" to "Copy Original URL"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

