### PR TITLE
parity: 2.0.8 -> 2.1.6; parity-beta: 2.1.3 -> 2.2.1

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,9 +1,9 @@
 let
-  version     = "2.1.3";
-  sha256      = "0il18r229r32jzwsjksp8cc63rp6cf6c0j5dvbfzrnv1zndw0cg3";
-  cargoSha256 = "08dyb0lgf66zfq9xmfkhcn6rj070d49dm0rjl3v39sfag6sryz20";
+  version     = "2.2.1";
+  sha256      = "1m65pks2jk83j82f1i901p03qb54xhcp6gfjngcm975187zzvmcq";
+  cargoSha256 = "1mf1jgphwvhlqkvzrgbhnqfyqgf3ljc1l9zckyilzmw5k4lf4g1w";
   patches     = [
-    ./patches/vendored-sources-2.1.patch
+    ./patches/vendored-sources-2.2.patch
   ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,7 +1,7 @@
 let
-  version     = "2.0.8";
-  sha256      = "1bz6dvx8wxhs3g447s62d9091sard2x7w2zd6iy7hf76wg0p73hr";
-  cargoSha256 = "0wj93md87fr7a9ag73h0rd9xxqscl0lhbj3g3kvnqrqz9xxajing";
-  patches     = [ ./patches/vendored-sources-2.0.patch ];
+  version     = "2.1.6";
+  sha256      = "0njkypszi0fjh9y0zfgxbycs4c1wpylk7wx6xn1pp6gqvvri6hav";
+  cargoSha256 = "116sj7pi50k5gb1i618g4pgckqaf8kb13jh2a3shj2kwywzzcgjs";
+  patches     = [ ./patches/vendored-sources-2.1.patch ];
 in
   import ./parity.nix { inherit version sha256 cargoSha256 patches; }

--- a/pkgs/applications/altcoins/parity/patches/vendored-sources-2.1.patch
+++ b/pkgs/applications/altcoins/parity/patches/vendored-sources-2.1.patch
@@ -14,7 +14,7 @@ index 72652ad2f..3c0eca89a 100644
 +
 +[source."https://github.com/nikvolf/parity-tokio-ipc"]
 +git = "https://github.com/nikvolf/parity-tokio-ipc"
-+rev = "7c9bbe3bc45d8e72a92b0951acc877da228abd50"
++rev = "c0f80b40399d7f08ef1e6869569640eb28645f56"
 +replace-with = "vendored-sources"
 +
 +[source."https://github.com/nikvolf/tokio-named-pipes"]

--- a/pkgs/applications/altcoins/parity/patches/vendored-sources-2.2.patch
+++ b/pkgs/applications/altcoins/parity/patches/vendored-sources-2.2.patch
@@ -44,7 +44,7 @@ index 72652ad2f..3c0eca89a 100644
 +
 +[source."https://github.com/paritytech/jsonrpc.git"]
 +git = "https://github.com/paritytech/jsonrpc.git"
-+branch = "parity-1.11"
++branch = "parity-2.2"
 +replace-with = "vendored-sources"
 +
 +[source."https://github.com/paritytech/libusb-rs"]


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/paritytech/parity-ethereum/releases/tag/v2.2.1
* https://github.com/paritytech/parity-ethereum/releases/tag/v2.1.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

