### PR TITLE
at: run tests

### DIFF
--- a/pkgs/tools/system/at/default.nix
+++ b/pkgs/tools/system/at/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, bison, flex, pam
+{ stdenv, fetchurl, fetchpatch, bison, flex, pam, perl
 , sendmailPath ? "/run/wrappers/bin/sendmail"
 , atWrapperPath ? "/run/wrappers/bin/at"
 }:
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ bison flex ];
+  nativeBuildInputs = [ bison flex perl /* for `prove` (tests) */ ];
 
   buildInputs = [ pam ];
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     "--with-daemon_groupname=atd"
   ];
 
-  doCheck = false; # need "prove" tool
+  doCheck = true;
 
   # Ensure that "batch" can invoke the setuid "at" wrapper, if it exists, or
   # else we get permission errors (on NixOS). "batch" is a shell script, so


### PR DESCRIPTION
###### Motivation for this change
at has some tests which we could be running

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `nixos/tests/atd.nix`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

