### PR TITLE
nvidia_x11: 410.78 -> 415.25

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/atomic64_t.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/atomic64_t.patch
@@ -1,0 +1,12 @@
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index e8de161..6c284e9 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -1784,7 +1784,6 @@ compile_test() {
+                 atomic64_t data;
+                 atomic64_read(&data);
+                 atomic64_set(&data, 0);
+-                atomic64_inc(&data);
+             }"
+ 
+             compile_check_conftest "$CODE" "NV_ATOMIC64_PRESENT" "" "types"

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -33,11 +33,17 @@ installPhase() {
     # since version 391, 32bit libraries are bundled in the 32/ sub-directory
     if [ "$i686bundled" = "1" ]; then
         mkdir -p "$lib32/lib"
-        cp -prd 32/*.so.* 32/tls "$lib32/lib/"
+        cp -prd 32/*.so.* "$lib32/lib/"
+        if [ -d 32/tls ]; then
+            cp -prd 32/tls "$lib32/lib/"
+        fi
     fi
 
     mkdir -p "$out/lib"
-    cp -prd *.so.* tls "$out/lib/"
+    cp -prd *.so.* "$out/lib/"
+    if [ -d tls ]; then
+        cp -prd tls "$out/lib/"
+    fi
 
     for i in $lib32 $out; do
         rm -f $i/lib/lib{glx,nvidia-wfb}.so.* # handled separately

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -16,17 +16,21 @@ let
 in
 rec {
   # Policy: use the highest stable version as the default (on our master).
-  stable = if stdenv.hostPlatform.system != "x86_64-linux"
-    then legacy_390
-    else generic {
-      version = "410.78";
-      sha256_64bit = "1ciabnmvh95gsfiaakq158x2yws3m9zxvnxws3p32lz9riblpdjx";
-      settingsSha256 = "1677g7rcjbcs5fja1s4p0syhhz46g9x2qqzyn3wwwrjsj7rwaz77";
-      persistencedSha256 = "01kvd3zp056i4n8vazj7gx1xw0h4yjdlpazmspnsmwg24ijb82x4";
-    };
+  stable = if stdenv.hostPlatform.system == "x86_64-linux" then stable_410 else legacy_390;
 
   # No active beta right now
   beta = stable;
+
+  stable_410 = generic {
+    version = "415.25";
+    sha256_64bit = "0jck3sjhkdf9j40fqa6hpm2m9i11bfka9diaxmk2apni4f4mpdk4";
+    settingsSha256 = "0x5a9dhr29g67rbgl1w973fzgjfg1lyn3dpq7fpc7chfp91vxzrp";
+    persistencedSha256 = "0z1d7hrz7zvi4x3ir1c3gcfpsj57wdr5pylvmjhdi3x47cb1w34f";
+
+    patches = lib.optional (kernel.meta.branch == "4.20") [
+      ./atomic64_t.patch
+    ];
+  };
 
   # Last one supporting x86
   legacy_390 = generic {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

