### PR TITLE
Add flexmock, sqlalchemy-utils, pgpy, and py-gfm

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -644,6 +644,11 @@
     github = "bricewge";
     name = "Brice Waegeneire";
   };
+  bsima = {
+    email = "ben@bsima.me";
+    github = "bsima";
+    name = "Ben Sima";
+  };
   bstrik = {
     email = "dutchman55@gmx.com";
     github = "bstrik";

--- a/pkgs/development/python-modules/flexmock/default.nix
+++ b/pkgs/development/python-modules/flexmock/default.nix
@@ -19,6 +19,11 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = https://flexmock.readthedocs.io/en/latest/;
     description = "flexmock is a testing library for Python.";
+    longDescription = ''
+      flexmock is a testing library for Python that makes it easy to create
+      mocks, stubs and fakes.
+    '';
     license = licenses.bsd2;
+    maintainers = [ maintainers.bsima ];
   };
 }

--- a/pkgs/development/python-modules/flexmock/default.nix
+++ b/pkgs/development/python-modules/flexmock/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "fe95c8727f4db73dc8f2f7b4548bffe7992440a965fefd60da291abda5352c2b";
   };
 
-  buildInputs = [ nose pytest ];
+  checkInputs = [ nose pytest ];
 
   meta = with lib; {
     homepage = https://flexmock.readthedocs.io/en/latest/;

--- a/pkgs/development/python-modules/flexmock/default.nix
+++ b/pkgs/development/python-modules/flexmock/default.nix
@@ -15,4 +15,10 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ nose pytest ];
+
+  meta = with lib; {
+    homepage = https://flexmock.readthedocs.io/en/latest/;
+    description = "flexmock is a testing library for Python.";
+    license = licenses.bsd2;
+  };
 }

--- a/pkgs/development/python-modules/flexmock/default.nix
+++ b/pkgs/development/python-modules/flexmock/default.nix
@@ -1,0 +1,18 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, nose
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "flexmock";
+  version = "0.10.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fe95c8727f4db73dc8f2f7b4548bffe7992440a965fefd60da291abda5352c2b";
+  };
+
+  buildInputs = [ nose pytest ];
+}

--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
       4880.
     '';
     license = licenses.bsd3;
+    maintainers = [ maintainers.bsima ];
   };
 }

--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -20,7 +20,12 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = https://github.com/SecurityInnovation/PGPy;
-    description = "PGPy is a Python (2 and 3) library for implementing Pretty Good Privacy into Python programs, conforming to the OpenPGP specification per RFC 4880.";
+    description = "Pretty Good Privacy for Python 2 and 3.";
+    longDescription = ''
+      PGPy is a Python (2 and 3) library for implementing Pretty Good Privacy
+      into Python programs, conforming to the OpenPGP specification per RFC
+      4880.
+    '';
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "04412dddd6882ac0c5d5daf4326c28d481421851a68e25e7ac8e06cc9dc2b902";
   };
 
-  buildInputs = [ cryptography pyasn1 six singledispatch ];
+  propogatedBuildInputs = [ cryptography pyasn1 six singledispatch ];
 
   meta = with lib; {
     homepage = https://github.com/SecurityInnovation/PGPy;

--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, cryptography
+, pyasn1
+, six
+, singledispatch
+}:
+
+buildPythonPackage rec {
+  pname = "PGPy";
+  version = "0.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04412dddd6882ac0c5d5daf4326c28d481421851a68e25e7ac8e06cc9dc2b902";
+  };
+
+  buildInputs = [ cryptography pyasn1 six singledispatch ];
+}

--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -17,4 +17,10 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ cryptography pyasn1 six singledispatch ];
+
+  meta = with lib; {
+    homepage = https://github.com/SecurityInnovation/PGPy;
+    description = "PGPy is a Python (2 and 3) library for implementing Pretty Good Privacy into Python programs, conforming to the OpenPGP specification per RFC 4880.";
+    license = licenses.bsd3;
+  };
 }

--- a/pkgs/development/python-modules/py-gfm/default.nix
+++ b/pkgs/development/python-modules/py-gfm/default.nix
@@ -18,6 +18,12 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = https://github.com/zopieux/py-gfm;
     description = "GitHub-Flavored Markdown as an extension to the Python Markdown library.";
+    longDescription = ''
+      This is an implementation of GitHub-Flavored Markdown written as an
+      extension to the Python Markdown library. It aims for maximal
+      compatibility with GitHub's rendering.
+    '';
     license = licenses.bsd3;
+    maintainers = [ maintainers.bsima ];
   };
 }

--- a/pkgs/development/python-modules/py-gfm/default.nix
+++ b/pkgs/development/python-modules/py-gfm/default.nix
@@ -14,4 +14,10 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ markdown ];
+
+  meta = with lib; {
+    homepage = https://github.com/zopieux/py-gfm;
+    description = "This is an implementation of GitHub-Flavored Markdown written as an extension to the Python Markdown library. It aims for maximal compatibility with GitHub's rendering.";
+    license = licenses.bsd3;
+  };
 }

--- a/pkgs/development/python-modules/py-gfm/default.nix
+++ b/pkgs/development/python-modules/py-gfm/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = https://github.com/zopieux/py-gfm;
-    description = "This is an implementation of GitHub-Flavored Markdown written as an extension to the Python Markdown library. It aims for maximal compatibility with GitHub's rendering.";
+    description = "GitHub-Flavored Markdown as an extension to the Python Markdown library.";
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/py-gfm/default.nix
+++ b/pkgs/development/python-modules/py-gfm/default.nix
@@ -1,0 +1,17 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, markdown
+}:
+
+buildPythonPackage rec {
+  pname = "py-gfm";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ef6750c579d26651cfd23968258b604228fd71b2a4e1f71dea3bea289e01377e";
+  };
+
+  buildInputs = [ markdown ];
+}

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -25,5 +25,10 @@ buildPythonPackage rec {
     homepage = https://github.com/kvesteri/sqlalchemy-utils;
     description = "Various utility functions and datatypes for SQLAlchemy.";
     license = licenses.bsd3;
+    longDescription = ''
+      SQLAlchemy-Utils provides custom data types and various utility functions
+      for SQLAlchemy.
+    '';
+    maintainers = [ maintainers.bsima ];
   };
 }

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = https://github.com/kvesteri/sqlalchemy-utils;
     description = "Various utility functions and datatypes for SQLAlchemy.";
-    license = licenses.bsd;
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, six
+, sqlalchemy
+, pytest
+, flexmock
+, mock
+, python-dateutil
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "SQLAlchemy-Utils";
+  version = "0.33.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "45ab41c90bfb8dd676e83179be3088b3f2d64b613e3b590187163dd941c22d4c";
+  };
+  checkInputs = [ pytest flexmock mock python-dateutil pytz ];
+  buildInputs = [ six sqlalchemy ];
+
+  meta = with lib; {
+    homepage = https://github.com/kvesteri/sqlalchemy-utils;
+    description = "Various utility functions and datatypes for SQLAlchemy.";
+    license = licenses.bsd;
+  };
+}

--- a/pkgs/development/python-modules/sshpubkeys/default.nix
+++ b/pkgs/development/python-modules/sshpubkeys/default.nix
@@ -23,5 +23,11 @@ buildPythonPackage rec {
     homepage = https://github.com/ojarva/python-sshpubkeys;
     description = "OpenSSH public key parser for Python";
     license = licenses.bsd3;
+    longDescription = ''
+      Native implementation for validating OpenSSH public keys.  Currently
+      ssh-rsa, ssh-dss (DSA), ssh-ed25519 and ecdsa keys with NIST curves are
+      supported.
+    '';
+    maintainers = [ maintainers.bsima ];
   };
 }

--- a/pkgs/development/python-modules/sshpubkeys/default.nix
+++ b/pkgs/development/python-modules/sshpubkeys/default.nix
@@ -18,4 +18,10 @@ buildPythonPackage rec {
 
   # For some reason nix can't find the "tests" module.
   doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/ojarva/python-sshpubkeys;
+    description = "OpenSSH public key parser for Python";
+    license = licenses.bsd3;
+  };
 }

--- a/pkgs/development/python-modules/sshpubkeys/default.nix
+++ b/pkgs/development/python-modules/sshpubkeys/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, cryptography
+, ecdsa
+}:
+
+buildPythonPackage rec {
+  pname = "sshpubkeys";
+  version = "3.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b388399caeeccdc145f06fd0d2665eeecc545385c60b55c282a15a022215af80";
+  };
+
+  buildInputs = [ cryptography ecdsa ];
+
+  # For some reason nix can't find the "tests" module.
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7101,6 +7101,8 @@ in {
 
   sqlalchemy_migrate = callPackage ../development/python-modules/sqlalchemy-migrate { };
 
+  sqlalchemy-utils = callPackage ../development/python-modules/sqlalchemy-utils { };
+
   sqlparse = buildPythonPackage rec {
     name = "sqlparse-${version}";
     version = "0.2.2";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -520,6 +520,8 @@ in {
 
   py-cpuinfo = callPackage ../development/python-modules/py-cpuinfo { };
 
+  py-gfm = callPackage ../development/python-modules/py-gfm { };
+
   pydbus = callPackage ../development/python-modules/pydbus { };
 
   pydocstyle = callPackage ../development/python-modules/pydocstyle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2322,6 +2322,8 @@ in {
 
   flask_wtf = callPackage ../development/python-modules/flask-wtf { };
 
+  flexmock = callPackage ../development/python-modules/flexmock { };
+
   wtforms = callPackage ../development/python-modules/wtforms { };
 
   graph-tool = callPackage ../development/python-modules/graph-tool/2.x.x.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -688,6 +688,8 @@ in {
 
   sslib = callPackage ../development/python-modules/sslib { };
 
+  sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
+
   statistics = callPackage ../development/python-modules/statistics { };
 
   sumo = callPackage ../development/python-modules/sumo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3530,6 +3530,8 @@ in {
 
   pgspecial = callPackage ../development/python-modules/pgspecial { };
 
+  pgpy = callPackage ../development/python-modules/pgpy { };
+
   pickleshare = buildPythonPackage rec {
     version = "0.7.4";
     name = "pickleshare-${version}";


### PR DESCRIPTION
###### Motivation for this change

Trying to build [core.sr.ht](https://git.sr.ht/~sircmpwn/core.sr.ht) for NixOS and running into missing packages, figured I would add them upstream. I tested each one with `nix-build -A pythonPackages.<pkgname>` to make sure they built.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

