### PR TITLE
netdata: 1.10.0 -> 1.11.0

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -12,7 +12,7 @@ let
 
   localConfig = {
     global = {
-      "plugins directory" = "${wrappedPlugins}/libexec/netdata/plugins.d ${pkgs.netdata}/libexec/netdata/plugins.d";
+      "plugins directory" = "${pkgs.netdata}/libexec/netdata/plugins.d ${wrappedPlugins}/libexec/netdata/plugins.d";
     };
     web = {
       "web files owner" = "root";
@@ -96,7 +96,7 @@ in {
     };
 
     security.wrappers."apps.plugin" = {
-      source = "${pkgs.netdata}/libexec/netdata/plugins.d/apps.plugin";
+      source = "${pkgs.netdata}/libexec/netdata/plugins.d/apps.plugin.org";
       capabilities = "cap_dac_read_search,cap_sys_ptrace+ep";
       owner = cfg.user;
       group = cfg.group;

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec{
     ./no-files-in-etc-and-var.patch
   ];
 
+  postInstall = stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    # rename this plugin so netdata will look for setuid wrapper
+    mv $out/libexec/netdata/plugins.d/apps.plugin \
+      $out/libexec/netdata/plugins.d/apps.plugin.org
+  '';
+
   configureFlags = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,39 +1,36 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, zlib, pkgconfig, libuuid }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, zlib, libuuid, libossp_uuid, CoreFoundation, IOKit }:
 
 stdenv.mkDerivation rec{
-  version = "1.10.0";
+  version = "1.11.0";
   name = "netdata-${version}";
 
-  src = fetchFromGitHub {
-    rev = "v${version}";
-    owner = "firehol";
-    repo = "netdata";
-    sha256 = "02spfisabjkkgd9fairldlf84n83vbv2xafg0g5jrpfa972pjl9r";
+  src = fetchurl {
+    url = "https://github.com/netdata/netdata/releases/download/v${version}/netdata-v${version}.tar.gz";
+    sha256 = "17b14w34jif6bviw3s81imbazkvvafwxff7d5zjy6wicq88q8b64";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ zlib libuuid ];
+  buildInputs = [ zlib ]
+    ++ (if stdenv.isDarwin then [ libossp_uuid CoreFoundation IOKit ] else [ libuuid ]);
 
   # Build will fail trying to create /var/{cache,lib,log}/netdata without this
   postPatch = ''
-   sed -i '/dist_.*_DATA = \.keep/d' src/Makefile.am
+    substituteInPlace Makefile.am --replace "installer/.keep" ""
   '';
 
   configureFlags = [
     "--localstatedir=/var"
   ];
 
-  # App fails on runtime if the default config file is not detected
-  # The upstream installer does prepare an empty file too
-  postInstall = ''
-    touch $out/etc/netdata/netdata.conf
+  postFixup = ''
+    rm -r $out/sbin
   '';
 
   meta = with stdenv.lib; {
     description = "Real-time performance monitoring tool";
-    homepage = http://netdata.firehol.org;
+    homepage = https://my-netdata.io/;
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.lethalman ];
   };
 

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -13,13 +13,13 @@ stdenv.mkDerivation rec{
   buildInputs = [ zlib ]
     ++ (if stdenv.isDarwin then [ libossp_uuid CoreFoundation IOKit ] else [ libuuid ]);
 
-  # Build will fail trying to create /var/{cache,lib,log}/netdata without this
-  postPatch = ''
-    substituteInPlace Makefile.am --replace "installer/.keep" ""
-  '';
+  patches = [
+    ./no-files-in-etc-and-var.patch
+  ];
 
   configureFlags = [
     "--localstatedir=/var"
+    "--sysconfdir=/etc"
   ];
 
   postFixup = ''

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,0 +1,86 @@
+diff -ruN orig/Makefile.am new/Makefile.am
+--- orig/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/Makefile.am	2018-11-16 10:30:22.000000000 -0500
+@@ -99,10 +99,10 @@
+ 	$(NULL)
+ 
+ sbin_PROGRAMS =
+-dist_cache_DATA = installer/.keep
+-dist_varlib_DATA = installer/.keep
+-dist_registry_DATA = installer/.keep
+-dist_log_DATA = installer/.keep
++dist_cache_DATA =
++dist_varlib_DATA =
++dist_registry_DATA =
++dist_log_DATA =
+ plugins_PROGRAMS =
+ 
+ LIBNETDATA_FILES = \
+diff -ruN orig/collectors/charts.d.plugin/Makefile.am new/collectors/charts.d.plugin/Makefile.am
+--- orig/collectors/charts.d.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/collectors/charts.d.plugin/Makefile.am	2018-11-16 11:16:47.000000000 -0500
+@@ -32,7 +32,6 @@
+ 
+ userchartsconfigdir=$(configdir)/charts.d
+ dist_userchartsconfig_DATA = \
+-    $(top_srcdir)/installer/.keep \
+     $(NULL)
+ 
+ chartsconfigdir=$(libconfigdir)/charts.d
+diff -ruN orig/collectors/node.d.plugin/Makefile.am new/collectors/node.d.plugin/Makefile.am
+--- orig/collectors/node.d.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/collectors/node.d.plugin/Makefile.am	2018-11-16 11:16:42.000000000 -0500
+@@ -23,7 +23,6 @@
+ 
+ usernodeconfigdir=$(configdir)/node.d
+ dist_usernodeconfig_DATA = \
+-    $(top_srcdir)/installer/.keep \
+     $(NULL)
+ 
+ nodeconfigdir=$(libconfigdir)/node.d
+diff -ruN orig/collectors/python.d.plugin/Makefile.am new/collectors/python.d.plugin/Makefile.am
+--- orig/collectors/python.d.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/collectors/python.d.plugin/Makefile.am	2018-11-16 10:56:06.000000000 -0500
+@@ -29,7 +29,6 @@
+ 
+ userpythonconfigdir=$(configdir)/python.d
+ dist_userpythonconfig_DATA = \
+-    $(top_srcdir)/installer/.keep \
+     $(NULL)
+ 
+ pythonconfigdir=$(libconfigdir)/python.d
+diff -ruN orig/collectors/statsd.plugin/Makefile.am new/collectors/statsd.plugin/Makefile.am
+--- orig/collectors/statsd.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/collectors/statsd.plugin/Makefile.am	2018-11-16 10:53:04.000000000 -0500
+@@ -15,6 +15,5 @@
+ 
+ userstatsdconfigdir=$(configdir)/statsd.d
+ dist_userstatsdconfig_DATA = \
+-    $(top_srcdir)/installer/.keep \
+     $(NULL)
+ 
+diff -ruN orig/health/Makefile.am new/health/Makefile.am
+--- orig/health/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/health/Makefile.am	2018-11-16 10:56:30.000000000 -0500
+@@ -16,7 +16,6 @@
+ 
+ userhealthconfigdir=$(configdir)/health.d
+ dist_userhealthconfig_DATA = \
+-    $(top_srcdir)/installer/.keep \
+     $(NULL)
+ 
+ healthconfigdir=$(libconfigdir)/health.d
+diff -ruN orig/system/Makefile.am new/system/Makefile.am
+--- orig/system/Makefile.am	2018-11-02 08:56:21.000000000 -0500
++++ new/system/Makefile.am	2018-11-16 10:29:21.000000000 -0500
+@@ -17,10 +17,6 @@
+ include $(top_srcdir)/build/subst.inc
+ SUFFIXES = .in
+ 
+-dist_config_SCRIPTS = \
+-    edit-config \
+-    $(NULL)
+-
+ nodist_noinst_DATA = \
+ 	netdata-openrc \
+ 	netdata.logrotate \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3766,7 +3766,9 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
-  netdata = callPackage ../tools/system/netdata { };
+  netdata = callPackage ../tools/system/netdata {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
+  };
 
   netsurf = recurseIntoAttrs (let callPackage = newScope pkgs.netsurf; in rec {
     # ui could be gtk, sixel or framebuffer. Note that console display (sixel)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

