### PR TITLE
makeRustPlatform: refactor to make it easier to understand

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,9 +1,5 @@
-{ stdenv, cacert, git, rust, cargo-vendor, python3 }:
-let
-  fetchcargo = import ./fetchcargo.nix {
-    inherit stdenv cacert git rust cargo-vendor python3;
-  };
-in
+{ stdenv, cacert, git, cargo, rustc, cargo-vendor, fetchcargo, python3 }:
+
 { name, cargoSha256 ? "unset"
 , src ? null
 , srcs ? null
@@ -45,7 +41,7 @@ in stdenv.mkDerivation (args // {
 
   patchRegistryDeps = ./patch-registry-deps;
 
-  buildInputs = [ cacert git rust.cargo rust.rustc ] ++ buildInputs;
+  buildInputs = [ cacert git cargo rustc ] ++ buildInputs;
 
   patches = cargoPatches ++ patches;
 

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -1,4 +1,4 @@
-{ stdenv, cacert, git, rust, cargo-vendor, python3 }:
+{ stdenv, cacert, git, cargo, cargo-vendor, python3 }:
 let cargo-vendor-normalise = stdenv.mkDerivation {
   name = "cargo-vendor-normalise";
   src = ./cargo-vendor-normalise.py;
@@ -20,7 +20,7 @@ in
 { name ? "cargo-deps", src, srcs, patches, sourceRoot, sha256, cargoUpdateHook ? "" }:
 stdenv.mkDerivation {
   name = "${name}-vendor";
-  nativeBuildInputs = [ cacert cargo-vendor git cargo-vendor-normalise rust.cargo ];
+  nativeBuildInputs = [ cacert cargo-vendor git cargo-vendor-normalise cargo ];
   inherit src srcs patches sourceRoot;
 
   phases = "unpackPhase patchPhase installPhase";

--- a/pkgs/build-support/rust/make-rust-platform.nix
+++ b/pkgs/build-support/rust/make-rust-platform.nix
@@ -1,0 +1,18 @@
+{ callPackage }:
+{ rustc, cargo, ... }: {
+  rust = {
+    inherit rustc cargo;
+  };
+
+  buildRustPackage = callPackage ./default.nix {
+    inherit rustc cargo;
+
+    fetchcargo = callPackage ./fetchcargo.nix {
+      inherit cargo;
+    };
+  };
+
+  rustcSrc = callPackage ../../development/compilers/rust/rust-src.nix {
+    inherit rustc;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7384,22 +7384,8 @@ with pkgs;
 
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };
 
+  makeRustPlatform = callPackage ../build-support/rust/make-rust-platform.nix {};
   rustPlatform = recurseIntoAttrs (makeRustPlatform rust);
-
-  makeRustPlatform = rust: lib.fix (self:
-    let
-      callPackage = newScope self;
-    in {
-      inherit rust;
-
-      buildRustPackage = callPackage ../build-support/rust {
-        inherit rust;
-      };
-
-      rustcSrc = callPackage ../development/compilers/rust/rust-src.nix {
-        inherit (rust) rustc;
-      };
-    });
 
   cargo-download = callPackage ../tools/package-management/cargo-download { };
   cargo-edit = callPackage ../tools/package-management/cargo-edit { };


### PR DESCRIPTION
###### Motivation for this change

It is now clearer what is supposed to be in the rust attribute set
without having studied type theory. The amount of code is identically.

Let's see if the ofborg's evaluation can confirm that this is noop.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

