### PR TITLE
{easyrpg-player,liblcf}: 0.5.3 -> 0.5.4

### DIFF
--- a/pkgs/development/libraries/liblcf/default.nix
+++ b/pkgs/development/libraries/liblcf/default.nix
@@ -2,19 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "liblcf-${version}";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "EasyRPG";
     repo = "liblcf";
     rev = version;
-    sha256 = "1y3pbl3jxan9f0cb1rxkibqjc0h23jm3jlwlv0xxn2pgw8l0fk34";
+    sha256 = "1842hns0rbjncrhwjj7fzg9b3n47adn5jp4dg2zz34gfah3q4ig8";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ expat icu ];
+  propagatedBuildInputs = [ expat icu ];
 
   meta = with stdenv.lib; {
+    description = "Library to handle RPG Maker 2000/2003 and EasyRPG projects";
     homepage = https://github.com/EasyRPG/liblcf;
     license = licenses.mit;
     maintainers = with maintainers; [ yegortimoshenko ];

--- a/pkgs/games/easyrpg-player/default.nix
+++ b/pkgs/games/easyrpg-player/default.nix
@@ -1,31 +1,41 @@
-{ stdenv, fetchFromGitHub, cmake, doxygen ? null, pkgconfig, freetype ? null, harfbuzz ? null
-, liblcf, libpng, libsndfile ? null, libxmp ? null, libvorbis ? null, mpg123 ? null
-, opusfile ? null, pixman, SDL2, speexdsp ? null, wildmidi ? null, zlib }:
+{ stdenv, fetchFromGitHub, cmake, doxygen ? null, pkgconfig, freetype ? null, glib, harfbuzz ? null
+, liblcf, libpng, libsndfile ? null, libvorbis ? null, libxmp ? null
+, libXcursor, libXext, libXi, libXinerama, libXrandr, libXScrnSaver, libXxf86vm
+, mpg123 ? null, opusfile ? null, pcre, pixman, SDL2_mixer, speexdsp ? null, wildmidi ? null, zlib }:
 
 stdenv.mkDerivation rec {
   name = "easyrpg-player-${version}";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "EasyRPG";
     repo = "Player";
     rev = version;
-    sha256 = "1cn3g08ap6cf812s8p3ilf31q7y7y4knp1s0gk45mqcz215cpd8q";
+    sha256 = "1k1b5ws48h1ylarbcfsxyvajl0fdzmi3db8y3m8iq4fg3f0yslg8";
   };
 
   nativeBuildInputs = [ cmake doxygen pkgconfig ];
 
   buildInputs = [
     freetype
+    glib
     harfbuzz
     liblcf
     libpng
     libsndfile
-    libxmp
     libvorbis
+    libxmp
+    libXcursor
+    libXext
+    libXi
+    libXinerama
+    libXrandr
+    libXScrnSaver
+    libXxf86vm
     mpg123
     opusfile
-    SDL2
+    SDL2_mixer
+    pcre
     pixman
     speexdsp
     wildmidi
@@ -33,6 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
+    description = "RPG Maker 2000/2003 and EasyRPG games interpreter";
     homepage = https://easyrpg.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ yegortimoshenko ];


### PR DESCRIPTION
###### Motivation for this change

Closes #50061 (liblcf and easyrpg-player needs to be updated together)
`expat` and `icu` are now propagatedBuildInputs of liblcf because easyrpg-player needs it
\+ added short descriptions to both packages

/cc @yegortimoshenko 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

