### PR TITLE
exiv2: backport 0.27-rc1 to 18.09

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -1,49 +1,19 @@
-{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, zlib, expat, gettext
-, autoconf }:
+{ stdenv, fetchurl, fetchFromGitHub, zlib, expat, gettext
+, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "exiv2-0.26.2018.06.09";
+  name = "exiv2-0.27-rc1";
 
-    #url = "http://www.exiv2.org/builds/${name}-trunk.tar.gz";
   src = fetchFromGitHub rec {
     owner = "exiv2";
     repo  = "exiv2";
-    rev = "4aa57ad";
-    sha256 = "1kblpxbi4wlb0l57xmr7g23zn9adjmfswhs6kcwmd7skwi2yivcd";
+    rev = "a099f24";
+    sha256 = "1nk5zy7rrf9sv4275gh3pd7k9bxh2h04fg4582d99s4s77gbr4c5";
   };
-
-  patches = [
-    (fetchurl rec {
-      name = "CVE-2017-9239.patch";
-      url = let patchname = "0006-1296-Fix-submitted.patch";
-          in "https://src.fedoraproject.org/lookaside/pkgs/exiv2/${patchname}"
-          + "/sha512/${sha512}/${patchname}";
-      sha512 = "3f9242dbd4bfa9dcdf8c9820243b13dc14990373a800c4ebb6cf7eac5653cfef"
-             + "e6f2c47a94fbee4ed24f0d8c2842729d721f6100a2b215e0f663c89bfefe9e32";
-    })
-    # Two backports from master, submitted as https://github.com/Exiv2/exiv2/pull/398
-    (fetchpatch {
-      name = "CVE-2018-12264.diff";
-      url = "https://github.com/vcunat/exiv2/commit/fd18e853.diff";
-      sha256 = "0y7ahh45lpaiazjnfllndfaa5pyixh6z4kcn2ywp7qy4ra7qpwdr";
-    })
-    (fetchpatch {
-      name = "CVE-2018-12265.diff";
-      url = "https://github.com/vcunat/exiv2/commit/9ed1671bd4.diff";
-      sha256 = "1cn446pfcgsh1bn9vxikkkcy1cqq7ghz2w291h1094ydqg6w7q6w";
-    })
-  ];
-
-  postPatch = "patchShebangs ./src/svn_version.sh";
-
-  preConfigure = "make config"; # needed because not using tarball
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [
-    gettext
-    autoconf # needed because not using tarball
-  ];
+  nativeBuildInputs = [ gettext cmake ];
   propagatedBuildInputs = [ zlib expat ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
fixes #50369

(cherry picked from commit bc88d15893529b0ebc522cd5cc358570c82c33e8)
Reason: adresses security fixes for #50369

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (nix-docker)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

