### PR TITLE
php: Fix CVE-2018-17082 (nixos-unstable)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -233,6 +233,13 @@
      options.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     PHP on Darwin no longer comes with the <literal>intl</literal> extension,
+     as there is a known security vulnerability on the latest version of
+     <literal>intl</literal> for PHP that supports Darwin.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
#### php: 7.2.10 -> 7.2.12, 7.1.22 -> 7.1.24

Also make Darwin align itself to Linux versions, due to CVE-2018-17082
forcing our hand on this. This means Darwin must compile without intl.

###### Motivation for this change

The alternative would be to backport the fix to a previous version of `php`. It looks [pretty easy](https://github.com/php/php-src/commit/23b057742e3cf199612fa8050ae86cae675e214e), but I know the PHP code base very little and wouldn't trust simply using this patch to fix the issue unless spending much more time on it.

cc @etu who introduced the split between darwin and linux

@GrahamcOfBorg build php71 php72
@GrahamcOfBorg test elk owncloud

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

