### PR TITLE
libjpeg-turbo: 1.5.3 -> 2.0.1

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, fetchurl, nasm
-}:
+{ stdenv, fetchurl, cmake, nasm }:
 
 stdenv.mkDerivation rec {
   name = "libjpeg-turbo-${version}";
-  version = "1.5.3";
+  version = "2.0.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/libjpeg-turbo/${name}.tar.gz";
-    sha256 = "08r5b5mywwrxv4axvq80dm31cklz81grczlzlxr2xqa6pgi90j5j";
-  }; # github releases still need autotools, surprisingly
+    sha256 = "1zv6z093l3x3jzygvni7b819j7xhn6d63jhcdrckj7fz67n6ry75";
+  };
 
   patches =
     stdenv.lib.optional (stdenv.hostPlatform.libc or null == "msvcrt")
@@ -16,12 +15,21 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
-  nativeBuildInputs = [ nasm ];
+  nativeBuildInputs = [ cmake nasm ];
 
-  enableParallelBuilding = true;
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DCMAKE_INSTALL_BINDIR=$bin/bin"
+      "-DWITH_JPEG8=1"
+      "-DWITH_JPEG9=1"
+    )
+  '';
 
   doCheck = true; # not cross;
   checkTarget = "test";
+  preCheck = ''
+    export LD_LIBRARY_PATH="$NIX_BUILD_TOP/${name}:$LD_LIBRARY_PATH"
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://libjpeg-turbo.virtualgl.org/;

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -20,8 +20,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     cmakeFlagsArray+=(
       "-DCMAKE_INSTALL_BINDIR=$bin/bin"
-      "-DWITH_JPEG8=1"
-      "-DWITH_JPEG9=1"
+      "-DENABLE_STATIC=0"
     )
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Update to version [2.0.1](https://github.com/libjpeg-turbo/libjpeg-turbo/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).