### PR TITLE
netdata: fix python plugins

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -53,6 +53,31 @@ in {
         '';
       };
 
+      python = {
+        enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Whether to enable python-based plugins
+          '';
+        };
+        extraPackages = mkOption {
+          default = ps: [];
+          defaultText = "ps: []";
+          example = literalExample ''
+            ps: [
+              ps.psycopg2
+              ps.docker
+              ps.dnspython
+            ]
+          '';
+          description = ''
+            Extra python packages available at runtime
+            to enable additional python plugins.
+          '';
+        };
+      };
+
       config = mkOption {
         type = types.attrsOf types.attrs;
         default = {};
@@ -75,10 +100,11 @@ in {
         }
       ];
     systemd.services.netdata = {
-      path = with pkgs; [ gawk curl ];
       description = "Real time performance monitoring";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      path = (with pkgs; [ gawk curl ]) ++ lib.optional cfg.python.enable
+        (pkgs.python3.withPackages cfg.python.extraPackages);
       preStart = concatStringsSep "\n" (map (dir: ''
         mkdir -vp ${dir}
         chmod 750 ${dir}
@@ -89,6 +115,7 @@ in {
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
+        Environment="PYTHONPATH=${pkgs.netdata}/libexec/netdata/python.d/python_modules";
         PermissionsStartOnly = true;
         ExecStart = "${pkgs.netdata}/bin/netdata -D -c ${configFile}";
         TimeoutStopSec = 60;


### PR DESCRIPTION
###### Motivation for this change

fixes #33366
cc @marsam

Tested here: https://netdata.thalheim.io/#menu_postgres_local_submenu_db_postgres;theme=slate;help=true


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

