### PR TITLE
nixos/murmur: log to systemd journal, expose wrapper

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -811,6 +811,13 @@ inherit (pkgs.nixos {
    </listitem>
    <listitem>
     <para>
+     <option>services.murmur</option> now exposes the <literal>murmurd-service</literal>
+     wrapping the executable with the config file,
+     mainly to allow to set the SuperUser password via <literal>sudo -u murmur murmurd-service -readsupw</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The Kubernetes package has been bumped to major version 1.11. Please
      consult the
      <link xlink:href="https://github.com/kubernetes/kubernetes/blob/release-1.11/CHANGELOG-1.11.md">release

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -207,11 +207,12 @@
    </listitem>
    <listitem>
     <para>
-     The <option>services.murmur</option> now logs to the systemd journal
+     <option>services.murmur</option> now logs to the systemd journal
      instead of <filename>/var/log/murmur/murmurd.log</filename>.
-     This is achieved by having systemd run the daemon in foreground
-     instead of letting it fork to the background.
-     Therefore, the <option>services.murmur.pidfile</option> is now deprecated.
+     This means that in addition to <literal>root</literal> and the <literal>murmur</literal> user,
+     all users in the <literal>journal</literal> group have access to the initial SuperUser password
+     as long as that is in the journal.
+     The SuperUser password can now be easily changed with <literal>sudo -u murmur murmurd-service -readsupw</literal>.
     </para>
    </listitem>
    <listitem>
@@ -246,6 +247,21 @@
      <literal>veracrypt</literal>. VeraCrypt is backward-compatible with
      TrueCrypt volumes. Note that <literal>cryptsetup</literal> also
      supports loading TrueCrypt volumes.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+      <option>services.murmur</option> now exposes <literal>murmurd-service</literal>
+      which wraps the daemon executable with the service config file.
+      This allows to change the SuperUser password with
+      <literal>sudo -u murmur murmurd-service -readsupw</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     To be able to log the output of <option>services.murmur></option> to the journal,
+     the systemd service now runs the daemon in foreground instead of letting it fork to the background.
+     Therefore, the <option>services.murmur.pidfile</option> is now deprecated.
     </para>
    </listitem>
    <listitem>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -207,6 +207,15 @@
    </listitem>
    <listitem>
     <para>
+     The <option>services.murmur</option> now logs to the systemd journal
+     instead of <filename>/var/log/murmur/murmurd.log</filename>.
+     This is achieved by having systemd run the daemon in foreground
+     instead of letting it fork to the background.
+     Therefore, the <option>services.murmur.pidfile</option> is now deprecated.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Package <literal>ckb</literal> is renamed to <literal>ckb-next</literal>,
      and options <literal>hardware.ckb.*</literal> are renamed to
      <literal>hardware.ckb-next.*</literal>.


### PR DESCRIPTION
###### Motivation for this change
Everything I have on my server logs to systemd journal by default - except murmur.
This takes murmur in line with all other services by changing that.

On the very first start, murmur writes the password of the SuperUser into the log file.
To change this if desired or if that entry is not available anymore, this exposes a wrapper combining the binary and the service config file as the `murmurd-service` executable. (open to better naming propositions!).

As long as it's in the journal, the initial SuperUser password is now readable for all users in the `journal` group instead of `root` and `murmur` only. In case that group is not equal with the murmur administrators, the password can be changed with the new wrapper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

