### PR TITLE
jackett: 0.10.420 -> 0.10.434

### DIFF
--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "jackett-${version}";
-  version = "0.10.420";
+  version = "0.10.434";
 
   src = fetchurl {
     url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.Mono.tar.gz";
-    sha256 = "192nj5k3ad8k4xdipr052sb3y3hi9csmyhjadlyy6xl8m2zz6win";
+    sha256 = "1vnkppmv7mw2p9bjcfmfxg66g02dq0020ad4z07gbp4dvixpzsnm";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Changelog from 0.10.420 : 

- Ethor.net: make MULTI replacement configurable (Thank you @kaso17)
- ImmortalSeed: fix skipped first release (Thank you @kaso17)
- GFXPeers: add freeleech detection (Thank you @kaso17)
- Nordicbits: category mapping and template 7 related fixes (Thank you @kaso17)
- RARBG: default to all categories (Thank you @kaso17)
- move from apollo to orpheus (#4149) (Thank you @sentriz)
- Myanonamouse: use API (Thank you @kaso17)
- MyAnonamouse: fix category handling (Thank you @kaso17)
- SceneHD: add indexer (Thank you @kaso17)
- Anthelion: renamed from TehConnection.me (Thank you @kaso17)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

