### PR TITLE
nixos-manual-combined: fix typo causing build failures

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -20,8 +20,8 @@
   <itemizedlist>
    <listitem>
     <para>
-    The default Python 3 interpreter is now CPython 3.7 instead of CPython 3.6.
-    <para />
+     The default Python 3 interpreter is now CPython 3.7 instead of CPython 3.6.
+    </para>
    </listitem>
   </itemizedlist>
  </section>


### PR DESCRIPTION
Regression from #49742. Invalid XML causes the manual to not build, leading to many broken derivations.

(FYI @FRidh / @timokau original author/committer.)

###### Motivation for this change

https://hydra.nixos.org/eval/1490725 shows +307 broken jobs. Many are caused by this typo.