### PR TITLE
monero-gui: 0.13.0.3 -> 0.13.0.4

### DIFF
--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -6,19 +6,20 @@
 , qtwebengine, qtx11extras, qtxmlpatterns
 , monero, unbound, readline, boost, libunwind
 , libsodium, pcsclite, zeromq, cppzmq, pkgconfig
+, hidapi
 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "0.13.0.3";
+  version = "0.13.0.4";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1rvxwz7p1yw9c817n07m60xvmv2p97s82sfzwkg2x880fpxb0gj9";
+    sha256 = "142yj5s15bhm300dislq3x5inw1f37shnrd5vyj78jjcvry3wymw";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
     qtwebchannel qtwebengine qtx11extras
     qtxmlpatterns monero unbound readline
     boost libunwind libsodium pcsclite zeromq
-    cppzmq makeWrapper
+    cppzmq makeWrapper hidapi
   ];
 
   patches = [
@@ -86,7 +87,7 @@ stdenv.mkDerivation rec {
     description = "Private, secure, untraceable currency";
     homepage    = https://getmonero.org/;
     license     = licenses.bsd3;
-    platforms   = platforms.all;
+    platforms   = [ "x86_64-linux" ];
     maintainers = with maintainers; [ rnhmjoj ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update gui following the monero(-cli) update.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested connection to a node and syncronization of blocks.
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I disabled the support for non-x86_64-linux platforms as I don't know how to test/fix the build.