### PR TITLE
wl-clipboard: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/wl-clipboard/default.nix
+++ b/pkgs/tools/misc/wl-clipboard/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig
+, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "wl-clipboard-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "bugaevc";
+    repo = "wl-clipboard";
+    rev = "v${version}";
+    sha256 = "03h6ajcc30w6928bkd4h6xfj4iy2359ww6hdlybq8mr1zwmb2h0q";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig wayland-protocols ];
+  buildInputs = [ wayland ];
+  mesonFlags = [ "-Dauto_features=enabled" ];
+
+  meta = with stdenv.lib; {
+    description = "Command-line copy/paste utilities for Wayland";
+    homepage = https://github.com/bugaevc/wl-clipboard;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dywedir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2413,6 +2413,8 @@ with pkgs;
     inherit (pythonPackages) sphinx;
   };
 
+  wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
+
   zabbix-cli = callPackage ../tools/misc/zabbix-cli { };
 
   ### DEVELOPMENT / EMSCRIPTEN


### PR DESCRIPTION
https://github.com/bugaevc/wl-clipboard#wl-clipboard-wayland-clipboard-utilities

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

