### PR TITLE
qemu: make qemu-ga and qemu-img top-level

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -192,7 +192,7 @@ in pkgs.vmTools.runInLinuxVM (
         ${if format == "raw" then ''
           mv $diskImage $out/${filename}
         '' else ''
-          ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
+          ${pkgs.qemu-img}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
         ''}
         diskImage=$out/${filename}
         ${postVM}

--- a/nixos/modules/virtualisation/brightbox-image.nix
+++ b/nixos/modules/virtualisation/brightbox-image.nix
@@ -22,7 +22,7 @@ in
             ''
               PATH=$PATH:${lib.makeBinPath [ pkgs.gnutar pkgs.gzip ]}
               pushd $out
-              ${pkgs.qemu_kvm}/bin/qemu-img convert -c -O qcow2 $diskImageBase nixos.qcow2
+              ${pkgs.qemu-img}/bin/qemu-img convert -c -O qcow2 $diskImageBase nixos.qcow2
               rm $diskImageBase
               popd
             '';

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -145,7 +145,7 @@ in {
 
       environment.LIBVIRTD_ARGS = ''--config "${configFile}" ${concatStringsSep " " cfg.extraOptions}'';
 
-      path = [ cfg.qemuPackage ] # libvirtd requires qemu-img to manage disk images
+      path = [ pkgs.qemu-img ]
              ++ optional vswitch.enable vswitch.package;
 
       preStart = ''

--- a/nixos/modules/virtualisation/qemu-guest-agent.nix
+++ b/nixos/modules/virtualisation/qemu-guest-agent.nix
@@ -25,7 +25,7 @@ in {
       systemd.services.qemu-guest-agent = {
         description = "Run the QEMU Guest Agent";
         serviceConfig = {
-          ExecStart = "${pkgs.qemu.ga}/bin/qemu-ga";
+          ExecStart = "${pkgs.qemu-ga}/bin/qemu-ga";
           Restart = "always";
           RestartSec = 0;
         };

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -19,6 +19,7 @@
 , smbdSupport ? false, samba
 , hostCpuOnly ? false
 , nixosTestRunner ? false
+, qemu-ga
 }:
 
 with stdenv.lib;
@@ -69,8 +70,6 @@ stdenv.mkDerivation rec {
     ++ optionals smbdSupport [ samba ];
 
   enableParallelBuilding = true;
-
-  outputs = [ "out" "ga" ];
 
   patches = [
     ./no-etc-install.patch
@@ -129,9 +128,6 @@ stdenv.mkDerivation rec {
       for exe in $out/bin/qemu-system-* ; do
         paxmark m $exe
       done
-      # copy qemu-ga (guest agent) to separate output
-      mkdir -p $ga/bin
-      cp $out/bin/qemu-ga $ga/bin/
     '';
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
@@ -144,6 +140,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     qemu-system-i386 = "bin/qemu-system-i386";
+    ga = qemu-ga; # backward compatible with old "pkgs.qemu.ga"
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/virtualization/qemu/qemu-ga.nix
+++ b/pkgs/applications/virtualization/qemu/qemu-ga.nix
@@ -1,0 +1,10 @@
+{ runCommand, qemu }:
+
+
+runCommand "qemu-ga-${qemu.version}" { } ''
+  install -Dm555 ${qemu}/bin/qemu-ga                      $out/bin/qemu-ga
+  install -Dm444 ${qemu}/share/man/man7/qemu-ga-ref.7.gz  $out/share/man/man7/qemu-ga-ref.7.gz
+  install -Dm444 ${qemu}/share/man/man8/qemu-ga.8.gz      $out/share/man/man8/qemu-ga.8.gz
+  install -Dm444 ${qemu}/share/doc/qemu-ga-ref.txt        $out/share/doc/qemu-ga-ref.txt
+  install -Dm444 ${qemu}/share/doc/qemu-ga-ref.html       $out/share/doc/qemu-ga-ref.html
+''

--- a/pkgs/applications/virtualization/qemu/qemu-img.nix
+++ b/pkgs/applications/virtualization/qemu/qemu-img.nix
@@ -1,0 +1,7 @@
+{ runCommand, qemu }:
+
+
+runCommand "qemu-img-${qemu.version}" { } ''
+  install -Dm555 ${qemu}/bin/qemu-img                     $out/bin/qemu-img
+  install -Dm444 ${qemu}/share/man/man1/qemu-img.1.gz     $out/share/man/man1/qemu-img.1.gz
+''

--- a/pkgs/build-support/vm/windows/bootstrap.nix
+++ b/pkgs/build-support/vm/windows/bootstrap.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, vmTools, writeScript, writeText, runCommand, makeInitrd
-, python, perl, coreutils, dosfstools, gzip, mtools, netcat-gnu, openssh, qemu
+, python, perl, coreutils, dosfstools, gzip, mtools, netcat-gnu, openssh, qemu-img
 , samba, socat, vde2, cdrkit, pathsFromGraph, gnugrep
 }:
 
@@ -22,7 +22,7 @@ let
 
   installer = import ./install {
     inherit controller mkCygwinImage;
-    inherit stdenv runCommand openssh qemu writeText dosfstools mtools;
+    inherit stdenv runCommand openssh qemu-img writeText dosfstools mtools;
   };
 in rec {
   installedVM = installer {
@@ -65,7 +65,7 @@ in rec {
   suspendedVM = stdenv.mkDerivation {
     name = "cygwin-suspended-vm";
     buildCommand = ''
-      ${qemu}/bin/qemu-img create \
+      ${qemu-img}/bin/qemu-img create \
         -b "${installedVM}/disk.img" \
         -f qcow2 winvm.img
       ${runAndSuspend}

--- a/pkgs/build-support/vm/windows/install/default.nix
+++ b/pkgs/build-support/vm/windows/install/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, openssh, qemu, controller, mkCygwinImage
+{ stdenv, runCommand, openssh, qemu-img, controller, mkCygwinImage
 , writeText, dosfstools, mtools
 }:
 
@@ -63,7 +63,7 @@ let
 in stdenv.mkDerivation {
   name = "cygwin-base-vm";
   buildCommand = ''
-    ${qemu}/bin/qemu-img create -f qcow2 winvm.img 2G
+    ${qemu-img}/bin/qemu-img create -f qcow2 winvm.img 2G
     ${installController}
     mkdir -p "$out"
     cp winvm.img "$out/disk.img"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18647,6 +18647,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa;
     inherit (darwin.stubs) rez setfile;
   };
+  qemu-ga = callPackage ../applications/virtualization/qemu/qemu-ga.nix { };
+  qemu-img = callPackage ../applications/virtualization/qemu/qemu-img.nix { };
 
   qgis = callPackage ../applications/gis/qgis {
     inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;


### PR DESCRIPTION
###### Motivation for this change

To avoid spreading many huge closures ("${qemu}/bin/qemu-img", "${qemu_kvm}/bin/qemu-img", ...) when only a small disk utility is needed

After discusstion in https://github.com/NixOS/nixpkgs/pull/48293

@xeji 