### PR TITLE
selfoss (service): fix port in service config

### DIFF
--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -11,7 +11,7 @@ let
   selfoss-config =
   let
     db_type = cfg.database.type;
-    default_port = if (db_type == "mysql") then "3306" else "5342";
+    default_port = if (db_type == "mysql") then 3306 else 5342;
   in
   pkgs.writeText "selfoss-config.ini" ''
     [globals]
@@ -21,8 +21,8 @@ let
       db_database=${cfg.database.name}
       db_username=${cfg.database.user}
       db_password=${cfg.database.password}
-      db_port=${if (cfg.database.port != null) then (toString cfg.database.port)
-                    else default_port}
+      db_port=${toString (if (cfg.database.port != null) then cfg.database.port
+                    else default_port)}
     ''
     }
     ${cfg.extraConfig}

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -11,7 +11,7 @@ let
   selfoss-config =
   let
     db_type = cfg.database.type;
-    default_port = if (db_type == "mysql") then 3306 else 5342;
+    default_port = if (db_type == "mysql") then "3306" else "5342";
   in
   pkgs.writeText "selfoss-config.ini" ''
     [globals]
@@ -21,7 +21,7 @@ let
       db_database=${cfg.database.name}
       db_username=${cfg.database.user}
       db_password=${cfg.database.password}
-      db_port=${if (cfg.database.port != null) then cfg.database.port
+      db_port=${if (cfg.database.port != null) then (toString cfg.database.port)
                     else default_port}
     ''
     }


### PR DESCRIPTION
###### Motivation for this change

The `services.selfoss.database.port` option has type `types.nullOr types.int`. However it is then used as a string, which makes even the default config fail. This change fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change ~~using `nix-shell -p nox --run "nox-review wip"`~~
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

