### PR TITLE
elfutils: 0.174 -> 0.175, clean a bit, fix and enable tests and hardening

### DIFF
--- a/pkgs/development/tools/misc/elfutils/backtrace-test-fix.patch
+++ b/pkgs/development/tools/misc/elfutils/backtrace-test-fix.patch
@@ -16,19 +16,6 @@ Signed-off-by: Mark Wielaard <mark@klomp.org>
  tests/backtrace-subr.sh | 1 +
  2 files changed, 6 insertions(+)
 
-diff --git a/tests/ChangeLog b/tests/ChangeLog
-index 08358d29..f6b0a672 100644
---- a/tests/ChangeLog
-+++ b/tests/ChangeLog
-@@ -1,3 +1,8 @@
-+2018-11-21  Mark Wielaard  <mark@klomp.org>
-+
-+	* backtrace-subr.sh (check_unsupported): Call test_cleanup before
-+	exit.
-+
- 2018-11-17  Mark Wielaard  <mark@klomp.org>
- 
- 	* run-strip-version.sh: New test.
 diff --git a/tests/backtrace-subr.sh b/tests/backtrace-subr.sh
 index ff42c6ff..53c719df 100644
 --- a/tests/backtrace-subr.sh

--- a/pkgs/development/tools/misc/elfutils/backtrace-test-fix.patch
+++ b/pkgs/development/tools/misc/elfutils/backtrace-test-fix.patch
@@ -1,0 +1,46 @@
+From 628b4a93c6863b9982d817db6acaacbc4e116453 Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Wed, 21 Nov 2018 20:07:14 +0100
+Subject: [PATCH] tests: Call test_cleanup in backtrace-subr.sh
+ check_unsupported.
+
+We want to make sure all (temporary) test files are cleaned up even when
+we exit 77 to skip the testcase.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=23901
+
+Tested-by: Kurt Roeckx <kurt@roeckx.be>
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+---
+ tests/ChangeLog         | 5 +++++
+ tests/backtrace-subr.sh | 1 +
+ 2 files changed, 6 insertions(+)
+
+diff --git a/tests/ChangeLog b/tests/ChangeLog
+index 08358d29..f6b0a672 100644
+--- a/tests/ChangeLog
++++ b/tests/ChangeLog
+@@ -1,3 +1,8 @@
++2018-11-21  Mark Wielaard  <mark@klomp.org>
++
++	* backtrace-subr.sh (check_unsupported): Call test_cleanup before
++	exit.
++
+ 2018-11-17  Mark Wielaard  <mark@klomp.org>
+ 
+ 	* run-strip-version.sh: New test.
+diff --git a/tests/backtrace-subr.sh b/tests/backtrace-subr.sh
+index ff42c6ff..53c719df 100644
+--- a/tests/backtrace-subr.sh
++++ b/tests/backtrace-subr.sh
+@@ -85,6 +85,7 @@ check_unsupported()
+   testname=$2
+   if grep -q ': Unwinding not supported for this architecture$' $err; then
+     echo >&2 $testname: arch not supported
++    test_cleanup
+     exit 77
+   fi
+ }
+-- 
+2.20.1
+

--- a/pkgs/development/tools/misc/elfutils/backtrace-test-touchup.patch
+++ b/pkgs/development/tools/misc/elfutils/backtrace-test-touchup.patch
@@ -1,0 +1,64 @@
+From 63160fceaaac2f9bd13da7abf929907a5f723aab Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Wed, 28 Nov 2018 13:58:31 +0100
+Subject: [PATCH] tests: Improve backtrace-data SKIP message.
+
+The backtrace-data testcase is x86_64 linux only because it uses its
+own set_initial_registers and scans its own /proc/pid/maps file.
+The SKIP message it gave on other platforms was misleading. It said
+"Unwinding not supported for this architecture". Change it to
+"x86_64 linux only test" to be less confusing.
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+---
+ tests/ChangeLog             | 5 +++++
+ tests/backtrace-data.c      | 2 +-
+ tests/run-backtrace-data.sh | 6 +++++-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/tests/ChangeLog b/tests/ChangeLog
+index f6b0a672..225a51d5 100644
+--- a/tests/ChangeLog
++++ b/tests/ChangeLog
+@@ -1,3 +1,8 @@
++2018-11-28  Mark Wielaard  <mark@klomp.org>
++
++	* backtrace-data.c (main): Improve error message.
++	* run-backtrace-data.sh: Skip exit 77 return.
++
+ 2018-11-21  Mark Wielaard  <mark@klomp.org>
+ 
+ 	* backtrace-subr.sh (check_unsupported): Call test_cleanup before
+diff --git a/tests/backtrace-data.c b/tests/backtrace-data.c
+index 67ecd475..3a91c664 100644
+--- a/tests/backtrace-data.c
++++ b/tests/backtrace-data.c
+@@ -47,7 +47,7 @@
+ int
+ main (int argc __attribute__ ((unused)), char **argv)
+ {
+-  fprintf (stderr, "%s: Unwinding not supported for this architecture\n",
++  fprintf (stderr, "%s: x86_64 linux only test\n",
+           argv[0]);
+   return 77;
+ }
+diff --git a/tests/run-backtrace-data.sh b/tests/run-backtrace-data.sh
+index 34a4f01d..3062c304 100755
+--- a/tests/run-backtrace-data.sh
++++ b/tests/run-backtrace-data.sh
+@@ -22,7 +22,11 @@
+ unset VALGRIND_CMD
+ 
+ tempfiles data.{bt,err}
+-(set +ex; testrun ${abs_builddir}/backtrace-data 1>data.bt 2>data.err; true)
++(set +ex;
++ testrun ${abs_builddir}/backtrace-data 1>data.bt 2>data.err;
++ if test $? == 77; then cat data.{bt,err}; exit 77; fi
++ true)
++
+ cat data.{bt,err}
+ check_unsupported data.err data
+ check_all data.{bt,err} data
+-- 
+2.20.1
+

--- a/pkgs/development/tools/misc/elfutils/backtrace-test-touchup.patch
+++ b/pkgs/development/tools/misc/elfutils/backtrace-test-touchup.patch
@@ -16,19 +16,6 @@ Signed-off-by: Mark Wielaard <mark@klomp.org>
  tests/run-backtrace-data.sh | 6 +++++-
  3 files changed, 11 insertions(+), 2 deletions(-)
 
-diff --git a/tests/ChangeLog b/tests/ChangeLog
-index f6b0a672..225a51d5 100644
---- a/tests/ChangeLog
-+++ b/tests/ChangeLog
-@@ -1,3 +1,8 @@
-+2018-11-28  Mark Wielaard  <mark@klomp.org>
-+
-+	* backtrace-data.c (main): Improve error message.
-+	* run-backtrace-data.sh: Skip exit 77 return.
-+
- 2018-11-21  Mark Wielaard  <mark@klomp.org>
- 
- 	* backtrace-subr.sh (check_unsupported): Call test_cleanup before
 diff --git a/tests/backtrace-data.c b/tests/backtrace-data.c
 index 67ecd475..3a91c664 100644
 --- a/tests/backtrace-data.c

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     patchShebangs tests
   '';
 
-  hardeningDisable = [ "format" ];
 
   # We need bzip2 in NativeInputs because otherwise we can't unpack the src,
   # as the host-bzip2 will be in the path.

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs }:
+{ lib, stdenv, fetchurl, fetchpatch, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs }:
 
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
@@ -10,7 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "0nx6nzbk0rw3pxbzxsfvrjjh37hibzd2gjz5bb8wccpf85ar5vzp";
   };
 
-  patches = [ ./debug-info-from-env.patch ];
+  patches = [
+    ./debug-info-from-env.patch
+    (fetchpatch {
+      name = "support-pax-flags.patch";
+      url = https://115100.bugs.gentoo.org/attachment.cgi?id=74902;
+      sha256 = "06gmpp0mi0i82gi5qpl33a9jai3048s19rd4j9y3crixb3cqbpdh";
+      extraPrefix = "";
+    })
+  ];
 
   postPatch = ''
     patchShebangs tests

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
       sha256 = "06gmpp0mi0i82gi5qpl33a9jai3048s19rd4j9y3crixb3cqbpdh";
       extraPrefix = "";
     })
+    ./backtrace-test-fix.patch
+    ./backtrace-test-touchup.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs }:
+{ lib, stdenv, fetchurl, fetchpatch, m4, zlib, bzip2, bison, flex, gettext, utillinux, xz, setupDebugInfoDirs }:
 
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     patchShebangs tests
   '';
 
-  nativeBuildInputs = [ m4 bison flex gettext ];
+  nativeBuildInputs = [ m4 bison flex gettext utillinux /* flock */ ];
   buildInputs = [ zlib bzip2 xz ];
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -67,8 +67,8 @@ stdenv.mkDerivation rec {
     cp version.h $out/include
   '';
 
-  doCheck = false; # fails 3 out of 174 tests
-  doInstallCheck = false; # fails 70 out of 174 tests
+  doCheck = true;
+  doInstallCheck = true;
 
   meta = {
     homepage = https://sourceware.org/elfutils/;

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -16,10 +16,7 @@ stdenv.mkDerivation rec {
     patchShebangs tests
   '';
 
-
-  # We need bzip2 in NativeInputs because otherwise we can't unpack the src,
-  # as the host-bzip2 will be in the path.
-  nativeBuildInputs = [ m4 bison flex gettext bzip2 ];
+  nativeBuildInputs = [ m4 bison flex gettext ];
   buildInputs = [ zlib bzip2 xz ];
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---