### PR TITLE
nordic: init at 1.2.1

### DIFF
--- a/pkgs/misc/themes/nordic/default.nix
+++ b/pkgs/misc/themes/nordic/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "nordic-${version}";
+  version = "1.2.1";
+
+  srcs = [
+    (fetchurl {
+      url = "https://github.com/EliverLara/Nordic/releases/download/v${version}/Nordic.tar.xz";
+      sha256 = "1k8fzvjb92wcqha378af5hk6r75xanff9iwlx51jmi67ny8z28pn";
+    })
+    (fetchurl {
+      url = "https://github.com/EliverLara/Nordic/releases/download/v${version}/Nordic-standard-buttons.tar.xz";
+      sha256 = "12w01z88rqkds1wm2kskql1x5c6prpgpc9cxxnl0b11knsfhi6jn";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -a Nordic* $out/share/themes
+    rm $out/share/themes/*/{LICENSE,README.md}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Dark Gtk theme created using the awesome Nord color pallete";
+    homepage = https://github.com/EliverLara/Nordic;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21004,6 +21004,8 @@ with pkgs;
 
   gnome-themes-extra = gnome3.gnome-themes-extra;
 
+  nordic = callPackage ../misc/themes/nordic { };
+
   numix-gtk-theme = callPackage ../misc/themes/numix { };
 
   numix-solarized-gtk-theme = callPackage ../misc/themes/numix-solarized { };


### PR DESCRIPTION
###### Motivation for this change

Add [Nordic](https://github.com/EliverLara/Nordic), a dark Gtk3.20+ theme created using the awesome [Nord](https://github.com/arcticicestudio/nord) color pallete.
![nautilus](https://user-images.githubusercontent.com/1217934/48872290-a52cf400-edcf-11e8-949c-e0581bde1f55.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).