### PR TITLE
nixos.tests.keymap: use new name of the colemak/en-latin9 keymap

### DIFF
--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -99,7 +99,7 @@ in pkgs.lib.mapAttrs mkKeyboardTest {
       homerow.expect = [ "a" "r" "s" "t" "n" "e" "i" "o"         ];
     };
 
-    extraConfig.i18n.consoleKeyMap = "en-latin9";
+    extraConfig.i18n.consoleKeyMap = "colemak/colemak";
     extraConfig.services.xserver.layout = "us";
     extraConfig.services.xserver.xkbVariant = "colemak";
   };


### PR DESCRIPTION
Commit f1987fb58f57828944ca822bbb39b3de87f01863 renamed colemak/en-latin9 to
colemak/colemak, but the keymap test wasn't adjusted to refer to the new path.

###### Motivation for this change

Tests regressed on 2018-10-19: https://hydra.nixos.org/build/83028812

Locally reproduced with `nix-build '<nixpkgs/nixos/release-combined.nix>' -A nixos.tests.keymap.colemak.x86_64-linux` -- fails on master, passes with this PR.