### PR TITLE
pythonPackages.nose-cov: init at 1.6

### DIFF
--- a/pkgs/development/python-modules/nose-cov/default.nix
+++ b/pkgs/development/python-modules/nose-cov/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, lib, nose, covCore }:
+
+buildPythonPackage rec {
+  pname = "nose-cov";
+  version = "1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04j4fw01bv648gimqqj4z88606lcczbm1k326agcc74gb4sh7v4b";
+  };
+
+  propagatedBuildInputs = [ nose covCore ];
+
+  meta = with lib; {
+    homepage = https://pypi.org/project/nose-cov/;
+    license = licenses.mit;
+    description = "This plugin produces coverage reports. It also supports coverage of subprocesses.";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2966,6 +2966,8 @@ in {
 
   nose = callPackage ../development/python-modules/nose { };
 
+  nose-cov = callPackage ../development/python-modules/nose-cov { };
+
   nose-exclude = callPackage ../development/python-modules/nose-exclude { };
 
   nose2 = callPackage ../development/python-modules/nose2 { };


### PR DESCRIPTION
###### Motivation for this change

Module for coverage reports with Python using nosetests.

cc @ironpinguin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

