### PR TITLE
androidndk: 17c -> 18b

### DIFF
--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -306,7 +306,21 @@ rec {
       x86_64-linux = "12cacc70c3fd2f40574015631c00f41fb8a39048";
     };
   };
-  androidndk = androidndk_17c;
+
+  androidndk_18b = pkgs.callPackage ./androidndk.nix {
+    inherit (buildPackages)
+      unzip makeWrapper;
+    inherit (pkgs)
+      stdenv fetchurl zlib ncurses5 lib python3 libcxx
+      coreutils file findutils gawk gnugrep gnused jdk which;
+    inherit platformTools;
+    version = "18b";
+    sha1s = {
+      x86_64-darwin = "98cb9909aa8c2dab32db188bbdc3ac6207e09440";
+      x86_64-linux = "500679655da3a86aecf67007e8ab230ea9b4dd7b";
+    };
+  };
+  androidndk = androidndk_18b;
 
   androidndk_r8e = import ./androidndk_r8e.nix {
     inherit (buildPackages)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

