### PR TITLE
Add check phase to ninja setup hook

### DIFF
--- a/pkgs/applications/audio/cozy-audiobooks/default.nix
+++ b/pkgs/applications/audio/cozy-audiobooks/default.nix
@@ -66,10 +66,6 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace cozy/magic/magic.py --replace "ctypes.util.find_library('magic')" "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
-  checkPhase = ''
-    ninja test
-  '';
-
   postInstall = ''
     ln -s $out/bin/com.github.geigi.cozy $out/bin/cozy
   '';

--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   checkInputs = [ gtest ];
-  checkPhase = "ctest";
   # doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
   doCheck = false; # fails to pick up supplied gtest, tries to download it instead
 

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -32,11 +32,6 @@ stdenv.mkDerivation rec {
 
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
   checkInputs = [ check ];
-  checkPhase = ''
-    runHook preCheck
-    ctest -VV
-    runHook postCheck
-  '';
 
   meta = with stdenv.lib; {
     description = "Lightweight Tox client";

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   installCheckPhase = let
     pluginPath = "${qtbase.bin}/${qtbase.qtPluginPrefix}";
   in lib.optionalString doInstallCheck ''
-    QT_PLUGIN_PATH=${lib.escapeShellArg pluginPath} CTEST_OUTPUT_ON_FAILURE=1 \
+    QT_PLUGIN_PATH=${lib.escapeShellArg pluginPath} \
       ${xvfb_run}/bin/xvfb-run -s '-screen 0 1024x768x24' make test \
       ARGS="-E '(reports-chart-test)'" # Test fails, so exclude it for now.
   '';

--- a/pkgs/applications/science/biology/EZminc/default.nix
+++ b/pkgs/applications/science/biology/EZminc/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec { pname = "EZminc";
                  "-DEZMINC_BUILD_MRFSEG=TRUE"
                  "-DEZMINC_BUILD_DD=TRUE" ];
 
-  checkPhase = "ctest --output-on-failure ../tests/";  # but ctest doesn't find the tests ...
-
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/biology/N3/default.nix
+++ b/pkgs/applications/science/biology/N3/default.nix
@@ -19,9 +19,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" "-DEBTKS_DIR=${EBTKS}/lib/" ];
 
-  checkPhase = "ctest --output-on-failure";
-  # don't run the tests as they fail at least due to missing program wrappers in this phase ...
-
   postFixup = ''
     for p in $out/bin/*; do
       wrapProgram $p --prefix PERL5LIB : $PERL5LIB

--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  checkPhase = "ctest";
-
   postInstall = ''
     for file in $out/bin/*; do
       wrapProgram $file --set ANTSPATH "$out/bin"

--- a/pkgs/applications/science/biology/inormalize/default.nix
+++ b/pkgs/applications/science/biology/inormalize/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" "-DEBTKS_DIR=${EBTKS}/lib/" ];
 
-  checkPhase = "ctest --output-on-failure";  # but no tests
-
   postFixup = ''
     for p in $out/bin/*; do
       wrapProgram $p --prefix PERL5LIB : $PERL5LIB

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" ];
 
-  checkPhase = "ctest --output-on-failure";  # still some weird test failures though
-
   postFixup = ''
     for prog in minccomplete minchistory mincpik; do
       wrapProgram $out/bin/$prog --prefix PERL5LIB : $PERL5LIB

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -38,8 +38,6 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  checkPhase = "ctest";
-
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = "evolution";

--- a/pkgs/development/libraries/arguments/default.nix
+++ b/pkgs/development/libraries/arguments/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
 
   #cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib" "-DBICPL_DIR=${bicpl}/lib" "-DBUILD_TESTING=FALSE" ];
 
-  checkPhase = "ctest --output-on-failure";
   doCheck = false;
   # internal_volume_io.h: No such file or directory
 

--- a/pkgs/development/libraries/cmark/default.nix
+++ b/pkgs/development/libraries/cmark/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   doCheck = !stdenv.isDarwin;
-  checkPhase = ''
+  preCheck = ''
     export LD_LIBRARY_PATH=$(readlink -f ./src)
-    CTEST_OUTPUT_ON_FAILURE=1 make test
+    export CTEST_OUTPUT_ON_FAILURE=1
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/cmark/default.nix
+++ b/pkgs/development/libraries/cmark/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
   preCheck = ''
     export LD_LIBRARY_PATH=$(readlink -f ./src)
-    export CTEST_OUTPUT_ON_FAILURE=1
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ libevent openssl ];
 
   doCheck = !stdenv.isDarwin;
-  checkPhase = "ctest";
 
   meta = with stdenv.lib; {
     description = "C client library for Couchbase";

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -31,7 +31,6 @@ let
 
     doCheck = false; # hangs, tries to access the net?
     checkInputs = [ check ];
-    checkPhase = "ctest";
 
     meta = with stdenv.lib; {
       description = "P2P FOSS instant messaging application aimed to replace Skype";

--- a/pkgs/development/libraries/pagmo2/default.nix
+++ b/pkgs/development/libraries/pagmo2/default.nix
@@ -31,10 +31,6 @@ stdenv.mkDerivation rec {
                  "-DNLOPT_LIBRARY=${nlopt}/lib/libnlopt_cxx.so" "-DPAGMO_WITH_IPOPT=yes"
                  "-DCMAKE_CXX_FLAGS='-fuse-ld=gold'" ];
 
-  checkPhase = ''
-    ctest
-  '';
-
   # All but one test pass skip for now (tests also take about 30 min to compile)
   doCheck = false;
 

--- a/pkgs/development/libraries/science/biology/EBTKS/default.nix
+++ b/pkgs/development/libraries/science/biology/EBTKS/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" ];
 
-  checkPhase = "ctest --output-on-failure";  # but cmake doesn't run the tests ...
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/BIC-MNI/${pname}";
     description = "Library for working with MINC files";

--- a/pkgs/development/libraries/science/biology/bicpl/default.nix
+++ b/pkgs/development/libraries/science/biology/bicpl/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib" "-DBUILD_TESTING=FALSE" ];
 
-  checkPhase = "ctest --output-on-failure";
   doCheck = false;
   # internal_volume_io.h: No such file or directory
 

--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python ];
   buildInputs = [ itk ];
 
-  checkPhase = "ctest";
-
   meta = with stdenv.lib; {
     homepage = http://elastix.isi.uu.nl/;
     description = "Image registration toolkit based on ITK";

--- a/pkgs/development/libraries/science/biology/nifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/nifticlib/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
 
-  checkPhase = "ctest";
   doCheck = false; # fails 7 out of 293 tests
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -42,10 +42,6 @@ stdenv.mkDerivation rec {
 
   doCheck = ! shared;
 
-  checkPhase = "
-    ctest
-  ";
-
   enableParallelBuilding = true;
 
   passthru = {

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       )
   '';
 
-  checkPhase = ''
+  preCheck = ''
     # make sure the test starts even if we have less than 4 cores
     export OMPI_MCA_rmaps_base_oversubscribe=1
 
@@ -35,9 +35,6 @@ stdenv.mkDerivation rec {
     export OMP_NUM_THREADS=1
 
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib
-    export CTEST_OUTPUT_ON_FAILURE=1
-
-    make test
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/simpleitk/default.nix
+++ b/pkgs/development/libraries/simpleitk/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_CXX_FLAGS='-Wno-attributes'" ];
 
-  checkPhase = "ctest";
-
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pythonix/default.nix
+++ b/pkgs/development/python-modules/pythonix/default.nix
@@ -18,10 +18,6 @@ buildPythonPackage rec {
 
   buildInputs = [ nix boost ];
 
-  checkPhase = ''
-    ninja test
-  '';
-
   meta = with stdenv.lib; {
     description = ''
        Eval nix code from python.

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -15,6 +15,8 @@ fixCmakeFiles() {
 cmakeConfigurePhase() {
     runHook preConfigure
 
+    export CTEST_OUTPUT_ON_FAILURE=1
+
     if [ -z "$dontFixCmake" ]; then
         fixCmakeFiles .
     fi

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -16,6 +16,9 @@ cmakeConfigurePhase() {
     runHook preConfigure
 
     export CTEST_OUTPUT_ON_FAILURE=1
+    if [ -n "${enableParallelChecking-1}" ]; then
+        export CTEST_PARALLEL_LEVEL=$NIX_BUILD_CORES
+    fi
 
     if [ -z "$dontFixCmake" ]; then
         fixCmakeFiles .

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -39,15 +39,3 @@ if [ -z "$dontUseMesonConfigure" -a -z "$configurePhase" ]; then
     setOutputFlags=
     configurePhase=mesonConfigurePhase
 fi
-
-mesonCheckPhase() {
-    runHook preCheck
-
-    meson test --print-errorlogs
-
-    runHook postCheck
-}
-
-if [ -z "$dontUseMesonCheck" -a -z "$checkPhase" ]; then
-    checkPhase=mesonCheckPhase
-fi

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -56,7 +56,7 @@ ninjaCheckPhase() {
     fi
 
     if [ -z "${checkTarget:-}" ]; then
-        echo "no check/test target in ${makefile:-Makefile}, doing nothing"
+        echo "no test target found in ninja, doing nothing"
     else
         local buildCores=1
 

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -50,7 +50,7 @@ ninjaCheckPhase() {
     runHook preCheck
 
     if [ -z "${checkTarget:-}" ]; then
-        if ninja -n test >/dev/null 2>&1; then
+        if ninja -t query test >/dev/null 2>&1; then
             checkTarget=test
         fi
     fi

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -11,7 +11,6 @@ ninjaBuildPhase() {
     local flagsArray=(
         -j$buildCores -l$buildCores
         $ninjaFlags "${ninjaFlagsArray[@]}"
-        $buildFlags "${buildFlagsArray[@]}"
     )
 
     echoCmd 'build flags' "${flagsArray[@]}"
@@ -31,7 +30,6 @@ ninjaInstallPhase() {
     # shellcheck disable=SC2086
     local flagsArray=(
         $ninjaFlags "${ninjaFlagsArray[@]}"
-        $installFlags "${installFlagsArray[@]}"
         ${installTargets:-install}
     )
 
@@ -67,7 +65,6 @@ ninjaCheckPhase() {
         local flagsArray=(
             -j$buildCores -l$buildCores
             $ninjaFlags "${ninjaFlagsArray[@]}"
-            $checkFlags "${checkFlagsArray[@]}"
             $checkTarget
         )
 

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -15,7 +15,6 @@ ninjaBuildPhase() {
 
     echoCmd 'build flags' "${flagsArray[@]}"
     ninja "${flagsArray[@]}"
-    unset flagsArray
 
     runHook postBuild
 }
@@ -35,7 +34,6 @@ ninjaInstallPhase() {
 
     echoCmd 'install flags' "${flagsArray[@]}"
     ninja "${flagsArray[@]}"
-    unset flagsArray
 
     runHook postInstall
 }
@@ -70,7 +68,6 @@ ninjaCheckPhase() {
 
         echoCmd 'check flags' "${flagsArray[@]}"
         ninja "${flagsArray[@]}"
-        unset flagsArray
     fi
 
     runHook postCheck

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -9,7 +9,7 @@ ninjaBuildPhase() {
     fi
 
     local flagsArray=(
-        -j$buildCores -l$buildCores
+        -j$buildCores -l$NIX_BUILD_CORES
         $ninjaFlags "${ninjaFlagsArray[@]}"
     )
 
@@ -63,7 +63,7 @@ ninjaCheckPhase() {
         fi
 
         local flagsArray=(
-            -j$buildCores -l$buildCores
+            -j$buildCores -l$NIX_BUILD_CORES
             $ninjaFlags "${ninjaFlagsArray[@]}"
             $checkTarget
         )


### PR DESCRIPTION
###### Motivation for this change

Most tests in Ninja packages were not getting run because the default check phase assumes you have a Makefile. This adds a check phase to Ninja's setup-hook to fix this. Here is what I changed:

- Respect installFlags
- Automatically add checkPhase (can be disabled with dontUseNinjaCheck
  in the same way as dontUseNinjaBuild and dontUseNinjaInstall). Tests
  are only run when "ninja test" exists.
- Error in build phase when build.ninja is missing. We don’t have a
  way to fall back to other build methods, so it’s best to be very
  clear when we aren’t able to build with ninja
- Set -l flag to 1 when enableParallelBuilding is disabled

Intended as an alternative to #50323.