### PR TITLE
nixos: switch the package installation prefix from `nixos.` to `nixpkgs.`

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -72,16 +72,16 @@ default. To figure out the proper attribute path, it's easiest to query for the
 path of a well-known Nixpkgs package, i.e.:
 ```
 $ nix-env -qaP coreutils
-nixos.coreutils  coreutils-8.23
+nixpkgs.coreutils  coreutils-8.23
 ```
 
 If your system responds like that (most NixOS installations will), then the
-attribute path to `haskellPackages` is `nixos.haskellPackages`. Thus, if you
+attribute path to `haskellPackages` is `nixpkgs.haskellPackages`. Thus, if you
 want to use `nix-env` without giving an explicit `-f` flag, then that's the way
 to do it:
 ```shell
-nix-env -qaP -A nixos.haskellPackages
-nix-env -iA nixos.haskellPackages.cabal-install
+nix-env -qaP -A nixpkgs.haskellPackages
+nix-env -iA nixpkgs.haskellPackages.cabal-install
 ```
 
 Our current default compiler is GHC 7.10.x and the `haskellPackages` set

--- a/doc/languages-frameworks/idris.section.md
+++ b/doc/languages-frameworks/idris.section.md
@@ -5,9 +5,6 @@
 The easiest way to get a working idris version is to install the `idris` attribute:
 
 ```
-$ # On NixOS
-$ nix-env -i nixos.idris
-$ # On non-NixOS
 $ nix-env -i nixpkgs.idris
 ```
 
@@ -19,9 +16,6 @@ $ nix-env -iE 'pkgs: pkgs.idrisPackages.with-packages (with pkgs.idrisPackages; 
 
 To see all available Idris packages:
 ```
-$ # On NixOS
-$ nix-env -qaPA nixos.idrisPackages
-$ # On non-NixOS
 $ nix-env -qaPA nixpkgs.idrisPackages
 ```
 

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -70,7 +70,7 @@ build-time.
 
 When run, `cargo build` produces a file called `Cargo.lock`,
 containing pinned versions of all dependencies. Nixpkgs contains a
-tool called `carnix` (`nix-env -iA nixos.carnix`), which can be used
+tool called `carnix` (`nix-env -iA nixpkgs.carnix`), which can be used
 to turn a `Cargo.lock` into a Nix expression.
 
 That Nix expression calls `rustc` directly (hence bypassing Cargo),
@@ -380,11 +380,11 @@ in the `~/.config/nixpkgs/overlays` directory.
 
 The latest version can be installed with the following command:
 
-    $ nix-env -Ai nixos.latest.rustChannels.stable.rust
+    $ nix-env -Ai nixpkgs.latest.rustChannels.stable.rust
 
 Or using the attribute with nix-shell:
 
-    $ nix-shell -p nixos.latest.rustChannels.stable.rust
+    $ nix-shell -p nixpkgs.latest.rustChannels.stable.rust
 
 To install the beta or nightly channel, "stable" should be substituted by
 "nightly" or "beta", or

--- a/nixos/doc/manual/configuration/ad-hoc-packages.xml
+++ b/nixos/doc/manual/configuration/ad-hoc-packages.xml
@@ -9,7 +9,7 @@
   With the command <command>nix-env</command>, you can install and uninstall
   packages from the command line. For instance, to install Mozilla Thunderbird:
 <screen>
-$ nix-env -iA nixos.thunderbird</screen>
+$ nix-env -iA nixpkgs.thunderbird</screen>
   If you invoke this as root, the package is installed in the Nix profile
   <filename>/nix/var/nix/profiles/default</filename> and visible to all users
   of the system; otherwise, the package ends up in

--- a/nixos/doc/manual/configuration/declarative-packages.xml
+++ b/nixos/doc/manual/configuration/declarative-packages.xml
@@ -23,11 +23,11 @@
   You can get a list of the available packages as follows:
 <screen>
 $ nix-env -qaP '*' --description
-nixos.firefox   firefox-23.0   Mozilla Firefox - the browser, reloaded
+nixpkgs.firefox   firefox-23.0   Mozilla Firefox - the browser, reloaded
 <replaceable>...</replaceable>
 </screen>
   The first column in the output is the <emphasis>attribute name</emphasis>,
-  such as <literal>nixos.thunderbird</literal>. (The <literal>nixos</literal>
+  such as <literal>nixpkgs.thunderbird</literal>. (The <literal>nixpkgs</literal>
   prefix allows distinguishing between different channels that you might have.)
  </para>
 

--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -22,7 +22,6 @@ pkgs.releaseTools.makeSourceTarball {
     mkdir -p $out/tarballs
     cp -prd . ../$releaseName
     chmod -R u+w ../$releaseName
-    ln -s . ../$releaseName/nixpkgs # hack to make ‘<nixpkgs>’ work
     NIX_STATE_DIR=$TMPDIR nix-env -f ../$releaseName/default.nix -qaP --meta --xml \* > /dev/null
     cd ..
     chmod -R u+w $releaseName

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -86,9 +86,6 @@ let format' = format; in let
     mkdir -p $out
     cp -prd ${nixpkgs} $out/nixos
     chmod -R u+w $out/nixos
-    if [ ! -e $out/nixos/nixpkgs ]; then
-      ln -s . $out/nixos/nixpkgs
-    fi
     rm -rf $out/nixos/.git
     echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
   '';

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -18,9 +18,6 @@ let
       mkdir -p $out
       cp -prd ${nixpkgs} $out/nixos
       chmod -R u+w $out/nixos
-      if [ ! -e $out/nixos/nixpkgs ]; then
-        ln -s . $out/nixos/nixpkgs
-      fi
       echo -n ${config.system.nixos.revision} > $out/nixos/.git-revision
       echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
       echo ${config.system.nixos.versionSuffix} | sed -e s/pre// > $out/nixos/svn-revision

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -31,13 +31,13 @@ The program ‘$program’ is currently not installed. It is provided by
 the package ‘$package’, which I will now install for you.
 EOF
         ;
-        exit 126 if system("nix-env", "-iA", "nixos.$package") == 0;
+        exit 126 if system("nix-env", "-iA", "nixpkgs.$package") == 0;
     } elsif ($ENV{"NIX_AUTO_RUN"} // "") {
         exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
     } else {
         print STDERR <<EOF;
 The program ‘$program’ is currently not installed. You can install it by typing:
-  nix-env -iA nixos.$package
+  nix-env -iA nixpkgs.$package
 EOF
     }
 } else {
@@ -45,7 +45,7 @@ EOF
 The program ‘$program’ is currently not installed. It is provided by
 several packages. You can install it by typing one of the following:
 EOF
-    print STDERR "  nix-env -iA nixos.$_->{package}\n" foreach @$res;
+    print STDERR "  nix-env -iA nixpkgs.$_->{package}\n" foreach @$res;
 }
 
 exit 127;

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -46,6 +46,14 @@ with lib;
                   ln -s /nix/var/nix/profiles/per-user/root/channels "$HOME/.nix-defexpr/channels_root"
               fi
           fi
+
+          # Alias the `nixpkgs` prefix to the `nixos` channel on NixOS
+          if [ ! -L "$HOME/.nix-defexpr/nixpkgs-compat/nixpkgs" ]; then
+            mkdir -p "$HOME/.nix-defexpr/nixpkgs-compat"
+            ln -s \
+              /nix/var/nix/profiles/per-user/root/channels/nixos \
+              "$HOME/.nix-defexpr/nixpkgs-compat/nixpkgs"
+          fi
         fi
       '';
 

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -31,7 +31,7 @@ let
 
           # Test whether the channel got installed correctly.
           $machine->succeed("nix-instantiate --dry-run '<nixpkgs>' -A hello");
-          $machine->succeed("nix-env --dry-run -iA nixos.procps");
+          $machine->succeed("nix-env --dry-run -iA nixpkgs.procps");
 
           $machine->shutdown;
         '';

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -38,7 +38,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   testScript =
     ''
       # Make sure we have a NixOS tree (required by ‘nixos-container create’).
-      $machine->succeed("PAGER=cat nix-env -qa -A nixos.hello >&2");
+      $machine->succeed("PAGER=cat nix-env -qa -A nixpkgs.hello >&2");
 
       # Create some containers imperatively.
       my $id1 = $machine->succeed("nixos-container create foo --ensure-unique-name");

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -147,12 +147,12 @@ let
       $machine->succeed("nix-store --verify --check-contents >&2");
 
       # Check whether the channel works.
-      $machine->succeed("nix-env -iA nixos.procps >&2");
+      $machine->succeed("nix-env -iA nixpkgs.procps >&2");
       $machine->succeed("type -tP ps | tee /dev/stderr") =~ /.nix-profile/
           or die "nix-env failed";
 
       # Check that the daemon works, and that non-root users can run builds (this will build a new profile generation through the daemon)
-      $machine->succeed("su alice -l -c 'nix-env -iA nixos.procps' >&2");
+      $machine->succeed("su alice -l -c 'nix-env -iA nixpkgs.procps' >&2");
 
       # We need a writable Nix store on next boot.
       $machine->copyFileFromHost(

--- a/nixpkgs
+++ b/nixpkgs
@@ -1,0 +1,1 @@
+nixpkgs


### PR DESCRIPTION
###### Motivation for this change

This is a proposal to change NixOS so that packages can also be installed with the same prefix as non-NixOS machines:

Before:

    $ nix-env -iA nixos.hello

After:

    $ nix-env -iA nixpkgs.hello

The goal is to reduce the complexity in installation instructions so we can tell all our users to use the same command to install packages. It also fixes issues where `nix search` will return one prefix and then `nix-env` will need the other-one. Or the user having to remember on which machine they are installing a package.

This change is backward-compatible. The main downside is that `nix-env -qaP` takes twice as long to execute.

EDIT: updated the proposal, it was initially about switching channels

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

