### PR TITLE
freesweep: use fetchFromGitHub instead of fetchurl as per #32997

### DIFF
--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -1,13 +1,15 @@
-{ fetchurl, ncurses, stdenv,
+{ fetchFromGitHub, ncurses, stdenv,
   updateAutotoolsGnuConfigScriptsHook }:
 
 stdenv.mkDerivation rec {
   name = "freesweep-${version}";
   version = "1.0.1";
 
-  src = fetchurl {
-    url = "https://github.com/rwestlund/freesweep/archive/v${version}.tar.gz";
-    sha256 = "0l2kf14558lsq9qd2hs0kcyn9bbl1jdbzwrvcs6mnyjl7zpizcpj";
+  src = fetchFromGitHub {
+    owner = "rwestlund";
+    repo = "freesweep";
+    rev = "v${version}";
+    sha256 = "0grkwmz9whg1vlnk6gbr0vv9i2zgbd036182pk0xj4cavaj9rpjb";
   };
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];


### PR DESCRIPTION
###### Motivation for this change

#32997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - no change
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

