### PR TITLE
firefoxen: remove unused gstreamer dependencies

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -19,7 +19,7 @@
 
 , alsaSupport ? stdenv.isLinux, alsaLib
 , pulseaudioSupport ? stdenv.isLinux, libpulseaudio
-, ffmpegSupport ? true, gstreamer, gst-plugins-base
+, ffmpegSupport ? true
 , gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
 , gssSupport ? true, kerberos
 
@@ -101,7 +101,6 @@ stdenv.mkDerivation rec {
   ++ lib.optional (lib.versionOlder ffversion "61") hunspell
   ++ lib.optional  alsaSupport alsaLib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
-  ++ lib.optionals ffmpegSupport [ gstreamer gst-plugins-base ]
   ++ lib.optional  gtk3Support gtk3
   ++ lib.optional  gssSupport kerberos
   ++ lib.optionals stdenv.isDarwin [ CoreMedia ExceptionHandling Kerberos
@@ -221,7 +220,6 @@ stdenv.mkDerivation rec {
   ++ flag pulseaudioSupport "pulseaudio"
   ++ flag ffmpegSupport "ffmpeg"
   ++ flag gssSupport "negotiateauth"
-  ++ lib.optional (!ffmpegSupport) "--disable-gstreamer"
   ++ flag webrtcSupport "webrtc"
   ++ flag crashreporterSupport "crashreporter"
   ++ lib.optional drmSupport "--enable-eme=widevine"

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -29,12 +29,9 @@
 
 # Media support (implies audio support)
 , mediaSupport ? false
-, gstreamer
-, gst-plugins-base
-, gst-plugins-good
-, gst-ffmpeg
-, gmp
 , ffmpeg
+
+, gmp
 
 # Pluggable transport dependencies
 , python27
@@ -85,19 +82,8 @@ let
   ]
   ++ optionals pulseaudioSupport [ libpulseaudio ]
   ++ optionals mediaSupport [
-    gstreamer
-    gst-plugins-base
-    gmp
     ffmpeg
   ];
-
-  gstPluginsPath = concatMapStringsSep ":" (x:
-    "${x}/lib/gstreamer-0.10") [
-      gstreamer
-      gst-plugins-base
-      gst-plugins-good
-      gst-ffmpeg
-    ];
 
   # Library search path for the fte transport
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
@@ -365,10 +351,6 @@ stdenv.mkDerivation rec {
       TOR_SKIP_LAUNCH="\''${TOR_SKIP_LAUNCH:-}" \
       TOR_CONTROL_PORT="\''${TOR_CONTROL_PORT:-}" \
       TOR_SOCKS_PORT="\''${TOR_SOCKS_PORT:-}" \
-      \
-      GST_PLUGIN_SYSTEM_PATH="${optionalString mediaSupport gstPluginsPath}" \
-      GST_REGISTRY="/dev/null" \
-      GST_REGISTRY_UPDATE="no" \
       \
       FONTCONFIG_FILE="$FONTCONFIG_FILE" \
       \

--- a/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
@@ -19,12 +19,9 @@
 
 # Media support (implies audio support)
 , mediaSupport ? false
-, gstreamer
-, gst-plugins-base
-, gst-plugins-good
-, gst-ffmpeg
-, gmp
 , ffmpeg
+
+, gmp
 
 # Extensions, common
 , zip
@@ -72,18 +69,7 @@ let
 
   fontsDir = "${fontsEnv}/share/fonts";
 
-  gstPluginsPath = concatMapStringsSep ":" (x:
-    "${x}/lib/gstreamer-0.10") [
-      gstreamer
-      gst-plugins-base
-      gst-plugins-good
-      gst-ffmpeg
-    ];
-
-  gstLibPath = makeLibraryPath [
-    gstreamer
-    gst-plugins-base
-    gmp
+  mediaLibPath = makeLibraryPath [
     ffmpeg
   ];
 in
@@ -207,7 +193,7 @@ stdenv.mkDerivation rec {
     ''}
 
     ${optionalString mediaSupport ''
-      wrapper_LD_LIBRARY_PATH=${gstLibPath}''${wrapper_LD_LIBRARY_PATH:+:$wrapper_LD_LIBRARY_PATH}
+      wrapper_LD_LIBRARY_PATH=${mediaLibPath}''${wrapper_LD_LIBRARY_PATH:+:$wrapper_LD_LIBRARY_PATH}
     ''}
 
     mkdir -p $out/bin
@@ -284,10 +270,6 @@ stdenv.mkDerivation rec {
     #
     # APULSE_PLAYBACK_DEVICE is for audio playback w/o pulseaudio (no capture yet)
     #
-    # GST_PLUGIN_SYSTEM_PATH is for HD video playback
-    #
-    # GST_REGISTRY is set to devnull to minimize disk writes
-    #
     # TOR_* is for using an external tor instance
     #
     # Parameters lacking a default value below are *required* (enforced by
@@ -313,10 +295,6 @@ stdenv.mkDerivation rec {
       FONTCONFIG_FILE="$TBDATA_IN_STORE/fonts.conf" \
       \
       APULSE_PLAYBACK_DEVICE="\''${APULSE_PLAYBACK_DEVICE:-plug:dmix}" \
-      \
-      GST_PLUGIN_SYSTEM_PATH="${optionalString mediaSupport gstPluginsPath}" \
-      GST_REGISTRY="/dev/null" \
-      GST_REGISTRY_UPDATE="no" \
       \
       TOR_SKIP_LAUNCH="\''${TOR_SKIP_LAUNCH:-}" \
       TOR_CONTROL_PORT="\''${TOR_CONTROL_PORT:-}" \


### PR DESCRIPTION
Firefox and, by extension, Tor browser don't support gstreamer any more, this
removes what are effectively unused dependencies.

https://bugzilla.mozilla.org/show_bug.cgi?id=1234092 "Remove gstreamer support"

###### Motivation for this change

Working towards https://github.com/NixOS/nixpkgs/issues/22372 and https://github.com/NixOS/nixpkgs/issues/39975 (removal of old gstreamer and ffmpeg versions).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Built `firefox`, `firefox-esr`, `tor-browser-bundle` and `tor-browser-bundle-bin` and verified media playback works in all (with `mediaSupport` enabled for the tor browsers).

/cc @joachifm @oxij for the tor browser changes

Not sure who, if anyone, to ping for the Firefox changes.