### PR TITLE
jxrlib: init at 1.1

### DIFF
--- a/pkgs/development/libraries/jxrlib/default.nix
+++ b/pkgs/development/libraries/jxrlib/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, python }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "jxrlib";
+  version = "1.1";
+
+  # Use the source from a fork on github because CodePlex does not
+  # deliver an easily downloadable tarball.
+  src = fetchFromGitHub {
+    owner = "4creators";
+    repo = pname;
+    rev = "f7521879862b9085318e814c6157490dd9dbbdb4";
+    sha256 = "0rk3hbh00nw0wgbfbqk1szrlfg3yq7w6ar16napww3nrlm9cj65w";
+  };
+
+  nativeBuildInputs = [ python ];
+
+  makeFlags = [ "DIR_INSTALL=$(out)" "SHARED=1" ];
+
+  meta = with stdenv.lib; {
+    description = "Implementation of the JPEG XR image codec standard";
+    homepage = https://jxrlib.codeplex.com;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10261,6 +10261,8 @@ with pkgs;
 
   jsonrpc-glib = callPackage ../development/libraries/jsonrpc-glib { };
 
+  jxrlib = callPackage ../development/libraries/jxrlib { };
+
   libjson = callPackage ../development/libraries/libjson { };
 
   libb64 = callPackage ../development/libraries/libb64 { };


### PR DESCRIPTION
###### Motivation for this change

Add [jxrlib](https://jxrlib.codeplex.com/).

`jxrlib` is JPEG XR Image Codec reference implementation library released by Microsoft under BSD-2-Clause License.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).