### PR TITLE
gnome3.gnome-desktop: fix path substitution

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch
@@ -8,7 +8,7 @@
 -	    "--ro-bind", "/usr", "/usr",
 -	    "--ro-bind", "/lib", "/lib",
 -	    "--ro-bind", "/lib64", "/lib64",
-+	    "@BUBBLEWRAP_BIN@",
++	    "@bubblewrap_bin@",
 +      "--ro-bind", "/nix/store", "/nix/store",
  	    "--proc", "/proc",
  	    "--dev", "/dev",

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./bubblewrap-paths.patch;
-      BUBBLEWRAP_BIN = "${bubblewrap}/bin/bwrap";
+      bubblewrap_bin = "${bubblewrap}/bin/bwrap";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

fixes https://github.com/NixOS/nixpkgs/issues/50494

I'll add the same fix to the gnome 3.30 PR.

###### Things done

Checked that thumbnail generation works in nautilus.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

