### PR TITLE
graalvm8: add passthru.home

### DIFF
--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -262,6 +262,9 @@ in rec {
       ./helloworld
       ./helloworld | fgrep 'Hello World'
     '';
+
+    passthru.home = graalvm8;
+
     meta = with stdenv.lib; {
       homepage = https://github.com/oracle/graal;
       description = "High-Performance Polyglot VM";


### PR DESCRIPTION
###### Motivation for this change
I've tried to setup graalvm8 as the default jre with a packageOverrides. However some derivations  like sbt require jre.home.

###### Things done
added graalvm8.home

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

