### PR TITLE
unicode-paracode: 2.5 -> 2.6, unicode 10 -> 11

### DIFF
--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "unicode-${version}";
-  version = "2.5";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "garabik";
     repo = "unicode";
     rev = "v${version}";
-    sha256 = "0vg1zshlzgdva8gzw6fya28fc4jhypjkj743x3q0yabx6934k0g2";
+    sha256 = "17hh4nwl5njsh7lnff583j2axn6rfvfbiqwp72n7vcsgkiszw4kg";
   };
 
   ucdtxt = fetchurl {

--- a/pkgs/tools/misc/unicode/default.nix
+++ b/pkgs/tools/misc/unicode/default.nix
@@ -12,8 +12,8 @@ python3Packages.buildPythonApplication rec {
   };
 
   ucdtxt = fetchurl {
-    url = http://www.unicode.org/Public/10.0.0/ucd/UnicodeData.txt;
-    sha256 = "1cfak1j753zcrbgixwgppyxhm4w8vda8vxhqymi7n5ljfi6kwhjj";
+    url = http://www.unicode.org/Public/11.0.0/ucd/UnicodeData.txt;
+    sha256 = "16b0jzvvzarnlxdvs2izd5ia0ipbd87md143dc6lv6xpdqcs75s9";
   };
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change


```
$ unicode 1F999
```

;)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---