### PR TITLE
pkgs/test/nixos-functions: use dummy versioning

### DIFF
--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -11,10 +11,17 @@ To run this test:
  */
 { pkgs, lib, stdenv, ... }:
 
-lib.optionalAttrs stdenv.hostPlatform.isLinux (
+let
+  dummyVersioning = {
+    revision = "test";
+    versionSuffix = "test";
+    label = "test";
+  };
+in lib.optionalAttrs stdenv.hostPlatform.isLinux (
   pkgs.recurseIntoAttrs {
 
     nixos-test = (pkgs.nixos {
+      system.nixos = dummyVersioning;
       boot.loader.grub.enable = false;
       fileSystems."/".device = "/dev/null";
     }).toplevel;
@@ -22,6 +29,7 @@ lib.optionalAttrs stdenv.hostPlatform.isLinux (
     nixosTest-test = pkgs.nixosTest ({ lib, pkgs, ... }: {
       name = "nixosTest-test";
       machine = { pkgs, ... }: {
+        system.nixos = dummyVersioning;
         environment.systemPackages = [ pkgs.hello ];
       };
       testScript = ''


### PR DESCRIPTION
With this OfBorg and similar tools won't report this derivation as changed every single time.

/cc @mic92 who can now unblacklist it in `nix-review` :)