### PR TITLE
chromiumOzone: init new chromium derivative package for Wayland

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -23,6 +23,11 @@ mkChromiumDerivation (base: rec {
             "$libExecPath/libwidevinecdmadapter.so"
     fi
 
+    if [ -e "$buildPath/libminigbm.so" ]; then
+      cp -v "$buildPath/libminigbm.so" \
+            "$libExecPath/libminigbm.so"
+    fi
+
     mkdir -p "$sandbox/bin"
     cp -v "$buildPath/chrome_sandbox" "$sandbox/bin/${sandboxExecutableName}"
 

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,6 +1,7 @@
 { newScope, config, stdenv, llvmPackages, gcc8Stdenv, llvmPackages_7
 , makeWrapper, makeDesktopItem, ed
 , glib, gtk3, gnome3, gsettings-desktop-schemas
+, libglvnd ? null
 
 # package customization
 , channel ? "stable"
@@ -10,6 +11,7 @@
 , proprietaryCodecs ? true
 , enablePepperFlash ? false
 , enableWideVine ? false
+, useOzone ? false
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
@@ -32,6 +34,7 @@ in let
     mkChromiumDerivation = callPackage ./common.nix {
       inherit enableNaCl gnomeSupport gnome
               gnomeKeyringSupport proprietaryCodecs cupsSupport pulseSupport
+              useOzone
               enableWideVine;
     };
 
@@ -92,6 +95,10 @@ in stdenv.mkDerivation {
   buildCommand = let
     browserBinary = "${chromium.browser}/libexec/chromium/chromium";
     getWrapperFlags = plugin: "$(< \"${plugin}/nix-support/wrapper-flags\")";
+    libPath = stdenv.lib.makeLibraryPath ([]
+      ++ stdenv.lib.optional useOzone libglvnd
+    );
+
   in with stdenv.lib; ''
     mkdir -p "$out/bin"
 
@@ -108,6 +115,8 @@ in stdenv.mkDerivation {
     else
       export CHROME_DEVEL_SANDBOX="$sandbox/bin/${sandboxExecutableName}"
     fi
+
+    export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:${libPath}"
 
     # libredirect causes chromium to deadlock on startup
     export LD_PRELOAD="\$(echo -n "\$LD_PRELOAD" | tr ':' '\n' | grep -v /lib/libredirect\\\\.so$ | tr '\n' ':')"

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -6,9 +6,9 @@
     version = "73.0.3683.56";
   };
   dev = {
-    sha256 = "1cfy6m1ijqh7b8rlrjym8igpm5i549kz1h3jwbpxn52zy3mlk7jr";
-    sha256bin64 = "02bgg20rh50lsz2ay4p7bkjfb18ay01hj0bcbd3g29valddr35p8";
-    version = "74.0.3717.0";
+    sha256 = "19fwzxnsd1parqghv4b2mif3cj1k1m5hzqnjsnglkgv6xnqny98g";
+    sha256bin64 = "1aag76dgcnwga1q4jdgm3ziqvxs1qvrsyqfd7bbsi7axz6qi135v";
+    version = "74.0.3724.8";
   };
   stable = {
     sha256 = "0ylig933xzn6c0018nxq95xhl0wkxcm95fdiy2c7s4a4h3hkr5dk";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16452,6 +16452,8 @@ in
 
   chromiumDev = lowPrio (chromium.override { channel = "dev"; });
 
+  chromiumOzone = lowPrio (chromium.override { channel = "dev"; useOzone = true; });
+
   chuck = callPackage ../applications/audio/chuck {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon CoreAudio CoreMIDI CoreServices Kernel;
   };


### PR DESCRIPTION
###### Motivation for this change

1. `firefox-nightly-bin` packages from `nixpkgs-mozilla` now have Wayland support enabled by default.

2. Chromium has some Wayland support via Ozone, but it's not the default build config.

3. The Chromium build infra is not simple, and I also don't have time to create a `chromium-git` to place in an overlay, which might be preferable to adding more variants of Chromium to nixpkgs.

4. This is working, in that as much work as is expected for an Ozone/Wayland build.

6. I'm pushing builds of `chromiumOzone` to `nixpkgs-wayland`'s cachix repo. More info: https://github.com/colemickens/nixpkgs-wayland. (Though I'm building this against `nixos-unstable`, whereas this PR targets `master`.)

Signed-off-by: Cole Mickens <cole.mickens@gmail.com>

#### LINKS ABOUT CHROMIUM/OZONE

* comment indicating that Ozone Wayland builds should be somewhat functional: https://bugs.chromium.org/p/chromium/issues/detail?id=578890&desc=2#c102
* docs on building for Linux desktop w/ Ozone-Wayland: https://chromium.googlesource.com/chromium/src/+/HEAD/docs/ozone_overview.md#linux-desktop-waterfall
* open issue indicating that upstream Chromium might need to be patched for Ozone on Linux scenarios: https://github.com/OSSystems/meta-browser/issues/187

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

