### PR TITLE
wtf: init at 0.4.0

### DIFF
--- a/pkgs/applications/misc/wtf/default.nix
+++ b/pkgs/applications/misc/wtf/default.nix
@@ -1,0 +1,28 @@
+{ buildGoPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildGoPackage rec {
+  name = "wtf-${version}";
+  version = "0.4.0";
+
+  goPackagePath = "github.com/senorprogrammer/wtf";
+
+  src = fetchFromGitHub {
+    owner = "senorprogrammer";
+    repo = "wtf";
+    rev = "${version}";
+    sha256 = "1vgjqmw27baiq9brmnafic3w3hw11p5qc6ahbdxi5n5n4bx7j6vn";
+  };
+
+  buildFlagsArray = [ "-ldflags=" "-X main.version=${version}" ];
+
+  meta = with lib; {
+    description = "The personal information dashboard for your terminal";
+    homepage = http://wtfutil.com/;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22868,6 +22868,8 @@ with pkgs;
 
   zimg = callPackage ../development/libraries/zimg { };
 
+  wtf = callPackage ../applications/misc/wtf { };
+
   zk-shell = callPackage ../applications/misc/zk-shell { };
 
   zuki-themes = callPackage ../misc/themes/zuki { };


### PR DESCRIPTION
###### Motivation for this change

A personal terminal-based dashboard utility, designed for displaying infrequently-needed, but very important, daily data.

<p align="center">
<img src="/senorprogrammer/wtf/raw/master/images/screenshot.jpg" title="screenshot" width="720" height="420" />
</p>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

