### PR TITLE
Add options to build disk image function

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -55,9 +55,6 @@ let format' = format; in let
 
   compress = optionalString (format' == "qcow2-compressed") "-c";
 
-  suffix = if config.nixpkgs.localSystem == config.nixpkgs.crossSystem
-           then "" else "-${config.nixpkgs.localSystem.config}";
-
   filename = "nixos." + {
     qcow2 = "qcow2";
     vpc   = "vhd";
@@ -184,7 +181,7 @@ let format' = format; in let
     nix-store --load-db < ${closureInfo}/registration
 
     echo "running nixos-install..."
-    nixos-install${suffix} --root $root --no-bootloader --no-root-passwd \
+    nixos-install --root $root --no-bootloader --no-root-passwd \
       --system ${config.system.build.toplevel} --channel ${channelSources} --substituters ""
 
     echo "copying staging root to image..."
@@ -233,7 +230,7 @@ in pkgs.vmTools.runInLinuxVM (
       ''}
 
       # Set up core system link, GRUB, etc.
-      NIXOS_INSTALL_BOOTLOADER=1 nixos-enter${suffix} --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+      NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 
       # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
       rm -f $mountPoint/etc/machine-id


### PR DESCRIPTION
###### Motivation for this change

I'd like to be able to build a disk image with a custom label. This patch simply adds an option to do that. When the option is omitted, this patch preserves the old behavior.

Additionally, when cross-compiling, `nixos-enter` has a suffix based on the target triple. This needs to be added to the nixos-enter commands for the cross-compile to succeed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

