### PR TITLE
Unbreak hg-git

### DIFF
--- a/pkgs/development/python-modules/hg-git/default.nix
+++ b/pkgs/development/python-modules/hg-git/default.nix
@@ -3,19 +3,28 @@
 , fetchPypi
 , dulwich
 , isPy3k
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "hg-git";
-  version = "0.8.11";
+  version = "0.8.12";
   disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "08kw1sj3sq1q1571hwkc51w20ks9ysmlg93pcnmd6gr66bz02dyn";
+    sha256 = "13hbm0ki6s88r6p65ibvrbxnskinzdz0m9gsshb8s571p91ymfjn";
   };
 
   propagatedBuildInputs = [ dulwich ];
+
+  # Needs patch to work with Mercurial 4.8
+  # https://bitbucket.org/durin42/hg-git/issues/264/unexpected-keyword-argument-createopts-hg
+  patches =
+    fetchpatch {
+      url = "https://bitbucket.org/rsalmaso/hg-git/commits/a778506fd4be0bf1afa75755f6ee9260fa234a0f/raw";
+      sha256 = "12r4qzbc5xcqwv0kvf8g4wjji7n45421zkbf6i75vyi4nl6n4j15";
+    };
 
   meta = with stdenv.lib; {
     description = "Push and pull from a Git server using Mercurial";


### PR DESCRIPTION
###### Motivation for this change

hg-git did not work with the current Mercurial because of well-known issues,
one of which is fixed in the latest release, the second one of which has a simple
patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

