### PR TITLE
ibus-table-chinese: init at 1.8.2

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchgit, fetchFromGitHub, pkgconfig,  ibus, ibus-table, python3, cmake }:
+
+let
+  src = fetchFromGitHub {
+    owner = "definite";
+    repo = "ibus-table-chinese";
+    rev = "f1f6a3384f021caa3b84c517e2495086f9c34507";
+    sha256 = "14wpw3pvyrrqvg7al37jk2dxqfj9r4zf88j8k2n2lmdc50f3xs7k";
+  };
+
+  cmakeFedoraSrc = fetchgit {
+    url = "https://pagure.io/cmake-fedora.git";
+    rev = "7d5297759aef4cd086bdfa30cf6d4b2ad9446992";
+    sha256 = "0mx9jvxpiva9v2ffaqlyny48iqr073h84yw8ln43z2avv11ipr7n";
+  };
+in stdenv.mkDerivation rec {
+  name = "ibus-table-chinese-${version}";
+  version = "1.8.2";
+
+  srcs = [ src cmakeFedoraSrc ];
+  sourceRoot = src.name;
+
+  postUnpack = ''
+    chmod u+w -R ${cmakeFedoraSrc.name}
+    mv ${cmakeFedoraSrc.name}/* source/cmake-fedora
+  '';
+
+  preConfigure = ''
+    # cmake script needs ./Modules folder to link to cmake-fedora
+    ln -s cmake-fedora/Modules ./
+  '';
+
+  # Fails when writing to /prj_info.cmake in https://pagure.io/cmake-fedora/blob/master/f/Modules/ManageVersion.cmake
+  cmakeFlags = [ "-DPRJ_INFO_CMAKE_FILE=/dev/null" "-DPRJ_DOC_DIR=REPLACE" "-DDATA_DIR=share" ];
+  # Must replace PRJ_DOC_DIR with actual share/ folder for ibus-table-chinese
+  # Otherwise it tries to write to /ibus-table-chinese if not defined (!)
+  postConfigure = ''
+    substituteInPlace cmake_install.cmake --replace '/build/source/REPLACE' $out/share/ibus-table-chinese
+  '';
+  # Fails otherwise with "no such file or directory: <table>.txt"
+  dontUseCmakeBuildDir = true;
+  # Fails otherwise sometimes with
+  # FileExistsError: [Errno 17] File exists: '/build/tmp.BfVAUM4llr/ibus-table-chinese/.local/share/ibus-table'
+  enableParallelBuilding = false;
+
+  preBuild = ''
+    export HOME=$(mktemp -d)/ibus-table-chinese
+  '';
+
+  postFixup = ''
+    rm -rf $HOME
+  '';
+
+  buildInputs = [ pkgconfig ibus ibus-table python3 cmake ];
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description  = "Chinese tables for IBus-Table";
+    homepage     = https://github.com/definite/ibus-table-chinese;
+    license      = licenses.gpl3;
+    platforms    = platforms.linux;
+    maintainers  = with maintainers; [ pneumaticat ];
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
         -e "/export IBUS_DATAROOTDIR=/ s/^.$//" \
         -e "/export IBUS_LOCALEDIR=/ s/^.$//" \
         -i "setup/ibus-setup-table.in"
+    substituteInPlace engine/tabcreatedb.py --replace '/usr/share/ibus-table' $out/share/ibus-table
   '';
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1995,6 +1995,10 @@ with pkgs;
       inherit (gnome3) dconf;
     };
 
+    table-chinese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-chinese {
+      ibus-table = ibus-engines.table;
+    };
+
     table-others = callPackage ../tools/inputmethods/ibus-engines/ibus-table-others {
       ibus-table = ibus-engines.table;
     };


### PR DESCRIPTION
###### Motivation for this change

[ibus-table-chinese](https://github.com/definite/ibus-table-chinese) adds support for several Chinese IMEs in ibus, including Wubizixing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

