### PR TITLE
xsv: Add darwin.Security as dependency on MacOS

### DIFF
--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform }:
+{ stdenv, fetchFromGitHub, rustPlatform, pkgs }:
 
 rustPlatform.buildRustPackage rec {
   name = "xsv-${version}";
@@ -12,6 +12,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "1qk5wkjm3d4dz5fldlq7rjlm602v0l04hxrbar2j6vhcz9w2r4n6";
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin pkgs.darwin.Security;
 
   meta = with stdenv.lib; {
     description = "A fast CSV toolkit written in Rust";

--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkgs }:
+{ stdenv, fetchFromGitHub, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
   name = "xsv-${version}";
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1qk5wkjm3d4dz5fldlq7rjlm602v0l04hxrbar2j6vhcz9w2r4n6";
 
-  buildInputs = stdenv.lib.optional stdenv.isDarwin pkgs.darwin.Security;
+  buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 
   meta = with stdenv.lib; {
     description = "A fast CSV toolkit written in Rust";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6341,7 +6341,9 @@ with pkgs;
 
   xsel = callPackage ../tools/misc/xsel { };
 
-  xsv = callPackage ../tools/text/xsv { };
+  xsv = callPackage ../tools/text/xsv {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   xtreemfs = callPackage ../tools/filesystems/xtreemfs {
     boost = boost165;


### PR DESCRIPTION
###### Motivation for this change

xsv failed to build for me on MacOS 10.13.6 after upgrading the channel nixpkgs-unstable. I also attempted to build it from master with the same error:

```
error: linking with `/nix/store/l928iaj0m48lfb7dib6h7p22d50l566x-clang-wrapper-5.0.2/bin/cc` failed: exit code: 1 
|
  = note: "/nix/store/l928iaj0m48lfb7dib6h7p22d50l566x-clang-wrapper-5.0.2/bin/cc" "-m64" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.0.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.1.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.10.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.11.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.12.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.13.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.14.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.15.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.2.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.3.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.4.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.5.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.6.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.7.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.8.rcgu.o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.serde_derive.ektx1vlp-cgu.9.rcgu.o" "-o" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/libserde_derive-8479381264722504.dylib" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/serde_derive-8479381264722504.5b5pnbs7ysgi257p.rcgu.o" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/libsyn-1dc782ec30bc4245.rlib" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/libquote-85bceeed12796714.rlib" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/libproc_macro2-84d8f71df10ed916.rlib" "/private/tmp/nix-build-xsv-0.13.0.drv-0/source/target/release/deps/libunicode_xid-3e48e37f11f82db2.rlib" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lproc_macro-3c3310d56327c751" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lsyntax-5804bc44f6aa386c" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lrustc_target-9b72dc107559762c" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lrustc_errors-4eab085f8d21579c" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lsyntax_pos-af163bbd2a3b6cd4" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-larena-640d3352917efd05" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lrustc_data_structures-2444c86d41a6f566" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lrustc_cratesio_shim-89f003a3cf6a0f50" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lserialize-48f4ceb2315fb290" "-L" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib" "-lstd-8b3bb8561e753cc3" "/nix/store/9mlgmipqar210mkaiqz3c5il0lxdyrl6-rustc-1.30.0/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-b360031db1b4c6a3.rlib" "-framework" "Security" "-lSystem" "-lresolv" "-lpthread" "-lc" "-lm" "-dynamiclib" "-Wl,-dylib"
  = note: ld: framework not found Security
          clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to previous error

error: Could not compile `serde_derive`.

To learn more, run the command again with --verbose.
builder for '/nix/store/rw0gwasxkdnvcjzwy7y10b5s8yafq5m2-xsv-0.13.0.drv' failed with exit code 101
```

Please note that I'm way in over my head here – I don't know anything about buildRustPackage and very little about nix. But with this addition it builds, at least for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
