### PR TITLE
make-wrapper should use runtimeShell, not $SHELL, for cross-compilation

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -40,7 +40,7 @@ makeWrapper() {
 
     mkdir -p "$(dirname "$wrapper")"
 
-    echo "#! $SHELL -e" > "$wrapper"
+    echo "#! @shell@ -e" > "$wrapper"
 
     params=("$@")
     for ((n = 2; n < ${#params[*]}; n += 1)); do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -356,7 +356,7 @@ with pkgs;
       inherit contents compressor prepend;
     };
 
-  makeWrapper = makeSetupHook { deps = [ dieHook ]; }
+  makeWrapper = makeSetupHook { deps = [ dieHook ]; substitutions = { shell = pkgs.runtimeShell; }; }
                               ../build-support/setup-hooks/make-wrapper.sh;
 
   makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false }:


### PR DESCRIPTION
###### Motivation for this change

`make-wrapper.sh` is used to wrap python programs (and others perhaps). Write now it uses the value of $SHELL to get the shell it should use to build its wrapper. However, this only works if the shell being used is the same one as the shell the script will be executed under. This assumption does not hold for cross-compilation. Without this patch, cross-compiled python scripts get a shebang asking to be executed using the build architecture's shell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

