### PR TITLE
cyrus-sasl 2.1.26 -> 2.1.27 w/ cross-compiling support

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/cyrus-sasl-ac-try-run-fix.patch
+++ b/pkgs/development/libraries/cyrus-sasl/cyrus-sasl-ac-try-run-fix.patch
@@ -1,0 +1,12 @@
+--- a/m4/sasl2.m4	2018-11-18 22:33:29.902625600 +0300
++++ b/m4/sasl2.m4	2018-11-18 22:33:59.828746176 +0300
+@@ -339,7 +339,8 @@
+ ],	
+ 	[ AC_DEFINE(HAVE_GSS_SPNEGO,,[Define if your GSSAPI implementation supports SPNEGO])
+ 	AC_MSG_RESULT(yes) ],
+-	AC_MSG_RESULT(no))
++	AC_MSG_RESULT(no),
++    AC_MSG_RESULT(no))
+   LIBS="$cmu_save_LIBS"
+ 
+ else

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -1,32 +1,33 @@
 { lib, stdenv, fetchurl, openssl, openldap, kerberos, db, gettext,
-  pam, fixDarwinDylibNames, autoreconfHook, fetchpatch, enableLdap ? false }:
+  pam, fixDarwinDylibNames, autoreconfHook, fetchpatch, enableLdap ? false,
+  buildPackages, autoconf, automake, libtool }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "cyrus-sasl-${version}${optionalString (kerberos == null) "-without-kerberos"}";
-  version = "2.1.26";
+  version = "2.1.27";
 
   src = fetchurl {
     url = "ftp://ftp.cyrusimap.org/cyrus-sasl/${name}.tar.gz";
-    sha256 = "1hvvbcsg21nlncbgs0cgn3iwlnb3vannzwsp6rwvnn9ba4v53g4g";
+    sha256 = "1m85zcpgfdhm43cavpdkhb1s2zq1b31472hq1w1gs3xh94anp1i6";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  #doCheck = true; # false; # stdenv.hostPlatform != stdenv.buildPlatform;
 
+  nativeBuildInputs = [ stdenv.cc autoconf automake libtool ];
   buildInputs =
     [ openssl db gettext kerberos ]
     ++ lib.optional enableLdap openldap
-    ++ lib.optional stdenv.isFreeBSD autoreconfHook
+    # ++ lib.optional stdenv.isFreeBSD autoreconfHook
+    ++ [autoreconfHook]
     ++ lib.optional stdenv.isLinux pam
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   patches = [
     ./missing-size_t.patch # https://bugzilla.redhat.com/show_bug.cgi?id=906519
-    (fetchpatch {
-      name = "CVE-2013-4122.patch";
-      url = "http://sourceforge.net/projects/miscellaneouspa/files/glibc217/cyrus-sasl-2.1.26-glibc217-crypt.diff";
-      sha256 = "05l7dh1w9d5fvzg0pjwzqh0fy4ah8y5cv6v67s4ssbq8xwd4pkf2";
-    })
+    ./cyrus-sasl-ac-try-run-fix.patch
   ] ++ lib.optional stdenv.isFreeBSD (
       fetchurl {
         url = "http://www.linuxfromscratch.org/patches/blfs/svn/cyrus-sasl-2.1.26-fixes-3.patch";
@@ -41,10 +42,6 @@ stdenv.mkDerivation rec {
     "--enable-login"
     "--enable-shared"
   ] ++ lib.optional enableLdap "--with-ldap=${openldap.dev}";
-
-  # Avoid triggering regenerating using broken autoconf/libtool bits.
-  # (many distributions carry patches to remove/replace, but this works for now)
-  dontUpdateAutotoolsGnuConfigScripts = if stdenv.hostPlatform.isMusl then true else null;
 
   installFlags = lib.optional stdenv.isDarwin [ "framedir=$(out)/Library/Frameworks/SASL2.framework" ];
 


### PR DESCRIPTION
###### Motivation for this change
New version of cyrus-sasl with cross-compilation support.

See: https://github.com/NixOS/nixpkgs/pull/50546 and https://github.com/NixOS/nixpkgs/issues/50539

Thanks to @dtzWill 

ping @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

