### PR TITLE
boinc: 7.8.0 -> 7.14.2

### DIFF
--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -1,10 +1,10 @@
 { fetchFromGitHub, stdenv, autoconf, automake, pkgconfig, m4, curl,
-libGLU_combined, libXmu, libXi, freeglut, libjpeg, libtool, wxGTK, xcbutil,
+libGLU_combined, libXmu, libXi, freeglut, libjpeg, libtool, wxGTK30, xcbutil,
 sqlite, gtk2, patchelf, libXScrnSaver, libnotify, libX11, libxcb }:
 
 let
-  majorVersion = "7.8";
-  minorVersion = "0";
+  majorVersion = "7.14";
+  minorVersion = "2";
 in
 
 stdenv.mkDerivation rec {
@@ -16,13 +16,13 @@ stdenv.mkDerivation rec {
     owner = "BOINC";
     repo = "boinc";
     rev = "client_release/${majorVersion}/${version}";
-    sha256 = "08kv3fai79cc28vmyi0y4xcdd5h9xgkn9yyc6y36c0mglaxsn4pr";
+    sha256 = "0nicpkag18xq0libfqqvs0im22mijpsxzfk272iwdd9l0lmgfvyd";
   };
 
   nativeBuildInputs = [ libtool automake autoconf m4 pkgconfig ];
 
   buildInputs = [
-    curl libGLU_combined libXmu libXi freeglut libjpeg wxGTK sqlite gtk2 libXScrnSaver
+    curl libGLU_combined libXmu libXi freeglut libjpeg wxGTK30 sqlite gtk2 libXScrnSaver
     libnotify patchelf libX11 libxcb xcbutil
   ];
 


### PR DESCRIPTION
###### Motivation for this change

BOINC has had a few releases. Upgrading to 7.14.2 also now lets `boincmgr` work, the GUI interface for the BOINC client.

(Fixes #13987)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

