### PR TITLE
autoPatchelfHook: Fixes/improvements for Android SDK emulator

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2421,12 +2421,31 @@ addEnvHooks "$hostOffset" myBashFunction
       <para>
        This is a special setup hook which helps in packaging proprietary
        software in that it automatically tries to find missing shared library
-       dependencies of ELF files. All packages within the
-       <envar>runtimeDependencies</envar> environment variable are
-       unconditionally added to executables, which is useful for programs that
-       use <citerefentry>
-       <refentrytitle>dlopen</refentrytitle>
-       <manvolnum>3</manvolnum> </citerefentry> to load libraries at runtime.
+       dependencies of ELF files based on the given
+       <varname>buildInputs</varname> and <varname>nativeBuildInputs</varname>.
+      </para>
+      <para>
+       You can also specify a <envar>runtimeDependencies</envar> environment
+       variable which lists dependencies that are unconditionally added to all
+       executables.
+      </para>
+      <para>
+       This is useful for programs that use <citerefentry>
+        <refentrytitle>dlopen</refentrytitle>
+        <manvolnum>3</manvolnum>
+       </citerefentry> to load libraries at runtime.
+      </para>
+      <para>
+        In certain situations you may want to run the main command
+        (<command>autoPatchelf</command>) of the setup hook on a file or a set
+        of directories instead of unconditionally patching all outputs. This
+        can be done by setting the <envar>dontAutoPatchelf</envar> environment
+        variable to a non-empty value.
+      </para>
+      <para>
+        The <command>autoPatchelf</command> command also recognizes a
+        <parameter class="command">--no-recurse</parameter> command line flag,
+        which prevents it from recursing into subdirectories.
       </para>
      </listitem>
     </varlistentry>

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -173,7 +173,7 @@ addAutoPatchelfSearchPath() {
 }
 
 autoPatchelf() {
-    local -a norecurse=
+    local norecurse=
 
     while [ $# -gt 0 ]; do
         case "$1" in

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -205,9 +205,12 @@ autoPatchelf() {
     # outside of this function.
     while IFS= read -r -d $'\0' file; do
       isELF "$file" || continue
+      segmentHeaders="$(LANG=C readelf -l "$file")"
+      # Skip if the ELF file doesn't have segment headers (eg. object files).
+      echo "$segmentHeaders" | grep -q '^Program Headers:' || continue
       if isExecutable "$file"; then
           # Skip if the executable is statically linked.
-          LANG=C readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+          echo "$segmentHeaders" | grep -q "^ *INTERP\\>" || continue
       fi
       autoPatchelfFile "$file"
     done < <(find "$@" ${norecurse:+-maxdepth 1} -type f -print0)

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -180,6 +180,11 @@ autoPatchelf() {
 # So what we do here is basically run in postFixup and emulate the same
 # behaviour as fixupOutputHooks because the setup hook for patchelf is run in
 # fixupOutput and the postFixup hook runs later.
-postFixupHooks+=(
-    'autoPatchelf $(for output in $outputs; do echo "${!output}"; done)'
-)
+postFixupHooks+=('
+    if [ -z "$dontAutoPatchelf" ]; then
+        autoPatchelf $(for output in $outputs; do
+            [ -e "${!output}" ] || continue
+            echo "${!output}"
+        done)
+    fi
+')

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -153,7 +153,7 @@ autoPatchelf() {
     # Add all shared objects of the current output path to the start of
     # cachedDependencies so that it's choosen first in findDependency.
     cachedDependencies+=(
-        $(find "$prefix" \! -type d \( -name '*.so' -o -name '*.so.*' \))
+        $(find "$@" \! -type d \( -name '*.so' -o -name '*.so.*' \))
     )
     local elffile
 
@@ -169,7 +169,7 @@ autoPatchelf() {
           LANG=C readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
       fi
       autoPatchelfFile "$file"
-    done < <(find "$prefix" -type f -print0)
+    done < <(find "$@" -type f -print0)
 }
 
 # XXX: This should ultimately use fixupOutputHooks but we currently don't have
@@ -181,5 +181,5 @@ autoPatchelf() {
 # behaviour as fixupOutputHooks because the setup hook for patchelf is run in
 # fixupOutput and the postFixup hook runs later.
 postFixupHooks+=(
-    'for output in $outputs; do prefix="${!output}" autoPatchelf; done'
+    'autoPatchelf $(for output in $outputs; do echo "${!output}"; done)'
 )


### PR DESCRIPTION
This is related to #50596, which refactors the `androidenv` implementation.

For patching various ELF files, a similar implementation to `autoPatchelfHook` was introduced there and after talking with @svanderburg, I went on to improve the hook in a way so that it's possible to be also used for `androidenv`, which also makes it less confusing for users having two things doing roughly the same but are named similarly.

Essentially, these changes make it easier to use only the `autoPatchelf` command without automatically patching *all* the build outputs.

For example:

```nix
with import <nixpkgs> {}; stdenv.mkDerivation {
  name = "foo";
  ...
  nativeBuildInputs = [ autoPatchelfHook ];
  dontAutoPatchelf = true;
  postPatch = ''
    autoPatchelf foo
    autoPatchelf --no-recurse bar
  '';
}
```

The `--no-recurse` flag here only patches files within the `bar` directory but not files in subdirectories like `bar/a/b/c`.

In order to make sure these changes do not break existing users of this hook, I've tested it using the following Nix expression and looking for symbol lookup errors:

```nix
with import ./. { config.allowUnfree = true; };

runCommand "test-executables" {
  drvs = [
    anydesk cups-kyodialog3 elasticsearch franz gurobi
    masterpdfeditor oracle-instantclient powershell reaper
    sourcetrail teamviewer unixODBCDrivers.msodbcsql17 virtlyst
    vk-messenger wavebox zoom-us nomachine-client polar-bookshelf
  ];
} ("for i in $drvs; do for b in $i/bin/*; do " +
   "[ -x \"$b\" ] && timeout 10 \"$b\" || :; done; done")
```