### PR TITLE
pythonPackages.simplekml: Init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/simplekml/default.nix
+++ b/pkgs/development/python-modules/simplekml/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   doCheck = false; # no tests are defined in 1.3.1
 
   meta = with lib; {
-    description = "Simplekml is a python package which enables you to generate KML with as little effort as possible.";
+    description = "Generate KML with as little effort as possible";
     homepage =  https://readthedocs.org/projects/simplekml/;
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ rvolosatovs ];

--- a/pkgs/development/python-modules/simplekml/default.nix
+++ b/pkgs/development/python-modules/simplekml/default.nix
@@ -1,0 +1,20 @@
+{ lib , buildPythonPackage , fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "simplekml";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "30c121368ce1d73405721730bf766721e580cae6fbb7424884c734c89ec62ad7";
+  };
+
+  doCheck = false; # no tests are defined in 1.3.1
+
+  meta = with lib; {
+    description = "Simplekml is a python package which enables you to generate KML with as little effort as possible.";
+    homepage =  https://readthedocs.org/projects/simplekml/;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3829,6 +3829,8 @@ in {
 
   simplejson = callPackage ../development/python-modules/simplejson { };
 
+  simplekml = callPackage ../development/python-modules/simplekml { };
+
   slimit = callPackage ../development/python-modules/slimit { };
 
   snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

