### PR TITLE
pythonPackages.fs-s3fs: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/fs-s3fs/default.nix
+++ b/pkgs/development/python-modules/fs-s3fs/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, lib, fs, six, boto3 }:
+
+buildPythonPackage rec {
+  pname = "fs-s3fs";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1czv67zs4sl5l3rv9l3hzn22zzzqm372lq1wlhihigir4cfyslak";
+  };
+
+  propagatedBuildInputs = [ fs six boto3 ];
+
+  # tests try to integrate an s3 bucket which can't be tested properly in an isolated environment.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://pypi.org/project/fs-s3fs/;
+    license = licenses.mit;
+    description = "Amazon S3 filesystem for PyFilesystem2";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/development/python-modules/pyftpdlib/default.nix
+++ b/pkgs/development/python-modules/pyftpdlib/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage rec {
   checkInputs = [ mock psutil ];
   propagatedBuildInputs = [ pyopenssl pysendfile ];
 
-  checkPhase = ''
-    ${python.interpreter} pyftpdlib/test/runner.py
-  '';
+  # impure filesystem-related tests cause timeouts
+  # on Hydra: https://hydra.nixos.org/build/84374861
+  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/giampaolo/pyftpdlib/;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2658,6 +2658,8 @@ in {
 
   fs = callPackage ../development/python-modules/fs { };
 
+  fs-s3fs = callPackage ../development/python-modules/fs-s3fs { };
+
   libcloud = callPackage ../development/python-modules/libcloud { };
 
   libgpuarray = callPackage ../development/python-modules/libgpuarray {


### PR DESCRIPTION
###### Motivation for this change

`fs` is a python-based file system abstraction layer. The new package
`fs-s3fs` is an implementation of it which stores files inside an S3
bucket.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

