### PR TITLE
[wip] Remove lib functions from all-packages.nix attrs

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -95,7 +95,7 @@ let
       makeScope;
     inherit (meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset lowPrio lowPrioSet hiPrio
-      hiPrioSet;
+      hiPrioSet recurseIntoAttrs;
     inherit (sources) pathType pathIsDirectory cleanSourceFilter
       cleanSource sourceByRegex sourceFilesBySuffices
       commitIdFromGitRepo cleanSourceWith pathHasContext

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -86,4 +86,9 @@ rec {
         then { system = elem; }
         else { parsed = elem; };
     in lib.matchAttrs pattern platform;
+
+  # Applying this to an attribute set will cause nix-env to look
+  # inside the set for derivations.
+  recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
+
 }

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -28,7 +28,7 @@ let
 
   ghq = callPackage ./ghq { };
 
-  git = appendToName "minimal" gitBase;
+  git = lib.appendToName "minimal" gitBase;
 
   git-absorb = callPackage ./git-absorb {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -47,7 +47,7 @@ let
   };
 
   # Git with SVN support, but without GUI.
-  gitSVN = lowPrio (appendToName "with-svn" (gitBase.override {
+  gitSVN = lib.lowPrio (lib.appendToName "with-svn" (gitBase.override {
     svnSupport = true;
   }));
 

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv }:
+{ pkgs, lib }:
 
 rec {
 
@@ -7,7 +7,7 @@ rec {
   callPackageWith = autoArgs: fn: args:
     let
       f = if pkgs.lib.isFunction fn then fn else import fn;
-      auto = builtins.intersectAttrs (stdenv.lib.functionArgs f) autoArgs;
+      auto = builtins.intersectAttrs (lib.functionArgs f) autoArgs;
     in f (auto // args);
 
   callPackage = callPackageWith pkgs;
@@ -31,7 +31,7 @@ rec {
       builder = callPackage ../../development/interpreters/erlang/generic-builder.nix args;
     in
       callPackage drv {
-        mkDerivation = pkgs.makeOverridable builder;
+        mkDerivation = lib.makeOverridable builder;
       };
 
   /* Uses generic-builder to evaluate provided drv containing Elixir version
@@ -52,7 +52,7 @@ rec {
       builder = callPackage ../interpreters/elixir/generic-builder.nix args;
     in
       callPackage drv {
-        mkDerivation = pkgs.makeOverridable builder;
+        mkDerivation = lib.makeOverridable builder;
       };
 
   /* Uses generic-builder to evaluate provided drv containing Elixir version
@@ -73,7 +73,7 @@ rec {
       builder = callPackage ../interpreters/lfe/generic-builder.nix args;
     in
       callPackage drv {
-        mkDerivation = pkgs.makeOverridable builder;
+        mkDerivation = lib.makeOverridable builder;
       };
 
 }

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ newScope, pkgs, stdenv, cmake, libstdcxxHook
 , libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -27,12 +27,12 @@ let
       inherit clang-tools-extra_src;
     };
 
-    llvm-manpages = lowPrio (tools.llvm.override {
+    llvm-manpages = stdenv.lib.lowPrio (tools.llvm.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });
 
-    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+    clang-manpages = stdenv.lib.lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ lib, newScope, pkgs, stdenv, cmake, libstdcxxHook
 , libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -34,12 +34,12 @@ let
       inherit clang-tools-extra_src;
     };
 
-    llvm-manpages = lowPrio (tools.llvm.override {
+    llvm-manpages = lib.lowPrio (tools.llvm.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });
 
-    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+    clang-manpages = lib.lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ newScope, pkgs, stdenv, cmake, libstdcxxHook
 , libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -34,12 +34,12 @@ let
       inherit clang-tools-extra_src;
     };
 
-    llvm-manpages = lowPrio (tools.llvm.override {
+    llvm-manpages = stdenv.lib.lowPrio (tools.llvm.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });
 
-    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+    clang-manpages = stdenv.lib.lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -1,4 +1,4 @@
-{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+{ newScope, pkgs, stdenv, cmake, libstdcxxHook
 , libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
@@ -34,12 +34,12 @@ let
       inherit clang-tools-extra_src;
     };
 
-    llvm-manpages = lowPrio (tools.llvm.override {
+    llvm-manpages = stdenv.lib.lowPrio (tools.llvm.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });
 
-    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+    clang-manpages = stdenv.lib.lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
       python = pkgs.python;  # don't use python-boot
     });

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, recurseIntoAttrs, makeRustPlatform, llvm, fetchurl
+{ stdenv, callPackage, makeRustPlatform, llvm, fetchurl
 , CoreFoundation, Security
 , targets ? []
 , targetToolchains ? []
@@ -6,7 +6,7 @@
 }:
 
 let
-  rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
+  rustPlatform = makeRustPlatform (callPackage ./bootstrap.nix {});
   version = "1.30.0";
   cargoVersion = "1.30.0";
   src = fetchurl {

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, stdenvNoCC, gccStdenv, lib, recurseIntoAttrs }:
+{ pkgs, stdenv, stdenvNoCC, gccStdenv, lib }:
 
 # To whomever it may concern:
 #
@@ -99,12 +99,12 @@ let
     dwarf-fortress-full = callPackage ./lazy-pack.nix {
       inherit df-games versionToName latestVersion;
     };
-    
+
     soundSense = callPackage ./soundsense.nix { };
 
     legends-browser = callPackage ./legends-browser {};
 
-    themes = recurseIntoAttrs (callPackage ./themes {
+    themes = lib.recurseIntoAttrs (callPackage ./themes {
       stdenv = stdenvNoCC;
     });
 

--- a/pkgs/os-specific/bsd/default.nix
+++ b/pkgs/os-specific/bsd/default.nix
@@ -1,5 +1,5 @@
-{ callPackages, recurseIntoAttrs }:
+{ callPackages, lib }:
 
 rec {
-  netbsd = recurseIntoAttrs (callPackages ./netbsd {});
+  netbsd = lib.recurseIntoAttrs (callPackages ./netbsd {});
 }

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -6,7 +6,6 @@
 , callPackage, ghostscriptX, harfbuzz, poppler_min
 , makeWrapper, python, ruby, perl
 , useFixedHashes ? true
-, recurseIntoAttrs
 }:
 let
   # various binaries (compiled)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -367,7 +367,7 @@ with pkgs;
 
   singularity-tools = callPackage ../build-support/singularity-tools { };
 
-  srcOnly = args: callPackage ../build-support/src-only args;
+  srcOnly = callPackage ../build-support/src-only;
 
   substituteAll = callPackage ../build-support/substitute/substitute-all.nix { };
 
@@ -400,9 +400,6 @@ with pkgs;
   makeGCOVReport = makeSetupHook
     { deps = [ pkgs.lcov pkgs.enableGCOVInstrumentation ]; }
     ../build-support/setup-hooks/make-coverage-analysis-report.sh;
-
-  # intended to be used like nix-build -E 'with import <nixpkgs> {}; enableDebugging fooPackage'
-  enableDebugging = pkg: pkg.override { stdenv = stdenvAdapters.keepDebugInfo pkg.stdenv; };
 
   findXMLCatalogs = makeSetupHook { } ../build-support/setup-hooks/find-xml-catalogs.sh;
 
@@ -15608,8 +15605,6 @@ with pkgs;
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme {
     gtk = self.gtk2;
   };
-
-  themes = name: callPackage (../data/misc/themes + ("/" + name + ".nix")) {};
 
   theano = callPackage ../data/fonts/theano { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10,10 +10,18 @@ self: pkgs:
 
 with pkgs;
 
-{
+let
+
+  inherit (lib) lowPrio hiPrio appendToName makeOverridable stringsWithDeps
+                recurseIntoAttrs;
+
+in {
 
   # Allow callPackage to fill in the pkgs argument
   inherit pkgs;
+
+  ### Helper functions.
+  inherit lib config;
 
   # A stdenv capable of building 32-bit binaries.  On x86_64-linux,
   # it uses GCC compiled with multilib support; on i686-linux, it's
@@ -40,18 +48,6 @@ with pkgs;
 
   # For convenience, allow callers to get the path to Nixpkgs.
   path = ../..;
-
-
-  ### Helper functions.
-  inherit lib config;
-
-  inherit (lib) lowPrio hiPrio appendToName makeOverridable;
-
-  # Applying this to an attribute set will cause nix-env to look
-  # inside the set for derivations.
-  recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
-
-  stringsWithDeps = lib.stringsWithDeps;
 
   ### Evaluating the entire Nixpkgs naively will fail, make failure fast
   AAAAAASomeThingsFailToEvaluate = throw ''
@@ -4575,9 +4571,9 @@ with pkgs;
       pam = if stdenv.isLinux then pam else null;
     };
 
-  openssh_hpn = pkgs.appendToName "with-hpn" (openssh.override { hpnSupport = true; });
+  openssh_hpn = appendToName "with-hpn" (openssh.override { hpnSupport = true; });
 
-  openssh_gssapi = pkgs.appendToName "with-gssapi" (openssh.override {
+  openssh_gssapi = appendToName "with-gssapi" (openssh.override {
     withGssapiPatches = true;
   });
 
@@ -14997,7 +14993,7 @@ with pkgs;
 
   # In nixos, you can set systemd.package = pkgs.systemd_with_lvm2 to get
   # LVM2 working in systemd.
-  systemd_with_lvm2 = pkgs.appendToName "with-lvm2" (pkgs.lib.overrideDerivation pkgs.systemd (p: {
+  systemd_with_lvm2 = appendToName "with-lvm2" (pkgs.lib.overrideDerivation pkgs.systemd (p: {
       postInstall = p.postInstall + ''
         cp "${pkgs.lvm2}/lib/systemd/system-generators/"* $out/lib/systemd/system-generators
       '';

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, newScope, recurseIntoAttrs, ocamlPackages_4_05 }:
+{ lib, callPackage, newScope, ocamlPackages_4_05 }:
 
 let
   mkCoqPackages' = self: coq:
@@ -6,7 +6,7 @@ let
       inherit callPackage coq;
       coqPackages = self;
 
-      contribs = recurseIntoAttrs
+      contribs = lib.recurseIntoAttrs
         (callPackage ../development/coq-modules/contribs {});
 
       autosubst = callPackage ../development/coq-modules/autosubst {};

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -89,7 +89,7 @@ in {
       integerSimpleGhcNames = pkgs.lib.filter
         (name: ! builtins.elem name integerSimpleExcludes)
         (pkgs.lib.attrNames compiler);
-    in pkgs.recurseIntoAttrs (pkgs.lib.genAttrs
+    in pkgs.lib.recurseIntoAttrs (pkgs.lib.genAttrs
       integerSimpleGhcNames
       (name: compiler."${name}".override { enableIntegerSimple = true; }));
   };

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs, lib }:
 
 with pkgs;
 
@@ -8,7 +8,7 @@ let
 in {
   inherit mavenbuild fetchMaven;
 
-  mavenPlugins = recurseIntoAttrs (callPackage ../development/java-modules/mavenPlugins.nix { });
+  mavenPlugins = lib.recurseIntoAttrs (callPackage ../development/java-modules/mavenPlugins.nix { });
 
   inherit (callPackage ../development/java-modules/eclipse/aether-util.nix { inherit fetchMaven; })
     aetherUtil_0_9_0_M2;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1094,7 +1094,7 @@ in {
   bugzilla = callPackage ../development/python-modules/bugzilla { };
 
   buildbot = callPackage ../development/python-modules/buildbot { };
-  buildbot-plugins = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/buildbot/plugins.nix { });
+  buildbot-plugins = recurseIntoAttrs (callPackage ../development/python-modules/buildbot/plugins.nix { });
   buildbot-ui = self.buildbot.withPlugins (with self.buildbot-plugins; [ www ]);
   buildbot-full = self.buildbot.withPlugins (with self.buildbot-plugins; [ www console-view waterfall-view grid-view wsgi-dashboards ]);
   buildbot-worker = callPackage ../development/python-modules/buildbot/worker.nix { };


### PR DESCRIPTION
###### Motivation for this change

There are a bunch of these lib functions exposed in all-packages.nix. We should be able to hide them behind a let binding.

