### PR TITLE
pymssql: init at 2.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4907,4 +4907,9 @@
     github = "zzamboni";
     name = "Diego Zamboni";
   };
+  mredaelli = {
+    email = "massimo@typish.io";
+    github = "mredaelli";
+    name = "Massimo Redaelli";
+  };
 }

--- a/pkgs/development/python-modules/pymssql/default.nix
+++ b/pkgs/development/python-modules/pymssql/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, freetds, cython, setuptools-git }:
+
+buildPythonPackage rec {
+  pname = "pymssql";
+  version = "2.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yvs3azd8dkf40lybr9wvswvf4hbxn5ys9ypansmbbb328dyn09j";
+  };
+
+  buildInputs = [cython setuptools-git];
+  propagatedBuildInputs = [freetds];
+
+  # The tests require a running instance of SQLServer, so we skip them
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = http://pymssql.org/en/stable/;
+    description = "A simple database interface for Python that builds on top
+      of FreeTDS to provide a Python DB-API (PEP-249) interface to Microsoft
+      SQL Server";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11071,6 +11071,8 @@ EOF
 
   scour = callPackage ../development/python-modules/scour { };
 
+  pymssql = callPackage ../development/python-modules/pymssql { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Missing package from python collection

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

