### PR TITLE
morph: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -73,6 +73,11 @@
     github = "acowley";
     name = "Anthony Cowley";
   };
+  adamt = {
+    email = "mail@adamtulinius.dk";
+    github = "adamtulinius";
+    name = "Adam Tulinius";
+  };
   adelbertc = {
     email = "adelbertc@gmail.com";
     github = "adelbertc";

--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -1,0 +1,37 @@
+{ buildGoPackage, fetchFromGitHub, go-bindata, lib }:
+
+buildGoPackage rec {
+  name = "morph-${version}";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "dbcdk";
+    repo = "morph";
+    rev = "v${version}";
+    sha256 = "0pixm48is9if9d2b4qc5mwwa4lzma6snkib6z2a1d4pmdx1lmpmm";
+  };
+
+  goPackagePath = "github.com/dbcdk/morph";
+  goDeps = ./deps.nix;
+
+  buildInputs = [ go-bindata ];
+
+  prePatch = ''
+    go-bindata -pkg assets -o assets/assets.go data/
+  '';
+
+  postInstall = ''
+    mkdir -p $lib
+    cp -v $src/data/*.nix $lib
+  '';
+
+  outputs = [ "out" "bin" "lib" ];
+
+  meta = with lib; {
+    description = "Morph is a NixOS host manager written in Golang.";
+    license = licenses.mit;
+    homepage = "https://github.com/dbcdk/morph";
+    maintainers = with maintainers; [adamt johanot];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/package-management/morph/deps.nix
+++ b/pkgs/tools/package-management/morph/deps.nix
@@ -1,0 +1,66 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/dbcdk/kingpin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dbcdk/kingpin";
+      rev =  "8554767bc91254c59c7297a99e9867c770e4eadb";
+      sha256 = "05hfpgylv5mfnjz2mdd3jl8p3psmczvdbs4ydf9xvvc17c9mlrpq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev =  "a0175ee3bccc567396460bf5acd36800cb10c49c";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev =  "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gobwas/glob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobwas/glob";
+      rev =  "5ccd90ef52e1e632236f7326478d4faa74f99438";
+      sha256 = "0jxk1x806zn5x86342s72dq2qy64ksb3zrvrlgir2avjhwb18n6z";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "0e37d006457bf46f9e6692014ba72ef82c33022c";
+      sha256 = "1fj8rvrhgv5j8pmckzphvm3sqkzhcqp3idkxvgv13qrjdfycsa5r";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "ee1b12c67af419cf5a9be3bdbeea7fc1c5f32f11";
+      sha256 = "0cgp0xzbhg3fr77n2qrfmmsvhc287srnwi4mghwcjdxp6rx0s988";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/mattes/go-expand-tilde.v1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattes/go-expand-tilde";
+      rev =  "cb884138e64c9a8bf5c7d6106d74b0fca082df0c";
+      sha256 = "06xrp05njwam4sn031fkmd4gym5wfsw5q0v24nqhs4883lsx9dwq";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22167,6 +22167,8 @@ with pkgs;
 
   mongoc = callPackage ../development/libraries/mongoc { };
 
+  morph = callPackage ../tools/package-management/morph { };
+
   mupen64plus = callPackage ../misc/emulators/mupen64plus { };
 
   muse = callPackage ../applications/audio/muse { };


### PR DESCRIPTION
morph is a NixOS host manager written in Go by @adamtulinius and myself (@johanot). 
More info at: https://github.com/DBCDK/morph

###### Motivation for this change
We want to make a Nix packaged version of morph available upstream such that morph can be easily installed on any NixOS system.

###### Things done

- added adamt to maintainers-list.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
