### PR TITLE
modularity: Document the ability to use non-files in imports

### DIFF
--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -127,4 +127,23 @@ nix-repl> map (x: x.hostName) config.<xref linkend="opt-services.httpd.virtualHo
 [ "example.org" "example.gov" ]
 </screen>
  </para>
+
+ <para>
+   While abstracting your configuration, you may find it useful to generate
+   modules using code, instead of writing files. This is also an option; the
+   below would have the same effect as importing a file which sets those
+   options.
+   <screen>
+     { config, pkgs, ... }:
+
+     let netConfig = { hostName }: {
+       networking.hostName = hostName;
+       networking.useDHCP = false;
+    };
+
+    in
+
+    { imports = [ (netConfig "nixos.localdomain") ]; }
+  </screen>
+</para>
 </section>

--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -130,7 +130,7 @@ nix-repl> map (x: x.hostName) config.<xref linkend="opt-services.httpd.virtualHo
 
  <para>
    While abstracting your configuration, you may find it useful to generate
-   modules using code, instead of writing files. This is also an option; the
+   modules using code, instead of writing files. The example
    below would have the same effect as importing a file which sets those
    options.
    <screen>


### PR DESCRIPTION
###### Motivation for this change
There are no examples of using anything but files in the imports list. Users might be confused into thinking that's all that's possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

