### PR TITLE
fpart: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/fpart/default.nix
+++ b/pkgs/tools/misc/fpart/default.nix
@@ -1,13 +1,17 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "fpart-${version}";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src = fetchurl {
-    url = "http://contribs.martymac.org/fpart/${name}.tar.gz";
-    sha256 = "1p0ajmry18lcg82znfp8nxs4w3izic775l7df08hywlq4vfa66pg";
+  src = fetchFromGitHub {
+    owner = "martymac";
+    repo = "fpart";
+    rev = name;
+    sha256 = "0h3mqc1xj5j2z8s8g3pvvpbjs6x74dj8niyh3p2ymla35kbzskf4";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   postInstall = ''
     sed "s|^FPART_BIN=.*|FPART_BIN=\"$out/bin/fpart\"|" \


### PR DESCRIPTION
###### Motivation for this change
Noticed fpart was on [github](https://github.com/martymac/fpart) which will be https instead of http://contribs.martymac.org/fpart/${name}.tar.gz

Closes #50770

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

