### PR TITLE
[staging] nss, libpng updates

### DIFF
--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -3,20 +3,20 @@
 assert zlib != null;
 
 let
-  patchVersion = "1.6.34";
+  patchVersion = "1.6.35";
   patch_src = fetchurl {
     url = "mirror://sourceforge/libpng-apng/libpng-${patchVersion}-apng.patch.gz";
-    sha256 = "1ha4npf9mfrzp0srg8a5amks5ww84xzfpjbsj8k3yjjpai798qg6";
+    sha256 = "011fq5wgyz07pfrqs9albixbiksx3agx5nkcf3535gbvhlwv5khq";
   };
   whenPatched = stdenv.lib.optionalString apngSupport;
 
 in stdenv.mkDerivation rec {
   name = "libpng" + whenPatched "-apng" + "-${version}";
-  version = "1.6.34";
+  version = "1.6.35";
 
   src = fetchurl {
     url = "mirror://sourceforge/libpng/libpng-${version}.tar.xz";
-    sha256 = "1xjr0v34fyjgnhvaa1zixcpx5yvxcg4zwvfh0fyklfyfj86rc7ig";
+    sha256 = "1mxwjf5cdzk7g0y51gl9w3f0j5ypcls05i89kgnifjaqr742x493";
   };
   postPatch = whenPatched "gunzip < ${patch_src} | patch -Np1";
 

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -8,11 +8,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.39";
+  version = "3.40";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_39_RTM/src/${name}.tar.gz";
-    sha256 = "0jw6qlfl2g47hhx056nvnj6h92bk3sn46hy3ig61a911dzblvrkb";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_40_RTM/src/${name}.tar.gz";
+    sha256 = "1p9jidi3nysirf3lhkrqkjjrf2cw3y2wz2jgjvsjn1ysidxhhqh5";
   };
 
   buildInputs = [ perl zlib sqlite ]


### PR DESCRIPTION
###### Motivation for this change

I am trying to get all the dependencies for the next Firefox releasesup to date early this time.

These changes are the ones that I could identify & bump so far.

I did try these changes on top of master and they did compile fine. I am still building them based on the staging branch but do not expect breakage.

At some point we should probably port them back to 18.09 so we can ship the FFX update there as well..
