### PR TITLE
zafiro-icons: init at 0.7.2

### DIFF
--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, gtk3 }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "zafiro-icons";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "zayronxio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1rs3wazmvidlkig5q7x1n9nz7jhfq18wps3wsplax9zcdy0hv248";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  installPhase = ''
+    mkdir -p $out/share/icons/Zafiro
+    cp -a * $out/share/icons/Zafiro
+    gtk-update-icon-cache "$out"/share/icons/Zafiro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Icon pack flat with light colors";
+    homepage = https://github.com/zayronxio/Zafiro-icons;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15683,6 +15683,8 @@ with pkgs;
 
   xorg-rgb = callPackage ../data/misc/xorg-rgb {};
 
+  zafiro-icons = callPackage ../data/icons/zafiro-icons { };
+
   zeal = libsForQt5.callPackage ../data/documentation/zeal { };
 
   zilla-slab = callPackage ../data/fonts/zilla-slab { };


### PR DESCRIPTION
###### Motivation for this change

Add [zafiro-icons](https://github.com/zayronxio/Zafiro-icons).

>Minimalist icons created with the flat-desing technique, utilizing washed out colors and always accompanied by white. The priority is simplicity.
![preview](https://user-images.githubusercontent.com/1217934/48784851-a6c0c400-ecca-11e8-8c82-9cc90ac2f76d.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).