### PR TITLE
autospotting: init at unstable-2018-11-17

### DIFF
--- a/pkgs/applications/misc/autospotting/default.nix
+++ b/pkgs/applications/misc/autospotting/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "AutoSpotting-${version}";
+  version = "unstable-2018-11-17";
+  goPackagePath = "github.com/AutoSpotting/AutoSpotting";
+
+  src = fetchFromGitHub {
+    owner = "AutoSpotting";
+    repo = "AutoSpotting";
+    rev = "122ab8f292a2f718dd85e79ec22acd455122907e";
+    sha256 = "0p48lgig9kblxvgq1kggczkn4qdbx6ciq9c8x0179i80vl4jf7v6";
+  };
+
+  goDeps = ./deps.nix;
+
+  # patching path where repository used to exist
+  postPatch = ''
+   sed -i "s+github.com/cristim/autospotting/core+github.com/AutoSpotting/AutoSpotting/core+" autospotting.go
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/AutoSpotting/AutoSpotting;
+    description = "Automatically convert your existing AutoScaling groups to up to 90% cheaper spot instances with minimal(often zero) configuration changes";
+    license = licenses.free;
+    maintainers = [ maintainers.costrouc ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/applications/misc/autospotting/deps.nix
+++ b/pkgs/applications/misc/autospotting/deps.nix
@@ -1,0 +1,75 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/aws/aws-lambda-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-lambda-go";
+      rev =  "2d482ef09017ae953b1e8d5a6ddac5b696663a3c";
+      sha256 = "06v2yfvn4sn116lds0526a8mfrsng4vafrdjf1dhpalqarrbdvmz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev =  "9333060a8d957db41bff1c80603a802aa674fad8";
+      sha256 = "0fnypw6zm6k70fzhm5a8g69ag64rxbrrpdk7l3rkfqd99slyg5kz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cristim/ec2-instances-info";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cristim/ec2-instances-info";
+      rev =  "73c042a5558cd6d8b61fb82502d6f7aec334e9ed";
+      sha256 = "1xajrkxqqz5wlbi9w2wdhnk115rbmqxyga29f8v9psq8hzwgi0rg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "d8f796af33cc11cb798c1aaeb27a4ebc5099927d";
+      sha256 = "19z27f306fpsrjdvkzd61w1bdazcdbczjyjck177g33iklinhpvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev =  "5cf292cae48347c2490ac1a58fe36735fb78df7e";
+      sha256 = "0xbnw1nd22q6k863n5gs0nxld15w0p8qxbhfky85akcb5rk1vwi9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev =  "0b12d6b5";
+      sha256 = "1vv6hph8j6xgv7gwl9vvhlsaaqsm22sxxqmgmldi4v11783pc1ld";
+    };
+  }
+  {
+    goPackagePath  = "github.com/namsral/flag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/namsral/flag";
+      rev =  "67f268f20922975c067ed799e4be6bacf152208c";
+      sha256 = "1lmxq3z276zrsggpfq9b7yklzzxdyib49zr8sznb1lcqlvxqsr47";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -591,6 +591,8 @@ with pkgs;
 
   autoflake = callPackage ../development/tools/analysis/autoflake { };
 
+  autospotting = callPackage ../applications/misc/autospotting { };
+
   avfs = callPackage ../tools/filesystems/avfs { };
 
   avldrums-lv2 = callPackage ../applications/audio/avldrums-lv2 { };


### PR DESCRIPTION
###### Motivation for this change

Init package from @coretemp request. https://github.com/NixOS/nixpkgs/issues/50304

###### Things done

autospotting: init at unstable-2018-11-17

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

