### PR TITLE
pythonPackages.drmaa: init at 0.7.9

### DIFF
--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -12,6 +12,7 @@ python.buildPythonPackage rec {
     ConfigArgParse
     datrie
     docutils
+    drmaa
     jsonschema
     pyyaml
     ratelimiter

--- a/pkgs/development/libraries/libcondordrmaa/default.nix
+++ b/pkgs/development/libraries/libcondordrmaa/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libcondordrmaa-${version}";
+  version = "1.6.2";
+
+  src = fetchurl {
+    url = "http://parrot.cs.wisc.edu/externals/drmaa-${version}.tar.gz";
+    sha256 = "0yxrlp38qj60b5f74anlnr89ihijs2kmig9y0rwxwzian59cyawh";
+  };
+
+  soext = stdenv.hostPlatform.extensions.sharedLibrary;
+
+  installPhase = ''
+    install -Dm755 libdrmaa${soext} "$out"/lib/libdrmaa${soext}
+    install -Dm644 drmaa.h "$out"/include/drmaa.h
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with stdenv.lib; {
+    description = "Implementation of DRMAA 1.0 API on top of htcondor CLI";
+    homepage = https://sourceforge.net/projects/condor-ext/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ veprbl ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libcondordrmaa/setup-hook.sh
+++ b/pkgs/development/libraries/libcondordrmaa/setup-hook.sh
@@ -1,0 +1,1 @@
+export DRMAA_LIBRARY_PATH=@out@/lib/libdrmaa@soext@

--- a/pkgs/development/python-modules/drmaa/default.nix
+++ b/pkgs/development/python-modules/drmaa/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, python }:
+
+buildPythonPackage rec {
+  pname = "drmaa";
+  version = "0.7.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hjmkyfdlbpw84gl0bra352ir3a68q77p3gknb0dah7wibchqm0j";
+  };
+
+  doCheck = false; # testing requires a specific DRMAA system running
+
+  meta = with lib; {
+    description = "Python wrapper around the C DRMAA library";
+    homepage = https://github.com/pygridtools/drmaa-python;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10408,6 +10408,8 @@ with pkgs;
 
   libclxclient = callPackage ../development/libraries/libclxclient  { };
 
+  libcondordrmaa = callPackage ../development/libraries/libcondordrmaa { };
+
   libconfuse = callPackage ../development/libraries/libconfuse { };
 
   inherit (gnome3) libcroco;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -328,6 +328,8 @@ in {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  drmaa = callPackage ../development/python-modules/drmaa { };
+
   eradicate = callPackage ../development/python-modules/eradicate {  };
 
   fido2 = callPackage ../development/python-modules/fido2 {  };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

