### PR TITLE
retdec: bump yaramod dep to fix 2/bison 3.2+

### DIFF
--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , fetchzip
 , lib
 , callPackage
@@ -70,8 +71,8 @@ let
   yaramod = fetchFromGitHub {
     owner = "avast-tl";
     repo = "yaramod";
-    rev = "v2.1.2";
-    sha256 = "1rpyqzkrqvk721hf75wb7aasw5mzp9wz4j89p0x1l9p5x1b3maz3";
+    rev = "v2.2.2";
+    sha256 = "0cq9h4h686q9ybamisbl797g6xjy211s3cq83nixkwkigmz48ccp";
   };
   jsoncpp = fetchFromGitHub {
     owner = "open-source-parsers";
@@ -179,6 +180,20 @@ in stdenv.mkDerivation rec {
     (tinyxml2 // { dep_name = "tinyxml2"; })
     (yaracpp // { dep_name = "yaracpp"; })
     (yaramod // { dep_name = "yaramod"; })
+  ];
+
+  # Use newer yaramod to fix w/bison 3.2+
+  patches = [
+    # 2.1.2 -> 2.2.1
+    (fetchpatch {
+      url = https://github.com/avast-tl/retdec/commit/c9d23da1c6e23c149ed684c6becd3f3828fb4a55.patch;
+      sha256 = "0hdq634f72fihdy10nx2ajbps561w03dfdsy5r35afv9fapla6mv";
+    })
+    # 2.2.1 -> 2.2.2
+    (fetchpatch {
+      url = https://github.com/avast-tl/retdec/commit/fb85f00754b5d13b781385651db557741679721e.patch;
+      sha256 = "0a8mwmwb39pr5ag3q11nv81ncdk51shndqrkm92shqrmdq14va52";
+    })
   ];
 
   postPatch = (lib.concatMapStrings patchDep external_deps) + ''


### PR DESCRIPTION
###### Motivation for this change

Sending to staging since that's where the bison upgrade is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---