### PR TITLE
ocamlPackages.menhir: 20181026 -> 20181113

### DIFF
--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild
-, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20181026" else "20140422"
+, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20181113" else "20140422"
 }@args:
 
 let
   src = fetchurl (
   if version == "20140422" then { url = "http://cristal.inria.fr/~fpottier/menhir/menhir-20140422.tar.gz"; sha256 = "1ki1f2id6a14h9xpv2k8yb6px7dyw8cvwh39csyzj4qpzx7wia0d"; }
   else if version == "20170712" then { url = "http://gallium.inria.fr/~fpottier/menhir/menhir-20170712.tar.gz"; sha256 = "006hq3bwj81j67f2k9cgzj5wr4hai8j36925p5n3sd2j01ljsj6a"; }
-  else if version == "20181026" then { url = "https://gitlab.inria.fr/fpottier/menhir/repository/20181026/archive.tar.gz"; sha256 = "1zhacw60996i9b88kbnfvrvjk3ps9p9n9syjk9np545jp8l0582g"; }
+  else if version == "20181113" then { url = "https://gitlab.inria.fr/fpottier/menhir/repository/20181113/archive.tar.gz"; sha256 = "0hl611l0gyl7b2bm7m0sk7vjz14m0i7znrnjq3gw58pylj934dx4"; }
   else throw ("menhir: unknown version " ++ version)
   );
 in


### PR DESCRIPTION
###### Motivation for this change

[New rule syntax](https://gitlab.inria.fr/fpottier/menhir/blob/master/doc/new-rule-syntax-summary.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

