### PR TITLE
[18.09] live555: 2018.02.28 -> 2018.10.17

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -37,16 +37,17 @@ stdenv.mkDerivation rec {
     systemd gnutls avahi libcddb SDL SDL_image libmtp unzip taglib libarchive
     libkate libtiger libv4l samba liboggz libass libdvbpsi libva
     xorg.xlibsWrapper xorg.libXv xorg.libXvMC xorg.libXpm xorg.xcbutilkeysyms
-    libdc1394 libraw1394 libopus libebml libmatroska libvdpau libsamplerate live555
+    libdc1394 libraw1394 libopus libebml libmatroska libvdpau libsamplerate
     fluidsynth wayland wayland-protocols
-  ] ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
+  ] ++ optional (!stdenv.hostPlatform.isAarch64) live555
+    ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
     ++ optional jackSupport libjack2;
 
   nativeBuildInputs = [ autoreconfHook perl pkgconfig ];
 
   enableParallelBuilding = true;
 
-  LIVE555_PREFIX = live555;
+  LIVE555_PREFIX = if (!stdenv.hostPlatform.isAarch64) then live555 else null;
 
   # vlc depends on a c11-gcc wrapper script which we don't have so we need to
   # set the path to the compiler

--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -1,15 +1,13 @@
 { stdenv, fetchurl, lib, darwin }:
 
 # Based on https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD
-let
-  version = "2018.02.28";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "live555-${version}";
+  version = "2018.10.17";
 
   src = fetchurl { # the upstream doesn't provide a stable URL
     url = "mirror://sourceforge/slackbuildsdirectlinks/live.${version}.tar.gz";
-    sha256 = "0zi47asv1qmb09g321m02q684i3c90vci0mgkdh1mlmx2rbg1d1d";
+    sha256 = "1s69ipvdc6ldscp0cr1zpsll8xc3qcagr95nl84x7b1rbg4xjs3w";
   };
 
   postPatch = ''
@@ -23,23 +21,33 @@ stdenv.mkDerivation {
   '';
 
   configurePhase = ''
+    runHook preConfigure
+
     ./genMakefiles ${{
       x86_64-darwin = "macosx";
       i686-linux = "linux";
       x86_64-linux = "linux-64bit";
       aarch64-linux = "linux-64bit";
     }.${stdenv.hostPlatform.system}}
+
+    runHook postConfigure
   '';
 
   installPhase = ''
+    runHook preInstall
+
     for dir in BasicUsageEnvironment groupsock liveMedia UsageEnvironment; do
       install -dm755 $out/{bin,lib,include/$dir}
       install -m644 $dir/*.a "$out/lib"
       install -m644 $dir/include/*.h* "$out/include/$dir"
     done
+
+    runHook postInstall
   '';
 
   nativeBuildInputs = lib.optional stdenv.isDarwin darwin.cctools;
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Set of C++ libraries for multimedia streaming, using open standard protocols (RTP/RTCP, RTSP, SIP)";

--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.live555.com/liveMedia/;
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
+    broken = stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Backport of #50612 addressing CVE-2018-4013
\+ disabling `live555` on aarch64 as it has been failing for a long time now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

