### PR TITLE
tmuxPlugins.sensible: hardcode the path of reattach-to-user-namespace

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1,4 +1,9 @@
-{ fetchgit, stdenv, pkgs }:
+{ fetchgit
+, lib
+, pkgs
+, reattach-to-user-namespace
+, stdenv
+}:
 
 let
   rtpPath = "share/tmux-plugins";
@@ -187,6 +192,9 @@ in rec {
       rev = "e91b178ff832b7bcbbf4d99d9f467f63fd1b76b5";
       sha256 = "1z8dfbwblrbmb8sgb0k8h1q0dvfdz7gw57las8nwd5gj6ss1jyvx";
     };
+    postInstall = lib.optionalString pkgs.stdenv.isDarwin ''
+      sed -e 's:reattach-to-user-namespace:${reattach-to-user-namespace}/bin/reattach-to-user-namespace:g' -i $target/sensible.tmux
+    '';
   };
 
   sessionist = mkDerivation {


### PR DESCRIPTION
###### Motivation for this change

On Mac, the sensible plugin is useless if `reattach-to-user-namespace` was not found in PATH. This changeset hardcodes the location of the `reattach-to-user-namespace` binary so it's always found and used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

