### PR TITLE
Add spruned application and nixos module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -609,6 +609,7 @@
   ./services/networking/smokeping.nix
   ./services/networking/softether.nix
   ./services/networking/spiped.nix
+  ./services/networking/spruned.nix
   ./services/networking/squid.nix
   ./services/networking/sslh.nix
   ./services/networking/ssh/lshd.nix

--- a/nixos/modules/services/networking/spruned.nix
+++ b/nixos/modules/services/networking/spruned.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.spruned;
+
+  cliArgs = "--datadir ${cfg.dataDir} --network bitcoin.${cfg.network} ${cfg.extraArguments}";
+in
+{
+  options = {
+    services.spruned = {
+      enable = mkEnableOption "The spruned lightweight Bitcoin pseudonode daemon service";
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/spruned";
+        description = ''
+          Directory to store cached block data and spruned logs.
+        '';
+      };
+      network = mkOption {
+        type = types.enum [ "mainnet" "testnet" ];
+        default = "mainnet";
+        description = ''
+          Whether to use Bitcoin mainnet or testnet.
+        '';
+      };
+      extraArguments = mkOption {
+        type = types.separatedString " ";
+        example = "--mempoolsize 20 --debug";
+        default = "";
+        description = ''
+          Additional arguments to be passed to spruned.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.spruned = {
+      description = "spruned service";
+      after = [ "local-fs.target" "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Restart = "on-abort";
+        ExecStart = "${pkgs.spruned}/bin/spruned ${cliArgs}";
+      };
+    };
+  };
+}

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, boost165, openssl_1_1, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3, buildGo110Package }:
+{ callPackage, boost155, boost165, openssl_1_1, darwin, libsForQt5, miniupnpc_2, python3, buildGo110Package }:
 
 rec {
 

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -7,6 +7,7 @@ rec {
   bitcoin  = libsForQt5.callPackage ./bitcoin.nix { miniupnpc = miniupnpc_2; withGui = true; };
   bitcoind = callPackage ./bitcoin.nix { miniupnpc = miniupnpc_2; withGui = false; };
   clightning = callPackage ./clightning.nix { };
+  spruned = callPackage ./spruned { };
 
   bitcoin-abc  = libsForQt5.callPackage ./bitcoin-abc.nix { boost = boost165; withGui = true; };
   bitcoind-abc = callPackage ./bitcoin-abc.nix { boost = boost165; withGui = false; };

--- a/pkgs/applications/altcoins/spruned/default.nix
+++ b/pkgs/applications/altcoins/spruned/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, python3 }:
+
+let
+  pythonPackages = python3.pkgs;
+in
+with stdenv.lib;
+pythonPackages.buildPythonApplication rec {
+  pname = "spruned";
+  version = "0.0.4b4";
+
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "b156ad410ae71651aafb4ffc639ad491614622a53b3cb8211fd49e2579642f18";
+  };
+
+  disabled = ! pythonPackages.pythonAtLeast "3.5";
+
+  propagatedBuildInputs =
+    with pythonPackages; [
+      async-timeout
+      jsonrpcserver
+      sqlalchemy
+      plyvel
+      daemonize
+      aiohttp
+      pycoin
+    ];
+
+  patchPhase = ''
+    sed -i 's,import spruned,,;s,spruned.__version__,"${version}",' setup.py
+
+    substituteInPlace spruned/application/tools.py \
+      --replace "subprocess.call(['ping" "subprocess.call(['/run/wrappers/bin/ping"
+
+    substituteInPlace requirements.txt \
+      --replace 'sqlalchemy==1.2.6' 'sqlalchemy==1.2.*' \
+      --replace 'aiohttp==3.0.0b0' aiohttp \
+      --replace 'daemonize==2.4.7' daemonize \
+      --replace 'async-timeout==2.0.1' async-timeout \
+      --replace 'jsonrpcserver==3.5.3' jsonrpcserver \
+      --replace 'plyvel==0.9.0' plyvel
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A Bitcoin lightweight pseudonode with RPC that can fetch any block or transaction";
+    homepage = https://github.com/gdassori/spruned;
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/apply-defaults/default.nix
+++ b/pkgs/development/python-modules/apply-defaults/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "apply_defaults";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b8c1bc511a0368dabe1af4d80b97186296e25182d7e371d920a9633cf6a2a385";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/bcb/apply_defaults;
+    description = "Apply default values to functions";
+    license = licenses.free;
+    maintainers = with maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/development/python-modules/jsonrpcserver/default.nix
+++ b/pkgs/development/python-modules/jsonrpcserver/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, jsonschema, funcsigs, apply-defaults, mypy, six
+}:
+
+buildPythonPackage rec {
+  pname = "jsonrpcserver";
+  version = "3.5.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8442af3632ebf012c773aea78639e1ad3f605cda2ffcc58d6e4e34ecf8b4a167";
+  };
+
+  propagatedBuildInputs = [ apply-defaults jsonschema funcsigs six ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/bcb/jsonrpcserver;
+    description = "Process JSON-RPC requests in Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/development/python-modules/pycoin/default.nix
+++ b/pkgs/development/python-modules/pycoin/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchPypi, buildPythonPackage, tox, pytest }:
+
+buildPythonPackage rec {
+  pname = "pycoin";
+  version = "0.80";
+
+  src = fetchPypi{
+    inherit pname version;
+    sha256 = "a79a7771c3f6ca2e35667e80983987f0c799c5db01e58016c22a12e8484b2034";
+  };
+
+  checkInputs = [ tox pytest ];
+
+  checkPhase = "tox";
+
+  meta = with stdenv.lib; {
+    description = "Utilities for Bitcoin and altcoin addresses and transaction manipulation";
+    homepage = https://github.com/richardkiss/pycoin;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15819,6 +15819,7 @@ with pkgs;
 
   bitcoin = altcoins.bitcoin;
   clightning = altcoins.clightning;
+  spruned = altcoins.spruned;
 
   bitcoin-xt = altcoins.bitcoin-xt;
   cryptop = altcoins.cryptop;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1265,6 +1265,8 @@ in {
 
   jsonrpc-websocket = callPackage ../development/python-modules/jsonrpc-websocket { };
 
+  jsonrpcserver = callPackage ../development/python-modules/jsonrpcserver {};
+
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
 
   pyunifi = callPackage ../development/python-modules/pyunifi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1317,6 +1317,8 @@ in {
 
   cffi = callPackage ../development/python-modules/cffi { };
 
+  pycoin = callPackage ../development/python-modules/pycoin { };
+
   pycollada = callPackage ../development/python-modules/pycollada { };
 
   pycontracts = callPackage ../development/python-modules/pycontracts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -182,6 +182,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  apply-defaults = callPackage ../development/python-modules/apply-defaults { };
+
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
###### Motivation for this change

spruned is a lightweight Bitcoin pseudonode with RPC that can fetch any block or transaction

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

