### PR TITLE
hmmer: 3.1b2 -> 3.2.1

### DIFF
--- a/pkgs/applications/science/biology/hmmer/default.nix
+++ b/pkgs/applications/science/biology/hmmer/default.nix
@@ -1,28 +1,25 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "3.1b2";
+  version = "3.2.1";
   name = "hmmer-${version}";
 
   src = fetchurl {
-    url = "http://eddylab.org/software/hmmer3/${version}/${name}.tar.gz";
-    sha256 = "0djmgc0pfli0jilfx8hql1axhwhqxqb8rxg2r5rg07aw73sfs5nx";
+    url = "http://eddylab.org/software/hmmer/${name}.tar.gz";
+    sha256 = "171bivy6xhgjsz5nv53n81pc3frnwz29ylblawk2bv46szwjjqd5";
   };
 
   meta = with stdenv.lib; {
     description = "Biosequence analysis using profile hidden Markov models";
     longDescription = ''
-HMMER is used for searching sequence databases for sequence homologs, and for making sequence alignments. It implements methods using probabilistic models called profile hidden Markov models (profile HMMs).
-
-HMMER is often used together with a profile database, such as Pfam or many of the databases that participate in Interpro. But HMMER can also work with query sequences, not just profiles, just like BLAST. For example, you can search a protein query sequence against a database with phmmer, or do an iterative search with jackhmmer.
-
-HMMER is designed to detect remote homologs as sensitively as possible, relying on the strength of its underlying probability models. In the past, this strength came at significant computational expense, but as of the new HMMER3 project, HMMER is now essentially as fast as BLAST.
-
-HMMER can be downloaded and installed as a command line tool on your own hardware, and now it is also more widely accessible to the scientific community via new search servers at the European Bioinformatics Institute.
+      HMMER is used for searching sequence databases for sequence homologs, and for making sequence alignments. It implements methods using probabilistic models called profile hidden Markov models (profile HMMs).
+      HMMER is often used together with a profile database, such as Pfam or many of the databases that participate in Interpro. But HMMER can also work with query sequences, not just profiles, just like BLAST. For example, you can search a protein query sequence against a database with phmmer, or do an iterative search with jackhmmer.
+      HMMER is designed to detect remote homologs as sensitively as possible, relying on the strength of its underlying probability models. In the past, this strength came at significant computational expense, but as of the new HMMER3 project, HMMER is now essentially as fast as BLAST.
+      HMMER can be downloaded and installed as a command line tool on your own hardware, and now it is also more widely accessible to the scientific community via new search servers at the European Bioinformatics Institute.
     '';
     homepage = http://hmmer.org/;
     license = licenses.gpl3;
     maintainers = [ maintainers.iimog ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This version was released in June 2018 and has many bug fixes
and improvements compared to the previous version from 2015.
See: https://cryptogenomicon.org/2018/06/07/hmmer-3-2-release/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

