### PR TITLE
dbeaver: 5.2.4 -> 5.2.5 (18.09)

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "5.2.4";
+  version = "5.2.5";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "1zwbqr5s76r77x7klydpqbaqakzzilzv92ddyck1sj5jiy5prwpp";
+    sha256 = "0xjggjq2brhi9x3i4d7hqfi18cd8czs6rzvihvspfxaqilsai0dm";
   };
 
   installPhase = ''


### PR DESCRIPTION
(cherry picked from commit 47d1bcc8732a82cafaf7e664d5cd00b1ef7df21b)

###### Motivation for this change

 * [Updates dbeaver 5.2.5](https://dbeaver.io/2018/11/18/dbeaver-5-2-5/).

This cherry-picks #50659

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> *As a side note, #34182 is still open and I will still gladly accept any help in figuring out how to build this using the source release.*