### PR TITLE
stress-ng: 0.06.14 -> 0.09.46

### DIFF
--- a/pkgs/tools/system/stress-ng/default.nix
+++ b/pkgs/tools/system/stress-ng/default.nix
@@ -1,15 +1,21 @@
-{ stdenv, fetchurl, attr, keyutils }:
+{ stdenv, fetchurl
+, attr, keyutils, libaio, libapparmor, libbsd, libcap, libgcrypt, lksctp-tools, zlib
+}:
 
 stdenv.mkDerivation rec {
   name = "stress-ng-${version}";
-  version = "0.06.14";
+  version = "0.09.46";
 
   src = fetchurl {
-    sha256 = "06kycxfwkdrm2vs9xk8cb6c1mki29ymrrqwwxxqx4icnwvq135hv";
-    url = "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/${name}.tar.gz";
+    url = "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/${name}.tar.xz";
+    sha256 = "0m1f46vqixx2mgqdrjwkl8w9did7n99sy96rbcgkkn9g99y59qjm";
   };
 
-  buildInputs = [ attr keyutils ];
+  # All platforms inputs then Linux-only ones
+  buildInputs = [ libbsd libgcrypt zlib ]
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isLinux [
+      attr keyutils libaio libapparmor libcap lksctp-tools
+    ];
 
   patchPhase = ''
     substituteInPlace Makefile --replace "/usr" ""
@@ -36,9 +42,10 @@ stdenv.mkDerivation rec {
       hardware issues such as thermal overruns as well as operating system
       bugs that only occur when a system is being thrashed hard.
     '';
-    homepage = http://kernel.ubuntu.com/~cking/stress-ng;
+    homepage = http://kernel.ubuntu.com/~cking/stress-ng/;
     downloadPage = http://kernel.ubuntu.com/~cking/tarballs/stress-ng/;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ c0bw3b ];
+    platforms = platforms.linux; # TODO: fix https://github.com/NixOS/nixpkgs/pull/50506#issuecomment-439635963
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Package update
\+ should be multi-platform
\+ added build inputs recommended upstream

See: http://kernel.ubuntu.com/git/cking/stress-ng.git/plain/README

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```rust
$ ./result/bin/stress-ng --cpu 4 --vm 2 --hdd 1 --fork 8 --switch 4 --timeout 5m --metrics-brief
stress-ng: info:  [11495] dispatching hogs: 4 cpu, 2 vm, 1 hdd, 8 fork, 4 switch
stress-ng: info:  [11495] successful run completed in 300.36s (5 mins, 0.36 secs)
stress-ng: info:  [11495] stressor       bogo ops real time  usr time  sys time   bogo ops/s   bogo ops/s
stress-ng: info:  [11495]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: info:  [11495] cpu               63197    300.05    216.18    141.30       210.62       176.78
stress-ng: info:  [11495] vm              1330056    300.02    125.27     71.72      4433.17      6751.90
stress-ng: info:  [11495] hdd             1413827    300.36      0.80     78.57      4707.16     17813.12
stress-ng: info:  [11495] fork             356007    300.00     53.90     62.94      1186.69      3046.96
stress-ng: info:  [11495] switch         47303035    300.00     32.37    373.77    157676.69    116469.78
```