### PR TITLE
 nixos/slurm: set slurmd KillMode and add extraConfigPaths

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -46,7 +46,7 @@ let
   # in the same directory as slurm.conf
   etcSlurm = pkgs.symlinkJoin {
     name = "etc-slurm";
-    paths = [ configFile cgroupConfig plugStackConfig ];
+    paths = [ configFile cgroupConfig plugStackConfig ] ++ cfg.extraConfigPaths;
   };
 
 in
@@ -236,6 +236,17 @@ in
         description = ''
           Extra configuration for <literal>cgroup.conf</literal>. This file is
           used when <literal>procTrackType=proctrack/cgroup</literal>.
+        '';
+      };
+
+      extraConfigPaths = mkOption {
+        type = with types; listOf path;
+        default = [];
+        description = ''
+          Slurm expects config files for plugins in the same path
+          as <literal>slurm.conf</literal>. Add extra nix store
+          paths that should be merged into same directory as
+          <literal>slurm.conf</literal>.
         '';
       };
 

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -303,6 +303,7 @@ in
 
       serviceConfig = {
         Type = "forking";
+        KillMode = "process";
         ExecStart = "${wrappedSlurm}/bin/slurmd";
         PIDFile = "/run/slurmd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -101,6 +101,7 @@ in {
   subtest "can_start_slurmdbd", sub {
     $dbd->succeed("systemctl restart slurmdbd");
     $dbd->waitForUnit("slurmdbd.service");
+    $dbd->waitForOpenPort(6819);
   };
 
   # there needs to be an entry for the current

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -63,6 +63,12 @@ in {
             ensurePermissions = { "slurm_acct_db.*" = "ALL PRIVILEGES"; };
             name = "slurm";
           }];
+          extraOptions = ''
+            # recommendations from: https://slurm.schedmd.com/accounting.html#mysql-configuration
+            innodb_buffer_pool_size=1024M
+            innodb_log_file_size=64M
+            innodb_lock_wait_timeout=900
+          '';
         };
       };
 


### PR DESCRIPTION
###### Motivation for this change

- set slurmd systemd service `KillMode` to `process`: In the standard configuration all jobs are killed when slurmd is restarted (e.g. when the configuration is updated). This is quite disruptive in a production environment. Setting `KillMode=process` kills only slurmd but not slurmstepd and thus not the running job. This is also the standard behavior of the systemd files delivered from slurm.
- add new option `extraConfigPaths`: This allows to add custom config files to slurm configuration. All plugins that come with config files need to be in the same directory as slurm.conf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
`nixos/tests/slurm.nix` succeeds.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

