### PR TITLE
kythe: Add missing executable, fix rpath and symlink executables into bin

### DIFF
--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     done
     cd ../
     cp -R ./ $out
+    ln -s $out/tools $out/bin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     cd tools
     for exe in http_server \
                 kythe read_entries triples verifier \
-                write_entries write_tables; do
+                write_entries write_tables entrystream; do
       echo "Patching:" $exe
       patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $exe
       patchelf --set-rpath "${stdenv.cc.cc.lib}/lib64:${ncurses5}/lib" $exe

--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, binutils , fetchurl, glibc }:
+{ stdenv, binutils , fetchurl, glibc, ncurses5 }:
 
 stdenv.mkDerivation rec {
   version = "0.0.28";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
                 write_entries write_tables; do
       echo "Patching:" $exe
       patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $exe
-      patchelf --set-rpath "${stdenv.cc.cc.lib}/lib64" $exe
+      patchelf --set-rpath "${stdenv.cc.cc.lib}/lib64:${ncurses5}/lib" $exe
     done
     cd ../
     cp -R ./ $out


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

