### PR TITLE
nodePackages.cpy-cli: init at 2.0.0

### DIFF
--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -13,13 +13,13 @@ let
         sha512 = "nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==";
       };
     };
-    "ajv-5.5.2" = {
+    "ajv-6.5.5" = {
       name = "ajv";
       packageName = "ajv";
-      version = "5.5.2";
+      version = "6.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz";
-        sha1 = "73b5eeca3fab653e3d3f9422b341ad42205dc965";
+        url = "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz";
+        sha512 = "7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==";
       };
     };
     "ansi-regex-2.1.1" = {
@@ -254,15 +254,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz";
         sha512 = "qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==";
-      };
-    };
-    "co-4.6.0" = {
-      name = "co";
-      packageName = "co";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/co/-/co-4.6.0.tgz";
-        sha1 = "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184";
       };
     };
     "code-point-at-1.1.0" = {
@@ -508,13 +499,13 @@ let
         sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
       };
     };
-    "fast-deep-equal-1.1.0" = {
+    "fast-deep-equal-2.0.1" = {
       name = "fast-deep-equal";
       packageName = "fast-deep-equal";
-      version = "1.1.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
-        sha1 = "c053477817c86b51daa853c81e059b733d023614";
+        url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz";
+        sha1 = "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49";
       };
     };
     "fast-json-stable-stringify-2.0.0" = {
@@ -715,13 +706,13 @@ let
         sha1 = "a94c2224ebcac04782a0d9035521f24735b7ec92";
       };
     };
-    "har-validator-5.1.0" = {
+    "har-validator-5.1.3" = {
       name = "har-validator";
       packageName = "har-validator";
-      version = "5.1.0";
+      version = "5.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz";
-        sha512 = "+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==";
+        url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz";
+        sha512 = "sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==";
       };
     };
     "has-unicode-2.0.1" = {
@@ -1075,13 +1066,13 @@ let
         sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
       };
     };
-    "json-schema-traverse-0.3.1" = {
+    "json-schema-traverse-0.4.1" = {
       name = "json-schema-traverse";
       packageName = "json-schema-traverse";
-      version = "0.3.1";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz";
-        sha1 = "349a6d44c53a51de89b40805c5d5e59b417d3340";
+        url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
+        sha512 = "xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
       };
     };
     "json-stringify-safe-5.0.1" = {
@@ -1422,7 +1413,7 @@ let
       packageName = "os-homedir";
       version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz";
+        url = "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz";
         sha1 = "ffbc4988336e0e833de0c168c7ef152121aa7fb3";
       };
     };
@@ -1431,7 +1422,7 @@ let
       packageName = "os-tmpdir";
       version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
+        url = "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
         sha1 = "bbe67406c79aa85c5cfec766fe5734555dfa1274";
       };
     };
@@ -1476,7 +1467,7 @@ let
       packageName = "path-is-absolute";
       version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
+        url = "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
         sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
       };
     };
@@ -1550,6 +1541,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz";
         sha1 = "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e";
+      };
+    };
+    "punycode-2.1.1" = {
+      name = "punycode";
+      packageName = "punycode";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz";
+        sha512 = "XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==";
       };
     };
     "qs-6.5.2" = {
@@ -1885,13 +1885,13 @@ let
         sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     };
-    "tar-4.4.7" = {
+    "tar-4.4.8" = {
       name = "tar";
       packageName = "tar";
-      version = "4.4.7";
+      version = "4.4.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-4.4.7.tgz";
-        sha512 = "mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==";
+        url = "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz";
+        sha512 = "LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==";
       };
     };
     "to-object-path-0.3.0" = {
@@ -1973,6 +1973,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz";
         sha1 = "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559";
+      };
+    };
+    "uri-js-4.2.2" = {
+      name = "uri-js";
+      packageName = "uri-js";
+      version = "4.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz";
+        sha512 = "KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==";
       };
     };
     "urix-0.1.0" = {
@@ -2382,7 +2391,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
@@ -2396,7 +2405,6 @@ in
       sources."block-stream-0.0.9"
       sources."brace-expansion-1.1.11"
       sources."caseless-0.12.0"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.7"
       sources."concat-map-0.0.1"
@@ -2408,7 +2416,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -2419,7 +2427,7 @@ in
       sources."glob-7.1.3"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
@@ -2431,7 +2439,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."mime-db-1.37.0"
@@ -2452,7 +2460,7 @@ in
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.0"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
@@ -2467,9 +2475,14 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."tar-2.2.1"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
@@ -2575,7 +2588,7 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
-      sources."tar-4.4.7"
+      sources."tar-4.4.8"
       sources."util-deprecate-1.0.2"
       sources."wide-align-1.1.3"
       sources."wrappy-1.0.2"
@@ -2593,10 +2606,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "2.17.7";
+    version = "2.18.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.17.7.tgz";
-      sha512 = "FwZFpKSL4BNu1IGIScveHqZALpm6jSF7QR90CZXW4RfKaLpNYcIkkFC9iPBT4AdpPSv1UR/gYUWyQdTZBx2a5g==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.18.2.tgz";
+      sha512 = "yJu5pCPFmzxD9xQtWay4nI7JdcrpIIom/VwwMmUvU6itN0wAbbyIaGKz57JCu1E+ZfbOvcaOzEmifbypHfFNXw==";
     };
     buildInputs = globalBuildInputs;
     meta = {

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -13,13 +13,13 @@ let
         sha512 = "nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==";
       };
     };
-    "ajv-5.5.2" = {
+    "ajv-6.5.5" = {
       name = "ajv";
       packageName = "ajv";
-      version = "5.5.2";
+      version = "6.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz";
-        sha1 = "73b5eeca3fab653e3d3f9422b341ad42205dc965";
+        url = "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz";
+        sha512 = "7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==";
       };
     };
     "ansi-regex-2.1.1" = {
@@ -254,15 +254,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz";
         sha512 = "qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==";
-      };
-    };
-    "co-4.6.0" = {
-      name = "co";
-      packageName = "co";
-      version = "4.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/co/-/co-4.6.0.tgz";
-        sha1 = "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184";
       };
     };
     "code-point-at-1.1.0" = {
@@ -508,13 +499,13 @@ let
         sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
       };
     };
-    "fast-deep-equal-1.1.0" = {
+    "fast-deep-equal-2.0.1" = {
       name = "fast-deep-equal";
       packageName = "fast-deep-equal";
-      version = "1.1.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
-        sha1 = "c053477817c86b51daa853c81e059b733d023614";
+        url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz";
+        sha1 = "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49";
       };
     };
     "fast-json-stable-stringify-2.0.0" = {
@@ -715,13 +706,13 @@ let
         sha1 = "a94c2224ebcac04782a0d9035521f24735b7ec92";
       };
     };
-    "har-validator-5.1.0" = {
+    "har-validator-5.1.3" = {
       name = "har-validator";
       packageName = "har-validator";
-      version = "5.1.0";
+      version = "5.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz";
-        sha512 = "+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==";
+        url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz";
+        sha512 = "sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==";
       };
     };
     "has-unicode-2.0.1" = {
@@ -1075,13 +1066,13 @@ let
         sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
       };
     };
-    "json-schema-traverse-0.3.1" = {
+    "json-schema-traverse-0.4.1" = {
       name = "json-schema-traverse";
       packageName = "json-schema-traverse";
-      version = "0.3.1";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz";
-        sha1 = "349a6d44c53a51de89b40805c5d5e59b417d3340";
+        url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
+        sha512 = "xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
       };
     };
     "json-stringify-safe-5.0.1" = {
@@ -1422,7 +1413,7 @@ let
       packageName = "os-homedir";
       version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz";
+        url = "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz";
         sha1 = "ffbc4988336e0e833de0c168c7ef152121aa7fb3";
       };
     };
@@ -1431,7 +1422,7 @@ let
       packageName = "os-tmpdir";
       version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
+        url = "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz";
         sha1 = "bbe67406c79aa85c5cfec766fe5734555dfa1274";
       };
     };
@@ -1476,7 +1467,7 @@ let
       packageName = "path-is-absolute";
       version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
+        url = "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
         sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
       };
     };
@@ -1550,6 +1541,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz";
         sha1 = "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e";
+      };
+    };
+    "punycode-2.1.1" = {
+      name = "punycode";
+      packageName = "punycode";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz";
+        sha512 = "XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==";
       };
     };
     "qs-6.5.2" = {
@@ -1885,13 +1885,13 @@ let
         sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     };
-    "tar-4.4.7" = {
+    "tar-4.4.8" = {
       name = "tar";
       packageName = "tar";
-      version = "4.4.7";
+      version = "4.4.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-4.4.7.tgz";
-        sha512 = "mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==";
+        url = "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz";
+        sha512 = "LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==";
       };
     };
     "to-object-path-0.3.0" = {
@@ -1973,6 +1973,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz";
         sha1 = "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559";
+      };
+    };
+    "uri-js-4.2.2" = {
+      name = "uri-js";
+      packageName = "uri-js";
+      version = "4.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz";
+        sha512 = "KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==";
       };
     };
     "urix-0.1.0" = {
@@ -2382,7 +2391,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
@@ -2396,7 +2405,6 @@ in
       sources."block-stream-0.0.9"
       sources."brace-expansion-1.1.11"
       sources."caseless-0.12.0"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.7"
       sources."concat-map-0.0.1"
@@ -2408,7 +2416,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -2419,7 +2427,7 @@ in
       sources."glob-7.1.3"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
@@ -2431,7 +2439,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."mime-db-1.37.0"
@@ -2452,7 +2460,7 @@ in
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.0"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
@@ -2467,9 +2475,14 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."tar-2.2.1"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
@@ -2575,7 +2588,7 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
-      sources."tar-4.4.7"
+      sources."tar-4.4.8"
       sources."util-deprecate-1.0.2"
       sources."wide-align-1.1.3"
       sources."wrappy-1.0.2"
@@ -2593,10 +2606,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "2.17.7";
+    version = "2.18.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.17.7.tgz";
-      sha512 = "FwZFpKSL4BNu1IGIScveHqZALpm6jSF7QR90CZXW4RfKaLpNYcIkkFC9iPBT4AdpPSv1UR/gYUWyQdTZBx2a5g==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.18.2.tgz";
+      sha512 = "yJu5pCPFmzxD9xQtWay4nI7JdcrpIIom/VwwMmUvU6itN0wAbbyIaGKz57JCu1E+ZfbOvcaOzEmifbypHfFNXw==";
     };
     buildInputs = globalBuildInputs;
     meta = {

--- a/pkgs/development/node-packages/node-packages-v8.json
+++ b/pkgs/development/node-packages/node-packages-v8.json
@@ -12,6 +12,7 @@
 , "coinmon"
 , "configurable-http-proxy"
 , "cordova"
+, "cpy-cli"
 , "create-cycle-app"
 , "create-react-app"
 , "create-react-native-app"

--- a/pkgs/development/node-packages/node-packages-v8.nix
+++ b/pkgs/development/node-packages/node-packages-v8.nix
@@ -13,6 +13,15 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
+    "@apollographql/apollo-tools-0.2.6" = {
+      name = "_at_apollographql_slash_apollo-tools";
+      packageName = "@apollographql/apollo-tools";
+      version = "0.2.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.2.6.tgz";
+        sha512 = "IKn35EzAHFQw4x8THux+fkVLkFNs8HDzIgKqcU5ZMfkDt3MOa1nfMbGVoVh2YdvpIjPtyUR3kvAAVQwmRPRjAQ==";
+      };
+    };
     "@apollographql/apollo-upload-server-5.0.3" = {
       name = "_at_apollographql_slash_apollo-upload-server";
       packageName = "@apollographql/apollo-upload-server";
@@ -742,13 +751,13 @@ let
         sha512 = "O/IyiB5pfztCdmxQZg0/xeq5w+YiP3gtJz8d4We2EpLPKzbDVjOrtfLKYgVfm6Ya6mbvDge1uLkSRwaoVCWKnA==";
       };
     };
-    "@comandeer/babel-plugin-banner-4.0.0" = {
+    "@comandeer/babel-plugin-banner-4.1.0" = {
       name = "_at_comandeer_slash_babel-plugin-banner";
       packageName = "@comandeer/babel-plugin-banner";
-      version = "4.0.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-4.0.0.tgz";
-        sha512 = "JhkNsBm8n4Z3rU1Sl2ivPX+Gd3dBcxLUdhLrn3Yok33uBGmoT0wNspXjOgToPxFqDAHHAWj83uj7MSLEJCLpxQ==";
+        url = "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-4.1.0.tgz";
+        sha512 = "9hKVIN2+maygxkngnXDsZXRZqCYDY4pxIRljJqqJ5A+eJZzW3k/NZj5lixEmStjWFjlPlOHGYBytBehpf0l+hA==";
       };
     };
     "@commitlint/cli-7.2.1" = {
@@ -1705,13 +1714,13 @@ let
         sha512 = "A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==";
       };
     };
-    "@types/node-10.12.5" = {
+    "@types/node-10.12.6" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.12.5";
+      version = "10.12.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.12.5.tgz";
-        sha512 = "GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.12.6.tgz";
+        sha512 = "+ZWB5Ec1iki99xQFzBlivlKxSZQ+fuUKBott8StBOnLN4dWbRHlgdg1XknpW6g0tweniN5DcOqA64CJyOUPSAw==";
       };
     };
     "@types/node-8.10.37" = {
@@ -1786,31 +1795,31 @@ let
         sha512 = "r+R+5LI6IHHPI5tbOSDy5DpiY5O9eTy8LPr/QCPb5RIOg+Pg03VlElW4BL69hePXEHCQZZDsOzgItSmat6mBhg==";
       };
     };
-    "@vue/cli-ui-3.1.1" = {
+    "@vue/cli-ui-3.1.2" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.1.1.tgz";
-        sha512 = "37L4nuV3dgsgI14Ry2EeSRlhLoY3WU1jQ0YcMpnk/uHpXA3hblWK7iixrQNkC0nftt2S8NTzOJFmCfRFisUgLQ==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.1.2.tgz";
+        sha512 = "PvadRrLAdIPB0PVIQDdNHhUdurP6EHg3XTs66Rame71yNUyyVI+l9Wh9xz3kFYC5CBsW/UrrdMJqU/ejXww17w==";
       };
     };
-    "@vue/cli-ui-addon-webpack-3.1.1" = {
+    "@vue/cli-ui-addon-webpack-3.1.2" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.1.1.tgz";
-        sha512 = "ICIJKyML277EbOSPwjQGx1voKR4LTXOsM5oIqkjeH94ME6TEkVrzJwoFBMDnCRwUQ6cdDCn06D+FZY355jpVcg==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.1.2.tgz";
+        sha512 = "gob0dKcaewb/FfrhZ4qmN4KkrgVm6bfCml0zPAJZAWxUZ3PvuZ3sG9cpmYYhaC4ACBd5aOo/yys0qdGnaL29hA==";
       };
     };
-    "@vue/cli-ui-addon-widgets-3.1.1" = {
+    "@vue/cli-ui-addon-widgets-3.1.2" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.1.1.tgz";
-        sha512 = "PJCAHYb0g1BBfmDk/DLpHJFOG5RpihbTa3DVAfW3U1adlrRLMKh21t/TelryFkjRTIDqglGDCMMa5ZT1JOW3tA==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.1.2.tgz";
+        sha512 = "ZICSwa5lRfmeBySdKyL63nWUwC5QDrVm8KZDeFbxwxbSKIgeGksfKfMILDGShytKPCC5Nj99lgs6a9Ft3/jf4Q==";
       };
     };
     "@webassemblyjs/ast-1.7.11" = {
@@ -2353,13 +2362,13 @@ let
         sha512 = "rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==";
       };
     };
-    "acorn-walk-6.1.0" = {
+    "acorn-walk-6.1.1" = {
       name = "acorn-walk";
       packageName = "acorn-walk";
-      version = "6.1.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz";
-        sha512 = "ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==";
+        url = "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz";
+        sha512 = "OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==";
       };
     };
     "active-x-obfuscator-0.0.1" = {
@@ -2450,6 +2459,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz";
         sha512 = "L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==";
+      };
+    };
+    "adm-zip-0.4.13" = {
+      name = "adm-zip";
+      packageName = "adm-zip";
+      version = "0.4.13";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz";
+        sha512 = "fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==";
       };
     };
     "adm-zip-0.4.7" = {
@@ -2947,13 +2965,13 @@ let
         sha512 = "+Du0/4kUSuf5PjPx0+pvgMGV12ezbHA8/hubYuqRQoy/4AWb4faa61CgJNI6cKz2mhDd9m94VTNKTX11NntwkQ==";
       };
     };
-    "apollo-cache-control-0.3.0" = {
+    "apollo-cache-control-0.3.1" = {
       name = "apollo-cache-control";
       packageName = "apollo-cache-control";
-      version = "0.3.0";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.3.0.tgz";
-        sha512 = "XtkinmravL9/IEAPXzJod9fKx4iesS0TNBV/619xwurv8eopZkbAiKVZ3WB4rbjoGQpBgEs0bekWIAhYGWLyOw==";
+        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.3.1.tgz";
+        sha512 = "k5jIdTEaFbxwsx7kqTfzwWF32zS1qfY2RNby0/z2AYD5Xn37fpfS1cn+CA0SgJC944G/4ybmOlKcmLjqAVU41g==";
       };
     };
     "apollo-cache-inmemory-1.3.9" = {
@@ -2992,13 +3010,13 @@ let
         sha512 = "WJM9Ix3uogIfAG7mjL1NZQM9+45rcikn4mPWhE1Iuyw2+Y857J3uKJqQgF5h9Fg64SlCJh9u5WL3N7N5mg1fVw==";
       };
     };
-    "apollo-engine-reporting-0.1.0" = {
+    "apollo-engine-reporting-0.1.1" = {
       name = "apollo-engine-reporting";
       packageName = "apollo-engine-reporting";
-      version = "0.1.0";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.1.0.tgz";
-        sha512 = "OjG9MmNWRS3ZMSDc44Z6QMFQ66VDzs/E4H1yZELZ77BVrLsDx4i8Fft95byywACUpLvXhrCRtOdSZIwRPDq+cw==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.1.1.tgz";
+        sha512 = "HlUvOH+BLwhYVECY+FMivInInkA9EhtIIkTm/grqTKcrqCk8qcWHIPW1vXFt5qgAMfXnYIXuf4/xRz9fgsOyXw==";
       };
     };
     "apollo-engine-reporting-protobuf-0.1.0" = {
@@ -3008,6 +3026,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.1.0.tgz";
         sha512 = "GReJtAYTmpwg0drb9VgFtqObYYTCHkJhlHEYCeXY8bJV4fOgXsAZ7CIXR9nPKO0mBaoHIHaGYvXGcyCLrZ36VA==";
+      };
+    };
+    "apollo-env-0.2.3" = {
+      name = "apollo-env";
+      packageName = "apollo-env";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-env/-/apollo-env-0.2.3.tgz";
+        sha512 = "7hRWPG8tWQNXCNrZsOMqxtkHGqhTzFgsw7RpFDyC1xgcZvVFCJvthWgWO07EhcaHhRqvrPxmicLnoTw2e/iCsA==";
       };
     };
     "apollo-link-1.2.3" = {
@@ -3082,13 +3109,13 @@ let
         sha512 = "/v7xWEcyyahs3hwX4baH/GekuHz3LRt9NoIYwg869G1eeqjuwY6NsowRIujZ100anJQwm9v5A9/sLtHBFvbgYg==";
       };
     };
-    "apollo-server-core-2.2.0" = {
+    "apollo-server-core-2.2.1" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.2.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.2.0.tgz";
-        sha512 = "Pd9YpC/xSzpVOr6KM5bDHQdcI8jjKu3hb8x7eyevh/Q7eyrF+ClmfPZvY5EnG4ETIJsTS0+fU1dnoGMmyxCBKw==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.2.1.tgz";
+        sha512 = "/oj5EN3g81gXfRQWqNbnBW3hNrqA5/3F3AbOxOaZVgWVTK6PS+GN1Yn9DZURMYBKiEo8HU35ioLL9kdP95XWsg==";
       };
     };
     "apollo-server-env-2.2.0" = {
@@ -3109,31 +3136,31 @@ let
         sha512 = "gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg==";
       };
     };
-    "apollo-server-express-2.2.0" = {
+    "apollo-server-express-2.2.1" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.2.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.2.0.tgz";
-        sha512 = "E6WpImvCHKR9MHs64gTHhMrehk6/1NRE2+bblsHZg7ot8Iy6hVmzsCIzSmlPYh5uozpcyeRdC1pV0nwERtQKog==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.2.1.tgz";
+        sha512 = "Ow8Ff8KbqZ8ljNQLwHHYSdKIgbJDo/x8zb00jK5fJ4GAJaIwV4OEgvGM+/uPWAAEgLoTCFDIV+vfqG26yfECCA==";
       };
     };
-    "apollo-server-plugin-base-0.1.0" = {
+    "apollo-server-plugin-base-0.1.1" = {
       name = "apollo-server-plugin-base";
       packageName = "apollo-server-plugin-base";
-      version = "0.1.0";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.1.0.tgz";
-        sha512 = "ptaVBjR+Q1swdzsh84tY5Qb0yyTMO/IOBsBJzCdxuAKs+PAVFw7ZMQoe5bT0DJjKJXHjtfMiTF77mRLLBq2dEw==";
+        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.1.1.tgz";
+        sha512 = "ELs4LorMiQhBk9hWjlCAyLIMcWiu6+LFD3xAoOxpqvY7s2sj+0GCH763gRyBkcglPwyI+SazjLz9NERqFQT3wA==";
       };
     };
-    "apollo-tracing-0.3.0" = {
+    "apollo-tracing-0.3.1" = {
       name = "apollo-tracing";
       packageName = "apollo-tracing";
-      version = "0.3.0";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.3.0.tgz";
-        sha512 = "fkSpvzldDo1jBFap0d5lJYghEiH55eRVQzrC6vGvwr7rZNK5Moznwn9sBqy+4QsOaIp+wYc6pz/a+hwG4pasig==";
+        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.3.1.tgz";
+        sha512 = "xMWYN0/ZPZcmu/GB5g4O+gvF8iNh0wjaK7fliVYFjC4jGEFkj6yUkLVnAXkln1mjSUgTbOJNCOejvhG4Vwe2zQ==";
       };
     };
     "apollo-upload-client-9.1.0" = {
@@ -4018,13 +4045,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.353.0" = {
+    "aws-sdk-2.354.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.353.0";
+      version = "2.354.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.353.0.tgz";
-        sha512 = "c5MwJhfcHwA2lC1Wq9csQvP9gz8dVGpZ64s5j9f/sWY6eZiDCQ6OWjxj+VJfpnCmfxyC/pdZO7JDGwems7dqIQ==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.354.0.tgz";
+        sha512 = "5X3Iz2sm+oC1pgJ5mgCBVo1zzQtXR0GGUhHRats43GTVoMmH9UyHWqPPifPwDHtwbU2qO1J/Up8ks6mJLdKNUw==";
       };
     };
     "aws-sign-0.2.1" = {
@@ -6574,13 +6601,13 @@ let
         sha1 = "0d808801b6342ad33c91df9d0b44dc09b91e5c3d";
       };
     };
-    "cacheable-request-5.1.0" = {
+    "cacheable-request-5.2.0" = {
       name = "cacheable-request";
       packageName = "cacheable-request";
-      version = "5.1.0";
+      version = "5.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cacheable-request/-/cacheable-request-5.1.0.tgz";
-        sha512 = "UCdjX4N/QjymZGpKY7hW4VJsxsVJM+drIiCxPa9aTvFQN5sL2+kJCYyeys8f2W0dJ0sU6Et54Ovl0sAmCpHHsA==";
+        url = "https://registry.npmjs.org/cacheable-request/-/cacheable-request-5.2.0.tgz";
+        sha512 = "h1n0vjpFaByTvU6PiyTKk2kx4OnuV1aVUynCUd/FiKl4icpPSceowk3rHczwFEBuZvz+E1EU4KExR0MCPeQfaQ==";
       };
     };
     "cached-path-relative-1.0.2" = {
@@ -7447,13 +7474,13 @@ let
         sha1 = "a211e09c6a3de3ba1af27d049d301250d18812bc";
       };
     };
-    "clipboard-2.0.1" = {
+    "clipboard-2.0.4" = {
       name = "clipboard";
       packageName = "clipboard";
-      version = "2.0.1";
+      version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz";
-        sha512 = "7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==";
+        url = "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz";
+        sha512 = "Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==";
       };
     };
     "clipboardy-1.2.3" = {
@@ -9041,6 +9068,15 @@ let
         sha512 = "RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==";
       };
     };
+    "core-js-3.0.0-beta.3" = {
+      name = "core-js";
+      packageName = "core-js";
+      version = "3.0.0-beta.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.0.0-beta.3.tgz";
+        sha512 = "kM/OfrnMThP5PwGAj5HhQLdjUqzjrllqN2EVnk/X9qrLsfYjR2hzZ+E/8CzH0xuosexZtqMTLQrk//BULrBj9w==";
+      };
+    };
     "core-util-is-1.0.2" = {
       name = "core-util-is";
       packageName = "core-util-is";
@@ -9129,6 +9165,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/count-trailing-zeros/-/count-trailing-zeros-1.0.1.tgz";
         sha1 = "aba6c5833be410d45b1eca3e6d583844ce682c77";
+      };
+    };
+    "cp-file-6.0.0" = {
+      name = "cp-file";
+      packageName = "cp-file";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cp-file/-/cp-file-6.0.0.tgz";
+        sha512 = "OtHMgPugkgwHlbph25wlMKd358lZNhX1Y2viUpPoFmlBPlEiPIRhztYWha11grbGPnlM+urp5saVmwsChCIOEg==";
+      };
+    };
+    "cpy-7.0.1" = {
+      name = "cpy";
+      packageName = "cpy";
+      version = "7.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cpy/-/cpy-7.0.1.tgz";
+        sha512 = "Zo52tXKLJcgy/baacn6KaNoRAakkl2wb+R4u6qJ4wlD0uchncwRQcIk66PlGlkzuToCJO6A6PWX27Tdwc8LU2g==";
       };
     };
     "crc-0.2.0" = {
@@ -13146,13 +13200,13 @@ let
         sha1 = "8435a9aaa02d79248d17d704e76259301d99280a";
       };
     };
-    "fast-glob-2.2.3" = {
+    "fast-glob-2.2.4" = {
       name = "fast-glob";
       packageName = "fast-glob";
-      version = "2.2.3";
+      version = "2.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.3.tgz";
-        sha512 = "NiX+JXjnx43RzvVFwRWfPKo4U+1BrK5pJPsHQdKMlLoFHrrGktXglQhHliSihWAq+m1z6fHk3uwGHrtRbS9vLA==";
+        url = "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz";
+        sha512 = "FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==";
       };
     };
     "fast-json-parse-1.0.3" = {
@@ -14964,15 +15018,6 @@ let
         sha1 = "9e6af6299d8d3bd2bd40430832bd113df906c5ae";
       };
     };
-    "glob-slash-1.0.0" = {
-      name = "glob-slash";
-      packageName = "glob-slash";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob-slash/-/glob-slash-1.0.0.tgz";
-        sha1 = "fe52efa433233f74a2fe64c7abb9bc848202ab95";
-      };
-    };
     "glob-stream-3.1.18" = {
       name = "glob-stream";
       packageName = "glob-stream";
@@ -15109,13 +15154,13 @@ let
         sha512 = "glWGTgPzsOQs0mPRxHnWIwqYrEuQcxYpUFWF7BJxJL+c2F4fW304vdn53pqgod4PzOqZKDr1cex+a/pXCwrncA==";
       };
     };
-    "globals-11.8.0" = {
+    "globals-11.9.0" = {
       name = "globals";
       packageName = "globals";
-      version = "11.8.0";
+      version = "11.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz";
-        sha512 = "io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==";
+        url = "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz";
+        sha512 = "5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==";
       };
     };
     "globals-9.18.0" = {
@@ -15397,13 +15442,13 @@ let
         sha512 = "7Qh3TzZS3hwZpJbTNfTHXBM6UbzV7DMik9Mc95Rz76yTAs7Wr83xBFsH4Ap1NWlqBgANfO3cLLI4YomDJmO5SA==";
       };
     };
-    "graphql-extensions-0.3.0" = {
+    "graphql-extensions-0.3.1" = {
       name = "graphql-extensions";
       packageName = "graphql-extensions";
-      version = "0.3.0";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.3.0.tgz";
-        sha512 = "+ppyD7g6acX0y2vj5hm5mRlCBngdHD2dE1jW7abAG4PAWg275TrczA3WXUxB6P9Q4uw0XA886Q+aagI5EmTSaA==";
+        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.3.1.tgz";
+        sha512 = "F0Nu7uuGYaQUogL82QzSqT1VydrwHhBIrJq/USjnCQ2WZDpIlC48jrVuIHq6bOKHyNtY9U46ZPuR+STssOGLbw==";
       };
     };
     "graphql-import-0.4.5" = {
@@ -15694,13 +15739,13 @@ let
         sha1 = "ba402c266194f15956ef15e0fcf242993f6a7dfd";
       };
     };
-    "har-validator-5.1.0" = {
+    "har-validator-5.1.3" = {
       name = "har-validator";
       packageName = "har-validator";
-      version = "5.1.0";
+      version = "5.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz";
-        sha512 = "+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==";
+        url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz";
+        sha512 = "sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==";
       };
     };
     "has-1.0.3" = {
@@ -16171,13 +16216,13 @@ let
         sha512 = "Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==";
       };
     };
-    "hoek-6.0.2" = {
+    "hoek-6.0.3" = {
       name = "hoek";
       packageName = "hoek";
-      version = "6.0.2";
+      version = "6.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz";
-        sha512 = "0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA==";
+        url = "https://registry.npmjs.org/hoek/-/hoek-6.0.3.tgz";
+        sha512 = "TU6RyZ/XaQCTWRLrdqZZtZqwxUVr6PDMfi6MlWNURZ7A6czanQqX4pFE1mdOUQR9FdPCsZ0UzL8jI/izZ+eBSQ==";
       };
     };
     "hogan.js-3.0.2" = {
@@ -19872,22 +19917,22 @@ let
         sha1 = "51a1a9e7448ecbd32cda54421675bb21bc093da6";
       };
     };
-    "libnested-1.3.2" = {
+    "libnested-1.4.0" = {
       name = "libnested";
       packageName = "libnested";
-      version = "1.3.2";
+      version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libnested/-/libnested-1.3.2.tgz";
-        sha512 = "YvMQglpk/DyB8vFL5usJe6IZTqOU/fRopoUpoOt9TavYh5CaGdTp6zYqrA7DW8tHmZAr8fj+pDXbHBwlVrcVXQ==";
+        url = "https://registry.npmjs.org/libnested/-/libnested-1.4.0.tgz";
+        sha512 = "txW/cdkfe0eYhIfLbZl8pfkMu2NWEVWAuDAaiDawahx1hqTaDVoFbjISdWgU24XUI/10kBjJYDsisoPSMJKnpw==";
       };
     };
-    "libnpmaccess-3.0.0" = {
+    "libnpmaccess-3.0.1" = {
       name = "libnpmaccess";
       packageName = "libnpmaccess";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.0.tgz";
-        sha512 = "SiE4AZAzMpD7pmmXHfgD7rof8QIQGoKaeyAS8exgx2CKA6tzRTbRljq1xM4Tgj8/tIg+KBJPJWkR0ifqKT3irQ==";
+        url = "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz";
+        sha512 = "RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==";
       };
     };
     "libqp-1.1.0" = {
@@ -22680,13 +22725,13 @@ let
         sha1 = "23215833f1da13fd606ccb8087b44852dcb821fd";
       };
     };
-    "module-deps-6.1.0" = {
+    "module-deps-6.2.0" = {
       name = "module-deps";
       packageName = "module-deps";
-      version = "6.1.0";
+      version = "6.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/module-deps/-/module-deps-6.1.0.tgz";
-        sha512 = "NPs5N511VD1rrVJihSso/LiBShRbJALYBKzDW91uZYy7BpjnO4bGnZL3HjZ9yKcFdZUWwaYjDz9zxbuP7vKMuQ==";
+        url = "https://registry.npmjs.org/module-deps/-/module-deps-6.2.0.tgz";
+        sha512 = "hKPmO06so6bL/ZvqVNVqdTVO8UAYsi3tQWlCa+z9KuWhoN4KDQtb5hcqQQv58qYiDE21wIvnttZEPiDgEbpwbA==";
       };
     };
     "mold-source-map-0.4.0" = {
@@ -23729,6 +23774,15 @@ let
         sha512 = "MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==";
       };
     };
+    "nested-error-stacks-2.1.0" = {
+      name = "nested-error-stacks";
+      packageName = "nested-error-stacks";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz";
+        sha512 = "AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==";
+      };
+    };
     "net-browserify-alt-1.1.0" = {
       name = "net-browserify-alt";
       packageName = "net-browserify-alt";
@@ -23909,13 +23963,13 @@ let
         sha1 = "ab884e8e7e57e38a944753cec706f788d1768bb5";
       };
     };
-    "node-fetch-2.2.1" = {
+    "node-fetch-2.3.0" = {
       name = "node-fetch";
       packageName = "node-fetch";
-      version = "2.2.1";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz";
-        sha512 = "ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ==";
+        url = "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz";
+        sha512 = "MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==";
       };
     };
     "node-fetch-npm-2.0.2" = {
@@ -24828,13 +24882,13 @@ let
         sha1 = "7e7d858b781bd7c991a41ba975ed3812754e998c";
       };
     };
-    "object-hash-1.3.0" = {
+    "object-hash-1.3.1" = {
       name = "object-hash";
       packageName = "object-hash";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz";
-        sha512 = "05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ==";
+        url = "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz";
+        sha512 = "OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==";
       };
     };
     "object-inspect-1.6.0" = {
@@ -30752,13 +30806,13 @@ let
         sha1 = "935d240cdfe0f5805307fdfe967d88942a2cbcf0";
       };
     };
-    "serve-handler-5.0.3" = {
+    "serve-handler-5.0.7" = {
       name = "serve-handler";
       packageName = "serve-handler";
-      version = "5.0.3";
+      version = "5.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serve-handler/-/serve-handler-5.0.3.tgz";
-        sha512 = "qtIOHXC+pgEQO+bMwtcQBP3IjuKH5vXwnTb0J9SzTORDqGHvQmPXO3v/DEIEHI1oENWLmbDRBezRnJiw3t/2nA==";
+        url = "https://registry.npmjs.org/serve-handler/-/serve-handler-5.0.7.tgz";
+        sha512 = "PuLoJHAO2jj3p1fYWfXVHsEqNesx1+h+6qj0FIWrCe526ZtpDqeYuKA4knE5pjK9xoOVShoB+qGOP93EY46xEw==";
       };
     };
     "serve-index-1.7.3" = {
@@ -30946,7 +31000,7 @@ let
       packageName = "shelljs";
       version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz";
+        url = "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz";
         sha1 = "3596e6307a781544f591f37da618360f31db57b1";
       };
     };
@@ -30955,7 +31009,7 @@ let
       packageName = "shelljs";
       version = "0.5.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz";
+        url = "http://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz";
         sha1 = "c54982b996c76ef0c1e6b59fbdc5825f5b713113";
       };
     };
@@ -32998,7 +33052,7 @@ let
       packageName = "streamline";
       version = "0.10.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/streamline/-/streamline-0.10.17.tgz";
+        url = "http://registry.npmjs.org/streamline/-/streamline-0.10.17.tgz";
         sha1 = "fa2170da74194dbd0b54f756523f0d0d370426af";
       };
     };
@@ -33007,7 +33061,7 @@ let
       packageName = "streamline";
       version = "0.4.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/streamline/-/streamline-0.4.11.tgz";
+        url = "http://registry.npmjs.org/streamline/-/streamline-0.4.11.tgz";
         sha1 = "0e3c4f24a3f052b231b12d5049085a0a099be782";
       };
     };
@@ -36720,6 +36774,15 @@ let
         sha512 = "3bB+Vc4kqvZYF8NW9D77HcIQpqwfLM3MvQEDjRvKEFeN+ZdJ9jtmcg+CUPm7li6xMkYWyFJcOSyI8kMYRfYFcw==";
       };
     };
+    "vue-cli-version-marker-3.1.2" = {
+      name = "vue-cli-version-marker";
+      packageName = "vue-cli-version-marker";
+      version = "3.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vue-cli-version-marker/-/vue-cli-version-marker-3.1.2.tgz";
+        sha512 = "aQe0I6AlB/RYw7C79wPjP+CuloWCcWHecfBiEB1K7Wxj73ybEE3tRmCkVDkp0nK7ix8XXQXwU5DhS2RZ1ooVnw==";
+      };
+    };
     "walk-2.3.14" = {
       name = "walk";
       packageName = "walk";
@@ -38281,7 +38344,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."asynckit-0.4.0"
@@ -38295,7 +38358,6 @@ in
       sources."caseless-0.12.0"
       sources."chainsaw-0.1.0"
       sources."chromium-pickle-js-0.2.0"
-      sources."co-4.6.0"
       sources."combined-stream-1.0.7"
       sources."commander-2.19.0"
       sources."concat-map-0.0.1"
@@ -38307,7 +38369,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -38317,7 +38379,7 @@ in
       sources."glob-6.0.4"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
@@ -38326,7 +38388,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
@@ -38345,7 +38407,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."q-1.5.1"
       sources."qs-6.5.2"
       sources."readable-stream-1.1.14"
@@ -38365,10 +38427,15 @@ in
           sources."nopt-1.0.10"
         ];
       })
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."traverse-0.3.9"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."uri-js-4.2.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
       sources."wrappy-1.0.2"
@@ -38394,7 +38461,7 @@ in
       sources."@types/node-8.10.37"
       sources."JSV-4.0.2"
       sources."adal-node-0.1.28"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."amdefine-1.0.1"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
@@ -38518,7 +38585,6 @@ in
       sources."caseless-0.11.0"
       sources."chalk-1.1.3"
       sources."clone-1.0.4"
-      sources."co-4.6.0"
       sources."colors-1.1.2"
       sources."combined-stream-1.0.7"
       sources."commander-1.0.4"
@@ -38554,7 +38620,7 @@ in
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."eyes-0.1.8"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-patch-0.5.6"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fibers-1.0.15"
@@ -38605,7 +38671,7 @@ in
       sources."jsbn-0.1.1"
       sources."json-edm-parser-0.1.2"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonlint-1.6.2"
       sources."jsonminify-0.4.1"
@@ -38699,7 +38765,7 @@ in
           sources."aws-sign2-0.7.0"
           sources."caseless-0.12.0"
           sources."form-data-2.3.3"
-          sources."har-validator-5.1.0"
+          sources."har-validator-5.1.3"
           sources."http-signature-1.2.0"
           sources."oauth-sign-0.9.0"
           sources."qs-6.5.2"
@@ -38742,6 +38808,11 @@ in
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
       sources."underscore-1.4.4"
+      (sources."uri-js-4.2.2" // {
+        dependencies = [
+          sources."punycode-2.1.1"
+        ];
+      })
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
       (sources."utile-0.2.1" // {
@@ -39015,7 +39086,7 @@ in
       sources."acorn-6.0.4"
       sources."acorn-dynamic-import-4.0.0"
       sources."acorn-node-1.6.2"
-      sources."acorn-walk-6.1.0"
+      sources."acorn-walk-6.1.1"
       sources."array-filter-0.0.1"
       sources."array-map-0.0.0"
       sources."array-reduce-0.0.0"
@@ -39104,7 +39175,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."module-deps-6.1.0"
+      sources."module-deps-6.2.0"
       sources."once-1.4.0"
       sources."os-browserify-0.3.0"
       sources."pako-1.0.6"
@@ -39722,8 +39793,8 @@ in
           sources."acorn-6.0.4"
         ];
       })
-      sources."acorn-walk-6.1.0"
-      sources."ajv-5.5.2"
+      sources."acorn-walk-6.1.1"
+      sources."ajv-6.5.5"
       sources."aliasify-2.1.0"
       sources."ansi-0.3.1"
       sources."ansi-align-2.0.0"
@@ -39801,7 +39872,6 @@ in
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-1.0.2"
       sources."cli-width-1.1.1"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -39905,7 +39975,7 @@ in
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."falafel-2.1.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."figures-1.7.0"
       sources."finalhandler-1.1.1"
@@ -39925,7 +39995,7 @@ in
       sources."got-6.7.1"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -39991,7 +40061,7 @@ in
       sources."jsbn-0.1.1"
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stable-stringify-0.0.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonify-0.0.0"
@@ -40201,6 +40271,11 @@ in
           sources."supports-color-5.5.0"
         ];
       })
+      (sources."uri-js-4.2.2" // {
+        dependencies = [
+          sources."punycode-2.1.1"
+        ];
+      })
       (sources."url-0.11.0" // {
         dependencies = [
           sources."punycode-1.3.2"
@@ -40242,6 +40317,321 @@ in
     production = true;
     bypassCache = true;
   };
+  cpy-cli = nodeEnv.buildNodePackage {
+    name = "cpy-cli";
+    packageName = "cpy-cli";
+    version = "2.0.0";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/cpy-cli/-/cpy-cli-2.0.0.tgz";
+      sha512 = "LzrtY3lBWvFZcw4lXgkEbbDUd7y78juC3C5l7gj3UyezMEZF0Be9fjCVLN1HoZAzdMDeC3KHehWpHBJvgVAPkw==";
+    };
+    dependencies = [
+      sources."@mrmlnc/readdir-enhanced-2.2.1"
+      sources."@nodelib/fs.stat-1.1.3"
+      sources."arr-diff-4.0.0"
+      sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
+      sources."array-find-index-1.0.2"
+      sources."array-union-1.0.2"
+      sources."array-uniq-1.0.3"
+      sources."array-unique-0.3.2"
+      sources."arrify-1.0.1"
+      sources."assign-symbols-1.0.0"
+      sources."atob-2.1.2"
+      sources."balanced-match-1.0.0"
+      (sources."base-0.11.2" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      sources."brace-expansion-1.1.11"
+      (sources."braces-2.3.2" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."builtin-modules-1.1.1"
+      sources."cache-base-1.0.1"
+      sources."call-me-maybe-1.0.1"
+      sources."camelcase-4.1.0"
+      sources."camelcase-keys-4.2.0"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."collection-visit-1.0.0"
+      sources."component-emitter-1.2.1"
+      sources."concat-map-0.0.1"
+      sources."copy-descriptor-0.1.1"
+      sources."cp-file-6.0.0"
+      sources."cpy-7.0.1"
+      sources."currently-unhandled-0.4.1"
+      sources."debug-2.6.9"
+      sources."decamelize-1.2.0"
+      (sources."decamelize-keys-1.1.0" // {
+        dependencies = [
+          sources."map-obj-1.0.1"
+        ];
+      })
+      sources."decode-uri-component-0.2.0"
+      sources."define-property-2.0.2"
+      sources."dir-glob-2.0.0"
+      sources."error-ex-1.3.2"
+      (sources."expand-brackets-2.1.4" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."fast-glob-2.2.4"
+      (sources."fill-range-4.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."find-up-2.1.0"
+      sources."for-in-1.0.2"
+      sources."fragment-cache-0.2.1"
+      sources."fs.realpath-1.0.0"
+      sources."get-value-2.0.6"
+      sources."glob-7.1.3"
+      (sources."glob-parent-3.1.0" // {
+        dependencies = [
+          sources."is-glob-3.1.0"
+        ];
+      })
+      sources."glob-to-regexp-0.3.0"
+      sources."globby-8.0.1"
+      sources."graceful-fs-4.1.15"
+      sources."has-value-1.0.0"
+      (sources."has-values-1.0.0" // {
+        dependencies = [
+          sources."kind-of-4.0.0"
+        ];
+      })
+      sources."hosted-git-info-2.7.1"
+      sources."ignore-3.3.10"
+      sources."indent-string-3.2.0"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.3"
+      sources."is-accessor-descriptor-1.0.0"
+      sources."is-arrayish-0.2.1"
+      sources."is-buffer-1.1.6"
+      sources."is-builtin-module-1.0.0"
+      sources."is-data-descriptor-1.0.0"
+      sources."is-descriptor-1.0.2"
+      sources."is-extendable-0.1.1"
+      sources."is-extglob-2.1.1"
+      sources."is-glob-4.0.0"
+      (sources."is-number-3.0.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."is-plain-obj-1.1.0"
+      sources."is-plain-object-2.0.4"
+      sources."is-windows-1.0.2"
+      sources."isarray-1.0.0"
+      sources."isobject-3.0.1"
+      sources."json-parse-better-errors-1.0.2"
+      sources."kind-of-6.0.2"
+      sources."load-json-file-4.0.0"
+      sources."locate-path-2.0.0"
+      sources."loud-rejection-1.6.0"
+      sources."make-dir-1.3.0"
+      sources."map-cache-0.2.2"
+      sources."map-obj-2.0.0"
+      sources."map-visit-1.0.0"
+      sources."meow-5.0.0"
+      sources."merge2-1.2.3"
+      sources."micromatch-3.1.10"
+      sources."minimatch-3.0.4"
+      sources."minimist-options-3.0.2"
+      (sources."mixin-deep-1.3.1" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."ms-2.0.0"
+      sources."nanomatch-1.2.13"
+      sources."nested-error-stacks-2.1.0"
+      sources."normalize-package-data-2.4.0"
+      (sources."object-copy-0.1.0" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."is-accessor-descriptor-0.1.6"
+          sources."is-data-descriptor-0.1.4"
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."object-visit-1.0.1"
+      sources."object.pick-1.3.0"
+      sources."once-1.4.0"
+      sources."p-limit-1.3.0"
+      sources."p-locate-2.0.0"
+      sources."p-try-1.0.0"
+      sources."parse-json-4.0.0"
+      sources."pascalcase-0.1.1"
+      sources."path-dirname-1.0.2"
+      sources."path-exists-3.0.0"
+      sources."path-is-absolute-1.0.1"
+      sources."path-type-3.0.0"
+      sources."pify-3.0.0"
+      sources."posix-character-classes-0.1.1"
+      sources."quick-lru-1.1.0"
+      sources."read-pkg-3.0.0"
+      sources."read-pkg-up-3.0.0"
+      sources."redent-2.0.0"
+      sources."regex-not-1.0.2"
+      sources."repeat-element-1.1.3"
+      sources."repeat-string-1.6.1"
+      sources."resolve-url-0.2.1"
+      sources."ret-0.1.15"
+      sources."safe-buffer-5.1.2"
+      sources."safe-regex-1.1.0"
+      sources."semver-5.6.0"
+      (sources."set-value-2.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."signal-exit-3.0.2"
+      sources."slash-1.0.0"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      (sources."snapdragon-util-3.0.1" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."source-map-0.5.7"
+      sources."source-map-resolve-0.5.2"
+      sources."source-map-url-0.4.0"
+      sources."spdx-correct-3.0.2"
+      sources."spdx-exceptions-2.2.0"
+      sources."spdx-expression-parse-3.0.0"
+      sources."spdx-license-ids-3.0.2"
+      sources."split-string-3.1.0"
+      (sources."static-extend-0.1.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."strip-bom-3.0.0"
+      sources."strip-indent-2.0.0"
+      (sources."to-object-path-0.3.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-2.1.1"
+      sources."trim-newlines-2.0.0"
+      (sources."union-value-1.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+          sources."set-value-0.4.3"
+        ];
+      })
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+          sources."has-values-0.1.4"
+        ];
+      })
+      sources."urix-0.1.0"
+      sources."use-3.1.1"
+      sources."validate-npm-package-license-3.0.4"
+      sources."wrappy-1.0.2"
+      sources."yargs-parser-10.1.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Copy files";
+      homepage = "https://github.com/sindresorhus/cpy-cli#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+  };
   create-cycle-app = nodeEnv.buildNodePackage {
     name = "create-cycle-app";
     packageName = "create-cycle-app";
@@ -40261,7 +40651,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.0"
-      sources."@types/node-10.12.5"
+      sources."@types/node-10.12.6"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
@@ -40553,7 +40943,7 @@ in
     };
     dependencies = [
       sources."abstract-random-access-1.1.2"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-align-2.0.0"
       sources."ansi-diff-1.1.1"
       sources."ansi-regex-3.0.0"
@@ -40611,7 +41001,6 @@ in
       sources."cli-spinners-1.3.1"
       sources."cli-truncate-1.1.0"
       sources."cliclopts-1.1.1"
-      sources."co-4.6.0"
       sources."codecs-1.2.1"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -40694,7 +41083,7 @@ in
       sources."extsprintf-1.3.0"
       sources."eyes-0.1.8"
       sources."fast-bitfield-1.2.1"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fd-read-stream-1.1.0"
       sources."figures-2.0.0"
@@ -40718,7 +41107,7 @@ in
       sources."got-6.7.1"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       sources."http-methods-0.1.0"
       sources."http-signature-1.2.0"
@@ -40775,7 +41164,7 @@ in
       sources."iterators-0.1.0"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."k-bucket-3.3.1"
@@ -40868,7 +41257,7 @@ in
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
       sources."pump-3.0.0"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."random-access-file-2.0.1"
       sources."random-access-memory-3.0.0"
@@ -40949,7 +41338,11 @@ in
           sources."debug-2.6.9"
         ];
       })
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."township-client-1.3.2"
       sources."trim-0.0.1"
       sources."ttl-1.3.1"
@@ -40964,6 +41357,7 @@ in
       sources."untildify-3.0.3"
       sources."unzip-response-2.0.1"
       sources."update-notifier-2.5.0"
+      sources."uri-js-4.2.2"
       sources."url-parse-lax-1.0.0"
       sources."util-deprecate-1.0.2"
       sources."utile-0.3.0"
@@ -41336,12 +41730,12 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-2.6.1"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.353.0"
+      sources."aws-sdk-2.354.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."base64-js-1.3.0"
@@ -41350,7 +41744,6 @@ in
       sources."buffer-queue-1.0.0"
       sources."bytes-3.0.0"
       sources."caseless-0.12.0"
-      sources."co-4.6.0"
       sources."combined-stream-1.0.7"
       sources."core-util-is-1.0.2"
       sources."dashdash-1.14.1"
@@ -41360,13 +41753,13 @@ in
       sources."events-1.1.1"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."getpass-0.1.7"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
       sources."ieee754-1.1.8"
       sources."inherits-2.0.3"
@@ -41377,7 +41770,7 @@ in
       sources."jmespath-0.15.0"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
@@ -41415,6 +41808,11 @@ in
       })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      (sources."uri-js-4.2.2" // {
+        dependencies = [
+          sources."punycode-2.1.1"
+        ];
+      })
       sources."url-0.10.3"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.1.0"
@@ -41459,7 +41857,7 @@ in
       sha512 = "qKYcejb/fXOaZ1dg6N2JQqMc1QLuk1SKZHN2uP4eg+HQIlxWkQ7HQE2Kgo3bojMfdo0t0ZbGS6yhe06NmdeGmg==";
     };
     dependencies = [
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-styles-3.2.1"
       sources."anymatch-2.0.0"
       sources."arr-diff-4.0.0"
@@ -41516,7 +41914,6 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."co-4.6.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -41562,7 +41959,7 @@ in
         ];
       })
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."fill-range-4.0.0" // {
         dependencies = [
@@ -41596,7 +41993,7 @@ in
       })
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-flag-2.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -41629,7 +42026,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
@@ -41687,7 +42084,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."readdirp-2.2.1"
@@ -41776,7 +42173,11 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       (sources."union-value-1.0.0" // {
@@ -41797,6 +42198,7 @@ in
         ];
       })
       sources."upath-1.1.0"
+      sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
@@ -42109,7 +42511,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.3"
-      sources."globals-11.8.0"
+      sources."globals-11.9.0"
       (sources."globby-6.1.0" // {
         dependencies = [
           sources."pify-2.3.0"
@@ -42257,7 +42659,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.3"
-      sources."globals-11.8.0"
+      sources."globals-11.9.0"
       (sources."globby-6.1.0" // {
         dependencies = [
           sources."pify-2.3.0"
@@ -42375,7 +42777,7 @@ in
       sha1 = "81f5f98043cc2517053f96ba5d61ef5db430c010";
     };
     dependencies = [
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-escapes-1.4.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
@@ -42413,7 +42815,7 @@ in
       sources."extend-3.0.2"
       sources."extract-zip-1.6.7"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fd-slicer-1.0.1"
       sources."find-up-1.1.2"
@@ -42424,7 +42826,7 @@ in
       sources."getpass-0.1.7"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hasha-2.2.0"
@@ -42443,7 +42845,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
@@ -42502,7 +42904,7 @@ in
       sources."progress-1.1.8"
       sources."promise-phantom-3.1.6"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
@@ -42528,11 +42930,16 @@ in
       sources."supports-color-2.0.0"
       sources."throttleit-1.0.0"
       sources."tmp-0.0.31"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."trim-newlines-1.0.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."validate-npm-package-license-3.0.4"
@@ -43441,7 +43848,13 @@ in
       sources."graphql-schema-linter-0.1.1"
       sources."graphql-static-binding-0.9.3"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      (sources."har-validator-5.1.3" // {
+        dependencies = [
+          sources."ajv-6.5.5"
+          sources."fast-deep-equal-2.0.1"
+          sources."json-schema-traverse-0.4.1"
+        ];
+      })
       sources."has-flag-3.0.0"
       sources."header-case-1.0.1"
       sources."homedir-polyfill-1.0.1"
@@ -43566,7 +43979,7 @@ in
       sources."negotiator-0.6.1"
       sources."nice-try-1.0.5"
       sources."no-case-2.3.2"
-      sources."node-fetch-2.2.1"
+      sources."node-fetch-2.3.0"
       sources."node-request-by-swagger-1.1.4"
       sources."normalize-package-data-2.4.0"
       sources."npm-path-2.0.4"
@@ -43626,7 +44039,7 @@ in
       sources."prr-1.0.1"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."range-parser-1.2.0"
       (sources."raw-body-2.3.3" // {
@@ -43714,7 +44127,11 @@ in
       sources."tmp-0.0.33"
       sources."tmp-graphql-config-extension-openapi-1.0.7"
       sources."to-fast-properties-2.0.0"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."traverse-chain-0.1.0"
       sources."trim-right-1.0.1"
       sources."tunnel-agent-0.6.0"
@@ -43727,6 +44144,7 @@ in
       sources."update-notifier-2.5.0"
       sources."upper-case-1.1.3"
       sources."upper-case-first-1.1.2"
+      sources."uri-js-4.2.2"
       sources."url-join-4.0.0"
       sources."url-parse-lax-1.0.0"
       sources."url-regex-3.2.0"
@@ -44898,7 +45316,7 @@ in
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abbrev-1.1.1"
       sources."agent-base-4.2.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
@@ -44991,7 +45409,7 @@ in
       })
       sources."extsprintf-1.3.0"
       sources."eyes-0.1.8"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-levenshtein-2.0.6"
       sources."fd-slicer-1.0.1"
@@ -45021,7 +45439,7 @@ in
       sources."graceful-fs-4.1.15"
       sources."graphlib-2.1.5"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       (sources."hasbin-1.2.3" // {
         dependencies = [
@@ -45081,7 +45499,7 @@ in
         ];
       })
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
@@ -45169,7 +45587,7 @@ in
       sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       (sources."raw-body-2.3.3" // {
         dependencies = [
@@ -45246,7 +45664,11 @@ in
       sources."thunkify-2.1.2"
       sources."tmp-0.0.33"
       sources."toml-2.3.3"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tslib-1.9.3"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -45261,6 +45683,7 @@ in
       sources."unicode-5.2.0-0.7.5"
       sources."unique-string-1.0.0"
       sources."unpipe-1.0.0"
+      sources."uri-js-4.2.2"
       sources."util-0.10.4"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
@@ -46063,7 +46486,7 @@ in
       sources."normalize-package-data-2.4.0"
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
-      sources."object-hash-1.3.0"
+      sources."object-hash-1.3.1"
       sources."once-1.4.0"
       sources."opentracing-0.14.3"
       sources."p-limit-1.3.0"
@@ -46218,7 +46641,7 @@ in
       sha512 = "KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==";
     };
     dependencies = [
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-1.0.0"
@@ -46231,7 +46654,6 @@ in
       sources."buffer-from-1.1.1"
       sources."caseless-0.12.0"
       sources."cli-1.0.1"
-      sources."co-4.6.0"
       sources."colors-1.0.3"
       sources."combined-stream-1.0.7"
       sources."concat-map-0.0.1"
@@ -46266,7 +46688,7 @@ in
       sources."extract-zip-1.6.7"
       sources."extsprintf-1.3.0"
       sources."eyes-0.1.8"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fd-slicer-1.0.1"
       sources."forever-agent-0.6.1"
@@ -46277,7 +46699,7 @@ in
       sources."glob-7.1.3"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."hasha-2.2.0"
       sources."htmlparser2-3.8.3"
       sources."http-signature-1.2.0"
@@ -46290,7 +46712,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
@@ -46315,7 +46737,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."progress-1.1.8"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-1.1.14"
       sources."request-2.88.0"
@@ -46330,11 +46752,16 @@ in
       sources."strip-json-comments-1.0.4"
       sources."throttleit-1.0.0"
       sources."through-2.3.8"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
       sources."unicode-5.2.0-0.7.5"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
@@ -46377,7 +46804,7 @@ in
       sha512 = "qVNq7ZZ7ZbLdzorvSlRDadS0Rh5oyItaE95v6I4wbbuSiijxn7SnnsV6dvKlcXuO2jX7lK8tn9fBulx34K/Ejg==";
     };
     dependencies = [
-      sources."@types/node-10.12.5"
+      sources."@types/node-10.12.6"
       sources."@types/semver-5.5.0"
       sources."abbrev-1.1.1"
       sources."commander-2.19.0"
@@ -46536,7 +46963,7 @@ in
     };
     dependencies = [
       sources."accepts-1.3.5"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-align-2.0.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
@@ -46558,7 +46985,6 @@ in
       sources."ci-info-1.6.0"
       sources."cli-boxes-1.0.0"
       sources."cliui-4.1.0"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -46605,7 +47031,7 @@ in
       })
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."finalhandler-1.1.1" // {
         dependencies = [
@@ -46624,7 +47050,7 @@ in
       sources."got-6.7.1"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       sources."http-errors-1.6.3"
       sources."http-signature-1.2.0"
@@ -46653,7 +47079,7 @@ in
       sources."jsbn-0.1.1"
       sources."json-parse-helpfulerror-1.0.3"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."latest-version-3.1.0"
@@ -46704,7 +47130,7 @@ in
       sources."proxy-addr-2.0.4"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.3"
@@ -46741,7 +47167,11 @@ in
       sources."supports-color-5.5.0"
       sources."term-size-1.2.0"
       sources."timed-out-4.0.1"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
@@ -46749,6 +47179,7 @@ in
       sources."unpipe-1.0.0"
       sources."unzip-response-2.0.1"
       sources."update-notifier-2.5.0"
+      sources."uri-js-4.2.2"
       sources."url-parse-lax-1.0.0"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
@@ -47796,7 +48227,7 @@ in
       sources."abbrev-1.1.1"
       sources."agent-base-4.2.1"
       sources."agentkeepalive-3.5.2"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
@@ -47886,7 +48317,6 @@ in
       })
       sources."clone-1.0.4"
       sources."cmd-shim-2.0.2"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
@@ -47983,8 +48413,8 @@ in
         ];
       })
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
-      (sources."fast-glob-2.2.3" // {
+      sources."fast-deep-equal-2.0.1"
+      (sources."fast-glob-2.2.4" // {
         dependencies = [
           sources."is-glob-4.0.0"
         ];
@@ -48062,7 +48492,7 @@ in
         ];
       })
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       sources."has-unicode-2.0.1"
       sources."has-value-1.0.0"
@@ -48146,14 +48576,14 @@ in
       sources."jsbn-0.1.1"
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-4.0.0"
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
       sources."kind-of-6.0.2"
       sources."lcid-2.0.0"
-      (sources."libnpmaccess-3.0.0" // {
+      (sources."libnpmaccess-3.0.1" // {
         dependencies = [
           sources."aproba-2.0.0"
         ];
@@ -48307,7 +48737,7 @@ in
           sources."pump-2.0.1"
         ];
       })
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."q-1.5.1"
       sources."qs-6.5.2"
       sources."quick-lru-1.1.0"
@@ -48459,12 +48889,12 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."tough-cookie-2.4.3"
-      (sources."tr46-1.0.1" // {
+      (sources."tough-cookie-2.4.3" // {
         dependencies = [
-          sources."punycode-2.1.1"
+          sources."punycode-1.4.1"
         ];
       })
+      sources."tr46-1.0.1"
       sources."trim-newlines-2.0.0"
       sources."trim-off-newlines-1.0.1"
       sources."tslib-1.9.3"
@@ -48497,6 +48927,7 @@ in
           sources."has-values-0.1.4"
         ];
       })
+      sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
@@ -48545,7 +48976,7 @@ in
       sha512 = "8HFGuWmL3FhQR0aH89escFNBQH/nEiYPP2ltDFdQw2chE28Yx2E3lhAIq9Y2saYwLSwa699s4dBVEfCY8Drf7Q==";
     };
     dependencies = [
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
@@ -48555,7 +48986,6 @@ in
       sources."bcrypt-pbkdf-1.0.2"
       sources."caseless-0.12.0"
       sources."clone-2.1.2"
-      sources."co-4.6.0"
       sources."combined-stream-1.0.7"
       sources."core-util-is-1.0.2"
       sources."dashdash-1.14.1"
@@ -48564,21 +48994,21 @@ in
       sources."errno-0.1.7"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."getpass-0.1.7"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
       sources."image-size-0.5.5"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."mime-1.6.0"
@@ -48591,16 +49021,21 @@ in
       sources."promise-7.3.1"
       sources."prr-1.0.1"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."request-2.88.0"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."source-map-0.6.1"
       sources."sshpk-1.15.2"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."uri-js-4.2.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
     ];
@@ -49050,7 +49485,7 @@ in
     dependencies = [
       sources."accepts-1.3.5"
       sources."after-0.8.2"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."anymatch-1.3.2"
       sources."argparse-1.0.10"
       sources."arr-diff-2.0.0"
@@ -49110,7 +49545,6 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."co-4.6.0"
       sources."collection-visit-1.0.0"
       sources."combined-stream-1.0.7"
       sources."component-bind-1.0.0"
@@ -49166,7 +49600,7 @@ in
       })
       sources."extglob-0.3.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."filename-regex-2.0.1"
       sources."fill-range-2.2.4"
@@ -49190,7 +49624,7 @@ in
       sources."glob-parent-2.0.0"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
         dependencies = [
           sources."isarray-2.0.1"
@@ -49258,7 +49692,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."kind-of-3.2.2"
@@ -49335,7 +49769,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."proxy-addr-2.0.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       (sources."randomatic-3.1.1" // {
         dependencies = [
@@ -49495,7 +49929,11 @@ in
           sources."is-number-3.0.0"
         ];
       })
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
@@ -49519,6 +49957,7 @@ in
           sources."isobject-3.0.1"
         ];
       })
+      sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
@@ -49617,13 +50056,13 @@ in
       sources."@babel/traverse-7.1.5"
       sources."@babel/types-7.1.5"
       sources."@calebboyd/semaphore-1.3.1"
-      sources."@comandeer/babel-plugin-banner-4.0.0"
+      sources."@comandeer/babel-plugin-banner-4.1.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
       sources."@sindresorhus/is-0.7.0"
       sources."@szmarczak/http-timer-1.1.1"
       sources."@types/estree-0.0.39"
-      sources."@types/node-10.12.5"
+      sources."@types/node-10.12.6"
       sources."@webassemblyjs/ast-1.7.11"
       sources."@webassemblyjs/floating-point-hex-parser-1.7.11"
       sources."@webassemblyjs/helper-api-error-1.7.11"
@@ -50007,7 +50446,7 @@ in
       })
       sources."extglob-0.3.2"
       sources."fast-deep-equal-2.0.1"
-      (sources."fast-glob-2.2.3" // {
+      (sources."fast-glob-2.2.4" // {
         dependencies = [
           sources."arr-diff-4.0.0"
           sources."array-unique-0.3.2"
@@ -50096,7 +50535,7 @@ in
       sources."glob-parent-2.0.0"
       sources."glob-to-regexp-0.3.0"
       sources."global-modules-path-2.3.0"
-      sources."globals-11.8.0"
+      sources."globals-11.9.0"
       (sources."globby-8.0.1" // {
         dependencies = [
           sources."pify-3.0.0"
@@ -50110,7 +50549,7 @@ in
       (sources."got-9.3.2" // {
         dependencies = [
           sources."@sindresorhus/is-0.12.0"
-          sources."cacheable-request-5.1.0"
+          sources."cacheable-request-5.2.0"
           sources."get-stream-4.1.0"
           sources."http-cache-semantics-4.0.0"
           sources."normalize-url-3.3.0"
@@ -50296,7 +50735,7 @@ in
         ];
       })
       sources."nice-try-1.0.5"
-      sources."node-fetch-2.2.1"
+      sources."node-fetch-2.3.0"
       (sources."node-libs-browser-2.1.0" // {
         dependencies = [
           sources."base64-js-1.3.0"
@@ -50898,7 +51337,7 @@ in
         ];
       })
       sources."acorn-5.7.3"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       (sources."align-text-0.1.4" // {
         dependencies = [
           sources."kind-of-3.2.2"
@@ -50982,7 +51421,6 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."co-4.6.0"
       sources."collection-visit-1.0.0"
       sources."color-support-1.1.3"
       sources."combined-stream-1.0.7"
@@ -51074,7 +51512,7 @@ in
       })
       sources."extsprintf-1.3.0"
       sources."fancy-log-1.3.2"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."fill-range-4.0.0" // {
         dependencies = [
@@ -51196,7 +51634,7 @@ in
       })
       sources."gulplog-1.0.0"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
       sources."has-gulplog-0.1.0"
       sources."has-symbols-1.0.0"
@@ -51242,7 +51680,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stable-stringify-1.0.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonify-0.0.0"
@@ -51371,7 +51809,7 @@ in
         ];
       })
       sources."pumpify-1.5.1"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       (sources."readable-stream-1.0.34" // {
         dependencies = [
@@ -51494,7 +51932,11 @@ in
           sources."through2-2.0.5"
         ];
       })
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typescript-3.1.6"
@@ -51522,6 +51964,7 @@ in
           sources."has-values-0.1.4"
         ];
       })
+      sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."use-3.1.1"
       sources."user-home-1.1.1"
@@ -51690,7 +52133,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
@@ -51705,7 +52148,6 @@ in
       sources."builtin-modules-1.1.1"
       sources."builtins-1.0.3"
       sources."caseless-0.12.0"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.7"
       sources."concat-stream-1.6.2"
@@ -51718,7 +52160,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."findit-2.0.0"
       sources."foreachasync-3.0.0"
@@ -51738,7 +52180,7 @@ in
       sources."getpass-0.1.7"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.7.1"
       sources."http-signature-1.2.0"
@@ -51751,7 +52193,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
@@ -51786,7 +52228,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."proto-list-1.2.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
@@ -51810,11 +52252,16 @@ in
       sources."strip-ansi-3.0.1"
       sources."tar-3.1.15"
       sources."temp-0.8.3"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
       sources."uid-number-0.0.5"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."validate-npm-package-license-3.0.4"
@@ -51844,7 +52291,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
@@ -51858,7 +52305,6 @@ in
       sources."block-stream-0.0.9"
       sources."brace-expansion-1.1.11"
       sources."caseless-0.12.0"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.7"
       sources."concat-map-0.0.1"
@@ -51870,7 +52316,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -51881,7 +52327,7 @@ in
       sources."glob-7.1.3"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
@@ -51893,7 +52339,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."mime-db-1.37.0"
@@ -51914,7 +52360,7 @@ in
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.0"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
@@ -51929,9 +52375,14 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."tar-2.2.1"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
@@ -52766,7 +53217,6 @@ in
       sources."caseless-0.12.0"
       sources."cheerio-0.22.0"
       sources."clone-2.1.2"
-      sources."co-4.6.0"
       sources."combined-stream-1.0.7"
       sources."commander-2.17.1"
       sources."commist-1.0.0"
@@ -52870,11 +53320,9 @@ in
       })
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      (sources."har-validator-5.1.0" // {
+      (sources."har-validator-5.1.3" // {
         dependencies = [
-          sources."ajv-5.5.2"
-          sources."fast-deep-equal-1.1.0"
-          sources."json-schema-traverse-0.3.1"
+          sources."ajv-6.5.5"
         ];
       })
       sources."hash-sum-1.0.2"
@@ -53292,7 +53740,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
@@ -53308,7 +53756,6 @@ in
       sources."brace-expansion-1.1.11"
       sources."caseless-0.12.0"
       sources."chownr-0.0.2"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."coffee-script-1.12.7"
       sources."combined-stream-1.0.7"
@@ -53327,7 +53774,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."findit-1.2.0"
       sources."foreachasync-3.0.0"
@@ -53351,7 +53798,7 @@ in
       sources."glob-7.1.3"
       sources."graceful-fs-2.0.3"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
@@ -53363,7 +53810,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
@@ -53398,7 +53845,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."proto-list-1.2.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
@@ -53425,11 +53872,16 @@ in
           sources."rimraf-2.1.4"
         ];
       })
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."underscore-1.4.4"
       sources."underscore.string-2.3.3"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
@@ -53787,7 +54239,7 @@ in
     };
     dependencies = [
       sources."accepts-1.3.5"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."argparse-1.0.10"
       sources."array-flatten-1.1.1"
@@ -53824,7 +54276,6 @@ in
       sources."caseless-0.12.0"
       sources."clarinet-0.11.0"
       sources."cliui-3.2.0"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."colors-1.3.2"
       sources."combined-stream-1.0.7"
@@ -53869,7 +54320,7 @@ in
       sources."express-handlebars-3.0.0"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."finalhandler-1.1.1" // {
         dependencies = [
@@ -53894,7 +54345,7 @@ in
         ];
       })
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-symbols-1.0.0"
       sources."hat-0.0.3"
       sources."hosted-git-info-2.7.1"
@@ -53917,7 +54368,7 @@ in
       sources."js-yaml-3.12.0"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       (sources."kad-git+https://github.com/gwicke/kad.git#master" // {
@@ -54007,7 +54458,7 @@ in
       sources."promise-7.3.1"
       sources."proxy-addr-2.0.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.3"
@@ -54051,12 +54502,17 @@ in
       sources."string_decoder-0.10.31"
       sources."strip-ansi-3.0.1"
       sources."strip-bom-2.0.0"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
       sources."uglify-js-3.4.9"
       sources."unpipe-1.0.0"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
@@ -54952,10 +55408,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "2.17.8";
+    version = "2.18.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.17.8.tgz";
-      sha512 = "Lfqyq7foOu0HTHhimOAOmgDwN5uH1e4VwfyRnTJgalhVC317QL9y1df6jHATGf0Vy3uhW3AAt4JMuX48wDeFlg==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.18.2.tgz";
+      sha512 = "yJu5pCPFmzxD9xQtWay4nI7JdcrpIIom/VwwMmUvU6itN0wAbbyIaGKz57JCu1E+ZfbOvcaOzEmifbypHfFNXw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -54996,7 +55452,7 @@ in
       sources."acorn-6.0.4"
       sources."acorn-dynamic-import-4.0.0"
       sources."acorn-node-1.6.2"
-      sources."acorn-walk-6.1.0"
+      sources."acorn-walk-6.1.1"
       sources."anymatch-2.0.0"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
@@ -55892,7 +56348,7 @@ in
       sha1 = "c8fa1fffb8258ce68adf75df73f90fbb6f23d198";
     };
     dependencies = [
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."asynckit-0.4.0"
@@ -55903,7 +56359,6 @@ in
       sources."buffer-crc32-0.2.1"
       sources."bytes-0.2.1"
       sources."caseless-0.12.0"
-      sources."co-4.6.0"
       sources."coffee-script-1.6.3"
       sources."combined-stream-1.0.7"
       sources."commander-2.0.0"
@@ -55941,7 +56396,7 @@ in
       })
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -55949,7 +56404,7 @@ in
       sources."fresh-0.2.0"
       sources."getpass-0.1.7"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."http-auth-2.0.7"
       sources."http-signature-1.2.0"
       sources."inherits-2.0.3"
@@ -55958,7 +56413,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."keypress-0.1.0"
@@ -55984,7 +56439,7 @@ in
       sources."pause-0.0.1"
       sources."performance-now-2.1.0"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-0.6.5"
       sources."range-parser-0.0.4"
       sources."raw-body-0.0.3"
@@ -55998,10 +56453,15 @@ in
       sources."stream-counter-0.2.0"
       sources."string-1.6.1"
       sources."string_decoder-0.10.31"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uid2-0.0.3"
+      sources."uri-js-4.2.2"
       sources."util-0.4.9"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
@@ -56358,7 +56818,7 @@ in
         ];
       })
       sources."levelup-2.0.2"
-      sources."libnested-1.3.2"
+      sources."libnested-1.4.0"
       sources."libsodium-0.7.3"
       sources."libsodium-wrappers-0.7.3"
       sources."log-symbols-1.0.2"
@@ -56853,13 +57313,14 @@ in
   serve = nodeEnv.buildNodePackage {
     name = "serve";
     packageName = "serve";
-    version = "10.0.2";
+    version = "10.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serve/-/serve-10.0.2.tgz";
-      sha512 = "9BDXCSpCUDjoPhb37JJGqgnMSfO0HjU5I6g8KxwBA40TvMk9pDxTuDWNKzBJEGXhH5h55Qe8fqSqwpeyQmnhJQ==";
+      url = "https://registry.npmjs.org/serve/-/serve-10.1.1.tgz";
+      sha512 = "B1ca73zGFRS/bYQkbDw6BVEpRiUKdtnkwtvkMjx598jU5tyieua9lHyqdwUoup4/ek20I74EzncTC0gZuYng4Q==";
     };
     dependencies = [
       sources."@zeit/schemas-2.6.0"
+      sources."accepts-1.3.5"
       sources."ajv-6.5.3"
       sources."ansi-align-2.0.0"
       sources."ansi-regex-3.0.0"
@@ -56880,9 +57341,12 @@ in
       })
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
+      sources."compressible-2.0.15"
+      sources."compression-1.7.3"
       sources."concat-map-0.0.1"
       sources."content-disposition-0.5.2"
       sources."cross-spawn-5.1.0"
+      sources."debug-2.6.9"
       sources."deep-extend-0.6.0"
       sources."escape-string-regexp-1.0.5"
       sources."execa-0.7.0"
@@ -56894,7 +57358,6 @@ in
         ];
       })
       sources."get-stream-3.0.0"
-      sources."glob-slash-1.0.0"
       sources."has-flag-3.0.0"
       sources."ini-1.3.5"
       sources."is-fullwidth-code-point-2.0.0"
@@ -56902,11 +57365,14 @@ in
       sources."isexe-2.0.0"
       sources."json-schema-traverse-0.4.1"
       sources."lru-cache-4.1.3"
-      sources."mime-db-1.33.0"
-      sources."mime-types-2.1.18"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
+      sources."ms-2.0.0"
+      sources."negotiator-0.6.1"
       sources."npm-run-path-2.0.2"
+      sources."on-headers-1.0.1"
       sources."p-finally-1.0.0"
       sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
@@ -56918,7 +57384,12 @@ in
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
       sources."safe-buffer-5.1.2"
-      sources."serve-handler-5.0.3"
+      (sources."serve-handler-5.0.7" // {
+        dependencies = [
+          sources."mime-db-1.33.0"
+          sources."mime-types-2.1.18"
+        ];
+      })
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
@@ -56930,6 +57401,7 @@ in
       sources."term-size-1.2.0"
       sources."update-check-1.5.2"
       sources."uri-js-4.2.2"
+      sources."vary-1.1.2"
       sources."which-1.3.1"
       sources."widest-line-2.0.1"
       sources."yallist-2.1.2"
@@ -56956,7 +57428,7 @@ in
       sources."CSSwhat-0.4.7"
       sources."accepts-1.3.5"
       sources."after-0.8.1"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."array-flatten-1.1.1"
       sources."arraybuffer.slice-0.0.6"
       sources."asn1-0.2.4"
@@ -56975,7 +57447,6 @@ in
       sources."callsite-1.0.0"
       sources."caseless-0.12.0"
       sources."cheerio-0.17.0"
-      sources."co-4.6.0"
       sources."combined-stream-1.0.7"
       sources."commander-2.19.0"
       sources."component-bind-1.0.0"
@@ -57022,7 +57493,7 @@ in
       sources."express-4.16.4"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."finalhandler-1.1.1"
       sources."flatmap-stream-0.1.1"
@@ -57034,7 +57505,7 @@ in
       sources."getpass-0.1.7"
       sources."global-https://github.com/component/global/archive/v2.0.1.tar.gz"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-binary-data-0.1.1"
       sources."has-cors-1.0.3"
       (sources."htmlparser2-3.7.3" // {
@@ -57055,7 +57526,7 @@ in
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."json3-3.2.6"
       sources."jsprim-1.4.1"
@@ -57088,7 +57559,7 @@ in
       sources."performance-now-2.1.0"
       sources."proxy-addr-2.0.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.3"
@@ -57136,11 +57607,16 @@ in
       sources."through-2.3.8"
       sources."tinycolor-0.0.1"
       sources."to-array-0.1.3"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
       sources."unpipe-1.0.0"
+      sources."uri-js-4.2.2"
       sources."utf8-2.0.0"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
@@ -57173,7 +57649,7 @@ in
     dependencies = [
       sources."JSONStream-1.3.5"
       sources."accepts-1.3.5"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."amdefine-1.0.1"
       sources."ansi-styles-3.2.1"
       sources."argparse-1.0.10"
@@ -57201,7 +57677,6 @@ in
       sources."bytes-1.0.0"
       sources."caseless-0.12.0"
       sources."chalk-2.4.1"
-      sources."co-4.6.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.7"
@@ -57248,7 +57723,7 @@ in
       sources."express-json5-0.1.0"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."finalhandler-1.1.1" // {
         dependencies = [
@@ -57268,7 +57743,7 @@ in
       })
       sources."handlebars-2.0.0"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       sources."highlight.js-8.9.1"
       (sources."htmlparser2-3.10.0" // {
@@ -57293,7 +57768,7 @@ in
       sources."js-yaml-3.12.0"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
@@ -57340,7 +57815,7 @@ in
       })
       sources."proxy-addr-2.0.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."range-parser-1.2.0"
       sources."raw-body-1.3.4"
@@ -57377,7 +57852,11 @@ in
       sources."supports-color-5.5.0"
       sources."through-2.3.8"
       sources."toidentifier-1.0.0"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
@@ -57388,6 +57867,7 @@ in
         ];
       })
       sources."unpipe-1.0.0"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
@@ -58980,7 +59460,7 @@ in
     dependencies = [
       sources."acorn-6.0.4"
       sources."acorn-loose-6.0.0"
-      sources."acorn-walk-6.1.0"
+      sources."acorn-walk-6.1.1"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."concat-map-0.0.1"
@@ -59061,7 +59541,7 @@ in
     };
     dependencies = [
       sources."adm-zip-0.4.11"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-2.6.1"
@@ -59084,7 +59564,7 @@ in
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."eyes-0.1.8"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."fields-0.1.24" // {
         dependencies = [
@@ -59097,14 +59577,14 @@ in
       sources."getpass-0.1.7"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
       sources."humanize-0.0.9"
       sources."is-typedarray-1.0.0"
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-4.0.0"
       sources."jsprim-1.4.1"
@@ -59126,12 +59606,16 @@ in
       sources."performance-now-2.1.0"
       sources."pkginfo-0.3.1"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       (sources."request-2.87.0" // {
         dependencies = [
+          sources."ajv-5.5.2"
+          sources."fast-deep-equal-1.1.0"
           sources."har-validator-5.0.3"
+          sources."json-schema-traverse-0.3.1"
           sources."oauth-sign-0.8.2"
+          sources."punycode-1.4.1"
           sources."tough-cookie-2.3.4"
         ];
       })
@@ -59145,11 +59629,16 @@ in
       sources."sshpk-1.15.2"
       sources."stack-trace-0.0.10"
       sources."temp-0.8.3"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uglify-js-3.4.9"
       sources."universalify-0.1.2"
+      sources."uri-js-4.2.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
       (sources."winston-1.1.2" // {
@@ -59642,7 +60131,7 @@ in
       sources."abbrev-1.1.1"
       sources."accepts-1.3.5"
       sources."after-0.8.2"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-regex-2.1.1"
       sources."aproba-1.2.0"
       (sources."are-we-there-yet-1.1.5" // {
@@ -59688,7 +60177,6 @@ in
         ];
       })
       sources."clone-2.1.2"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."color-3.0.0"
       sources."color-convert-1.9.3"
@@ -59774,7 +60262,7 @@ in
       })
       sources."extsprintf-1.3.0"
       sources."eyes-0.1.8"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       (sources."finalhandler-1.1.1" // {
         dependencies = [
@@ -59800,7 +60288,7 @@ in
       sources."glob-7.1.3"
       sources."graceful-fs-4.1.15"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
         dependencies = [
           sources."isarray-2.0.1"
@@ -59838,7 +60326,7 @@ in
       sources."jquery-ui-bundle-1.12.1"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."just-detect-adblock-1.0.0"
@@ -59921,7 +60409,7 @@ in
       sources."proxy-addr-2.0.4"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."random-bytes-1.0.0"
       sources."range-parser-1.2.0"
@@ -60017,7 +60505,11 @@ in
         ];
       })
       sources."to-array-0.1.4"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.16"
@@ -60027,6 +60519,7 @@ in
       sources."ultron-1.1.1"
       sources."underscore-1.5.2"
       sources."unpipe-1.0.0"
+      sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
@@ -60079,11 +60572,7 @@ in
     };
     dependencies = [
       sources."absolute-0.0.1"
-      (sources."ajv-5.5.2" // {
-        dependencies = [
-          sources."co-4.6.0"
-        ];
-      })
+      sources."ajv-6.5.5"
       sources."ansi-escapes-3.1.0"
       sources."ansi-red-0.1.1"
       sources."ansi-regex-3.0.0"
@@ -60163,7 +60652,7 @@ in
       sources."extend-shallow-2.0.1"
       sources."external-editor-3.0.3"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
+      sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fd-slicer-1.1.0"
       sources."figures-2.0.0"
@@ -60186,7 +60675,7 @@ in
       sources."gray-matter-2.1.1"
       sources."handlebars-4.0.12"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       (sources."has-ansi-2.0.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -60220,7 +60709,7 @@ in
       sources."js-yaml-3.12.0"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
@@ -60273,7 +60762,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."proto-list-1.2.4"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."read-metadata-1.0.0"
       sources."readable-stream-2.3.6"
@@ -60311,7 +60800,11 @@ in
       sources."tmp-0.0.33"
       sources."to-buffer-1.1.1"
       sources."toml-2.3.3"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."trim-repeated-1.0.0"
       sources."tslib-1.9.3"
       sources."tunnel-agent-0.6.0"
@@ -60325,6 +60818,7 @@ in
       sources."unbzip2-stream-1.3.1"
       sources."unyield-0.0.1"
       sources."unzip-response-2.0.1"
+      sources."uri-js-4.2.2"
       sources."url-parse-lax-1.0.0"
       sources."url-to-options-1.0.1"
       sources."user-home-2.0.0"
@@ -60353,13 +60847,14 @@ in
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "3.1.1";
+    version = "3.1.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.1.1.tgz";
-      sha512 = "FUL6sBmg50/1Y5GtOxMeFniqkpDCXBm2rlVgL+64eN+N9qIOKMZDAtfTy/F/d3TUn9Bc1lvPO6/6Xm9m68TnEg==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.1.3.tgz";
+      sha512 = "n2K36rlDioPKnJPVdtIt8GebwalkooGUdWYRmDO/qXB7q5izDoSlg3T6LMTjUeQW9GoHheSslUUUa0cYccDJLg==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
+      sources."@apollographql/apollo-tools-0.2.6"
       sources."@apollographql/apollo-upload-server-5.0.3"
       sources."@apollographql/graphql-playground-html-1.6.4"
       sources."@babel/runtime-corejs2-7.1.5"
@@ -60385,35 +60880,40 @@ in
       sources."@types/express-serve-static-core-4.16.0"
       sources."@types/long-4.0.0"
       sources."@types/mime-2.0.0"
-      sources."@types/node-10.12.5"
+      sources."@types/node-10.12.6"
       sources."@types/range-parser-1.2.2"
       sources."@types/serve-static-1.13.2"
       sources."@types/ws-6.0.1"
       sources."@types/zen-observable-0.8.0"
       sources."@vue/cli-shared-utils-3.1.1"
-      (sources."@vue/cli-ui-3.1.1" // {
+      (sources."@vue/cli-ui-3.1.2" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-3.1.1"
-      sources."@vue/cli-ui-addon-widgets-3.1.1"
+      sources."@vue/cli-ui-addon-webpack-3.1.2"
+      sources."@vue/cli-ui-addon-widgets-3.1.2"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.5"
       sources."aggregate-error-1.0.0"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-align-2.0.0"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."anymatch-2.0.0"
       sources."apollo-cache-1.1.20"
-      sources."apollo-cache-control-0.3.0"
+      sources."apollo-cache-control-0.3.1"
       sources."apollo-cache-inmemory-1.3.9"
       sources."apollo-client-2.4.5"
       sources."apollo-datasource-0.2.0"
-      sources."apollo-engine-reporting-0.1.0"
+      sources."apollo-engine-reporting-0.1.1"
       sources."apollo-engine-reporting-protobuf-0.1.0"
+      (sources."apollo-env-0.2.3" // {
+        dependencies = [
+          sources."core-js-3.0.0-beta.3"
+        ];
+      })
       sources."apollo-link-1.2.3"
       sources."apollo-link-context-1.0.9"
       sources."apollo-link-dedup-1.0.10"
@@ -60422,12 +60922,12 @@ in
       sources."apollo-link-state-0.4.2"
       sources."apollo-link-ws-1.0.9"
       sources."apollo-server-caching-0.2.0"
-      sources."apollo-server-core-2.2.0"
+      sources."apollo-server-core-2.2.1"
       sources."apollo-server-env-2.2.0"
       sources."apollo-server-errors-2.2.0"
-      sources."apollo-server-express-2.2.0"
-      sources."apollo-server-plugin-base-0.1.0"
-      sources."apollo-tracing-0.3.0"
+      sources."apollo-server-express-2.2.1"
+      sources."apollo-server-plugin-base-0.1.1"
+      sources."apollo-tracing-0.3.1"
       sources."apollo-upload-client-9.1.0"
       sources."apollo-utilities-1.0.25"
       sources."argparse-1.0.10"
@@ -60520,10 +61020,9 @@ in
       sources."cli-cursor-2.1.0"
       sources."cli-spinners-1.3.1"
       sources."cli-width-2.2.0"
-      sources."clipboard-2.0.1"
+      sources."clipboard-2.0.4"
       sources."clone-1.0.4"
       sources."cmd-shim-2.0.2"
-      sources."co-4.6.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -60663,8 +61162,8 @@ in
       })
       sources."extract-files-4.1.0"
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
-      sources."fast-glob-2.2.3"
+      sources."fast-deep-equal-2.0.1"
+      sources."fast-glob-2.2.4"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fd-slicer-1.1.0"
       sources."figures-2.0.0"
@@ -60726,14 +61225,14 @@ in
       sources."graceful-readlink-1.0.1"
       sources."graphql-14.0.2"
       sources."graphql-anywhere-4.1.22"
-      sources."graphql-extensions-0.3.0"
+      sources."graphql-extensions-0.3.1"
       sources."graphql-subscriptions-1.0.0"
       sources."graphql-tag-2.10.0"
       sources."graphql-tools-4.0.3"
       sources."graphql-type-json-0.2.1"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
@@ -60814,7 +61313,7 @@ in
       sources."js-yaml-3.12.0"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stable-stringify-1.0.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-4.0.0"
@@ -60884,7 +61383,7 @@ in
       })
       sources."negotiator-0.6.1"
       sources."nice-try-1.0.5"
-      sources."node-fetch-2.2.1"
+      sources."node-fetch-2.3.0"
       sources."node-ipc-9.1.1"
       sources."node-notifier-5.3.0"
       sources."nodemon-1.18.6"
@@ -61150,7 +61649,7 @@ in
       sources."to-regex-range-2.1.1"
       (sources."topo-3.0.3" // {
         dependencies = [
-          sources."hoek-6.0.2"
+          sources."hoek-6.0.3"
         ];
       })
       sources."touch-3.1.0"
@@ -61192,6 +61691,7 @@ in
       sources."unzip-response-2.0.1"
       sources."upath-1.1.0"
       sources."update-notifier-2.5.0"
+      sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."url-parse-lax-1.0.0"
       sources."url-to-options-1.0.1"
@@ -61204,6 +61704,7 @@ in
       sources."vary-1.1.2"
       sources."verror-1.10.0"
       sources."vue-cli-plugin-apollo-0.17.4"
+      sources."vue-cli-version-marker-3.1.2"
       sources."watch-1.0.2"
       sources."wcwidth-1.0.1"
       sources."which-1.3.1"
@@ -61435,7 +61936,7 @@ in
     };
     dependencies = [
       sources."abbrev-1.1.1"
-      sources."adm-zip-0.4.11"
+      sources."adm-zip-0.4.13"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
       sources."asn1-0.2.4"
@@ -62367,7 +62868,7 @@ in
       })
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
-      sources."@types/node-10.12.5"
+      sources."@types/node-10.12.6"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONSelect-0.2.1"
       sources."abbrev-1.1.1"
@@ -62392,7 +62893,7 @@ in
           sources."yargs-parser-10.1.0"
         ];
       })
-      sources."adm-zip-0.4.11"
+      sources."adm-zip-0.4.13"
       sources."agent-base-4.2.1"
       sources."ajv-6.5.4"
       sources."ajv-keywords-3.2.0"
@@ -62808,7 +63309,7 @@ in
         ];
       })
       sources."global-dirs-0.1.1"
-      sources."globals-11.8.0"
+      sources."globals-11.9.0"
       (sources."globby-6.1.0" // {
         dependencies = [
           sources."pify-2.3.0"
@@ -62820,11 +63321,9 @@ in
       sources."graphlib-2.1.5"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
-      (sources."har-validator-5.1.0" // {
+      (sources."har-validator-5.1.3" // {
         dependencies = [
-          sources."ajv-5.5.2"
-          sources."fast-deep-equal-1.1.0"
-          sources."json-schema-traverse-0.3.1"
+          sources."ajv-6.5.5"
         ];
       })
       sources."has-1.0.3"
@@ -63645,7 +64144,7 @@ in
       sources."@nodelib/fs.stat-1.1.3"
       sources."@sindresorhus/is-0.7.0"
       sources."aggregate-error-1.0.0"
-      sources."ajv-5.5.2"
+      sources."ajv-6.5.5"
       sources."ansi-0.3.1"
       sources."ansi-align-2.0.0"
       sources."ansi-escapes-3.1.0"
@@ -63735,7 +64234,6 @@ in
       sources."clone-regexp-1.0.1"
       sources."clone-response-1.0.2"
       sources."clone-stats-0.0.1"
-      sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
@@ -63822,8 +64320,8 @@ in
         ];
       })
       sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-1.1.0"
-      sources."fast-glob-2.2.3"
+      sources."fast-deep-equal-2.0.1"
+      sources."fast-glob-2.2.4"
       sources."fast-json-stable-stringify-2.0.0"
       sources."figures-2.0.0"
       (sources."fill-range-4.0.0" // {
@@ -63862,7 +64360,7 @@ in
       sources."graceful-fs-4.1.15"
       sources."grouped-queue-0.3.3"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.1.0"
+      sources."har-validator-5.1.3"
       (sources."has-ansi-2.0.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -63946,7 +64444,7 @@ in
       sources."json-buffer-3.0.0"
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.3.1"
+      sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."keyv-3.0.0"
@@ -64094,7 +64592,7 @@ in
       sources."proto-list-1.2.4"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
-      sources."punycode-1.4.1"
+      sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."query-string-5.1.1"
       sources."rc-1.2.8"
@@ -64271,7 +64769,11 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."tough-cookie-2.4.3"
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
       sources."trim-newlines-1.0.0"
       sources."tslib-1.9.3"
       sources."tunnel-0.0.5"
@@ -64299,6 +64801,7 @@ in
       sources."untildify-3.0.3"
       sources."unzip-response-2.0.1"
       sources."update-notifier-2.5.0"
+      sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."url-parse-lax-3.0.0"
       sources."url-to-options-1.0.1"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

