### PR TITLE
mosquitto: enable websockets support

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     substituteInPlace man/manpage.xsl \
       --replace /usr/share/xml/docbook/stylesheet/ ${docbook_xsl}/share/xml/
 
+    for f in {lib,lib/cpp,src}/CMakeLists.txt ; do
+      substituteInPlace $f --replace /sbin/ldconfig ldconfig
+    done
+
     # the manpages are not generated when using cmake
     pushd man
     make
@@ -39,6 +43,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_THREADING=ON"
+    "-DWITH_WEBSOCKETS=ON"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

We were already providing the websockets library as a dependency - we just weren't using it for anything...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

