### PR TITLE
nixos/clightning: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -493,6 +493,7 @@
   ./services/networking/btsync.nix
   ./services/networking/charybdis.nix
   ./services/networking/chrony.nix
+  ./services/networking/clightning.nix
   ./services/networking/cjdns.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix

--- a/nixos/modules/services/networking/clightning.nix
+++ b/nixos/modules/services/networking/clightning.nix
@@ -1,0 +1,108 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.clightning;
+
+  mkLightningNode = cfg: network:
+    let
+      configFile = pkgs.writeText "clightning-${network}.conf" cfg.config;
+    in
+    {
+      description = "clightning ${network} node";
+
+      # clightning requires bitcoin-cli to talk to either spruned or bitcoind
+      path = [ pkgs.altcoins.bitcoind ];
+
+      after = [ "network.target" ];
+      wantedBy = optional cfg.autoStart "multi-user.target";
+
+      serviceConfig.ExecStart = "${pkgs.clightning}/bin/lightningd --lightning-dir=${cfg.dataDir} --conf=${configFile}";
+      serviceConfig.Restart = "on-abort";
+    };
+in
+{
+  options = {
+    services.clightning = {
+      networks = mkOption {
+        default = {};
+
+        description = ''
+          Each attribute of this option defines a systemd user service that runs a
+          clightning node. The name of each systemd service is
+          <literal>clightning-<replaceable>network</replaceable>.service</literal>,
+          where <replaceable>network</replaceable> is the corresponding attribute
+          name.
+        '';
+
+        example = ''
+          {
+            mainnet = {
+              dataDir = "/home/user/.lightning-bitcoin";
+              config = '''
+                fee-per-satoshi=9000
+                lightning-dir=/home/user/.lightning-bitcoin
+                network=bitcoin
+                log-level=info
+                alias=mynode
+                rgb=ff0000
+              ''';
+            };
+
+            testnet = {
+              dataDir = "/home/user/.lightning-testnet";
+              config = '''
+                fee-per-satoshi=1000
+                network=testnet
+                log-level=debug
+                alias=my-testnet-node
+                rgb=00ff00
+              ''';
+            };
+          }
+        '';
+
+
+
+        type = types.attrsOf (types.submodule {
+          options = {
+
+            dataDir = mkOption {
+              type = types.path;
+              description = ''
+                clightning data directory
+              '';
+            };
+
+            config = mkOption {
+              type = types.lines;
+              description = ''
+                Configuration of this clightning node.
+              '';
+            };
+
+            autoStart = mkOption {
+              default = true;
+              type = types.bool;
+              description = "Whether this clightning instance should be started automatically.";
+            };
+          };
+        });
+
+      };
+
+    };
+
+  };
+
+  config = mkIf (cfg.networks != {}) {
+
+    systemd.user.services =
+      listToAttrs (mapAttrsFlatten (name: value: nameValuePair "clightning-${name}" (mkLightningNode value name)) cfg.networks);
+
+    environment.systemPackages = [ pkgs.clightning ];
+
+  };
+
+}


### PR DESCRIPTION
I copied a lot of stuff from the openvpn module for this one to support multiple networks at once.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

