### PR TITLE
Fix test evaluation in restrict-eval

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,7 +97,7 @@ let
       appendToName mapDerivationAttrset lowPrio lowPrioSet hiPrio
       hiPrioSet;
     inherit (sources) pathType pathIsDirectory cleanSourceFilter
-      cleanSource sourceByRegex sourceFilesBySuffices
+      cleanSource cleanSourceForImport sourceByRegex sourceFilesBySuffices
       commitIdFromGitRepo cleanSourceWith pathHasContext
       canCleanSource;
     inherit (modules) evalModules closeModules unifyModuleSyntax

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -32,6 +32,18 @@ rec {
   #          cleanSource ./.
   cleanSource = src: cleanSourceWith { filter = cleanSourceFilter; inherit src; };
 
+  # Cleans the source if not operating in restrict-eval. This will make
+  # it possible to import from the cleaned source.
+  #
+  # Example:
+  #          cleanSourceForImport ./..
+  cleanSourceForImport = src:
+    # This is using a very ugly hack to know whether we're evaluating in restrict-mode.
+    # Please don't do this at home.
+    if builtins.pathExists "/"
+    then cleanSource src
+    else src;
+
   # Like `builtins.filterSource`, except it will compose with itself,
   # allowing you to chain multiple calls together without any
   # intermediate copies being put in the nix store.

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -2,7 +2,7 @@
 # and nixos-14.04). The channel is updated every time the ‘tested’ job
 # succeeds, and all other jobs have finished (they may fail).
 
-{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
+{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 654321; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" ]
 , limitedSupportedSystems ? [ "i686-linux" ]

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -2,7 +2,7 @@
 # and nixos-14.04). The channel is updated every time the ‘tested’ job
 # succeeds, and all other jobs have finished (they may fail).
 
-{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 654321; shortRev = "gfedcba"; }
+{ nixpkgs ? { outPath = (import ../lib).cleanSourceForImport ./..; revCount = 654321; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" ]
 , limitedSupportedSystems ? [ "i686-linux" ]

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -2,7 +2,7 @@
 # small subset of Nixpkgs, mostly useful for servers that need fast
 # security updates.
 
-{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
+{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 654321; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" ] # no i686-linux
 }:

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -2,7 +2,7 @@
 # small subset of Nixpkgs, mostly useful for servers that need fast
 # security updates.
 
-{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 654321; shortRev = "gfedcba"; }
+{ nixpkgs ? { outPath = (import ../lib).cleanSourceForImport ./..; revCount = 654321; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" ] # no i686-linux
 }:

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -1,6 +1,8 @@
 with import ../lib;
 
-{ nixpkgs ? { outPath = cleanSource ./..; revCount = 654321; shortRev = "gfedcba"; }
+# `revCount` and `shortRev` are placeholders, that should be filled
+# automatically for releases by passing the `nixpkgs` argument
+{ nixpkgs ? { outPath = cleanSourceForImport ./..; revCount = 654321; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
 , configuration ? {}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -1,6 +1,6 @@
 with import ../lib;
 
-{ nixpkgs ? { outPath = cleanSource ./..; revCount = 130979; shortRev = "gfedcba"; }
+{ nixpkgs ? { outPath = cleanSource ./..; revCount = 654321; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
 , configuration ? {}


### PR DESCRIPTION
This will be more easily reviewed commit-by-commit.

For the `revCount` reset, I'm not 100% sure of myself, but with `shortRev` being a placeholder and the previous value being `56789` I'm ~99% sure it was supposed to be a placeholder too.

I have checked that the `--option restrict-eval true` reproducers now appear to build correctly locally.

Commit messages for easier reading:

#### release: reset `revCount` to a dummy placeholder

Placeholder had been removed in 7e968a4.

Additionally, bumps the `revCount` from `release-small.nix` and
`release-combined.nix` so that it's more obvious it's a placeholder.

CC: @vcunat

####  release: do not cleanSource when evaluating in restrict-eval

The current behavior, breaking restrict-eval=true, had been introduced
in 209f8b1. See also [1].

This change uses a hack to identify whether we're evaluating in
restrict-eval, keeping the optimization when not and reverting to the
old behavior when evaluating in restrict-eval.

This should fix the issues that appeared at [2] and [3], that followed
the change making us actually use this `nixpkgs` argument for tests
since 83b27f6 [4].

CC: @roberth

[1] https://github.com/NixOS/nixpkgs/commit/209f8b1acd4c#commitcomment-28419462

[2] https://github.com/NixOS/nixpkgs/pull/50233#issuecomment-438512807

[3] #50186

[4] #50233

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

