### PR TITLE
Fix haskellPackages.fltkhs

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -694,9 +694,12 @@ self: super: {
   # We cannot build this package w/o the C library from <http://www.phash.org/>.
   phash = markBroken super.phash;
 
-  # https://github.com/deech/fltkhs/issues/16
-  # linking fails because the build doesn't pull in the libGLU_combined libraries
-  fltkhs = markBroken super.fltkhs;
+  fltkhs = let inherit (pkgs.lib) flip foldr; in foldr (f: x: f x) super.fltkhs [
+    (flip appendConfigureFlag "-fopengl")
+    (flip addPkgconfigDepend pkgs.libGLU_combined)
+    (flip addExtraLibrary super.OpenGLRaw)
+    (flip addSetupDepend pkgs.fltk14)
+  ];
   fltkhs-fluid-examples = dontDistribute super.fltkhs-fluid-examples;
 
   # We get lots of strange compiler errors during the test suite run.

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl, pkgconfig, xlibsWrapper, inputproto, libXi
+, freeglut, libGLU_combined, libjpeg, zlib, libXft, libpng
+, libtiff, freetype, cf-private, Cocoa, AGL, GLUT
+}:
+
+let
+  version = "1.4.x-r13121";
+in stdenv.mkDerivation {
+  name = "fltk-${version}";
+
+  src = fetchurl {
+    url = "http://fltk.org/pub/fltk/snapshots/fltk-${version}.tar.gz";
+    sha256 = "1v8wxvxcbk99i82x2v5fpqg5vj8n7g8a38g30ry7nzcjn5sf3r63";
+  };
+
+  preConfigure = "make clean";
+
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./nsosv.patch ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    libGLU_combined
+    libjpeg
+    zlib
+    libpng
+    libXft
+  ];
+
+  configureFlags = [
+    "--enable-gl"
+    "--enable-largefile"
+    "--enable-shared"
+    "--enable-threads"
+    "--enable-xft"
+  ];
+
+  propagatedBuildInputs = [ inputproto ]
+    ++ (if stdenv.isDarwin
+        then [ Cocoa AGL GLUT freetype libtiff cf-private  /* Needed for NSDefaultRunLoopMode */ ]
+        else [ xlibsWrapper libXi freeglut ]);
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A C++ cross-platform lightweight GUI library";
+    homepage = http://www.fltk.org;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    license = stdenv.lib.licenses.gpl2;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9601,6 +9601,10 @@ with pkgs;
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Cocoa AGL GLUT;
   };
+  fltk14 = callPackage ../development/libraries/fltk/1.4.nix {
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) Cocoa AGL GLUT;
+  };
   fltk = self.fltk13;
 
   flyway = callPackage ../development/tools/flyway { };


### PR DESCRIPTION
###### Motivation for this change

`haskellPackages.fltkhs` was marked as broken. It apparently requires FLTK >= 1.4 (see https://github.com/deech/fltkhs/issues/93), which we didn't have yet. As far as I can tell, FLTK 1.4 isn't actually released yet, so I didn't think it was appropriate to *replace* the FLTK 1.3 package that we already have, so I added a new version. This fixes the Haskell package.

While I was at it, I also added the dependencies required to enable OpenGL support in fltkhs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @deech
