### PR TITLE
xorg: init xf86-video-vboxvideo at 1.0.0

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -13,7 +13,8 @@ let
 
   # Map video driver names to driver packages. FIXME: move into card-specific modules.
   knownVideoDrivers = {
-    virtualbox = { modules = [ kernelPackages.virtualboxGuestAdditions ]; driverName = "vboxvideo"; };
+    # Alias so people can keep using "virtualbox" instead of "vboxvideo".
+    virtualbox = { modules = [ xorg.xf86videovboxvideo ]; driverName = "vboxvideo"; };
 
     # modesetting does not have a xf86videomodesetting package as it is included in xorgserver
     modesetting = {};
@@ -563,8 +564,6 @@ in
            else null)
           knownVideoDrivers;
       in optional (driver != null) ({ inherit name; modules = []; driverName = name; } // driver));
-
-    nixpkgs.config = optionalAttrs (elem "vboxvideo" cfg.videoDrivers) { xorg.abiCompat = "1.18"; };
 
     assertions = [
       { assertion = config.security.polkit.enable;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2470,6 +2470,19 @@ lib.makeScope newScope (self: with self; {
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
 
+  xf86videovboxvideo = callPackage ({ stdenv, pkgconfig, fetchurl, fontsproto, libpciaccess, randrproto, renderproto, xextproto, xorgserver, xproto }: stdenv.mkDerivation {
+    name = "xf86-video-vboxvideo-1.0.0";
+    builder = ./builder.sh;
+    src = fetchurl {
+      url = mirror://xorg/individual/driver/xf86-video-vboxvideo-1.0.0.tar.bz2;
+      sha256 = "195z1js3i51qgxvhfw4bxb4dw3jcrrx2ynpm2y3475dypjzs7dkz";
+    };
+    hardeningDisable = [ "bindnow" "relro" ];
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [ fontsproto libpciaccess randrproto renderproto xextproto xorgserver xproto ];
+    meta.platforms = stdenv.lib.platforms.unix;
+  }) {};
+
   xf86videovesa = callPackage ({ stdenv, pkgconfig, fetchurl, fontsproto, libpciaccess, randrproto, renderproto, xextproto, xorgserver, xproto }: stdenv.mkDerivation {
     name = "xf86-video-vesa-2.4.0";
     builder = ./builder.sh;

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -164,6 +164,7 @@ mirror://xorg/individual/driver/xf86-video-tdfx-1.4.7.tar.bz2
 mirror://xorg/individual/driver/xf86-video-tga-1.2.2.tar.bz2
 mirror://xorg/individual/driver/xf86-video-trident-1.3.8.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-video-v4l-0.2.0.tar.bz2
+mirror://xorg/individual/driver/xf86-video-vboxvideo-1.0.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-vesa-2.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-vmware-13.2.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.5.tar.bz2


### PR DESCRIPTION
... and switch to it by default in virtualbox guests

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/31889

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] **Tested execution of all binary files (usually in `./result/bin/`)**
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

