### PR TITLE
firefox-bin: 63.0 -> 63.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "63.0";
+  version = "63.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ach/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ach/firefox-63.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "0557937473fe8758371d21ec4b0d983ac2db59e8b9d3d627a318d3adf9a0cd0712f3e9b375f0cd6d9acf3f39b0c42fbcdb31364c5973916c7287f618a5f074ec";
+      sha512 = "fcf06e003f7e3bfc79288d9f0199ad2ca13a91eee718437d25c745381dbb351483b992b0cad929e9c869d4a993eee66b2206ddb6e98023f12f4351f41e61313b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/af/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/af/firefox-63.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "4b0d715ba2a7edd648bcc2c396ea764e8a29fce69d526803e6621053f3886df44d758fdbf2c8af8a9e3acd307e10dcdcf3e13eff0e60bce28885b699cf2426d0";
+      sha512 = "8b8515147df6deaff4356fee727acb377c3f46cc288271da813f6bb752a3a62585262d0e5a5760d6bc5c8d6f7e84b2d76825ff55dab8bdb5e20fe345230a3bc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/an/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/an/firefox-63.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "79665a9586e0fceacb0a49560d0fc2a72a76187799563b0f8ef972043020744dafc971cb94b52b30df6056673aea4e0885f994d55c99c7976f9f7805c30e5796";
+      sha512 = "c532a212522ad51e0718339e1962f275b49d15a0e67cf397c1fc9dfdfddeb746a59572ef2cf1661f480736ecb7a77ce7da62f65f3e7898e2fe53321512820a70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ar/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ar/firefox-63.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "d338b5fdf1dc4bb920bd372ba69934ddf39bdc7e37b725a010fbc9fd71ff487181d898e863c7ce9a21039d51d256c4ec1ca2cdcf0da078788243e867b0bc151f";
+      sha512 = "35fbbb6d2f53293eaee86d9d402d556abea5a5c62a1a282f35ea97d7afee57e2b222ad96f2c91ac8b30f6501e96d8702a52e2f96556abd838c244a36720d123f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/as/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/as/firefox-63.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "2022a993455456d0c900ddaf8e6a74a3d5478edec456df0cba627dfa1ad41f0274053c21b9c1ca4ca6b640e26993d60ffcc2f879c68143699f6e31d43f7acc19";
+      sha512 = "86fc2f0b5089997dff76f5b5b4ef1e4be465da16a8fc119ab88ddf96cf6fbdfb4dca1e384ce336a033ca5430f041c60d34afaa3dfee9a8afb93d26c7717314b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ast/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ast/firefox-63.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "1eca2ca8385215a886a16de77988d76e41b7257a41fceacd3df18e21ba82c8c67df045aa8201a2b18032f1690997b4b8bfb55a80c47341335aab45cbb15eefd1";
+      sha512 = "ba960a426f0c6ccd703e3b12bc08c29dff71cb829a66346cceb689233c62777ed22ea047624833f6584867cf78c040684cccbae99a9518eaff069af756eeb983";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/az/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/az/firefox-63.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "3788f68a69a8605e3185e5e776edf3339a650e010fc4810f574e5c0a62c9aaf30c84151ea169c005c1f381c3eaa4c3a8f6758c336a9423cfeaffb83aef96dc73";
+      sha512 = "6e2e9231fe88fed849c2d1850f24ab169a901b68be4bde9d9875d2cb736ae4c1456f53c2964f4f00b80ecf2e46543b4cd25cfed31cb04dbe4fae3a040432352c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/be/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/be/firefox-63.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "f538b9f8d566f7f3c5bc92a24127966d618b47dd368ecbb4fae0e5c90045bb75cb1b921edd865227ca6c34e3e2e037acb81d9f7368cfdee59cbdcf6ff2798ffe";
+      sha512 = "379ec5a79a4af1b141485230b9c5af0b622845df43499616417debead4db466ad16f7a63c1c0e8c09b4bddae288772bfcd2aea115a780a551e90001b2d353364";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/bg/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bg/firefox-63.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "497a95b4309e60093ec3f1b0a72ac05d1b9a47d78799ca33492394c7bf0b81e64e60103218c479b4ff3a3b2acfcf95493f43be23feb89fbdfebe42ec8a124132";
+      sha512 = "4aed2144069d39f00a0ab2f45ca7532f9f97684ff18cb2596b20b6639edbd793e0c4857b784657c354caa7503c2df6497ef0f298fbf438954c2c46de3c2f29b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/bn-BD/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bn-BD/firefox-63.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "3c2123b34ebb2e3c6def220c679069b31b3d7a2110ec2eadea88a930b6582fcab0452bce97f0302a39af324ca1b58ec49ed49aa865ade7d814152bf16fd1cadc";
+      sha512 = "bf87308c72330e32efe1473d879f36097fc1d0e697ab6f9034a03c5e872353ab5c2cb7391aa274b35e08c6102986a08ede184810e821f8ba02838d469b623528";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/bn-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bn-IN/firefox-63.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "55fdb9a3efe54db994706fb8345918f5c19f1a24f77107e6819dd1272a09900ef3534897c1d3b38c331c94813446694b2422356ae6ca2356338d6253e15a37e1";
+      sha512 = "0063c6dce614b8efa9a663c60d2d393816f6a65c87aa1a1a6a96f501cfc7e86a05b038ab5173b13bd86a2a02dcb3ac6ed15bb4e4c8eefd371027e07cb31c1e5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/br/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/br/firefox-63.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "c35e40bfd6b1fb06c8426c6f9f834f8a6d658ced8892c575079d852dbb2e24f09657b1f37bc8af3588cc2c8b9ba1924cf5a85c7be0d6db4334c592f03abeb142";
+      sha512 = "93c3a9a59386c211c32c9aec1aeca3ab0a3f0b878001f6485a42283c2ca6fedc6847d7c2fddea870da462967dfddb94f518cbe0f115838b313d803ae8f12df65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/bs/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bs/firefox-63.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "ea63659f3a930b4d0a8add69cd8ca1a3d98e015aab1b6bc607c8e0fbd610de8fdc49ac290c61bcd762092d4f56554f70f029a18be4bcf426cafffc6fe9677699";
+      sha512 = "d191539482457407ae37e47b52b4d79eb99ebf2ed2999921c695268b6e3dc75b96ba93131f70666b29a3c2e73bad0a470abfd99c2f51d2ea3eb4af52296846fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ca/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ca/firefox-63.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "10993691fe9072706f1c092199dadea2f1ffbcfecede53771326dd03b88387133aa23e75f96bebe7117eb02ea2775e5758c36064c5ddd72f7aab441feca659e4";
+      sha512 = "41520a18c201bea97b56a70a74546f7a2f2f1909f303740e14cf79701499bd26494cd453ebd630ce100ddd17b5ffcea08e8a9d95f908425da0a9ad22dd751dea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/cak/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/cak/firefox-63.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "0413afe78e4c8ca1af3edad09c801607c73069366a255d4d1d9e6d4589ba3757c732a2cd691b8f223ab10cc99cdcc322e98d8daca49b3107082a8cb41cd278ff";
+      sha512 = "24aaa62ff598ee48d9c9b6b19e92adc38d00eeaec7d7d562160955c751ba5e3b01f281cc59a0fcecdfd24d6a792f070c151c58ba23d1db55699c25988ea9412f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/cs/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/cs/firefox-63.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "d4ee0844c1587ed0d65d40a444fd130022f99831749f721523b0f594d4967e723fd8af10c363f53b4fdca91f676962882e93327dd5b1529d3d66c27f17bf29a4";
+      sha512 = "b29c9ae988b40ba77cf036d92b4d9cbcdc8af0c7c8e76f97222a3544bef06c81682fa35ab9e24a5f3d224873d2359e3c1f73b61de4101106ab4da57d3a362d44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/cy/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/cy/firefox-63.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "103177bdcb204d0da7dc8fbfcd82a52bbf3956b13f716de1547252a076d68b21f9bf4684ed63a62aa4635fa39cb776a64942d81333ebf41dfc5f12d6087261af";
+      sha512 = "99963d98d62d811c03b2a841fb97b31f10b5d14a98b5bc5918f4c7164663511efc9a36a7271a6927fcbcfe00fb7d15693a7d031f6305d9dbc0e7e0718699d314";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/da/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/da/firefox-63.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "38cc06165c713ffdb5a2bcef9b8e6c7f55c2e821c4e4c87d30b613cd78aa6320761e709f3a784a0f55da283dd7088ab67d0e58a16a90bbd182985d29691bd50e";
+      sha512 = "622cf4fd584b9e4bc07661874093b1281b53e985355679b914b5becdd78b25daa43b3e6f0a220707fbe21f4a41c85d81728ccd2af998ca0be938e8ae955d6e56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/de/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/de/firefox-63.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "076276ef8556922e80bf74aaf3624e6604eb904ec6dda35df7f91edf99c62015d1309ea1a5cc28d84ce96f9924dc908c81f959ecf93f2419156d07bb303fcbd9";
+      sha512 = "af9d143a4d5f26f81474681945b171fb9be80f7e679aeaeb08175d3b0957e274ea1ee4112781607c170a0af479dd45c5ec3d88b5cd39bac37e59d1343474dc02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/dsb/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/dsb/firefox-63.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "979013e2bc62db710891d95d8898857e51bc1a2073e3a56948af57c9676fdbc87b6a9d827177a5a1d7926f71d83e9df706c42ea98bca98fab998815daf50458d";
+      sha512 = "963604bcd19ee34949ab256e1276423d3de262a87d8d5f3e098cab11af2ed62ecb793b86817e54f490f5accd32d7c35a50aab583118eee79270e827032edc464";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/el/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/el/firefox-63.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "1f4e5983ca94ecd9da6d65ec7c39ef7e01296f957cbe3812a20981bafdd9a2c0e07bb5814b5caab781ed1f2f6fb2ce2079557e3b9bbc1422b2fb7d882b921ffb";
+      sha512 = "9831e750314c3514e6e885dc4930836e296537cb16c8a9da189c9f53d122e0731e30fc068fbdc8cefe2582aad715d9eb36746bf7b289a45410c99e8ffcc4ee8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/en-CA/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-CA/firefox-63.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "77a9038b33a15a2f12db383039f89d29f1e855aad6354375517726d28c5e1984fe77993cb802f17975488441ef36ac143c1e4e2d29c7104143db511229e9b28a";
+      sha512 = "6cb022756601db6273bfc2e84e9e7fc24e8d427ae5905c85b8f674132a740a9f7b1eb34562f996bb31be03cb7fa6173f3aff80fcec6c41c0e0e25a34180d8cc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/en-GB/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-GB/firefox-63.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "62f5374d07b90e80d9f67b04a647f68fc75af267e9b9c04674d754b0d023ed9d78241a693f11504d5b74902328c68414be394923493c17c551a62d06621edf4d";
+      sha512 = "1ecfd9ed098a97c9b6952f5ee56560cc7e5c9ee8976a0e744e8c50debd2eb100e4f4d3842593dfd6244740b7b48a9e64e49b082345197f969e4a0b52f9866196";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/en-US/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-US/firefox-63.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "906376e344b9f01c5eca8a6e24386927a68613a74202062fe52de5bc1b9d1073103e9c59d19f40f33efabf0f5e4852210195691a73f1bd05db790e7c1eac5f28";
+      sha512 = "49d776cfb5f42c6e5ea1a55a80d9f6bad223080b16baa0d39de63534c25e68340091b4e16be5355d565f81291cb94fb996f03ae7e3e4c7a28021b0a0929daf58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/en-ZA/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-ZA/firefox-63.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "895f9dbd5ef281a48e5c3124dcb668b9fe4d6b41a3402850e68e138190b756ab10292bd002c36a1f8391ff3598c48a8623552ac35d18d0948dbe194b28684f81";
+      sha512 = "b3c8b9282822eca4a0be69eb4b26cc9e6fb0e20e7cb0e8244a1e54a680dee570ada3f6085e4efab67c63b68cbea64c8978a3ea430a791ae1b3bd71d31c03302f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/eo/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/eo/firefox-63.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "defe31badc0ce4c41785abf6aef543584778e5c6f373300c2fc3582c89daaa500cc9aedac55e1a1569abd8eb0de207268e31b9eae61565e76a43eecf41ef774f";
+      sha512 = "c08f5dce7559e3e363b8b66a3402697ec1b62e893c825c5820c8a0978a6d41431101a479a59b04065bd36f50c044c79de4e45e23fdd0a819fbd379bdbf65be22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/es-AR/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-AR/firefox-63.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "bfe81fbc669fa156c6741c62b00c9ebcf74fb2f49c92206c5ca79986358e7b8ec29d98d206c4d0e21e81a781ed8216fde5b072f0f1a19604ed7c3784b82829c5";
+      sha512 = "ebbc1b36010ee9988ad2f63b100d48e52be391ea85ef170a8838978471b9354aa1d9a55a27d8214d4639c60879fecd56f0a488a38da5520dfb79aab078571a35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/es-CL/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-CL/firefox-63.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "cd3bc97552a30c9eabf8627ef97db2d4f48f2fbce4c72b5e6b41000a623ab1782f87ee8ac61dde5e3fccc59a91f87b4a3b279b90de3b08e90293329bc85976d9";
+      sha512 = "aaa97d383fa7efa07d8958603f5bd5a0022bfd94f99d0644adf824544e4c1a932ec1b0bc10b78a409accd3c1e1e9e51231186f8063d9bf7cda5958447a27cc9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/es-ES/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-ES/firefox-63.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "1d761d479df22483c576598db8248b3ab6a7b838c518058c6903d7097452c4027b9c38cacd206063816669ce664501c138741044369de04eafcd40087ccc3688";
+      sha512 = "cd742475b06eaeee5edd8561c9c5b45e95f0544a3a9e607b961827bf3dac722ea1fa124dd2eecfd18e339cf784694d267a83efd09c798608d99db66c0cbc078b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/es-MX/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-MX/firefox-63.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "934aabdcb204dcdc80d9e35cf19aaf83dc235f95d597f5b2a6302635275aa68245932f4b5f1b2725ec84711e8d0f2c830aaa45406ada91efa2d21c8b31995939";
+      sha512 = "704856a075a4ddaf811856e3e2258e267bef132d9760e7ae61c81c5c832cbeece35cfd5018b69155a7673e93b439ab6997920164e6bf90d2564858385667b9a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/et/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/et/firefox-63.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "5b669b4adb7d14eb4550fcbcd05a1e7a1a186954bfba39d491248b177d057662227b672d2902273315c12e9d57bb944ea2df41d7cb35514fa00d79d235c178c0";
+      sha512 = "462bf71afc7ee40e2ddadd80f07d154b940075f1d88bd132513a6db776c6fb6ea98a02137cb60a3d8ad12c999313401ff4ec3fe498a2a2374cd8d11b6b0cc149";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/eu/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/eu/firefox-63.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c8555e93e6cc7d4fe179ad68ad1b2fe3f0735134c8a30bb9911b0bf5475e169e07640eee85afa2c7193b27d96c8cebe2227d38e1ff7499b3470b68a04bff2953";
+      sha512 = "7869247c5b534874836ec636dcdd4186eaf5ad760eba1e7430b207d76454c5d9384f5b6d3ddd638380383504a17012ccd4c54acf4088aa428220e2be40e197ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/fa/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fa/firefox-63.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "c607251f6b855fd86504fec3780ba66d8d451d76a16d0541fe5b96ba5b8d809ecd7d591209f3320bfb044463470b394862a6c0717cd9398048a154d6c2b93bad";
+      sha512 = "6dd1a2cda0e1e3837d8aa5fbbbd8a842dfedaa90a5e5b07249d904046b7645b5b025b90a2302e5b4751b958fa506305a9bedc89db7eabc663fc8a4461427572d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ff/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ff/firefox-63.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "d9850e4d78d6bebb9d342898bea876d66a9811ac62ffcd56ab8ca662a4db6bd872a643ac233e02fdebb9dc107349d7f0f258ad790ac11bfdd791a2d8336197a0";
+      sha512 = "2c5da87b5879283fab3f59f5a7e628464efc1132f36f753404a805a2805e0305642cdbd1f6cee22384b1fad26315666fdcbe954e28a1661b27a2d8d9731b3f46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/fi/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fi/firefox-63.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "8be60c2bc3c175aedc3a1c062107c5368f503bbea245e87f5f269c9faed3832ff8c93f221815637b3947c474b44be31f3ea09955e7a87d2be67454dbb4d4e9b4";
+      sha512 = "9c4fecc333e4cdd779ac3e0f08f6c5dfb65d685a82295d0d6b24ca5d7709d5287e1e21515b41cb86014e59b2c87b8fb83f1625b8a1e8b1e74c1819d21fc02c3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/fr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fr/firefox-63.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "ac559deff6caa20f40bb561e350129e765ba7f63ee8758dc01542fb5f685262c0bd6ec0d13fd65c196aecb352b72b62d10335d121edcca11500684fdb1be8be3";
+      sha512 = "3bf8845b1b1630fde8d86e0d163ddfa7d1bb2482f43e2cd22ed6208666087aa0af54a4bd2d93f56c0cec32a8621b5698531a5ae252cd1ceda197f9e4d773b47f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/fy-NL/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fy-NL/firefox-63.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "c6a19730d2861a20a69ec8a7ded79377849554f21143e3b55ef0b009519b52d9ba2fa0f2e58ef592f3eba00305d0e2dcf44df958ed22043a83a86ed7fa72362a";
+      sha512 = "aa17ff3c7b218ccc959d1746a9597837f0b2d1b1cb068a5dc4639fe2858cd3aadd4f981290eed5bb7c9729f1418f4ddbc8d309107ca3deb6b7a57d67611af110";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ga-IE/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ga-IE/firefox-63.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "28c68d871e4e025eb22f19fc1c4d786185934bd6254f03061b95eea8459776c9c28a903e30edbcd53f6e0cc5b24b6c65e2311a6483e18620b246ca8ce2fc5470";
+      sha512 = "eaca615bbd2d675d9d1bedde308700226fcc7ad529f1d0a3a432b04b1f7cbac582ce99645f23805dc7dd39029210c0b71855d4126dcd69de635d5465885697ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/gd/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gd/firefox-63.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "d6e9b226b893050925259a7de5dfc67104b6defc76778272adb8e5b41427a646549ddf6e38d58d9ee4bd27c476406ac9e65244fc57f78a3ef54d7c7bc758df80";
+      sha512 = "ed71b7907f8303ce9fdf6bc5b6aac7f7eb00b0be60eebc37f84158b22c54911479d2bd5122683ae0e2ffb662611e4510daae4cd17fe2271d3f361019a516d6fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/gl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gl/firefox-63.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "3f73ec82235a8345c2e1e86b521f062a5f45bf0fdb884533c22f1661bff430c1a3c440c5fa5c209474c2eb542d1be25ab2c6a4aa50b872ffe34bb66ef2da6e0d";
+      sha512 = "d99b88e5530b08f406a85567070f3f4d709586815c7eb48254491442238b0cb5868a1afdc418739f8b33972ab94b38cad3a06a7211cff1a3e32ab5d0384e18a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/gn/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gn/firefox-63.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "4be814c72579653264990737b7eefed0ed7f332da1317bbff3a0a1d6f45aecdac12552eb0e6897ac0bae64f261de6b46b36588623a8523a51b880d1bde5d763c";
+      sha512 = "0bc5d75e74d9b8aadda1d6a2c2379049bd269378a3c383b0afa787bbb4b35ab78a06492928a5c4aff2eb66f7897641f8c64240190e1987fdfb4059d743218266";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/gu-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gu-IN/firefox-63.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "00670cb7caec8f841f17e613a86554182512e0aa49ff7c8298c9d3c9d364d7fd391063b890461cc41966e5facde0a8a325ac97e08bd0bd9d25858b32c348fa81";
+      sha512 = "8231b8dddf89310ca92707e2bd6ba84b3cdca7e22c641c0fb307fd45dfd1b7de6ff5f29413a7bc303adf0d7601eedb560680b016d1e896deef6ee93a8767adb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/he/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/he/firefox-63.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "653538026ba533c7446108a2277dc7f87a2e519583d27c028be2b056c67299ceb9b2296dd83f94c3a043a2bb9fbb05de2260248d408f3279a7c8fc49e0e84416";
+      sha512 = "14625dd32723b4d207fa545959d8af1a78cec0601a7b1073086c5b2da20ab54e679bb248bbab5fab05628665727058c00175d6826915779423b5709d166f7315";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/hi-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hi-IN/firefox-63.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "a4989edea0edf4f509d4387b225340a4b67805b3f8cd7af67b575b1b3b5a8cc98f9a8d6d2a05ee878e15dd8ac2b0c35f43fae52917a8b667098f1812e361fbef";
+      sha512 = "5e8c2792d5509e2cdaa95d26829827cb5d183a734e46d11d91f94406267a481e5d780e233475ab87901c260e7c1cfc0b9584fca8b300c076921eda140f71c3ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/hr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hr/firefox-63.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "b762c1bf922e72a9cd8570012962fb63c5658de25fa08ce4532c6c96b7b06c0e13bc71b2306219a6e0219a8ef7aef168a8523cf39b1cc1e6362198fac0696545";
+      sha512 = "f1753eb8e18920507d210c16c6b9da944444ab771b456871cface1e867afb142c24fd7e5b7ccbccae47dabedc396b47dbe68bd36b2a1ca723d1ff927a90f85e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/hsb/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hsb/firefox-63.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "22ea6afb26555d88680cea7bc1fba6570aa7e0b8517b23f4f5a7d3f2fee285315e29e818954dacd29768642e62a57adea282fa35116a7733c1012d2578647bbe";
+      sha512 = "04e39227067e6a98d2398e0b832c0c3d18dbcaed3b683a6508479a29d20860117c2ca04489990508d503b045e882e388d198e62503a0446cfa40ced150000858";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/hu/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hu/firefox-63.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "cbd0d026cfb693c7eda3f58f0954bad41ec260e307b8a4a9d4e774e2277786420f99c8afab9ee0fc9f7cf7f9e4542904c6d1c1b92c1c3bffa62f8dd9aedd8a73";
+      sha512 = "f260853efc310b0426e72a50e272c810f390069d743c5c0e64d1400d87df860704d87d1fb1b3f2c13a857ea0c15713561379a9e027db86f92cfcdb2e52c6bae5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/hy-AM/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hy-AM/firefox-63.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "59315b0561ccccfc031b240b699b019c3b6d2769cda6d816bd60c359ca1a4076c4fcd8342bbff6cd4cf66243dc5164e1c0066bc7821275cf5c11caff0e86a6e4";
+      sha512 = "5f1b3fe9cf4ce690105e99bf492ca4e67bcd4fe0a09aac45435bc1dd2acdcfd7d2c5faa7125e6ed14a4da1710e1e8564ef969e70cd0ff3b53fa434035d7232c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ia/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ia/firefox-63.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "2addd61131770c825227639d5d7790bc0c9f0be430077fa31cb11cf74f6ec191f6dbdd88c4e0b2fc199eeee7ecc39c6dce8c790924224ab0603e0af41e082a63";
+      sha512 = "d4e20bf61a36438b018c5e69cb5fb9a305f4b67d1c1be82c619afb44faa536903944204d9cbbb05b766076038ffc0e0a51af528dbc93fe1690cf1f4ac8a0382d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/id/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/id/firefox-63.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "81a68f78f003685e1a06d242ca3c24df27b7a0b28d0a5df2f41cbe9b92e312b32a35608c7e094ca136d6f6356e523c62baded1cc027d19342ba44cf88b479843";
+      sha512 = "0987ea50242ea6e843df40537519b13e6a0b6c85cafa9ea5957b69648b8aadbd12527e4adf04d135b98f50e1413a71f85e327fc3025897beaa0178b7013015ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/is/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/is/firefox-63.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "cabbb8d0f7b5009aa6e889c983046a5c806f1c077c8e27f7cd148b54a25c9cadb5010acb97b2cdbe6480463f205bd7a4edb966fae0a92a8380439082542dd9bc";
+      sha512 = "185e9bf39d07a0455b609286c498fe24e301cd7779913da4e16d36e36edb640d0d2e09bf04d85209f2879238f0596fb5a7ef3d9b53b611101cfa78ca8ec27166";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/it/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/it/firefox-63.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "8d3eb041fccf54dfe389566cd11b2dad4276fee3b902914bdb4a8cf06c6613a39f4ebe7d00d33a1873bcee32f398b0527d4807d08ee91e0accabb92205eff51f";
+      sha512 = "334d4f61f8bf56123a57a488da8af7ad364fa4998d41b0cf4052bcb33494642eb0f429b97193b36a23947350e94f97a37dcfa4092fc8c642321fffa66f2c022d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ja/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ja/firefox-63.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "facf7aa7f639104956f44dd4f2a6f4064ac4474d3c3bf2e355f1934c68831bb774172b719b2f0685435e3f3cd56ed589980d06a1d2dbb6e405a5f5c32395136f";
+      sha512 = "51f4d9a5ad768d34354fa56839412ae4f89fc46bdcb0f4d427a58bbe7d7ecd5d6ac6d3282d305b69325d3bb360d6356d8915ac200efaaf645504d1d607a75eb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ka/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ka/firefox-63.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "c8d5407fd932d83fe6d55fa012c9fab70a4d67fc6043dc4c9e18c6f6e25bd4fb8feb0dba97ec7a8a3f1cccfa37c46cae482b9fab90ac29c34b57a35387742b66";
+      sha512 = "973e37affd3574b682a245d4366c5868520ae832000f96c2c7ef7b0bfed82e65e838fd8895069d5c4b03b8553233928798bbfa94c20e713367f84845639d5217";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/kab/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/kab/firefox-63.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "0949d40892060b97c1fdf69d9777893b2456d5c936d29876832aa41492c01c1a07c88665fb669d53b8cb91f23757cd14636f87ecfae7aa112384658288afd4e0";
+      sha512 = "0d13ac3a4783623e09028d5ea9b860db230f8c9c5c98fa83d1db33ee1adf09f18b312412040a997293c53fcf4e9ebabdf3d5f935689f45613f1c70e959ee6ead";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/kk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/kk/firefox-63.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "30d3e966ebad9eca27d255c20bf11bdc5c6073f0cec8954c568c4abda86f689e5a9c4c2f508cbe09687e0efdd2ea8f5f8ef5de781c3fde399f39bd9b229bd187";
+      sha512 = "822c5d0a3f4ee7327712734258afbd4ac5216fefea0cb6d3dcdf144af7ac04ac79a2c5f09c79bbb9a1adf7d57f8d0ad3300d6e56a483b3d1c149723a1aebf9b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/km/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/km/firefox-63.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "f9514178a460bc3f1a6e56878f951208d6afe92de893ff1861e38ece04909535d9a5de8d59359b6de32f0bf4ad462c6958b0b881c3678da074cddcc5a6ad8150";
+      sha512 = "8bcdc71c8d707295e753c5a9a06d47fd932a7acd35516cf857fc74d3e9025156c0a5ddef34cfc9b98311e672b386bb06c241c949fb34e238f1353d2ffd2b7385";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/kn/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/kn/firefox-63.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "cc229a04e851f479f785d1abc0e2b486f20797ae0269d62cb64aa6bf8a3925958b9271bcbaf0acc3dcd7fe7f39b9077b1a8a7650055d2fceeb2ca6db676240e3";
+      sha512 = "a6c6e301ce118c4b7f133255a082d0c9615e2de3977a7500d900ab24c8c6d585132f52d120c32b85892bf9df1fa6855e66a5ff4145fdceece917f81b92bed62f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ko/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ko/firefox-63.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "6d7ccf3e6d062014af2c59abf03b3f9300a1045855cd6f6c37d8a9c9733ec7c2775fb702ce219b96d6c0aea4dc1121188805324e1f65e5b222190c5fe34a9fd9";
+      sha512 = "950a8573fc2ec19b5cee1bdc8709d7724df4a89942b64a0e31969fc8e7802b16b1309fb98d7ccd929ac7e6a0444b4fee60db3d934346ac8c4209c9be467121d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/lij/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/lij/firefox-63.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "3ab2e904fd162bada37cb2536c928fb2f5bec09d8023556b42c9b0a77395f1288f65cec792d0bb6def19952e0d49dc6e3ae7a8398697ba2341750d7707c89fef";
+      sha512 = "88a746f55e3f3d8fc5ea8b1f73c9112af0c87e18ac365341c7ce655edf25db58064c9bddf8e7ac9242fd67cca0911597ee795a222ca8cdaf37627f3addfae981";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/lt/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/lt/firefox-63.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "3e821ba12956af86bedc0d179542cff85631fd20bec53c34c410f5e3315be076634548ea512041241d82c46a88387a830af483fcb35cc6a4d897f09f3fb93be8";
+      sha512 = "f7e7ec28ce981a931d2e5892d85ed5e6ef2685af52309ea5f8a779b3569b5a84bec5c7c1cd5583785211a5748663eca2e6b0db13ad0a1b846deafd7135db4afa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/lv/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/lv/firefox-63.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "21d5e0fad3bd77c2e414044dae95e8464d33fa41badaa0049294a142b04ccdeb62708f209b5ad8c07d7eb5064479b6f4a58433b0ca7fd0436e62ccbb5ff52786";
+      sha512 = "78de629ab28273c18717f07d3609bea0e0690b5cf95c9ee380a4ff7b11d06b91a596fabff78c8935e7d52c2720875b224381f5e537bddc83ae7ad9c3fc80b802";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/mai/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/mai/firefox-63.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "c3e34de39bf5c77cf1c61d3e691b838ac4a560ce098540d6e58be13d7b1760a670f00aff505bbbb417b37190e494e48426bba73cee3e8e2454a73c15975465ab";
+      sha512 = "aa0f2b177337837b9515ad1d14748f7e68146ce5d2b3f6fd128be1cd2c09a62538d0f79320e74c17c8ddad8b084705803a42a86bb621f8ae227363686d8469a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/mk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/mk/firefox-63.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "9a26b08ba538caf677e1a2f3f3c98e5c67e51e7dec72e73097036c6f34bbab2d5b77ec9bcc96679bd3ab7ae83c3bd94d2c3307843d82f8b1e9ea95455ec91308";
+      sha512 = "36de8542490f43e7b63db4bbca49933716f79b85b4292a89aa16817c11bcaedc95e966529ab14fac87eced7a2feb5c0d4c077c0218c5dbd49567b0b77fc47d98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ml/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ml/firefox-63.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "924193b490fb8d65604fc7f61a6f00b79074b61ba437060fc35efdfa117d5014144c285ab149fe7b9dcdb75486ffe516ef1109eb751a6951c88e317d0c3bf222";
+      sha512 = "fc31609037e0f3796ae2fced50953042560e991059f565a3096fb30f27abe741933866442d6a6aa4e5c9beb60f5275b14576ec7424f0dd57b42e097b25cd9736";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/mr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/mr/firefox-63.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "163b3aee29777bef44bdfb56a637c3fd06c435acd05294818f3993f32f8062d0f1ae4fce96c48c05d99a9d97521e58230fa7ee7a9129b63956fd5522722b5c8a";
+      sha512 = "43aab6723f6f21087848358fc7a29c4c41f8a527c818c75b078f1a9b2db2ee28d25f12dc3456fd82400f75e22761063a51de8d237fbb8f72c45fb1be700b3c46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ms/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ms/firefox-63.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "7eb5b0f2d0b69e56e01c3aed184a995e3634853a267d30fb5149850269c3f1efcabdda8625a367ffd0b70282d5853158084e5890c1e79078818c19a94630d9e7";
+      sha512 = "3e6a411e234ba04e61337200f81dc8a4260be1d7fd7bebfafbf9430e25a96d3a0d944096feee643d34163f53f848caa6c27d6c6cfda5389cb59128ac98a1949d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/my/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/my/firefox-63.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "41eda41795d4db0198bf3b603ce097cafcab58e37bb58678aaef7ffad424fb6b9bf462801052a78c9d02092fef58a845cff5ab5640714efaf7eb94adeae2a669";
+      sha512 = "6b61f60a70997576f2a08abf95f0647725a0df92c348173f64428187f9020e451077de36ae7ee2912ab8b708314effd4c8c6aec4958c14825266e82b6114534b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/nb-NO/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/nb-NO/firefox-63.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "d87d4b281238d8c54468196c3a3ac55a2774fc4d04a4e9939cb47f526c57fbc1366c2ffc590d01767bdb14448edf9a11a21e8e221044529d0b0bb83532476040";
+      sha512 = "5b58f0fe658ef9bcffe9eb8553875a4ce01071b050ebe4c14dbbeaad0304d9eedcb18b5cc411c992c97ff043e9453f4bab937203d4c6f704fbdd02cba1415f65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ne-NP/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ne-NP/firefox-63.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "3cb49431e5831d63dd849aec87affb63e170f4feabd6701d520fbebe9ca16aafe448152231b4823c494d0595d23eae81fa79e5b9778a1c1a08d5011e7ad25908";
+      sha512 = "f3acdc3d0b9cd75b70e5c01e38d20c7c3071f175e1d50daba8c4851ce56c8e1f54eb19eaa198bfed2a70903d796e4457a2a8afac57ce4b8f9f16b139c8277e1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/nl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/nl/firefox-63.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "d29c06e0829eb07930605ac1c438175c65029f9635d0feda571c944e91e93332c99a697c47acd55f27f0adab49f46fae5f81955e783ae70cb1247029b0687de8";
+      sha512 = "f106e3c846869bb55baa612960e2713ab89edc156b31bbdfb86b40be160c4ad97fd402a3ada7a5729bd94415c1d21e234b4c0212bb2f31407bb71e49aaf0adab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/nn-NO/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/nn-NO/firefox-63.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "2f9acb29eeba9aaff86ebec0de7e67a6b17ec48607b5bd1c9c9466d465fba2825d41c86e0ae7492873e093f7ac36ffaaf1c744a5e3ffe0f3b2b5ac468aa43c33";
+      sha512 = "5a7371cbffd421e07e45120f87e85add83c75fcc62596321c08a1f5fd03b607a1d9f54f9be7d6174cb8f325aa77186728cca15e6d8a1a3f537cce5c996bcd477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/oc/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/oc/firefox-63.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "bad2f0d5f7a9a7013d74002ead12768d16cf949b7bb5ac3a130c5cfd1a8911a68da27d4682a7cfb31ba20f4d826ece3578aa46258c8773def49449e21d0bdbd5";
+      sha512 = "de159758170c954884d76f5325c7c88c5650044a4867a833ec79a9b6fc3addcddc8703620548e44801313326d5827df18ca688d67de9354a3ce1890e6bcea3d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/or/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/or/firefox-63.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "aca0bdc501ca0d4de6f8036b3aa3670ac6044563d54aac931fdeb154f796b2814a420432644a53329d46677cf7b77d5d3a8e4a3f6aab5469708ef9e4364590ea";
+      sha512 = "29c89abeb78cd688a2664dca3f6cf4da984187608f6c2e5e876bc7b15d744bce23a2a45de8bba87b3fcfcdd08d501f78c1ac6da44dca1391d0d9f391d371a8ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/pa-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pa-IN/firefox-63.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "e20d542fc62d4610f85c0c02737c294f4ffe14f88da9f15f557ae170c332f131900a59718cd725dccaf282fe29c22c85c8466267f6b0d16464f5992e9876b536";
+      sha512 = "a4d4f1ba14a664d8df73d46695ab2ff403630c290a2e65dc7bd0896b5e6dcfd9175f09a1470f62c19b2f7d6a0c83105baa26625a4a63dba034150c6dc9b8ff79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/pl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pl/firefox-63.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "e3848d7706e78f36ff41ad10656976b11ca12c98285bd5b18afb13dae9cfd43f2a38378ccdbbd741b6a2603daa1b3ed72eda4e8f47153e2eedcb066cf073877e";
+      sha512 = "bb8da953e6d290e7c89e1da82929c19b9918b1ba9edb020bf242bdda0999bd2af35c67b31f6ea9856a25e08330d25ba2f71f42ab00b1396173fdf97a8034e334";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/pt-BR/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pt-BR/firefox-63.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "9848181304658218d4bc0e2c21dbd878f40d3ec5a7d93d9ca6c7e1efc803f957e845344b15f697f347da0a743b7f25bce2e5b822a81c4e0f038380ea95509605";
+      sha512 = "02f3b9091ee88864d5979631e4b968a8bd8d8530b47bb74b2ce32e34f7a91146d4acff58c122dae9b97db38b8dbda90aafed0a9d463ee7bc4871788bb112d042";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/pt-PT/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pt-PT/firefox-63.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "8d9e9f52b80bd790a919442a970dc8e0f19f8ed5b64de22c4756fa9c0f7d1b72998a62aa249a9e8f3dc1caed1e74a07cc91ea15ee5b3f5ed1e5e340cf148eec7";
+      sha512 = "8cb41e6c6d14e4721ecff46b84af58c689d987f42cd6cc3abcc06c1e265b95421a7858bbd665395b86a0f101c78270c12d1d7fd6efb256871aef1b8f620c0234";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/rm/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/rm/firefox-63.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "ea7cfa4dcf6b3cd3a483b73c8360b525d8002773a5c766887306320d99183b035f6acb9761384cd44cf5cf3391e3fc06d554e68cc95814ddd3548de5ff2e311b";
+      sha512 = "1ac1d855316f38a0e570be034301fced730e61a5cfddfd43964689f003e454c9870ef215dfedba5027d2d291926cb3c26deaa9872b91686315ef76d14de2489f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ro/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ro/firefox-63.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "97271af95125b146c4d3655daa99e59c2b3f1dba57e9c947b7337cfacebdda5517be62f14a5a3eda723bd1dbba6437c0825e0f5200f9895fe678ae80708b53ee";
+      sha512 = "431100bb1d819ae8bf5de1883210f96de661b5c1a8e735e70b2df6c7517190d4c9703aea6e406371f49e6b1287a8e9d53e6ed4a228a521b8f4a8a532e442bc1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ru/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ru/firefox-63.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "e8e3fefa17ae3ff51bec782b163049eb10398cb1a46b2fbc8124e9000ea0a37a0adaeb71794ef392fbad501bb4c04b0f98765cb94f90cdee4a46a30fa07dd925";
+      sha512 = "35527353ebca6f60f310705dfd53f2a9dae16317c39bf05eac1f5ef4ebe9e5ba08d36c5557dba8a607d604483b4d02aa3085352c11295bbad1ad57d0e2a02ab6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/si/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/si/firefox-63.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "d16d3ae7c5b5ef04b09b6c0afcf4fc55f8e47b20729bef33d2278bcf4727703710f27cfc610b78ebf8e9d45f80bdb3119f438da2598a4922a43cdd88967485f6";
+      sha512 = "9ac19eb2441202229e730f8af9a23092b6da83aab1d879aab07affb39a37bbb8908c452721f37d2f6e062b871441aef9ce4aa5b616f1307f70091269fda8e3ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/sk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sk/firefox-63.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "3d23ce446b62314b5b6281aa4e8fa7e38ae3ea9ed7be7ae3d37d223b69ab8ab20a2e2d772d278538db8a572b839d59ebf4b7aa40211049f81641784c523e6fcc";
+      sha512 = "b599713ba833c15c2626c174efe93bd34b63d78fcf06b1507ba0ac905bda58da37e138df4eb01bf560c5551156cc9468ca062846b4083ce0d217164deeb31f21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/sl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sl/firefox-63.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "25e2bb9a9e92ebe5507ecea35302792acb7be4666fcbfe3dc7b0cd8ffe77ccfd514f92b9762346a5a71d55e28ed654ad55752b4ca82686d3e8fba97473afb6b8";
+      sha512 = "506e20b8c55a6d3e20e24400bfc784fe81e135f2b71f761c10312b1af9983f43d6e71b77578dbb221247d730a1f372261a83db6b7fa1382c06407fc6d0599230";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/son/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/son/firefox-63.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "13f167d22fb355b90b02c4d8fd8f9aa38e7f6e626c633276a34088d5ea83e410cf3a0c00d33560c4ab48aac4613cb0d422751f8c8b7440c0fd59b8e8be0ef204";
+      sha512 = "41c7f4a449d181bb352c2e9f3b7c43b8e5782c9d86265992788ce8ba5b2e1c7fc1ce93a5f41973650ee816b60f6874e375cf780e1b76102dd7662d1f8651ec96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/sq/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sq/firefox-63.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "f57dc4ec2cd1b8a45ac114b7f838d34f766f4f1f4fa9308504e6c9bfce05fb977e2982c1d83f433a957098d9069b58dc0c578af948b38f3d5f53ed59ecd3ef24";
+      sha512 = "d73f03127c26cf55352e7963d4222efa26c43aca5d2b2a45a5bb958f9c4d7f0d618e018ed8ee86ba009b360338c2c559f553caace5735e27474357a392f2e80e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/sr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sr/firefox-63.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "89ab6e7a42ccc21b0a2c3c2a55b0e3920d0addb4505dcdb98ff6d93e995f18130b31dc92c55a0f72301c59cccbd142f439a24962e19ae24ee25af59c6611c668";
+      sha512 = "0f70af467f21d399258a41a9cf89b01f8461d9063d23e7e15c269effaa7d7c3a70fd034a4a1939fab1f31dcbcf293452c48ae5c49bacfb2a2e6151f343c30866";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/sv-SE/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sv-SE/firefox-63.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "e5e1e25d4c5d1c97e715bb984c0862237602329a786776b3b3a5407e585399fc3d5ea7c8e6927292f25b97924a568c95bcd758e23b74ce71cb7592877a5da3ad";
+      sha512 = "dd2f383544dbd19efab3c967e762a54209da2ee3d6001d07f173141ce5abedd62216fb9888569e04f409def45b38d95989dbf3165a46a0270151c72bee4d3bd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ta/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ta/firefox-63.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "4f9e44175061339559ee743528f4e7dbe4e9b0a3d92cc178879aa71f1a30fb260be307ff75722a2f69259e3fb13e509228ab86d4a6e9708564c3696ac3531afe";
+      sha512 = "4c625d005c97f8dd8e31990c97d35fe51dcb614e6e8737d60daa42271b15c9a705cbcfa71a32b3a88860c57e7ed0dd3e22bde0b9485ec30d2dcfce9802a10f60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/te/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/te/firefox-63.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "99e52a537ec1048b63dd77a9a9ccd1e44e8a00af256ad8b0f61ecd4e2767591550a000e66cfc1b3db4819580cb05dd7a76f2d64a4839a9e72dc43e65940afb73";
+      sha512 = "77a995c552e01b688de4651eab8df025d8163684a4096bec415f40468f49fc5bbce667748bbcf989c636440e8343eaeeb228a9b612d989c520c07420c2888a4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/th/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/th/firefox-63.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "2db11524432184bff0646b86f665431cf71a1f3389185e1e85312af7cc75be26f55f0d899262405db411acc21a549a8d451b63d1c060fb892040c72b996c0b0c";
+      sha512 = "c51fbc08ec739f0c410537cb9f1897c3aba11c916c739c143ddf3e19cc6fc743ce50fbaaa95569302fb3411cee9d4a4ab6b525a02e1583387113a1cedfc4af94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/tr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/tr/firefox-63.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "90b2543238e92f66981c0aa6cc0e563eb1bd623c7bfcc9a72aa3f158b52ddf8fc7c0b550312cdb279dbb192c3cb5d2f9019817435a17d79b31239564771ea644";
+      sha512 = "1aac702b3f84217813d76248e201c1923e812f57ae7fea00cb00f12874f8cdc17e6e90a633aa578673b793760bd2300d5f0a2bb7e5f3bb5d61dec8e082e45b2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/uk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/uk/firefox-63.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "cc3973e6ebcc956a626292e09629a5041bdab89e92c94c4ef461e01f2384021b39057c04981d61deaae238bcfc6cbf0eda2ac19e271fb7fecc4c22f42808ed36";
+      sha512 = "cf8bb456b740d856201d6a832c809b1be7a0b9541c73988d9d526b5251c5036d46fe1e2c26dabacaed9afc17cbff53f2f5beea3a5018d4ebb82c1085e272846e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/ur/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ur/firefox-63.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "0efd6d37984445601e5076cfd19e345c2f0d038d4eb88e4543c90b27c468164ee16bf7695fe8a8f1d6fc2fdec1c8ff6525886da5b84ccb8ee6ceee8d751884b1";
+      sha512 = "02f5ba3d99d84ae6990fa2fe7739365dded19914271f4967671365a6dee76e3fa125d523aa042a70f4fdce7144bc29349158834ad75cf5b195ff8f3bf916bb30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/uz/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/uz/firefox-63.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "61ff04342906c902710dae18b8c83e40e14120bba2276aa677543032bb0667b12ff7c9df70ed5e478eb3fe79fcc1ba306b738ec5ea2b3bed2728698f49f7b1c2";
+      sha512 = "fe7cd3f100ae5515304ece3341e5308a2efe2a650a603f8e4979097e95281f7e0f75470e599a2292ef5296cd001d3778bbfb877c8b80bec22a27c95b7c06010b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/vi/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/vi/firefox-63.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "615754da0770dc5ac5347f7fd3ab5d4ef7aad96167deb5e7b22714595ad96e59069794abb676bc553b8aff226fe37f3db84c63ee2f662a71bd3f9163698beb0f";
+      sha512 = "293434d3817d02efe5af252e39f4cd9bcc9629f67011294f3e64c3700a0d41524fd2c7cbf7f7f38503422743006a57168d00251633d29f6dafdf2bc27ca9bfc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/xh/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/xh/firefox-63.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "4f82fe26348a515871f1c5775dc0ef4b31fff9a3bf48944379d08aed499bab55b314227e354ca17fe644807f1d2b1f732b8204c3179907c05f9c6d168c7fca3b";
+      sha512 = "e1f3490f6809f98bfa6dc38e40d2bc2642bd9a161b54e43fa5d1f4891d1698d32a074f241ec68ca2bfedaf7f2a7912a9632c9292d4bb3fb9932640b274a73c67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/zh-CN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/zh-CN/firefox-63.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "2d13d782b2988389d2bbdb5560d494c77d2ef0ec479289ab683a3a7336200d2775577b2508f23587bcc8d3441693c07593c3f040fa767ea19a8adf29ed9b9b0a";
+      sha512 = "e66e82965e5aa68e82d1f85bed52bd79ac0729224ad5ae5fb4801cc1702c7578e3e9c8af5c3b1659e481076912796c608ed365b88c1fae1b4ee01dce15b22052";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-x86_64/zh-TW/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/zh-TW/firefox-63.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "af0c5f6d98fa4cd4556c46740edbbaa76653630d1b8fe265e63caa54e51977e6eacfbe4523ab29d3b9c9af466775dae5f62b00468cc644d6e84332d59605d6e7";
+      sha512 = "ac6e7df610a1d49b655f084eb280468e711f1df668b8d6d077b7c84dba1aa8c0d47e7993e4322de8fb45d8bad7f7bdaf3325c1716501fa12f59e881cfa68172d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ach/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ach/firefox-63.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "d4b255e6675e460c80df56aac8a81a531d90c4b6ebeab018a1c5d333da440d780a89ece811f2a24616949bd71e7471925059b13fd32a3376b636012b0b035f84";
+      sha512 = "ba1444fa8ccebe86891a2777c5d8bb11d8098e2c61574b86e916e98c9fa6dbfea99c19fefae42708ee17142d095122c9a83303ed8a2143872f23bd0f3e63c7c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/af/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/af/firefox-63.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "61ce8c74d62b9b2e35d7a46e0b1284ffcc3837247b12e8e5ae0242049631b5c8050b353ea07ecf7a925e237dec111d10fe10c86e49fada11f007db0b3ef3c29d";
+      sha512 = "ad827930699e223cbb0ee7b34e89a76922f83f5ccc1bf14fc1743cae156623a190eb4d73ffb7cbdd9483460f30e868ee9a471af78d5f4aecb1c924e9a039fb74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/an/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/an/firefox-63.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "eeb42821c1e94ab24cb4438245aa018d44b84c89afcbbf271e4905929e6908ddc922768868b3c9bb4e6a83ccb266ea6b4f2d82f4a3a35c527130f3bb2aab88cf";
+      sha512 = "bce2959772589d2b356b3d3e0af7ed62448f77b66badd59ecdd4dad7fb7d43cce99aa5b3088770cd509dd262c585336b084982ad77b4328b4d3ac47ef7b0daf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ar/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ar/firefox-63.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "068310cf06b3149b8c54cbc8f56f4334eb1a5b0cab1ba5d7bcb899f507836240528d48c3762af4f37e4d5a9a1eb7bb0a5610d66e0911aba47c3e1ead3a0281b8";
+      sha512 = "1ec918fb0cce996b80a5f3702720dccc09682a5d223d049eb9f69c4486de24196ce0760e2f33f76a613554e5feca71af392fa8a9938a4b4d8a1d48ed88bd0307";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/as/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/as/firefox-63.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "1487c99d76cf37a4a53b6849501670fa8a80c6f7431f6b9503bd493dceb4786697685bb6d3970c4f47b121c8cf83299225112421217a314640ea7027cfc2c0bc";
+      sha512 = "8fe8b70c8ca653885bfaf94875a9239b38477d1bba36b6c5c3cd5a76a444ff846d9ff49d07ab7460e56261458135a797cc3cc557aa0296cac12f428785801f06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ast/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ast/firefox-63.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "cd8205327bcef45ef0610c4c8e5010c6eb3b488401b776186350351f433a3dd3639f9c8c7a2fc26c3a3d578f85f49a1f3525a84b40a473443ca81d8d8823454a";
+      sha512 = "b83bf7d6797f652c10eeb1ec268fbf8bd892fce13590f506b076fd05e423e113eae859fc4833d9192b9e7fbbdffce1be59356e04b1e60505d1b0efe97b25dc08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/az/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/az/firefox-63.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "0a7f11ea5f476e0a45e70bf8a1c6779ba32b96f81bff2f88c8cfd6ff29b6951456dc9aba4146ff13faaa35481c1fdb26ca944709dbbc72e4c11d9854cfc2476e";
+      sha512 = "3a3178afd4616dd0949d92f886ba62105f182eaae574f4d9abec54851314bc67175c6a9c4f8f8490446505be456bdae59715cc50e08d563d43821011b598cedb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/be/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/be/firefox-63.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "8e34c1b191e2d2cae88c94d99dc3d5bf6afd8a658601fb723d1b0f75f3dc7dc85b9f3bb6ecf24bb75e94a411f82c56fc88dd8a548c670351f19fc4137ad77751";
+      sha512 = "a70e7754379993e6d616374a337fc41d5ca3146b19d91290a09b6224eb6d38a0684466e1ea358268683296ad7c8cc34df51011d316239da2ef942ce5782e2238";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/bg/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bg/firefox-63.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "b7ba0be703e7e52abd61e8e27a25ee7a8868c1872f4babf82b3b1775abfd073c4112f738eb1ff9f341c56a15bbce5d5663895f342618e7b81fea0cfa35f3ae2d";
+      sha512 = "3a55a9bab9b175a167c3044c873ba356868fa11b6da85a6ff8af155c21c604504b74018eb72f7ba17a4a31ba14020b9e4c13f9428e4759772771038996a242f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/bn-BD/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bn-BD/firefox-63.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "ccf789ace9b1e5b378a8e37fa8e1c68e52f70247305e369c536981424f6baa9d8bb132475b4af512780a6b881d5e2090ee985c9fc9481c0a0718b0028b516dd2";
+      sha512 = "e5a110accd63efa525b608b7c30d2468e5b6f1e0dcac670b09fa834d6964d5663b70783adcc4085caf6520f72d2e4faeda037ab0a5b2f5c105aae449cf8b6078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/bn-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bn-IN/firefox-63.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "4ca51c703f5a394b149e7c9fec038a84558fc2eab0f8ac7a2b7109e5e73207b94cfa998c9fa8f4d2ac4bec65e7f6ebdee804c5f0801bc815dc5aaa50aeda3db5";
+      sha512 = "26f033b925adcf250619fe624eccd86350a4fddcf2eda3dedabfd5814d5ec7543173f0412b42dec6af6cd919041d8ed82867839f65c574f3a5c53bb7edfdf192";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/br/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/br/firefox-63.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "750480cb435134377e0d09a1c0b342e104903bcec9c68ba08827ea20027754f55cde63b0d44bc248800f85f26747f5d5552bffb7f5344bd5848d6fd7d72d0269";
+      sha512 = "adc30801180e72a4f6e5ef439aa1cb7fc0707b6b0f2b8439d5e5bf8f797ba568d2b66110b013079f251b80119dfd8c2cc6a6350ebc90e65a6aa189d56dd2bd50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/bs/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bs/firefox-63.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "1d8fdd486341c623b46a93d36bce8ce71e92269348f7e344122b9f8908c6db882d79f5d46b2498e3177df73b5344747f809b6938ee5f59f4fee43a3e1b116624";
+      sha512 = "635b6c284cca1c601d6868f51e7528768691245501e95f8dfa575aed3f31f39a466e33355f228d080f406af9d9fc178d75f614a18f29f3d1263fb4c1fe59fd98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ca/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ca/firefox-63.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "760d086dec533bd4bd98760a9de99557591c9916bfd930de061105bccf97420d2662b9286287f6d92d5d81f37a08bc30fa57874d992592eca0c531faa61f98eb";
+      sha512 = "3a0a0cef6114539553d1ae40cca4c71393a757d3eddab862e9d4192afb5c5e28c1c6884b929fd9de43bf122d4e8d73dbb0d46254393fbbd25ac0f88b3e6e7510";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/cak/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/cak/firefox-63.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "e6238a1dd0ce26d80b3237f70ee822bcde3ec9149a55a152f24d4f9a44021044b8e15a2a386f731a4d7b026391fa72f3a28055f1f02dcae11d6feff670581f00";
+      sha512 = "67967b99868c100d9014bd03e171be755993d476e9831cfdfbac8eeec97ab05c11959cbec0c4ef2da34a4c406f9fb4cd171293103e0cba131d6a05e1ebaa4d50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/cs/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/cs/firefox-63.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "e96e451f5ad543bdcc44b87227190716f0e864408a006043dfebb37d6f5d464e08ace9c98c0fb9e51531c7aba364532a2b3147519bf6d521336d6950e4d54078";
+      sha512 = "3d642f59728b4655e770f554eb5fa7c1893e581a1bc35aa5c680efd41a5e2747560b28acd6ae4a68aa2668098ad4b638673a033d4da19d2c2e4e9cc42165a48e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/cy/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/cy/firefox-63.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "0ea943b9b5156f4e814e501c8b7a589d888e1a2f9340f0c064b134d2299e40fc766e5fb8ac89ba82e3c5c586b410af16cc86caeb71285b94efde9e171652f57f";
+      sha512 = "877caaef6d1398416f44a53b0a91d1d49e5694c319da19d0b5c5ff71164b80a30530a4ed4c2a22602f3daad37be28e499930099edec3668bb0cc008afc5b3404";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/da/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/da/firefox-63.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "6e2b71137d36912e6c4f28907b251a19bcb1f6a3f9d830b6c7b3e90fd28c5d4dfd5f31496ec45728141596b6b37c78b3c29fcf07b85fe0facf1e47c4953edf31";
+      sha512 = "eb911318ee4231558a16b809ee69b936692c6a88d891041630eb01d3dfe9eb061a51313d07a3616140b30617b67620cbee00c3a0dfaa6e9c4f4fcedb84bcc770";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/de/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/de/firefox-63.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "def2445efecbd7a998cf846c438e85e4b751655d36212b46227aa95483b474a78249e46e5d44beeb8a2ceb4baaf1e0ea84cb742993941fa2ec0f90f13f11f098";
+      sha512 = "f7f5a05c8c83eee203fa741a1cc09124688c21eac32f5122bf3e3f7b4a389dc37acbdb3ae6990b4413970c98eedafc0df4ecc08b508d52692d2fd3d9ece46538";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/dsb/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/dsb/firefox-63.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "3cf731e4247dfc99ac7eaf85001b70413447a5409518a8aa7791e8affe85efa703c607ee9b2c3896b1ab3c640e0d80610bcca3600b057c8d0c09cedcc9e3b93e";
+      sha512 = "f003cd4232bb20585aa08a7cd07e7d717eda2f6bca941cbf01615d1143015806423e3d6b55dccce207d9af6250e4e3c6e3470c4bf6b0055c8174bc17c8652e3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/el/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/el/firefox-63.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "8ac061359a5806661eabe8c5e22c30ce795b0e019abf6f2d6b673d37b2842887525a4ced40b6aecc6fb2f02ec841d309866fe638f105ffef8576af5d3fc6cb9c";
+      sha512 = "f172315fa9608aa89e53c0db3fccb68e0e5313d18a8effa514049d555dffcada49693d4bb65c1f987ed5c28a92591daf1a85e0f4186bba7d2b53dbb98a485d9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/en-CA/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-CA/firefox-63.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "9d62cfe7f055db10bdb8dd152d6dbbc40ce12b9ef4fe59086fe9818f87d95c9ea79092d25d3bf8a34cf2977b28a505f3ded4406a864d493a6f4bf2d625bf124e";
+      sha512 = "0040a4809792c5739f68e5d95a4d4068f165daaca55408ba89641acee502ad3237dc1e9d6a2d37afe3feed0f44c3883b50b837f5626b5b86cca1430db46556fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/en-GB/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-GB/firefox-63.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "ce98acdad497391f8872ee0c41d2fed73a51c0d52e8e812aa7a426684bc0f39103f95cbda3bde1006aeb95d8662275211efd32cfe82609a344178089153db2bd";
+      sha512 = "4661b07660719c0d3ceac74642c4e70d9b406dee58f8ff0f7c40a006fc76dfe3e2a81699b70027e3ae209e05fe321d58a124d37bef10a1e1283cbc07643c0852";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/en-US/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-US/firefox-63.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "06d5c79c57ac5b46cbd452a3a095ff0b87ed9a4cdfdb02d73d90947c29a8ab4c34f2bfc3f537a0dc2e60c83350531aae07f58d1808a08bd57a79bf2881144ee5";
+      sha512 = "4d09db5a69fe203386e05bfeb909fcc798fcdce2c3a14c27af18cd1a3837439cd3fed50c6bf951b4882a125f181dc24d5ec201899097e65e279834db63018fad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/en-ZA/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-ZA/firefox-63.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "a162dc2aaa5f2036849bd73bf0014f073235c853b3fab0e3571c08a85f6fefcbd9a7d3c033d5515126e72eb1cb54ad9f68241201ca9bbc786253f0c84f6e3590";
+      sha512 = "85befa2c7d200fe88128724743186c354efc6eef85d780b245f05e0f657f898061862673be6816c9d13e2e37a4a6c1c8efdfb1bd8716c424e9a45f139cdebdd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/eo/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/eo/firefox-63.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "1639bf250506d4dc4aff272ab0517c76eff75cc3fb4e8e9fadd2028f877e204d0bf19e3eccd7107fe448f1372e3f6dd19c99ad2f8aa1891b1c3b2dbb4b8c34ed";
+      sha512 = "12af4981f2da08abd4027052ea0fb6ce24af2aaf19c18190fadb19bf9a99326307f1ecef484f50ab0880e183ad971ffcc4853814ff97fdd0e32387434fcc731a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/es-AR/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-AR/firefox-63.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "b9afb2474208530ca83b4d8bbd59176f02558d21143227f695a8705a70b16e6089d86316105deff2c89b857fd14a5c5bbd6c057aa9b66e9ebaaaff763321a86a";
+      sha512 = "6d244ec1c396e165fd5507af11e74f202ca7793fbc4c2fd9e47eddf429bf6aac4477a2994fd2ca146f5d8eba1307fd7877406ee62bebb73c098d5dc342b1a64f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/es-CL/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-CL/firefox-63.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "134eefbb975dc1ad3f98cf340b0c544f084bd2a1bd1432594bf228e0a23e402461e936e777ee3fe0c9a86bfc59947c35f6c6d7cd74deaf6cdbf1224c9fbdf4ff";
+      sha512 = "18ecebef241940ba62771850ae78d4249ff937c0c069782d0e1f83bc7d162fc0b2792a16231ee943ff1e93141fef860f9e376a1357c30375c5458d01156cfe82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/es-ES/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-ES/firefox-63.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "66fac925408ea40d3348f207716e732f878bf5bf5837499a9a27a9b1e8e4a9210c3400fe90faf2807aa30d49f67dae2324e7b41d80a21daeb531e907bbdb35b9";
+      sha512 = "3edb35b0e6a8d0d8838fa9d648f138980e68bc08e6a36c78db8fc3053123f364cc888937722c6b2bb892586bdc9b9a7de730270fc433bfd1461a5d2c8a689f92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/es-MX/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-MX/firefox-63.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "e1dd051782b59f9b2601b051459e4f23bbf949b0d257dd70cd8bd171429f661274f3b7bd5d8d16a5daacf5a08a488db85b462c667c3c3ce0ea280648c5b2820c";
+      sha512 = "a157fdfdc2488233c56b93a015f33e96c6ba2c7b9112bce83a1f53931421cc9523f3db0fa1cf428fe35c1ea0c1e9579b237c44537da89a8d05d4116d43db4eab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/et/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/et/firefox-63.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "9b46809e42acaa8dbbcdce1df8f7471d20cf40b0a84384edafaad1a0afd17a1f2385c6d41d7eb5b472205e80c528e3408282ba0d81cd19b8d92c7f0550c4a5a2";
+      sha512 = "7f118ae92f0a38ddd9a0eb35089f99c09771e377e6e6864006d8f2ae604d9ad76d38d641723660cfba138694840bfd5ad8cb9ffce87a4dee76fdd032d2ff3bc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/eu/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/eu/firefox-63.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "790dcd461764cad902cba93054c35539d2aeb30bb5fd3a6f940ae125368944e20fdbdba9899f3b52b6774fd27fe73a13c0eed7e269b20a7b73dc4fa123122a1d";
+      sha512 = "f354842728b0821dd779957d7bc5ea58f7f498f26dba21f8822b6198148e47caa7e33b18e37651a92620387046eb2f494d9efa6f8a83091dd945191a24afb3f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/fa/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fa/firefox-63.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "4e0608da711a17faa10b5a043192b52e6d88360752d9c388e173bbee3de86bddf9693dfc75cba7ac42153e95a8056c6d0ba48141cde476b524d1fadfe3a3bc10";
+      sha512 = "473441e4410cf8683a536802a1ba15cbbe0c802fc43e03eaca0b458ac8222f5f8b3f43cf4e85018288967ba2a305db8360c6d583e5aabb80b4146d8bd6c96865";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ff/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ff/firefox-63.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "1f50eae02bed18b0230c824c9768b13e2ede4c622e42120f6cc684f7cdfae4753eb31f867cfb272710b2fb2ad9e649a99d2187eeefa74a5afc1999e002b6cfaa";
+      sha512 = "e8e1c2fd944f6839560e3182b2933b2cf9d62628589b9f3116179d918ff9b5aa8b518c5150d9178dd3aa4571e7e6c1a7c21e263faa409c106b0a63fdb9ea07ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/fi/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fi/firefox-63.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "5f089861d3a67b754e5ddad49858789d6d6ee309507baf9ff5198e011c26f970cef54ed37398458a3729beebfe9451fb16981ef32607cf1635cc40b7556a7f9a";
+      sha512 = "5c5360aa4afb19fc04126e3ac59eaf0ddcde87fbd702fff8c81084b1b14932de8a17965138eef2473532c7ce6a624ff89f7fe6f8f096aee42162fa26a6e4156e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/fr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fr/firefox-63.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "5f8963809cc8cc33dfce49b2ce7e44c8351d8a3d193766eea99c668533abdea89d53233ced42c9a8d57356195a3f31f549a486a42f9f06c8ee6d32720856ab1f";
+      sha512 = "7be9df5480663cba5ca9d0ad5ae163073689395ff353e68deeb89714d5c535ddb2313f8495ff7933208c64360e74f6704a92e50c15a7b5c8b752e73080f0d743";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/fy-NL/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fy-NL/firefox-63.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "50e1a6c68daa2d330ce9f8b070413e100bfc29f7a0f1a7794c58473de04961ff62f776e2c343452ed6ddc3cb309f615ebdada91e4d259e60f066398068141e3e";
+      sha512 = "a376fa68939d16fe7dbbbf91437f7b757b66e7948eab2bb1170f390a310dbfb02f9ddac481896d1eb9deb5a12c942e7bb7e133dcad4fcbbdf90024d56a887e6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ga-IE/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ga-IE/firefox-63.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "42b2b796a5ab27137e5207ead28daec4d9a0a0fdd58336064c30a56f13a4389d49188c91b6d2101d49550b071584ebefb81d1c3fcc3d9948e2b14f00a7c0feb9";
+      sha512 = "90ee86c14d64bad009d4a976bb6290d4ff2c521422a12e42eaf31a58991d2d3cc20239f6c16b12aa7f11b5fc0f219ee0baeb660f1bf6036fb1b93a8d25da7ccc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/gd/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gd/firefox-63.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "794193059ee643092981491b0c32886e77be4faef7948c5db2b79a76e3ad4baf30dc149cc63d935a9210c02ccaa843521398e9274dacfa6f98ef4f49caf65c70";
+      sha512 = "c3c1ef229cb2fb1c77ea10c13fb53a2b87cb43068f39182517787fa14043ca4e47b4a262b3ab11ee33ce28340ceadb1486127d280718b58f4d3d28c6d1e56155";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/gl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gl/firefox-63.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "3a494f60eefef37ad8b62b30d1e32ce9e783bbea29e594668839bceb416d6cc16786a95f9cba06f31b027b4bd40528738ad26c955adac3a433ac083e49642b90";
+      sha512 = "8e403f07b874ca951b0fd0811308dbb6766a82ae9cdd2e826fc93e19fa89be075f2a480ba403c534ce7f078e29b92b2ecddec1cd461dfde5e7503ffe10757d77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/gn/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gn/firefox-63.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "ddc555b5f0aeefd9fd435442a457c7c37d4bf4e338b16bf10e1f1798735c52a758b30beab270f03d425dae187bf9d83f828afee627c7d0eb3dc7615bf22f684d";
+      sha512 = "288a0c5e1217924cc4b7596a4367d05914d4e3846871a7cabe0f733eac998cd18651e1083d23e034a22feec764f809bbea0ada464a19fb49673b86bc86cdd7b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/gu-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gu-IN/firefox-63.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "a3b67578d9ab00920489d088d59f3ff1845319d9b4467ae3854ad9b08df72a07be94f2436f93db7524bed13a467ed0acf1d271dd6faa86ba9ce74535aee3d35d";
+      sha512 = "39acbba4c189498cd9682a80475404ab8cb5fc344cc3daac6a2bc9161f062d4888fec2a7c6c710463f86c286d0ecd5ada624265ed0894cbb37b6d516b22daae8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/he/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/he/firefox-63.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "a6da54477d9a4ba632ab0c077904ead3f83c1e268781ca2bd8fbeecf15da62a3d1393c8cf316716c3c22f7c949a48e2cc7e90bf6d394b5dbf5559cb8c92c8097";
+      sha512 = "8950daf8e742b4d643fb7f6fde87c80bc62e9af98896270bbc834b9e7bc73ed7ae1c9696b9a8c14b2ed372c05ab3b5206e9582b6aaca224a73d3260ea3a7ba91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/hi-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hi-IN/firefox-63.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "708c9f75ff02efca7cbc7a2483aba15cbe1b22fcc5d4a743633d027afcb22a0ca5778fa05ce40786279a1d145f75c4b9bb64a16bdcad87c9f6f6a439ff748fd8";
+      sha512 = "902547d964746179ac21b4b6c3bdc92b1a11125fdbae97d501d497c882002e6c2ee1ce339b2447c6e650571b02803f51a009b751d6b100939ad5a09eb3e682c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/hr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hr/firefox-63.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "6cc028e94748d9133887398299e21f70abffa4df216ab629eb579270be8c5ff9b600fbc2094b9d47ec60c577a2158ef3d3e81d63492954260d4b53bc19868769";
+      sha512 = "f94af79ed665da21b9c798331409a1b1542d45e4abfe9a1124b0c5d38e175d7653cc2916fa59f380b8288766da88526742947902edcf147fd93b1f63f29af1eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/hsb/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hsb/firefox-63.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "81e8f54353a6279041694ff9e95eeb730d3ccf7438cf0b1c4c45425144b3f9e655656b9ac912405f85b9206ddd37ea31bcd6e975b25a14b179849a33368c0693";
+      sha512 = "10ce80b0c58913a50d279c9276365994597dbb2688aae32a8eab851a2fdcef4829e9f3b217b14103d82cd67aa586c7ef184121b688979080ee87b152738abfbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/hu/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hu/firefox-63.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "cbdc13d964387f0a5add945cb5f5f71fe2d4c6da9d37f77883074a5ffb22121c293e7c665580bea27a43d98547e2459c7d42cec60af80f44b0d5650b3b6d9042";
+      sha512 = "909de698586db1192f09d8cc9b707c2487784910184ff2e72d1e5d8bdae103b4b4e3296073d57e5827f8063e17310632aba79acffa47313f577bdca30e35354a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/hy-AM/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hy-AM/firefox-63.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "16aa31cd906a9dcc41cdee45e00df6fbffd1fc83fe9fe5a7c10e0b6007f3ab542bfe328b456f8ec68283a6633d63457ce61dde4661283e75917a0198b38c1a72";
+      sha512 = "4c5dc3c1030dae4153911faf69f5399b7e90927c8419a742f7fc7e319924a67e508c32d07be16d178fa579a4dda39373a828f32fa112a99a6da05dbcfa0b271b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ia/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ia/firefox-63.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "f622f1a1c95bff1b68beb21398fc22e88e05350a2ca1d6d0c018db4d30962f1b5ee4bcc0b9fee7484b02bf06326596f702a1a9e5b0acad5e0fdb73be1c1dab45";
+      sha512 = "bf6fdb4ec04641a9e9a7e349df82a431c78b4d3402a0f145309f364028e33d05a0126bcd236d69c355c8a60c3e3dbbd0db373bc9d5ceef1f7a2a1fcecd998a05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/id/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/id/firefox-63.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "9d44617bac45ccfc191ee02a3c6f994734c9a1bbd5f6cb160808361522430a57798493a33b774eeb331846c99ac09b46788e06abfc716a0a634324b2992085ff";
+      sha512 = "66bc5e37493b5d49202a1a49b2a688e04fc279b4fc59b39501b1ca263d273fe64e4d100af49425be7487cd190cdc4774f1ed076bd9d31d6f10be099afe5a206e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/is/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/is/firefox-63.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "6c64320f40b41fc0ba93b94302d83cfdeaa90992681a5ef810399b35fb1f1d40406b2ed80148cecbf6603bd9dc1298dc6b3b334b98a13ffcbdc0b2e19615051f";
+      sha512 = "b0e5c494eaa593fce4e683fcb3483dfed0b23931eaaac632289cd4064c1244eaac82da8966db7fc85a9b380a5993cb1e21a3c5b811ae53bc4ecafba0e8a62842";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/it/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/it/firefox-63.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "deaf12ee7fa25a650116dc21b2507df41ed0535821f43cf7e469d870154f4e0d9d66ade3ed3463742e1c5b28d4526f4cccecba4f3995178ad7f6b82d29ea0e88";
+      sha512 = "e03a88871c696ea20917dc6e43707895bc8a2d12d1478b18f3f7059cb7d73d86a690038a0e65ad5434749c01874a41d414494544fc40c7a74a278fec6c409ea7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ja/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ja/firefox-63.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "e4c1a5724c77bd99d9d10bff3f9e011f35bc130aa711e629df458e7ee46a3bdf1fcfb4bdeba4852bd0dda773b8327bb3ddeba2115406517c77d0f4d224267af6";
+      sha512 = "60548d2697967ba841350488239e061a597f56e1eb9285b763f83bb57df6c0906f39eb9d030cd649f496ad3ed54c717cc4ac71fa44bbdaf3f18e32288c6dd434";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ka/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ka/firefox-63.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "1040735b4e1f6616ac9b2676b7007435c7423116e5fdcf8a0a9b472c5cb0c17c089dda5d711fa10129d6bb1c84082602adf20161f5d6d560fbfa12f6225635c4";
+      sha512 = "2c3a2454ef64a184b1a28f884462ee63806ac61b578f59f61ec194691690880a9ce2d76e0e183ed16ef9ad570383161ce9370cdc97515a1b33a6b279d134ca6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/kab/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/kab/firefox-63.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "511ccb5a8745fb1b93fdd49ec9369498b577a155fe5134b9990e6740505f342e76b0da136cb3ebfd2a15921b677be7cab6099cdc8cdea9d6040b989cb12672db";
+      sha512 = "0ab0ae54fb5472af7dadd987c2d8a5a6d820670b1d6fd2bf17eb036fbfa4151e7ae754028570be254d8520f98b2cfc953d50e98774be0ab5736c3ad52313aed7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/kk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/kk/firefox-63.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "1e5d5aec9db2fc36a56acd1d9e723659c3425ab4f048966f0550eb1723ffa27b0b91acf8daf8cac9bd6f9929a5fd880edbb4ec1aa4359282f4d4c4532bd6636d";
+      sha512 = "0fe809a4ceedc163dc3923397c51ebce0bc933fa8d728fe8da44eea098a3a150ab3d86bef8e6904f59d20440dafe16a8c45be3d8d00f4a0392e446a3f60c925d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/km/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/km/firefox-63.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "76063e3d83454f4850849af7084d9489baf4d354001277a9f606a28db089e589147033c132320b34c59032b2dfc7611ee52786c960bd280b5426781a0a0b7be3";
+      sha512 = "5ca1faa0a2dd1fbc1c2ea9b7c631ca682c442ad26a384065f27261265a731003214560fbb6b90be791b07f10a5ca7ee33d22c682a61f2eb65f813c9af06d6ea7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/kn/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/kn/firefox-63.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "14fdec60154ffe181f00808f8877de3b045c72b91b0a6c017951033eae786ee26e4f96555034b8161318edafb8ff07ac41203a9bce91ddc20215be87571c5e11";
+      sha512 = "f4df227197c065304532c5dfc2e86393adcee0d494223d7771c724bcf8e11205db7e4085373c3b43b51c84274bf741d39712cc2143c7361c706ce0613e244c96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ko/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ko/firefox-63.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "7990af9dc0df8f9fae35d928ee5b476dde1e12db6294f5a3033d37e73e44fb8d0bcbf7916f79459dcc6c8f05ef065ff4b0dea95bc2c342ae81f2161fd61b2fd0";
+      sha512 = "1e98e25daa86dd69a06c69146f171c84ae45c42e5906fb04aec245235c3eaab310bda6a08822081a18ea75c934905b3beee22d17f9f2a2f3cf823c3c0b695f08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/lij/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/lij/firefox-63.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "42faccbb1029df56f17b94c7a5d9e6f6d5fcd7c5e6b623a6fe8f89f143c909961dba135e02d0ade1bd57399bed1279a61ae16381402ca391aeb55761428f97dc";
+      sha512 = "864335bc53c70d738d0338426e499bb8aec9b35edb2e63451805a064c8601b6698293f1fc759a4cc3d38b556fb7ca83f4a1d15c7ae9aed7f668d9d901b47c456";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/lt/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/lt/firefox-63.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "b4079f36c1a4788f8da2a4e1efd0ab4bb166ec45dcda1ff0077746a85ed5d34b8cd498a0f1d12463349d4fcfae820db39946caf7e55f4ae9ff1c9ec587a95fd0";
+      sha512 = "676ffb0616224c53b61c5e13713fcd59078d9acd46268a76321e199414acdc734093979a71b1e7a054d690f6e62f1ef28f807345cad620e7b6ab7920f84a7559";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/lv/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/lv/firefox-63.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "5a8eeb1274c30e57f7ecaf307e23eddaabbd7272128063ece88f480c7a8bdf96efbf8d2db2416e0232773457b10474a531ace2eac264175e590050662c8d606b";
+      sha512 = "ee93f40d4e624e24dd9fba0951d6f0d67e4caea63fe8d24ee1641f44de3c44f214aee0f26ce9a04418c585e9a6486d50957a68bfffabe614cdd9243604b9b519";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/mai/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/mai/firefox-63.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "b2ff3a58ff0216df0d980c941648e143a3dea87e1c90c4ef1367a3a75d5052b1c1e54b07476602a91adb691bca2fe4e9b70d89895773b3a021944257b0429518";
+      sha512 = "c71cd9d320f09e0d6307cf1e04cebee3ee565078a73630a32fe461815098c3dc09053fcfe15c51736da2686b6edee435138cf953931500bfa3b049a31cdc086d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/mk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/mk/firefox-63.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "4ee9b4744ed73d866d6d2e73d0a9aae983d063af3fb4e313e8c6a2fec055b10bb1d414cbf87c0909119f1f804cd64eacb981b5c17ecc87e29ab246d736b6f9df";
+      sha512 = "d04883a77536aeefe29ec9efab45bac90ab548a9d67076911446f4f8d7e86ec01055367b5fdd089f857bb3e6e108ae1e4ff6727db2cafc17ef25ba9ac52914c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ml/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ml/firefox-63.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "9bdd87f047491ba138796e48e46dd4fefbccac03adb4d652978d51b933327f007ca89d41929c075dc61353584cfb5a3fbd94986ca791750117b55a4ed65b7994";
+      sha512 = "d9c71712d7b852c4585245d87fd060b707c1789a5406e69248d46b8b6a2145fba33cdc5a31dcfb654e7386fb1b2b70be7f6e22c320d5fa85927d1bb9867280a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/mr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/mr/firefox-63.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "7680c9af0d556599120b3d8a2883a4bfb9bd0dca47a2d2b3dec669fe2852de39c134cfaec0f53082b269245a28588bc699250d438668264c778c7cbf3037a50f";
+      sha512 = "fc82d00af91de103828c99eab71ebdf0f047d978c7477f57bb7df64fa20b4fedc39bf0fcaeac4239981cd0a0eb845509e78e4b645860f2bc1835a2a3dd1c32b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ms/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ms/firefox-63.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "ae78016ae552d10f4220e68259b464097464081cc2b3c114648a6e36e4381df7e9333f7c13c08e0346bdaaaaaadbbc9a111dea55cb6b4daafef29ff0b0db5afd";
+      sha512 = "935f32b98168d0b136a6e1d1fed10b8636e74100f0f40d94273483acfc239e818907159e1b6009fec132ef88710a2a4189689a1313bb26eb7d3c7bf13cf365ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/my/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/my/firefox-63.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "e682f1e998a946053672d61f880a75472d692ea9f7232df9e2a51c6b3d27f7d5496138144dc17a56cd07378b20bde48450a27157782e9ff0463ce922c08c6e3f";
+      sha512 = "74d85bc47ba363f889f1d8785756406643f03e60d04a340f99a79f0fdd4ff733cab1807b16e76bdb1bc0fb8f8f69397624d8d8aea934e689637b90d283c171a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/nb-NO/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/nb-NO/firefox-63.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "b6b68de70089bc3f02741de04138922b3a4b6ea760d5b43c00bc636a3f60fdc510886e76b989facbc4db23e72e0659db9ed38705c8c56851ef9cb9209524d58a";
+      sha512 = "a9e43f742b720a03b9c7ba43e812225c6d32174e908dad8de15a72e758dc2f6374aaca5eb7ed7abbfe7180d06936bf7eef6f021c25bf3d440d63c1a0bc3c1804";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ne-NP/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ne-NP/firefox-63.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "057ba9953a8ff6824567de1d3629b7d995924a7da49f9b03e1b5e872cafe750dfafe05a74b72cc360c932237445712bddb646cad2a961523d29a8b5327ca3bc6";
+      sha512 = "c20328156416c0678d701c386999a9de88365bda8b033804661158098911247b883e4521d7881d63fec08713136a457f1fa52cae000e7cea7e8392baef7986d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/nl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/nl/firefox-63.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "abfa808668e527940d7f344522650cccb4272555b67e4d90398faeb7aa31766002287c5e73f259b2ebeafdba890b0ca9940fe0bd12926f8b748ce172ff786abd";
+      sha512 = "b1d16825d152c208108938846397d6fe1315493e5e5166835c546c611badd25f3e21aa2bd044ab84b827e81f3eef0094af8196d58dd84bb1cff604bd63e7fab6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/nn-NO/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/nn-NO/firefox-63.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "e5048346227c41b20534e71042a911a74348e403283ecbcd3a90f1ecf3154907e0c7c21eb26b67f2ba09a6e8d04200c990f7a4babe4ea5782a847a31a6a880ab";
+      sha512 = "7f86b552c74fae7a7d0ee81edb44696770cd31ad17fbb1cf8bf1a9cf6c102b006d76204185a6d36eba2c73fe9220735668ad12fdadeff6dfaf4a4fdf507c47af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/oc/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/oc/firefox-63.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "ec1f24de15020cd6a16d95d47db8e2e73d1b3aa269e27d30421c15e3d71b57625c10e7c20427fb1fcf2ca7b2e1aeb0f16b254c1107aee28c2e8522fb535d4a5d";
+      sha512 = "496cc5e21d8dee68a929d9338d3b7c341579af2092279168c846efb355eb28d47180173d159d3e93f279e1494fea778b0e769a2b87e483abaec3da4baf0a258f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/or/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/or/firefox-63.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "c55f10e0a9a3cd3403eb9167139b4c6f0e8a5f66e3f33b12efb40bb6b2bbb7d1dc2aa365b1ab375f41da34e7d21d2848223934ffd2ab61fa93220bccbe9fc720";
+      sha512 = "a4df6ee8516b67bfc783d566e3e78490ee89cc74645e1caef73cfb4623bb571df292b03a8796c313338df637ffd3825e7ee6dd0779e2217319fdce7b07bc9b8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/pa-IN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pa-IN/firefox-63.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "f74dd4d54680d94ea270bb7755f6ea4fe058899cea2472c08ebe5f34b8323be7157b060abc83ec80aef8f2ca63f3c806a7a4d831a4e72025ad25d4ca40783cd8";
+      sha512 = "7e6efcd008e69c56ee21d8f00a7d0766c2c9a79d8a2b01cf7b9deae0dce7e03ff3148b2ebacc587268d39a3564fe9870c5cd12db836ffa96891953306e6822ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/pl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pl/firefox-63.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "05c82b2e08f65e37d4e82fd93d3d2ebe6a5d5441ab11069cbc66b18af0ed93e877466daf1d804c53ac3c712307aea475c99f922b5064cb551d136e5378e23765";
+      sha512 = "947ad8bffca0d619d0c3a4fd77830120395592cdc342ea462c793c298252fe76819999110ba4dbb9b3b6189b107aa307a5b04270b4642113f634593a3813b565";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/pt-BR/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pt-BR/firefox-63.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "c8f2d36ada67a2fa7717527355a0e083ca5891ece1de70505efeac51dad5f6985666e2be0bdf23ad0f4402d6ee96fa2e12af50369297a3e46b9804cb0b830c89";
+      sha512 = "9b465f5c34fafc80b33b45d03933c81dd7f2e1d54417d5b80953b35addce08b011d0ccd1a75353f5e600d4567794e62268c27603d5fa9ef6bd2e5ce83889ea6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/pt-PT/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pt-PT/firefox-63.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "5e4478ab220636c747ce9c5564a1b71554b1c67999722bc55204f747d0ad430eb2a0b71336997e80ca391d7680ebf92c66ea7ef4d25dc568f8c6860cd31ee26b";
+      sha512 = "4a9c47304cbd015ab36e5763ab0b6564cf81ae4c791d28c1c37d49224e4fd9aff186815b19a4047c7d6b713a6c4ea7f3d341d11e56885ee5b73cd2f2a2048efe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/rm/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/rm/firefox-63.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "67438f3cb1a89a0258890448de6d16be5f79291d4c0989691d9c8f38966a7a4ba2f8eaccb26ee4458a81a733ae9513555a22f8b57652b4fce1eb1e3ab2368848";
+      sha512 = "24dd07cee63e1a3370b970c5a2e0c215e6587ff17ca0438bb8b52313eeb52e9b241c56fb31740602067b635b314cf20d63e03fe269ae35b4374f2043c8292af9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ro/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ro/firefox-63.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "3cdc7f593af3bbd858285237a9ffaa07aa76cbfc67c0f7d22d5cf261a19756ba3aa8971d54a10b820344beb509810b601faf0cc89c86636bc60ea1a6d8421873";
+      sha512 = "25c0d057571ca970344f91a07ee1437e290ffeaec2c15a3b106e4c690afcdf7b3bc9f92f28b11d179cb8912697b1d7e255a6596bebbe8e1488dcf4347cc7fecf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ru/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ru/firefox-63.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "7b6b03cca2fe3887d7ee86eeb8ee699157a6cd828108737e26724a48af72cf3fe326024f41c6afc13f7e332c262a4e991728ad5d46ac6fb6942c5c3b4ea93a9c";
+      sha512 = "7110c2ff51b8d5539018383560c113e63ba1a870510501b0bfa1294bd5c19a992d07786732bbcbb820ece4045fb826bfcc778200dd3ad63504e64cc2d85deb4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/si/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/si/firefox-63.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "10f9fe43304931dbce1d0073ec4e827f369291b3705b322a3f3ba8f7002a974c019be8f5a594d8c88add527667d9295a27e85f2b1072e16ef1720e9e433111b3";
+      sha512 = "6dcb0eccef3c582545e7de5d9c33c80690db698a9b28dc7fe654187b60e69a41309c3326eb2b73ed6869a4278c22db369e12a8fca5f2553327b2b6fa7fdf389d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/sk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sk/firefox-63.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "6b90fd21c51d48ca997ad47025aef3a4280e30152a0f18d0ab8948e055b80e5aa7cf1374b2eeeb1432d8892fb07de505adb9ae6c57e776ced4c429859577f040";
+      sha512 = "9e7b74a0c495cc6247c5d37931d6038508186070de80a935d2a39540960d3d57996f47497fa430b24cc9164bae5bf5e761558cf60231594ab9637956a26326ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/sl/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sl/firefox-63.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "55faeb2d5310266395a442d0d9ce4a1020197d0ce7655caa8d00efd022db9e1c9926b7418f4cfa380d04e1971ed47e7025d434a36ca0fe6f58f02be7f0e26a69";
+      sha512 = "6c65c39d0ae8a398e25733f0be9180dad1bc17d3ffa58f02844d6750bbb64a0d70f31b565e3ed606b6452431d0aa705f671b45dc2280cbb90aaba741b60d82a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/son/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/son/firefox-63.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "63f104da43ff4103b40e271de6c962fae3d77891f50fe5b39698d3c2e382b4234dad41a3a64794015ad88d34a7e2b819c0ecb62b1bb44a4d8e83eadbc1803151";
+      sha512 = "55ea357bf7f6ddb7e8b51796ef199168c89ff5959e5e64fdbe8e362bfb1efa19f9f407c20510139c52cf44058a5c4823b2c1c10821a2ee06a18b19d48a85a403";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/sq/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sq/firefox-63.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "534ce38e5dec85de50e9dd541f6d8445e95fdfac074a51866c993e97d020b9a310abebffa2162fc513572d202f9fec8e3a267207bf9c401b27c8541534ee2aaf";
+      sha512 = "5fd975a71f9899b9eb90f46adaab044c2d21ac64cc71558748368c41bc50ea8ae688fffb0579693633f1ed82970917e1b46a41133af3133950dfb051c33556a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/sr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sr/firefox-63.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "1174da8c998cdd62370bb8c80c6a47360cdcc84144b03ab33f10367b5622ecf6ff3058e4f525e46ddb523f13e29b6fe557b7442dfec92956b34eaf507bd5f8c8";
+      sha512 = "e8cc283b6d87718f81a619e0c54a2e440e21940375f8eabb318d24c22b5e04fa387d27dd6b2c28c98c65a94cc8aa1966ea8c6ac346f3012df0a6f268c9aac67a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/sv-SE/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sv-SE/firefox-63.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "7c24f0d4552ca7bc3076b9b0485c757e0547713a58d09cd568e506e37dd6133c5c7a7ad3edcffdd387cc0c5661d3602f4252d778174bf78812788ad1daa9384a";
+      sha512 = "324c7b8b0b313d9de9d83f05d2e802c9733537a5bc1a77bc7335f2551f1466da9c276622a848440e7a353f944e463e1b323fea7655985cf755b38c80e17fe335";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ta/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ta/firefox-63.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "4387b1cfd77da777a3257e714b014c686ad8c5ff1edb7ba0e2d01f62621eaec92766ccc3bbeb93be45c0b414b9b31676692e75b366a7ed0fb8e0526f95126807";
+      sha512 = "6f35862c7052f55b06ffcf0205331288c4278fd2de713c57a509543a02394978a9726fe747709f4972ee2c43a5a001c0f7c5e58e63269047abcb5f4f26e78ff3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/te/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/te/firefox-63.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "8ad96e47cfc1066d27560a5ad26659dba098724374605520198d580867be3bcc05a63120865745055ef00163b8c7cb97ac35f18bfcdc3d171e7eed6a05f50855";
+      sha512 = "4a5534580d90af3f27ab1d66f54f38782179ab239ad913153660539591001db9dad409ef849df97f5f382388f559eef336c2f9245180704caf9d414e0965c17c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/th/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/th/firefox-63.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "74272739144c6ae69dba8229420894b10e0dd9d75ae386f1221b17f8e54baf8c3d921591c5707ab5d8847deedad2daa3061fff03add11a2e450fdf691dd49f9a";
+      sha512 = "1a21c20e0f410aaff94eb4dee6f26555515c0095aae9cc5e7ec8c90e57bbc73e8dd5a931b9f6fae52d5ebf7de4a3aea2176b973effe3e65e844e1936387ed8d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/tr/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/tr/firefox-63.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "0cddf14cd7a7cd4594ca04d1416b3ab32db42a287e62b68197fe8e08078999028e47074e563302c77e480d02563932d20ceffdd89c53b53c79221f3cc309e802";
+      sha512 = "1e69c3de2d1836082369994ea843e164212527a13808153b16c02e5a3986a3f11c87abbe0fb2eb9077f1273ff14cbb545856c376945a9e40143217896a444e17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/uk/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/uk/firefox-63.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "17e3d498e900ddfc4b00e3ea99b7b2f55c0252e88eede45b47b020293131d6adf5642c1bf94c39bba5b9042e2f9e20ba5399e6717e6965e65d90c4717a236832";
+      sha512 = "87c4e1b907db9bdce6d8dcd2e4c70d57a4e8ce5125473727582987c2eea25543d2d97596d0f3c776962c003f2a5356260d3d9f18410448dec4198fead5461da1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/ur/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ur/firefox-63.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "cef0ade8282d3360e27d51b4c5487882ae8dc78c598b4150cd3053cc442843cd58f5c362ed6c5ea8362517633dfbb2751a894c6cbc45bac796c181f32f095dc8";
+      sha512 = "533dc9eefd4b7604d92420333aa4f6e1b741ac545814ec1a868393e321d3e84e5d3ba475a98cf1e226b746f1f6b5b42db082d7a6d65b10971b2576e0a3d4cc69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/uz/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/uz/firefox-63.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "e8dc2b26f35f5ddbc93e4891d7b9b4dfd932ba6c7d1da19a6bec1f5c259f78c1c3105d9f2c89cd97c91f4032489f95a339ba5a22dc4daf3c948a968bf580d4bf";
+      sha512 = "e3830088e08eb8e16e6d7196e153eddc85bfb1bab3a29904aeb59c427215fdf82d7a5e50ab9db5e7abaa74b88ca7a4c002fef11883ab000b3b10814650d337e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/vi/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/vi/firefox-63.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "6dc0945c634052824326cfe8558d1eddb192dbb4eca9eac458b8cfb3680cb1cf5537dd8ff4237ed32264d730e95287d9504fd0b1528fa33907dc1a2b4558ea61";
+      sha512 = "5cfce3e3a278964aec4b8b863caa60618691fcd959009395a705b8ccbc51fb7b30adcc84de3be6e2627329d0d61fc7ab7d6c2ab15f93c255c336f327b8aa8a13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/xh/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/xh/firefox-63.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "3792ce77db9de5080437b2aad6537f00963593ff98cdd47a145ffef8243a5ea23e8cd42f82e217885601b04df4c17d833aa88b9d15cad7a6840978af3a756b05";
+      sha512 = "61630ecd035d69866d0934f3a4ef4b574c4ae1205af3c130889d1eb132066fd2068a4583eb87b9e214f033184a671bb973368faf417aaa3018e8badd16295592";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/zh-CN/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/zh-CN/firefox-63.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "8043f8900ef35f85cb05f2092829899d119e079210dcb8bd9d369c7d73ff901e80afc4eecb25421058b65e5e267f7cf671c62cdec5849c2ff0da104f4ec12ad2";
+      sha512 = "968987d12dcf4a9ac0e078132ae50b321987c990c9bd8cd3388d981c7e5dc94d26c7af14492e356d2b984badd595998bc7e9f955e0772534b5adf31886c319b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0/linux-i686/zh-TW/firefox-63.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/zh-TW/firefox-63.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "614b7835c82f80dd27c841023aca6aa8580bdadac8241f08fc053fe7657f069d6337e3edbe0bebcc4018d47f3d9f2d328176add89aacd9847393ebd21f3e9230";
+      sha512 = "286919b5f69f2585c291c0736dec6b37493a809e7e2b342743523d73e749ac4e860236da061ffb14c28452884f72055d47084fa3455898f9afee798c1ec7cdea";
     }
     ];
 }


### PR DESCRIPTION
(cherry picked from commit 213407d47116f954fd2c1327330f295aa2a64edf)

###### Motivation for this change

Version update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

