### PR TITLE
Enable musl support for ebtables

### DIFF
--- a/pkgs/os-specific/linux/ebtables/default.nix
+++ b/pkgs/os-specific/linux/ebtables/default.nix
@@ -1,6 +1,17 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, enableDebug ? false, enableStatic ? false }:
 
-stdenv.mkDerivation rec {
+let staticBuildOpts = {
+      buildFlags = [ "static" ];
+
+      installPhase = ''
+        mkdir -p $out/bin
+        cp static $out/bin/ebtables
+
+        mkdir -p $out/etc
+        cp ethertypes $out/etc/ethertypes
+      '';
+    };
+in stdenv.mkDerivation (rec {
   name = "ebtables-${version}";
   version = "2.0.10-4";
 
@@ -12,16 +23,28 @@ stdenv.mkDerivation rec {
   makeFlags =
     [ "LIBDIR=$(out)/lib" "BINDIR=$(out)/sbin" "MANDIR=$(out)/share/man"
       "ETCDIR=$(out)/etc" "INITDIR=$(TMPDIR)" "SYSCONFIGDIR=$(out)/etc/sysconfig"
-      "LOCALSTATEDIR=/var"
+      "LOCALSTATEDIR=/var" "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
     ];
+
+  patches = lib.optional stdenv.hostPlatform.isMusl ./musl-compatibility.patch ++
+            lib.optional stdenv.hostPlatform.isAarch32 ./no-as-needed.patch;
 
   preBuild =
     ''
       substituteInPlace Makefile --replace '-o root -g root' ""
     '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+  NIX_CFLAGS_COMPILE = lib.concatStringsSep " " (
+    ["-Wno-error"] ++
+    lib.optionals stdenv.hostPlatform.isMusl [
+      "-D__THROW="
+      "-Du_int8_t=uint8_t"
+      "-Du_int32_t=uint32_t"
+    ] ++
+    lib.optional enableDebug "-g3"
+  );
 
+  dontStrip = enableDebug;
   preInstall = "mkdir -p $out/etc/sysconfig";
 
   meta = with stdenv.lib; {
@@ -30,4 +53,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
   };
-}
+} // (if enableStatic then staticBuildOpts else {}))

--- a/pkgs/os-specific/linux/ebtables/default.nix
+++ b/pkgs/os-specific/linux/ebtables/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, enableStatic ? false }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "ebtables-${version}";
   version = "2.0.10-4";
 
@@ -41,7 +41,6 @@ stdenv.mkDerivation (rec {
       "-Du_int32_t=uint32_t"
     ];
 
-  dontStrip = enableDebug;
   preInstall = "mkdir -p $out/etc/sysconfig";
 
   meta = with stdenv.lib; {
@@ -50,4 +49,4 @@ stdenv.mkDerivation (rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
   };
-};
+}

--- a/pkgs/os-specific/linux/ebtables/musl-compatibility.patch
+++ b/pkgs/os-specific/linux/ebtables/musl-compatibility.patch
@@ -1,0 +1,29 @@
+diff -ru '-x=~' ./include/linux/netfilter_bridge/ebtables.h ../ebtables-v2.0.10-4/include/linux/netfilter_bridge/ebtables.h
+--- ./include/linux/netfilter_bridge/ebtables.h	2018-11-02 22:33:49.240988662 -0700
++++ ../ebtables-v2.0.10-4/include/linux/netfilter_bridge/ebtables.h	2018-11-02 22:43:13.916282778 -0700
+@@ -15,7 +15,9 @@
+ #define __LINUX_BRIDGE_EFF_H
+ #include <linux/if.h>
+ #include <linux/netfilter_bridge.h>
++#define ethhdr ethhdr_lx
+ #include <linux/if_ether.h>
++#undef ethhdr
+ 
+ #define EBT_TABLE_MAXNAMELEN 32
+ #define EBT_CHAIN_MAXNAMELEN EBT_TABLE_MAXNAMELEN
+Only in ../ebtables-v2.0.10-4/include/linux/netfilter_bridge: ebtables.h~
+diff -ru '-x=~' ./include/linux/netfilter_bridge.h ../ebtables-v2.0.10-4/include/linux/netfilter_bridge.h
+--- ./include/linux/netfilter_bridge.h	2018-11-02 22:33:49.241988663 -0700
++++ ../ebtables-v2.0.10-4/include/linux/netfilter_bridge.h	2018-11-02 22:43:28.363296929 -0700
+@@ -5,7 +5,9 @@
+  */
+ 
+ #include <linux/netfilter.h>
++#define ethhdr ethhdr_lx
+ #include <linux/if_ether.h>
++#undef ethhdr
+ #include <linux/if_vlan.h>
+ #include <linux/if_pppox.h>
+ 
+Only in ../ebtables-v2.0.10-4/include/linux: netfilter_bridge.h~
+Only in ../ebtables-v2.0.10-4/: useful_functions.c~

--- a/pkgs/os-specific/linux/ebtables/no-as-needed.patch
+++ b/pkgs/os-specific/linux/ebtables/no-as-needed.patch
@@ -1,0 +1,11 @@
+--- ebtables-v2.0.10-4.orig/Makefile	2011-12-15 12:02:47.000000000 -0800
++++ ebtables-v2.0.10-4/Makefile	2012-12-17 22:09:45.065973753 -0800
+@@ -90,7 +90,7 @@
+ 	$(CC) -shared $(LDFLAGS) -Wl,-soname,libebtc.so -o libebtc.so -lc $(OBJECTS2)
+ 
+ ebtables: $(OBJECTS) ebtables-standalone.o libebtc.so
+-	$(CC) $(CFLAGS) $(CFLAGS_SH_LIB) $(LDFLAGS) -o $@ ebtables-standalone.o -I$(KERNEL_INCLUDES) -L. -Lextensions -lebtc $(EXT_LIBSI) \
++	$(CC) $(CFLAGS) $(CFLAGS_SH_LIB) $(LDFLAGS) -o $@ ebtables-standalone.o -I$(KERNEL_INCLUDES) -L. -Lextensions -Wl,--no-as-needed $(EXT_LIBSI) -lebtc \
+ 	-Wl,-rpath,$(LIBDIR)
+ 
+ ebtablesu: ebtablesu.c

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14143,7 +14143,7 @@ with pkgs;
 
   lightum = callPackage ../os-specific/linux/lightum { };
 
-  ebtables = callPackage ../os-specific/linux/ebtables { };
+  ebtables = callPackage ../os-specific/linux/ebtables { enableStatic = stdenv.hostPlatform.isMusl; };
 
   facetimehd-firmware = callPackage ../os-specific/linux/firmware/facetimehd-firmware { };
 


### PR DESCRIPTION
###### Motivation for this change

By default, `ebtables` depends on shared object initialization routines which are not supported in the musl dynamic linker. `ebtables` can also be built statically, and then works fine with musl. This patch adds an option to enable static builds for `ebtables`, and enables this by default for musl.

Additionally, there is some name-shadowing going on with the `ethhdr` struct. I used the C preprocessor to get rid of this, but I'm open to suggestions on how to make this better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

