### PR TITLE
Add traverso: init at 0.49.5

### DIFF
--- a/pkgs/applications/audio/traverso/default.nix
+++ b/pkgs/applications/audio/traverso/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, cmake, pkgconfig
+, alsaLib, fftw, flac, lame, libjack2, libmad, libpulseaudio
+, libsamplerate, libsndfile, libvorbis, portaudio, qtbase, wavpack
+}:
+stdenv.mkDerivation rec {
+  name = "traverso-${version}";
+  version = "0.49.5";
+
+  src = fetchurl {
+    url = "http://traverso-daw.org/traverso-0.49.5.tar.gz";
+    sha256 = "169dsqrf807ciavrd82d3iil0xy0r3i1js08xshcrn80ws9hv63m";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ alsaLib fftw flac.dev libjack2 lame
+                  libmad libpulseaudio libsamplerate.dev libsndfile.dev libvorbis
+                  portaudio qtbase wavpack ];
+
+  cmakeFlags = [ "-DWANT_PORTAUDIO=1" "-DWANT_PULSEAUDIO=1" "-DWANT_MP3_ENCODE=1" "-DWANT_LV2=0" ];
+
+  enableParallelBuilding = true;
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform multitrack audio recording and audio editing suite";
+    homepage = http://traverso-daw.org/;
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ coconnor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19387,6 +19387,8 @@ with pkgs;
 
   transgui = callPackage ../applications/networking/p2p/transgui { };
 
+  traverso = libsForQt5.callPackage ../applications/audio/traverso { };
+
   trayer = callPackage ../applications/window-managers/trayer { };
 
   tree = callPackage ../tools/system/tree {};


### PR DESCRIPTION
###### Motivation for this change

add traverso and WavePack dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

