### PR TITLE
nixos/firewall: merge global and interface specific rules

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -508,14 +508,12 @@ in
       };
 
       interfaces = mkOption {
-        default = {
-          default = mapAttrs (name: value: cfg."${name}") commonOptions;
-        };
+        default = { };
         type = with types; attrsOf (submodule [ { options = commonOptions; } ]);
         description =
           ''
-            Interface-specific open ports. Setting this value will override
-            all values of the <literal>networking.firewall.allowed*</literal>
+            Interface-specific open ports. These values will be merged with
+            the values of the <literal>networking.firewall.allowed*</literal>
             options.
           '';
       };
@@ -531,6 +529,9 @@ in
   config = mkIf cfg.enable {
 
     networking.firewall.trustedInterfaces = [ "lo" ];
+    networking.firewall.interfaces.default =
+      mapAttrs (name: value: cfg."${name}") commonOptions //
+        cfg.interfaces.default;
 
     environment.systemPackages = [ pkgs.iptables ] ++ cfg.extraPackages;
 


### PR DESCRIPTION
Merge global and interface specific firewall.allowed* rules, instead of
silently dropping global rules when both types are set.

###### Motivation for this change

Currently global `networking.firewall.allowed*` are dropped for interfaces when they have interface specific rules. Although this was documented, the more intuitive option would be to merge the rules.
 
#47580

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

   Ran `nix-build firewall.nix`, I'm not sure if it finished cleanly, it ends with:

~~~
syncing
walled: running command: sync
walled: exit status 0
attacker: running command: sync
attacker: exit status 0
test script finished in 22.48s
cleaning up
killing walled (pid 600)
killing attacker (pid 612)
vde_switch: EOF on stdin, cleaning up and exiting
vde_switch: Could not remove ctl dir '/build/vde1.ctl': Directory not empty
/nix/store/i6v45ivxy6r3w2hkhg4ifv8qcd5k4qxb-vm-test-run-firewall
~~~

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

