### PR TITLE
firefox-bin: 63.0.1 -> 63.0.3

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "63.0.1";
+  version = "63.0.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ach/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ach/firefox-63.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "fcf06e003f7e3bfc79288d9f0199ad2ca13a91eee718437d25c745381dbb351483b992b0cad929e9c869d4a993eee66b2206ddb6e98023f12f4351f41e61313b";
+      sha512 = "d3b6903784c12e088e7e899c00321a6589f1cad08149cfaa169ea0c4608ef5f736c85bf6d447bcfdf3f9be28c9edc0e91dacbc77c0927a76807a6b133013f45e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/af/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/af/firefox-63.0.3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "8b8515147df6deaff4356fee727acb377c3f46cc288271da813f6bb752a3a62585262d0e5a5760d6bc5c8d6f7e84b2d76825ff55dab8bdb5e20fe345230a3bc0";
+      sha512 = "439042bb60b1a10e9e2b8fe0d8278b9d0fc86629e37ca009bb5ada25fac3d2ec264b6f4a5c238c28278870fe9b9582f4e6d45d17e3d524a79fdac3bf4d0c001f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/an/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/an/firefox-63.0.3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "c532a212522ad51e0718339e1962f275b49d15a0e67cf397c1fc9dfdfddeb746a59572ef2cf1661f480736ecb7a77ce7da62f65f3e7898e2fe53321512820a70";
+      sha512 = "47f76b7a5d5581b01d11671b46aad00d5b7cfd839638e17fab1776b8daa77c5331467cecf49049eb2432bf44cc4481a95edfa31dc9d7f5c06d0cf48ffd9ff58c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ar/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ar/firefox-63.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "35fbbb6d2f53293eaee86d9d402d556abea5a5c62a1a282f35ea97d7afee57e2b222ad96f2c91ac8b30f6501e96d8702a52e2f96556abd838c244a36720d123f";
+      sha512 = "36be60b55d68baf409967fd8baee8bdfecb6d3028f9eab7f5c1f05e509346d24a7da0b02dd9432e951f9e0c68dcc8b2dd20fd706c385102b0f6c66dd4dc27274";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/as/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/as/firefox-63.0.3.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "86fc2f0b5089997dff76f5b5b4ef1e4be465da16a8fc119ab88ddf96cf6fbdfb4dca1e384ce336a033ca5430f041c60d34afaa3dfee9a8afb93d26c7717314b4";
+      sha512 = "4b646edb3120c5cf0cfc43f92088769283bd00b532ec3fcb6842cc1579e7929e29ff2927a2cd7466082ab439832fa7fcb3b4e47f35e004795c9922209146184d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ast/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ast/firefox-63.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "ba960a426f0c6ccd703e3b12bc08c29dff71cb829a66346cceb689233c62777ed22ea047624833f6584867cf78c040684cccbae99a9518eaff069af756eeb983";
+      sha512 = "721bde1824cabba2a93dc87c44274c0bc2707768a6f4b6e53b78934de01ae6c49d305390df97a9d38453711ad29aadf9ba7097e7cc0a52bdb7a1d24e660ba1b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/az/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/az/firefox-63.0.3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "6e2e9231fe88fed849c2d1850f24ab169a901b68be4bde9d9875d2cb736ae4c1456f53c2964f4f00b80ecf2e46543b4cd25cfed31cb04dbe4fae3a040432352c";
+      sha512 = "ec5379e1b265f5f37f07a078832bbffe39171056fc7df67347f7895f156434df82d9686491d353b323c15d5d012033109abd13f1ae02fb1d8d91f0123c95ae21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/be/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/be/firefox-63.0.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "379ec5a79a4af1b141485230b9c5af0b622845df43499616417debead4db466ad16f7a63c1c0e8c09b4bddae288772bfcd2aea115a780a551e90001b2d353364";
+      sha512 = "b350d461721a7805906b42f1af650cb575cd6dba5d92345d2096218781328e20e2867ec712b8bc266a79e6246fae6391d698122b50abadd16c7db8edb293eedb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bg/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/bg/firefox-63.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "4aed2144069d39f00a0ab2f45ca7532f9f97684ff18cb2596b20b6639edbd793e0c4857b784657c354caa7503c2df6497ef0f298fbf438954c2c46de3c2f29b1";
+      sha512 = "5b31fd7bd8645b143c2728a5ccb29bd41469237ba56bd443897b8e475f3b46e549feecbfe6a4ccaaab9f3455f42d23b04aaa3cfe8d7c34543b9cc32d712dc911";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bn-BD/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/bn-BD/firefox-63.0.3.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "bf87308c72330e32efe1473d879f36097fc1d0e697ab6f9034a03c5e872353ab5c2cb7391aa274b35e08c6102986a08ede184810e821f8ba02838d469b623528";
+      sha512 = "a9b9ca336c633d9e24af47d9bf521a60ad5208a29721fab9fa4b2f9b91e80e8d572e4e0c0e5180e4da964db66a8cd5468a942e4b6270ba9c7a182de9aa34387c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bn-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/bn-IN/firefox-63.0.3.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "0063c6dce614b8efa9a663c60d2d393816f6a65c87aa1a1a6a96f501cfc7e86a05b038ab5173b13bd86a2a02dcb3ac6ed15bb4e4c8eefd371027e07cb31c1e5c";
+      sha512 = "f9ff091a08629ab3ea91de7cee5a54b62533f776bcb4cb1765e3162d407b2151c507eaf3ab0543b08674386ca86d6669af6e13211bb9acc0ccba964cc82f932f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/br/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/br/firefox-63.0.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "93c3a9a59386c211c32c9aec1aeca3ab0a3f0b878001f6485a42283c2ca6fedc6847d7c2fddea870da462967dfddb94f518cbe0f115838b313d803ae8f12df65";
+      sha512 = "9812e0aa9078cbceebb43cc0413c5695499487164d18ea25cacff1cbe1a112870a833ee18f65738baa0210c7cadcda26edd7dd2ad96a423b67c4b5ad6d9000d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/bs/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/bs/firefox-63.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "d191539482457407ae37e47b52b4d79eb99ebf2ed2999921c695268b6e3dc75b96ba93131f70666b29a3c2e73bad0a470abfd99c2f51d2ea3eb4af52296846fe";
+      sha512 = "5a7fa12e6aaffdd0c5f40ec10e237e66c43009340fb8223cb40becb98bc8dfa03478f9d586e25b7c4008aaed8f3be57b40b568193771aac5bea3e57eb49d7e58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ca/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ca/firefox-63.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "41520a18c201bea97b56a70a74546f7a2f2f1909f303740e14cf79701499bd26494cd453ebd630ce100ddd17b5ffcea08e8a9d95f908425da0a9ad22dd751dea";
+      sha512 = "391eeb7a5157e329ac4382d11ee5212c72721a176cfdacadea7abb65c41453e8b67b31a6f8f58e60ddb87d4b78460d10a8d4fbc64c94ce65790ead041dfdbce9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/cak/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/cak/firefox-63.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "24aaa62ff598ee48d9c9b6b19e92adc38d00eeaec7d7d562160955c751ba5e3b01f281cc59a0fcecdfd24d6a792f070c151c58ba23d1db55699c25988ea9412f";
+      sha512 = "5d54a2703261759948b3214498b73bfa5c56e01f2dcf29ed473c88a0e4ba1ef7e700e45d70710dbd0ad6e146538898537e11c1577e2f9a4fc03bd58f66ad9484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/cs/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/cs/firefox-63.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "b29c9ae988b40ba77cf036d92b4d9cbcdc8af0c7c8e76f97222a3544bef06c81682fa35ab9e24a5f3d224873d2359e3c1f73b61de4101106ab4da57d3a362d44";
+      sha512 = "07229a1818d82890a880dd62b3e9bfa693696c78d4c2a994499d6505c5326be42cb5924ae6a00a745999e0e4537b60203991eda2ce08818c0a66c1333b13e80a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/cy/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/cy/firefox-63.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "99963d98d62d811c03b2a841fb97b31f10b5d14a98b5bc5918f4c7164663511efc9a36a7271a6927fcbcfe00fb7d15693a7d031f6305d9dbc0e7e0718699d314";
+      sha512 = "a076631f14cb3a03e1e2dd857d1265eda0a4c5393c18104dae32c6b80c58035d39614cdd732224c74fa3e35b292b6d1e43cb573e19263d7a5976b9d7e4faf762";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/da/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/da/firefox-63.0.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "622cf4fd584b9e4bc07661874093b1281b53e985355679b914b5becdd78b25daa43b3e6f0a220707fbe21f4a41c85d81728ccd2af998ca0be938e8ae955d6e56";
+      sha512 = "6f8d9acb5698043f40888af0f91119f3d94177d2d0b6b3fcc476f7acb5d084559e87e6a9954dd19582fe21e08b506ded8b10bcff88d740dd07ee070c93d52455";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/de/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/de/firefox-63.0.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "af9d143a4d5f26f81474681945b171fb9be80f7e679aeaeb08175d3b0957e274ea1ee4112781607c170a0af479dd45c5ec3d88b5cd39bac37e59d1343474dc02";
+      sha512 = "50b188ff30d83025d3f563555acca80d5aa668aabd0399767915f27a84f43aeb4c19fc880e1b56a1bf365b937634496fa07ba26159c1d90c139a26c2b057fb7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/dsb/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/dsb/firefox-63.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "963604bcd19ee34949ab256e1276423d3de262a87d8d5f3e098cab11af2ed62ecb793b86817e54f490f5accd32d7c35a50aab583118eee79270e827032edc464";
+      sha512 = "00dd71e17b27d1a237d006ab12cb5e7a4e9b0d8468b2fcf971c43bfc80af4699ad0b7dd2de91eb6ece867a15ca7cfedf46131c422f25830527ca039c5f7dbd78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/el/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/el/firefox-63.0.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "9831e750314c3514e6e885dc4930836e296537cb16c8a9da189c9f53d122e0731e30fc068fbdc8cefe2582aad715d9eb36746bf7b289a45410c99e8ffcc4ee8a";
+      sha512 = "fb70f41a2c7a9e4ce80954b59ce7ae3c9dcff830154ec1228cd1e426e130d4cfd3455a067deecc787d086dcbd6ddf682c6ddcb6d303b5228fb5cae3058e4c543";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-CA/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/en-CA/firefox-63.0.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "6cb022756601db6273bfc2e84e9e7fc24e8d427ae5905c85b8f674132a740a9f7b1eb34562f996bb31be03cb7fa6173f3aff80fcec6c41c0e0e25a34180d8cc7";
+      sha512 = "d0b7e57956b3a68dfc6cc08e184f12319f728230facc26ab10d59d6810a415216dd68c000e0697a17f0371dc7d36286fe08dd3ddf47e13f0f87132756997cd27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-GB/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/en-GB/firefox-63.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "1ecfd9ed098a97c9b6952f5ee56560cc7e5c9ee8976a0e744e8c50debd2eb100e4f4d3842593dfd6244740b7b48a9e64e49b082345197f969e4a0b52f9866196";
+      sha512 = "8c7fd388742c1a663beca3bcc84d28824a1b59d606e3ddede3e285783f3b4594633cf8fbf11b4c046ba99d74d1ca77f8bb142fa6fbb6710af00a515a87205153";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-US/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/en-US/firefox-63.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "49d776cfb5f42c6e5ea1a55a80d9f6bad223080b16baa0d39de63534c25e68340091b4e16be5355d565f81291cb94fb996f03ae7e3e4c7a28021b0a0929daf58";
+      sha512 = "d91a0351d1504a184293161fc1f3dd7d1280612e63f08662ac6f95564a72dbcf6ea455f193239ca8fef014c32c024ce1765b708b427ab3c1bafb00fdd8d0a4c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/en-ZA/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/en-ZA/firefox-63.0.3.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "b3c8b9282822eca4a0be69eb4b26cc9e6fb0e20e7cb0e8244a1e54a680dee570ada3f6085e4efab67c63b68cbea64c8978a3ea430a791ae1b3bd71d31c03302f";
+      sha512 = "32fbff149611344304e258d3c649bc26aa971c86ffe9ea6e8088a57e4e8af55643dcbc8ee662305633f2d0fa9ebaf5bef149621db39110892191d3f9b717fef6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/eo/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/eo/firefox-63.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "c08f5dce7559e3e363b8b66a3402697ec1b62e893c825c5820c8a0978a6d41431101a479a59b04065bd36f50c044c79de4e45e23fdd0a819fbd379bdbf65be22";
+      sha512 = "56a5212f84b01fe0607ec746e6fc87a855ed5b47f4db9a5326da097c0fba6c7ebadfb237f535b99b614d3c987c7b70669196394271a12335df76968e36f642ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-AR/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/es-AR/firefox-63.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "ebbc1b36010ee9988ad2f63b100d48e52be391ea85ef170a8838978471b9354aa1d9a55a27d8214d4639c60879fecd56f0a488a38da5520dfb79aab078571a35";
+      sha512 = "e010e4f110938477bee317dcd4b8351568300c3539172721736fc2c63ba2ed14d88188c1d172afa10cf39c4cad6ed71d2e1b806d0197836c5fae6c98768686f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-CL/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/es-CL/firefox-63.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "aaa97d383fa7efa07d8958603f5bd5a0022bfd94f99d0644adf824544e4c1a932ec1b0bc10b78a409accd3c1e1e9e51231186f8063d9bf7cda5958447a27cc9b";
+      sha512 = "7590deb6e39b5c983ed04f3bef77146153d4e2c41e6fb9d47a042a6943295588ac536f682c21adc06d2e63d6656b74bbab7a4bece22e948d26869502f5e1d89e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-ES/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/es-ES/firefox-63.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "cd742475b06eaeee5edd8561c9c5b45e95f0544a3a9e607b961827bf3dac722ea1fa124dd2eecfd18e339cf784694d267a83efd09c798608d99db66c0cbc078b";
+      sha512 = "0acb74dd10d3d35fb175d8376d548f7546447f9328d9c47b18ba829a1b4dfdaa13798aa235212ac5d30d5f297ceb22bd63003cec43e6869ffefdd362250def1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/es-MX/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/es-MX/firefox-63.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "704856a075a4ddaf811856e3e2258e267bef132d9760e7ae61c81c5c832cbeece35cfd5018b69155a7673e93b439ab6997920164e6bf90d2564858385667b9a8";
+      sha512 = "c71d592ee0aeeac6e8ee4ea9ecd8626b0d2f96c82e7571c3c0983703507be68bb84e414461e064a8bbadd57f3462d9a1bed5effde1f459a5cb95e554f02a4fc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/et/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/et/firefox-63.0.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "462bf71afc7ee40e2ddadd80f07d154b940075f1d88bd132513a6db776c6fb6ea98a02137cb60a3d8ad12c999313401ff4ec3fe498a2a2374cd8d11b6b0cc149";
+      sha512 = "92675de877c8248dbf1a8bb820235a41f2daa172ea81e0124fe12ba4f31f891f027e54b9a0cec7f51e6b2f133708491474760cfc27d896e163ec1e6fc214ef4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/eu/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/eu/firefox-63.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "7869247c5b534874836ec636dcdd4186eaf5ad760eba1e7430b207d76454c5d9384f5b6d3ddd638380383504a17012ccd4c54acf4088aa428220e2be40e197ff";
+      sha512 = "bf7bcb992fab3a332ac9a1b5bf965c403c676542acff0990ce8f7ae32823ee84401af0117690e390c70583debdc7070e2b3ae4055ba4bdfaa83fb3717510f3be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fa/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/fa/firefox-63.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "6dd1a2cda0e1e3837d8aa5fbbbd8a842dfedaa90a5e5b07249d904046b7645b5b025b90a2302e5b4751b958fa506305a9bedc89db7eabc663fc8a4461427572d";
+      sha512 = "76c1f2343695954da3a54c53522e5a3fcca47134419ad470f468fa14aa404bfb2065cb47bab72348b84e6b52ee36e3731eb2c724078a1e8925d62e0439ae079a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ff/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ff/firefox-63.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "2c5da87b5879283fab3f59f5a7e628464efc1132f36f753404a805a2805e0305642cdbd1f6cee22384b1fad26315666fdcbe954e28a1661b27a2d8d9731b3f46";
+      sha512 = "fdd12b9f1dbe7836368f93ca9bc27387affafd0bb2dcb37bba66aa9610595fb8ab490f597d4ecacbc0a568d266aeebe0293704d141590b3ee49fdfea2ae703e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fi/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/fi/firefox-63.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "9c4fecc333e4cdd779ac3e0f08f6c5dfb65d685a82295d0d6b24ca5d7709d5287e1e21515b41cb86014e59b2c87b8fb83f1625b8a1e8b1e74c1819d21fc02c3e";
+      sha512 = "17670fae7a12fb633d02bba4aaf204159a9149e1a7fc2819e600dddb05ddc910278e0b8f4034fc0d53ddb52a1ab76b6e65bcf612d22dbaf1fdca66125be7133d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/fr/firefox-63.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "3bf8845b1b1630fde8d86e0d163ddfa7d1bb2482f43e2cd22ed6208666087aa0af54a4bd2d93f56c0cec32a8621b5698531a5ae252cd1ceda197f9e4d773b47f";
+      sha512 = "9607c991d0eac8b482c4c9629d6f4748abcc59d9a1b820eab0c61d6a859b517898e6071086210591a0e0a6f91df405a00ab0108748d955d2d6d559998e44365c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/fy-NL/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/fy-NL/firefox-63.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "aa17ff3c7b218ccc959d1746a9597837f0b2d1b1cb068a5dc4639fe2858cd3aadd4f981290eed5bb7c9729f1418f4ddbc8d309107ca3deb6b7a57d67611af110";
+      sha512 = "70d2179b8dccaaf6c2047588b076bbb4e7e2f4d344795055550e26d7c02a2f387f0c123bba4ca637b2b1ed63a3a835b90253e5a4c920c808ac4d023bae89b529";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ga-IE/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ga-IE/firefox-63.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "eaca615bbd2d675d9d1bedde308700226fcc7ad529f1d0a3a432b04b1f7cbac582ce99645f23805dc7dd39029210c0b71855d4126dcd69de635d5465885697ac";
+      sha512 = "e7fa7d1eaadfdfc4eb889857ef2145c812f3c1bb68d6bd78981510d89f9c8fac8a8e8fb9313df6eebfc6d26433daef90a5fd009a35259d451120ef2fc7b69c55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gd/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/gd/firefox-63.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "ed71b7907f8303ce9fdf6bc5b6aac7f7eb00b0be60eebc37f84158b22c54911479d2bd5122683ae0e2ffb662611e4510daae4cd17fe2271d3f361019a516d6fe";
+      sha512 = "e8c11924dba7f56a8a5417bdaae58bce06c936038980796ccee0c4672991ecb548457358662f0ac2c78035057248458419cb56e182809d64e6ab4e3d3a6cdcde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/gl/firefox-63.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "d99b88e5530b08f406a85567070f3f4d709586815c7eb48254491442238b0cb5868a1afdc418739f8b33972ab94b38cad3a06a7211cff1a3e32ab5d0384e18a6";
+      sha512 = "21bfd5ace2663d50d88e4eb2394e0dd80b407545a803febe7294e259c218cbf6f998a3ef1556e4dc53cf5ba603633f5d59ca110e5485d29c93736dafce776164";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gn/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/gn/firefox-63.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "0bc5d75e74d9b8aadda1d6a2c2379049bd269378a3c383b0afa787bbb4b35ab78a06492928a5c4aff2eb66f7897641f8c64240190e1987fdfb4059d743218266";
+      sha512 = "f41048a577c432d5d0fe4ca620ed25936d838242ca6666b7c2403c14ffc5c2d882649afa7957b7af7a6e88ed625050792ca8afa063c83de78ec29f157602b36c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/gu-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/gu-IN/firefox-63.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "8231b8dddf89310ca92707e2bd6ba84b3cdca7e22c641c0fb307fd45dfd1b7de6ff5f29413a7bc303adf0d7601eedb560680b016d1e896deef6ee93a8767adb2";
+      sha512 = "fa2d5c01f2d312cef2e89df9fe3a6b288d2d9de94ca04598dfb8ea8d63a7a330809d8065e1e087a511d6fd2118be661125ffdfd95624d3e6338b29da7bc2d7f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/he/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/he/firefox-63.0.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "14625dd32723b4d207fa545959d8af1a78cec0601a7b1073086c5b2da20ab54e679bb248bbab5fab05628665727058c00175d6826915779423b5709d166f7315";
+      sha512 = "9996f77bf81b050ff3b74336109ba6dfd39f7ab8f552d2f83ff4a2fb4f3f34d5dbc2aa6d62aeba7fdeb076b94b443bd954aacb4aba7cc1eff734a6265ed82f32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hi-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/hi-IN/firefox-63.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "5e8c2792d5509e2cdaa95d26829827cb5d183a734e46d11d91f94406267a481e5d780e233475ab87901c260e7c1cfc0b9584fca8b300c076921eda140f71c3ae";
+      sha512 = "26a57a66d9d41c5c7d1f1e152086b7fcd667ef567a4993414f060e608434cde84b76d318a6ac8c280f08fabf5828bbc981afe1b5cb545c4aaaa90c2aa6dfaaa2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/hr/firefox-63.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "f1753eb8e18920507d210c16c6b9da944444ab771b456871cface1e867afb142c24fd7e5b7ccbccae47dabedc396b47dbe68bd36b2a1ca723d1ff927a90f85e9";
+      sha512 = "787c8168397598e2ed07fad060ff82b5b8584e14248d2b998f28ffacbe16c9c93940fee4a0a0e7931bbed9ee9ba12c119fd52c74fa8e33f70b380ec21e3f7074";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hsb/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/hsb/firefox-63.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "04e39227067e6a98d2398e0b832c0c3d18dbcaed3b683a6508479a29d20860117c2ca04489990508d503b045e882e388d198e62503a0446cfa40ced150000858";
+      sha512 = "a7208bf18dffaf1d8330734604254a97e5a91aafe1c972bce612f6b0c7f269c03b103de9d8ddb04e9620259d7f8c5616471c29449bf31f63e5f4f5812db1a94d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hu/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/hu/firefox-63.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "f260853efc310b0426e72a50e272c810f390069d743c5c0e64d1400d87df860704d87d1fb1b3f2c13a857ea0c15713561379a9e027db86f92cfcdb2e52c6bae5";
+      sha512 = "6f6eb65f731fc0be11e37849c0d88aca3117832761600607b94ca3aa540599dd82d3df5a3949fd2e677d1701fc15f3f56cd1bbed1a3d0dc21f9dcd01a8e7b732";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/hy-AM/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/hy-AM/firefox-63.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "5f1b3fe9cf4ce690105e99bf492ca4e67bcd4fe0a09aac45435bc1dd2acdcfd7d2c5faa7125e6ed14a4da1710e1e8564ef969e70cd0ff3b53fa434035d7232c7";
+      sha512 = "7b065a87d5f699d967a171f468abf579f2f8a6e14a8acd9842dcb990511eaf30ec9a840741a452455da1e5262460a997ef272cf8d27f2389d220df3d08088ba2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ia/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ia/firefox-63.0.3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "d4e20bf61a36438b018c5e69cb5fb9a305f4b67d1c1be82c619afb44faa536903944204d9cbbb05b766076038ffc0e0a51af528dbc93fe1690cf1f4ac8a0382d";
+      sha512 = "d4ba40f54d6eed2faf7710798f06c47381a396a72e56c54c0629cfed8a976d2364c8dd33f58a7175f6b92a97ed2e0a300af0523dd5f01d11105f7bf8e3ef2b39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/id/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/id/firefox-63.0.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "0987ea50242ea6e843df40537519b13e6a0b6c85cafa9ea5957b69648b8aadbd12527e4adf04d135b98f50e1413a71f85e327fc3025897beaa0178b7013015ec";
+      sha512 = "0449dad064c631858f7099c5deb8297c8793d293fe7649f073d3500d6ef3da4add1d254ce40236b20a13ee0bf763bb3c90a7e5248a7180751544f4a4e6c385f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/is/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/is/firefox-63.0.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "185e9bf39d07a0455b609286c498fe24e301cd7779913da4e16d36e36edb640d0d2e09bf04d85209f2879238f0596fb5a7ef3d9b53b611101cfa78ca8ec27166";
+      sha512 = "05389a0b2804e3379c1b75db9786d43aeac91215613a4ff1f1d3f4cdbfa9587be6f2f0605e254c82c00f957e9624cf3a07ef4232eef2e882316479b5696275ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/it/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/it/firefox-63.0.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "334d4f61f8bf56123a57a488da8af7ad364fa4998d41b0cf4052bcb33494642eb0f429b97193b36a23947350e94f97a37dcfa4092fc8c642321fffa66f2c022d";
+      sha512 = "bdb07a16d905eaba62d521c97234d73605acbfd73729e021d74ca5b4848bb06065e30742bc9cabc986aa17b852037cc4f0e100a0276b76962035421cf977e07b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ja/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ja/firefox-63.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "51f4d9a5ad768d34354fa56839412ae4f89fc46bdcb0f4d427a58bbe7d7ecd5d6ac6d3282d305b69325d3bb360d6356d8915ac200efaaf645504d1d607a75eb7";
+      sha512 = "11efde6d19d11e1cc9ff8746e5a1c77ee7535e52b55b372f3cdd4c416fd9a3749fcf41ca5a287b1ca4335f64f746b2bb9e4af5babd4cfa7e48baf94f6448ed7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ka/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ka/firefox-63.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "973e37affd3574b682a245d4366c5868520ae832000f96c2c7ef7b0bfed82e65e838fd8895069d5c4b03b8553233928798bbfa94c20e713367f84845639d5217";
+      sha512 = "4887fa901705ecc4b820545ebff2ce31f658a4254b78e07ebcf05ca849defd576b86b86b46eab42c13736249360bb058bdc2a70e7f743e654f8d87d8cdaf26c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/kab/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/kab/firefox-63.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "0d13ac3a4783623e09028d5ea9b860db230f8c9c5c98fa83d1db33ee1adf09f18b312412040a997293c53fcf4e9ebabdf3d5f935689f45613f1c70e959ee6ead";
+      sha512 = "06ab67dace653368bf81f2110f69f391c7cfa3103df28805b2933ab64914b1c95a847ff16285ac0d68eb7ef4fbc2a964185e259de872a1302e9313712d2e8cf4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/kk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/kk/firefox-63.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "822c5d0a3f4ee7327712734258afbd4ac5216fefea0cb6d3dcdf144af7ac04ac79a2c5f09c79bbb9a1adf7d57f8d0ad3300d6e56a483b3d1c149723a1aebf9b2";
+      sha512 = "e51b5f053313a541285ca2e7c1a8699544f876e8bd65dd6c144d16cd2b75cd3f8be3c7376812f343dda7a41aa3df5ccb7816c59af757ea969e96834d362c33c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/km/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/km/firefox-63.0.3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "8bcdc71c8d707295e753c5a9a06d47fd932a7acd35516cf857fc74d3e9025156c0a5ddef34cfc9b98311e672b386bb06c241c949fb34e238f1353d2ffd2b7385";
+      sha512 = "2af0aaa8e05ff566e79e97179e12cfc020f6bcd8b28946c4c9545da20cfe391b3d1e6c1db56d040244a027add1fec1835f49a8d28fa960b586f60b6d22994dc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/kn/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/kn/firefox-63.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "a6c6e301ce118c4b7f133255a082d0c9615e2de3977a7500d900ab24c8c6d585132f52d120c32b85892bf9df1fa6855e66a5ff4145fdceece917f81b92bed62f";
+      sha512 = "352f95594e97ef6ee5c34fd815ce24d285be86cbc858581e2b57f5ca25bfd4bc24f998cac4f155f3501d5a1ed51173a947944908c3fc975c97c08d8d2b10cc16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ko/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ko/firefox-63.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "950a8573fc2ec19b5cee1bdc8709d7724df4a89942b64a0e31969fc8e7802b16b1309fb98d7ccd929ac7e6a0444b4fee60db3d934346ac8c4209c9be467121d4";
+      sha512 = "f40a6139131a11d3e7bea6e47833ad8c400b6c8acb7efb45dd2ff6b31036e24d51bcc4639272f99d9bf1b6f92794886f68292ef60a8b5eec510b1b041cfef566";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/lij/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/lij/firefox-63.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "88a746f55e3f3d8fc5ea8b1f73c9112af0c87e18ac365341c7ce655edf25db58064c9bddf8e7ac9242fd67cca0911597ee795a222ca8cdaf37627f3addfae981";
+      sha512 = "02f2e102a219d07e6d5aef408959ab88204b363d73359ca86a8cac6be087e4ed46735c2c5fd605c398a2b4e3a72ed7cf4d0dbd250651074212cee99708d86376";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/lt/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/lt/firefox-63.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f7e7ec28ce981a931d2e5892d85ed5e6ef2685af52309ea5f8a779b3569b5a84bec5c7c1cd5583785211a5748663eca2e6b0db13ad0a1b846deafd7135db4afa";
+      sha512 = "28983337150861e4edd9b279f1576719fc16fe8584bf118e719765da6fa423140c33dfc093d3ec2c66afe807cf9c5bdd8914cb214fe07199ee5d3715c0c94391";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/lv/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/lv/firefox-63.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "78de629ab28273c18717f07d3609bea0e0690b5cf95c9ee380a4ff7b11d06b91a596fabff78c8935e7d52c2720875b224381f5e537bddc83ae7ad9c3fc80b802";
+      sha512 = "6cbc73044bfefb8ca04a001f1b9445b043b07fd87dd72a76823cf54c8c6b214d1dc5cc94f311335bdb2383e14ab6b4b39709a3cc285a80c9cd3ba3e24458ebbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/mai/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/mai/firefox-63.0.3.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "aa0f2b177337837b9515ad1d14748f7e68146ce5d2b3f6fd128be1cd2c09a62538d0f79320e74c17c8ddad8b084705803a42a86bb621f8ae227363686d8469a6";
+      sha512 = "9b15945b08830cd3d99f8c80948f7044d22b0a5a06a9e5edfc78c216c8d5b3ebe2bcd1fea6242381550eeb63d472f682d6cf976f70879df3d52c85348a232aa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/mk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/mk/firefox-63.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "36de8542490f43e7b63db4bbca49933716f79b85b4292a89aa16817c11bcaedc95e966529ab14fac87eced7a2feb5c0d4c077c0218c5dbd49567b0b77fc47d98";
+      sha512 = "ec07e5d57aa522b495e5a5791628a8475cf44f9ed93cb70b46747f822362807e2e14c7d6b7e5d12b432cbc3c9f8dea4e34e07e6a452c2fb6e049c1b857773fee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ml/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ml/firefox-63.0.3.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "fc31609037e0f3796ae2fced50953042560e991059f565a3096fb30f27abe741933866442d6a6aa4e5c9beb60f5275b14576ec7424f0dd57b42e097b25cd9736";
+      sha512 = "b2946c671fd6260c0d708344671e5e92aa723d3eaebd59629f8f8bcb063755b4808bc3cc2842b74866ef8207e3856f9b1c1dfd2d2a8ed621144e1ca5bb350d4b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/mr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/mr/firefox-63.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "43aab6723f6f21087848358fc7a29c4c41f8a527c818c75b078f1a9b2db2ee28d25f12dc3456fd82400f75e22761063a51de8d237fbb8f72c45fb1be700b3c46";
+      sha512 = "eb690ab6e5a8199b23ea8996ca2cfb6f1407f008563bc2c82fa67a48f794ece285ae16d459bf28ea42a8f3a9cec3b196834b174de36918c2f9cd66137c3b50e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ms/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ms/firefox-63.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "3e6a411e234ba04e61337200f81dc8a4260be1d7fd7bebfafbf9430e25a96d3a0d944096feee643d34163f53f848caa6c27d6c6cfda5389cb59128ac98a1949d";
+      sha512 = "268bb604f40d7bd5f1897459ada7b827b8d62f6c1869474e9607be48fe7b80387eab7065f5fec49f778c6046d18d29f22d3e04497a417dade2d78b0af2ccaaf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/my/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/my/firefox-63.0.3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "6b61f60a70997576f2a08abf95f0647725a0df92c348173f64428187f9020e451077de36ae7ee2912ab8b708314effd4c8c6aec4958c14825266e82b6114534b";
+      sha512 = "3dae4d7727ab40deb8755d501a3a2dbcf20727b38261108194416c592031bcc41a5cde98d5492d13943b5e4fb4acb5fb863d31470a09538b2561692cc450ed54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/nb-NO/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/nb-NO/firefox-63.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "5b58f0fe658ef9bcffe9eb8553875a4ce01071b050ebe4c14dbbeaad0304d9eedcb18b5cc411c992c97ff043e9453f4bab937203d4c6f704fbdd02cba1415f65";
+      sha512 = "73d0704ef41983289fb4005165c16e198bf665f465f533880fcc12a4ce523a1533aba2c5244f849efa963c5b9ca702385acadff3e49ba0f6d53b88fd5a0cc770";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ne-NP/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ne-NP/firefox-63.0.3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "f3acdc3d0b9cd75b70e5c01e38d20c7c3071f175e1d50daba8c4851ce56c8e1f54eb19eaa198bfed2a70903d796e4457a2a8afac57ce4b8f9f16b139c8277e1a";
+      sha512 = "0c99674cbefa358dd352458417fcb88bdf631677d14892ac011c9953e7af5431845d29a0185cd0c179fe9a37eafef8e56d064bbc4b6b5b7b0330dfdf9c8ff8d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/nl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/nl/firefox-63.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "f106e3c846869bb55baa612960e2713ab89edc156b31bbdfb86b40be160c4ad97fd402a3ada7a5729bd94415c1d21e234b4c0212bb2f31407bb71e49aaf0adab";
+      sha512 = "0ae4edb6189bb9e5f65e435246bfc171dfd29ec310a3ac213bd96fa62cf2caf0fe41d6a4016094720169976615ec08524793b3c0339c601063904147697d73c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/nn-NO/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/nn-NO/firefox-63.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5a7371cbffd421e07e45120f87e85add83c75fcc62596321c08a1f5fd03b607a1d9f54f9be7d6174cb8f325aa77186728cca15e6d8a1a3f537cce5c996bcd477";
+      sha512 = "d650afba6ef3d586eecc9df2db4cc7d9a9eef8cf58b903cae6162a2002933855991aa185915037af4b4b099efea244c0f9fb43eef52889ff37c9565437a74c4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/oc/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/oc/firefox-63.0.3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "de159758170c954884d76f5325c7c88c5650044a4867a833ec79a9b6fc3addcddc8703620548e44801313326d5827df18ca688d67de9354a3ce1890e6bcea3d5";
+      sha512 = "cd4843915232d3b1e4df335e05b0f4a8273339b3e2d88994ac9e7c3f33100a9eb76fc6593d53585a9b3bca096cfd29190d40e5bd25c72ef8928124c62c4a7bfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/or/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/or/firefox-63.0.3.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "29c89abeb78cd688a2664dca3f6cf4da984187608f6c2e5e876bc7b15d744bce23a2a45de8bba87b3fcfcdd08d501f78c1ac6da44dca1391d0d9f391d371a8ff";
+      sha512 = "7a82e3cb26d00d900c1624e835512ae30221f44fc4e95df653d8ff19d8bebe82fb0706a4d0739d59fa003007e5ab7dd26d97ea7b9235ede112fe2f0499ce177c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pa-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/pa-IN/firefox-63.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "a4d4f1ba14a664d8df73d46695ab2ff403630c290a2e65dc7bd0896b5e6dcfd9175f09a1470f62c19b2f7d6a0c83105baa26625a4a63dba034150c6dc9b8ff79";
+      sha512 = "5f8e658bbcbefcd8a98a2b07151aa94c2814df1d9f6fe050d9800633f17bb0b225626a497c5355a6941828016edf61dd3e326c0fdf2950d315c2b7cb16b74e49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/pl/firefox-63.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "bb8da953e6d290e7c89e1da82929c19b9918b1ba9edb020bf242bdda0999bd2af35c67b31f6ea9856a25e08330d25ba2f71f42ab00b1396173fdf97a8034e334";
+      sha512 = "a33d1c92c62aface88c6c9144fd80c0d32d834e1f8071555d146c0625ef5f903cd99d03489fdd52d87a031d5cdb3d9485112b2b2ea0fdc5c90973d822ea95f28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pt-BR/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/pt-BR/firefox-63.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "02f3b9091ee88864d5979631e4b968a8bd8d8530b47bb74b2ce32e34f7a91146d4acff58c122dae9b97db38b8dbda90aafed0a9d463ee7bc4871788bb112d042";
+      sha512 = "66fa889e90c92bd6e07153e86c526ee0c08774a81911c1941b22d1427871ebfbba2e5a85844512883f9d67ec1d746c06612e0fa3668a95a58f6c59cea6347e2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/pt-PT/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/pt-PT/firefox-63.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "8cb41e6c6d14e4721ecff46b84af58c689d987f42cd6cc3abcc06c1e265b95421a7858bbd665395b86a0f101c78270c12d1d7fd6efb256871aef1b8f620c0234";
+      sha512 = "cca4fdaa9f902efe0e80e6646c71ccc1e168c7a2a87194f191bf20b8604256675b070bf004192cca0b0b9c5146b31a56e748ed061717da350d250371c0228641";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/rm/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/rm/firefox-63.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "1ac1d855316f38a0e570be034301fced730e61a5cfddfd43964689f003e454c9870ef215dfedba5027d2d291926cb3c26deaa9872b91686315ef76d14de2489f";
+      sha512 = "991afdc42e258fd07283ac9c8c3a2bd276014d923a0ca90fcb4220fae74a35fbd0ba36406985be5d9061a6df30037e49eb16d3936a3734a0f98a2704bf62fb00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ro/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ro/firefox-63.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "431100bb1d819ae8bf5de1883210f96de661b5c1a8e735e70b2df6c7517190d4c9703aea6e406371f49e6b1287a8e9d53e6ed4a228a521b8f4a8a532e442bc1b";
+      sha512 = "fcb3ad91353157564baf8a82ee700c83c3d62b8194532fea123c06e6816f6d35d747d13ee1bdc6d17e633aaf4314529532729dfa5f7cde52c2b4669c64bebd89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ru/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ru/firefox-63.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "35527353ebca6f60f310705dfd53f2a9dae16317c39bf05eac1f5ef4ebe9e5ba08d36c5557dba8a607d604483b4d02aa3085352c11295bbad1ad57d0e2a02ab6";
+      sha512 = "dc3310a41f6298bf552dd22cc416dd3a8cb098abde3da47fb6b4f1573a38382c49a698157bc9196c11bf1e9593764247b6ad8ccdb5fce4216f94fa8e3145cbeb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/si/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/si/firefox-63.0.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "9ac19eb2441202229e730f8af9a23092b6da83aab1d879aab07affb39a37bbb8908c452721f37d2f6e062b871441aef9ce4aa5b616f1307f70091269fda8e3ed";
+      sha512 = "ef80b229b4008dbf7606b696400cb80cf39f81bcebf8bd424a720e93eea6fbc1c534b5e3cbef94a2b001b6117582f58b3f0a4517e7ae4aef06201d5518ac0365";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/sk/firefox-63.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "b599713ba833c15c2626c174efe93bd34b63d78fcf06b1507ba0ac905bda58da37e138df4eb01bf560c5551156cc9468ca062846b4083ce0d217164deeb31f21";
+      sha512 = "524441e5dd27831b0be2a75ef6cb7a1afc1dfb77cd5d1f96cc6a024eeec3ccb661e82961c35d55008849990e97b3b94a4359c38b272522fec624b0ba1dac041f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/sl/firefox-63.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "506e20b8c55a6d3e20e24400bfc784fe81e135f2b71f761c10312b1af9983f43d6e71b77578dbb221247d730a1f372261a83db6b7fa1382c06407fc6d0599230";
+      sha512 = "351083df0a639b290fa11456ee8969bf4b49c1a2c5d199bca0dd05115fc6bdab941e41a972e249713ae249aa884cb8b1e8ced5aff7a13566537636f0266fd7ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/son/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/son/firefox-63.0.3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "41c7f4a449d181bb352c2e9f3b7c43b8e5782c9d86265992788ce8ba5b2e1c7fc1ce93a5f41973650ee816b60f6874e375cf780e1b76102dd7662d1f8651ec96";
+      sha512 = "bfe898ecb294501388ca73dc8e1c846c9fbe0c501620da7237f5d8ce5655d1d458cbbecc0b8f6d54b4a57c779ff8533a2264f51e31cc463766b2debbc334c383";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sq/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/sq/firefox-63.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "d73f03127c26cf55352e7963d4222efa26c43aca5d2b2a45a5bb958f9c4d7f0d618e018ed8ee86ba009b360338c2c559f553caace5735e27474357a392f2e80e";
+      sha512 = "fd4e3be2a0d11c01e040bbf770a412a6a5cebc53788999a5b446eaad9c609e179abbdb6c3322fd3ffb322b5625c68f26d696782d9335895abdc4b38771856d38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/sr/firefox-63.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "0f70af467f21d399258a41a9cf89b01f8461d9063d23e7e15c269effaa7d7c3a70fd034a4a1939fab1f31dcbcf293452c48ae5c49bacfb2a2e6151f343c30866";
+      sha512 = "0659ac0ada51114f3bf7710441a3694f9dad1febcd2310c89fba42693cb4747545c25deb5a30c5e0eb8c03037724cd39da316d9e5d980b98e157002f5a6ebb7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/sv-SE/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/sv-SE/firefox-63.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "dd2f383544dbd19efab3c967e762a54209da2ee3d6001d07f173141ce5abedd62216fb9888569e04f409def45b38d95989dbf3165a46a0270151c72bee4d3bd4";
+      sha512 = "2d7b5b5f3ed0fc14f535a82fc2d955cc49255bfdbc197768de1cc206df594a24dfeb6cb0e4112b4bd8b747efce914eb4ce9b96b7ff629d48d045108645bce337";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ta/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ta/firefox-63.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "4c625d005c97f8dd8e31990c97d35fe51dcb614e6e8737d60daa42271b15c9a705cbcfa71a32b3a88860c57e7ed0dd3e22bde0b9485ec30d2dcfce9802a10f60";
+      sha512 = "bef25766649943bf6249a7c474e58cc5e311158aabb8364e0eb8e9570d538c542663462f0b030a446450b8c86d40b6dd291e419051135e911c6af623fd2ab264";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/te/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/te/firefox-63.0.3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "77a995c552e01b688de4651eab8df025d8163684a4096bec415f40468f49fc5bbce667748bbcf989c636440e8343eaeeb228a9b612d989c520c07420c2888a4f";
+      sha512 = "bc40367bdc0019a3de159846a4c0e2e2cb5d6c7c9a81e64f1be184427a15445673185a8e9da44705434ceee40218d10b385c0f0c5e2ce92e4ce40757467105d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/th/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/th/firefox-63.0.3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "c51fbc08ec739f0c410537cb9f1897c3aba11c916c739c143ddf3e19cc6fc743ce50fbaaa95569302fb3411cee9d4a4ab6b525a02e1583387113a1cedfc4af94";
+      sha512 = "8b6e6903da4a3b1e04fcba7f9d5c948b76fca498bcc18a60158ee65bfbe64af2e1463b7fde23b9d34b2ae9403a5d55cf09cb47bb9bb6de3d6a3a3a54c409e8d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/tr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/tr/firefox-63.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "1aac702b3f84217813d76248e201c1923e812f57ae7fea00cb00f12874f8cdc17e6e90a633aa578673b793760bd2300d5f0a2bb7e5f3bb5d61dec8e082e45b2c";
+      sha512 = "ea0e0619fd4dcbebc6392d1574f6d78605caeed066ad12c2eebd681ece04d5ebc0fa925a0c835a8750c522632575fb101ccb81d8dffb73a28b2efa3b8b8374ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/uk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/uk/firefox-63.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "cf8bb456b740d856201d6a832c809b1be7a0b9541c73988d9d526b5251c5036d46fe1e2c26dabacaed9afc17cbff53f2f5beea3a5018d4ebb82c1085e272846e";
+      sha512 = "4cc683b8425c8e70e7d41a2db0d94a515248b2b5a557db292dec3255b695063529d998d0b3eb1e017a143073ed0c871551d07fbdf69ffb226f1eb08bd610e780";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/ur/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/ur/firefox-63.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "02f5ba3d99d84ae6990fa2fe7739365dded19914271f4967671365a6dee76e3fa125d523aa042a70f4fdce7144bc29349158834ad75cf5b195ff8f3bf916bb30";
+      sha512 = "0d453f019cd093d927951bb9e702b5b763571f40d070aab36dfaacbedb804d836dddc24ea6c9160f8607933b6fe7500673804703feea767c9abe8c5ca799302a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/uz/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/uz/firefox-63.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "fe7cd3f100ae5515304ece3341e5308a2efe2a650a603f8e4979097e95281f7e0f75470e599a2292ef5296cd001d3778bbfb877c8b80bec22a27c95b7c06010b";
+      sha512 = "9d9a9de47f7fa9af563e3fd073c15246238d7d1ce61af62876b778f2bb12d0a008a65b50103f3bd8788ba10398020055050f96ef74dce623a6deade3b296bb59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/vi/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/vi/firefox-63.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "293434d3817d02efe5af252e39f4cd9bcc9629f67011294f3e64c3700a0d41524fd2c7cbf7f7f38503422743006a57168d00251633d29f6dafdf2bc27ca9bfc4";
+      sha512 = "c2c278f1eb303471059bfbded55dbf71561a45ec3bb2bc21a0d113ed01a779c3c996872696802b753c3bd9c7a3fb05446bc0bdcc6ac40ded8ab8618c05ae68c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/xh/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/xh/firefox-63.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "e1f3490f6809f98bfa6dc38e40d2bc2642bd9a161b54e43fa5d1f4891d1698d32a074f241ec68ca2bfedaf7f2a7912a9632c9292d4bb3fb9932640b274a73c67";
+      sha512 = "3c0f60156d55fad88c60de9d004b73969411ea981664e7b2f8b95d116f7fa110588fc406ff1796016d3b89bec2dad1eddf3e4cd7b52cc941c70bafe23a315883";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/zh-CN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/zh-CN/firefox-63.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "e66e82965e5aa68e82d1f85bed52bd79ac0729224ad5ae5fb4801cc1702c7578e3e9c8af5c3b1659e481076912796c608ed365b88c1fae1b4ee01dce15b22052";
+      sha512 = "046c929d1f764eaf434ee06ec270141c349fd0421c5a4ee3a6c0653db9f2f947569678d2e05f10f9b0a407010b87e02bcbd4310824025b620f6b36d3728f178d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-x86_64/zh-TW/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-x86_64/zh-TW/firefox-63.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "ac6e7df610a1d49b655f084eb280468e711f1df668b8d6d077b7c84dba1aa8c0d47e7993e4322de8fb45d8bad7f7bdaf3325c1716501fa12f59e881cfa68172d";
+      sha512 = "3c6055dc146482d38fbfa0265465e7a6ba9943fb5f96114873774a6c5ff85b0916661ebc6b85516bb268a7cb5b7e5130ec1a9cb68ef37f7791cde3bd5aa3ca79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ach/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ach/firefox-63.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "ba1444fa8ccebe86891a2777c5d8bb11d8098e2c61574b86e916e98c9fa6dbfea99c19fefae42708ee17142d095122c9a83303ed8a2143872f23bd0f3e63c7c2";
+      sha512 = "f607a7fa9d37a4b77c6135b000c95ef3108f7c9d0bed63169d980656d7109897da70485e732ff60d1b50cba4426035e253017088848f19d0c4cdb5ccbfceee83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/af/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/af/firefox-63.0.3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "ad827930699e223cbb0ee7b34e89a76922f83f5ccc1bf14fc1743cae156623a190eb4d73ffb7cbdd9483460f30e868ee9a471af78d5f4aecb1c924e9a039fb74";
+      sha512 = "247bdb69b2f09c5e15a4431971e9eab706ff3d2a05dc6b478f09d990410925bad15187e79acf6f0f1150743a47c332f4bc4ad295a38cc7e93f32fa6695c59d50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/an/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/an/firefox-63.0.3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "bce2959772589d2b356b3d3e0af7ed62448f77b66badd59ecdd4dad7fb7d43cce99aa5b3088770cd509dd262c585336b084982ad77b4328b4d3ac47ef7b0daf3";
+      sha512 = "9baf182dcb8f79f50c6110e6ffec49dedc48796fd2726e200700074ca9ab3f85585689d12d9e1dc9622cd8cb30df0335efc9978bd7609512e9e85090fb9b2d73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ar/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ar/firefox-63.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1ec918fb0cce996b80a5f3702720dccc09682a5d223d049eb9f69c4486de24196ce0760e2f33f76a613554e5feca71af392fa8a9938a4b4d8a1d48ed88bd0307";
+      sha512 = "472bbe989fd9ef9649fd48ffb1e7224238fdd0e42b3f813d0bdc26aa7ccb32b9782f5c9e682b24c0c1bcddd3b614438def737a07a67eace58ae9ada176644c7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/as/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/as/firefox-63.0.3.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "8fe8b70c8ca653885bfaf94875a9239b38477d1bba36b6c5c3cd5a76a444ff846d9ff49d07ab7460e56261458135a797cc3cc557aa0296cac12f428785801f06";
+      sha512 = "b07adc65d14995f5b9ba3b6ff5df1a718f37a975ef964e8df2eb96b44b24605c963c333bd336755ee5a63384e7dd14fbfb0e139af65721fa5a9cd5640ae66995";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ast/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ast/firefox-63.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "b83bf7d6797f652c10eeb1ec268fbf8bd892fce13590f506b076fd05e423e113eae859fc4833d9192b9e7fbbdffce1be59356e04b1e60505d1b0efe97b25dc08";
+      sha512 = "78e8e3221ae6d57257f405e4d01721eac1bedf1bd55993574574cf86f0415ed64c133afc174d06123addd334b0ab335704ccc2709c2c7ae7173b1e2b10a49d5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/az/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/az/firefox-63.0.3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "3a3178afd4616dd0949d92f886ba62105f182eaae574f4d9abec54851314bc67175c6a9c4f8f8490446505be456bdae59715cc50e08d563d43821011b598cedb";
+      sha512 = "1dfced8d0bcb66aec3cfeefc9731303626dcd72a30f07e4facf31a159e7fe55eaee18143c08f96c965e6c6ccc54027fdf421d40fbb8ca2ba08ea3d42d6687fa9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/be/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/be/firefox-63.0.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "a70e7754379993e6d616374a337fc41d5ca3146b19d91290a09b6224eb6d38a0684466e1ea358268683296ad7c8cc34df51011d316239da2ef942ce5782e2238";
+      sha512 = "eddd7a59348e2feddd6946d2603a37ff0b54b3df17646a4bd161546a680aabec3c6b9b0cde5fb62252239ad38c6f380b296469e100bf017944f8f75b72091af3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bg/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/bg/firefox-63.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "3a55a9bab9b175a167c3044c873ba356868fa11b6da85a6ff8af155c21c604504b74018eb72f7ba17a4a31ba14020b9e4c13f9428e4759772771038996a242f3";
+      sha512 = "6f5099fbf641785b4b946fdf88ca8ac297faaaa12c24ca38454a09487e8bfcbc75ff03304d77c14bed3dfb1ff06b2577b1df6a151221807aaafb08f467b8c5fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bn-BD/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/bn-BD/firefox-63.0.3.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "e5a110accd63efa525b608b7c30d2468e5b6f1e0dcac670b09fa834d6964d5663b70783adcc4085caf6520f72d2e4faeda037ab0a5b2f5c105aae449cf8b6078";
+      sha512 = "f280de1f55748b9ba64c415808e3027407ed42961327086fc3fffefd03f39fb6e17aecd2477b8fa5a7ddde2dbf79696ec0d8a5ec0116df4e1a88092508fc27a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bn-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/bn-IN/firefox-63.0.3.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "26f033b925adcf250619fe624eccd86350a4fddcf2eda3dedabfd5814d5ec7543173f0412b42dec6af6cd919041d8ed82867839f65c574f3a5c53bb7edfdf192";
+      sha512 = "2ce603f014777e998b968ccc305081e14b8bd7e4dc598fbf4a7d527eae26b24231b941defcd23a9d19aeac62e4ba89cb5d85719773c7734e5489634d7d18c3bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/br/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/br/firefox-63.0.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "adc30801180e72a4f6e5ef439aa1cb7fc0707b6b0f2b8439d5e5bf8f797ba568d2b66110b013079f251b80119dfd8c2cc6a6350ebc90e65a6aa189d56dd2bd50";
+      sha512 = "098e872ebefa533b24fc1c40dcb0bf0602f0c5cf07c74fd7034103c16f34c7df55c2391f0b075dad6e757bfd64d9c3ea19bf496a85d68646424f4b9cf424423c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/bs/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/bs/firefox-63.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "635b6c284cca1c601d6868f51e7528768691245501e95f8dfa575aed3f31f39a466e33355f228d080f406af9d9fc178d75f614a18f29f3d1263fb4c1fe59fd98";
+      sha512 = "df3121baa80ce8622141ef958244dbbc09226f135d19a84b9f840d37374a3b370de560e6c5588f11b6cbc150c5769ae7833b469d6724d78ff5760d8630240d0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ca/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ca/firefox-63.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "3a0a0cef6114539553d1ae40cca4c71393a757d3eddab862e9d4192afb5c5e28c1c6884b929fd9de43bf122d4e8d73dbb0d46254393fbbd25ac0f88b3e6e7510";
+      sha512 = "84a14b1956972c6fe92673f6fe2390e3c8a100c9b512fde763b7ae7c92016c060cee5e67073285ea5641a2a11937317e0ecb3aeb88b5b6853339d09f272c60f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/cak/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/cak/firefox-63.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "67967b99868c100d9014bd03e171be755993d476e9831cfdfbac8eeec97ab05c11959cbec0c4ef2da34a4c406f9fb4cd171293103e0cba131d6a05e1ebaa4d50";
+      sha512 = "c221c9af315c47d44be7cb0ddf88e8fbcf895b6b87d4b5df221fd09b217d7cc69e839e8d6b0898f4d8c6500ee9b2049d1f7e79b99fad03079d2d850443b09802";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/cs/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/cs/firefox-63.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "3d642f59728b4655e770f554eb5fa7c1893e581a1bc35aa5c680efd41a5e2747560b28acd6ae4a68aa2668098ad4b638673a033d4da19d2c2e4e9cc42165a48e";
+      sha512 = "418d32bff0321c81a09f166789be1bd63c7a51506038b6a6b16438cfcf0e6b67ceddc754c5de0a5c6fceb9bba82a1b4e89c79ad626242a1215a763830d252836";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/cy/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/cy/firefox-63.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "877caaef6d1398416f44a53b0a91d1d49e5694c319da19d0b5c5ff71164b80a30530a4ed4c2a22602f3daad37be28e499930099edec3668bb0cc008afc5b3404";
+      sha512 = "21faa65266c0acf840558919a56c3ad898461f04d93acd62ce05241b8577b061547c897d8bd72217f2767fa22408e3450edf8b73b82d282d636d1031f7fd714e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/da/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/da/firefox-63.0.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "eb911318ee4231558a16b809ee69b936692c6a88d891041630eb01d3dfe9eb061a51313d07a3616140b30617b67620cbee00c3a0dfaa6e9c4f4fcedb84bcc770";
+      sha512 = "8c1d330c86fd6c95940ca5e57acc2805afc41f88c213cb68434615a7b970d7957e2acee111049e9c090260d600defbd58e3a22ffb3bde80248755cb6542da80f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/de/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/de/firefox-63.0.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "f7f5a05c8c83eee203fa741a1cc09124688c21eac32f5122bf3e3f7b4a389dc37acbdb3ae6990b4413970c98eedafc0df4ecc08b508d52692d2fd3d9ece46538";
+      sha512 = "8b5321f333e25f9fd63ff7d76426793b69e646c6bf049d8f4e485f6056820d583a1f850121dc5a73e0b6545b13f05aac467ce3016cfc1dde5ebbda0b737cd96f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/dsb/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/dsb/firefox-63.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "f003cd4232bb20585aa08a7cd07e7d717eda2f6bca941cbf01615d1143015806423e3d6b55dccce207d9af6250e4e3c6e3470c4bf6b0055c8174bc17c8652e3e";
+      sha512 = "91883ce7ecde4d52e10d95961c4fe4ce6f2f6c91460a662342529122d97e3fb87c927ce6b998920a06859c4186fad14f70f9fae28e5657929510390c8543e755";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/el/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/el/firefox-63.0.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "f172315fa9608aa89e53c0db3fccb68e0e5313d18a8effa514049d555dffcada49693d4bb65c1f987ed5c28a92591daf1a85e0f4186bba7d2b53dbb98a485d9f";
+      sha512 = "d9ab8b8924938123f03dfed4a95988436e0f910fd5bcf898d69a4c26d5c09670bf7b38e86cf9dae8c65286c9ba3d4f763ed2ead306f5d62a85f963c99f5e1225";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-CA/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/en-CA/firefox-63.0.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "0040a4809792c5739f68e5d95a4d4068f165daaca55408ba89641acee502ad3237dc1e9d6a2d37afe3feed0f44c3883b50b837f5626b5b86cca1430db46556fb";
+      sha512 = "36135d4f4fd1271fe1f2c1a9508b477a235bc8b76546afffebb3c313e9ae3aae2b59ef3cec39fc67031a1a3eb98d3b3ab79de27995aa6e195e190819023c9ba7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-GB/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/en-GB/firefox-63.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "4661b07660719c0d3ceac74642c4e70d9b406dee58f8ff0f7c40a006fc76dfe3e2a81699b70027e3ae209e05fe321d58a124d37bef10a1e1283cbc07643c0852";
+      sha512 = "a799f334fe5b30dc30a8649cefa3daa7390c049078db0570adcc8275beb17f96cf4907b1e7b7fb6f5775a0c31743409a1ff08d0862bd9cc442f3c9e5241cfe6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-US/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/en-US/firefox-63.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "4d09db5a69fe203386e05bfeb909fcc798fcdce2c3a14c27af18cd1a3837439cd3fed50c6bf951b4882a125f181dc24d5ec201899097e65e279834db63018fad";
+      sha512 = "1cf8cb7f05fbf618bfcde3a73f309dbe10fa744b4b7400be50817f3c7ff4a97897d0c9474617b50de39e28d086bc52a2bd4466162fe08d3338faf9ac9e4de3c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/en-ZA/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/en-ZA/firefox-63.0.3.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "85befa2c7d200fe88128724743186c354efc6eef85d780b245f05e0f657f898061862673be6816c9d13e2e37a4a6c1c8efdfb1bd8716c424e9a45f139cdebdd5";
+      sha512 = "6c238214f57304c546c41c9ecd264ef8d155ecf9d8de0d2a3d2bad3302679e486a2068e06050917b3be02aa4f3c003be1149754d832acaf79c5a7f84b52310f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/eo/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/eo/firefox-63.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "12af4981f2da08abd4027052ea0fb6ce24af2aaf19c18190fadb19bf9a99326307f1ecef484f50ab0880e183ad971ffcc4853814ff97fdd0e32387434fcc731a";
+      sha512 = "ce1a7a296736eeee750b8162b7eda7ae3df79edd9bb5817c511f1a9c5e718e3c4d3f2420f5c1bc203afbae6ce84c22ab52daa0a2853c2a93e637fa376662252a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-AR/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/es-AR/firefox-63.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "6d244ec1c396e165fd5507af11e74f202ca7793fbc4c2fd9e47eddf429bf6aac4477a2994fd2ca146f5d8eba1307fd7877406ee62bebb73c098d5dc342b1a64f";
+      sha512 = "b63569678b14e6b5f6aef8c2ccb7b8f5f1097b4f51112aedb80807c087b264180102f9a66443bc58fdca13993cc9b407176861e1f11db3a38f2332c391a8aa75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-CL/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/es-CL/firefox-63.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "18ecebef241940ba62771850ae78d4249ff937c0c069782d0e1f83bc7d162fc0b2792a16231ee943ff1e93141fef860f9e376a1357c30375c5458d01156cfe82";
+      sha512 = "7c48cbb6b9be0dd3b13ef6e838e169afa555e36d5d0f21e825662bd89477aaaa6bc0a3f2076a56a32793b495eabe32c9a286e9103297833dc04298a682e4279b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-ES/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/es-ES/firefox-63.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "3edb35b0e6a8d0d8838fa9d648f138980e68bc08e6a36c78db8fc3053123f364cc888937722c6b2bb892586bdc9b9a7de730270fc433bfd1461a5d2c8a689f92";
+      sha512 = "7ebe4ae6ef712b0b49909946ddd98461708305b1f418d8c32ca50a5e1872b9b7fbb73d322f00cdb2550701b743fcf3829f214679e5b0eb57939fedf3ff18889c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/es-MX/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/es-MX/firefox-63.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "a157fdfdc2488233c56b93a015f33e96c6ba2c7b9112bce83a1f53931421cc9523f3db0fa1cf428fe35c1ea0c1e9579b237c44537da89a8d05d4116d43db4eab";
+      sha512 = "a66b3569fd40f98577056134d54f5d7f8363dc88a17902472d8c33ae6bd76548e1c8e05f0d433fe3d3a82e0a527415f53722698cde7cd7b5a6a86b09dbf06d9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/et/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/et/firefox-63.0.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "7f118ae92f0a38ddd9a0eb35089f99c09771e377e6e6864006d8f2ae604d9ad76d38d641723660cfba138694840bfd5ad8cb9ffce87a4dee76fdd032d2ff3bc2";
+      sha512 = "8df22fb76c8b5bdf19d4b9a34313afd8d90a22e28e558d1f9faf4e91ae3c6e034a40262da4fac829b50a44d549fe6d6a8aca3488bc58213c816745346c9496fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/eu/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/eu/firefox-63.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "f354842728b0821dd779957d7bc5ea58f7f498f26dba21f8822b6198148e47caa7e33b18e37651a92620387046eb2f494d9efa6f8a83091dd945191a24afb3f9";
+      sha512 = "682980f115c5d89e4cd5a9c5c519d8348f0ecf7a8f571cfec59015035b7a96f53d8d518ab1dfadfd7df0dbfe1ba6ca96ab0fddb36f1b86a54df588e2ea685c76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fa/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/fa/firefox-63.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "473441e4410cf8683a536802a1ba15cbbe0c802fc43e03eaca0b458ac8222f5f8b3f43cf4e85018288967ba2a305db8360c6d583e5aabb80b4146d8bd6c96865";
+      sha512 = "9e239945cccec9909ce9fd453ea66fc974f047cda704a6c56300e19fbcb456a64829032e9a207a25785a6d2ebd0d6734c1555bf0275787168bf717e01f43fd49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ff/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ff/firefox-63.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "e8e1c2fd944f6839560e3182b2933b2cf9d62628589b9f3116179d918ff9b5aa8b518c5150d9178dd3aa4571e7e6c1a7c21e263faa409c106b0a63fdb9ea07ab";
+      sha512 = "45f592ff155f29bb3a1e59d78b93467974665a467509bb3e435de97495df9bcc466e0315ad31415ff8a2c08e46066b5c11cd2cf4eeb7889cc90b4e2d2db23597";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fi/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/fi/firefox-63.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "5c5360aa4afb19fc04126e3ac59eaf0ddcde87fbd702fff8c81084b1b14932de8a17965138eef2473532c7ce6a624ff89f7fe6f8f096aee42162fa26a6e4156e";
+      sha512 = "8bb1e61fdf8283b6105104a8b5bc467e812c9fb9844e69ddf9b0f83315b26577b275770231f1fbe03cf9c80b4757d7208749b4014a957ca7ab37cc7c54a7f3a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/fr/firefox-63.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "7be9df5480663cba5ca9d0ad5ae163073689395ff353e68deeb89714d5c535ddb2313f8495ff7933208c64360e74f6704a92e50c15a7b5c8b752e73080f0d743";
+      sha512 = "ee89b1a7af3e3d176e8d6221bea53c86e340772f62c10ffb3631a1f584e4ae2ef6631128e609b4ba029fdca4f358af0d1eee9e60dc14123be9bab7e0755e1ed3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/fy-NL/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/fy-NL/firefox-63.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "a376fa68939d16fe7dbbbf91437f7b757b66e7948eab2bb1170f390a310dbfb02f9ddac481896d1eb9deb5a12c942e7bb7e133dcad4fcbbdf90024d56a887e6f";
+      sha512 = "cf94472b88fc2825e79658283133ef501e0a57469ecfaa787c04649865b5366776dec1c21a5c087ab588a5abbc3951ef627aa3cad510e4185f30510d12cd4ac4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ga-IE/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ga-IE/firefox-63.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "90ee86c14d64bad009d4a976bb6290d4ff2c521422a12e42eaf31a58991d2d3cc20239f6c16b12aa7f11b5fc0f219ee0baeb660f1bf6036fb1b93a8d25da7ccc";
+      sha512 = "b2df9d225a9b903ecd8f2c2f3990980fdf0a16bfeaf04640d13f25eda58aada47620669ee479ef34144ee28a490c125b9e9ac5a10e961374cd3715e6d7f1e9c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gd/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/gd/firefox-63.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "c3c1ef229cb2fb1c77ea10c13fb53a2b87cb43068f39182517787fa14043ca4e47b4a262b3ab11ee33ce28340ceadb1486127d280718b58f4d3d28c6d1e56155";
+      sha512 = "a5fc5582241fdf0a0783ccf0e7c23c2e7032f12b13517d8bdeee21c64a0118b38913a28660838ecf41299ce3955020fe6dfdff25e72b6647cf82faa0bda209f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/gl/firefox-63.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "8e403f07b874ca951b0fd0811308dbb6766a82ae9cdd2e826fc93e19fa89be075f2a480ba403c534ce7f078e29b92b2ecddec1cd461dfde5e7503ffe10757d77";
+      sha512 = "d748e3eb036e780278b8fbb9f3d30c319f0cc72a2fdc490abf54e6a532768d2050be0b8448b80f70db1ae573b6a618be3938d5123a5876c8fcabe8d47067f77b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gn/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/gn/firefox-63.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "288a0c5e1217924cc4b7596a4367d05914d4e3846871a7cabe0f733eac998cd18651e1083d23e034a22feec764f809bbea0ada464a19fb49673b86bc86cdd7b0";
+      sha512 = "fff41e2fb5b4e394144f9620978d8fa1dea4579c20e1c9092925b68f553134e58d4635db20ecec07f5ff8a7694a1a3101c92206aaf16df00eb40fd4d3ad46402";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/gu-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/gu-IN/firefox-63.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "39acbba4c189498cd9682a80475404ab8cb5fc344cc3daac6a2bc9161f062d4888fec2a7c6c710463f86c286d0ecd5ada624265ed0894cbb37b6d516b22daae8";
+      sha512 = "ec754e86ba03986e454f7473bb1b38bfb47174215489348cd6c2a06accc3bb64036a497c3834787f71568abc82d56d6fbb331d4a666f036c4a11c301200980ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/he/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/he/firefox-63.0.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "8950daf8e742b4d643fb7f6fde87c80bc62e9af98896270bbc834b9e7bc73ed7ae1c9696b9a8c14b2ed372c05ab3b5206e9582b6aaca224a73d3260ea3a7ba91";
+      sha512 = "b5afbce3908e6d67a9773ac1350d3e94660fd04e4be3cb46f72ec0c90fb75f1de77ab751e0086cebeaaa123baf00cc171e558a7aca7e5f7689bc5b5371671f18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hi-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/hi-IN/firefox-63.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "902547d964746179ac21b4b6c3bdc92b1a11125fdbae97d501d497c882002e6c2ee1ce339b2447c6e650571b02803f51a009b751d6b100939ad5a09eb3e682c4";
+      sha512 = "6f7510b0d390a7ca7e5a248fed08d21f60f3f59eb0e064ca837cc4a96664443d9145a1e2ab5b5f8a4d3bbcbf978b220b0271bbe883944a0b9f91dda3c75e040a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/hr/firefox-63.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "f94af79ed665da21b9c798331409a1b1542d45e4abfe9a1124b0c5d38e175d7653cc2916fa59f380b8288766da88526742947902edcf147fd93b1f63f29af1eb";
+      sha512 = "66eb45f1f232409bb134c86c5b99128cf497db845e0e4ccf8212342dac144bfa195f6c6f0b75655e05dceeec52ccee546ef8298d253a535ce8853bbbb6137e59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hsb/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/hsb/firefox-63.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "10ce80b0c58913a50d279c9276365994597dbb2688aae32a8eab851a2fdcef4829e9f3b217b14103d82cd67aa586c7ef184121b688979080ee87b152738abfbb";
+      sha512 = "5365d3125d0e58ed39beeb4793196fb8a7809a74165ddfa9cfcd3d4f9358b71f68e531bcd7242013b8085db17bbf2585c46e101f704af7fa668f1e6bfab10b89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hu/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/hu/firefox-63.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "909de698586db1192f09d8cc9b707c2487784910184ff2e72d1e5d8bdae103b4b4e3296073d57e5827f8063e17310632aba79acffa47313f577bdca30e35354a";
+      sha512 = "1f488e2ee4a88c2f2aae4501c4b9442e750a800dff3f2b38e5ea48156be83bac7a3870b1a18860d3adc4900eec6ce9822d5558b5a1eea83017f7dbc6c19382ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/hy-AM/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/hy-AM/firefox-63.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "4c5dc3c1030dae4153911faf69f5399b7e90927c8419a742f7fc7e319924a67e508c32d07be16d178fa579a4dda39373a828f32fa112a99a6da05dbcfa0b271b";
+      sha512 = "bb62de549b9c1de22dc17a0fbccc16b8d8d89f093b783c3a5976ea9594b84bb4495ca2a9522444f84e1a4b66517b59b8901b411b0fcd29477c869ad9ef664f7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ia/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ia/firefox-63.0.3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "bf6fdb4ec04641a9e9a7e349df82a431c78b4d3402a0f145309f364028e33d05a0126bcd236d69c355c8a60c3e3dbbd0db373bc9d5ceef1f7a2a1fcecd998a05";
+      sha512 = "c4eeddbe81a02ae264127f0fc1437c68d13ecacae07707ecabd71ac4a1d2845cdf164767ddf85f960c7e6c3574fe1f0a4cbd6d77f1d14a0944efc75acc999bdb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/id/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/id/firefox-63.0.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "66bc5e37493b5d49202a1a49b2a688e04fc279b4fc59b39501b1ca263d273fe64e4d100af49425be7487cd190cdc4774f1ed076bd9d31d6f10be099afe5a206e";
+      sha512 = "6a492b6b1e0bd3522f80e3b450c40c575ab873644705939485f6a4e42a92c6024da434d90da88e4d9ba9b85df94df358d98950f0faa3c5d20a23f49e177231cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/is/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/is/firefox-63.0.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "b0e5c494eaa593fce4e683fcb3483dfed0b23931eaaac632289cd4064c1244eaac82da8966db7fc85a9b380a5993cb1e21a3c5b811ae53bc4ecafba0e8a62842";
+      sha512 = "fd10450ace7b24ea214bbcedc0af6c29e4dacb3b542ff53098f414ca990b572cc18550578583fd94f4c4f9823b9e6e2a022114f883a6c2af970db9f98843f86d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/it/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/it/firefox-63.0.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "e03a88871c696ea20917dc6e43707895bc8a2d12d1478b18f3f7059cb7d73d86a690038a0e65ad5434749c01874a41d414494544fc40c7a74a278fec6c409ea7";
+      sha512 = "d4793bf2afab3d1e70ca75ca7e0b516bd1615b969bb32de230956d8e720a7857b7cf5941a6b5b3d04dd491740e59e7ffd61d82f3055972c136ebc6d9d5450fe9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ja/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ja/firefox-63.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "60548d2697967ba841350488239e061a597f56e1eb9285b763f83bb57df6c0906f39eb9d030cd649f496ad3ed54c717cc4ac71fa44bbdaf3f18e32288c6dd434";
+      sha512 = "742e390b3a6d1856166d952c9154be9f9fd1439fff295a6179b13c8884ce02053fac2c5aadd411d79dee5916b8d1e86cf8675f7929afd3b78b071b17521efa44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ka/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ka/firefox-63.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "2c3a2454ef64a184b1a28f884462ee63806ac61b578f59f61ec194691690880a9ce2d76e0e183ed16ef9ad570383161ce9370cdc97515a1b33a6b279d134ca6b";
+      sha512 = "334cde60d0b9913016e5e3064943bdd703153634f73f19773cc86cc4948ad69943f668505fbfa76dba5f563eddc0f9ad2f305f283b3b5c94f4fa38d8d780c4b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/kab/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/kab/firefox-63.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "0ab0ae54fb5472af7dadd987c2d8a5a6d820670b1d6fd2bf17eb036fbfa4151e7ae754028570be254d8520f98b2cfc953d50e98774be0ab5736c3ad52313aed7";
+      sha512 = "7cf9a06820e3f60028f359a354139e9241a993c2820b7fb4b5f1eda4690c80c1dc7c740f96cca8a4070290624df378f711592000a8d009d69039d432c882f75e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/kk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/kk/firefox-63.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "0fe809a4ceedc163dc3923397c51ebce0bc933fa8d728fe8da44eea098a3a150ab3d86bef8e6904f59d20440dafe16a8c45be3d8d00f4a0392e446a3f60c925d";
+      sha512 = "a8be8575aa1d8ae527d4aa206a9f78a7ed5904f4562a90851bd532b4293baeb9deeb4f6ca827d2fc5a4b3fe5a2c852e575729d3860c3f7197462c4bd4ae5a924";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/km/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/km/firefox-63.0.3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "5ca1faa0a2dd1fbc1c2ea9b7c631ca682c442ad26a384065f27261265a731003214560fbb6b90be791b07f10a5ca7ee33d22c682a61f2eb65f813c9af06d6ea7";
+      sha512 = "ff55a3ddcc5c428ed1374b2e9dab78e8712c9af89be52980cc252d6c0fdc47990ee7133663db59d7fc421184d84d4c8aaa8213ce2dbb37e9073e5dce46876900";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/kn/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/kn/firefox-63.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "f4df227197c065304532c5dfc2e86393adcee0d494223d7771c724bcf8e11205db7e4085373c3b43b51c84274bf741d39712cc2143c7361c706ce0613e244c96";
+      sha512 = "ac6c0cca9716a53485c54a11ff36a9dbba041c4b4d10dba578160e35738393e3c639ac789e09a88b849aaf7e2778bd6667d3ac421047d824b58c2d48f2dedda2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ko/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ko/firefox-63.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "1e98e25daa86dd69a06c69146f171c84ae45c42e5906fb04aec245235c3eaab310bda6a08822081a18ea75c934905b3beee22d17f9f2a2f3cf823c3c0b695f08";
+      sha512 = "c007bfbe54c17ec9be73e78b82eda62368a32143868f4b080d33c9702e771436f6cc25751d6f41bc523b49db5975901c7eab1f788ed9dab908c5853050ecfcbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/lij/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/lij/firefox-63.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "864335bc53c70d738d0338426e499bb8aec9b35edb2e63451805a064c8601b6698293f1fc759a4cc3d38b556fb7ca83f4a1d15c7ae9aed7f668d9d901b47c456";
+      sha512 = "2e61125910f090b63211dc5ee382558f2581b1cf2b5d68cc223569712e4d144af87d36e3b4315f8aa2f7c4385f379c41ba60154478f780116ba21e3a2b3b5fd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/lt/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/lt/firefox-63.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "676ffb0616224c53b61c5e13713fcd59078d9acd46268a76321e199414acdc734093979a71b1e7a054d690f6e62f1ef28f807345cad620e7b6ab7920f84a7559";
+      sha512 = "5bdf6a74728f7e0bb65a65e4cd3c391c584afbeefb84781ff6fd1b6ed69953f45049b09e62b30c7b7e1560db04a5969ba04bef5bb52b41a773f47dbe1386ea2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/lv/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/lv/firefox-63.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "ee93f40d4e624e24dd9fba0951d6f0d67e4caea63fe8d24ee1641f44de3c44f214aee0f26ce9a04418c585e9a6486d50957a68bfffabe614cdd9243604b9b519";
+      sha512 = "84849a4352f947f8db8542b9ab357f62f5fd814b8459d326475851aeb31718a253e7b73f7da399920505cd2b2a0b3aa0c7b91eb843bae1c99e330ba13445a7c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/mai/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/mai/firefox-63.0.3.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "c71cd9d320f09e0d6307cf1e04cebee3ee565078a73630a32fe461815098c3dc09053fcfe15c51736da2686b6edee435138cf953931500bfa3b049a31cdc086d";
+      sha512 = "87cbcaff0f938faf1717e8ff1a890f8bcd098643c4aee794acb639111e40328330909596278fadc9396ac5fb6ad1b4753c7ec0b4f3d565d80eaba001070058d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/mk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/mk/firefox-63.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "d04883a77536aeefe29ec9efab45bac90ab548a9d67076911446f4f8d7e86ec01055367b5fdd089f857bb3e6e108ae1e4ff6727db2cafc17ef25ba9ac52914c0";
+      sha512 = "a737229c2dd055539500e8b5584f75ba9827b898f9f9ae934ed50df4313b40fe2a9fd834d731248469a3811f1afacd64f4e3af0c4611974d50e5410174f989e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ml/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ml/firefox-63.0.3.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "d9c71712d7b852c4585245d87fd060b707c1789a5406e69248d46b8b6a2145fba33cdc5a31dcfb654e7386fb1b2b70be7f6e22c320d5fa85927d1bb9867280a8";
+      sha512 = "3fff2d733985f39c2f0db1e4528694f8b51479b2528782213ce822ba50bd65c2f56e0d3ed06676e3099474a8ebd9aca4ac539dc259dbb38308ba1500a5a45352";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/mr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/mr/firefox-63.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "fc82d00af91de103828c99eab71ebdf0f047d978c7477f57bb7df64fa20b4fedc39bf0fcaeac4239981cd0a0eb845509e78e4b645860f2bc1835a2a3dd1c32b7";
+      sha512 = "940fc88c218cc97d41729f2ead303e972b2d811d863fa3d5e6de22e5d07eb815cfc6a8819108990b06f47a1d2dd10188bc042e13c9ff3a38af919d45942f4ab9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ms/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ms/firefox-63.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "935f32b98168d0b136a6e1d1fed10b8636e74100f0f40d94273483acfc239e818907159e1b6009fec132ef88710a2a4189689a1313bb26eb7d3c7bf13cf365ee";
+      sha512 = "650f327446d64c761e4baf1b7c06757a2848622cfa1b6799a1d2d60eb39dad3298a2671b97db735f1dca169eed86e7ec2782c083451b1eb474de99bc862f1d6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/my/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/my/firefox-63.0.3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "74d85bc47ba363f889f1d8785756406643f03e60d04a340f99a79f0fdd4ff733cab1807b16e76bdb1bc0fb8f8f69397624d8d8aea934e689637b90d283c171a8";
+      sha512 = "9e6e1715864f6f200b01003fb27434c9d6c29b4aa4b53d5637f9c3ce429f10f2c307f776fb574ccfee88e89060e1b45905eae704ebd0a54b1332d046910addb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/nb-NO/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/nb-NO/firefox-63.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "a9e43f742b720a03b9c7ba43e812225c6d32174e908dad8de15a72e758dc2f6374aaca5eb7ed7abbfe7180d06936bf7eef6f021c25bf3d440d63c1a0bc3c1804";
+      sha512 = "0c200a9f928f2c9d42d763cb90bd4d82896075f0b4398a20172ce88e31f9aaaa3f7d76bbb4c7f4b1e396ac6f4a9e71b1f51b98b34b5f562236d889fd566dc61b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ne-NP/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ne-NP/firefox-63.0.3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "c20328156416c0678d701c386999a9de88365bda8b033804661158098911247b883e4521d7881d63fec08713136a457f1fa52cae000e7cea7e8392baef7986d1";
+      sha512 = "9f30351f78c2288d24bef10b99387caa88e183a59a1ce1963789912552f9a097b30ffc3e2765c6da5d22bdec4ddb1a6cffb8375f85e25eaa8fc5c742c65c6351";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/nl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/nl/firefox-63.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "b1d16825d152c208108938846397d6fe1315493e5e5166835c546c611badd25f3e21aa2bd044ab84b827e81f3eef0094af8196d58dd84bb1cff604bd63e7fab6";
+      sha512 = "2053d3a73479089c260d93680d7c00666f9685502d4a47db756e4bc72ee0d63675ace48043ef3ab7161c8f7632a79136fcff551cd13ca5ae419795be02936a60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/nn-NO/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/nn-NO/firefox-63.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "7f86b552c74fae7a7d0ee81edb44696770cd31ad17fbb1cf8bf1a9cf6c102b006d76204185a6d36eba2c73fe9220735668ad12fdadeff6dfaf4a4fdf507c47af";
+      sha512 = "19f40aa2f87966bbfde26b0b3af1f14ae39d5eb79e8aeedd798de8ab09e94f50a2365b8ec506ffbb7fdfb97ee5b799d7d687963709fd76c388e0d8f5d5f43093";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/oc/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/oc/firefox-63.0.3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "496cc5e21d8dee68a929d9338d3b7c341579af2092279168c846efb355eb28d47180173d159d3e93f279e1494fea778b0e769a2b87e483abaec3da4baf0a258f";
+      sha512 = "d022cb815fc72a5aad403652ee97a16fc56b76b8596031191620916103dda35db28df70f73f16a1c32f73654f8080c95fb5d34194be20c71847a9352ae04c54a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/or/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/or/firefox-63.0.3.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "a4df6ee8516b67bfc783d566e3e78490ee89cc74645e1caef73cfb4623bb571df292b03a8796c313338df637ffd3825e7ee6dd0779e2217319fdce7b07bc9b8d";
+      sha512 = "93de7611b6d1190c683e16485fb29eeefedb61ee1405b8c6028e0063d843bbf54db64eb62c543143c140345d7491467895214311bcc01bc1b80ae547c0587912";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pa-IN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/pa-IN/firefox-63.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "7e6efcd008e69c56ee21d8f00a7d0766c2c9a79d8a2b01cf7b9deae0dce7e03ff3148b2ebacc587268d39a3564fe9870c5cd12db836ffa96891953306e6822ab";
+      sha512 = "dbf63ddf9115783bb6131689221728db59a3cf22d6654b913ad895c42fafcd768609586f5029e958e2e4cf9e4ceba1f8a843e0a962ba9d966f6df2352619c1ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/pl/firefox-63.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "947ad8bffca0d619d0c3a4fd77830120395592cdc342ea462c793c298252fe76819999110ba4dbb9b3b6189b107aa307a5b04270b4642113f634593a3813b565";
+      sha512 = "27bbdaf6ae09a3c572438fcdc3ab7360c522cc2ac49d81d25358531192ef443656cf6b53d53ed65f30f5fb3081157367fa87c7b7fccef1f02539b584b6b2542b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pt-BR/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/pt-BR/firefox-63.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "9b465f5c34fafc80b33b45d03933c81dd7f2e1d54417d5b80953b35addce08b011d0ccd1a75353f5e600d4567794e62268c27603d5fa9ef6bd2e5ce83889ea6b";
+      sha512 = "1b391caa2ea9b0f1df1894ccd843d5b5a138b2df22754c112a613757cf415c948c32ce0f98996c0527a619324346876880651893bf1c2c644f4eb9bc1268ffba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/pt-PT/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/pt-PT/firefox-63.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "4a9c47304cbd015ab36e5763ab0b6564cf81ae4c791d28c1c37d49224e4fd9aff186815b19a4047c7d6b713a6c4ea7f3d341d11e56885ee5b73cd2f2a2048efe";
+      sha512 = "df21c64905749b2fd9223164832edbf77822c961b17c5e6537acd67a9a4a31f06fed222465099e3fd53a05da8b347a9e82b217f61d397eef54b1cc068dd9ead9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/rm/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/rm/firefox-63.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "24dd07cee63e1a3370b970c5a2e0c215e6587ff17ca0438bb8b52313eeb52e9b241c56fb31740602067b635b314cf20d63e03fe269ae35b4374f2043c8292af9";
+      sha512 = "427b2ce953a5cb43dccb82890829f02f4583370a2ad5e7f257000950fb8bf33c1c8e52656627c4bac43ed9e0c3df5e5ad378c9d42f8d50b14a7079a8fd667ea8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ro/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ro/firefox-63.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "25c0d057571ca970344f91a07ee1437e290ffeaec2c15a3b106e4c690afcdf7b3bc9f92f28b11d179cb8912697b1d7e255a6596bebbe8e1488dcf4347cc7fecf";
+      sha512 = "f6a19326ac0c5fa214870699a8ba50e37fee551f14e089506860750afd634dda4fff262e39d2cb10aa4bb5a60bb54eaa807494d11f67c05b5eede9299d593a6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ru/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ru/firefox-63.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "7110c2ff51b8d5539018383560c113e63ba1a870510501b0bfa1294bd5c19a992d07786732bbcbb820ece4045fb826bfcc778200dd3ad63504e64cc2d85deb4c";
+      sha512 = "cd9f92ac9673806094550b37f498c70f598de2f1ad0ce7f9c4f74b2e22460369ac41e65768a722a9234fd746c81b9f7ea762dd59352d4c3c849ad1ef72a8bacc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/si/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/si/firefox-63.0.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "6dcb0eccef3c582545e7de5d9c33c80690db698a9b28dc7fe654187b60e69a41309c3326eb2b73ed6869a4278c22db369e12a8fca5f2553327b2b6fa7fdf389d";
+      sha512 = "29636b6005b85f51bc5656e9d5f6539120427ae92903427eb3ef86eb002544c83103ba273a3c887d228c664c54d7be8bd2903346d6915c2c6c19f734440091b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/sk/firefox-63.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "9e7b74a0c495cc6247c5d37931d6038508186070de80a935d2a39540960d3d57996f47497fa430b24cc9164bae5bf5e761558cf60231594ab9637956a26326ae";
+      sha512 = "a52cf23baffd28c0ebbab2af9a3d4f9004f43e9f9a9d0bbe60a72e9f613247bfd31c4d05a6822753ce5c2bc5bd83a2ba1fa328bcba7756354744b02d15c731be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sl/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/sl/firefox-63.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "6c65c39d0ae8a398e25733f0be9180dad1bc17d3ffa58f02844d6750bbb64a0d70f31b565e3ed606b6452431d0aa705f671b45dc2280cbb90aaba741b60d82a9";
+      sha512 = "2ddc599462520f10d1e4a81c884b6090602d00ede09e984d3234b6206cd0896064f94918c7987f0d247ab21a3f8e01b37db51af8d9240c9af93d94736b8fdfb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/son/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/son/firefox-63.0.3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "55ea357bf7f6ddb7e8b51796ef199168c89ff5959e5e64fdbe8e362bfb1efa19f9f407c20510139c52cf44058a5c4823b2c1c10821a2ee06a18b19d48a85a403";
+      sha512 = "0d5801acc43e5be55585f2a7559eedfdf745b2f421f981fe0f06bdbc1ce42304384415c00bc79de224b1772cbd7be7154b82e73c9ac4818350704feb7d0f137d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sq/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/sq/firefox-63.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "5fd975a71f9899b9eb90f46adaab044c2d21ac64cc71558748368c41bc50ea8ae688fffb0579693633f1ed82970917e1b46a41133af3133950dfb051c33556a1";
+      sha512 = "4b08fad1990903119a1d4a127955eb0bf0b92bbca825c530f77bb2a04a00817d6ad82b1f8e588c6773a7e55021f6c71396c8538757eafa8d11a0e142cd44d948";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/sr/firefox-63.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "e8cc283b6d87718f81a619e0c54a2e440e21940375f8eabb318d24c22b5e04fa387d27dd6b2c28c98c65a94cc8aa1966ea8c6ac346f3012df0a6f268c9aac67a";
+      sha512 = "bb778423708d853e7e1cd53cbc5dc2de6bf519edca9cda53b005718331a9f58aa94f17793f6d236ff34865c012bf411da243fecc98cc26c7c3214244ab06a936";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/sv-SE/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/sv-SE/firefox-63.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "324c7b8b0b313d9de9d83f05d2e802c9733537a5bc1a77bc7335f2551f1466da9c276622a848440e7a353f944e463e1b323fea7655985cf755b38c80e17fe335";
+      sha512 = "a443a9a90cf3babbbfb0d7dd65a254a9f76906dde9765de83138345b86673251d13e6ae77cafa6283bd5fcd3431e94842b466e09e2a8fdb450aebd247dfa4e06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ta/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ta/firefox-63.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "6f35862c7052f55b06ffcf0205331288c4278fd2de713c57a509543a02394978a9726fe747709f4972ee2c43a5a001c0f7c5e58e63269047abcb5f4f26e78ff3";
+      sha512 = "406262d0a7cc447b7825330f007c2a7638620931aca61c43df13b347bd0db631fc5186e7d185aadcc5cdfb160a33094a02eec67fde837b54ea368af6d74f9d0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/te/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/te/firefox-63.0.3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "4a5534580d90af3f27ab1d66f54f38782179ab239ad913153660539591001db9dad409ef849df97f5f382388f559eef336c2f9245180704caf9d414e0965c17c";
+      sha512 = "3c350590828689d9e7d8cf7a70c4573192d05e1df9f8c577f7613347b55b7612c0ef2e1152f0de5be1beb4f7fa8e23415bd99a2a5fd81b4d60c9e2e05b9f8f09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/th/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/th/firefox-63.0.3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "1a21c20e0f410aaff94eb4dee6f26555515c0095aae9cc5e7ec8c90e57bbc73e8dd5a931b9f6fae52d5ebf7de4a3aea2176b973effe3e65e844e1936387ed8d6";
+      sha512 = "f9bb79c836e3fad0d29ee5f17e5753af8fd81bfc53bd29e80fbda7e6d643e913b1be3ce86eb7ec79e4547cf1512c6c58769c3c13480e78b26947a85588235b61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/tr/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/tr/firefox-63.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "1e69c3de2d1836082369994ea843e164212527a13808153b16c02e5a3986a3f11c87abbe0fb2eb9077f1273ff14cbb545856c376945a9e40143217896a444e17";
+      sha512 = "9996bef2a7aca694cb670650b84e27d593dd107293e51c392466c5d688f11cffd4511b1086d0014966d7d53849c83301d3250e021d7f95545f10ba681c01f434";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/uk/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/uk/firefox-63.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "87c4e1b907db9bdce6d8dcd2e4c70d57a4e8ce5125473727582987c2eea25543d2d97596d0f3c776962c003f2a5356260d3d9f18410448dec4198fead5461da1";
+      sha512 = "5310d6f1350a6b553f3093b2a3e8b9267bd866aabcfa43c3dde0af7f0b7e2314d49ac828c5f457a71dab93b7db3e042d9b8a662a7cc1960b992657bd0b4807da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/ur/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/ur/firefox-63.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "533dc9eefd4b7604d92420333aa4f6e1b741ac545814ec1a868393e321d3e84e5d3ba475a98cf1e226b746f1f6b5b42db082d7a6d65b10971b2576e0a3d4cc69";
+      sha512 = "682beaffb5f7c378ce73ed0b1d2b71977d4c4d9c676aa18e6db49d8667e614e839b51b77a70db08d2fa8f76bbf4f657459fbafdd27d571a4f499184d482a2ace";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/uz/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/uz/firefox-63.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "e3830088e08eb8e16e6d7196e153eddc85bfb1bab3a29904aeb59c427215fdf82d7a5e50ab9db5e7abaa74b88ca7a4c002fef11883ab000b3b10814650d337e6";
+      sha512 = "28ce6fae535c55052c8e35138f4a65d82b68538cd711afdcda87edfd741435ce259fc333015a5185a9cf4e93aeb8ffee3ff3e0a7790e69bcb25ba4d1a8c65b56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/vi/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/vi/firefox-63.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "5cfce3e3a278964aec4b8b863caa60618691fcd959009395a705b8ccbc51fb7b30adcc84de3be6e2627329d0d61fc7ab7d6c2ab15f93c255c336f327b8aa8a13";
+      sha512 = "88de4e5dfd4458984d3e5bcde90cde378fe5751358c96195260ee556f6d74f9f117933cf58ed112ab4d5967ecf1302ab446467030d87750abdc8035194a32257";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/xh/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/xh/firefox-63.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "61630ecd035d69866d0934f3a4ef4b574c4ae1205af3c130889d1eb132066fd2068a4583eb87b9e214f033184a671bb973368faf417aaa3018e8badd16295592";
+      sha512 = "735c9ec6d8737ec719b2402bb19ae5c08b35ecc3ebbbfa9c329c3cb86f98abb2d556a2695ad6507b3f0d09833b5acfc1ba604b34d66f744c12c4c1bf5c6bd300";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/zh-CN/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/zh-CN/firefox-63.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "968987d12dcf4a9ac0e078132ae50b321987c990c9bd8cd3388d981c7e5dc94d26c7af14492e356d2b984badd595998bc7e9f955e0772534b5adf31886c319b6";
+      sha512 = "7dad35201518a38e2e438fb110b0e70f72b285dba5d2434020a1e75ad95e9e42e794cff3f2c991c640c9e19683075285ec5aec70fb7737ae2309d85a9f7e5a92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.1/linux-i686/zh-TW/firefox-63.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/63.0.3/linux-i686/zh-TW/firefox-63.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "286919b5f69f2585c291c0736dec6b37493a809e7e2b342743523d73e749ac4e860236da061ffb14c28452884f72055d47084fa3455898f9afee798c1ec7cdea";
+      sha512 = "092c048c5cb2dc7b80db629f937095dfcfa63ebfce4b1a2a8acdddeac7b14c2b07e965d3b28a35ca9a471a8b6667eadfedba33dd3aa824cf061b94cec733191e";
     }
     ];
 }


### PR DESCRIPTION
(cherry picked from commit fa138b55a6d289151a2b4f7b0ea1b18d22ee6576)

###### Motivation for this change

Multiple critical security vulnerabilities:
https://www.mozilla.org/en-US/security/advisories/mfsa2018-24/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

