### PR TITLE
python.pkgs.internetarchive: 1.7.2 -> 1.8.1

### DIFF
--- a/pkgs/development/python-modules/internetarchive/default.nix
+++ b/pkgs/development/python-modules/internetarchive/default.nix
@@ -1,46 +1,41 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pytest, six, clint, pyyaml, docopt
-, requests, jsonpatch, args, schema, responses, backports_csv }:
+{ buildPythonPackage, fetchFromGitHub, pytest, six, clint, pyyaml, docopt
+, requests, jsonpatch, args, schema, responses, backports_csv, isPy3k
+, lib, glibcLocales }:
 
 buildPythonPackage rec {
-
   pname = "internetarchive";
-  version = "1.7.2";
+  version = "1.8.1";
 
   # Can't use pypi, data files for tests missing
   src = fetchFromGitHub {
     owner = "jjjake";
     repo = "internetarchive";
     rev = "v${version}";
-    sha256 = "1cijagy22qi8ydrvizqmi1whnc3qr94yk0910lwgpxjywcygggir";
+    sha256 = "1fdb0kr9hzgyh0l8d02khcjpsgyd63nbablhc49ncdsav3dhhr3f";
   };
-    # It is hardcoded to specific versions, I don't know why.
-    preConfigure = ''
-        sed "s/schema>=.*/schema>=0.4.0',/" -i setup.py
-        sed "/backports.csv/d" -i setup.py
-    '';
 
-    #phases = [ "unpackPhase" "configurePhase" "installPhase" "fixupPhase" "installCheckPhase" ];
-    buildInputs = [ pytest responses ];
-    propagatedBuildInputs = [
-      six
-      clint
-      pyyaml
-      docopt
-      requests
-      jsonpatch
-      args
-      schema
-      backports_csv
-    ];
+  propagatedBuildInputs = [
+    six
+    clint
+    pyyaml
+    docopt
+    requests
+    jsonpatch
+    args
+    schema
+  ] ++ lib.optional (!isPy3k) backports_csv;
 
-    # Tests disabled because ia binary doesn't exist when tests run
-    doCheck = false;
+  checkInputs = [ pytest responses glibcLocales ];
 
-    checkPhase = "pytest tests";
+  # tests depend on network
+  doCheck = false;
 
+  checkPhase = ''
+    LC_ALL=en_US.utf-8 pytest tests
+  '';
 
-  meta = with stdenv.lib; {
-      description = "A python wrapper for the various Internet Archive APIs";
+  meta = with lib; {
+    description = "A python wrapper for the various Internet Archive APIs";
     homepage = https://github.com/jjjake/internetarchive;
     license = licenses.agpl3;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---