### PR TITLE
inter-ui: refactored to make the fetchzip hash match upstream zip

### DIFF
--- a/pkgs/data/fonts/inter-ui/default.nix
+++ b/pkgs/data/fonts/inter-ui/default.nix
@@ -1,18 +1,19 @@
 { stdenv, fetchzip }:
 
-let
+stdenv.mkDerivation rec {
   version = "2.5";
-in fetchzip {
   name = "inter-ui-${version}";
 
-  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-UI-${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-UI-${version}.zip";
+    sha256 = "0m81n89s3miaxfbaa2v2hklffq4kk37kg9rrmb9yjy4zjxqyli1f";
+    stripRoot = false;
+  };
 
-  postFetch = ''
+  installPhase = ''
     mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    cp 'Inter UI (OTF)'/*.otf $out/share/fonts/opentype
   '';
-
-  sha256 = "1d88y6c9vbjz5siazhavnpfpazfkvpbcbb4pdycbnj03mmx6y07v";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;
@@ -22,4 +23,3 @@ in fetchzip {
     maintainers = with maintainers; [ demize ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

This makes it less of a PITA to update, since otherwise you essentially need to try and fail to build the package to get the proper hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
