### PR TITLE
xercesc: disable SSE2 extension

### DIFF
--- a/pkgs/development/libraries/xercesc/default.nix
+++ b/pkgs/development/libraries/xercesc/default.nix
@@ -9,8 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "04q4c460wqzyzmprjm22igcm1d52xr20ajxnhr33nv95mbw92qfx";
   };
 
+  # Disable SSE2 extensions on platforms for which they are not enabled by default
+  configureFlags = [ "--disable-sse2" ];
+  enableParallelBuilding = true;
+
   meta = {
-    homepage = http://xerces.apache.org/xerces-c/;
+    homepage = https://xerces.apache.org/xerces-c/;
     description = "Validating XML parser written in a portable subset of C++";
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;


### PR DESCRIPTION
###### Motivation for this change

> Disable SSE2 extensions on platforms for which they are not enabled
> by default. This does not disable sse2 extensions on systems for
> which they are enabled by default, such as amd64.

This only prevents segfaults on i686 with no SSE2 support and doesn't change anything on x64.
It was uncovered in #38545 where `xmlcopyeditor` complains at first launch that xerces-c is built with SSE2 support and that it is not thread-safe.

Turns out that all major distros are passing the flag `--disable-sse2` to it.
¤ Debian : bug [#574857](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=574857)
¤ [CentOS](https://centos.pkgs.org/6/centos-i386/xerces-c-3.0.1-20.el6.i686.rpm.html) and [Fedora](https://koji.fedoraproject.org/koji/buildinfo?buildID=1149526) changelogs : `- Disable explicit -msse2 to make sure the binaries run on non-SSE2 i686`
¤ Arch [PKGBUILD](https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/xerces-c) for this

Also done :
\+ enabled parallel building
\+ changed homepage to use https

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

