### PR TITLE
nixopsUnstable: 1.6.1pre2622_f10999a -> 1.6.1pre2706_d5ad09c

### DIFF
--- a/pkgs/tools/package-management/nixops/generic.nix
+++ b/pkgs/tools/package-management/nixops/generic.nix
@@ -26,6 +26,7 @@ python2Packages.buildPythonApplication {
       datadog
       digital-ocean
       libvirt
+      typing
     ];
 
   doCheck = false;

--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -5,9 +5,9 @@
 # Then copy the URL to the tarball.
 
 callPackage ./generic.nix (rec {
-  version = "1.6.1pre2622_f10999a";
+  version = "1.6.1pre2706_d5ad09c";
   src = fetchurl {
-    url = "https://hydra.nixos.org/build/73716350/download/2/nixops-${version}.tar.bz2";
-    sha256 = "08886b6vxhjc3cp0ikxp920zap7wp6r92763fp785rvxrmb00rbd";
+    url = "https://hydra.nixos.org/build/84098258/download/2/nixops-${version}.tar.bz2";
+    sha256 = "0lr963a0bjrblv0d1nfl4d0p76jkq6l9xj3vxgzg38q0ld5qw345";
   };
 })


### PR DESCRIPTION
This fixes evaluation with the latest master.
See also https://github.com/NixOS/nixpkgs/issues/50419

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

