### PR TITLE
sonota: init at 2018-10-07

### DIFF
--- a/pkgs/tools/misc/sonota/default.nix
+++ b/pkgs/tools/misc/sonota/default.nix
@@ -1,0 +1,54 @@
+{ fetchFromGitHub, fetchurl, lib, python3Packages
+, coreVersion ? "1.13.3" # the version of the binary espurna image to flash
+, coreSize    ? "1MB"    # size of the binary image to flash
+, coreSha256  ? "0pkb2nmml0blrfiqpc46xpjc2dw927i89k1lfyqx827wanhc704x" }:
+
+with python3Packages;
+
+let
+  core = fetchurl {
+    url    = "https://github.com/xoseperez/espurna/releases/download/${coreVersion}/espurna-${coreVersion}-espurna-core-${coreSize}.bin";
+    sha256 = coreSha256;
+  };
+
+in buildPythonApplication rec {
+  name = "sonota-unstable-${version}";
+  version = "2018-10-07";
+
+  src = fetchFromGitHub {
+    owner  = "mirko";
+    repo   = "SonOTA";
+    rev    = "d7f4b353858aae7ac403f95475a35560fb7ffeae";
+    sha256 = "0jd9xrhcyk8d2plbjnrlpn87536zr6n708797n0k5blf109q3c1z";
+  };
+
+  patches = [
+    ./set_resource_path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace sonota.py --subst-var out
+  '';
+
+  format = "other";
+
+  propagatedBuildInputs = [ httplib2 netifaces tornado ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 sonota.py $out/bin/sonota
+    install -d $out/share/sonota
+    cp -r ssl static $out/share/sonota
+    cp ${core} $out/share/sonota/static/image_arduino.bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Flash Itead Sonoff devices with custom firmware via original OTA mechanism";
+    homepage = src.meta.homepage;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/tools/misc/sonota/set_resource_path.patch
+++ b/pkgs/tools/misc/sonota/set_resource_path.patch
@@ -1,0 +1,20 @@
+diff --git a/sonota.py b/sonota.py
+index f67128b..9f2752e 100644
+--- a/sonota.py
++++ b/sonota.py
+@@ -475,14 +475,7 @@ def promptforval(msg):
+             return val
+
+ def resource_path(relative_path):
+-    """ Get absolute path to resource, works for dev and for PyInstaller """
+-    try:
+-        # PyInstaller creates a temp folder and stores path in _MEIPASS
+-        base_path = sys._MEIPASS
+-    except Exception:
+-        base_path = os.path.dirname(sys.argv[0])
+-
+-    return os.path.join(base_path, relative_path)
++    return os.path.join("@out@/share/sonota", relative_path)
+
+ def checkargs():
+     # Make sure all of the binary files that are needed are there

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2378,6 +2378,8 @@ in
 
   s-tar = callPackage ../tools/archivers/s-tar {};
 
+  sonota = callPackage ../tools/misc/sonota { };
+
   tealdeer = callPackage ../tools/misc/tealdeer { };
 
   teamocil = callPackage ../tools/misc/teamocil { };


### PR DESCRIPTION
###### Motivation for this change

This is super useful for doing what is essentially a MITM attack on Sonoff devices in order to do OTA upgrades to open source firmware.

Tried it out successfully on a few different devices (S20, T1-1, T1-3). Doesn't work with the B1 though.

Cc: @fpletz 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

