### PR TITLE
pythonPackages.magic-wormhole: 0.10.5 -> 0.11.2

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, attrs, twisted, pyopenssl, service-identity, autobahn, treq, mock }:
+
+buildPythonPackage rec {
+  version = "0.3.1";
+  pname = "magic-wormhole-mailbox-server";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q6zhbx8fcpk7rchclm7yqcxdsc1x97hki2ji61sa544r5xvxv55";
+  };
+
+  propagatedBuildInputs = [ six attrs twisted pyopenssl service-identity autobahn ];
+  checkInputs = [ treq mock ];
+
+  meta = with stdenv.lib; {
+    description = "Securely transfer data between computers";
+    homepage = https://github.com/warner/magic-wormhole-mailbox-server;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -1,8 +1,6 @@
-{ lib
+{ stdenv
 , buildPythonPackage
 , fetchPypi
-, pythonAtLeast
-, python
 , spake2
 , pynacl
 , six
@@ -14,49 +12,42 @@
 , tqdm
 , click
 , humanize
-, ipaddress
 , txtorcon
 , nettools
-, glibc
 , glibcLocales
 , mock
 , magic-wormhole-transit-relay
+, magic-wormhole-mailbox-server
 }:
 
 buildPythonPackage rec {
   pname = "magic-wormhole";
-  version = "0.10.5";
+  version = "0.11.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9558ea1f3551e535deec3462cd5c8391cb32ebb12ecd8b40b36861dbee4917ee";
+    sha256 = "01fr4bi6kc6fz9n3c4qq892inrc3nf6p2djy65yvm7xkvdxncydf";
   };
 
-  checkInputs = [ mock magic-wormhole-transit-relay ];
-  buildInputs = [ nettools glibcLocales ];
-  propagatedBuildInputs = [ spake2 pynacl six attrs twisted autobahn automat hkdf tqdm click humanize ipaddress txtorcon ];
+  buildInputs = [ glibcLocales ];
+  propagatedBuildInputs = [ spake2 pynacl six attrs twisted autobahn automat hkdf tqdm click humanize txtorcon ];
+  checkInputs = [ mock magic-wormhole-transit-relay magic-wormhole-mailbox-server ];
 
   postPatch = ''
     sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py
-    sed -i -e "s|if (os.path.dirname(os.path.abspath(wormhole))|if not os.path.abspath(wormhole).startswith('/nix/store') and (os.path.dirname(os.path.abspath(wormhole))|" src/wormhole/test/test_cli.py
-
-    # magic-wormhole will attempt to find all available locales by running
-    # 'locale -a'.  If we're building on Linux, then this may result in us
-    # running the system's locale binary instead of the one from Nix, so let's
-    # ensure we patch this.
-    sed -i -e 's|getProcessOutputAndValue("locale"|getProcessOutputAndValue("${glibc}/bin/locale"|' src/wormhole/test/test_cli.py
-  '' + lib.optionalString (pythonAtLeast "3.3") ''
-    sed -i -e 's|"ipaddress",||' setup.py
   '';
 
-  checkPhase = ''
-    export PATH="$PATH:$out/bin"
+  preCheck = ''
+    export PATH=$out/bin:$PATH
     export LANG="en_US.UTF-8"
     export LC_ALL="en_US.UTF-8"
-    ${python.interpreter} -m wormhole.test.run_trial wormhole
+    substituteInPlace src/wormhole/test/test_cli.py \
+      --replace 'getProcessOutputAndValue("locale", ["-a"])' 'getProcessOutputAndValue("locale", ["-a"], env=os.environ)' \
+      --replace 'if (os.path.dirname(os.path.abspath(wormhole))' 'if not os.path.abspath(wormhole).startswith("/nix/store") and (os.path.dirname(os.path.abspath(wormhole))' \
+      --replace 'locale_env = dict(LC_ALL=locale, LANG=locale)' 'locale_env = dict(LC_ALL=locale, LANG=locale, LOCALE_ARCHIVE=os.getenv("LOCALE_ARCHIVE"))'
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Securely transfer data between computers";
     homepage = https://github.com/warner/magic-wormhole;
     license = licenses.mit;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3916,6 +3916,8 @@ in {
 
   magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
 
+  magic-wormhole-mailbox-server = callPackage ../development/python-modules/magic-wormhole-mailbox-server { };
+
   magic-wormhole-transit-relay = callPackage ../development/python-modules/magic-wormhole-transit-relay { };
 
   wxPython = self.wxPython30;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

