### PR TITLE
amass: 2.8.3 -> 2.8.5

### DIFF
--- a/pkgs/tools/networking/amass/default.nix
+++ b/pkgs/tools/networking/amass/default.nix
@@ -1,11 +1,12 @@
 { buildGoPackage
 , fetchFromGitHub
+, fetchpatch
 , lib
 }:
 
 buildGoPackage rec {
   name = "amass-${version}";
-  version = "2.8.3";
+  version = "2.8.5";
 
   goPackagePath = "github.com/OWASP/Amass";
 
@@ -13,16 +14,18 @@ buildGoPackage rec {
     owner = "OWASP";
     repo = "Amass";
     rev = version;
-    sha256 = "1pidi7bpg5z04l6ryfd7rqxshayvkqmgav0f6f1fxz4jwrmx9nnc";
+    sha256 = "1nsqg1p7hcv369d53n13xps3ks6fgzkkp6v9q87l04yj32nbr5qy";
   };
 
-  # NOTE: this must be removed once amass > 2.8.3 is released. This version has
-  # a broken import caused by the project migrating to a new home.
-  preBuild = ''
-    sed -e 's:github.com/caffix/amass/amass/core:github.com/OWASP/Amass/amass/core:g' -i "go/src/${goPackagePath}/cmd/amass.netdomains/main.go"
-  '';
+  outputs = [ "bin" "out" "wordlists" ];
 
   goDeps = ./deps.nix;
+
+  postInstall = ''
+    mkdir -p $wordlists
+    cp -R $src/wordlists/*.txt $wordlists
+    gzip $wordlists/*.txt
+  '';
 
   meta = with lib; {
     description = "In-Depth DNS Enumeration and Network Mapping";
@@ -33,6 +36,9 @@ buildGoPackage rec {
       uses the IP addresses obtained during resolution to discover associated
       netblocks and ASNs. All the information is then used to build maps of the
       target networks.
+
+      Amass ships with a set of wordlist (to be used with the amass -w flag)
+      that are found under the wordlists output.
       '';
     homepage = https://www.owasp.org/index.php/OWASP_Amass_Project;
     license = licenses.asl20;

--- a/pkgs/tools/networking/amass/deps.nix
+++ b/pkgs/tools/networking/amass/deps.nix
@@ -94,8 +94,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev = "93218def8b18e66adbdab3eca8ec334700329f1f";
-      sha256 = "0v0zdnsi0vw03dcfir7b228g02ag7jr7mgbgv6lnjwbbccxv07pz";
+      rev = "ec83556a53fe16b65c452a104ea9d1e86a671852";
+      sha256 = "1ijlbyn5gs8g6z2pjlj5h77lg7wrljqxdls4xlcfqxmghxiyci2f";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

The updated Amass is shipped with the wordlists in the `wordlists` output. See https://github.com/NixOS/nixpkgs/pull/50490#pullrequestreview-176085536 and https://github.com/OWASP/Amass/pull/56 for the context of this update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@c0bw3b please review this change providing the wordlists output. Please do not merge it, Amass is not ready on the develop branch and I intend to update this PR once 2.8.4 has been released.