### PR TITLE
aws-google-auth: init at 0.0.29

### DIFF
--- a/pkgs/tools/admin/aws-google-auth/default.nix
+++ b/pkgs/tools/admin/aws-google-auth/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, beautifulsoup4
+, boto3
+, configparser
+, keyring
+, keyrings-alt
+, lxml
+, pillow
+, requests
+, six
+, tabulate
+, tzlocal
+, nose
+, mock
+, withU2F ? false, python-u2flib-host
+}:
+
+buildPythonApplication rec {
+  pname = "aws-google-auth";
+  version = "0.0.29";
+
+  # Pypi doesn't ship the tests, so we fetch directly from GitHub
+  # https://github.com/cevoaustralia/aws-google-auth/issues/120
+  src = fetchFromGitHub {
+    owner = "cevoaustralia";
+    repo = "aws-google-auth";
+    rev = version;
+    sha256 = "06dalrwjy1sbc5wvj5ip4h999izlb0j5g6b6f3l5znnsm0vfvfia";
+  };
+
+  propagatedBuildInputs = [ 
+    beautifulsoup4
+    boto3
+    configparser
+    keyring
+    keyrings-alt
+    lxml
+    pillow
+    requests
+    six
+    tabulate
+    tzlocal
+  ] ++ lib.optional withU2F python-u2flib-host;
+  
+  checkInputs = [ 
+    mock
+    nose 
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = with lib; {
+    description = "Acquire AWS STS (temporary) credentials via Google Apps SAML Single Sign On";
+    homepage = https://github.com/cevoaustralia/aws-google-auth;
+    maintainers = [ maintainers.marsam ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -607,6 +607,8 @@ with pkgs;
 
   aws-env = callPackage ../tools/admin/aws-env { };
 
+  aws-google-auth = pythonPackages.callPackage ../tools/admin/aws-google-auth { };
+
   aws-okta = callPackage ../tools/security/aws-okta { };
 
   aws-rotate-key = callPackage ../tools/admin/aws-rotate-key { };


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/50840

cc: @coretemp 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

