### PR TITLE
heptio-ark: 0.9.6 -> 0.10.0

### DIFF
--- a/pkgs/applications/networking/cluster/heptio-ark/default.nix
+++ b/pkgs/applications/networking/cluster/heptio-ark/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "heptio-ark-${version}";
-  version = "0.9.6";
+  version = "0.10.0";
 
   goPackagePath = "github.com/heptio/ark";
 
@@ -10,10 +10,10 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "heptio";
     repo = "ark";
-    sha256 = "0q353a6f3hvg1gr6rmg8pbqnkrbgjchdr7f6f9503l1qbyyf95fz";
+    sha256 = "18h9hvp95va0hyl268gnzciwy1dqmc57bpifbj885870rdfp0ffv";
   };
 
-  postInstall = "rm $bin/bin/generate";
+  postInstall = "rm $bin/bin/issue-template-gen";
 
   meta = with stdenv.lib; {
     description = "A utility for managing disaster recovery, specifically for your Kubernetes cluster resources and persistent volumes";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

