### PR TITLE
marp: 0.0.13 -> 0.0.14

### DIFF
--- a/pkgs/applications/office/marp/default.nix
+++ b/pkgs/applications/office/marp/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/yhatt/marp/releases/download/v${version}/${version}-Marp-linux-x64.tar.gz";
-    sha256 = "0yx6qxrjfs4q4p6j11zxydr23r9y16l8arygr0yjl4dlzffdygxm";
+    sha256 = "0nklzxwdx5llzfwz1hl2jpp2kwz78w4y63h5l00fh6fv6zisw6j4";
   };
 
   unpackPhase = ''
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    chmod u+x $out/bin/Marp
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${atomEnv.libPath}:${stdenv.lib.makeLibraryPath [ libXScrnSaver gtk2 ]}:$out/lib/marp" \
       $out/bin/Marp

--- a/pkgs/applications/office/marp/default.nix
+++ b/pkgs/applications/office/marp/default.nix
@@ -1,24 +1,30 @@
-{ stdenv, fetchurl, atomEnv, libXScrnSaver }:
+{ stdenv, fetchurl, atomEnv, libXScrnSaver, gtk2 }:
 
 stdenv.mkDerivation rec {
   name = "marp-${version}";
-  version = "0.0.13";
+  version = "0.0.14";
 
   src = fetchurl {
     url = "https://github.com/yhatt/marp/releases/download/v${version}/${version}-Marp-linux-x64.tar.gz";
-    sha256 = "1120mbw4mf7v4qfmss3121gkgp5pn31alk9cssxbrmdcsdkaq5ld";
+    sha256 = "0yx6qxrjfs4q4p6j11zxydr23r9y16l8arygr0yjl4dlzffdygxm";
   };
-  sourceRoot = ".";
+
+  unpackPhase = ''
+    mkdir {locales,resources}
+    tar --delay-directory-restore -xf $src
+    chmod u+x {locales,resources}
+  '';
 
   installPhase = ''
-      mkdir -p $out/lib/marp $out/bin
-      cp -r ./* $out/lib/marp
-      ln -s $out/lib/marp/Marp $out/bin
+    mkdir -p $out/lib/marp $out/bin
+    cp -r ./* $out/lib/marp
+    ln -s $out/lib/marp/Marp $out/bin
   '';
 
   postFixup = ''
+    chmod u+x $out/bin/Marp
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${atomEnv.libPath}:${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}:$out/lib/marp" \
+      --set-rpath "${atomEnv.libPath}:${stdenv.lib.makeLibraryPath [ libXScrnSaver gtk2 ]}:$out/lib/marp" \
       $out/bin/Marp
   '';
 


### PR DESCRIPTION
I think 0.0.13 never worked. The 0.0.14 download is weird.

https://github.com/yhatt/marp/issues/258

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

