### PR TITLE
python-mnist: init at 0.6

### DIFF
--- a/pkgs/development/python-modules/python-mnist/default.nix
+++ b/pkgs/development/python-modules/python-mnist/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "python-mnist";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5d59a44335eccb4b310efb2ebb76f44e8588a1732cfb4923f4a502b61d8b653a";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sorki/python-mnist;
+    description = "Simple MNIST data parser written in Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -617,6 +617,8 @@ in {
 
   python-ldap-test = callPackage ../development/python-modules/python-ldap-test { };
 
+  python-mnist = callPackage ../development/python-modules/python-mnist { };
+
   python-igraph = callPackage ../development/python-modules/python-igraph {
     pkgconfig = pkgs.pkgconfig;
     igraph = pkgs.igraph;


### PR DESCRIPTION
###### Motivation for this change

This adds the `python-mnist` Python package that acts as a "parser" and loader of MNIST and EMNIST data.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

