### PR TITLE
Fix typo in nixpkgs manual

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -263,7 +263,7 @@ genericBuild
    corresponding sort so that the platform rules still line up. The exact rules
    for dependency propagation can be given by assigning each sort of dependency
    two integers based one how it's host and target platforms are offset from
-   the depending derivation's platforms. Those offsets are given are given
+   the depending derivation's platforms. Those offsets are given
    below in the descriptions of each dependency list attribute.
    Algorithmically, we traverse propagated inputs, accumulating every
    propagated dep's propagated deps and adjusting them to account for the


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

