### PR TITLE
minishift: add openshift input

### DIFF
--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -4,11 +4,11 @@
 }:
 
 let
-  version = "1.25.0";
+  version = "1.27.0";
 
   # Update these on version bumps according to Makefile
   b2dIsoVersion = "v1.3.0";
-  centOsIsoVersion = "v1.12.0";
+  centOsIsoVersion = "v1.13.0";
   openshiftVersion = "v3.11.0";
 
 in buildGoPackage rec {
@@ -19,7 +19,7 @@ in buildGoPackage rec {
     owner = "minishift";
     repo = "minishift";
     rev = "v${version}";
-    sha256 = "12a1irj92lplzkr88g049blpjsdsfwfihs2xix971cq7v0w38fkf";
+    sha256 = "1zd9fjw90h8dlr5w7pdf1agvm51b1zckf3grwwjdg64jqpzdwg9f";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];

--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -1,5 +1,5 @@
 { lib, buildGoPackage, fetchFromGitHub, go-bindata, pkgconfig, makeWrapper
-, glib, gtk3, libappindicator-gtk3, gpgme, ostree, libselinux, btrfs-progs
+, glib, gtk3, libappindicator-gtk3, gpgme, openshift, ostree, libselinux, btrfs-progs
 , lvm2, docker-machine-kvm
 }:
 
@@ -31,6 +31,11 @@ in buildGoPackage rec {
   postPatch = ''
     substituteInPlace vendor/github.com/containers/image/storage/storage_image.go \
       --replace 'nil, diff' 'diff'
+
+    # minishift downloads openshift if not found therefore set the cache to /nix/store/...
+    substituteInPlace pkg/minishift/cache/oc_caching.go \
+      --replace 'filepath.Join(oc.MinishiftCacheDir, OC_CACHE_DIR, oc.OpenShiftVersion, runtime.GOOS)' '"${openshift}/bin"' \
+      --replace '"runtime"' ""
   '';
 
   buildFlagsArray = ''
@@ -49,7 +54,7 @@ in buildGoPackage rec {
 
   postInstall = ''
     wrapProgram "$bin/bin/minishift" \
-      --prefix PATH ':' '${lib.makeBinPath [ docker-machine-kvm ]}'
+      --prefix PATH ':' '${lib.makeBinPath [ docker-machine-kvm openshift ]}'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

```minishift``` depdends on ```oc``` to control the ```openshift``` installation.
If ```openshift``` is not present, ```minishift``` tries to download ```openshift``` into cache and fails executing it because of wrong interpreter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

