### PR TITLE
Add openconnect pa

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -762,6 +762,11 @@
     github = "ChengCat";
     name = "Yucheng Zhang";
   };
+  chessai = {
+    email = "chessai1996@gmail.com";
+    github = "chessai";
+    name = "Daniel Cartwright";
+  };
   chiiruno = {
     email = "okinan@protonmail.com";
     github = "chiiruno";

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     urls = [
       "ftp://ftp.infradead.org/pub/openconnect/${name}.tar.gz"
     ];
-    sha256 = "00wacb79l2c45f94gxs63b9z25wlciarasvjrb8jb8566wgyqi00";
+    sha256 = "00wacb79l2c45f94gxs63b9z25wlciarasvjrb8jb8566wgyqi0w";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     urls = [
       "ftp://ftp.infradead.org/pub/openconnect/${name}.tar.gz"
     ];
-    sha256 = "00wacb79l2c45f94gxs63b9z25wlciarasvjrb8jb8566wgyqi0w";
+    sha256 = "00wacb79l2c45f94gxs63b9z25wlciarasvjrb8jb8566wgyqi00";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, pkgconfig, vpnc, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib, autoreconfHook } :
+
+assert (openssl != null) == (gnutls == null);
+
+let
+  version = "7.08";
+  name = "openconnect_pa-${version}";
+in stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchFromGitHub {
+    owner = "dlenski";
+    repo = "openconnect";
+    rev = "e5fe063a087385c5b157ad7a9a3fa874181f6e3b";
+    sha256 = "0ywacqs3nncr2gpjjcz2yc9c6v4ifjssh0vb07h0qff06whqhdax"; 
+  };
+
+  outputs = [ "out" ];
+
+  preConfigure = ''
+      export PKG_CONFIG=${pkgconfig}/bin/pkg-config
+      export LIBXML2_CFLAGS="-I ${libxml2.dev}/include/libxml2"
+      export LIBXML2_LIBS="-L${libxml2.out}/lib -lxml2"
+  '';
+
+  configureFlags = [
+    "--with-vpnc-script=${vpnc}/etc/vpnc/vpnc-script"
+    "--disable-nls"
+    "--without-openssl-version-check"
+  ];
+
+  postInstall = ''
+    # ldconfig
+  '';
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  propagatedBuildInputs = [ vpnc openssl gnutls gmp libxml2 stoken zlib ];
+  
+  meta = {
+    description = "OpenConnect client extended to support Palo Alto Networks' GlobalProtect VPN";
+    homepage = https://github.com/dlenski/openconnect/;
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ chessai ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -8,6 +8,8 @@ let
 in stdenv.mkDerivation {
   inherit name;
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "dlenski";
     repo = "openconnect";

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -5,7 +5,7 @@ assert (openssl != null) == (gnutls == null);
 let
   version = "unstable-2018-10-08";
   name = "openconnect_pa-${version}";
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
   inherit name;
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -36,7 +36,7 @@ in stdenv.mkDerivation {
     description = "OpenConnect client extended to support Palo Alto Networks' GlobalProtect VPN";
     homepage = https://github.com/dlenski/openconnect/;
     license = licenses.lgpl21;
-    maintainers = with stdenv.lib.maintainers; [ chessai ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ chessai ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -2,12 +2,10 @@
 
 assert (openssl != null) == (gnutls == null);
 
-let
+stdenv.mkDerivation rec {
   version = "unstable-2018-10-08";
   name = "openconnect_pa-${version}";
-in stdenv.mkDerivation rec {
-  inherit name;
-
+  
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -3,7 +3,7 @@
 assert (openssl != null) == (gnutls == null);
 
 let
-  version = "2018-10-08";
+  version = "unstable-2018-10-08";
   name = "openconnect_pa-${version}";
 in stdenv.mkDerivation {
   inherit name;

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -15,7 +15,6 @@ in stdenv.mkDerivation {
     sha256 = "0ywacqs3nncr2gpjjcz2yc9c6v4ifjssh0vb07h0qff06whqhdax"; 
   };
 
-  outputs = [ "out" ];
 
   preConfigure = ''
       export PKG_CONFIG=${pkgconfig}/bin/pkg-config

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -3,7 +3,7 @@
 assert (openssl != null) == (gnutls == null);
 
 let
-  version = "7.08";
+  version = "2018-10-08";
   name = "openconnect_pa-${version}";
 in stdenv.mkDerivation {
   inherit name;

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
     sha256 = "0ywacqs3nncr2gpjjcz2yc9c6v4ifjssh0vb07h0qff06whqhdax"; 
   };
 
-
   preConfigure = ''
       export PKG_CONFIG=${pkgconfig}/bin/pkg-config
       export LIBXML2_CFLAGS="-I ${libxml2.dev}/include/libxml2"

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -29,10 +29,6 @@ in stdenv.mkDerivation {
     "--without-openssl-version-check"
   ];
 
-  postInstall = ''
-    # ldconfig
-  '';
-
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   propagatedBuildInputs = [ vpnc openssl gnutls gmp libxml2 stoken zlib ];
   

--- a/pkgs/tools/networking/openconnect_pa/default.nix
+++ b/pkgs/tools/networking/openconnect_pa/default.nix
@@ -36,10 +36,10 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   propagatedBuildInputs = [ vpnc openssl gnutls gmp libxml2 stoken zlib ];
   
-  meta = {
+  meta = with stdenv.lib; {
     description = "OpenConnect client extended to support Palo Alto Networks' GlobalProtect VPN";
     homepage = https://github.com/dlenski/openconnect/;
-    license = stdenv.lib.licenses.lgpl21;
+    license = licenses.lgpl21;
     maintainers = with stdenv.lib.maintainers; [ chessai ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5976,6 +5976,10 @@ with pkgs;
     SDL = SDL_sixel;
   };
 
+  openconnect_pa = callPackage ../tools/networking/openconnect_pa {
+    openssl = null;    
+  };
+
   openconnect = openconnect_gnutls;
 
   openconnect_openssl = callPackage ../tools/networking/openconnect {


### PR DESCRIPTION
###### Motivation for this change

openconnect does not support Palo Alto Network's GlobalProtect protocol. I use a fork of openconnect regularly at work, where all of our traffic goes through a PA firewall. The package is actively maintained by @dlenski and is in use by many active developers. The fork is located at https://github.com/dlenski/openconnect

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
   - [x] Ubuntu 16.04
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
