### PR TITLE
fetchgit: add tag argument

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -82,7 +82,7 @@ let
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath makePerlPath makeFullPerlPath optionalString
       hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeShellArg escapeShellArgs replaceChars lowerChars
+      escapeShellArg escapeShellArgs escapeUriSegment replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast getVersion
       nameFromURL enableFeature enableFeatureAs withFeature

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -315,6 +315,23 @@ rec {
   */
   escapeNixString = s: escape ["$"] (builtins.toJSON s);
 
+  /* Encode string for safe use in URI segments
+
+     https://en.wikipedia.org/wiki/Percent-encoding
+
+     Type: string -> string
+
+     Example:
+       escapeUriSegment "foo/bar?baz=qux&quux=quuz#corge"
+       => "foo%2Fbar%3Fbaz%3Dqux%26quux%3Dquuz%23corge"
+  */
+  escapeUriSegment = arg:
+    let
+      raw = [ "%" "!" "#" "$" "&" "'" "(" ")" "*" "+" "," "/" ":" ";" "=" "?" "@" "[" "]" ];
+      encoded = [ "%%" "%21" "%23" "%24" "%26" "%27" "%28" "%29" "%2A" "%2B" "%2C" "%2F" "%3A" "%3B" "%3D" "%3F" "%40" "%5B" "%5D" ];
+    in
+      replaceStrings raw encoded (toString arg);
+
   # Obsolete - use replaceStrings instead.
   replaceChars = builtins.replaceStrings or (
     del: new: s:


### PR DESCRIPTION
###### Motivation for this change
While it is possible to pass `rev = tag` to `fetchgit`, it may result in ambiguity when here is a branch with the same name as the tag. To be sure, we need to use `rev = "refs/tags/${tag}"`.

Since that is quite ugly, this commit introduces a shortcut, allowing us to just `inherit tag`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

