### PR TITLE
Update gambit and gerbil to new upstream releases

### DIFF
--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, autoconf, ... }:
+{ stdenv, fetchurl, autoconf, git, ... }:
 
 stdenv.mkDerivation rec {
   name    = "gambit-bootstrap-${version}";
-  version = "4.8.9";
-  tarball_version = "v4_8_9";
+  version = "4.9.1";
+  tarball_version = "v4_9_1";
 
   src = fetchurl {
-    url    = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.8/source/gambit-${tarball_version}-devel.tgz";
-    sha256 = "b7f86c794711792ca556ce41f8bc7043dffc395c01bb6d8d119bc2f454f89fbf";
+    url    = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-${tarball_version}-devel.tgz";
+    sha256 = "10kzv568gimp9nzh5xw0h01vw50wi68z3awfp9ibqrpq2l0n7mw7";
   };
 
-  buildInputs = [ autoconf ];
+  buildInputs = [ autoconf git ];
 
   configurePhase = ''
     ./configure --prefix=$out

--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -1,8 +1,8 @@
-{ stdenv, git, openssl, autoconf, pkgs, makeStaticLibraries, version, SRC }:
+{ stdenv, git, openssl, autoconf, pkgs, makeStaticLibraries, version, src }:
 
 stdenv.mkDerivation rec {
   name    = "gambit-${version}";
-  src     = SRC;
+  inherit src;
 
   bootstrap = import ./bootstrap.nix ( pkgs );
 

--- a/pkgs/development/compilers/gambit/default.nix
+++ b/pkgs/development/compilers/gambit/default.nix
@@ -1,11 +1,10 @@
 { stdenv, callPackage, fetchurl }:
 
 callPackage ./build.nix {
-  version = "4.9.0";
-
-  SRC = fetchurl {
-    url = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-v4_9_0-devel.tgz";
-    sha256 = "0wyfpjs244zrbrdil9rfkdgcawvms84z0r77qwhwadghma4dqgjf";
+  version = "4.9.1";
+  src = fetchurl {
+    url = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-v4_9_1-devel.tgz";
+    sha256 = "10kzv568gimp9nzh5xw0h01vw50wi68z3awfp9ibqrpq2l0n7mw7";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,12 +1,13 @@
-{ stdenv, callPackage, fetchgit }:
+{ stdenv, callPackage, fetchFromGitHub }:
 
 callPackage ./build.nix {
-  version = "unstable-2018-09-03";
-# git-version = "4.9.0";
-  SRC = fetchgit {
-    url = "https://github.com/feeley/gambit.git";
-    rev = "7cdc7e7b9194b2c088c0667efaf7686a4ffd0d8a";
-    sha256 = "06mmi8jkinihfirz4gjfw2lhxhskiqf3d47sihzx10r60asyqcxg";
+  version = "unstable-2018-11-19";
+# git-version = "4.9.1-8-g61c6cb50";
+  src = fetchFromGitHub {
+    owner = "feeley";
+    repo = "gambit";
+    rev = "61c6cb500f4756be1e52095d5ab4501752525a70";
+    sha256 = "1knpb40y1g09c6yqd2fsxm3bk56bl5xrrwfsd7nqa497x6ngm5pn";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -1,20 +1,20 @@
 { stdenv, makeStaticLibraries,
   coreutils, rsync, bash,
   openssl, zlib, sqlite, libxml2, libyaml, mysql, lmdb, leveldb, postgresql,
-  version, git-version, GAMBIT, SRC }:
+  version, git-version, gambit, src }:
 
 # TODO: distinct packages for gerbil-release and gerbil-devel
 # TODO: make static compilation work
 
 stdenv.mkDerivation rec {
   name    = "gerbil-${version}";
-  src     = SRC;
+  inherit src;
 
   # Use makeStaticLibraries to enable creation of statically linked binaries
   buildInputs_libraries = [ openssl zlib sqlite libxml2 libyaml mysql.connector-c lmdb leveldb postgresql ];
   buildInputs_staticLibraries = map makeStaticLibraries buildInputs_libraries;
 
-  buildInputs = [ GAMBIT coreutils rsync bash ]
+  buildInputs = [ gambit rsync bash ]
     ++ buildInputs_libraries ++ buildInputs_staticLibraries;
 
   NIX_CFLAGS_COMPILE = [ "-I${mysql.connector-c}/include/mysql" "-L${mysql.connector-c}/lib/mysql" ];
@@ -66,9 +66,9 @@ EOF
 export GERBIL_HOME=$out
 case "\$1" in -:*) GSIOPTIONS=\$1 ; shift ;; esac
 if [[ \$# = 0 ]] ; then
-  exec ${GAMBIT}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init \$GERBIL_HOME/lib/gxi-interactive - ;
+  exec ${gambit}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init \$GERBIL_HOME/lib/gxi-interactive - ;
 else
-  exec ${GAMBIT}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init "\$@"
+  exec ${gambit}/bin/gsi \$GSIOPTIONS \$GERBIL_HOME/lib/gxi-init "\$@"
 fi
 EOF
     runHook postInstall

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, callPackage, fetchurl, gambit }:
+{ stdenv, callPackage, fetchFromGitHub, gambit }:
 
-callPackage ./build.nix {
-  version = "0.13";
-  git-version = "0.13";
-  GAMBIT = gambit;
-  SRC = fetchurl {
-    url = "https://github.com/vyzo/gerbil/archive/v0.13.tar.gz";
-    sha256 = "1qs0vdq2lgxlpw20s8jzw2adx1xk9wb3w2m4a8vp6bb8hagmfr5l";
+callPackage ./build.nix rec {
+  version = "0.14";
+  git-version = "0.14";
+  inherit gambit;
+  src = fetchFromGitHub {
+    owner = "vyzo";
+    repo = "gerbil";
+    rev = "v${version}";
+    sha256 = "0n078lkf8m391kr99ipb1v2dpi5vkikz9nj0p7kfjg43868my3v7";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,13 +1,14 @@
-{ stdenv, callPackage, fetchgit, gambit-unstable }:
+{ stdenv, callPackage, fetchFromGitHub, gambit-unstable }:
 
 callPackage ./build.nix {
-  version = "unstable-2018-09-06";
-  git-version = "0.14-DEV";
-  GAMBIT = gambit-unstable;
-  SRC = fetchgit {
-    url = "https://github.com/vyzo/gerbil.git";
-    rev = "184cb635c82517d5d75d7966dcdf1d25ad863dac";
-    sha256 = "1ljzbpc36i9zpzfwra5hpfbgzj1dyzzp50h5jf976n8qr9x4l7an";
+  version = "unstable-2018-11-19";
+  git-version = "0.15-DEV-2-g7d09a4ce";
+  gambit = gambit-unstable;
+  src = fetchFromGitHub {
+    owner = "vyzo";
+    repo = "gerbil";
+    rev = "7d09a4cebe03d755a1791e77279e156a74e07685";
+    sha256 = "1mqi9xcjk59sqbh1fx65a4fa4mqm35py4xqxq6086bcyhkm1nzwa";
   };
   inherit stdenv;
 }


### PR DESCRIPTION
###### Motivation for this change

Update gambit and gerbil to new upstream releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
