### PR TITLE
nixos-functions: remove recurseIntoAttrs

### DIFF
--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -11,23 +11,19 @@ To run this test:
  */
 { pkgs, lib, stdenv, ... }:
 
-lib.optionalAttrs stdenv.hostPlatform.isLinux (
-  pkgs.recurseIntoAttrs {
+lib.optionalAttrs stdenv.hostPlatform.isLinux ({
+  nixos-test = (pkgs.nixos {
+    boot.loader.grub.enable = false;
+    fileSystems."/".device = "/dev/null";
+  }).toplevel;
 
-    nixos-test = (pkgs.nixos {
-      boot.loader.grub.enable = false;
-      fileSystems."/".device = "/dev/null";
-    }).toplevel;
-
-    nixosTest-test = pkgs.nixosTest ({ lib, pkgs, ... }: {
-      name = "nixosTest-test";
-      machine = { pkgs, ... }: {
-        environment.systemPackages = [ pkgs.hello ];
-      };
-      testScript = ''
+  nixosTest-test = pkgs.nixosTest ({ lib, pkgs, ... }: {
+    name = "nixosTest-test";
+    machine = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.hello ];
+    };
+    testScript = ''
         $machine->succeed("hello");
-      '';
-    });
-
-  }
-)
+    '';
+  });
+})


### PR DESCRIPTION
This prevents from tooling like nix-review/nox-review from trying to build those.
Also we probably don't want to evaluate nixos when updating the nix search index.
Hopefully also fix https://github.com/NixOS/ofborg/issues/269
