### PR TITLE
vimPlugins.vim-ps1: init at 2017-10-20

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2871,6 +2871,16 @@
     };
   };
 
+  vim-ps1 = buildVimPluginFrom2Nix {
+    name = "vim-ps1-2017-10-20";
+    src = fetchFromGitHub {
+      owner = "PProvost";
+      repo = "vim-ps1";
+      rev = "0b2509f210f5dc73001fdcfe8fd7ac354b363388";
+      sha256 = "0fkqd9xnr0310pmi5hjxfwh9x6b75z6q1w8qp1alm4qcv425q9rm";
+    };
+  };
+
   vim-puppet = buildVimPluginFrom2Nix {
     name = "vim-puppet-2018-09-24";
     src = fetchFromGitHub {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -217,6 +217,7 @@ phanviet/vim-monokai-pro
 plasticboy/vim-markdown
 posva/vim-vue
 powerman/vim-plugin-AnsiEsc
+PProvost/vim-ps1
 python-mode/python-mode
 Quramy/tsuquyomi
 racer-rust/vim-racer


### PR DESCRIPTION
###### Motivation for this change

Add syntax highlighting for powershell scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

