### PR TITLE
php: Fix CVE-2018-17082 (release-18.03)

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -6,6 +6,7 @@
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium }:
 
+assert (config.php.intl or false) -> !stdenv.isDarwin;
 let
 
   generic =
@@ -260,7 +261,7 @@ let
         opensslSupport = config.php.openssl or true;
         mbstringSupport = config.php.mbstring or true;
         gdSupport = config.php.gd or true;
-        intlSupport = config.php.intl or true;
+        intlSupport = config.php.intl or (!stdenv.isDarwin);
         exifSupport = config.php.exif or true;
         xslSupport = config.php.xsl or false;
         mcryptSupport = config.php.mcrypt or true;
@@ -351,12 +352,12 @@ in {
   };
 
   php71 = generic {
-    version = "7.1.21";
-    sha256 = "104mn4kppklb21hgz1a50kgmc0ak5y996sx990xpc8yy9dbrqh62";
+    version = "7.1.24";
+    sha256 = "02qy76krbdhlbkzs9k1sa5mgmj0qnbb8gcf1j3q0cq3z7kkj9pk6";
   };
 
   php72 = generic {
-    version = "7.2.8";
-    sha256 = "1rky321gcvjm0npbfd4bznh36an0y14viqcvn4yzy3x643sni00z";
+    version = "7.2.12";
+    sha256 = "1dpnbsv4bdlc5v40ddddi971f456jp1qrn89w5di1dj70g1c895p";
   };
 }


### PR DESCRIPTION
#### php: 5.6.32 -> 5.6.38, 7.0.28 -> 7.0.32, 7.1.21 -> 7.1.24, 7.2.8 -> 7.2.12

Also make Darwin align itself to Linux versions, due to CVE-2018-17082
forcing our hand on this. This means Darwin must compile without intl.

Fixes https://github.com/NixOS/nixpkgs/issues/50368

###### Things done

Tested with `./result/bin/php` passing `<?php echo "a\nb\n";` and checked it did output correctly `a` and `b`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

