### PR TITLE
astroquery: init at 0.3.8

### DIFF
--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   meta = with pkgs.lib; {
     description = "Functions and classes to access online data resources";
     homepage = "https://astroquery.readthedocs.io/";
-    license = licenses.bsdOriginal;
+    license = licenses.bsd3;
     maintainers = [ maintainers.smaret ];
   };
 }

--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -1,0 +1,30 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, astropy
+, requests
+, keyring
+, beautifulsoup4
+, html5lib
+}:
+
+buildPythonPackage rec {
+  pname = "astroquery";
+  version = "0.3.8";
+
+  doCheck = false; # Tests require the pytest-astropy package
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "800d9730c9e2bd299f14c29b4d709d1605c82833223a2e4f784fea7ad805c168";
+  };
+
+  propagatedBuildInputs = [ astropy requests keyring beautifulsoup4 html5lib ];
+
+  meta = with pkgs.lib; {
+    description = "Functions and classes to access online data resources";
+    homepage = "https://astroquery.readthedocs.io/";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -196,6 +196,8 @@ in {
 
   astropy = callPackage ../development/python-modules/astropy { };
 
+  astroquery = callPackage ../development/python-modules/astroquery { }; 
+
   atom = callPackage ../development/python-modules/atom { };
 
   augeas = callPackage ../development/python-modules/augeas {


### PR DESCRIPTION
###### Motivation for this change

Package for the [astroquery](https://astroquery.readthedocs.io/en/latest/) Python module for Nix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
