### PR TITLE
Licence fixes

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -105,12 +105,6 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = ''BSD 4-clause "Original" or "Old" License'';
   };
 
-  bsl10 = {
-    fullName = "Business Source License 1.0";
-    url = https://mariadb.com/bsl10;
-    free = false;
-  };
-
   bsl11 = {
     fullName = "Business Source License 1.1";
     url = https://mariadb.com/bsl11;

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -47,6 +47,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
   amd = {
     fullName = "AMD License Agreement";
     url = http://developer.amd.com/amd-license-agreement/;
+    free = false;
   };
 
   apsl20 = spdx {
@@ -107,11 +108,13 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
   bsl10 = {
     fullName = "Business Source License 1.0";
     url = https://mariadb.com/bsl10;
+    free = false;
   };
 
   bsl11 = {
     fullName = "Business Source License 1.1";
     url = https://mariadb.com/bsl11;
+    free = false;
   };
 
   clArtistic = spdx {


### PR DESCRIPTION
###### Motivation for this change
Some of the licences are incorrectly assumed to be free.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

