### PR TITLE
procdump: init at 1.0.1

### DIFF
--- a/pkgs/os-specific/linux/procdump/default.nix
+++ b/pkgs/os-specific/linux/procdump/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, fetchpatch, bash, coreutils, gdb, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "procdump-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "Microsoft";
+    repo = "ProcDump-for-Linux";
+    rev = version;
+    sha256 = "1lkm05hq4hl1vadj9ifm18hi7cbf5045xlfxdfbrpsl6kxgfwcc4";
+  };
+
+  nativeBuildInputs = [ zlib ];
+  buildInputs = [ bash coreutils gdb ];
+
+  patches = [
+    # Fix name conflict when built with musl
+    # TODO: check if fixed upstream https://github.com/Microsoft/ProcDump-for-Linux/pull/50
+    (fetchpatch {
+      url = "https://github.com/Microsoft/ProcDump-for-Linux/commit/1b7b50b910f20b463fb628c8213663c8a8d11d0d.patch";
+      sha256 = "0h0dj3gi6hw1wdpc0ih9s4kkagv0d9jzrg602cr85r2z19lmb7yk";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/CoreDumpWriter.c \
+      --replace '"gcore ' '"${gdb}/bin/gcore ' \
+      --replace '"rm ' '"${coreutils}/bin/rm ' \
+      --replace '/bin/bash' '${bash}/bin/bash'
+  '';
+
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "INSTALLDIR=/bin"
+    "MANDIR=/share/man/man1"
+  ];
+
+  doCheck = false; # needs root
+
+  meta = with stdenv.lib; {
+    description = "A Linux version of the ProcDump Sysinternals tool";
+    homepage = https://github.com/Microsoft/ProcDump-for-Linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ c0bw3b ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14884,6 +14884,8 @@ with pkgs;
   procps = if stdenv.isLinux then callPackage ../os-specific/linux/procps-ng { }
            else unixtools.procps;
 
+  procdump = callPackage ../os-specific/linux/procdump { };
+
   qemu_kvm = lowPrio (qemu.override { hostCpuOnly = true; });
 
   # See `xenPackages` source for explanations.


### PR DESCRIPTION
###### Motivation for this change

Resolves #49771
/cc @colemickens 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

