### PR TITLE
mnist: init at 2018-11-16

### DIFF
--- a/pkgs/data/machine-learning/mnist/default.nix
+++ b/pkgs/data/machine-learning/mnist/default.nix
@@ -1,0 +1,45 @@
+{ stdenvNoCC, fetchurl }:
+let
+  srcs = {
+    train-images = fetchurl {
+      url = "http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz";
+      sha256 = "029na81z5a1c9l1a8472dgshami6f2iixs3m2ji6ym6cffzwl3s4";
+    };
+    train-labels = fetchurl {
+      url = "http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz";
+      sha256 = "0p152200wwx0w65sqb65grb3v8ncjp230aykmvbbx2sm19556lim";
+    };
+    test-images = fetchurl {
+      url = "http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz";
+      sha256 = "1rn4vfigaxn2ms24bf4jwzzflgp3hvz0gksvb8j7j70w19xjqhld";
+    };
+    test-labels = fetchurl {
+      url = "http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz";
+      sha256 = "1imf0i194ndjxzxdx87zlgn728xx3p1qhq1ssbmnvv005vwn1bpp";
+    };
+  };
+in
+  stdenvNoCC.mkDerivation rec {
+    name = "mnist-${version}";
+    version = "2018-11-16";
+    installPhase = ''
+      mkdir -p $out
+      ln -s "${srcs.train-images}" "$out/${srcs.train-images.name}"
+      ln -s "${srcs.train-labels}" "$out/${srcs.train-labels.name}"
+      ln -s "${srcs.test-images}" "$out/${srcs.test-images.name}"
+      ln -s "${srcs.test-labels}" "$out/${srcs.test-labels.name}"
+    '';
+    phases = [ "installPhase" ];
+    meta = with stdenvNoCC.lib; {
+      description = "A large database of handwritten digits";
+      longDescription = ''
+        The MNIST database (Modified National Institute of Standards and
+        Technology database) is a large database of handwritten digits that is
+        commonly used for training various image processing systems.
+      '';
+      homepage = http://yann.lecun.com/exdb/mnist/index.html;
+      license = licenses.cc-by-sa-30;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ cmcdragonkai ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15404,6 +15404,8 @@ with pkgs;
 
   medio = callPackage ../data/fonts/medio { };
 
+  mnist = callPackage ../data/machine-learning/mnist { };
+
   mobile-broadband-provider-info = callPackage ../data/misc/mobile-broadband-provider-info { };
 
   monoid = callPackage ../data/fonts/monoid { };


### PR DESCRIPTION
###### Motivation for this change

Adding the MNIST dataset. This makes it really useful to use any ML applications that depends on this dataset, and tests can be ran using this smaller dataset.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

