### PR TITLE
nixos/tests/installer: add missing system.extraDependencies

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -244,6 +244,7 @@ let
                 shared-mime-info
                 texinfo
                 xorg.lndir
+                gtk3
 
                 # add curl so that rather than seeing the test attempt to download
                 # curl's tarball, we see what it's trying to download


### PR DESCRIPTION
###### Motivation for this change

since 39a9b865b57a35911d5783ab245217f5f7098e64 the test VM
depends on some extra packages to build the system to be installed.
This broke the installer test as it tried to download/build these
packages in a sandbox.

original issue : #45866

###### Things done

I did what @xeji did in 43e30b1eadac5f86fe6f91b13ebcace88bf8a597

Running the test on my machine is working and is fixing the issue

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

