### PR TITLE
kpcli: fix wrong program name in prompt (#50845)

### DIFF
--- a/pkgs/tools/security/kpcli/default.nix
+++ b/pkgs/tools/security/kpcli/default.nix
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
   phases = [ "installPhase" "fixupPhase" ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp ${src} $out/bin/kpcli
-    chmod +x $out/bin/kpcli
+    mkdir -p $out/{bin,share}
+    cp ${src} $out/share/kpcli.pl
+    chmod +x $out/share/kpcli.pl
 
-    wrapProgram $out/bin/kpcli --set PERL5LIB \
+    makeWrapper $out/share/kpcli.pl $out/bin/kpcli --set PERL5LIB \
       "${with perlPackages; stdenv.lib.makePerlPath ([
          CaptureTiny Clipboard Clone CryptRijndael SortNaturally TermReadKey TermShellUI FileKeePass TermReadLineGnu XMLParser
       ] ++ stdenv.lib.optional stdenv.isDarwin MacPasteboard)}"


### PR DESCRIPTION
###### Motivation for this change

Addresses issue #50845.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

