### PR TITLE
flex_2_6_1: delete in favor of flex 2.6.4

### DIFF
--- a/pkgs/servers/nas/default.nix
+++ b/pkgs/servers/nas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, imake, bison, flex_2_6_1, gccmakedep
+{ stdenv, fetchurl, imake, bison, flex, gccmakedep
 , xproto, libXau, libXt, libXext, libXaw, libXpm, xorgcffiles }:
 
 let
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     sha256 = "17dk0ckm6mp1ajc0cd6bwyi638ynw2f6bhbn7gynrs0wfmiyldng";
   };
 
-  nativeBuildInputs = [ imake bison flex_2_6_1 gccmakedep ];
+  nativeBuildInputs = [ imake bison flex gccmakedep ];
 
   buildInputs = [ xproto libXau libXt libXext libXaw libXpm ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8510,7 +8510,6 @@ with pkgs;
   jdepend = callPackage ../development/tools/analysis/jdepend { };
 
   flex_2_5_35 = callPackage ../development/tools/parsing/flex/2.5.35.nix { };
-  flex_2_6_1 = callPackage ../development/tools/parsing/flex/2.6.1.nix { };
   flex = callPackage ../development/tools/parsing/flex { };
 
   flexcpp = callPackage ../development/tools/parsing/flexc++ { };


### PR DESCRIPTION
###### Motivation for this change

There is no need for `flex_2_6_1`: its last user `nas` builds with `flex`, currently at 2.6.4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
