### PR TITLE
slic3r-prusa3d: multiple fixes

### DIFF
--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, which, cmake, perl, perlPackages,
+{ stdenv, lib, fetchFromGitHub, makeWrapper, which, cmake, perl, perlPackages,
   boost, tbb, wxGTK30, pkgconfig, gtk3, fetchurl, gtk2, libGLU,
   glew, eigen, curl, gtest, nlopt, pcre, xorg }:
 let
@@ -98,6 +98,10 @@ stdenv.mkDerivation rec {
     # seems to be the easiest way.
     sed -i "s|\''${PERL_VENDORARCH}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
     sed -i "s|\''${PERL_VENDORLIB}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
+  '' + lib.optionalString (lib.versionOlder "2.5" nlopt.version) ''
+    # Since version 2.5.0 of nlopt we need to link to libnlopt, as libnlopt_cxx
+    # now seems to be integrated into the main lib.
+    sed -i 's|nlopt_cxx|nlopt|g' xs/src/libnest2d/cmake_modules/FindNLopt.cmake
   '';
 
   postInstall = ''

--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "Slic3r";
-    sha256 = "0068wwsjwmnxql7653vy3labcyslzf17kr8xdr4lg2jplm022hvy";
+    sha256 = "0crjrll8cjpkllval6abrqzvzp8g3rnb4vmwi5vivw0jvdv3w5y7";
     rev = "version_${version}";
   };
 

--- a/pkgs/development/libraries/nlopt/default.nix
+++ b/pkgs/development/libraries/nlopt/default.nix
@@ -1,13 +1,8 @@
 { fetchurl, stdenv, octave ? null, cmake }:
 
-let
-
-  version = "2.5.0";
-
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "nlopt-${version}";
+  version = "2.5.0";
 
   src = fetchurl {
     url = "https://github.com/stevengj/nlopt/archive/v${version}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

1. Fix sha256 for version 1.41.1 because the release tag was updated a few days after the initial release.
2. building of the package broke with the update to nlopt 2.5.0. After patching the lib name in the source it works just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc 
