### PR TITLE
lxd: Provide apparmor_parser

### DIFF
--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -2,6 +2,7 @@
 , makeWrapper, acl, rsync, gnutar, xz, btrfs-progs, gzip, dnsmasq
 , squashfsTools, iproute, iptables, ebtables, libcap, dqlite
 , sqlite-replication
+, writeShellScriptBin, apparmor-profiles, apparmor-parser
 }:
 
 buildGoPackage rec {
@@ -31,6 +32,9 @@ buildGoPackage rec {
 
     wrapProgram $bin/bin/lxd --prefix PATH ":" ${stdenv.lib.makeBinPath [
       acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute iptables ebtables
+      (writeShellScriptBin "apparmor_parser" ''
+        exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"
+      '')
     ]}
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Previously, `lxd` would complain about `apparmor_parser` being missing:

    lxd[1037]: lvl=warn msg="AppArmor support has been disabled because 'apparmor_parser' couldn't be found" t=2018-11-19T18:32:47-0800

We need to provide a wrapped `apparmor_parser` that knows where to find `<tunables/global>`, which is `#include`d by `lxd`’s generated profiles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

