### PR TITLE
pythonPackages.pyupdate: init at 0.2.16

### DIFF
--- a/pkgs/development/python-modules/pyupdate/default.nix
+++ b/pkgs/development/python-modules/pyupdate/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, requests }:
+
+buildPythonPackage rec {
+  pname = "pyupdate";
+  version = "0.2.16";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p4zpjvwy6h9kr0dp80z5k04s14r9f75jg9481gpx8ygxj0l29bi";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # As of 0.2.16, pyupdate is intimately tied to Home Assistant which is py3 only
+  disabled = !isPy3k;
+
+  # no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    # This description is terrible, but it's what upstream uses.
+    description = "Package to update stuff";
+    homepage = https://github.com/ludeeus/pyupdate;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3403,6 +3403,8 @@ in {
 
   pyspread = callPackage ../development/python-modules/pyspread { };
 
+  pyupdate = callPackage ../development/python-modules/pyupdate {};
+
   pyx = callPackage ../development/python-modules/pyx { };
 
   mmpython = callPackage ../development/python-modules/mmpython { };


### PR DESCRIPTION
###### Motivation for this change

This is needed for the HA ```custom_updater``` card.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

