### PR TITLE
nixos: Allow passing modules in programmatically

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,18 +1,19 @@
 { configuration ? import ./lib/from-env.nix "NIXOS_CONFIG" <nixos-config>
 , system ? builtins.currentSystem
+, modules ? []
 }:
 
 let
 
   eval = import ./lib/eval-config.nix {
     inherit system;
-    modules = [ configuration ];
+    modules = [ configuration ] ++ modules;
   };
 
   # This is for `nixos-rebuild build-vm'.
   vmConfig = (import ./lib/eval-config.nix {
     inherit system;
-    modules = [ configuration ./modules/virtualisation/qemu-vm.nix ];
+    modules = [ configuration ./modules/virtualisation/qemu-vm.nix ] ++ modules;
   }).config;
 
   # This is for `nixos-rebuild build-vm-with-bootloader'.
@@ -22,7 +23,7 @@ let
       [ configuration
         ./modules/virtualisation/qemu-vm.nix
         { virtualisation.useBootLoader = true; }
-      ];
+      ] ++ modules;
   }).config;
 
 in


### PR DESCRIPTION
###### Motivation for this change
As it says.

For instance, I have a piece of code that creates a large number of VMs, which differ only in their networking.hostName.

While wrapping 'configuration' does work, adding this parameter vastly simplifies said code, while minimizing coupling; it reduces to `nixos { configuration = ./base-node.nix; modules = [{ networking.hostName = hostName; }]; }`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

