### PR TITLE
valentina: don’t copy mailcap file into XDG MIME directory

### DIFF
--- a/pkgs/applications/misc/valentina/default.nix
+++ b/pkgs/applications/misc/valentina/default.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/mime/packages
     cp dist/debian/valentina.sharedmimeinfo $out/share/mime/packages/valentina.xml
-    cp dist/debian/valentina.mime $out/share/mime/packages/valentina
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

The mailcap file has no use here (and results in an error from QMimeDatabase trying to parse it) as we already have a sharedmimeinfo file there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Sorry for the noise.