### PR TITLE
Fix/bitwig

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/libxkbcommon_7.nix
+++ b/pkgs/development/libraries/libxkbcommon/libxkbcommon_7.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, pkgconfig, yacc, flex, xkeyboard_config, libxcb, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "libxkbcommon-0.7.2";
+
+  src = fetchurl {
+    url = "http://xkbcommon.org/download/${name}.tar.xz";
+    sha256 = "1n5rv5n210kjnkyrvbh04gfwaa7zrmzy1393p8nyqfw66lkxr918";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ yacc flex xkeyboard_config libxcb ];
+
+  configureFlags = [
+    "--with-xkb-config-root=${xkeyboard_config}/etc/X11/xkb"
+    "--with-x-locale-root=${libX11.out}/share/X11/locale"
+  ];
+
+  preBuild = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's/,--version-script=.*$//' Makefile
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library to handle keyboard descriptions";
+    homepage = http://xkbcommon.org;
+    license = licenses.mit;
+    maintainers = with maintainers; [ garbas ttuegel ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15731,6 +15731,7 @@ with pkgs;
 
   bitwig-studio1 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio1.nix {
     inherit (gnome3) zenity;
+    libxkbcommon = libxkbcommon_7;
   };
   bitwig-studio2 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio2.nix {
     inherit (gnome3) zenity;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11157,7 +11157,9 @@ with pkgs;
 
   libxdg_basedir = callPackage ../development/libraries/libxdg-basedir { };
 
-  libxkbcommon = callPackage ../development/libraries/libxkbcommon { };
+  libxkbcommon = libxkbcommon_8;
+  libxkbcommon_8 = callPackage ../development/libraries/libxkbcommon { };
+  libxkbcommon_7 = callPackage ../development/libraries/libxkbcommon/libxkbcommon_7.nix { };
 
   libxklavier = callPackage ../development/libraries/libxklavier { };
 


### PR DESCRIPTION
###### Motivation for this change

fixing #49530
I needed to split up libxkbcommon to version 8 and version 7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

