### PR TITLE
WIP: keras.weights: init at 2018-08-06

### DIFF
--- a/pkgs/applications/science/machine-learning/weights/keras/common.nix
+++ b/pkgs/applications/science/machine-learning/weights/keras/common.nix
@@ -1,0 +1,21 @@
+{ stdenvNoCC, fetchurl, model, version, weights, sha256 }:
+
+stdenvNoCC.mkDerivation rec {
+  inherit version;
+  name = "${model}-${version}";
+  src = fetchurl {
+    inherit sha256;
+    url = "https://github.com/keras-team/keras-applications/releases/download/${model}/${weights}";
+  };
+  installPhase = ''
+    ln -s "${src}" "$out"
+  '';
+  phases = [ "installPhase" ];
+  meta = with stdenvNoCC.lib; {
+    homepage = "https://github.com/keras-team/keras-applications";
+    description = "Keras ${name} weights";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/applications/science/machine-learning/weights/keras/resnet50.nix
+++ b/pkgs/applications/science/machine-learning/weights/keras/resnet50.nix
@@ -1,0 +1,12 @@
+{ stdenvNoCC, fetchurl, top ? false }:
+
+import ./common.nix {
+  inherit stdenvNoCC fetchurl;
+  model = "resnet50";
+  version = "2018-08-06";
+  weights =
+    if top
+    then "resnet50_weights_tf_dim_ordering_tf_kernels.h5"
+    else "resnet50_weights_tf_dim_ordering_tf_kernels_notop.h5";
+  sha256 = "017m98glf5jm9qwsb64mki6s28by2qm3s3pkqidw3z7kmwyv9j36";
+}


### PR DESCRIPTION
###### Motivation for this change

This is a WIP PR for integrating Keras weights into Nixpkgs. Resolving: https://github.com/NixOS/nixpkgs/issues/46922

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

