### PR TITLE
glibc: Add helpful comment.

### DIFF
--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -10,6 +10,12 @@ callPackage ./common.nix { inherit stdenv; } {
 
     inherit withLinuxHeaders profilingLibraries installLocales withGd;
 
+    # Note:
+    # Things you write here override, and do not add to,
+    # the values in `common.nix`.
+    # (For example, if you define `patches = [...]` here, it will
+    # override the patches in `common.nix`.)
+
     NIX_NO_SELF_RPATH = true;
 
     postConfigure = ''


### PR DESCRIPTION
This is a comment-only-change.


Intended to avoid contributor confusion as in #50231.


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---