### PR TITLE
lib2geom: init at 1.0

### DIFF
--- a/pkgs/applications/graphics/inkscape/1.0.nix
+++ b/pkgs/applications/graphics/inkscape/1.0.nix
@@ -1,0 +1,157 @@
+{ stdenv
+, fetchFromGitLab
+, substituteAll
+, boehmgc
+, boost
+, cmake
+, double-conversion
+, gdl
+, gettext
+, glib
+, glib-networking
+, glibmm
+, gsl
+, gtkspell3
+, gtkmm3
+, harfbuzz
+, hicolor-icon-theme
+, imagemagick
+, lcms2
+, libcdr
+, libexif
+, libpng
+, librevenge
+, librsvg
+, libsigcxx
+, libsoup
+, libvisio
+, libwpg
+, libXft
+, libxml2
+, libxslt
+, ninja
+, perlPackages
+, pkg-config
+, poppler
+, popt
+, potrace
+, python3
+, wrapGAppsHook
+, zlib
+}:
+let
+  python3Env = python3.withPackages
+    (ps: with ps; [
+      numpy
+      lxml
+      scour
+    ]);
+
+  extensions = fetchFromGitLab {
+    owner = "inkscape";
+    repo = "extensions";
+    rev = "cc4bedea16a964d91596cae5808664b13a2535c9";
+    sha256 = "RlY3nAm0IYxTWWmCMXvqxQnIbkv3V7xyBJ5z0vXqPrI=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "inkscape";
+  version = "1.0-rc1";
+
+  src = fetchFromGitLab {
+    owner = "inkscape";
+    repo = "inkscape";
+    rev = stdenv.lib.toUpper (stdenv.lib.replaceStrings [ "-" "." ] [ "_" "_" ] "${pname}-${version}");
+    sha256 = "m83hz0NJhYYA+hHDkkbWrlrp/kF4/+m45acw3ZYIm5w=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      # Python is used at run-time to execute scripts, e.g., those from
+      # the "Effects" menu.
+      python = "${python3Env}/bin/python";
+    })
+  ];
+
+  # Inkscape hits the ARGMAX when linking on macOS. It appears to be
+  # CMake’s ARGMAX check doesn’t offer enough padding for NIX_LDFLAGS.
+  # Setting strictDeps it avoids duplicating some dependencies so it
+  # will leave us under ARGMAX.
+  strictDeps = true;
+
+  postPatch = ''
+    cp -r ${extensions}/* share/extensions
+
+    patchShebangs \
+      man/fix-roff-punct \
+      share/templates/create_defaults.pl
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    ninja
+    wrapGAppsHook
+    python3Env
+    gettext
+  ] ++ (with perlPackages; [
+    perl
+    XMLParser
+  ]);
+
+  buildInputs = [
+    boehmgc
+    boost
+    double-conversion
+    gdl
+    glib
+    glib-networking
+    glibmm
+    gsl
+    gtkspell3
+    gtkmm3
+    harfbuzz
+    hicolor-icon-theme
+    imagemagick
+    lcms2
+    libcdr
+    libexif
+    libpng
+    librevenge
+    librsvg # for loading icons
+    libsigcxx
+    libsoup
+    libvisio
+    libwpg
+    libXft
+    libxml2
+    libxslt
+    perlPackages.perl
+    poppler
+    popt
+    potrace
+    python3Env
+    zlib
+  ];
+
+  # Make sure PyXML modules can be found at run-time.
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -change $out/lib/libinkscape_base.dylib $out/lib/inkscape/libinkscape_base.dylib $out/bin/inkscape
+    install_name_tool -change $out/lib/libinkscape_base.dylib $out/lib/inkscape/libinkscape_base.dylib $out/bin/inkview
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Vector graphics editor";
+    homepage = https://www.inkscape.org;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.all;
+    longDescription = ''
+      Inkscape is a feature-rich vector graphics editor that edits
+      files in the W3C SVG (Scalable Vector Graphics) file format.
+
+      If you want to import .eps files install ps2edit.
+    '';
+  };
+}

--- a/pkgs/applications/graphics/inkscape/fix-paths.patch
+++ b/pkgs/applications/graphics/inkscape/fix-paths.patch
@@ -1,0 +1,17 @@
+diff --git a/src/extension/implementation/script.cpp b/src/extension/implementation/script.cpp
+index b3e4492de..48e509729 100644
+--- a/src/extension/implementation/script.cpp
++++ b/src/extension/implementation/script.cpp
+@@ -77,10 +77,10 @@ Script::interpreter_t const Script::interpreterTab[] = {
+         { "python", "python-interpreter", "pythonw" },
+ #elif defined __APPLE__
+         { "perl",   "perl-interpreter",   "perl"    },
+-        { "python", "python-interpreter", "python3" },
++        { "python", "python-interpreter", "@python@" },
+ #else
+         { "perl",   "perl-interpreter",   "perl"    },
+-        { "python", "python-interpreter", "python"  },
++        { "python", "python-interpreter", "@python@"  },
+ #endif
+         { "ruby",   "ruby-interpreter",   "ruby"    },
+         { "shell",  "shell-interpreter",  "sh"      },

--- a/pkgs/development/libraries/lib2geom/default.nix
+++ b/pkgs/development/libraries/lib2geom/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, ninja
+, pkg-config
+, boost
+, glib
+, gsl
+, cairo
+, double-conversion
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lib2geom-unstable";
+  version = "2020-03-12";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitLab {
+    owner = "inkscape";
+    repo = "lib2geom";
+    rev = "226eb8c60f2af639d74a0229c0ba90e649e6451d";
+    sha256 = "BSuqasBfig6HiKY/xtJm7CjbSaV8cW45ip59iEO5Es4=";
+  };
+
+  patches = [
+    # Re-enable assertions for tests to work
+    # https://gitlab.com/inkscape/lib2geom/issues/5
+    # https://gitlab.com/inkscape/lib2geom/merge_requests/17
+    (fetchpatch {
+      url = "https://gitlab.com/inkscape/lib2geom/commit/4aa78f52232682b353eb15c219171e466987bac7.patch";
+      sha256 = "XsX8SPft0RwDemJujc8lierBe4s3iw8YkW4CSlY5LsY=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    glib
+    gsl
+    cairo
+    double-conversion
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeBuildType = "RelWithDebugInfo"; # needed to keep assertions for tests working
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Easy to use 2D geometry library in C++";
+    homepage = "https://gitlab.com/inkscape/lib2geom";
+    license = [ licenses.lgpl21 licenses.mpl11 ];
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20039,6 +20039,8 @@ in
     lcms = lcms2;
   };
 
+  inkscape1 = callPackage ../applications/graphics/inkscape/1.0.nix { };
+
   inspectrum = libsForQt5.callPackage ../applications/radio/inspectrum { };
 
   ion3 = callPackage ../applications/window-managers/ion-3 {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12330,6 +12330,8 @@ in
 
   leptonica = callPackage ../development/libraries/leptonica { };
 
+  lib2geom = callPackage ../development/libraries/lib2geom { };
+
   lib3ds = callPackage ../development/libraries/lib3ds { };
 
   lib3mf = callPackage ../development/libraries/lib3mf { };


### PR DESCRIPTION
###### Motivation for this change
https://inkscape.org/news/2018/11/11/graphics-math-library-2geoms-first-release-availab/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

