### PR TITLE
waifu2x-converter-cpp: init at 5.2.1

### DIFF
--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, opencv3, opencl-headers,
+  cudaSupport ? false , cudatoolkit ? null }:
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "waifu2x-converter-cpp";
+  version = "5.2.1";
+
+  src = fetchFromGitHub {
+    owner = "DeadSix27";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1cfab4239zidql7wgn0gprnz0zp6sy2dknxr5pa8vx7c6g6vgh20";
+  };
+
+  preConfigure = ''
+    mkdir -p $out
+    cp -r models_rgb $out/
+    substituteInPlace src/main.cpp --replace "models_rgb" "$out/models_rgb"
+  '';
+
+  buildInputs =
+    [ opencv3 opencl-headers ] ++ stdenv.lib.optional cudaSupport cudatoolkit;
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/DeadSix27/waifu2x-converter-cpp;
+    description = "Improved fork of Waifu2X C++ using OpenCL and OpenCV";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ mt-caret ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5991,6 +5991,8 @@ with pkgs;
 
   vtun = callPackage ../tools/networking/vtun { };
 
+  waifu2x-converter-cpp = callPackage ../tools/graphics/waifu2x-converter-cpp { };
+
   wakatime = pythonPackages.callPackage ../tools/misc/wakatime { };
 
   weather = callPackage ../applications/misc/weather { };


### PR DESCRIPTION
###### Motivation for this change

Adds waifu2x-converter-cpp, an anime image superresolution tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

