### PR TITLE
Nextcloud: add openFirewall setting

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -50,6 +50,13 @@ in {
       default = false;
       description = "Enable if there is a TLS terminating proxy in front of nextcloud.";
     };
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to automatically open the specified ports in the firewall.
+      '';
+    };
 
     maxUploadSize = mkOption {
       default = "512M";
@@ -254,6 +261,10 @@ in {
           message = "Please specify exactly one of adminpass or adminpassFile";
         }
       ];
+    }
+
+    {
+      networking.firewall.allowedTCPPorts = if cfg.openFirewall then [ 80 443 ] else [];
     }
 
     { systemd.timers."nextcloud-cron" = {

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -38,7 +38,10 @@ in {
     enable = mkEnableOption "nextcloud";
     hostName = mkOption {
       type = types.str;
-      description = "FQDN for the nextcloud instance.";
+      description = ''
+        FQDN for the nextcloud instance. Automatically added to
+        <literal>extraTrustedDomains</literal> are accepted.
+      '';
     };
     home = mkOption {
       type = types.str;
@@ -216,8 +219,8 @@ in {
         default = [];
         description = ''
           Trusted domains, from which the nextcloud installation will be
-          acessible.  You don't need to add
-          <literal>services.nextcloud.hostname</literal> here.
+          acessible.  You don't need to add either localhost or
+          <literal>services.nextcloud.hostName</literal> here.
         '';
       };
     };


### PR DESCRIPTION
###### Motivation for this change
adding openFirewall setting as is done for sshd so that the firewall ports get coupled with nextcloud (they get removed along with nextcloud => more secure).
https://github.com/NixOS/nixpkgs/issues/48881



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

