### PR TITLE
pythonPackages.docutils: fix python3 build

### DIFF
--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -14,17 +14,15 @@ buildPythonPackage rec {
     sha256 = "0x22fs3pdmr42kvz6c654756wja305qv6cx1zbhwlagvxgr4xrji";
   };
 
-  checkPhase = if isPy3k then ''
-    ${python.interpreter} test3/alltests.py
-  '' else ''
-    ${python.interpreter} test/alltests.py
+  checkPhase = ''
+    LANG="en_US.UTF-8" ${python.interpreter} ${if isPy3k then "test3/alltests.py" else "test/alltests.py"}
   '';
 
   # Create symlinks lacking a ".py" suffix, many programs depend on these names
   postFixup = ''
-    (cd $out/bin && for f in *.py; do
-      ln -s $f $(echo $f | sed -e 's/\.py$//')
-    done)
+    for f in $out/bin/*.py; do
+      ln -s $(basename $f) $out/bin/$(basename $f .py)
+    done
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

