### PR TITLE
fusee-launcher: init at unstable-2018-07-14

### DIFF
--- a/pkgs/development/tools/fusee-launcher/default.nix
+++ b/pkgs/development/tools/fusee-launcher/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, python3Packages
+, python3
+, fetchFromGitHub
+, pkgsCross
+, makeWrapper
+} :
+
+stdenv.mkDerivation rec {
+  name = "fusee-launcher-${version}";
+  version = "unstable-2018-07-14";
+
+  src = fetchFromGitHub {
+    owner = "Cease-and-DeSwitch";
+    repo = "fusee-launcher";
+    rev = "265e8f3e1987751ec41db6f1946d132b296aba43";
+    sha256 = "1pqkgw5bk0xcz9x7pc1f0r0b9nsc8jnnvcs1315d8ml8mx23fshm";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    cp fusee-launcher.py $out/bin/fusee-launcher
+    cp intermezzo.bin $out/share/intermezzo.bin
+
+    # Wrap with path to intermezzo.bin relocator binary in /share
+    wrapProgram $out/bin/fusee-launcher \
+      --add-flags "--relocator $out/share/intermezzo.bin" \
+      --prefix PYTHONPATH : "$PYTHONPATH:$(toPythonPath $out)"
+  '';
+
+  nativeBuildInputs = [ pkgsCross.arm-embedded.buildPackages.gcc makeWrapper python3Packages.wrapPython ];
+  buildInputs = [ python3 python3Packages.pyusb ];
+  pythonPath = with python3Packages; [ pyusb ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Cease-and-DeSwitch/fusee-launcher;
+    description = "Work-in-progress launcher for one of the Tegra X1 bootROM exploits";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pneumaticat ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2768,6 +2768,8 @@ with pkgs;
 
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
+  fusee-launcher = callPackage ../development/tools/fusee-launcher { };
+
   fwknop = callPackage ../tools/security/fwknop { };
 
   exfat = callPackage ../tools/filesystems/exfat { };


### PR DESCRIPTION
###### Motivation for this change

> [The Fusée Launcher is a proof-of-concept arbitrary code loader for a variety of Tegra processors, which takes advantage of CVE-2018-6242 ("Fusée Gelée") to gain arbitrary code execution and load small payloads over USB.](https://github.com/Cease-and-DeSwitch/fusee-launcher)

It launches custom firmware payloads for the Nintendo Switch, essentially. It's useful to have running as a systemd service so that you can plug in the switch and auto-exploit it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

