### PR TITLE
nixos/gtk.iconCache: Disable by default

### DIFF
--- a/nixos/modules/config/gtk/gtk-icon-cache.nix
+++ b/nixos/modules/config/gtk/gtk-icon-cache.nix
@@ -5,7 +5,7 @@ with lib;
   options = {
     gtk.iconCache.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to build icon theme caches for GTK+ applications.
       '';


### PR DESCRIPTION
###### Motivation for this change
Unblock the installer tests.

Discussion has been taking place (#48116) on how to default enable this in eg. xserver.enable or something similar, but as far as I can tell nothing has been concluded yet. Meanwhile, on a barebones system this should surely be false, so this seems like the right default in the module itself.

cc @romildo @matthewbauer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

