### PR TITLE
50629.cross compile libksba

### DIFF
--- a/pkgs/development/libraries/libksba/default.nix
+++ b/pkgs/development/libraries/libksba/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "info" ];
 
   buildInputs = [ gettext ];
+  propagatedBuildInputs = [ libgpgerror ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   configureFlags = [ "--with-libgpg-error-prefix=${libgpgerror.dev}" ];

--- a/pkgs/development/libraries/libksba/default.nix
+++ b/pkgs/development/libraries/libksba/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gettext, libgpgerror }:
+{ buildPackages, stdenv, fetchurl, gettext, libgpgerror }:
 
 stdenv.mkDerivation rec {
   name = "libksba-1.3.5";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "info" ];
 
   buildInputs = [ gettext ];
-  propagatedBuildInputs = [ libgpgerror ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  configureFlags = [ "--with-libgpg-error-prefix=${libgpgerror.dev}" ];
 
   postInstall = ''
     mkdir -p $dev/bin


### PR DESCRIPTION
###### Motivation for this change

libksba fails to cross-compile.  Fixes #50629

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

