### PR TITLE
netselect: 0.3 -> 0.4

### DIFF
--- a/pkgs/tools/networking/netselect/default.nix
+++ b/pkgs/tools/networking/netselect/default.nix
@@ -1,19 +1,28 @@
-{stdenv, fetchurl}:
+{ stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
-  name = "netselect-0.3";
+stdenv.mkDerivation rec {
+  name = "netselect-${version}";
+  version = "0.4";
 
-  src = fetchurl {
-    url = http://alumnit.ca/~apenwarr/netselect/netselect-0.3.tar.gz;
-    sha256 = "0y69z59vylj9x9nk5jqn6ihx7dkzg09gpv2w1q1rs8fmi4jr90gy";
+  src = fetchFromGitHub {
+    owner = "apenwarr";
+    repo = "netselect";
+    rev = name;
+    sha256 = "1zncyvjzllrjbdvz7c50d1xjyhs9mwqfy92ndpfc5b3mxqslw4kx";
   };
 
-  preBuild = ''
-    makeFlagsArray=(PREFIX=$out)
-    substituteInPlace Makefile \
-      --replace "-o root" "" \
-      --replace "-g root" "" \
-      --replace "4755"    "0755"
+  postPatch = ''
+    substituteInPlace netselect-apt \
+      --replace "/usr/bin/" ""
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 -t $out/bin netselect netselect-apt
+    install -Dm444 -t $out/share/man/man1 *.1
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Pkg update
and fetch from GH repo since http://alumnit.ca/~apenwarr/netselect/ is gone

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

