### PR TITLE
imwheel: init at 1.0.0pre12

### DIFF
--- a/pkgs/tools/X11/imwheel/default.nix
+++ b/pkgs/tools/X11/imwheel/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, libX11, libXext, libXi, libXmu, libXt, libXtst }:
+
+stdenv.mkDerivation rec {
+  name = "imwheel-1.0.0pre12";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/imwheel/${name}.tar.gz";
+    sha256 = "2320ed019c95ca4d922968e1e1cbf0c075a914e865e3965d2bd694ca3d57cfe3";
+  };
+
+  buildInputs = [ libX11 libXext libXi libXmu libXt libXtst ];
+
+  postPatch = ''
+    substituteInPlace Makefile.in --replace "ETCDIR = " "ETCDIR = $out"
+    substituteInPlace util.c --replace "/etc/X11/imwheel" "$out/etc/X11/imwheel"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://imwheel.sourceforge.net/";
+    description = "Mouse wheel configuration tool for XFree86/Xorg";
+    maintainers = with maintainers; [ jhillyerd ];
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20980,6 +20980,8 @@ with pkgs;
 
   hsetroot = callPackage ../tools/X11/hsetroot { };
 
+  imwheel = callPackage ../tools/X11/imwheel { };
+
   kakasi = callPackage ../tools/text/kakasi { };
 
   lumina = libsForQt5.callPackage ../desktops/lumina { };


### PR DESCRIPTION
###### Motivation for this change

Add imwheel package, allowing configuration of mouse scroll wheel for X11 users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

