### PR TITLE
gettext: remove cross suffix from envHook

### DIFF
--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -2,7 +2,7 @@ gettextDataDirsHook() {
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRoleEnvHook
     if [ -d "$1/share/gettext" ]; then
-        addToSearchPath "GETTEXTDATADIRS${role_post}" "$1/share/gettext"
+        addToSearchPath GETTEXTDATADIRS "$1/share/gettext"
     fi
 }
 


### PR DESCRIPTION
###### Motivation for this change

`role_post` is meant for cross compilation, eg. `CC_FOR_BUILD` and
`CC_FOR_TARGET`. There's no such concept for `GETTEXTDATADIRS`.

In particular we hit this with `cantarell-fonts`, where only
`GETTEXTDATADIRS_FOR_BUILD` is defined due to empty buildInputs.

see https://github.com/NixOS/nixpkgs/issues/50855

cc @Ericson2314 as this was introduced in https://github.com/NixOS/nixpkgs/commit/2110c0bd3009279ceec291f07bfbf063cb5ba6a0
