### PR TITLE
fasm: init at 1.73.04

### DIFF
--- a/pkgs/development/compilers/fasm/bin.nix
+++ b/pkgs/development/compilers/fasm/bin.nix
@@ -1,0 +1,24 @@
+{ stdenvNoCC, lib, fetchurl }:
+
+stdenvNoCC.mkDerivation rec {
+  name = "fasm-bin-${version}";
+
+  version = "1.73.04";
+
+  src = fetchurl {
+    url = "https://flatassembler.net/fasm-${version}.tgz";
+    sha256 = "0y0xkf9fzcm5gklhdi61wjpd1p8islpbcnkv5k16aqci3qsd0ia1";
+  };
+
+  installPhase = ''
+    install -D fasm${lib.optionalString stdenvNoCC.isx86_64 ".x64"} $out/bin/fasm
+  '';
+
+  meta = with lib; {
+    description = "x86(-64) macro assembler to binary, MZ, PE, COFF, and ELF";
+    homepage = https://flatassembler.net/download.php;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ orivej ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/compilers/fasm/default.nix
+++ b/pkgs/development/compilers/fasm/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fasm-bin, isx86_64 }:
+
+stdenv.mkDerivation rec {
+  inherit (fasm-bin) version src meta;
+
+  name = "fasm-${version}";
+
+  nativeBuildInputs = [ fasm-bin ];
+
+  buildPhase = ''
+    fasm source/Linux${lib.optionalString isx86_64 "/x64"}/fasm.asm fasm
+    for tool in listing prepsrc symbols; do
+      fasm tools/libc/$tool.asm
+      cc -o tools/libc/fasm-$tool tools/libc/$tool.o
+    done
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  installPhase = ''
+    install -Dt $out/bin fasm tools/libc/fasm-*
+
+    docs=$doc/share/doc/fasm
+    mkdir -p $docs
+    cp -r examples/ *.txt tools/fas.txt $docs
+    cp tools/readme.txt $docs/tools.txt
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6644,6 +6644,11 @@ with pkgs;
 
   apache-flex-sdk = callPackage ../development/compilers/apache-flex-sdk { };
 
+  fasm = pkgsi686Linux.callPackage ../development/compilers/fasm {
+    inherit (stdenv) isx86_64;
+  };
+  fasm-bin = callPackage ../development/compilers/fasm/bin.nix { };
+
   fpc = callPackage ../development/compilers/fpc { };
 
   gambit = callPackage ../development/compilers/gambit { stdenv = gccStdenv; };


### PR DESCRIPTION
###### Motivation for this change

See https://flatassembler.net/download.php . (This is the main page, not only downloads.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).