### PR TITLE
pythonPackages.pytesseract: init at 0.2.5

### DIFF
--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage, fetchPypi, lib, pillow, tesseract, substituteAll }:
+
+buildPythonPackage rec {
+  pname = "pytesseract";
+  version = "0.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wlz1vbg1k8cdrpzvrahjnbsfs4ki6xqhbkv17ycfchh7h6kfkfm";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./tesseract-binary.patch;
+      drv = "${tesseract}";
+    })
+  ];
+
+  buildInputs = [ tesseract ];
+  propagatedBuildInputs = [ pillow ];
+
+  # the package doesn't have any tests.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://pypi.org/project/pytesseract/;
+    license = licenses.gpl3;
+    description = "A Python wrapper for Google Tesseract";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/python-modules/pytesseract/tesseract-binary.patch
+++ b/pkgs/development/python-modules/pytesseract/tesseract-binary.patch
@@ -1,0 +1,13 @@
+diff --git a/src/pytesseract.py b/src/pytesseract.py
+index 32713cf..5f9209d 100755
+--- a/src/pytesseract.py
++++ b/src/pytesseract.py
+@@ -25,7 +25,7 @@ if numpy_installed:
+     from numpy import ndarray
+ 
+ # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
+-tesseract_cmd = 'tesseract'
++tesseract_cmd = '@drv@/bin/tesseract'
+ RGB_MODE = 'RGB'
+ OSD_KEYS = {
+     'Page number': ('page_num', int),

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -607,6 +607,8 @@ in {
 
   pystache = callPackage ../development/python-modules/pystache { };
 
+  pytesseract = callPackage ../development/python-modules/pytesseract { };
+
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
   python-binance = callPackage ../development/python-modules/python-binance { };


### PR DESCRIPTION
###### Motivation for this change

Simple python wrapper for Tesseract, an OCR engine to detect and read
text from images.

See https://pypi.org/project/pytesseract/

cc @divb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

