### PR TITLE
scikitlearn: 0.19.2 -> 0.20.0

### DIFF
--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage rec {
 
   LC_ALL="en_US.UTF-8";
 
+  doCheck = !stdenv.isAarch64;
   # Skip test_feature_importance_regression - does web fetch
   checkPhase = ''
     cd $TMPDIR

--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -1,33 +1,30 @@
 { stdenv, buildPythonPackage, fetchPypi, python
-, nose, pillow
 , gfortran, glibcLocales
-, numpy, scipy
+, numpy, scipy, pytest, pillow
 }:
 
 buildPythonPackage rec {
   pname = "scikit-learn";
-  version = "0.19.2";
+  version = "0.20.0";
   # UnboundLocalError: local variable 'message' referenced before assignment
-  doCheck = false;
   disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b276739a5f863ccacb61999a3067d0895ee291c95502929b2ae56ea1f882e888";
+    sha256 = "064cbxsis6m7l6pr09ijjwqdv0c0yrfnazabwq8p09gcz1qxklcp";
   };
 
-  buildInputs = [ nose pillow gfortran glibcLocales ];
+  buildInputs = [ pillow gfortran glibcLocales ];
   propagatedBuildInputs = [ numpy scipy numpy.blas ];
+  checkInputs = [ pytest ];
 
   LC_ALL="en_US.UTF-8";
 
-  # Disable doctests on OSX: https://github.com/scikit-learn/scikit-learn/issues/10213
-  # Disable doctests everywhere: https://github.com/NixOS/nixpkgs/issues/35436
+  # Skip test_feature_importance_regression - does web fetch
   checkPhase = ''
-    HOME=$TMPDIR OMP_NUM_THREADS=1 nosetests --doctest-options=+SKIP $out/${python.sitePackages}/sklearn/
+    cd $TMPDIR
+    HOME=$TMPDIR OMP_NUM_THREADS=1 pytest -k "not test_feature_importance_regression" --pyargs sklearn
   '';
-
-
 
   meta = with stdenv.lib; {
     description = "A set of python modules for machine learning and data mining";


### PR DESCRIPTION
Re-enable tests, as upstream now uses pytest and it works.

###### Motivation for this change

I needed the `output_dict` option for `sklearn.metrics.classification_report`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

