### PR TITLE
python3Packages.async_generator: fix build on python3.5

### DIFF
--- a/pkgs/development/python-modules/async_generator/default.nix
+++ b/pkgs/development/python-modules/async_generator/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder, pytest, pytest-asyncio }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy35, pytest, pytest-asyncio }:
 
 buildPythonPackage rec {
   pname = "async_generator";
@@ -16,6 +16,9 @@ buildPythonPackage rec {
   checkPhase = ''
     pytest -W error -ra -v --pyargs async_generator
   '';
+
+  # disable tests on python3.5 to avoid circular dependency with pytest-asyncio
+  doCheck = !isPy35;
 
   meta = with lib; {
     description = "Async generators and context managers for Python 3.5+";

--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest, isPy3k }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, isPy3k, isPy35, async_generator }:
 buildPythonPackage rec {
   pname = "pytest-asyncio";
   version = "0.9.0";
@@ -10,7 +10,8 @@ buildPythonPackage rec {
     sha256 = "fbd92c067c16111174a1286bfb253660f1e564e5146b39eeed1133315cf2c2cf";
   };
 
-  buildInputs = [ pytest ];
+  buildInputs = [ pytest ]
+    ++ stdenv.lib.optionals isPy35 [ async_generator ];
 
   # No tests in archive
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

fixes #50271

async_generator is supported on python3.5 https://pypi.org/project/async_generator/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

