### PR TITLE
treewide: support i386-pc-elf target, make errors prettier

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -26,7 +26,8 @@ rec {
       platform = platforms.selectBySystem final.system;
       # Derived meta-data
       libc =
-        /**/ if final.isDarwin              then "libSystem"
+        /**/ if final.isNone                then null
+        else if final.isDarwin              then "libSystem"
         else if final.isMinGW               then "msvcrt"
         else if final.isMusl                then "musl"
         else if final.isUClibc              then "uclibc"

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -8,6 +8,10 @@ let abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) abis
 
 rec {
   patterns = rec {
+    # NOTE: normal stuff should use i686, this type is purely for
+    # "i386-pc-elf" target (e.g. coreboot and its payloads)
+    isi386         = { cpu = cpuTypes.i386; };
+
     isi686         = { cpu = cpuTypes.i686; };
     isx86_64       = { cpu = cpuTypes.x86_64; };
     isPowerPC      = { cpu = cpuTypes.powerpc; };
@@ -25,6 +29,8 @@ rec {
     is64bit        = { cpu = { bits = 64; }; };
     isBigEndian    = { cpu = { significantByte = significantBytes.bigEndian; }; };
     isLittleEndian = { cpu = { significantByte = significantBytes.littleEndian; }; };
+
+    isNone         = { kernel = { families = { inherit (kernelFamilies) none; }; }; };
 
     isBSD          = { kernel = { families = { inherit (kernelFamilies) bsd; }; }; };
     isDarwin       = { kernel = { families = { inherit (kernelFamilies) darwin; }; }; };

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -178,6 +178,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isAarch32     then endianPrefix + "arm"
       else if targetPlatform.isx86_64  then "x86-64"
       else if targetPlatform.isi686    then "i386"
+      else if targetPlatform.isi386    then "i386"
       else if targetPlatform.isMips    then {
           "mips"     = "btsmipn32"; # n32 variant
           "mipsel"   = "ltsmipn32"; # n32 variant

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9784,8 +9784,8 @@ with pkgs;
     stdenv = crossLibcStdenv;
   };
 
-  # We can choose:
-  libcCrossChooser = name:
+  libcCross = assert stdenv.targetPlatform != stdenv.buildPlatform;
+    let name = stdenv.targetPlatform.libc; in
     # libc is hackily often used from the previous stage. This `or`
     # hack fixes the hack, *sigh*.
     /**/ if name == "glibc" then targetPackages.glibcCross or glibcCross
@@ -9797,9 +9797,8 @@ with pkgs;
     else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
     else if stdenv.targetPlatform.useiOSPrebuilt then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries
     else if name == "libSystem" then targetPackages.darwin.xcode
+    else if name == null then throw "Target platform ${stdenv.targetPlatform.config} has no libc"
     else throw "Unknown libc";
-
-  libcCross = assert stdenv.targetPlatform != stdenv.buildPlatform; libcCrossChooser stdenv.targetPlatform.libc;
 
   # Only supported on Linux, using glibc
   glibcLocales = if stdenv.hostPlatform.libc == "glibc" then callPackage ../development/libraries/glibc/locales.nix { } else null;


### PR DESCRIPTION
This target used by coreboot and its payloads.

/cc @Ericson2314