### PR TITLE
kodi-cli: Init at 1.1.1

### DIFF
--- a/pkgs/applications/video/kodi-cli/default.nix
+++ b/pkgs/applications/video/kodi-cli/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, makeWrapper, curl, bash, jq, youtube-dl, gnome3 }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.1";
+  name = "kodi-cli";
+  
+  src = fetchFromGitHub {
+    owner = "nawar";
+    repo = name;
+    rev = version;
+    sha256 = "0f9wdq2fg8hlpk3qbjfkb3imprxkvdrhxfkcvr3dwfma0j2yfwam";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a kodi-cli $out/bin
+    wrapProgram $out/bin/kodi-cli --prefix PATH : ${stdenv.lib.makeBinPath [ curl bash ]}
+    cp -a playlist_to_kodi $out/bin
+    wrapProgram $out/bin/playlist_to_kodi --prefix PATH : ${stdenv.lib.makeBinPath [ curl bash gnome3.zenity jq youtube-dl ]}
+  '';
+  
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Kodi/XBMC bash script to send Kodi commands using JSON RPC. It also allows sending YouTube videos to Kodi";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.pstn ];
+ };
+}

--- a/pkgs/tools/misc/kodi-cli/default.nix
+++ b/pkgs/tools/misc/kodi-cli/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, makeWrapper, curl, bash, jq, youtube-dl, gnome3 }:
 
 stdenv.mkDerivation rec {
+  pname = "kodi-cli";
   version = "1.1.1";
-  name = "kodi-cli";
   
   src = fetchFromGitHub {
     owner = "nawar";
-    repo = name;
+    repo = pname;
     rev = version;
     sha256 = "0f9wdq2fg8hlpk3qbjfkb3imprxkvdrhxfkcvr3dwfma0j2yfwam";
   };
@@ -22,10 +22,10 @@ stdenv.mkDerivation rec {
   '';
   
   meta = with stdenv.lib; {
-    inherit (src.meta) homepage;
+    homepage = https://github.com/nawar/kodi-cli;
     description = "Kodi/XBMC bash script to send Kodi commands using JSON RPC. It also allows sending YouTube videos to Kodi";
     license = licenses.gpl2;
-    platforms = platforms.all;
+    platforms = platforms.unix;
     maintainers = [ maintainers.pstn ];
  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19915,7 +19915,7 @@ with pkgs;
     kodi = kodiPlain;
   };
 
-  kodi-cli = callPackage ../applications/video/kodi-cli { };
+  kodi-cli = callPackage ../tools/misc/kodi-cli { };
 
   kodi-retroarch-advanced-launchers =
     callPackage ../misc/emulators/retroarch/kodi-advanced-launchers.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19915,6 +19915,8 @@ with pkgs;
     kodi = kodiPlain;
   };
 
+  kodi-cli = callPackage ../applications/video/kodi-cli { };
+
   kodi-retroarch-advanced-launchers =
     callPackage ../misc/emulators/retroarch/kodi-advanced-launchers.nix {
       cores = retroArchCores;


### PR DESCRIPTION
###### Motivation for this change
Added the handy utility `kodi-cli` for controlling remote kodi instances with a cli.
I was on the fence myself about PRing this, so I asked in #nixos. A few people wanted to have it, so here it is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

