### PR TITLE
pyCA: init at 2.1

### DIFF
--- a/pkgs/applications/video/pyca/default.nix
+++ b/pkgs/applications/video/pyca/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, pycurl, dateutil, configobj, sqlalchemy, sdnotify, flask }:
+
+buildPythonApplication rec {
+  pname = "pyca";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "opencast";
+    repo = "pyCA";
+    rev = "v${version}";
+    sha256 = "0cvkmdlcax9da9iw4ls73vw0pxvm8wvchab5gwdy9w9ibqdpcmwh";
+  };
+
+  propagatedBuildInputs = [
+    pycurl
+    dateutil
+    configobj
+    sqlalchemy
+    sdnotify
+    flask
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A fully functional Opencast capture agent written in Python";
+    homepage = https://github.com/opencast/pyCA;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ pmiddend ];
+  };
+}
+

--- a/pkgs/development/python-modules/sdnotify/default.nix
+++ b/pkgs/development/python-modules/sdnotify/default.nix
@@ -1,0 +1,21 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "sdnotify";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    sha256 = "1wdrdg2j16pmqhk0ify20s5pngijh7zc6hyxhh8w8v5k8v3pz5vk";
+    inherit pname version;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A pure Python implementation of systemd's service notification protocol";
+    homepage = https://github.com/bb4242/sdnotify;
+    license = licenses.mit;
+    maintainers = with maintainers; [ pmiddend ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1579,6 +1579,8 @@ with pkgs;
 
   parallel-rust = callPackage ../tools/misc/parallel-rust { };
 
+  pyCA = python3Packages.callPackage ../applications/video/pyca {};
+
   scour = with python3Packages; toPythonApplication scour;
 
   s2png = callPackage ../tools/graphics/s2png { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4650,6 +4650,8 @@ in {
 
   tvdb_api = callPackage ../development/python-modules/tvdb_api { };
 
+  sdnotify = callPackage ../development/python-modules/sdnotify { };
+
   tvnamer = callPackage ../development/python-modules/tvnamer { };
 
   threadpool = callPackage ../development/python-modules/threadpool { };


### PR DESCRIPTION
###### Motivation for this change

I wanted pyCA in nix! This needed the Python package sdnotify, too. Hope it's okay to add it inside this PR as well. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

