### PR TITLE
pkgconf: init at 1.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4853,6 +4853,11 @@
     github = "umazalakain";
     name = "Unai Zalakain";
   };
+  zaninime = {
+    email = "francesco@zanini.me";
+    github = "zaninime";
+    name = "Francesco Zanini";
+  };
   zarelit = {
     email = "david@zarel.net";
     github = "zarelit";

--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, automake, autoconf, libtool }:
 
-# with stdenv.lib;
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "pkgconf-1.5.4";
@@ -19,10 +19,10 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  #meta = {
-  #  description = "TODO";
-  #  homepage = "TODO";
-  #  platforms = "TODO";
-  #  license = "TODO";
-  #};
+  meta = {
+    description = "Package compiler and linker metadata toolkit";
+    homepage = https://git.dereferenced.org/pkgconf/pkgconf;
+    platforms = platforms.all;
+    license = licenses.isc;
+  };
 }

--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, automake, autoconf, libtool }:
+
+# with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "pkgconf-1.5.4";
+
+  src = fetchgit {
+    url = "https://git.dereferenced.org/pkgconf/pkgconf.git";
+    rev = "74133eda31bc1ed5947b4a3a854001e320b6c1fe";
+    sha256 = "159fxbwm5shz8p95jp28wrjvinlhmp42dy60pqg34psjn41wq1q4";
+  };
+
+  buildInputs = [ automake autoconf libtool ];
+
+  preConfigurePhases = ["autogenPhase"];
+
+  autogenPhase = ''
+    ./autogen.sh
+  '';
+
+  #meta = {
+  #  description = "TODO";
+  #  homepage = "TODO";
+  #  platforms = "TODO";
+  #  license = "TODO";
+  #};
+}

--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchgit, automake, autoconf, libtool }:
 
-with stdenv.lib;
-
 stdenv.mkDerivation rec {
   name = "pkgconf-1.5.4";
 
@@ -19,10 +17,11 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Package compiler and linker metadata toolkit";
     homepage = https://git.dereferenced.org/pkgconf/pkgconf;
     platforms = platforms.all;
     license = licenses.isc;
+    maintainers = with maintainers; [ zaninime ];
   };
 }

--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,21 +1,12 @@
-{ stdenv, fetchgit, automake, autoconf, libtool }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "pkgconf-1.5.4";
 
-  src = fetchgit {
-    url = "https://git.dereferenced.org/pkgconf/pkgconf.git";
-    rev = "74133eda31bc1ed5947b4a3a854001e320b6c1fe";
-    sha256 = "159fxbwm5shz8p95jp28wrjvinlhmp42dy60pqg34psjn41wq1q4";
+  src = fetchurl {
+    url = "https://distfiles.dereferenced.org/pkgconf/${name}.tar.xz";
+    sha256 = "0r26qmij9lxpz183na3dxj6lamcma94cjhasy19fya44w2j68n4w";
   };
-
-  buildInputs = [ automake autoconf libtool ];
-
-  preConfigurePhases = ["autogenPhase"];
-
-  autogenPhase = ''
-    ./autogen.sh
-  '';
 
   meta = with stdenv.lib; {
     description = "Package compiler and linker metadata toolkit";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8801,9 +8801,12 @@ with pkgs;
 
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
+  pkgconf = callPackage ../development/tools/misc/pkgconf {};
+
   pkgconfig = callPackage ../development/tools/misc/pkgconfig {
     fetchurl = fetchurlBoot;
   };
+
   pkgconfigUpstream = lowPrio (pkgconfig.override { vanilla = true; });
 
   postiats-utilities = callPackage ../development/tools/postiats-utilities {};


### PR DESCRIPTION
###### Motivation for this change
Add a new derivation.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

