### PR TITLE
home-assistant: add support for waze, bluetooth tracker and  IFTTT

### DIFF
--- a/pkgs/development/python-modules/WazeRouteCalculator/default.nix
+++ b/pkgs/development/python-modules/WazeRouteCalculator/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, requests }:
+
+buildPythonPackage rec {
+  pname = "WazeRouteCalculator";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zmnw4198a2kvqvsz1i4a3aa20r4afp2lai6fxbpq1ppv120h857";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # there are no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Calculate actual route time and distance with Waze API";
+    homepage = https://github.com/kovacsbalu/WazeRouteCalculator;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/bt-proximity/default.nix
+++ b/pkgs/development/python-modules/bt-proximity/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, pybluez }:
+
+buildPythonPackage rec {
+  pname = "bt-proximity";
+  version = "0.0.20180217";
+
+  # pypi only has a pre-compiled wheel and no sources
+  src = fetchFromGitHub {
+    owner  = "FrederikBolding";
+    repo   = "bluetooth-proximity";
+    rev    = "463bade8a9080b47f09bf4a47830b31c69c5dffd";
+    sha256 = "0anfh90cj3c2g7zqrjvq0d6dzpb4hjl6gk8zw0r349j2zw9i4h7y";
+  };
+
+  propagatedBuildInputs = [ pybluez ];
+
+  # there are no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Bluetooth Proximity Detection using Python";
+    homepage = https://github.com/FrederikBolding/bluetooth-proximity;
+    maintainers = with maintainers; [ peterhoeg ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/pyfttt/default.nix
+++ b/pkgs/development/python-modules/pyfttt/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, requests }:
+
+buildPythonPackage rec {
+  pname = "pyfttt";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10iq7c9c832ssl2xrvf62xf7znfvqzax6sq8ppsibq6wpb8dlnj5";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # tests need a server to run against
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Package for sending events to the IFTTT Webhooks Channel";
+    homepage = https://github.com/briandconnelly/pyfttt;
+    maintainers = with maintainers; [ peterhoeg ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -326,7 +326,7 @@
     "device_tracker.automatic" = ps: with ps; [ aiohttp-cors ];
     "device_tracker.bbox" = ps: with ps; [  ];
     "device_tracker.bluetooth_le_tracker" = ps: with ps; [  ];
-    "device_tracker.bluetooth_tracker" = ps: with ps; [  ];
+    "device_tracker.bluetooth_tracker" = ps: with ps; [ bt_proximity ];
     "device_tracker.bmw_connected_drive" = ps: with ps; [  ];
     "device_tracker.bt_home_hub_5" = ps: with ps; [  ];
     "device_tracker.cisco_ios" = ps: with ps; [ pexpect ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1112,7 +1112,7 @@
     "sensor.vultr" = ps: with ps; [ vultr ];
     "sensor.waqi" = ps: with ps; [  ];
     "sensor.waterfurnace" = ps: with ps; [  ];
-    "sensor.waze_travel_time" = ps: with ps; [  ];
+    "sensor.waze_travel_time" = ps: with ps; [ WazeRouteCalculator ];
     "sensor.whois" = ps: with ps; [  ];
     "sensor.wink" = ps: with ps; [  ];
     "sensor.wirelesstag" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -20,7 +20,7 @@
     "alarm_control_panel.envisalink" = ps: with ps; [  ];
     "alarm_control_panel.homematicip_cloud" = ps: with ps; [  ];
     "alarm_control_panel.ialarm" = ps: with ps; [  ];
-    "alarm_control_panel.ifttt" = ps: with ps; [ aiohttp-cors ];
+    "alarm_control_panel.ifttt" = ps: with ps; [ aiohttp-cors pyfttt ];
     "alarm_control_panel.manual" = ps: with ps; [  ];
     "alarm_control_panel.manual_mqtt" = ps: with ps; [ paho-mqtt ];
     "alarm_control_panel.mqtt" = ps: with ps; [ paho-mqtt ];
@@ -477,7 +477,7 @@
     "hue.const" = ps: with ps; [  ];
     "hue.errors" = ps: with ps; [  ];
     "hydrawise" = ps: with ps; [  ];
-    "ifttt" = ps: with ps; [ aiohttp-cors ];
+    "ifttt" = ps: with ps; [ aiohttp-cors pyfttt ];
     "ihc" = ps: with ps; [  ];
     "ihc.const" = ps: with ps; [  ];
     "ihc.ihcdevice" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -512,6 +512,8 @@ in {
 
   pyfakefs = callPackage ../development/python-modules/pyfakefs {};
 
+  pyfttt = callPackage ../development/python-modules/pyfttt { };
+
   pygame = callPackage ../development/python-modules/pygame { };
 
   pygame-git = callPackage ../development/python-modules/pygame/git.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -696,6 +696,8 @@ in {
 
   pyunbound = callPackage ../tools/networking/unbound/python.nix { };
 
+  WazeRouteCalculator = callPackage ../development/python-modules/WazeRouteCalculator { };
+
   # packages defined here
 
   aafigure = callPackage ../development/python-modules/aafigure { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -272,6 +272,8 @@ in {
 
   browsermob-proxy = disabledIf isPy3k (callPackage ../development/python-modules/browsermob-proxy {});
 
+  bt_proximity = callPackage ../development/python-modules/bt-proximity { };
+
   bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
 
   cachecontrol = callPackage ../development/python-modules/cachecontrol { };


### PR DESCRIPTION
###### Motivation for this change

A few missing python modules needed for HA.

Status:
 - waze works
 - IFTTT was tested ages ago and worked but I'm no longer using it
 - bluetooth has not been tested yet

Cc: @dotlambda 

The ```bt_proximity``` package is pulled from GH instead of pypi as pypi only has a precompiled wheel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

