### PR TITLE
opengrok: 0.12.1.5 -> 1.0

### DIFF
--- a/pkgs/development/tools/misc/opengrok/default.nix
+++ b/pkgs/development/tools/misc/opengrok/default.nix
@@ -1,30 +1,22 @@
-{ fetchurl, stdenv, jre, ctags, makeWrapper, coreutils, git }:
+{ stdenv, fetchurl, jre, ctags, makeWrapper, coreutils, git }:
 
 stdenv.mkDerivation rec {
   name = "opengrok-${version}";
   version = "1.0";
 
-  # 1.0 is the latest distributed as a .tar.gz file.
-  # Newer are distribued as .zip so a source build is required.
-
-  # if builded from source
-  #src = fetchurl {
-  #  url = "https://github.com/OpenGrok/OpenGrok/archive/${version}.tar.gz";
-  #  sha256 = "01r7ipnj915rnyxyqrnmjfagkip23q5lx9g787qb7qrnbvgfi118";
-  #};
-
   # binary distribution
   src = fetchurl {
-    url = https://github.com/OpenGrok/OpenGrok/files/213268/opengrok-0.12.1.5.tar.gz;
-    sha256 = "1bafiq4s9sqldinl6fy931rm0x8zj2magfdlbi3nqlnidsghgkn3";
+    url = "https://github.com/oracle/opengrok/releases/download/${version}/${name}.tar.gz";
+    sha256 = "0h4rwfh8m41b7ij931gcbmkihri25m48373qf6ig0714s66xwc4i";
   };
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out
     cp -a * $out/
-    substituteInPlace $out/bin/OpenGrok --replace /bin/uname ${coreutils}/bin/uname
+    substituteInPlace $out/bin/OpenGrok --replace "/bin/uname" "${coreutils}/bin/uname"
+    substituteInPlace $out/bin/Messages --replace "#!/bin/ksh" "#!/bin/sh"
     wrapProgram $out/bin/OpenGrok \
       --prefix PATH : "${stdenv.lib.makeBinPath [ ctags git ]}" \
       --set JAVA_HOME "${jre}" \


### PR DESCRIPTION
###### Motivation for this change

Follow up to #36639 which changed the version in derivation name but we were still fetching the source tarball of v0.12.1.5
The SHA hash was the same, just changed from base16 to base32.

This PR actually updates opengrok to v1.0
/cc @lethalman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

