### PR TITLE
nixos/fprintd : use correct path for read/write configuration

### DIFF
--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libfprint glib dbus-glib polkit nss pam systemd ];
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  configureFlags = [ "--with-systemdsystemunitdir=$(out)/lib/systemd/system" ];
+  configureFlags = [ "--with-systemdsystemunitdir=$(out)/lib/systemd/system" "--localstatedir=/var" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/fprint/fprintd/;


### PR DESCRIPTION
###### Motivation for this change
Actually the service `fprintd` don't use correct path for write a configuration.
On ArchLinux it's the way it works https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/fprintd

It works for my T440p laptop on Nixos 18.09 on nixos-unstable channel.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

