### PR TITLE
nixnote2: fix window icon and themes

### DIFF
--- a/pkgs/applications/misc/nixnote2/default.nix
+++ b/pkgs/applications/misc/nixnote2/default.nix
@@ -30,8 +30,9 @@ mkDerivation rec {
     substituteInPlace nixnote.cpp --replace 'tidyProcess.start("tidy' 'tidyProcess.start("${html-tidy}/bin/tidy'
   '';
 
-  postInstal = ''
+  postInstall = ''
     cp images/windowIcon.png $out/share/pixmaps/nixnote2.png
+    cp theme.ini $out/share/nixnote2/theme.ini
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

nixnote2 was missing a file that the upstream author recommends to manually install into `share` -- `themes.ini`. See https://github.com/baumgarr/nixnote2/issues/320. Without this change, the application does not support any theme except for the default.

While making this change I noticed that `postInstall` was typo'd (as `postInstal`) preventing the application's icon from being installed correctly.

###### Things done

I tested the binary file via `nix-env -f . -iA nixnote2` on NixOS -- the application icon and selection of themes were fixed.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

