### PR TITLE
Enable cross compilation for cpython 2.7

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/cross-compile.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/cross-compile.patch
@@ -1,0 +1,32 @@
+--- ./setup.py.orig	2018-04-29 15:47:33.000000000 -0700
++++ ./setup.py	2018-11-11 09:41:58.097682221 -0800
+@@ -458,8 +458,6 @@
+         if not cross_compiling:
+             add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
+-        if cross_compiling:
+-            self.add_gcc_paths()
+         self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+@@ -517,7 +515,10 @@
+         # be assumed that no additional -I,-L directives are needed.
+         inc_dirs = self.compiler.include_dirs[:]
+         lib_dirs = self.compiler.library_dirs[:]
+-        if not cross_compiling:
++        if cross_compiling:
++            inc_dirs = []
++            lib_dirs = []
++        else:
+             for d in (
+                 '/usr/include',
+                 ):
+@@ -582,6 +584,8 @@ class PyBuildExt(build_ext):
+         # Some modules that are normally always on:
+         #exts.append( Extension('_weakref', ['_weakref.c']) )
+ 
++        self.compiler.library_dirs = lib_dirs + [ '.' ]
++
+         # array objects
+         exts.append( Extension('array', ['arraymodule.c']) )
+ 

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -104,6 +104,8 @@ let
       # only works for GCC and Apple Clang. This makes distutils to call C++
       # compiler when needed.
       ./python-2.7-distutils-C++.patch
+    ] ++ optional (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ./cross-compile.patch
     ];
 
   preConfigure = ''
@@ -176,10 +178,15 @@ let
     LIBRARY_PATH = makeLibraryPath paths;
   };
 
+  # Python 2.7 needs this
+  crossCompileEnv = if stdenv.hostPlatform != stdenv.buildPlatform
+                    then { _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config; }
+		    else { };
+
   # Build the basic Python interpreter without modules that have
   # external dependencies.
 
-in stdenv.mkDerivation {
+in stdenv.mkDerivation ({
     name = "python-${version}";
     pythonVersion = majorVersion;
 
@@ -278,4 +285,4 @@ in stdenv.mkDerivation {
       # in case both 2 and 3 are installed.
       priority = -100;
     };
-  }
+  } // crossCompileEnv)

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -179,9 +179,8 @@ let
   };
 
   # Python 2.7 needs this
-  crossCompileEnv = if stdenv.hostPlatform != stdenv.buildPlatform
-                    then { _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config; }
-		    else { };
+  crossCompileEnv = stdenv.lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform)
+                      { _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config; };
 
   # Build the basic Python interpreter without modules that have
   # external dependencies.


### PR DESCRIPTION
###### Motivation for this change

CPython 2.7 cross-compilation currently 'succeeds' but produces a non-working installation. For example, all C modules silently fail to compile. You can see this if you build CPython 2.7 for another architecture (like ARM), and then attempt to import `functools` in the resulting interpreter. You'll get an error like:

```
2018-11-10_16:44:02.47232   File "/nix/store/5kfa26ykmihsllf1crz5v56345pv1zkj-python-2.7.15-armv7l-unknown-linux-musleabihf/lib/python2.7/functools.py", line 10, in <module>
2018-11-10_16:44:02.47236     from _functools import partial, reduce
2018-11-10_16:44:02.47244 ImportError: No module named _functools
```

Python has its own build process, which appears tailored to distributions like ubuntu and debian, not NixOS.

The setup.py script is the culprit here. It attempts to pick up library directories to include on the linker command line. However, it gets confused and picks up the native python library directory. Examining the build output, you'll see that the native modules fail to compile because the `libpython2.7.so` it finds is not of the right architecture. This patch gets rid of all the setup.py library searching logic and replaces it with the library set nixpkgs has already provided us.

Additionally, the `_PYTHON_HOST_PLATFORM` env variable apparently needs to be set to get CPython to recognize it's being cross-compiled to begin with.

With these fixes, importing `functools` now works. 

CPython >3 seems to cross-compile fine without any changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

