### PR TITLE
eigen3_3: fix EIGEN3_INCLUDE_DIR location

### DIFF
--- a/pkgs/development/libraries/eigen/3.3.nix
+++ b/pkgs/development/libraries/eigen/3.3.nix
@@ -5,19 +5,19 @@ let
 in
 stdenv.mkDerivation {
   name = "eigen-${version}";
-  
+
   src = fetchurl {
     url = "https://bitbucket.org/eigen/eigen/get/${version}.tar.gz";
     name = "eigen-${version}.tar.gz";
     sha256 = "13p60x6k61zq2y2in7g4fy5p55cr5dbmj3zvw10zcazxraxbcm04";
   };
 
+  patches = [
+    ./include-dir.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
-  postInstall = ''
-    sed -e '/Cflags:/s@''${prefix}/@@' -i "$out"/share/pkgconfig/eigen3.pc
-  '';
-   
   meta = with stdenv.lib; {
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
     license = licenses.lgpl3Plus;

--- a/pkgs/development/libraries/eigen/include-dir.patch
+++ b/pkgs/development/libraries/eigen/include-dir.patch
@@ -1,0 +1,49 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(Eigen3)
+ 
+-cmake_minimum_required(VERSION 2.8.5)
++cmake_minimum_required(VERSION 3.7)
+ 
+ # guard against in-source builds
+ 
+@@ -408,13 +408,6 @@ install(FILES
+   DESTINATION ${INCLUDE_INSTALL_DIR} COMPONENT Devel
+   )
+ 
+-if(EIGEN_BUILD_PKGCONFIG)
+-    configure_file(eigen3.pc.in eigen3.pc @ONLY)
+-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eigen3.pc
+-        DESTINATION ${PKGCONFIG_INSTALL_DIR}
+-        )
+-endif()
+-
+ add_subdirectory(Eigen)
+ 
+ add_subdirectory(doc EXCLUDE_FROM_ALL)
+@@ -510,8 +503,15 @@ set ( EIGEN_VERSION_MAJOR  ${EIGEN_WORLD_VERSION} )
+ set ( EIGEN_VERSION_MINOR  ${EIGEN_MAJOR_VERSION} )
+ set ( EIGEN_VERSION_PATCH  ${EIGEN_MINOR_VERSION} )
+ set ( EIGEN_DEFINITIONS "")
+-set ( EIGEN_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_DIR}" )
+ set ( EIGEN_ROOT_DIR ${CMAKE_INSTALL_PREFIX} )
++GNUInstallDirs_get_absolute_install_dir(EIGEN_INCLUDE_DIR INCLUDE_INSTALL_DIR)
++
++if(EIGEN_BUILD_PKGCONFIG)
++    configure_file(eigen3.pc.in eigen3.pc @ONLY)
++    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eigen3.pc
++        DESTINATION ${PKGCONFIG_INSTALL_DIR}
++        )
++endif()
+ 
+ # Interface libraries require at least CMake 3.0
+ if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+--- a/eigen3.pc.in
++++ b/eigen3.pc.in
+@@ -6,4 +6,4 @@ Description: A C++ template library for linear algebra: vectors, matrices, and r
+ Requires:
+ Version: @EIGEN_VERSION_NUMBER@
+ Libs:
+-Cflags: -I${prefix}/@INCLUDE_INSTALL_DIR@
++Cflags: -I@EIGEN_INCLUDE_DIR@


### PR DESCRIPTION
###### Motivation for this change

Eigen assumes that `CMAKE_INSTALL_INCLUDEDIR` is a path relative to `CMAKE_INSTALL_PREFIX` (typically `include`), but CMake supports it being an absolute path, which is the case in Nixpkgs. This resulted in `EIGEN3_INCLUDE_DIR` being set to `/nix/store/…eigen…//nix/store/…eigen…/include/eigen3`.

`GNUInstallDirs_get_absolute_install_dir` requires CMake 3.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
