### PR TITLE
Backport #50879

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/8.4/git.json
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/git.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/ghcjs/ghcjs",
-  "rev": "d20da90a4819faad1c6309a06363b34edac0374c",
-  "sha256": "0jmxgfm1zwg6xscjcaycfam7zss8ik4ql4ii5lpryh4h6cdhvkbr",
+  "rev": "81bf5f31dabaa711aab234cb119eb9c998ccb129",
+  "sha256": "1bgnc71kjqicqv2xq8p70nck600yi2p7g4k9r1jclv21ib7i5hmx",
   "fetchSubmodules": true
 }

--- a/pkgs/development/compilers/ghcjs-ng/8.4/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/stage0.nix
@@ -156,6 +156,7 @@
         tree-diff
       ];
       testToolDepends = [ hspec-discover ];
+      doHaddock = false;
       homepage = "http://www.haskell.org/haddock/";
       description = "Library exposing some functionality of Haddock";
       license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change

Backporting #50879 to 18.09. This change should be considered a bugfix change, and so should be consider safe for a stable channel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

