### PR TITLE
Ntp default restrictions

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -111,6 +111,15 @@
    </listitem>
    <listitem>
     <para>
+      The <literal>ntp</literal> module now has sane default restrictions.
+      If you're relying on it being wide-open, you can set
+      <varname>services.ntp.restrictDefault</varname> and
+      <varname>services.ntp.restrictSource</varname> to
+      <literal>[]</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Package <varname>rabbitmq_server</varname> is renamed to
      <varname>rabbitmq-server</varname>.
     </para>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -112,7 +112,8 @@
    <listitem>
     <para>
       The <literal>ntp</literal> module now has sane default restrictions.
-      If you're relying on it being wide-open, you can set
+      If you're relying on the previous defaults, which permitted all queries
+      and commands from all firewall-permitted sources, you can set
       <varname>services.ntp.restrictDefault</varname> and
       <varname>services.ntp.restrictSource</varname> to
       <literal>[]</literal>.

--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -49,6 +49,7 @@ in
         type = types.listOf types.str;
         description = ''
           The restriction flags to be set by default.
+          As recommended by 6.5.1.1.3 "No" of http://support.ntp.org/bin/view/Support/AccessRestrictions
         '';
         default = [ "limited" "kod" "nomodify" "notrap" "noquery" "nopeer" ];
       };
@@ -57,6 +58,7 @@ in
         type = types.listOf types.str;
         description = ''
           The restriction flags to be set on source.
+          This allows peers to be added by ntpd from configured pool(s), but not by other means.
         '';
         default = [ "limited" "kod" "nomodify" "notrap" "noquery" ];
       };

--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -40,9 +40,11 @@ in
       enable = mkOption {
         default = false;
         description = ''
-          Whether to synchronise your machine's time using ntpd.
-
-          Disables systemd.timesyncd if enabled.
+          Whether to synchronise your machine's time using ntpd, as a peer in
+          the NTP network.
+          </para>
+          <para>
+          Disables <literal>systemd.timesyncd</literal> if enabled.
         '';
       };
 
@@ -50,10 +52,11 @@ in
         type = types.listOf types.str;
         description = ''
           The restriction flags to be set by default.
-
+          </para>
+          <para>
           The default flags prevent external hosts from using ntpd as a DDoS
-          reflector, seting system time, and querying OS/ntpd version.
-          As recommended by 6.5.1.1.3 "No" of
+          reflector, setting system time, and querying OS/ntpd version. As
+          recommended in section 6.5.1.1.3, answer "No" of
           http://support.ntp.org/bin/view/Support/AccessRestrictions
         '';
         default = [ "limited" "kod" "nomodify" "notrap" "noquery" "nopeer" ];
@@ -63,7 +66,8 @@ in
         type = types.listOf types.str;
         description = ''
           The restriction flags to be set on source.
-
+          </para>
+          <para>
           The default flags allow peers to be added by ntpd from configured
           pool(s), but not by other means.
         '';
@@ -80,7 +84,7 @@ in
       extraFlags = mkOption {
         type = types.listOf types.str;
         description = "Extra flags passed to the ntpd command.";
-        example = ''[ "--interface=eth0" ]'';
+        example = literalExample ''[ "--interface=eth0" ]'';
         default = [];
       };
 

--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -15,6 +15,10 @@ let
   configFile = pkgs.writeText "ntp.conf" ''
     driftfile ${stateDir}/ntp.drift
 
+    restrict default ${toString cfg.restrictDefault}
+    restrict -6 default ${toString cfg.restrictDefault}
+    restrict source ${toString cfg.restrictSource}
+
     restrict 127.0.0.1
     restrict -6 ::1
 
@@ -39,6 +43,22 @@ in
           Whether to synchronise your machine's time using the NTP
           protocol.
         '';
+      };
+
+      restrictDefault = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          The restriction flags to be set by default.
+        '';
+        default = [ "limited" "kod" "nomodify" "notrap" "noquery" "nopeer" ];
+      };
+
+      restrictSource = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          The restriction flags to be set on source.
+        '';
+        default = [ "limited" "kod" "nomodify" "notrap" "noquery" ];
       };
 
       servers = mkOption {

--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -40,8 +40,9 @@ in
       enable = mkOption {
         default = false;
         description = ''
-          Whether to synchronise your machine's time using the NTP
-          protocol.
+          Whether to synchronise your machine's time using ntpd.
+
+          Disables systemd.timesyncd if enabled.
         '';
       };
 
@@ -49,7 +50,11 @@ in
         type = types.listOf types.str;
         description = ''
           The restriction flags to be set by default.
-          As recommended by 6.5.1.1.3 "No" of http://support.ntp.org/bin/view/Support/AccessRestrictions
+
+          The default flags prevent external hosts from using ntpd as a DDoS
+          reflector, seting system time, and querying OS/ntpd version.
+          As recommended by 6.5.1.1.3 "No" of
+          http://support.ntp.org/bin/view/Support/AccessRestrictions
         '';
         default = [ "limited" "kod" "nomodify" "notrap" "noquery" "nopeer" ];
       };
@@ -58,7 +63,9 @@ in
         type = types.listOf types.str;
         description = ''
           The restriction flags to be set on source.
-          This allows peers to be added by ntpd from configured pool(s), but not by other means.
+
+          The default flags allow peers to be added by ntpd from configured
+          pool(s), but not by other means.
         '';
         default = [ "limited" "kod" "nomodify" "notrap" "noquery" ];
       };
@@ -73,6 +80,7 @@ in
       extraFlags = mkOption {
         type = types.listOf types.str;
         description = "Extra flags passed to the ntpd command.";
+        example = ''[ "--interface=eth0" ]'';
         default = [];
       };
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/50732

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

