### PR TITLE
doc/reviewing-contributions: fix build error

### DIFF
--- a/doc/reviewing-contributions.xml
+++ b/doc/reviewing-contributions.xml
@@ -583,7 +583,7 @@ $ nix-shell -p nox --run "nox-review -k pr PRNUMBER"
    pull requests fitting this category.
   </para>
  </section>
- <section xml:id="reviewing-contributions--merging-pull requests">
+ <section xml:id="reviewing-contributions--merging-pull-requests">
   <title>Merging pull requests</title>
 
   <para>


### PR DESCRIPTION
Regression from #50674. Section IDs cannot contain spaces.

###### Motivation for this change

https://hydra.nixos.org/build/84345439

Tested fix with a local `nix-build`, fails at HEAD, works after this PR.