### PR TITLE
Fix release notes XML para closing tag

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -21,7 +21,7 @@
    <listitem>
     <para>
     The default Python 3 interpreter is now CPython 3.7 instead of CPython 3.6.
-    <para />
+    </para>
    </listitem>
   </itemizedlist>
  </section>


### PR DESCRIPTION
###### Motivation for this change

`master` can't build release notes after this morning's merge:

```
building '/nix/store/p21i185hrck1q1gn3xlhqy8q9gi4il4q-nixos-manual-combined.drv'...
release-notes/rl-1903.xml:25: parser error : Opening and ending tag mismatch: para line 22 and listitem
   </listitem>
              ^
release-notes/rl-1903.xml:26: parser error : Opening and ending tag mismatch: listitem line 21 and itemizedlist
  </itemizedlist>
                 ^
release-notes/rl-1903.xml:27: parser error : Opening and ending tag mismatch: itemizedlist line 20 and section
 </section>
           ^
release-notes/rl-1903.xml:268: parser error : Premature end of data in tag section line 1

^
release-notes/release-notes.xml:11: element include: XInclude error : could not load release-notes/rl-1903.xml, and no fallback was found

manual-combined.xml:62283: element para: Relax-NG validity error : Did not expect element para there
 62279              </filename></member></simplelist></listitem></varlistentry></variablelist>
 62280   </appendix>
 62281   <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" xml:id="ch-release-notes" xml:base="release-notes/release-notes.xml">
 62282   <title>Release Notes</title>
 62283   <para>
 62284    This section lists the release notes for each stable version of NixOS and
 62285    current unstable revision.

manual-combined.xml:62287: element include: Relax-NG validity error : Did not expect element include there
 62283   <para>
 62284    This section lists the release notes for each stable version of NixOS and
 62285    current unstable revision.
 62286   </para>
 62287   <xi:include href="rl-1903.xml"/>
 62288   <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" xml:id="sec-release-18.09">
 62289   <title>Release 18.09 (&#x201C;Jellyfish&#x201D;, 2018/10/05)</title>

manual-combined.xml:62287: element include: Relax-NG validity error : Element appendix has extra content: include
 62283   <para>
 62284    This section lists the release notes for each stable version of NixOS and
 62285    current unstable revision.
 62286   </para>
 62287   <xi:include href="rl-1903.xml"/>
 62288   <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" xml:id="sec-release-18.09">
 62289   <title>Release 18.09 (&#x201C;Jellyfish&#x201D;, 2018/10/05)</title>

manual-combined.xml:3: element info: Relax-NG validity error : Element book has extra content: info
     1  <?xml version="1.0"?>
     2  <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" version="5.0" xml:id="book-nixos-manual">
     3   <info>
     4    <title>NixOS Manual</title>
     5    <subtitle>Version 19.03
     6    </subtitle>
     7   </info>

manual-combined.xml fails to validate
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

