### PR TITLE
openssl: fix `cryptodev` fallout

### DIFF
--- a/pkgs/development/libraries/openssl/chacha.nix
+++ b/pkgs/development/libraries/openssl/chacha.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, perl, zlib
-, withCryptodev ? false, cryptodevHeaders
+, withCryptodev ? false, cryptodev
 }:
 
 with stdenv.lib;
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   setOutputFlags = false;
 
   nativeBuildInputs = [ perl zlib ];
-  buildInputs = stdenv.lib.optional withCryptodev cryptodevHeaders;
+  buildInputs = stdenv.lib.optional withCryptodev cryptodev;
 
   configureScript = "./config";
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, buildPackages, perl, coreutils
-, withCryptodev ? false, cryptodevHeaders
+, withCryptodev ? false, cryptodev
 , enableSSL2 ? false
 , static ? false
 }:
@@ -44,7 +44,7 @@ let
     separateDebugInfo = stdenv.hostPlatform.isLinux;
 
     nativeBuildInputs = [ perl ];
-    buildInputs = stdenv.lib.optional withCryptodev cryptodevHeaders;
+    buildInputs = stdenv.lib.optional withCryptodev cryptodev;
 
     # TODO(@Ericson2314): Improve with mass rebuild
     configurePlatforms = [];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11700,20 +11700,11 @@ with pkgs;
 
   inherit (callPackages ../development/libraries/openssl {
       fetchurl = fetchurlBoot;
-      cryptodevHeaders = linuxPackages.cryptodev.override {
-        fetchurl = fetchurlBoot;
-        onlyHeaders = true;
-      };
     })
     openssl_1_0_2
     openssl_1_1;
 
-  openssl-chacha = callPackage ../development/libraries/openssl/chacha.nix {
-    cryptodevHeaders = linuxPackages.cryptodev.override {
-      fetchurl = fetchurlBoot;
-      onlyHeaders = true;
-    };
-  };
+  openssl-chacha = callPackage ../development/libraries/openssl/chacha.nix { };
 
   opensubdiv = callPackage ../development/libraries/opensubdiv {
     cudaSupport = config.cudaSupport or false;
@@ -14640,6 +14631,8 @@ with pkgs;
     };
 
   buildLinux = attrs: callPackage ../os-specific/linux/kernel/generic.nix attrs;
+
+  cryptodev = linuxPackages_4_9.cryptodev;
 
   dpdk = callPackage ../os-specific/linux/dpdk {
     kernel = null; # dpdk modules are in linuxPackages.dpdk.kmod


### PR DESCRIPTION
from d836b811cb533c4cacba9a932d4906cbb41abc7c. A noop.