### PR TITLE
nixos/firewall: Always use global firewall.allowed rules

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -220,6 +220,13 @@
      reset to the default value (<literal>false</literal>).
     </para>
    </listitem>
+   <listitem>
+    <para>
+     NixOS global firewall allow options (<literal>networking.firewall.allow*</literal>)
+     are now preserved when setting interface specific rules such as
+     <literal>networking.firewall.interfaces.en0.allow*</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -222,9 +222,13 @@
    </listitem>
    <listitem>
     <para>
-     NixOS global firewall allow options (<literal>networking.firewall.allow*</literal>)
-     are now preserved when setting interface specific rules such as
-     <literal>networking.firewall.interfaces.en0.allow*</literal>.
+     Network interface indiscriminate NixOS firewall options
+     (<literal>networking.firewall.allow*</literal>) are now preserved when also
+     setting interface specific rules such as <literal>networking.firewall.interfaces.en0.allow*</literal>.
+     These rules continue to use the pseudo device "default"
+     (<literal>networking.firewall.interfaces.default.*</literal>), and assigning
+     to this pseudo device will override the (<literal>networking.firewall.allow*</literal>)
+     options.
     </para>
    </listitem>
   </itemizedlist>

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -58,8 +58,8 @@ let
     ${text}
   ''; in "${dir}/bin/${name}";
 
-  anyInterface = { any = mapAttrs (name: value: cfg."${name}") commonOptions; };
-  allInterfaces = anyInterface // cfg.interfaces;
+  defaultInterface = { default = mapAttrs (name: value: cfg."${name}") commonOptions; };
+  allInterfaces = defaultInterface // cfg.interfaces;
 
   startScript = writeShScript "firewall-start" ''
     ${helpers}
@@ -154,7 +154,7 @@ let
     ${concatStrings (mapAttrsToList (iface: cfg:
       concatMapStrings (port:
         ''
-          ip46tables -A nixos-fw -p tcp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
+          ip46tables -A nixos-fw -p tcp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
         ''
       ) cfg.allowedTCPPorts
     ) allInterfaces)}
@@ -164,7 +164,7 @@ let
       concatMapStrings (rangeAttr:
         let range = toString rangeAttr.from + ":" + toString rangeAttr.to; in
         ''
-          ip46tables -A nixos-fw -p tcp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
+          ip46tables -A nixos-fw -p tcp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
         ''
       ) cfg.allowedTCPPortRanges
     ) allInterfaces)}
@@ -173,7 +173,7 @@ let
     ${concatStrings (mapAttrsToList (iface: cfg:
       concatMapStrings (port:
         ''
-          ip46tables -A nixos-fw -p udp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
+          ip46tables -A nixos-fw -p udp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
         ''
       ) cfg.allowedUDPPorts
     ) allInterfaces)}
@@ -183,7 +183,7 @@ let
       concatMapStrings (rangeAttr:
         let range = toString rangeAttr.from + ":" + toString rangeAttr.to; in
         ''
-          ip46tables -A nixos-fw -p udp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
+          ip46tables -A nixos-fw -p udp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
         ''
       ) cfg.allowedUDPPortRanges
     ) allInterfaces)}

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -58,6 +58,9 @@ let
     ${text}
   ''; in "${dir}/bin/${name}";
 
+  anyInterface = { any = mapAttrs (name: value: cfg."${name}") commonOptions; };
+  allInterfaces = anyInterface // cfg.interfaces;
+
   startScript = writeShScript "firewall-start" ''
     ${helpers}
 
@@ -154,7 +157,7 @@ let
           ip46tables -A nixos-fw -p tcp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedTCPPorts
-    ) (cfg.interfaces // {any={allowedTCPPorts = cfg.allowedTCPPorts;};}))}
+    ) allInterfaces)}
 
     # Accept connections to the allowed TCP port ranges.
     ${concatStrings (mapAttrsToList (iface: cfg:
@@ -164,7 +167,7 @@ let
           ip46tables -A nixos-fw -p tcp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedTCPPortRanges
-    ) (cfg.interfaces // {any={allowedTCPPortRanges = cfg.allowedTCPPortRanges;};}))}
+    ) allInterfaces)}
 
     # Accept packets on the allowed UDP ports.
     ${concatStrings (mapAttrsToList (iface: cfg:
@@ -173,7 +176,7 @@ let
           ip46tables -A nixos-fw -p udp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedUDPPorts
-    ) (cfg.interfaces // {any={allowedUDPPorts = cfg.allowedUDPPorts;};}))}
+    ) allInterfaces)}
 
     # Accept packets on the allowed UDP port ranges.
     ${concatStrings (mapAttrsToList (iface: cfg:
@@ -183,7 +186,7 @@ let
           ip46tables -A nixos-fw -p udp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedUDPPortRanges
-    ) (cfg.interfaces // {any={allowedUDPPortRanges = cfg.allowedUDPPortRanges;};}))}
+    ) allInterfaces)}
 
     # Accept IPv4 multicast.  Not a big security risk since
     # probably nobody is listening anyway.

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -151,39 +151,39 @@ let
     ${concatStrings (mapAttrsToList (iface: cfg:
       concatMapStrings (port:
         ''
-          ip46tables -A nixos-fw -p tcp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
+          ip46tables -A nixos-fw -p tcp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedTCPPorts
-    ) cfg.interfaces)}
+    ) (cfg.interfaces // {any={allowedTCPPorts = cfg.allowedTCPPorts;};}))}
 
     # Accept connections to the allowed TCP port ranges.
     ${concatStrings (mapAttrsToList (iface: cfg:
       concatMapStrings (rangeAttr:
         let range = toString rangeAttr.from + ":" + toString rangeAttr.to; in
         ''
-          ip46tables -A nixos-fw -p tcp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
+          ip46tables -A nixos-fw -p tcp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedTCPPortRanges
-    ) cfg.interfaces)}
+    ) (cfg.interfaces // {any={allowedTCPPortRanges = cfg.allowedTCPPortRanges;};}))}
 
     # Accept packets on the allowed UDP ports.
     ${concatStrings (mapAttrsToList (iface: cfg:
       concatMapStrings (port:
         ''
-          ip46tables -A nixos-fw -p udp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
+          ip46tables -A nixos-fw -p udp --dport ${toString port} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedUDPPorts
-    ) cfg.interfaces)}
+    ) (cfg.interfaces // {any={allowedUDPPorts = cfg.allowedUDPPorts;};}))}
 
     # Accept packets on the allowed UDP port ranges.
     ${concatStrings (mapAttrsToList (iface: cfg:
       concatMapStrings (rangeAttr:
         let range = toString rangeAttr.from + ":" + toString rangeAttr.to; in
         ''
-          ip46tables -A nixos-fw -p udp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "default") "-i ${iface}"}
+          ip46tables -A nixos-fw -p udp --dport ${range} -j nixos-fw-accept ${optionalString (iface != "any") "-i ${iface}"}
         ''
       ) cfg.allowedUDPPortRanges
-    ) cfg.interfaces)}
+    ) (cfg.interfaces // {any={allowedUDPPortRanges = cfg.allowedUDPPortRanges;};}))}
 
     # Accept IPv4 multicast.  Not a big security risk since
     # probably nobody is listening anyway.
@@ -508,15 +508,11 @@ in
       };
 
       interfaces = mkOption {
-        default = {
-          default = mapAttrs (name: value: cfg."${name}") commonOptions;
-        };
+        default = { };
         type = with types; attrsOf (submodule [ { options = commonOptions; } ]);
         description =
           ''
-            Interface-specific open ports. Setting this value will override
-            all values of the <literal>networking.firewall.allowed*</literal>
-            options.
+            Interface-specific open ports.
           '';
       };
     } // commonOptions;


### PR DESCRIPTION
Apply global firewall.allowed* rules separately from the interface specific rules. This means setting interface specific rules (networking.firewall.INTERFACE.allowed*) will still apply global rules to all interfaces.

###### Motivation for this change

Currently global networking.firewall.allowed* are dropped for interfaces when they have interface specific rules. Although this was documented, the more intuitive option would be to merge the rules.

#47580 
(This supersedes my pull request fail #50625 sorry for that)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

