### PR TITLE
elm: extract makeDotElm and fetchElmDeps

### DIFF
--- a/pkgs/development/compilers/elm/fetchElmDeps.nix
+++ b/pkgs/development/compilers/elm/fetchElmDeps.nix
@@ -1,0 +1,11 @@
+{stdenv, lib, fetchurl}:
+
+{elmPackages, versionsDat}:
+
+let
+  makeDotElm = import ./makeDotElm.nix {inherit stdenv lib fetchurl versionsDat;};
+
+in
+''
+  export ELM_HOME=`pwd`/.elm
+'' + (makeDotElm "0.19.0" elmPackages)

--- a/pkgs/development/compilers/elm/makeDotElm.nix
+++ b/pkgs/development/compilers/elm/makeDotElm.nix
@@ -1,0 +1,30 @@
+{stdenv, lib, fetchurl, versionsDat}:
+
+ver: deps:
+  let cmds = lib.mapAttrsToList (name: info: let
+               pkg = stdenv.mkDerivation {
+                 name = lib.replaceChars ["/"] ["-"] name + "-${info.version}";
+
+                 src = fetchurl {
+                   url = "https://github.com/${name}/archive/${info.version}.tar.gz";
+                   meta.homepage = "https://github.com/${name}/";
+                   inherit (info) sha256;
+                 };
+
+                 phases = [ "unpackPhase" "installPhase" ];
+
+                 installPhase = ''
+                   mkdir -p $out
+                   cp -r * $out
+                 '';
+
+               };
+             in ''
+               mkdir -p .elm/${ver}/package/${name}
+               cp -R ${pkg} .elm/${ver}/package/${name}/${info.version}
+             '') deps;
+  in (lib.concatStrings cmds) + ''
+    mkdir -p .elm/${ver}/package;
+    cp ${versionsDat} .elm/${ver}/package/versions.dat;
+    chmod -R +w .elm
+  ''


### PR DESCRIPTION
###### Motivation for this change

supports creating nix expressions for other Elm packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).