### PR TITLE
hashcat: 4.2.1 -> 5.0.0

### DIFF
--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchurl, makeWrapper, opencl-headers, ocl-icd }:
+{ stdenv, fetchurl, makeWrapper, opencl-headers, ocl-icd, xxHash }:
 
 stdenv.mkDerivation rec {
   name    = "hashcat-${version}";
-  version = "4.2.1";
+  version = "5.0.0";
 
   src = fetchurl {
     url = "https://hashcat.net/files/hashcat-${version}.tar.gz";
-    sha256 = "082k5srjwkfvnvz0bfcg5r12m9c2qjyfhnp135mparkf831p7bbx";
+    sha256 = "13xh1lmzdppvx8wr8blqhdr8vpa24j099kz2xzb9pcnqy26dk4kh";
   };
+  patches = [ ./use-installed-xxhash.patch ];
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ opencl-headers ];
+  buildInputs = [ opencl-headers xxHash ];
 
   makeFlags = [
     "OPENCL_HEADERS_KHRONOS=${opencl-headers}/include"

--- a/pkgs/tools/security/hashcat/use-installed-xxhash.patch
+++ b/pkgs/tools/security/hashcat/use-installed-xxhash.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Makefile b/src/Makefile
+index 3a1cd680..576353fe 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -189,7 +189,7 @@ endif
+ # brain and xxHash
+ ifeq ($(ENABLE_BRAIN),1)
+ CFLAGS                  += -DWITH_BRAIN
+-CFLAGS                  += -Ideps/git/xxHash
++LFLAGS                  += -lxxhash
+ endif
+ 
+ ##
+@@ -313,7 +313,7 @@ WIN_32_OBJS             := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).WIN.32.o)
+ WIN_64_OBJS             := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).WIN.64.o)
+ 
+ ifeq ($(ENABLE_BRAIN),1)
+-OBJS_XXHASH             := xxhash
++OBJS_XXHASH             :=
+ 
+ NATIVE_STATIC_OBJS      += $(foreach OBJ,$(OBJS_XXHASH),obj/$(OBJ).NATIVE.STATIC.o)
+ NATIVE_SHARED_OBJS      += $(foreach OBJ,$(OBJS_XXHASH),obj/$(OBJ).NATIVE.SHARED.o)


### PR DESCRIPTION
This introduces a dependency on xxHash. Unfortunately, hashcat's
build system wants to rebuild xxHash from the source code located
in `<hashcat source root>/deps/git/xxHash`, a Git submodule whose
contents are not included in the source tarball we currently
download.

This could be fixed by either using a recursive git clone instead
a tarball download, or patching the build files to use an existing
installation of xxHash (i.e. the one already provided by Nix). I
believe the latter is preferable since it avoids the situation in
which the xxHash version used by hashcat is different to the xxHash
version used by all other Nix packages.

Fortunately, this situation has been [greatly improved](https://github.com/hashcat/hashcat/commit/4177e1ee286f80c344f7bae6a65c40192f523e0a) since
release 5.0.0; the next release of hashcat should drop usage of
git submodules and provide better support for using existing
installations of dependencies.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
   - Increase by 607 kB
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

