### PR TITLE
refind: 0.11.3 -> 0.11.4

### DIFF
--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -13,12 +13,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "refind-${version}";
-  version = "0.11.3";
+  version = "0.11.4";
   srcName = "refind-src-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/refind/${version}/${srcName}.tar.gz";
-    sha256 = "13q1yap9r4lzm5xjx1zi434gckd3gk5p8n4vh6jav0h3r3ayp633";
+    sha256 = "1bjd0dl77bc5k6g3kc7s8m57vpbg2zscph9qh84xll9rc10g3fir";
   };
 
   buildInputs = [ gnu-efi ];


### PR DESCRIPTION
###### Motivation for this change

[New update](https://sourceforge.net/projects/refind/files/0.11.4/), [changes here](https://sourceforge.net/p/refind/code/ci/1e2c1f9fece3407afcd5b87056b2b8b1cfcdf891/tree/NEWS.txt).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ❌ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also verified it works on my machine.