### PR TITLE
nixos/switch-to-configuration: restart changed socket units 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -220,6 +220,18 @@
      reset to the default value (<literal>false</literal>).
     </para>
    </listitem>
+   <listitem>
+      <para>
+        The <literal>services.fcgiwrap</literal> module has been converted to use
+        socket activation with <literal>systemd</literal>. You can now
+        configure the owner, group and mode of a unix socket. The service
+        won't be started as <literal>root</literal> anymore by default and the option
+        <literal>services.fcgiwrap.socketType</literal> was removed because
+        <literal>services.fcgiwrap.socketAddress</literal> now takes
+        addresses as defined in
+        <citerefentry><refentrytitle>systemd.socket</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+      </para>
+    </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -262,6 +262,7 @@ with lib;
     (mkRemovedOptionModule [ "virtualisation" "xen" "qemu" ] "You don't need this option anymore, it will work without it.")
     (mkRemovedOptionModule [ "services" "logstash" "enableWeb" ] "The web interface was removed from logstash")
     (mkRemovedOptionModule [ "boot" "zfs" "enableLegacyCrypto" ] "The corresponding package was removed from nixpkgs.")
+    (mkRemovedOptionModule [ "services" "fcgiwrap" "socketType" ] "Use services.fcgiwrap.socketAddress to specify the socket type instead.")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -229,7 +229,17 @@ while (my ($unit, $state) = each %{$activePrev}) {
                 # Reload the changed mount unit to force a remount.
                 $unitsToReload{$unit} = 1;
                 recordUnit($reloadListFile, $unit);
-            } elsif ($unit =~ /\.socket$/ || $unit =~ /\.path$/ || $unit =~ /\.slice$/) {
+            } elsif ($unit =~ /\.socket$/) {
+                my $unitInfo = parseUnit($newUnitFile);
+                # If a socket unit has been changed, the corresponding
+                # service unit has to be stopped before the socket can
+                # be restarted.
+                my $serviceUnit = $unitInfo->{'Unit'} // "$baseName.service";
+                $unitsToStop{$serviceUnit} = 1;
+                $unitsToStop{$unit} = 1;
+                $unitsToStart{$unit} = 1;
+                recordUnit($startListFile, $unit);
+            } elsif ($unit =~ /\.path$/ || $unit =~ /\.slice$/) {
                 # FIXME: do something?
             } else {
                 my $unitInfo = parseUnit($newUnitFile);

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -69,6 +69,7 @@ in
   elk = handleTestOn ["x86_64-linux"] ./elk.nix {};
   env = handleTest ./env.nix {};
   etcd = handleTestOn ["x86_64-linux"] ./etcd.nix {};
+  fcgiwrap = handleTest ./fcgiwrap.nix {};
   ferm = handleTest ./ferm.nix {};
   firefox = handleTest ./firefox.nix {};
   firewall = handleTest ./firewall.nix {};

--- a/nixos/tests/fcgiwrap.nix
+++ b/nixos/tests/fcgiwrap.nix
@@ -1,0 +1,54 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+let
+  helloScript = pkgs.writeShellScriptBin "hello" ''
+    echo "Status: 200 OK"
+    echo
+    echo "$out says: Hello World!"
+  '';
+
+  mkServer = extraConfig: { ... }:
+    lib.mkMerge [
+      { services.fcgiwrap.enable = true;
+        services.nginx.enable = true;
+        services.nginx.commonHttpConfig = ''
+          error_log syslog:server=unix:/dev/log;
+          access_log syslog:server=unix:/dev/log;
+        '';
+        services.nginx.virtualHosts."_".locations."/".extraConfig = ''
+          fastcgi_param SCRIPT_FILENAME ${helloScript}/bin/hello;
+          fastcgi_pass  unix:/run/fcgiwrap.sock;
+        '';
+      }
+      extraConfig
+    ];
+
+in
+
+{ name = "fcgiwrap";
+  meta = with pkgs.stdenv.lib.maintainers;
+  { maintainers = [ fpletz ]; };
+
+  nodes = {
+    working = mkServer {
+      services.fcgiwrap.socketGroup = "nginx";
+    };
+
+    permissionfail = mkServer {
+      services.fcgiwrap.socketGroup = "root";
+    };
+  };
+
+  testScript = { nodes, ... }: let
+    permissionfail = nodes.permissionfail.config.system.build.toplevel;
+  in ''
+    $working->start;
+
+    $working->waitForUnit("nginx");
+    $working->waitForOpenPort("80");
+    $working->succeed("curl http://localhost/ | tee /dev/stderr | grep 'Hello World!'");
+
+    $working->succeed("${permissionfail}/bin/switch-to-configuration test");
+    $working->fail("curl -f http://localhost/");
+  '';
+})

--- a/pkgs/servers/fcgiwrap/default.nix
+++ b/pkgs/servers/fcgiwrap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, systemd, fcgi, autoreconfHook, pkgconfig }:
+{ stdenv, fetchurl, fetchpatch, systemd, fcgi, autoreconfHook, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "fcgiwrap-${version}";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "http://github.com/gnosek/fcgiwrap/archive/${version}.tar.gz";
     sha256 = "07y6s4mm86cv7p1ljz94sxnqa89y9amn3vzwsnbq5hrl4vdy0zac";
   };
+
+  patches = [
+    # Support for custom working dir with the FCGI_CHDIR environment variable.
+    # https://github.com/gnosek/fcgiwrap/pull/21
+    (fetchpatch {
+      url = "https://github.com/gnosek/fcgiwrap/commit/caf1f5c7b3e9cf5b777139c0419d47fa933ff510.patch";
+      sha256 = "0npdicjvkhpjvd39parrc3wjwd0871d3vz34nwr7p2mk6x9q5dwi";
+    })
+  ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=implicit-fallthrough";
   configureFlags = [ "--with-systemd" "--with-systemdsystemunitdir=$(out)/etc/systemd/system" ];


### PR DESCRIPTION
###### Motivation for this change

Previously, socket units wouldn't be restarted if they were changed. To restart the socket, the service the socket is attached to needs to be stopped first before the socket can be restarted.

Discovered while converting fcgiwrap to full socket activation support and writing a test for it. These changes are also part of this PR as is the test that checks using fcgiwrap if sockets are properly restarted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

