### PR TITLE
trojita: build translation files

### DIFF
--- a/pkgs/applications/networking/mailreaders/trojita/default.nix
+++ b/pkgs/applications/networking/mailreaders/trojita/default.nix
@@ -1,19 +1,19 @@
 { mkDerivation
 , lib
-, fetchgit
+, fetchurl
 , cmake
 , qtbase
 , qtwebkit
+, qttools
 }:
 
 mkDerivation rec {
   name = "trojita-${version}";
   version = "0.7";
 
-  src = fetchgit {
-    url = "https://anongit.kde.org/trojita.git";
-    rev = "065d527c63e8e4a3ca0df73994f848b52e14ed58";
-    sha256 = "1zlwhir33hha2p3l08wnb4njnfdg69j88ycf1fa4q3x86qm3r7hw";
+  src = fetchurl {
+    url = "mirror://sourceforge/trojita/trojita/${name}.tar.xz";
+    sha256 = "1n9n07md23ny6asyw0xpih37vlwzp7vawbkprl7a1bqwfa0si3g0";
   };
 
   buildInputs = [
@@ -23,6 +23,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    qttools
   ];
 
 


### PR DESCRIPTION
###### Motivation for this change

Enable localization of Trojitá.

* Use the release tarball, because translation files are not included in the git repository.

* Add `qttools` needed for compiling translation files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

