### PR TITLE
x265: 2.7 -> 2.9

### DIFF
--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, yasm
+{ stdenv, fetchurl, fetchpatch, cmake, yasm
 , debugSupport ? false # Run-time sanity checks (debugging)
 , highbitdepthSupport ? false # false=8bits per channel, true=10/12bits per channel
 , werrorSupport ? false # Warnings as errors
@@ -16,19 +16,28 @@ in
 
 stdenv.mkDerivation rec {
   name = "x265-${version}";
-  version = "2.7";
+  version = "2.9";
 
   src = fetchurl {
     urls = [
-      "http://get.videolan.org/x265/x265_${version}.tar.gz"
-      "https://github.com/videolan/x265/archive/${version}.tar.gz"
+      "https://get.videolan.org/x265/x265_${version}.tar.gz"
+      "ftp://ftp.videolan.org/pub/videolan/x265/x265_${version}.tar.gz"
     ];
-    sha256 = "18llni1m8kfvdwy5bp950z6gyd0nijmvi3hzd6gd8vpy5yk5zrym";
+    sha256 = "090hp4216isis8q5gb7bwzia8rfyzni54z21jnwm97x3hiy6ibpb";
   };
 
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  patches = [
+    # Fix issue #442 (linking issue on non-x86 platforms)
+    # Applies on v2.9 only, this should be removed at next update
+    (fetchpatch {
+      url = "https://bitbucket.org/multicoreware/x265/commits/471726d3a0462739ff8e3518eb1a1e8a01de4e8d/raw";
+      sha256 = "0mj8lb8ng8lrhzjavap06vjhqf6j0r3sn76c6rhs3012f86lv928";
+    })
+  ];
+
+  postPatch = ''
     sed -i 's/unknown/${version}/g' source/cmake/version.cmake
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Targeting this at staging since it is quite a big rebuild + source URLs enhancement
Thanks @grische for the original pkg update

Encoder enhancements, AVX-512 support, ...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

