### PR TITLE
 thunderbird, thunderbird-bin: 60.3.0 -> 60.3.1 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "60.3.0";
+  version = "60.3.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ar/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ar/thunderbird-60.3.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "7cbd8c54fb220ad3f781cbc908d42f2723109786a1d7a947646bcc231e8849035c014335daa4ab85f9cd69646fa870cbfac3a0e0ec45d3fa82d0f0b74591b6a3";
+      sha512 = "57b092a02666d2ca2d2b13b04bc00114b7e14b8b23b82f0af53f0d53485a8db117eea3408affcebff6431133bf337f07ecc111cdd8c5f50b4a93594ad07c0a29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ast/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ast/thunderbird-60.3.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "936a6366add759a89db391394479ff2e7865248b46c81cf45457ddb6fa6b37660ca9efa6f125fe97b22f6db2cdfae7ad0abefdc3874820fa3ef0bee91f6caa74";
+      sha512 = "a0635e9006beec03cc5a6fb298cfc1f4bfce342bb537f1834d02f452e82285ac5853ea520c1275140ea812c742fcf19d5f6e662b7eba58bcf7e80d796236ca39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/be/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/be/thunderbird-60.3.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "4580436c4719a2ca5821d9676aa6bfd5f2c731cdf0bdc2969fd0177bfd2c3cc2570479de60515e59b152e0aec4611c437fedce7d0bd13c7a06bcebafff0bd20d";
+      sha512 = "f2860e9508278895198d87b54ac2984d961221fa0bac20dba505d01d762ea7041127323c67cd2288d2372f37d82e0870c6a832ff4113fe914927a377e22ced99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/bg/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/bg/thunderbird-60.3.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "fafc3c2d186616be2b56e1087df528d3fb93ce431ae24c286c0209177a9dcf5f229ec5aa521d68ae531c5d763ca4c2e339945a7f874825e73ad63f86d13b510b";
+      sha512 = "1d0070daf743b1c9e2b0a3471ff4f8bfd992279a422bb58daf6b7f96a6238adf654bfdf74d8414e758af2f033703a73cb0e1f71c0c72e0b7e61e62b6180ea185";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/br/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/br/thunderbird-60.3.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "71fe4d4e67971bfdc56ff6ad73eecffe15d2b808e07b25a7b4c827094b95afa7c04d451081dc45045e0d1eb83b15a3c8e964186a615f72a0a545dece221318d9";
+      sha512 = "f2bb792417855409c993a2d2e9ae627b800ef3dfc7a78fd82f3af400c2c4c964757662659a32b039e20e0330b7f16b502d011a104798c2dcc47235a8c561b9a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ca/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ca/thunderbird-60.3.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "0be271223abd6f0fe79d0914b037cea5ea765ac1486a78922123666bec1ce8ec3bcbfa54c7fa552101adbe4a22bed0628eabed39391e4ca1dbccb118157fbded";
+      sha512 = "e5ae4dbe02b38042ed64f399ea531203fd04d6358b70ddb2c67d29ccea45019a4226ea1719692ea48120c30af240d4d5470e4f64f09239dbfff2607569ad9bb7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/cs/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/cs/thunderbird-60.3.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "5d9f911af1f29928ddfb96d114fc7e484370e69f9f1aabdad753dae5ba0b6ad476d7b0c373919a2ccec3c2528f4fc78ee874a72fe691ad3e7d2e3e9e1650f76a";
+      sha512 = "b0f1440db8a329103f873a57988bc6fa66e36336752b7c215a952079f77182d91c6fdacc7815f74c18a4fe7c8a648e7aaf58cbb2fdabfda5b76daac81a602559";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/cy/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/cy/thunderbird-60.3.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "18c7dabbcdb5235bcfe0dd01746f39d82d88bc71c2a4c4986ee268d15ab5a5cc060273f4783b2e472dafbcdcd98f29f8ad2c2b33ed87a9a3c484f61dbf0a7492";
+      sha512 = "191f2113ffce94d1ebff5619aa84caea262f424217bf17882189f40f772704aa07ce4ac232292742493d1b1be564558907a418c0104be656ec1441bcaee7ebe0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/da/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/da/thunderbird-60.3.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "f6dcc69ed4509b6d81b856cf6981d7d00e3ca3689f3e28b64b858d64f96ef96196a4b9b2c14ee5292507b5ba00bedbfd5ecf4b2db241068b36d8ee786eacf1c0";
+      sha512 = "54611a769b3f06860a3d61519b992dc5e4605b13d8d7069031155a23b590230c003dde720dbaf161f6dee87d96df057f01d55e195ec34bb4fb55f1423b166ee2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/de/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/de/thunderbird-60.3.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "a60ab91787961d405c926027570d161e9f6cfef77f6e8d40a24e97ac5c0c9b515a31dde5b9386e7b2a855f4970ff7533be4252474136e242a998cafab123de66";
+      sha512 = "d1ea83e5402e68a93800491e091daf7bd9951be2de8e3c4e786061c57fe850cdd12bba4a35a24e4df44432a2124dc3b8c5732271a9a1c71f7fe2deebbfe94d88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/dsb/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/dsb/thunderbird-60.3.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "c827f7b392fe42cd2f6432870552239bd73e808ddfad10ac2c86968915697dfe119c965469baa6e2098bfd0fb61c36fbb5ed17378e423531b64b0ebd153602d4";
+      sha512 = "5f1d459902e2ed9eb6cfa10a0ea05068bda0eb3146e5bb9b20ca2c93d85521ff465d596e9348421dda839ebd0e55c480e277ae66ba10236533f9aba7c3c317cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/el/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/el/thunderbird-60.3.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "287be8c4ca83f7238833cad36de9476907bcf9c8c915626dd0c5114328160e75d95bfe25a0db10900f3c2a727e76f583fe1902a76c208106480fc3349c2ed917";
+      sha512 = "5f1702a2b78373f0cb408363621bbfaa377f1ca38eb17bc6dfbac582115a795c2d22220725378f67b49f8f7554a37a5af5f0a18f7584e54c7f62128fba3dec33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/en-GB/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/en-GB/thunderbird-60.3.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "aae1c22caeab14d262054af5855f6e983b34fc54e8f9d8cd0f49f5ae7ad3425d74f26025d85b4948a7d519ba771f7298ca7bf14fbd67c3d8ed84f0e9e394b9da";
+      sha512 = "754d330a04178aa68c15c6212a04dcd5547af820f82b55d7d36910b5c85fc3d28310fe24864dcf7e4ab21838589350a752dc220c9409307ea6059d3e9adc02f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/en-US/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/en-US/thunderbird-60.3.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "53b3872c3e4c49080e34540f95d5dec680b2320890601249eeb09e26d8aec66bce8e46e40368c8cfbc6937186a894a078348f64065ead28d32453a310a43891f";
+      sha512 = "3f8dd135299243996182ab9b8f38e5f7d6d486468b1afbeb52d481d8ad943cb9fec899cd56002ecb5f55f7b22e3184c4a5d114f55734b8e39debbe4ac4060b68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/es-AR/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/es-AR/thunderbird-60.3.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "9ae6f2a7c93a1d7a4efa22bdc8f6f5df8fb5a46f42507146eec7ceed6ee47d175d6c7791decc661be0c7d3cfd7513cc9a050138fe6661daf192f5f6064bc6a8f";
+      sha512 = "cbe6bbd993f84e583b3d399ac45626384969d6823ef21da84034f3bb3b26b1f86e4ba65a1bee73438ca75d8aeb9f61a75f1b8747b23f1ed5059796d7ec14adac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/es-ES/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/es-ES/thunderbird-60.3.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "6dcc03919a384f7dcfae1264e3176d57ced792cb40ce7aa469a1c5229c9c97bcc83a0e58947f0ed14ff0ff74ddc529c74e7bcd3e38fb89edcdc4038f491a1c08";
+      sha512 = "3c7c4b4cd9cfc2d867ed895adbcef4e1af487b5fe6bad6c5931ce055f2fa656de9b51d1008cfa9a342f7b8360ee6d39529d4e81dc773721157bd42841cde2d95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/et/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/et/thunderbird-60.3.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "eb18921995d209a95444ae213740596ebb0d70d362662741a94a196e75c8b5857ff999ab4c822c95eed1ba3339038b82c725dc46e05d21bc4a5692323a87c589";
+      sha512 = "ba2b2a7970a87d41c85aa5fea1cebed55755356fed7a82a08b0945e6311b410df25511e4886e6c066f43b31774fbd35fc65c10b155bab2aac5eb1918cdec8e3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/eu/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/eu/thunderbird-60.3.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "5fc6dd684e9f1ec9be951929f2bbed0e75f5e2c0215206496a2efecb361f194a2009fe5bf2e91f09cae63dfc3f08b51e47a2a82d6b59d425df8dcf4ba316b271";
+      sha512 = "3398a2c1a2fed97b8e17822d7b6048af686b67f91d2b096f1e0d58dc5d29c2eac60aed39b62b80788634c3996adb0bcb93cb07e5bfe7eb2d2a88e58e1cdfe8fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/fi/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/fi/thunderbird-60.3.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "9da23f9aba9cc5f8939bdcf632f764566acbafc48bd05dc04036eae5fc04f41df506a4f80f3543b60a09b057939c074f3ae9eefc2353f765256dc9e0db1aa8e0";
+      sha512 = "e7be730f994829e55a51754b569b8148cfc871fbf6dc28962f3d23400ed68105d813ead1612974f5f27148a57bfe099e4fd63ed4111eb877485314111fc046ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/fr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/fr/thunderbird-60.3.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "0c844ef274cf892cadceea78c93efde1f7a110bfd0bdbe3cfdba5c23fef0e2fbb7b3fc3dc59f9b6edbb5c346a6d5ac06b69f4b19541942d09c5d088d6b0e0322";
+      sha512 = "710a1da3b50dd50d01f29685c6bbb6a39849a5d0daf1c98c2722c5f823b501b9679f53ed72a0335143582e10d01605d57e474936278063254f01f41cc211d92d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/fy-NL/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/fy-NL/thunderbird-60.3.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "0df85e025f9a72255a23ca93a692a0f79a69c9447f8391ff97eea075077a147c6eb164f4851dee47d771dd3db3bacb3dcac71aed91b39fc34dbd65c8ae67bcf7";
+      sha512 = "dd08b6a9e99b2f639139bd8b2f83406229dc8470a66381bd625a15f17093f7996777d35c05bf8cfae930c1379e547236197f73620750a99c27cc2adf0b7688c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ga-IE/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ga-IE/thunderbird-60.3.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "e1feb134d5ed55269fead90efea01f4d74ab03517def2fb9418435c5c699735d14ef3f64bfd33109b87bedefcb90034b1c12da74b798eb0e6b7bc74766d3f425";
+      sha512 = "ef38f8713a7e792d7ccc62e360954c29675ce208e51c06dc3679869487059e5d768f803e751fd008c369a2e438f5c54d95f4b48d042deeb88b0c6e7c84bab213";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/gd/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/gd/thunderbird-60.3.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "3483c8655e81938554d95492952b967770cd659b625c25dc8864e59dfd5b6cc94bef725f495e725d6ceb24bc05edeb1d2c3ce41a303bc313715788ab03b75c9a";
+      sha512 = "9ea6406dbdca47e031af25139707707b9bc56957180ac73682b55c324980c6df0dc8b0ec4618cb175dfd489d7941f8f61f71551c9d221383698eaa6b300826e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/gl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/gl/thunderbird-60.3.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "012ca498f3907f077c9e75e2bceb53fd0a781752b98319cf3b7ccb94a9112896dc2360d45acc440d7c50bdad0a15e125ad8123e13203a3a017e905c2f0e3d252";
+      sha512 = "6ed22b1fe889a1b8109c180c90e35acabe3ce904a0d57824fdfc83f703814635123aa2fcc2f8a6edf50a33111698537ee284911a7eb3ce7f1dc8ec77819ee61f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/he/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/he/thunderbird-60.3.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "1d7f92a0274bed7390ad0f813066dd7d71bd66f03ea8203d71f025a8f8a8fb4480e2b660ecbc052290a27351662d3f7811c1311eb8ff02e63ffc5f0c8745edfd";
+      sha512 = "08c9923c10248b3b6e0c33b75dde8de66377404c979924c29ce602798ddec564fdb3e978a1345d9f2f734768301a262f8ce309bf002f7c7cf9434087e2439266";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/hr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hr/thunderbird-60.3.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "6d19c5ad55486b3aff055476a29353179bf8ff7e9285618f29490c430817af2ff3bc51cfa75c52c82d804a7bce0e367e8ee4d444a03b0bdf4bda57ab75bcd016";
+      sha512 = "95cb5f4d35174dffbf341d2d8986ae0b5248ca7e447aebb13d27915ac7968dc1454ee8fdad201b0de7fa6b9af0cd632c951a2aa9d43fc5f6aa6f7f205ec42cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/hsb/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hsb/thunderbird-60.3.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "452927013a6ddc2f2f0dfe3a69a585641df06aac24f6458bb269095abe35101bff6c1a37d21afe8f37f1856a7a3311d49409bd0c456b52eb494cf846e426e2dd";
+      sha512 = "903be2c67851f112092a09110b7abde2d05d1964e8c573962709b902a5335be3eda0f2c687e6cad67d42339e58559d633768d5b203ad482c1de6f31ba3b13a94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/hu/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hu/thunderbird-60.3.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "bbda4eceb8258bf46ed5a90d4bff27a769e0f74a14d76f50e77fc3b2f1b53863fe8a68f0e375aadcd0d60b177f7f31edc6876666dfb95e955083078f813896b8";
+      sha512 = "83a65776921962cc84f6c932e471d8a1532aeaae6edf95a9d8f68e301ad4383d0cfdb35469a51393c45628e89142c63af3886d1bfb31cb37eef188a07f96f352";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/hy-AM/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hy-AM/thunderbird-60.3.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "79ca9e61fcfb62da522c2cd23a39e1ec8be14dd09bbf3d1cee23bd2a74a9a94a4b9b20af6f37e2a6a75d4b416fbf2b8c3f5196ea4fa52495dc0628a2ae5b26bf";
+      sha512 = "42469e3b613321906f2573706a523af032e93abea2e579b1e768d75898a504c4ab5280d7f9ec1a2e25257ca4fd877d53092fd85813d59c6dc4e5eca058aad6b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/id/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/id/thunderbird-60.3.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "2959a8ed196509a6a844db918b283bb3b133b1489cf229e0649ea0033fcd0536cc8fa792554adc7148c41267dabc92309670da6fbaaa1329bb65340192ced249";
+      sha512 = "008e9b2949f55a400209440e6eefc6144b71f76589ce18c022e2fdfb203d75f97a93ec3f06a9810a72e0b5b0566d2403b16baee25a46dbaf77eaf36a1ad0bbf2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/is/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/is/thunderbird-60.3.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "f78de4c7e0125b14a5930cb081bae4b49010b47726268b4e6ce01a0eb0e26b627d5ba47284c060031175787146406d4bca86404fa3d79f3ea67a67443e813862";
+      sha512 = "130432feebe93be2c2d87febbf3a45be16c118a980d3fbb20a8d0fa42ea1898e70f60d758ce407df461ef6984a2e55d67594e50edcc4b9445468bb1ef5421889";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/it/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/it/thunderbird-60.3.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "2a855ca03a703a7e843c7101ff02be356e5851fd2f6d01d1c1a6012946fb5bc57c018fc4e9804cdf66a7febc91c80c278fd420f068bef36bf1daff6f8a3c7640";
+      sha512 = "1887f49727e3116bfecba4b084fe550b1b9b82f90b620ada9baa81825ab200489dbedab2f465cb52a0e22eb130069bc639eb54ab48b6e708c264bbc5bc076fbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ja/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ja/thunderbird-60.3.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "323222bffb53d7a8c983bd5a2e06d388fa64689e4a31f888e6919b1c5fd9fb192840fb6c914db1ef988ae0f7505339d086b5388e9690eb77d377ef8037880eef";
+      sha512 = "c60a6e44368387f424c9881702dcb4f3dcfe439bcef92a5e6791c7619f3fb71a36a83e6ec2142cfa556e36b0582070f1aee9973261afc1fdae55a6d5f5b808d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/kab/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/kab/thunderbird-60.3.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "432426fa6185ef49dc7a204f97e38214dbc70e63a960036ca96d85c1a8fe10e7818dec80013c7d812d40808303cc09b70bf1bac8534eebde089e0d41387be797";
+      sha512 = "1db688c67904b1f930133c5e711390d2fa1498e48db450f3ca41e6b039fd7cce4b68298ecfe5a47c20eda9ae0464ab9fe8d0907b28a59bb3fd95a7d895c02665";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/kk/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/kk/thunderbird-60.3.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "a0d4da436365759f0019250f42bb05304a5c80886268a0ac2ea76bb52167670be71fd036392efa6965d699171341b23e2360f795770de0ebc5f4973ce6cdadfe";
+      sha512 = "e24f8f451e39bf945e51dc9afc4f40f3e5239616cb838e977ab74151f64dc07c246dcded50976a721261a01d9de0d55b802077de18f7682bbd892c2282f7969d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ko/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ko/thunderbird-60.3.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "ed28830ab1af7482115e53b0a4486d74d2b87b98f8c12a45f6a54c2221de5fae7b7450f1cf07a095d68638bf9f8b25778784606d857067b2ddb142079b411fc2";
+      sha512 = "52296e8ba959fd82b29b8cd7eb57812955d2078fc7b8aeccab80b8a4d917a6459072a2a317feee41bf649c1806797767a85fcf81af656eb51dee70352b57ec17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/lt/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/lt/thunderbird-60.3.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "52d36def8bf79c58002e42d7912598630140646cfd23254821524c42faeba3782d2d9f16db4ecb432457298bad342648e2271ff71a2d1e6fcfd386134da2265f";
+      sha512 = "b5a1a8ce67d441e0d919e808a9f7b0e9dedbcdd7af105a372f071430ad1426847087b53ab2b7bb455d161216287e2c0a7e2639d80a0161f7a92a8e87337deb8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ms/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ms/thunderbird-60.3.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "d368bd578add39df284174dbf1eb97e5e3eda26b141af1c729db98f93782fb8da7dc44fdae0ce9a3c070c5905a73dd0dd25fd665144e7af33f975867997437b8";
+      sha512 = "8ebbee14a1c2b540baac19f6b154e74e3c39a3178b1ea32b55f35edaf2cf41f4e6096be3075b54c37f8b01e7e424dbc2f9d6b3fd04afd366ed854684e276f302";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/nb-NO/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/nb-NO/thunderbird-60.3.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "ef795c45d7ccf4b8c89abf804d5e758e14534b9d12a1424ae0fc58bb5681dc24e49d6972c128855f886b996dbeaa8a7af0a1af6f4959fbcacf575307332e528a";
+      sha512 = "8e9ae2aa4572e247ecf9d1715d0733bdf7123dc1fab7804a2dfb4f27aac589aecfa86824597e1efa218dfec4807730a697e36a813008b0b208c9181ae20592dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/nl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/nl/thunderbird-60.3.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "c4d62cdbc421c08d1fd4d8579d58993d51f6cca207d1619240d95b2d9f0484e7e93f4dc6e103d09918fefa384349e5d676973b43a6113f807c28879d829a6d3b";
+      sha512 = "a910555ed33fe721de624b591fa0a4aa769e8c8e3d78253eca907e0ad2f4ebe541e2b72ca3434d79aee9a59dde219c5b24d5b406f0dbafa0b1a8f080cd3f6e9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/nn-NO/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/nn-NO/thunderbird-60.3.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "f06459d02dc5d0be311d06c62cdb2a11199722d635411fd63773b01c9103ed232070b3cd9c6c3984e658a54007f8fbf728c51346cdd3a1eee243ecc3bda8bd9b";
+      sha512 = "9fb084d5ddaf22cd282b3ba001b39d926ef49a03c9ceb5624cf11bc637af5dbe3ad90d0282f6b90f794010f69104e5bb126ff5c8aafd7cbed82cae0834563e20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/pl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/pl/thunderbird-60.3.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "77b27ba6c8bc519aae04f1576d278690f24a165a53bee7f1341aa81d2441fe86bc02115a3ec6e3dd3f40d466d6a39bcca615d70e9504945355e706b69d9e68d3";
+      sha512 = "c5c4590b177775b559acd89d3aa2c4555fa4c8c564ed426cad567b68e2508560d6a8bf55c9b3665819be3ce9b42ef94b795082f18e27559d6f1087a51c26bd5d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/pt-BR/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/pt-BR/thunderbird-60.3.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "a480dae9a78d473a1614047d2e973f4706ab5a2b754fdecd83cb1eea988f78c53760fbaeea3e98206400a3809e419a5615aa745bd759d652d6f7ce8680d096db";
+      sha512 = "4d66d1774fea6fcf2c81bebb5035b4544ae6795077c8d12cfddd05257149a56ae91b280a28488483ddaa444533b253297f7e6d9c2314111db8013e0f8f0c234a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/pt-PT/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/pt-PT/thunderbird-60.3.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "af3fb38963879e99e2c3344ebeca0d300f87b96c4dc031f50dfb5c75e04e1189c930b2df46aa4a343ad93b9461ac38439936ca9a3bc83948668b662f6be69599";
+      sha512 = "1e24124c69e5c8b0293ea79c499329b0075fa795d87e8ebc78f322859bfb6e76f977daaaf1cb187bcff5239767fd55dd5e53884a785cc60bbf4c1180543c8c5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/rm/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/rm/thunderbird-60.3.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "454264f5629854bdc037c4d826ef31a5fb4857f14aee5780669832e298b788ca98d22c521360dfa5d4f3ff25a18ecc267120a8455423785c801b1a51115ad90c";
+      sha512 = "f2f6174e337010075ab78b88f9de1fb10d213fe1329ac185a64bde7c2efd9f5ad6a0151a42e0745694bb1f426246fba34cea5627316e17fa41bdc292ad692fc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ro/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ro/thunderbird-60.3.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "5c23f69b167807abd0823f2b0e81e58695fe7cc53f6edd5ed5f67da77ab3b461637cc3d84dc0c77680421cf70dcaae1190f653aeec82cd6e2e89d429a30f0f1a";
+      sha512 = "25daf13a075591ef46295b44c0977c8e159612862953e7c22a053a3958b765b8a5693e8aef691590031285605101024142a42922faafdf9c0c998554e154dd74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/ru/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ru/thunderbird-60.3.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "2a2cd091d81da62e24fe7b454fd28477f6089b0982a21973d2e68d78548d90d33eea34c324fe7389100a7938dad226be6f4a3095eed0587b047a9a0691d2f190";
+      sha512 = "a187abec0708338f7a0f593a2054fc20f4f018d1e2ceead6778c616450a2cb3fd2f959f4c7e6018ecefd07a984828efa2da3f91b34104dd62fbf5a5a97310082";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/si/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/si/thunderbird-60.3.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "75ca936cc8f3f17803e2e4f086da82598f6f78c4977c239bac929b950b388c61bf675d904638dd4b801afc7a9b58bd9ab0b04b2cecf5f2487e64ef0a599c2ad4";
+      sha512 = "076c69137e6d4067f553efde45d1676b386277c904f452ee1880a52ead9cc40a1bceab33a895886c32a203dc8aa6d2735b5f81b21b969ccccfd2d5e75a2db289";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/sk/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sk/thunderbird-60.3.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "cd34d310fd49a8c7fa47731ac8972c25b2d32a4000ccbc8ff0dc4c7b2d0c5905942176b6f85d777683204c9d35f4c49c5195740afa8971e4782441a1ea38a0a7";
+      sha512 = "669bf299926fb9f4b0201c9fbbb593eebe127ff64d9c3cd12f79aa56b2e9d8a9b68c34e8ee42b9cc1287972c1a3d28c080945c1f17f4fbf672bc90c1f86425e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/sl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sl/thunderbird-60.3.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "cacdb9aa0d01f9641863b52b0c2ec2c61e3c60c03fb7fc1da1fa42cbcedb94797543fe6984538d3ff75594726dc61a1676a2644abd6595902bcafad36d4d370a";
+      sha512 = "0d22ef11e347caa3e03b4a83c19dc1a230be3ed2e561ce84284b752abc7d64720e2d68d2fbdec19da73cdc13c5e90983179197e512f7db4f52c341539b8c1329";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/sq/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sq/thunderbird-60.3.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "6930f66acf54dd47e2cfcb50d2b451a90a4533f54c895d16a872dfb28266d33596929cfa81fbc21536ab1ab7f933d4fb9853979c8be9a621c416817ada423fd3";
+      sha512 = "ac5e98dc1660efc255bc07a545e47f2141a8468e8bb911ad1b42143e5e048a82d5771f32718983ab80695b357b3b2d08897cf98f791f466edfa57d75579920c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/sr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sr/thunderbird-60.3.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "ac987c431c719e2c4a61a421a0b2d03bde011579782b29f589efa7f5361879762c0df5d57e809b9386072004e2c85f5aeb770185c6ad3978ce1de0fdc6b6346c";
+      sha512 = "2215af6e62448949dbb89cc66a52c9f83eabf1074ad8cff437953123d53ad403537b5655509bcdbbdf239da32e5b9d689b02cd625e225ce74a0c22f07318ba1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/sv-SE/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sv-SE/thunderbird-60.3.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "078765f08b2f6f53f319037f1237bc68ffeebfa1437fd921051a1f804f8f6e4fdcf7faa377c0fc066f8adf49a0bd6429981708ac3e0dfaffee3f196c9f97c8e8";
+      sha512 = "c72db6a8ed31e7348df9a0fc3931c5b1520f7bc03ea47e92eab343acd58c3fb4574beb91fc932733bc52e670451a04a88262e6e29ad7c0dacbcb37da522537b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/tr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/tr/thunderbird-60.3.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "4ac98caac0d51467059c90ef0867b78847c7260b4fa36187ccd670f7275ebc1cdd93fbfb934575f82d2cc7f0b0cae6b781842a883e5a8242b3f8d6295d18ae33";
+      sha512 = "249d2320607100ec397556619872b701dea16142ee3ca0599fd17d66e5581d4753326a0aa9e2fff4b38c9a91ab8e923abeb0115cd8ad9e82cc871116d670cd4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/uk/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/uk/thunderbird-60.3.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "9a187b5a401eec58a0c15dceb0ad0e894036f4d2af3e3d129444e31169c1fafff7228093ebb0acf37b9896d72eb88d02d04f8bf16be14092bb27086816a06a65";
+      sha512 = "439d7018c6a6cb3544ec26fdf6bb93d6be2a7a4a6a19d6d5de40e7bcaf0281e42af6fbad23d4640959fae84ea4bf487c19fe07bb50334cd593a20c7c5db999e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/vi/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/vi/thunderbird-60.3.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "53388ca676a3c15b41c8ac68a75de4aa10cec3953ff30bec1f67008a26d64a16af8e996b9196e1a23db0f00d835ec5bd22e3bf7e411fa6f8e4d276256afc2a69";
+      sha512 = "0f7e6cc139cba5223fb75b0fff6b60e26d2783e6a78f22f3d8d1ec518f950856ecdef9b2aa31346aadbadcc08ee9b9a251e2fbdc5bc9655395fa2015530de050";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/zh-CN/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/zh-CN/thunderbird-60.3.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "05de7f60510764ddb49b81b907b2b0f3047b38da361a3ac655266b2ecd90320721b3023d943a5fa8fb20ae632625b7dba394bfa85e54434718d392c035abf29f";
+      sha512 = "3280a8085855b25b88e485581d3f275873c4c01f1ea9608d98b01553a0dacfa7226d405d055028b2a45daf6316004b12ccd8637deeffb30724540df1ee480773";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-x86_64/zh-TW/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/zh-TW/thunderbird-60.3.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "f2aeb51217083f284af5150179f4173212d9837e4b85225610db78524fad92ca5c29bf6461543e5ca6cdd2c31f11886837651912682d5e07a82f1bce9a82e879";
+      sha512 = "194cd71fd722d2f8f47ada2fcb02c018cace495d6d72c7eacfff38c6e5f30b7749dad41f2e28af8e935703c4033fcd5f7264ff828240008bb17a86e6894fedd8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ar/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ar/thunderbird-60.3.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "ccd98be198eeaa462e60815fd23a64b854294a63965302477006eb0650dacbf0a9b84d2252bf93a7203410ffece84da42170450303d8e398253f1675e870102d";
+      sha512 = "56a8a07096fb29db87dc2633aff725612ff8255991674c590dfff51970778bb6b118a2f025097bb139086cfb949d0f53b1a6b1e9670c4b3cb0fc9ecfe35f6065";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ast/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ast/thunderbird-60.3.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "95e3737727be104753390535d4b963316d95f80ebaf3e323d791287a12e3b3c137f991e4752dd1d6a7a9e9683d945c047963f7c2f7dc9041abf367a2e85741e5";
+      sha512 = "9475397f31e227e6a83b9572b82d7067fc633fde9a271fa68be5922f860346abb2bc879b14f489b54c3e518cd2d917b5e5ea2a03da3ab554607356cb7236f4b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/be/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/be/thunderbird-60.3.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "4d20ea0dfdf556b10d5a47795739aeccb992f5d5970d30c5d90040ec759dd269ec2a146d47074c19d5bae8f8add2bba37b8dfc9b5f16d1eeef88f0dadcd85543";
+      sha512 = "488cf4396202882d4499b0bf6a3c5fe636fd162c767c5344ccb033ad57c90f544fb1e4daf348f08863c990eed0a07bb543c8b9f648786535a3db2887e77a6823";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/bg/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/bg/thunderbird-60.3.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "085f87242fe9416d6078c1c921bee327772eceaf84787d8ab407fb836c70ef8cd955ef98ca5532952d6ff085005d197f240a92d71cda6f36c0cd171c840ec937";
+      sha512 = "62bd4387ede66078250b1a462ddd487c97addd044b8c04858de922b60b88823880869f7eee0cf618b51ef1de956007d4fc9a6ce05ffae209284104cec4557bb1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/br/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/br/thunderbird-60.3.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "4f95501c6fbfb6c24ae126f7d9e9244c76a84be001f97b0f052f4fd447fa2f8a9357838abb058839072ca5b77409ddf0ff3dde908a4fab884bf120d86c22483c";
+      sha512 = "39fd9e5b42000c9b1e37f7a0bdf03681a3372166cf90750495f7e2a0e10f45465b3eb7d68454022634ffa8dd7a280d0ba98fee9367fa6058223fb87c06349e75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ca/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ca/thunderbird-60.3.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "31329841c564aa4bf488d324b19d62cce15397e2c7bda7714c218907a404447187612b353ce712c647a8a5251ce41b7b07a9dc79e9c9991275e09276216c41fd";
+      sha512 = "9cde54a64916448a776de3c197851576c5d9e395bc90da1f18abc0f5f1bb27d267bfcda33cde51fb06c80277caf35a7b9f1fad6853f8d053d95abb8ed2e95f5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/cs/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/cs/thunderbird-60.3.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "f0daaad120fc7a8958f45193151307b386f703c745835c069db7627bd74a8be594d30e4706463468b6ca861c0e628176325bfcff02e3b24ee9e7ebc35ceb76f6";
+      sha512 = "1b5b8633a6502e731e9d187b0c3977db8338c3aac9d4b07c12468b143a11488c5c4b46b898f3ced8637b16abeacde0c0482b74d0c67c04bb4e1e40bce66d8151";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/cy/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/cy/thunderbird-60.3.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "e44f4003847e7c72c681f9cb8e8b02c05420a88d99a0f2831fe02e256410ed4a2d41070d3674227a436a9045fc3ccdd242532cd5aec8c31a93d7bac2f85e3308";
+      sha512 = "a4636852813f271fe7ded7665d386d34120f664e5e2c18bd923efb4f3ff4cc273fa6ce952b243a2e25840f96baa4ac28979201d6f9a99ce8ce2bd18be41f1f82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/da/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/da/thunderbird-60.3.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "7462c01d3b9e7ea07047115983985b8d9bf7e71f75ac091248b41bd1e50813971843dcf6da71dfbc5f7f74a5d5fdc50c1b464cec90c4c3e649c9efe3f045e5e2";
+      sha512 = "fb4b302ac628b6b84ee8c537ec533200421c0fa4ce5af2efbc92e1f62e23761f5a64e11ed004ebbada8c0f31a4576d8a006571470896470547622aefb27af4dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/de/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/de/thunderbird-60.3.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "0c6e1fa83a9a886062ca3123671091b9001c2f54d1b0988a7b68e4e5900c036f436d3686bb0cf346a92e7426b9153f6f58a992766f0df215dca33317b81d04bb";
+      sha512 = "76a213f0ee3fc1611d88d82639bdd3a90fb0cae0ef9c938087da3cc14c2802c6ab2bb5c73eb27e370fa45dcf25c075c27c86fc1b8f38b32aeaf76b796269293e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/dsb/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/dsb/thunderbird-60.3.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "de2ae2d5e7abf26e021671d4cc8b1ed69817b4ef2361416405f60737d6eb117b10fbf3fcac7d75a204ce483ac6d0623e0b78a27c8229d11214cb6ce02fa70756";
+      sha512 = "34e0fdc2179d4edd61044eb43f9fb4653e3a34e424ca68e549f430dd2398c6e8890b1ab5dc1aa08a1f93ce5e73774eb465e75ac13c6ec56ffe25de5e41b308bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/el/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/el/thunderbird-60.3.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "b52519e5a0040b92c59eefd9a6b6908711b9685fbdd46b9c26149a83c37e0b31aaa591259e6ec40088443a7c9ca2fbe5fc4a4ee046a226a6493eb17c12d1bab5";
+      sha512 = "c09cb6653d9bace2767c25fd7a2d8a0100c36a5f029e2950872a13cd2f2cdc56f4e4c5a53af36d1667cd23a0ed405e529d470b0405a0f615c4a1e78e08cc6c90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/en-GB/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/en-GB/thunderbird-60.3.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "9c0bb3da4f47a6541b8d4d2db5eaf37f04a0190f6761f6dd09aa67a58de66b81321b9985470c09cb6887c660939615971bdae6626c49fbc77365bbb93434449c";
+      sha512 = "df3b0c6e90fb683d7b67db078c4052be3066072032a99e9b1ec2bd1bc9f5f7a95952788c754efbfce9c5ca89a43d6b59953a3c5283eaef134457b79f7fa0c538";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/en-US/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/en-US/thunderbird-60.3.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "da73b44eb926b981ba6855b9b1e79a030740499ce6d374922a47e311e4b6bbe8c9f39da19bfa705392edd0c0c3e0de1ae86d76a81cd1508ecee50c69bc69e43d";
+      sha512 = "18794d71c1d904caa1959feeaeceee38c86bca0faa84438ac1e1355879ae832fd509d2124a6d9ecbac7242eef334793357caed871713a139511ae77107168933";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/es-AR/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/es-AR/thunderbird-60.3.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "fd66717fb818610199eb628e22c5067892740c04924b406ce951afb5ee2a6e7a872224c6419c185b327a4e59f984bdf144628903f8a7bed10d4ea9247afc188f";
+      sha512 = "69825a80a98ecaed860c5f31c63928f215736fd9eefeadd7be1d88659c17afa58d7975f0ceec26040a21ca048da7b06154a44798069092c0a4e2e6816e847aba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/es-ES/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/es-ES/thunderbird-60.3.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "078d8eb9a7f1373ec90f0e3a1f22881546489fbfaec1fc4c26c6b85867233194c595d417221f6bd801338798bcf46506390d43d835604f8e188a4010a4610500";
+      sha512 = "673b4d55bf3691cf972a1f1369486cd205d7c6e8bc91cd826050fa28dd6c313f872aca399191305320289962f93495ea6316ae2f2b29313d8b61c175ae0640cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/et/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/et/thunderbird-60.3.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "c10994ebbe72d3dc4fa27b8dab56baf1625f6d128f961bc935139d224874959f3fe7f6b0d30ec7e72a8c6d49fc81761da1231170cac8d0d74da4354b59e1a407";
+      sha512 = "1dd9ac5e292fdec230189de90fe5ca923351b98a95d72d302bbc2c838e48cda46bc2e8e4ac2f08d2356b7a596dc2210fb9f24c15319fbb519b29dab78e29f2c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/eu/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/eu/thunderbird-60.3.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "0ca85492207350ad85731606bc298765b594a33db3c7889771cd92676e1e04240b4bf4ed9c540b94e61306c0e581ef656ed05e2dda9e333cb107285dd5fc98d9";
+      sha512 = "acfa8190d55223752cd3c65fa87bff86b7f1f38d86365bba23190c4f16519feb8acc37e1a47497e69279a312e57d39a5830ba8d9c4391a1503024f125ab72b18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/fi/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/fi/thunderbird-60.3.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "9d5082cd17e1975152daca9247f103f0a6ddf09cad6c017f3d0ff9f185af58d88f6802e2bcc48206c97c40828335580584dd4ad62b322829169b509a48c353ff";
+      sha512 = "8a95970bd4fb56ff80324a743f02e9dfa21df698f761096ee5d425663e87590ca8d38ab62ccc97298f4d935f4713ded1e0acf01afbcea1d378ed2c065cee637d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/fr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/fr/thunderbird-60.3.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "33d0496886cd0ada4f944a409d5cef5294d5dd7a3a10874558538a1b5a31e212ae9b3d5661c9e719a64419859e9b1d2945f475b91106b3f30aecf617ee6dab18";
+      sha512 = "51111b8da2823523bdce77d9807535e09b54f1ca7e1621f3447c9e4bf44522a176263a843875a3f55602b7b53d60ae00fd5a59f22fb3119a792064ebb9ace209";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/fy-NL/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/fy-NL/thunderbird-60.3.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "64ad8e580e8b1f8acdbb52245dbeacc22cb15471f9aabd091bfb262669c81e59e2fcaa2b31ce7fbd2d634896a9b0d22884d4151b3d90bc50b75de7f2680be852";
+      sha512 = "144cf86e32fdad0f4eed95b461de9dc0713c3bc70ccd77c1db94ea53762bffe7a5254f3f898228347e7b1d26df0055dc04b0192d3b1a3653a8109ff8f4f712c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ga-IE/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ga-IE/thunderbird-60.3.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "0fa4eebfc335022de2118a1bf5b27f83969ab26bf2d03d011d732cb8f2614bd75a60629a4f6c410a4fdf8ac8b3043c849aced85d7cf21bcbd263025ee0338234";
+      sha512 = "7f411ee0f9b518dcf122eff2eb0b70fc1c7a71d2ccddb73482a17c9508f084ff0df6aa6d9a1555c576b0fbd32c9d65e106b8f98c7d603907c7a7189de034bbca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/gd/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/gd/thunderbird-60.3.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "7cd1f55355fa2eecc6e6f79bb642800a014de93d80c273b57c9e910111684cd5f59d26ef4fbfa1bf6a6b1aee12f19cb2a0d376a9822fe8230ee9c7f81deef54c";
+      sha512 = "116e72b7f9759576077d3d11b9913b78dc6356e98995f0ee1ce152d04da9d0d5db6d32218a8e3a9403ee64405c95413fda8f86c6fef85336f799324179896fb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/gl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/gl/thunderbird-60.3.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "b5c1853b7a225116bb0c6cbca7dcac6256c8d46382fba5af5bdbfd7fec0bf6ce01def72ca1fd26c8243c7f1d77de7fabcf691dc956eaa911997915629a03fac9";
+      sha512 = "1d06ad862128b2ecb38b885c868c153b78a2246cdc635a066634f8b1a9e08fcff83d30806f9906b8f2a5a929e702be51ebec7fec54f7b80d4544f20cd2ab84b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/he/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/he/thunderbird-60.3.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "9155a7f37288baccadf31063a9955a1b7f6a9a7172c2650c5fc5ea32f3f473e5a682a6e269efae4429f23dda15a2afe00119594e4a5e9225eb298fd8ab48ae84";
+      sha512 = "6858b78aa38171194ee1821f7266924301859921591d84ab057a52ffaced7665adaaeb1ba536f9f0a7b8cd79ccc253631ff1a3d205c43c2c08d161e520ce7a60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/hr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hr/thunderbird-60.3.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "7fd14cf6e2844d264c8931e740f0281efd3b205bbd3bef08906628e6a65a703642c0794e85c8f2d56d944b6bc5b0d4590c369c668a13f54379e91d16d124b29c";
+      sha512 = "eb3f16f0000ea85e420c8bc60abe7b509ba0d125b8f95fdfc67d4c0fcf87b6c0db86a0297e8ee2e7fcb419951fcb0ba42a7e59005742145ae6067be5e85f6e93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/hsb/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hsb/thunderbird-60.3.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "eec8cd8a07f1d044387fd540d7ab848c562f36bebae19ab4b90dee0043f0578b21af9b1894d88db344adbee1127df5822e50caa8563c15fe5f2996c8888c35ed";
+      sha512 = "55ee75a0158ef072c1698cefa5b6725da36e9286c6da004ceb58f2aec109609f7ca9937d8825b92ae2731ef156e562249093fd551064388bc73905fc9ad2545f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/hu/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hu/thunderbird-60.3.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "af2a83eb2cdcd184c36c4f190690b50747a7df4e9b962f4858e41657ca1ce589e9e7167192a3a678d60458cf7fca89a3788607c100b96522d58d465b3f84dfc7";
+      sha512 = "6b9fee4d7747af8b6d39654fcbd0c14e7762a1ab4fb7e7e133598fded0295020b39009e028ffb3d8db502811bd5ca9889abf5004cb01ff995bf9c13b871e11bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/hy-AM/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hy-AM/thunderbird-60.3.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "0647b06bb64dd7f749029d95c242acf3a9c27e75c234198275d8d533d3376d5b26e9c872a75b966d6dcf2ccedc9054d26c56a474286d4108d298b69687be908a";
+      sha512 = "e0aa3adb175fd1562e6292526f6512d5f6a9e6584d521aae3c97cc0143946a49e41e1914e9ba6d87f29409ab8b17f84cac9bd4a815e29f7c9ece1729d302881c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/id/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/id/thunderbird-60.3.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "3a9a6fc713a8fdd9e28db9f381632ca65f00d78e642922091a6df4386bff2db0f1925118a2362073bab3565cc6741a64804c17e577568e665a3ba2414bd43c87";
+      sha512 = "7839db4bb937e699688d1e2fd387cbfb25a0402529b183f09897535341324f4d92e774c3bf517ba3a51c86f74854508b5bd6a5560bc153bf3720ea8191c119ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/is/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/is/thunderbird-60.3.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "a041121fd514c3af8fca1451992cf15642a5bfbff14336769afb5de56017362e35cbd3c3a9717a1ef861b3b47f5951670f37bac50ed318c60bb932196aaf4798";
+      sha512 = "29b069bcad1cc668f65a3749a1d87b6582ad32400905bf446f8ccb86cf42100d7034bdb4c0d22a66b8f5ccf95659a5ee4c058f7c5a5ee2222dd0a93cd6236a9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/it/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/it/thunderbird-60.3.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "246dcdba4a29d3ef657edf9850727baccc3c6246a56cdf9b0634faf54ed2b2736cccf6c544fe34ada3efcfcff5ad334ad3a4b1f29e986518dc88816d727b42c7";
+      sha512 = "fdc47d3462cc3db49a8208423c19b0d74b65eeefaad2eca873eb194cc8c9691adfba7e87bbbc7c4a472423eff91ff8e21d78fafef18a4e841e922c72eb53d78b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ja/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ja/thunderbird-60.3.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "f6ada0506ce125d46721710dae96f086da51abb15c3b20c5d5425946362534d8c99d67e3002131390e774b2ef867f422db215b51f368074b54f1f91e7fece482";
+      sha512 = "068a15c6913a556c1c9d0deeb96c75087f68e62c0dd2eef3445c4460e08c314d457f799e82f96dfe00fabf9ce4cf7a7c379d08e7a7ebb2969c39ae87082bdef4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/kab/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/kab/thunderbird-60.3.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "3838eb63f96e916402bd158aacb082ae97a9044cd0a6133206da0f6f8d389c361b55e84295b8c483a4be5920aa12b2eb3961525cb011327efcd720856fff41ff";
+      sha512 = "d11ef24a47ff39eab178ad448ea2d1457978b31dbe5ab0da2b87011d351d92ba54245891a1c6be3ed7424ea9f5743093e1cd6eeaadfe016405ad53252b7d5590";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/kk/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/kk/thunderbird-60.3.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "a3d010da794cf16d8ddfc14ca50f8504c8063091dc2770eb673281bf52c47faca96f5fce87bba5a691294117e23c46edf5a54b8c8b56d9a57902c088e247142c";
+      sha512 = "e4bb916f3e04136b470d46b04d7d2ba4c3d9d703dc8fda44e7611ec51af06af4bf73ab30f4d4b578560a27a34adb6950534d0554573a21210bf825f2aec4ea73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ko/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ko/thunderbird-60.3.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "8243d3ae0cb32d8805887d41764f5bc06dab1d2777c32e5d3b3a95dc52755f79e5d11fad4f93553262749a2cc6151462091a3a1228d83c4bda7ab04a6c427b1f";
+      sha512 = "9453426d6bb088af4bc4e0e2eea7dd163d434fbb7a29993b82faea9e79a11aca95214aefbac6278a44b90356eaca050ba081dccbb0e57bf5eadfddb992251ee4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/lt/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/lt/thunderbird-60.3.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "8c9456bf6add79ef4cfc46b0400a7de4e6ff37e45788e524565bddbbc31152072ed6f10a033d5c77bfcbf46809132e87722dc5b77ac063a63cec6086d630e8d4";
+      sha512 = "a0a3580444318c1bae14d8123cb215c37c32ef4e7f0db87e118054c34d7c3fb9b4d3659241379a23360680ddef6bbaec9fd3a514790efd6cd5f43d58de2fab30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ms/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ms/thunderbird-60.3.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "a0df7d3fc076370728909e32f9205c98b5c0f14b829148348f02c4f10a20ff21bd3e37ba54784b93f6b577c5710f0c021181146f50119789fbecbf7afd86285f";
+      sha512 = "8295bef9738e4808fe0e72fdc27f772f493ef8ec0ba1ee66923a51e45088152bf61ef0dc1539af7de6e6c637dae1b9ea70ea89912e621a27083550f7abb47c70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/nb-NO/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/nb-NO/thunderbird-60.3.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "b363b84cec28b80b80a89ad0aa91d81952a7503aa985b705cd0f6045f309287d0a3671c96fc871cbc1dc51d62f30d00532914f1e06255e240593dfcf9b7f8ef5";
+      sha512 = "3311340af28fe81452c27c704420a9e30ca9c1ff1dc3b7ce2a49210e83149c0fdea1014f546109704f14cd467963624f8634568df7764085a88e078a58cf8af4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/nl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/nl/thunderbird-60.3.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "1f9184da2d2b28649f7051f00e68491694ab19de23a318429ea29dccf9175520dfe1c8fd4ab9040d9b4e8ec2f0b65a884d1c130d3df034193a9c8bb23b23f024";
+      sha512 = "7b6ebfa8c12da1e73769f74ea15fbd339e0886783bf4a51fb1c612d7d7372cddd0abdfe654760880c4bdbee6930349b6290c3d52d886915445110449cdef8d6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/nn-NO/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/nn-NO/thunderbird-60.3.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "f85bbd7f6a3bebe7485c678318183082dc09ac259316d35874eeab67b77358495c2a8a6e01d09364bf4b9da0608b99541704894b78946ddd3e2833694a1a9fe4";
+      sha512 = "d89fabc6c2bf7b64eeca36b4b0b20e64e8e317764c24c9b4cf9430c54635e81ddf66879a3bd1748c295d3b52c523b63d4871823d98e86e1be68c953e0639fe6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/pl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/pl/thunderbird-60.3.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "ffa67d8f9f8f923341bc8a9235503af0dd20798e65f406d7aefd4fa30a06371ba265b3b8b67f31ca0792cad09033ef46b7f064d6270c76af9191c3122933bd4d";
+      sha512 = "5ee0bf77ccbf7f57fd4b4c7cc71befa785590d68c67141e135ef5f399e73a7e3cf2b5256f9420963c63b27a680168308772b313fea8a29c6aa322b8eaa46f059";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/pt-BR/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/pt-BR/thunderbird-60.3.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "bd92b016722347ae7662e8d44bbe205b8db19a9a3f9c5e537db4e9bf7d84e8bb69ca860d34b2b78219f01c6130ffd8e79aaf842545397766dc1199e1df8af3c1";
+      sha512 = "2243bfd560aff648ffe73cc9e7c6218bf6a1dc81e9970a097742a37aef6becdb93e5226d7340d7b69ee7a7a74785f7c06d93d0da726869ad339a715c265dbd5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/pt-PT/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/pt-PT/thunderbird-60.3.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "f97d92c60f64380ee35c2eb41cc7c494e09b48a367a14ec1f2cf05f6bedda4bfc5014b41d456e0434a328c663e1adefc104b59c2c6366ccbf51c5a6466bb8e09";
+      sha512 = "06a4caf81f561fd943050bfbb36b2f9190790f407aaecd8f20a3dcaca82bd037edd70622ace1dcf41fa4be1109ad9e80fd40332e45034895dc3fec148fd334aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/rm/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/rm/thunderbird-60.3.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "03ab5b1eef8082489471159786027b8fdca8cadedd396c28e5c00bca31554ba4ce14b8e810b055c9852f1d8964c8b1bd83b34e1a79b840146806ad701ff8a4a5";
+      sha512 = "4664931159370d114a50f075d7fd0cec7fa0bb3e91b96d7778b206ed5e748bbe71a9f30ec1a3a7a41849b524b409e024346c5c5344d18b5eb94aa939b86f59e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ro/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ro/thunderbird-60.3.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "e7fd6217ecb683dd78ababecb4dc17e7705a04c6761f445b34fffdb32527818f5b71361a8613ef54250956462f305faa59267698c89c6ea64eae2c5bb80c1dc2";
+      sha512 = "f0b19356c5917e16edeb8f120b0765f948010198a1bb8fa45e4bf7965553677f01920cf34b816d0dc3ba9190a11b6fb72ee33f0239e2e5974c60bd2929924a7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/ru/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ru/thunderbird-60.3.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "051593bb3f0d0ce571aba9365455d97d392377b482db7fa0efa42a50ae52981c294e84f185abd0dd52a07fcbae852d55f0427ede0f5172632a8dac416ed528a1";
+      sha512 = "b79517c780485098ae0aa91d275e8f314b8914a1a84400646963e0a23bd9179fe9dd3b63b80e45cc102296364bed639ab45841932d0bf93142e38850764125e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/si/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/si/thunderbird-60.3.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "0e859053b989734e1134c365a28a5fdb628fd61125cd6c4d3b7cf598e861dc8b08330ec017c148eda8fd02df49a7688d6b5d7e057ab75b387362dca884c9a90d";
+      sha512 = "d7a4a804c0122a902d513e6bbde37fb75b35a6a49300992aa81f6590becff6315d757c095f35505dce48b1e4d6b4963f7484f636c0d87d5ecf0cdfc1b9f44464";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/sk/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sk/thunderbird-60.3.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "f7d8191bd1f8b78a1a04d669b5193d1067413f3d1f5600940129cf018e38aae85b2c7d274308ca56b2b871d3ec594703d5dde2d5ae12dafee0332ce37393142f";
+      sha512 = "f50653801aff3f8596cfcdaf53755b5557e69aa237a76bd5598bc349839616a18b2a7703ce79094b6719d7e544f66a114b5d61ac9ef65f20c4f10a2e7b2cbe45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/sl/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sl/thunderbird-60.3.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "c6e9ec49518f19bbfb045b85aec4f11e43645a55892cd3e8570f90b0c4fcc90f4e57848ed5419708c5544aa5df93b1a61786ca1422976938795bc7c5c2743098";
+      sha512 = "d98731420605736ec5ba1df75a38b8a44ebe2a29c307fb7e63f51db0b2f8d2fab0bde2c8e4d9778bba82545f04f42a80bff1659cf49f3a1db5ad5418cfe9c34f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/sq/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sq/thunderbird-60.3.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "e5586b535c014b400535680964c0ec03ef9a4d9cbd3bea4701293f681635faf6218744d8a8cb8781310ad4797143610ce1821de5c24232e990a24a87a57a7f2e";
+      sha512 = "8973e874151efb48343dec2c192e98015740d160dff902d1c07f6f1a5e770344ed07260bb4986892615f31b5c06f56a59406def6d7af20cab04edcba2e5b6003";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/sr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sr/thunderbird-60.3.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "7bbd3dd52ed742cc59d474f9235a1370d5cb8d9a805df87fffbc9eb13fa50d3bcba630a720effdfaab42580148a9328ba09869b09d06151eaa5ded55db13cbf3";
+      sha512 = "354706cac183b91067d55d49b16f525aef6c5abbedb729d321e615d8e29c05976ec8e33c905600584bf2e64ba8fb27472fe14a9390e2188fb2b236df0cf7d39e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/sv-SE/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sv-SE/thunderbird-60.3.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "157772822f5f28fbbc4fe2b19b38c1cee3e11d7c62c802620e3b3df17898cf61d3c7ffd1e77e2373ddbfd67452e177eabdd34c3a025f7b4bbcb587dc2fa607b2";
+      sha512 = "8714ecbaf368d5c405224163bc1f0047b498770167dc6ffd53cc1bb0828228cd48933a5ff7e5116634e1c50218d08d27fa667942878a19fa2f0a4398ab0fa458";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/tr/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/tr/thunderbird-60.3.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "7748d29478930265e632973ccee211d3edef2e5ee5ff363145d57c9bbaf7257e8e963287eb854cce4de16ad976d54305be14bb848e164c9feaf223ad40e1c8e2";
+      sha512 = "e8e62fdc8704f91754be9a97f288d113577039bbca1ed69c01e577cc8813e4302f9cd1842f38a91cb8d9899a7a9317b59e931e65f492e619b6b6c2a736117366";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/uk/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/uk/thunderbird-60.3.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "c8cc86f2c802f05131d2ceb2ab3fb1c3fc72c9253efd40833046c2022de61d581222275d84584938a3720f0d20df6eeee4ca50751554fe53fd7551577db0591b";
+      sha512 = "d948efc3e6bd4c9392fed77f52e77998f5b1a202945a6e4bd3b3bcc8332925c6d8de5d48c9737401e94ac701ee7d9e334819fd3718b600914650ee57bef5a5bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/vi/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/vi/thunderbird-60.3.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "81bd7e3276e2b7ad50456d29fc84260b0cd694acaeea6818b0fdfcda91ed0e04b3c03b8721303c5b3a6cb8a7570c5b925922c9d6725a258c525250ff42c076e8";
+      sha512 = "929f5c94418de4df462356e0321088482e1e7ece9fe1838123c12f7649c2762e53d20de75bb77f77bc54add23985653ba77b63502b19912b6bc82f2b0ef1dfa0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/zh-CN/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/zh-CN/thunderbird-60.3.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "2d120d666559ce4c0bbb1045d03aaa7c9f851c929b91fd6addc20c3a81ca7accba550f49540e3249ee227caa19aaf24414db995d930f0e02f651d75c230e3429";
+      sha512 = "b746273c7ad7651521d6072f211351c3b585d25ebd48027be3b93a3ce0e09abdaae2a63e97eca013dba046dbadf97f5d4a38fd08bf4a9304c7622881367af73a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.0/linux-i686/zh-TW/thunderbird-60.3.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/zh-TW/thunderbird-60.3.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "ad36e3c82d68215765a83cf0098bfc392b2e3f32dbdb7998f54e4b83885f5be53a65cf814990237d7cd35b4695a23f5a4dff363e185b5c75a5aa2248c96ab80e";
+      sha512 = "9251b5688967e87f521bc283b0000194eb98c2ce157aa8befe624146d5dcbf4e7237944d3ae8c0045a0667172fd68616e179fb3ecf6e0f848f7e15a6a2b21f00";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -24,11 +24,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "60.3.0";
+  version = "60.3.1";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "39sicxgfzfx4dm50nn2l8mimyjpvfigdpmkbxk6lvvbi8xxl527631xxq0gh1di6iyp590vpwk16z7hvdfbqj2pd3231knjkl991hvc";
+    sha512 = "266m4kwxiwh1zi60z4gcs54k4w903aximafngmmqaa5nkxnsxh6sp62j1mazdh52g40pzdy9sqb8zkcjsm7dp937kpcl2lvw778lanm";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
###### Motivation for this change

- Bug fixes

https://www.thunderbird.net/en-US/thunderbird/60.3.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

