### PR TITLE
dvd-vr: init at 0.9.7

### DIFF
--- a/pkgs/tools/cd-dvd/dvd-vr/default.nix
+++ b/pkgs/tools/cd-dvd/dvd-vr/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "dvd-vr-${version}";
+  version = "0.9.7";
+  src = fetchurl {
+    url = "https://www.pixelbeat.org/programs/dvd-vr/dvd-vr-${version}.tar.gz";
+    sha256 = "13wkdia3c0ryda40b2nzpb9vddimasgc4w95hvl0k555k9k8bl0r";
+  };
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://www.pixelbeat.org/programs/dvd-vr/;
+    downloadPage = https://www.pixelbeat.org/programs/dvd-vr/;
+    description = "A utility to identify and optionally copy recordings from a DVD-VR format disc";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2359,6 +2359,8 @@ with pkgs;
 
   duply = callPackage ../tools/backup/duply { };
 
+  dvd-vr = callPackage ../tools/cd-dvd/dvd-vr { };
+
   dvdisaster = callPackage ../tools/cd-dvd/dvdisaster { };
 
   dvdplusrwtools = callPackage ../tools/cd-dvd/dvd+rw-tools { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

