### PR TITLE
buck: use upstream version convention

### DIFF
--- a/pkgs/development/tools/build-managers/buck/default.nix
+++ b/pkgs/development/tools/build-managers/buck/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, jdk, ant, python2, python2Packages, watchman, bash, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "buck-unstable-${version}";
-  version = "2017-10-01";
+  name = "buck-${version}";
+  version = "2017.10.01.01";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "buck";
-    rev = "2025fd74327477728b524eafdd4619a0170a24ea";
+    rev = "v${version}";
     sha256 = "05nyyb6f0hv1h67zzvdq8297yl8zjhpbasx35lxnrsjz0m1h8ngw";
   };
 


### PR DESCRIPTION
Changes added in 4d1fd3775d33d5d46a8d691c4e12c7eef8fcefbd break
automated updates by moving to a custom version scheme.

This switches back to upstream versioning, while maintaining version
schema convention of `builtins.parseDrvName`.
See also issue #43717

This will help r-ryantm automated updates
```
2018-11-10T18:50:52 buck-unstable 2017-10-01 -> 2018.10.29.01
2018-11-10T18:51:02 Source url did not change.
2018-11-10T18:51:02 FAIL
```

/cc @r-ryantm ;-), @ryantm, @pSub, @matthewbauer