### PR TITLE
transcribe: 8.40 -> 8.72

### DIFF
--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchzip, lib, wrapGAppsHook, alsaLib, atk, cairo, gdk_pixbuf
-, glib, gst_all_1,  gtk3, libSM, libX11 , libpng12, pango, zlib }:
+{ stdenv, fetchzip, wrapGAppsHook, alsaLib, atk, cairo, gdk_pixbuf
+, glib, gst_all_1,  gtk3, libSM, libX11, libpng12, pango, zlib }:
 
 stdenv.mkDerivation rec {
   name = "transcribe-${version}";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   dontPatchELF = true;
 
-  libPath = with gst_all_1; lib.makeLibraryPath [
+  libPath = with gst_all_1; stdenv.lib.makeLibraryPath [
     stdenv.cc.cc glib gtk3 atk pango cairo gdk_pixbuf alsaLib
     libX11 libSM libpng12 gstreamer gst-plugins-base zlib
   ];

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -1,33 +1,31 @@
-{ stdenv, fetchzip, lib, makeWrapper, alsaLib, atk, cairo, gdk_pixbuf
-, glib, gst-ffmpeg, gst-plugins-bad, gst-plugins-base
-, gst-plugins-good, gst-plugins-ugly, gstreamer, gtk2, libSM, libX11
-, libpng12, pango, zlib }:
+{ stdenv, fetchzip, lib, wrapGAppsHook, alsaLib, atk, cairo, gdk_pixbuf
+, glib, gst_all_1,  gtk3, libSM, libX11 , libpng12, pango, zlib }:
 
 stdenv.mkDerivation rec {
   name = "transcribe-${version}";
-  version = "8.40";
+  version = "8.72";
 
   src = if stdenv.hostPlatform.system == "i686-linux" then
     fetchzip {
-      url = "https://www.seventhstring.com/xscribe/downlinux32_old/xscsetup.tar.gz";
-      sha256 = "1ngidmj9zz8bmv754s5xfsjv7v6xr03vck4kigzq4bpc9b1fdhjq";
+      url = "https://www.seventhstring.com/xscribe/downlinux32/xscsetup.tar.gz";
+      sha256 = "1h5l7ry9c9awpxfnd29b0wm973ifrhj17xl5d2fdsclw2swsickb";
     }
   else if stdenv.hostPlatform.system == "x86_64-linux" then
     fetchzip {
-      url = "https://www.seventhstring.com/xscribe/downlinux64_old/xsc64setup.tar.gz";
-      sha256 = "0svzi8svj6zn06gj0hr8mpnhq4416dvb4g5al0gpb1g3paywdaf9";
+      url = "https://www.seventhstring.com/xscribe/downlinux64/xsc64setup.tar.gz";
+      sha256 = "1rpd3ppnx5i5yrnfbjrx7h7dk48kwl99i9lnpa75ap7nxvbiznm0";
     }
   else throw "Platform not supported";
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ wrapGAppsHook ];
 
-  buildInputs = [ gst-plugins-base gst-plugins-good
-    gst-plugins-bad gst-plugins-ugly gst-ffmpeg ];
+  buildInputs = with gst_all_1; [ gst-plugins-base gst-plugins-good
+    gst-plugins-bad gst-plugins-ugly ];
 
   dontPatchELF = true;
 
-  libPath = lib.makeLibraryPath [
-    stdenv.cc.cc glib gtk2 atk pango cairo gdk_pixbuf alsaLib
+  libPath = with gst_all_1; lib.makeLibraryPath [
+    stdenv.cc.cc glib gtk3 atk pango cairo gdk_pixbuf alsaLib
     libX11 libSM libpng12 gstreamer gst-plugins-base zlib
   ];
 
@@ -42,13 +40,18 @@ stdenv.mkDerivation rec {
     patchelf \
       --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
       $out/libexec/transcribe
+  '';
 
-    wrapProgram $out/libexec/transcribe \
-      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH" \
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH_1_0"
       --prefix LD_LIBRARY_PATH : "${libPath}"
+    )
+  '';
 
+  postFixup = ''
     ln -s $out/libexec/transcribe $out/bin/
-    '';
+  '';
 
   meta = with stdenv.lib; {
     description = "Software to help transcribe recorded music";


### PR DESCRIPTION
###### Motivation for this change

Update to the latest release, drop dependencies on some obsolete libraries (old gstreamer, gtk, ffmpeg). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Admittedly I have not tested this much outside of very, very basic functionality; @michalrus would you mind reviewing / testing if you still use the package?