### PR TITLE
glibc, ghc: disable PIE hardening when enabled by default (musl for now :))

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -232,7 +232,7 @@ stdenv.mkDerivation (rec {
   checkTarget = "test";
   doCheck = false; # fails with "testsuite/tests: No such file or directory.  Stop."
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ] ++ stdenv.lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     for bin in "$out"/lib/${name}/bin/*; do

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -204,7 +204,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ] ++ stdenv.lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     for bin in "$out"/lib/${name}/bin/*; do

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -189,7 +189,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ] ++ stdenv.lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     for bin in "$out"/lib/${name}/bin/*; do

--- a/pkgs/development/compilers/ghc/8.6.2.nix
+++ b/pkgs/development/compilers/ghc/8.6.2.nix
@@ -189,7 +189,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ] ++ stdenv.lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     for bin in "$out"/lib/${name}/bin/*; do

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -171,7 +171,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ] ++ stdenv.lib.optional stdenv.targetPlatform.isMusl "pie";
 
   postInstall = ''
     for bin in "$out"/lib/${name}/bin/*; do

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -35,7 +35,10 @@ callPackage ./common.nix { inherit stdenv; } {
     # The stackprotector and fortify hardening flags are autodetected by glibc
     # and enabled by default if supported. Setting it for every gcc invocation
     # does not work.
-    hardeningDisable = [ "stackprotector" "fortify" ];
+    hardeningDisable = [ "stackprotector" "fortify" ]
+    # XXX: Not actually musl-speciic but since only musl enables pie by default,
+    #      limit rebuilds by only disabling pie w/musl
+      ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "pie";
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for
     # any program we run, because the gcc will have been placed at a new


### PR DESCRIPTION
###### Motivation for this change

Unbreak after well-intentioned (and IMO the right direct long-term anyway) change
enabling PIE by default when using musl.

~Still testing that this fixes GHC, currently the build is past where it failed before
but until it finishes who can say ;).~

This fixes GHC! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---