### PR TITLE
Update jflex urls, and version by the way

### DIFF
--- a/pkgs/development/libraries/java/jflex/default.nix
+++ b/pkgs/development/libraries/java/jflex/default.nix
@@ -10,15 +10,22 @@ stdenv.mkDerivation rec {
 
   sourceRoot = name;
 
-  phases = [ "unpackPhase" "installPhase" ];
-
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     cp -a * $out
     rm -f $out/bin/jflex.bat
 
     patchShebangs $out
     sed -i -e '/^JAVA=java/ s#java#${jre}/bin/java#' $out/bin/jflex
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preCheck
+    $out/bin/jflex --version
+    runHook postCheck
   '';
 
   meta = {

--- a/pkgs/development/libraries/java/jflex/default.nix
+++ b/pkgs/development/libraries/java/jflex/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "jflex-1.6.1";
 
   src = fetchurl {
-    url = "http://jflex.de/${name}.tar.gz";
+    url = "http://jflex.de/release/${name}.tar.gz";
     sha256 = "1h7q2vhb4s42g4pqz5xxxliagprray7i9krr6hyaz1mjlx7gnycq";
   };
 

--- a/pkgs/development/libraries/java/jflex/default.nix
+++ b/pkgs/development/libraries/java/jflex/default.nix
@@ -1,11 +1,11 @@
-{stdenv, fetchurl} :
+{stdenv, fetchurl, jre} :
 
 stdenv.mkDerivation rec {
-  name = "jflex-1.6.1";
+  name = "jflex-1.7.0";
 
   src = fetchurl {
     url = "http://jflex.de/release/${name}.tar.gz";
-    sha256 = "1h7q2vhb4s42g4pqz5xxxliagprray7i9krr6hyaz1mjlx7gnycq";
+    sha256 = "1k7bqw1mn569g9dxc0ia3yz1bzgzs5w52lh1xn3hgj7k5ymh54kk";
   };
 
   sourceRoot = name;
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -a * $out
+    rm -f $out/bin/jflex.bat
+
     patchShebangs $out
+    sed -i -e '/^JAVA=java/ s#java#${jre}/bin/java#' $out/bin/jflex
   '';
 
   meta = {


### PR DESCRIPTION
This is my @ryantm fixing spree ;-)
The download url has changed, and new versions could not be downloaded anymore.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---