### PR TITLE
gdb: 8.1.1 -> 8.2

### DIFF
--- a/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
+++ b/pkgs/development/tools/misc/gdb/debug-info-from-env.patch
@@ -1,81 +1,13 @@
-Look up .build-id files relative to the directories in the
-colon-separated environment variable NIX_DEBUG_INFO_DIRS, in addition
-to the existing debug-file-directory setting.
+Initialize debug-file-directory from NIX_DEBUG_INFO_DIRS, a colon-separated list
+of directories with separate debugging information files.
 
-diff -ru --exclude '*gcore' --exclude '*pdtrace' gdb-8.0-orig/gdb/build-id.c gdb-8.0/gdb/build-id.c
---- gdb-8.0-orig/gdb/build-id.c	2017-06-04 17:51:26.000000000 +0200
-+++ gdb-8.0/gdb/build-id.c	2017-07-28 13:18:10.797375927 +0200
-@@ -67,8 +67,8 @@
+--- a/gdb/main.c
++++ b/gdb/main.c
+@@ -551,3 +551,6 @@ captured_main_1 (struct captured_main_args *context)
  
- /* See build-id.h.  */
- 
--gdb_bfd_ref_ptr
--build_id_to_debug_bfd (size_t build_id_len, const bfd_byte *build_id)
-+static gdb_bfd_ref_ptr
-+build_id_to_debug_bfd_in (const char *directories, size_t build_id_len, const bfd_byte *build_id)
- {
-   char *link, *debugdir;
-   VEC (char_ptr) *debugdir_vec;
-@@ -78,7 +78,7 @@
-   int alloc_len;
- 
-   /* DEBUG_FILE_DIRECTORY/.build-id/ab/cdef */
--  alloc_len = (strlen (debug_file_directory)
-+  alloc_len = (strlen (directories)
- 	       + (sizeof "/.build-id/" - 1) + 1
- 	       + 2 * build_id_len + (sizeof ".debug" - 1) + 1);
-   link = (char *) alloca (alloc_len);
-@@ -86,7 +86,7 @@
-   /* Keep backward compatibility so that DEBUG_FILE_DIRECTORY being "" will
-      cause "/.build-id/..." lookups.  */
- 
--  debugdir_vec = dirnames_to_char_ptr_vec (debug_file_directory);
-+  debugdir_vec = dirnames_to_char_ptr_vec (directories);
-   back_to = make_cleanup_free_char_ptr_vec (debugdir_vec);
- 
-   for (ix = 0; VEC_iterate (char_ptr, debugdir_vec, ix, debugdir); ++ix)
-@@ -137,6 +137,30 @@
-   return abfd;
- }
- 
-+gdb_bfd_ref_ptr
-+build_id_to_debug_bfd (size_t build_id_len, const bfd_byte *build_id)
-+{
-+  gdb_bfd_ref_ptr abfd = build_id_to_debug_bfd_in(debug_file_directory, build_id_len, build_id);
+-  debug_file_directory = relocate_gdb_directory (DEBUGDIR,
++  debug_file_directory = getenv("NIX_DEBUG_INFO_DIRS");
 +
-+  if (abfd != NULL)
-+    return abfd;
-+
-+  static int init = 0;
-+  static char *env_var;
-+  if (!init)
-+    {
-+      env_var = getenv("NIX_DEBUG_INFO_DIRS");
-+      init = 1;
-+    }
-+
-+  if (env_var)
-+    {
-+      abfd = build_id_to_debug_bfd_in(env_var, build_id_len, build_id);
-+    }
-+
-+  return abfd;
-+}
-+
- /* See build-id.h.  */
- 
- char *
-diff -ru --exclude '*gcore' --exclude '*pdtrace' gdb-8.0-orig/gdb/symfile.c gdb-8.0/gdb/symfile.c
---- gdb-8.0-orig/gdb/symfile.c	2017-06-04 17:51:27.000000000 +0200
-+++ gdb-8.0/gdb/symfile.c	2017-07-28 12:54:05.401586174 +0200
-@@ -1415,8 +1415,8 @@
- 			   struct cmd_list_element *c, const char *value)
- {
-   fprintf_filtered (file,
--		    _("The directory where separate debug "
--		      "symbols are searched for is \"%s\".\n"),
-+		    _("The directories where separate debug "
-+		      "symbols are searched for are \"%s\".\n"),
- 		    value);
- }
- 
++  if (debug_file_directory == NULL)
++    debug_file_directory = relocate_gdb_directory (DEBUGDIR,
+ 						 DEBUGDIR_RELOCATABLE);

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 
 # Build time
-, fetchurl, pkgconfig, perl, texinfo, setupDebugInfoDirs
+, fetchurl, fetchpatch, pkgconfig, perl, texinfo, setupDebugInfoDirs
 
 # Run time
 , ncurses, readline, gmp, mpfr, expat, zlib, dejagnu
@@ -13,7 +13,7 @@
 
 let
   basename = "gdb-${version}";
-  version = "8.1.1";
+  version = "8.2";
 in
 
 assert pythonSupport -> python != null;
@@ -26,11 +26,20 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnu/gdb/${basename}.tar.xz";
-    sha256 = "0g6hv9xk12aa58w77fydaldqr9a6b0a6bnwsq87jfc6lkcbc7p4p";
+    sha256 = "0fbw6j4z7kmvywwgavn7w3knp860i5i9qnjffc5p52bwkji43963";
   };
 
-  patches = [ ./debug-info-from-env.patch ]
-    ++ stdenv.lib.optional stdenv.isDarwin ./darwin-target-match.patch;
+  patches = [
+    ./debug-info-from-env.patch
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    ./darwin-target-match.patch
+    (fetchpatch {
+      name = "gdb-aarch64-linux-tdep.patch";
+      url = "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=patch;h=0c0a40e0abb9f1a584330a1911ad06b3686e5361";
+      excludes = [ "gdb/ChangeLog" ];
+      sha256 = "16zjw99npyapj68sw52xzmbw671ajm9xv7g5jxfmp94if5y91mnj";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig texinfo perl setupDebugInfoDirs ];
 


### PR DESCRIPTION
###### Motivation for this change

This is an alternative to #46229 with a simpler patch: `debug-file-directory` can contain multiple colon separated directories.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).