### PR TITLE
houdini: 16.5.439 -> 17.0.352

### DIFF
--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -29,15 +29,15 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "16.5.439";
+  version = "16.5.634";
   name = "houdini-runtime-${version}";
   src = requireFile rec {
     name = "houdini-${version}-linux_x86_64_gcc4.8.tar.gz";
-    sha256 = "7e483072a0e6e751a93f2a2f968cccb2d95559c61106ffeb344c95975704321b";
+    sha256 = "1jl7i2arhwxz42wb872i6wxqxxgdj8rkgg5rn1phsljv5w4kqc68";
     message = ''
       This nix expression requires that ${name} is already part of the store.
       Download it from https://sidefx.com and add it to the nix store with:
-        
+
           nix-prefetch-url <URL>
 
       This can't be done automatically because you need to create an account on

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -29,11 +29,11 @@ let
   license_dir = "~/.config/houdini";
 in
 stdenv.mkDerivation rec {
-  version = "16.5.634";
+  version = "17.0.352";
   name = "houdini-runtime-${version}";
   src = requireFile rec {
-    name = "houdini-${version}-linux_x86_64_gcc4.8.tar.gz";
-    sha256 = "1jl7i2arhwxz42wb872i6wxqxxgdj8rkgg5rn1phsljv5w4kqc68";
+    name = "houdini-${version}-linux_x86_64_gcc6.3.tar.gz";
+    sha256 = "0cl5fkgaplb0cvv7mli06ffc9j4ngpy8hl5zqabj3d645gcgafjg";
     message = ''
       This nix expression requires that ${name} is already part of the store.
       Download it from https://sidefx.com and add it to the nix store with:


### PR DESCRIPTION
###### Motivation for this change

The version currently used in nixpkgs is no longer available from upstream's website (though it can be found with some digging in their FTP archives). Also, a new major release is out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

