### PR TITLE
rubber: 1.4 -> 1.5.1

### DIFF
--- a/pkgs/tools/typesetting/rubber/default.nix
+++ b/pkgs/tools/typesetting/rubber/default.nix
@@ -1,12 +1,12 @@
-{ fetchurl, stdenv, python2Packages, texinfo }:
+{ fetchurl, stdenv, python3Packages, texinfo }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "rubber-${version}";
-  version = "1.4";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "https://launchpad.net/rubber/trunk/${version}/+download/${name}.tar.gz";
-    sha256 = "1d7hq19vpb3l31grldbxg8lx1qdd18f5f3gqw96q0lhf58agcjl2";
+    sha256 = "178dmrp0mza5gqjiqgk6dqs0c10s0c517pk6k9pjbam86vf47a1p";
   };
 
   propagatedBuildInputs = [ texinfo ];
@@ -20,7 +20,7 @@ python2Packages.buildPythonApplication rec {
   # the check scripts forces python2. If we need to use python3 at some point, we should use
   # the correct python
   checkPhase = ''
-    sed -i 's|python=python2|python=${python2Packages.python.interpreter}|' tests/run.sh
+    sed -i 's|python=python3|python=${python3Packages.python.interpreter}|' tests/run.sh
     cd tests && ${stdenv.shell} run.sh
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Version bump.

###### Things done

- [?] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS) **I think I did this correctly**
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) **not applicable?**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` 
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) **I get an error about how I shouldn't evaluate the entire Nixpkgs?? -- not sure how to fix this**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

