### PR TITLE
openssl: 1.1.1a, 1.0.2q - security fixes

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -130,8 +130,8 @@ in {
   };
 
   openssl_1_1 = common {
-    version = "1.1.1";
-    sha256 = "0gbab2fjgms1kx5xjvqx8bxhr98k4r8l2fa8vw7kvh491xd8fdi8";
+    version = "1.1.1a";
+    sha256 = "0hcz7znzznbibpy3iyyhvlqrq44y88plxwdj32wjzgbwic7i687w";
   };
 
 }

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -125,8 +125,8 @@ let
 in {
 
   openssl_1_0_2 = common {
-    version = "1.0.2p";
-    sha256 = "003xh9f898i56344vpvpxxxzmikivxig4xwlm7vbi7m8n43qxaah";
+    version = "1.0.2q";
+    sha256 = "115nisqy7kazbg6br2wrcra9nphyph1l4dgp563b9cf2rv5wyi2p";
   };
 
   openssl_1_1 = common {

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -17,7 +17,7 @@ let
 
     patches =
       (args.patches or [])
-      ++ [ ./nix-ssl-cert-file.patch ]
+      ++ [(if versionOlder version "1.1.0" then ./nix-ssl-cert-file.patch else ./nix-ssl-cert-file-2.patch)]
       ++ optional (versionOlder version "1.1.0")
           (if stdenv.hostPlatform.isDarwin then ./use-etc-ssl-certs-darwin.patch else ./use-etc-ssl-certs.patch)
       ++ optional (versionOlder version "1.0.2" && stdenv.hostPlatform.isDarwin)

--- a/pkgs/development/libraries/openssl/nix-ssl-cert-file-2.patch
+++ b/pkgs/development/libraries/openssl/nix-ssl-cert-file-2.patch
@@ -9,7 +9,6 @@ diff -ru -x '*~' openssl-1.0.2j-orig/crypto/x509/by_file.c openssl-1.0.2j/crypto
 +            file = ossl_safe_getenv("NIX_SSL_CERT_FILE");
 +            if (!file)
 +                file = ossl_safe_getenv(X509_get_default_cert_file_env());
-
              if (file)
                  ok = (X509_load_cert_crl_file(ctx, file,
                                                X509_FILETYPE_PEM) != 0);


### PR DESCRIPTION
Since these are for security, unsure if should go to staging first
but if so please cherry-pick or rebase as seen fit.

Similarly should be backported.

###### Motivation for this change

See commits for CVE's,
and linked changelogs have more details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---