### PR TITLE
diskus: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1527,6 +1527,11 @@
     github = "ftrvxmtrx";
     name = "Siarhei Zirukin";
   };
+  fuerbringer = {
+    email = "severin@fuerbringer.info";
+    github = "fuerbringer";
+    name = "Severin Fürbringer";
+  };
   funfunctor = {
     email = "eocallaghan@alterapraxis.com";
     name = "Edward O'Callaghan";

--- a/pkgs/tools/misc/diskus/default.nix
+++ b/pkgs/tools/misc/diskus/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "diskus-${version}";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = "diskus";
+    rev = "cf4a5e0dc5bf3daedabe4b25343e7eb6238930c0";
+    sha256 = "1w5fnpwdsfaca2177qn0clf8j7zwgzhdckjdl2zdbs5qrdwdqrd2";
+  };
+
+  cargoSha256 = "08wm85cs0fi03a75wp276w5hgch3kd787py51jjcxdanm2viq7zv";
+
+  meta = with stdenv.lib; {
+    description = "A minimal, fast alternative to 'du -sh'";
+    homepage = https://github.com/sharkdp/diskus;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = [ maintainers.fuerbringer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -691,6 +691,8 @@ with pkgs;
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  diskus = callPackage ../tools/misc/diskus { };
+
   djmount = callPackage ../tools/filesystems/djmount { };
 
   dgsh = callPackage ../shells/dgsh { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

