### PR TITLE
niftyreg: init at 1.3.9; niftyseg: init at 1.0.0

### DIFF
--- a/pkgs/applications/science/biology/niftyreg/default.nix
+++ b/pkgs/applications/science/biology/niftyreg/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchurl, cmake, zlib }:
+
+stdenv.mkDerivation rec {
+  pname   = "niftyreg";
+  version = "1.3.9";
+  name    = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/nifty_reg-${version}/nifty_reg-${version}.tar.gz";
+    sha256 = "07v9v9s41lvw72wpb1jgh2nzanyc994779bd35p76vg8mzifmprl";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://cmictig.cs.ucl.ac.uk/wiki/index.php/NiftyReg;
+    description = "Medical image registration software";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = [ "x86_64-linux" ];
+    license   = licenses.bsd3;
+  };
+}

--- a/pkgs/applications/science/biology/niftyseg/default.nix
+++ b/pkgs/applications/science/biology/niftyseg/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchurl, cmake, eigen, zlib }:
+
+stdenv.mkDerivation rec {
+  pname   = "niftyseg";
+  version = "1.0";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url    = "https://github.com/KCL-BMEIS/NiftySeg/archive/v${version}.tar.gz";
+    sha256 = "11q6yldsxp3k6gfp94c0xhcan2y3finzv8lzizmrc79yps3wjkn0";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ eigen zlib ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://cmictig.cs.ucl.ac.uk/research/software/software-nifty/niftyseg;
+    description = "Software for medical image segmentation, bias field correction, and cortical thickness calculation";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.linux;
+    license   = licenses.bsd3;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21196,6 +21196,8 @@ with pkgs;
 
   niftyreg = callPackage ../applications/science/biology/niftyreg { };
 
+  niftyseg = callPackage ../applications/science/biology/niftyseg { };
+
   paml = callPackage ../applications/science/biology/paml { };
 
   picard-tools = callPackage ../applications/science/biology/picard-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21194,6 +21194,8 @@ with pkgs;
 
   ncbi_tools = callPackage ../applications/science/biology/ncbi-tools { };
 
+  niftyreg = callPackage ../applications/science/biology/niftyreg { };
+
   paml = callPackage ../applications/science/biology/paml { };
 
   picard-tools = callPackage ../applications/science/biology/picard-tools { };


### PR DESCRIPTION
###### Motivation for this change

New packages based on work by Linus Heckemann.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

