### PR TITLE
welle-io: 1.0-rc2 -> 1.0

### DIFF
--- a/pkgs/applications/misc/welle-io/default.nix
+++ b/pkgs/applications/misc/welle-io/default.nix
@@ -3,7 +3,7 @@
 , faad2, rtl-sdr, soapysdr-with-plugins, libusb, fftwSinglePrec }:
 let
 
-  version = "1.0-rc2";
+  version = "1.0";
 
 in stdenv.mkDerivation {
 
@@ -13,7 +13,7 @@ in stdenv.mkDerivation {
     owner = "AlbrechtL";
     repo = "welle.io";
     rev = "V${version}";
-    sha256 = "01x4ldq6lvmdrmxi857594nj9xpn2h7848vvf3f54sh1zrawn4k4";
+    sha256 = "1fsr0c2w16z45mcr85sqmllw1xf2gn6hp6f6fmgx2zfprq8gdmcr";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update to stable release. The next version should be picked up by the auto updater.
CC @ck3d 

###### Things done
Test with a RTL-SDR USB Stick

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

