### PR TITLE
python.pkgs.eyeD3: 0.7.8 -> 0.8.7

### DIFF
--- a/pkgs/development/python-modules/eyed3/default.nix
+++ b/pkgs/development/python-modules/eyed3/default.nix
@@ -1,22 +1,40 @@
 { stdenv
 , buildPythonPackage
-, fetchurl
+, fetchPypi
+, pythonAtLeast
+, pythonOlder
 , paver
 , python
 , isPyPy
+, six
+, pathlib
+, python_magic
+, isPy3k
+, lib
 }:
 
 buildPythonPackage rec {
-  version = "0.7.8";
+  version = "0.8.7";
   pname    = "eyeD3";
   disabled = isPyPy;
 
-  src = fetchurl {
-    url = "http://eyed3.nicfit.net/releases/${pname}-${version}.tar.gz";
-    sha256 = "1nv7nhfn1d0qm7rgkzksbccgqisng8klf97np0nwaqwd5dbmdf86";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fzqy6hkg73xvpapdjrdzr3r0fsamnplvjfl7dz7rzgzx2r4x4pg";
   };
 
+  # https://github.com/nicfit/eyeD3/pull/284
+  postPatch = lib.optionalString (pythonAtLeast "3.4") ''
+    sed -ie '/pathlib/d' requirements/requirements.yml
+  '';
+
   buildInputs = [ paver ];
+
+  # requires special test data:
+  # https://github.com/nicfit/eyeD3/blob/103198e265e3279384f35304e8218be6717c2976/Makefile#L97
+  doCheck = false;
+
+  propagatedBuildInputs = [ six python_magic ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   postInstall = ''
     for prog in "$out/bin/"*; do


### PR DESCRIPTION
part of https://discourse.nixos.org/t/nixpkgs-update-r-ryantm-logs/1464/5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---