### PR TITLE
gitAndTools.git-absorb: init at 0.3.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -30,6 +30,10 @@ let
 
   git = appendToName "minimal" gitBase;
 
+  git-absorb = callPackage ./git-absorb {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   git-appraise = callPackage ./git-appraise {};
 
   git-fame = callPackage ./git-fame {};

--- a/pkgs/applications/version-management/git-and-tools/git-absorb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-absorb/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform, libiconv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  name = "git-absorb-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner  = "tummychow";
+    repo   = "git-absorb";
+    rev    = "refs/tags/${version}";
+    sha256 = "1dm442lyk7f44bshm2ajync5pzdwvdc5xfpw2lkvjzxflmh5572z";
+  };
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  cargoSha256 = "0fvxs09b9x38vp0psvlvbj09myxrhabp95pp3nz7nxsgr7fxflrr";
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "git commit --fixup, but automatic";
+    license = [ licenses.bsd3 ];
+    maintainers = [ maintainers.marsam ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

