### PR TITLE
python.pkgs.beaker: 1.8.0 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/beaker/default.nix
+++ b/pkgs/development/python-modules/beaker/default.nix
@@ -9,25 +9,39 @@
 , isPy27
 , funcsigs
 , pycryptopp
+, redis
+, memcached
+, pylibmc
+, pymongo
+, cryptography
 }:
 
 buildPythonPackage rec {
   pname = "Beaker";
-  version = "1.8.0";
+  version = "1.10.0";
 
   # The pypy release do not contains the tests
   src = fetchFromGitHub {
     owner = "bbangert";
     repo = "beaker";
     rev = "${version}";
-    sha256 = "17yfr7a307n8rdl09was4j60xqk2s0hk0hywdkigrpj4qnw0is7g";
+    sha256 = "1xwbl8ggj0xlvih95m2b70cbrsazkzma7g6ivg724m6kh3xfwqhv";
   };
 
-  buildInputs =
-    [ nose
-      mock
-      webtest
-    ];
+  checkInputs = [
+    nose mock webtest redis memcached pylibmc pymongo cryptography
+  ];
+
+  postPatch = ''
+    # fails on import because it tries to make a connection
+    rm tests/test_memcached.py
+  '';
+
+  checkPhase = ''
+    # ignore external tests
+    NOSE_EXCLUDE=".*test_ext_.*" nosetests tests
+  '';
+
   propagatedBuildInputs = [
     sqlalchemy
     pycrypto


### PR DESCRIPTION
###### Motivation for this change

part of https://discourse.nixos.org/t/nixpkgs-update-r-ryantm-logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---