### PR TITLE
Go cross compilation

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
-, perl, which, pkgconfig, patch, procps, pcre, cacert, llvm, Security, Foundation }:
+, perl, which, pkgconfig, patch, procps, pcre, cacert, llvm, Security, Foundation
+, buildPackages, targetPackages }:
 
 let
 
@@ -7,11 +8,21 @@ let
 
   goBootstrap = runCommand "go-bootstrap" {} ''
     mkdir $out
-    cp -rf ${go_bootstrap}/* $out/
+    cp -rf ${buildPackages.go_bootstrap}/* $out/
     chmod -R u+w $out
     find $out -name "*.c" -delete
     cp -rf $out/bin/* $out/share/go/bin/
   '';
+
+  goarch = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system");
 
 in
 
@@ -26,13 +37,13 @@ stdenv.mkDerivation rec {
     sha256 = "0pk7pxfm3ij2ksdrg49jz501fr1d103zr4mjjwv821if9g279jc9";
   };
 
-  GOCACHE = "off";
-
   # perl is used for testing go vet
   nativeBuildInputs = [ perl which pkgconfig patch procps ];
   buildInputs = [ cacert pcre ]
     ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
     ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+
   propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
 
   hardeningDisable = [ "all" ];
@@ -126,62 +137,93 @@ stdenv.mkDerivation rec {
     substituteInPlace "src/cmd/link/internal/ld/lib.go" --replace dsymutil ${llvm}/bin/llvm-dsymutil
   '';
 
-  GOOS = stdenv.hostPlatform.parsed.kernel.name;
-  GOARCH = {
-    "i686" = "386";
-    "x86_64" = "amd64";
-    "aarch64" = "arm64";
-    "arm" = "arm";
-    "armv5tel" = "arm";
-    "armv6l" = "arm";
-    "armv7l" = "arm";
-  }.${stdenv.hostPlatform.parsed.cpu.name} or (throw "Unsupported system");
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if (stdenv.hostPlatform != stdenv.targetPlatform) then
+      "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc"
+    else if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${stdenv.cc.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET = if (stdenv.hostPlatform != stdenv.targetPlatform) then
+      "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++"
+    else if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${stdenv.cc.targetPrefix}c++"
+    else
+      null;
+
   GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
   GO386 = 387; # from Arch: don't assume sse2 on i686
   CGO_ENABLED = 1;
-  GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
   # Hopefully avoids test timeouts on Hydra
   GO_TEST_TIMEOUT_SCALE = 3;
 
-  # The go build actually checks for CC=*/clang and does something different, so we don't
-  # just want the generic `cc` here.
-  CC = if stdenv.isDarwin then "clang" else "cc";
+  # Indicate that we are running on build infrastructure
+  # Some tests assume things like home directories and users exists
+  GO_BUILDER_NAME = "nix";
 
-  configurePhase = ''
-    # Indicate that we are running on build infrastructure
-    # Some tests assume things like home directories and users exists
-    export GO_BUILDER_NAME=nix
+  GOROOT_BOOTSTRAP="${goBootstrap}/share/go";
 
-    mkdir -p $out/share/go/bin
-    export GOROOT=$out/share/go
-    export GOBIN=$GOROOT/bin
-    export PATH=$GOBIN:$PATH
+  postConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    # Independent from host/target, CC should produce code for the building system.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
     ulimit -a
   '';
 
-  installPhase = ''
-    runHook preInstall
-    cp -r . $GOROOT
-    ( cd $GOROOT/src && ./make.bash )
-    runHook postInstall
+  postBuild = ''
+    (cd src && ./make.bash)
   '';
 
-  doInstallCheck = true;
-  installCheckPhase = ''
+  doCheck = stdenv.hostPlatform == stdenv.targetPlatform;
+
+  checkPhase = ''
     runHook preCheck
-    ( cd $GOROOT/src && ./run.bash --no-rebuild)
+    (cd src && ./run.bash --no-rebuild)
     runHook postCheck
   '';
 
-  preFixup = ''
-    rm -r $out/share/go/pkg/bootstrap
-    rm -r $out/share/go/pkg/obj
-    ln -s $out/share/go/bin $out/bin
+  preInstall = ''
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform != stdenv.hostPlatform) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
+    ''}
+  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+    rm -rf bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
+    ''}
+  '' else "");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+    ln -s $GOROOT_FINAL/bin $out/bin
+    runHook postInstall
   '';
 
   setupHook = ./setup-hook.sh;
 
-  disallowedReferences = [ go_bootstrap ];
+  disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {
     branch = "1.11";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13024,13 +13024,13 @@ with pkgs;
   ### DEVELOPMENT / GO MODULES
 
   buildGo19Package = callPackage ../development/go-modules/generic {
-    go = go_1_9;
+    go = buildPackages.go_1_9;
   };
   buildGo110Package = callPackage ../development/go-modules/generic {
-    go = go_1_10;
+    go = buildPackages.go_1_10;
   };
   buildGo111Package = callPackage ../development/go-modules/generic {
-    go = go_1_11;
+    go = buildPackages.go_1_11;
   };
 
   buildGoPackage = buildGo111Package;


### PR DESCRIPTION
###### Motivation for this change

Mentally prepare myself to cross-compile rust.

###### Things that work:

- [x] Cross-compile go packages
  - [x] with c bindings
- [X] Cross-compile the go compiler itself
- platforms tested:
  - [x] for windows (tested with pkgsCross.mingwW64.direnv, see https://github.com/NixOS/nixpkgs/pull/50928)
  - [x] for aarch64-linux (tested with pkgsCross.aarch64-multiplatform.direnv)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

