### PR TITLE
easysnap: init -> 2018-11-19

### DIFF
--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sjau";
     repo = "easysnap";
-    rev = "aa2768762da7730aa3eb90fdc2190a8359976edc";
-    sha256 = "0csn7capsmlkin4cf1fgl766gvszvqfllqkiyz0g9bvbapxv7nba";
+    rev = "0d5726828646609fc90a8e2701f779ce5f1210df";
+    sha256 = "1xzqxz5111g5inx7qib7l99w9chllqfg6kkqyaxy95msza3xffb0";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Updating easysnap to fix a bug.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

