### PR TITLE
ocamlPackages.ocp-index: 1.1.6 -> 1.1.7

### DIFF
--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
 
-  version = "1.1.6";
+  version = "1.1.7";
   name = "ocaml${ocaml.version}-ocp-index-${version}";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "ocp-index";
     rev = version;
-    sha256 = "0p367aphz9w71qbm3y47qwhgqmyai28l96i1ifb6kg7awph5qmj3";
+    sha256 = "0i50y033y78wcfgz3b81d34p98azahl94w4b63ac0zyczlwlhvkf";
   };
 
   buildInputs = [ ocaml findlib dune ocp-build cmdliner re ];


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml 4.07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

