### PR TITLE
mxisd: init at 1.2.0 plus service with test

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -175,7 +175,7 @@
       dnsmasq = 141;
       uhub = 142;
       yandexdisk = 143;
-      #collectd = 144; #unused
+      mxisd = 144; # was once collectd
       consul = 145;
       mailpile = 146;
       redmine = 147;
@@ -483,7 +483,7 @@
       #dnsmasq = 141; # unused
       uhub = 142;
       #yandexdisk = 143; # unused
-      #collectd = 144; # unused
+      mxisd = 144; # was once collectd
       #consul = 145; # unused
       mailpile = 146;
       redmine = 147;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -559,6 +559,7 @@
   ./services/networking/miredo.nix
   ./services/networking/mstpd.nix
   ./services/networking/murmur.nix
+  ./services/networking/mxisd.nix
   ./services/networking/namecoind.nix
   ./services/networking/nat.nix
   ./services/networking/ndppd.nix

--- a/nixos/modules/services/networking/mxisd.nix
+++ b/nixos/modules/services/networking/mxisd.nix
@@ -1,0 +1,125 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mxisd;
+
+  server = optionalAttrs (cfg.server.name != null) { inherit (cfg.server) name; }
+        // optionalAttrs (cfg.server.port != null) { inherit (cfg.server) port; };
+
+  baseConfig = {
+    matrix.domain = cfg.matrix.domain;
+    key.path = "${cfg.dataDir}/signing.key";
+    storage = {
+      provider.sqlite.database = "${cfg.dataDir}/mxisd.db";
+    };
+  } // optionalAttrs (server != {}) { inherit server; };
+
+  # merges baseConfig and extraConfig into a single file
+  fullConfig = recursiveUpdate baseConfig cfg.extraConfig;
+
+  configFile = pkgs.writeText "mxisd-config.yaml" (builtins.toJSON fullConfig);
+
+in {
+  options = {
+    services.mxisd = {
+      enable = mkEnableOption "mxisd matrix federated identity server";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.mxisd;
+        defaultText = "pkgs.mxisd";
+        description = "The mxisd package to use";
+      };
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/mxisd";
+        description = "Where data mxisd uses resides";
+      };
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Extra options merged into the mxisd configuration";
+      };
+
+      matrix = {
+
+        domain = mkOption {
+          type = types.str;
+          description = ''
+            the domain of the matrix homeserver
+          '';
+        };
+
+      };
+
+      server = {
+
+        name = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            Public hostname of mxisd, if different from the Matrix domain.
+          '';
+        };
+
+        port = mkOption {
+          type = types.nullOr types.int;
+          default = null;
+          description = ''
+            HTTP port to listen on (unencrypted)
+          '';
+        };
+
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users = [
+      {
+        name = "mxisd";
+        group = "mxisd";
+        home = cfg.dataDir;
+        createHome = true;
+        shell = "${pkgs.bash}/bin/bash";
+        uid = config.ids.uids.mxisd;
+      }
+    ];
+
+    users.groups = [
+      {
+        name = "mxisd";
+        gid = config.ids.gids.mxisd;
+      }
+    ];
+
+    systemd.services.mxisd = {
+      description = "a federated identity server for the matrix ecosystem";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      # mxisd / spring.boot needs the configuration to be named "application.yaml"
+      preStart = ''
+        config=${cfg.dataDir}/application.yaml
+        cp ${configFile} $config
+        chmod 444 $config
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        User = "mxisd";
+        Group = "mxisd";
+        ExecStart = "${cfg.package}/bin/mxisd --spring.config.location=${cfg.dataDir}/ --spring.profiles.active=systemd --java.security.egd=file:/dev/./urandom";
+        WorkingDirectory = cfg.dataDir;
+        PermissionsStartOnly = true;
+        SuccessExitStatus = 143;
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/tests/mxisd.nix
+++ b/nixos/tests/mxisd.nix
@@ -1,0 +1,21 @@
+import ./make-test.nix ({ pkgs, ... } : {
+
+  name = "mxisd";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ mguentner ];
+  };
+
+  nodes = {
+    server_mxisd = args : {
+      services.mxisd.enable = true;
+      services.mxisd.matrix.domain = "example.org";
+    };
+  };
+
+  testScript = ''
+    startAll;
+    $server_mxisd->waitForUnit("mxisd.service");
+    $server_mxisd->waitForOpenPort(8090);
+    $server_mxisd->succeed("curl -Ssf \"http://127.0.0.1:8090/_matrix/identity/api/v1\"")
+  '';
+})

--- a/pkgs/servers/mxisd/0001-gradle.patch
+++ b/pkgs/servers/mxisd/0001-gradle.patch
@@ -1,0 +1,22 @@
+--- a/build.gradle	2018-11-16 15:15:29.021469758 +0100
++++ b/build.gradle	2018-11-16 15:16:50.982289782 +0100
+@@ -64,7 +64,7 @@
+ 
+ buildscript {
+     repositories {
+-        mavenCentral()
++    REPLACE
+     }
+ 
+     dependencies {
+@@ -73,9 +73,7 @@
+ }
+ 
+ repositories {
+-    mavenCentral()
+-    maven { url "https://kamax.io/maven/releases/" }
+-    maven { url "https://kamax.io/maven/snapshots/" }
++REPLACE
+ }
+ 
+ dependencies {

--- a/pkgs/servers/mxisd/default.nix
+++ b/pkgs/servers/mxisd/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchFromGitHub, jdk, jre, git, gradle_2_5, perl, makeWrapper, writeText }:
+
+let
+  name = "mxisd-${version}";
+  version = "1.2.0";
+  rev = "8c4ddd2e6526c1d2b284ba88cce3c2b926d99c62";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "kamax-matrix";
+    repo = "mxisd";
+    sha256 = "083plqg0rxsqwzyskin78wkmylhb7cqz37lpsa1zy56sxpdw1a3l";
+  };
+
+
+  deps = stdenv.mkDerivation {
+    name = "${name}-deps";
+    inherit src;
+    nativeBuildInputs = [ gradle_2_5 perl git ];
+
+    buildPhase = ''
+      export MXISD_BUILD_VERSION=${rev}
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon build -x test
+    '';
+
+     # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    dontStrip = true;
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0shshn05nzv23shry1xpcgvqg59gx929n0qngpfjhbq0kp7px68m";
+  };
+
+in
+stdenv.mkDerivation {
+  inherit name src version;
+  nativeBuildInputs = [ gradle_2_5 perl makeWrapper ];
+  buildInputs = [ jre ];
+
+  patches = [ ./0001-gradle.patch ];
+
+  buildPhase = ''
+    export MXISD_BUILD_VERSION=${rev}
+    export GRADLE_USER_HOME=$(mktemp -d)
+
+    sed -ie "s#REPLACE#mavenLocal(); maven { url '${deps}' }#g" build.gradle
+    gradle --offline --no-daemon build -x test
+  '';
+
+  installPhase = ''
+    install -D build/libs/source.jar $out/lib/mxisd.jar
+    makeWrapper ${jre}/bin/java $out/bin/mxisd --add-flags "-jar $out/lib/mxisd.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a federated matrix identity server";
+    homepage = https://github.com/kamax-matrix/mxisd;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ mguentner ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3762,6 +3762,8 @@ with pkgs;
 
   mxt-app = callPackage ../misc/mxt-app { };
 
+  mxisd = callPackage ../servers/mxisd { };
+
   nagstamon = callPackage ../tools/misc/nagstamon {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

I want to build a fully decentralized NixOS matrix node with synapse (already part of NixOS with very good support) and mxisd.

The matrix protocol is federated by design. However the default identity infrastructure is highly 
centralized.
mxisd was created to federate / decentralize the identity aspect of the matrix ecosystem.

More information: https://github.com/kamax-matrix/mxisd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

