### PR TITLE
bookworm: 2018-10-21 -> unstable-2018-11-19

### DIFF
--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -3,24 +3,16 @@
 
 stdenv.mkDerivation rec {
   pname = "bookworm";
-  version = "4f7b118281667d22f1b3205edf0b775341fa49cb";
+  version = "unstable-2018-11-19";
 
-  name = "${pname}-2018-10-21";
+  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "babluboy";
     repo = pname;
-    rev = version;
-    sha256 = "0bcyim87zk4b4xmgfs158lnds3y8jg7ppzw54kjpc9rh66fpn3b9";
+    rev = "4c3061784ff42151cac77d12bf2a28bf831fdfc5";
+    sha256 = "0yrqxa60xlvz249kx966z5krx8i7h17ac0hjgq9p8f0irzy5yp0n";
   };
-
-  # See: https://github.com/babluboy/bookworm/pull/220
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/worldofpeace/bookworm/commit/b2faf685c46b95d6a2d4ec3725e4e4122b61e99a.patch";
-      sha256 = "14az86cj5j65hngfflrp1rmnrkdrhg2a8pl7www3jgfwasxay975";
-    })
-  ];
 
   nativeBuildInputs = [
     bash


### PR DESCRIPTION
###### Motivation for this change
The author iterated off of https://github.com/babluboy/bookworm/pull/220 with their adapted solution https://github.com/babluboy/bookworm/commit/07fbf07ccf9591f69267b5783581b26ca27ff313.

So an update to include this proper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jtojnar
