### PR TITLE
cadence: fix wrong wrappings

### DIFF
--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -17,11 +17,8 @@
     sha256 = "07z1mnb0bmldb3i31bgw816pnvlvr9gawr51rpx3mhixg5wpiqzb";
   };
 
-  buildInputs = [
-    makeWrapper
-    pkgconfig
-    qtbase
-  ];
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
+  buildInputs = [ qtbase ];
 
   makeFlags = ''
     PREFIX=""
@@ -77,7 +74,7 @@
   meta = {
     homepage = https://github.com/falkTX/Cadence/;
     description = "Collection of tools useful for audio production";
-    license = stdenv.lib.licenses.mit;
+    license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ genesis ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -23,21 +23,6 @@
     qtbase
   ];
 
-  apps = [
-    "cadence"
-    "cadence-jacksettings"
-    "cadence-pulse2loopback"
-    "claudia"
-    "cadence-aloop-daemon"
-    "cadence-logs"
-    "cadence-render"
-    "catarina"
-    "claudia-launcher"
-    "cadence-pulse2jack"
-    "cadence-session-start"
-    "catia"
-  ];
-
   makeFlags = ''
     PREFIX=""
     DESTDIR=$(out)
@@ -46,13 +31,47 @@
   propagatedBuildInputs = with python3Packages; [ pyqt5 ];
 
   postInstall = ''
-    # replace with our own wrappers.
-    for app in $apps; do
-      rm $out/bin/$app
-      makeWrapper ${python3Packages.python.interpreter} $out/bin/$app \
-        --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
-        --add-flags "-O $out/share/cadence/src/$app.py"
-    done
+    # replace with our own wrappers. They need to be changed manually since it wouldn't work otherwise
+    rm $out/bin/cadence
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/cadence \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/cadence.py"
+    rm $out/bin/claudia
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/claudia \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/claudia.py"
+    rm $out/bin/catarina
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/catarina \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/catarina.py"
+    rm $out/bin/catia
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/catia \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/catia.py"
+    rm $out/bin/cadence-jacksettings
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/cadence-jacksettings \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/jacksettings.py"
+    rm $out/bin/cadence-aloop-daemon
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/cadence-aloop-daemon \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/cadence_aloop_daemon.py"
+    rm $out/bin/cadence-logs
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/cadence-logs \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/logs.py"
+    rm $out/bin/cadence-render
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/cadence-render \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/render.py"
+    rm $out/bin/claudia-launcher
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/claudia-launcher \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/claudia_launcher.py"
+    rm $out/bin/cadence-session-start
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/cadence-session-start \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+      --add-flags "-O $out/share/cadence/src/cadence_session_start.py"
   '';
 
   meta = {

--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -76,6 +76,6 @@
     description = "Collection of tools useful for audio production";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ genesis ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl
+, fetchzip
 , pkgconfig
 , qtbase
 , makeWrapper
@@ -12,9 +12,9 @@
   version = "0.9.0";
   name = "cadence";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/falkTX/Cadence/archive/v${version}.tar.gz";
-    sha256 = "07z1mnb0bmldb3i31bgw816pnvlvr9gawr51rpx3mhixg5wpiqzb";
+    sha256 = "08vcggypkdfr70v49innahs5s11hi222dhhnm5wcqzdgksphqzwx";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
This fixes #48790

Some moduls of the Packages were automatically wrapped, but the problem is that not all of them need to be wrapped and there are some name mismatches. E.g. one Package is called `cadence-logs` in the binaries but `logs.py` in the shared folder (instead of `cadence-logs.py`). also `-` in the bin folder is `_` in the shared folder.

Just to point out, there needs more to be done to make this package really usable, I just don't know how to do the fixes:

- almost all binaries immediately stop with the error message that jack is either not installed or can't be connected to (no matter if jack runs or not). I think this is because they all need `libjack.so.0`. which somehow is not available (The file `share/cadence/src/jacklib.py` wants to load it).
 I tried to fix it by adding `libjack2` to the buildinputs, but it made no difference. If somebody can point out how I can add `libjack.so.0` to the path, I can add a fix in this pull request.
- most included tools try to import `dbus.mainloop.pyqt5` which seems to not exist in the `dbus-python` version available on nixos. E.g. the program `claudia`  stops immediately saying `DBus is not available`. I guess we need to build a package containing `dbus.mainloop.pyqt5` before we can fix this issue...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

