### PR TITLE
cups-filters: add all needed execve runtime paths

### DIFF
--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -35,8 +35,12 @@ in stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
+    # TODO(Profpatsch): mupdf support
     "--with-pdftops=pdftops"
     "--with-pdftops-path=${poppler_utils}/bin/pdftops"
+    "--with-gs-path=${ghostscript}/bin/gs"
+    "--with-pdftocairo-path=${poppler_utils}/bin/pdftocairo"
+    "--with-ippfind-path=${cups}/bin/ippfind"
     "--enable-imagefilters"
     "--with-rcdir=no"
     "--with-shell=${stdenv.shell}"


### PR DESCRIPTION
Otherwise cupsd reports errors that e.g. `gs` cannot be
found (provided it’s not available in the system closure PATH).

- [x] tested on NixOS with the cups module

cc @jgeerds 