### PR TITLE
vimPlugins.vim-go: use the correct motion derivation for the dependency

### DIFF
--- a/pkgs/development/tools/go-motion/default.nix
+++ b/pkgs/development/tools/go-motion/default.nix
@@ -1,0 +1,38 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  name = "motion-unstable-${version}";
+  version = "2018-04-09";
+  rev = "218875ebe23806e7af82f3b5b14bb3355534f679";
+
+  goPackagePath = "github.com/fatih/motion";
+  excludedPackages = ''testdata'';
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "fatih";
+    repo = "motion";
+    sha256 = "08lp61hmb77p0cknf71jp8lssplxad3ddyqjxh8x3cr0bmn9ykr9";
+  };
+
+  meta = with lib; {
+    description = "Navigation and insight in Go";
+    longDescription = ''
+      Motion is a tool that was designed to work with editors. It is providing
+      contextual information for a given offset(option) from a file or
+      directory of files. Editors can use these informations to implement
+      navigation, text editing, etc... that are specific to a Go source code.
+
+      It's optimized and created to work with vim-go, but it's designed to work
+      with any editor. It's currently work in progress and open to change.
+    '';
+    homepage = https://github.com/fatih/motion;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -12,7 +12,7 @@
 
 # vim-go denpencies
 , asmfmt, delve, errcheck, godef, golint
-, gomodifytags, gotags, gotools, motion
+, gomodifytags, gotags, gotools, go-motion
 , gnused, reftools, gogetdoc, gometalinter
 , impl, iferr, gocode, gocode-gomod, go-tools
 }:
@@ -265,6 +265,7 @@ with generated;
       asmfmt
       delve
       errcheck
+      go-motion
       go-tools
       gocode
       gocode-gomod
@@ -277,7 +278,6 @@ with generated;
       gotools
       iferr
       impl
-      motion
       reftools
     ];
     in {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16629,6 +16629,8 @@ with pkgs;
 
   exercism = callPackage ../applications/misc/exercism { };
 
+  go-motion = callPackage ../development/tools/go-motion { };
+
   gpg-mdp = callPackage ../applications/misc/gpg-mdp { };
 
   icesl = callPackage ../applications/misc/icesl { };


### PR DESCRIPTION
###### Motivation for this change

vimPlugins.vim-go was using the wrong motion package, see https://github.com/NixOS/nixpkgs/pull/49669#commitcomment-31301419

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Mic92 