### PR TITLE
Go cross compilation preparation

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -160,8 +160,17 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
     cp -r . $GOROOT
-    ( cd $GOROOT/src && ./all.bash )
+    ( cd $GOROOT/src && ./make.bash )
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preCheck
+    ( cd $GOROOT/src && ./run.bash --no-rebuild)
+    runHook postCheck
   '';
 
   preFixup = ''

--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -5,11 +5,6 @@ let
 
   inherit (stdenv.lib) optionals optionalString;
 
-  clangHack = writeScriptBin "clang" ''
-    #!${stdenv.shell}
-    exec ${stdenv.cc}/bin/clang "$@" 2> >(sed '/ld: warning:.*ignoring unexpected dylib file/ d' 1>&2)
-  '';
-
   goBootstrap = runCommand "go-bootstrap" {} ''
     mkdir $out
     cp -rf ${go_bootstrap}/* $out/
@@ -162,10 +157,6 @@ stdenv.mkDerivation rec {
     export GOBIN=$GOROOT/bin
     export PATH=$GOBIN:$PATH
     ulimit -a
-  '';
-
-  postConfigure = optionalString stdenv.isDarwin ''
-    export PATH=${clangHack}/bin:$PATH
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

These are just two simple refactoring commits I picked from https://github.com/NixOS/nixpkgs/pull/50835
to prepare cross-compiling that should be non-controversial itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

