### PR TITLE
LizardFS: 3.11.3 -> 3.12.0, add Berkeley DB support

### DIFF
--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, fetchzip
 , fetchFromGitHub
 , cmake
 , makeWrapper
@@ -16,28 +17,46 @@
 , zlib # optional
 }:
 
-stdenv.mkDerivation rec {
+let
+  # See https://github.com/lizardfs/lizardfs/blob/3.12/cmake/Libraries.cmake
+  # We have to download it ourselves, as the build script normally does a download
+  # on-build, which is not good
+  spdlog = fetchzip {
+    name = "spdlog-0.14.0";
+    url = "https://github.com/gabime/spdlog/archive/v0.14.0.zip";
+    sha256 = "13730429gwlabi432ilpnja3sfvy0nn2719vnhhmii34xcdyc57q";
+  };
+in stdenv.mkDerivation rec {
   name = "lizardfs-${version}";
-  version = "3.11.3";
+  version = "3.12.0";
 
   src = fetchFromGitHub {
     owner = "lizardfs";
     repo = "lizardfs";
     rev = "v${version}";
-    sha256 = "1njgj242vgpdqb1di321jfqk4al5lk72x2iyp0nldy7h6r98l2ww";
+    sha256 = "0zk73wmx82ari3m2mv0zx04x1ggsdmwcwn7k6bkl5c0jnxffc4ax";
   };
 
-  buildInputs = 
-    [ cmake fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
-      zlib boost pkgconfig judy pam makeWrapper
+  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
+
+  buildInputs =
+    [ fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
+      zlib boost judy pam
     ];
+
+  patches = [
+    ./remove-download-external.patch
+  ];
+
+  postUnpack = ''
+    mkdir $sourceRoot/external/spdlog-0.14.0
+    cp -R ${spdlog}/* $sourceRoot/external/spdlog-0.14.0/
+    chmod -R 755 $sourceRoot/external/spdlog-0.14.0/
+  '';
 
   postInstall = ''
     wrapProgram $out/sbin/lizardfs-cgiserver \
         --prefix PATH ":" "${python}/bin"
-
-    # mfssnapshot and mfscgiserv are deprecated
-    rm $out/bin/mfssnapshot $out/sbin/mfscgiserv
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , makeWrapper
 , python
+, db
 , fuse
 , asciidoc
 , libxml2
@@ -40,7 +41,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
 
   buildInputs =
-    [ fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
+    [ db fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
       zlib boost judy pam
     ];
 

--- a/pkgs/tools/filesystems/lizardfs/remove-download-external.patch
+++ b/pkgs/tools/filesystems/lizardfs/remove-download-external.patch
@@ -1,0 +1,25 @@
+From d3f8111ade372c1eb7f3973031f59198508fb588 Mon Sep 17 00:00:00 2001
+From: Kevin Liu <kevin@potatofrom.space>
+Date: Thu, 23 Aug 2018 10:31:42 -0400
+Subject: [PATCH] Remove download_external for spdlog
+
+---
+ cmake/Libraries.cmake | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/cmake/Libraries.cmake b/cmake/Libraries.cmake
+index 1f951e59..2134444a 100644
+--- a/cmake/Libraries.cmake
++++ b/cmake/Libraries.cmake
+@@ -7,11 +7,6 @@ if(ENABLE_TESTS)
+                     "ef5e700c8a0f3ee123e2e0209b8b4961")
+ endif()
+ 
+-download_external(SPDLOG "spdlog-0.14.0"
+-                  "https://github.com/gabime/spdlog/archive/v0.14.0.zip"
+-                  "f213d83c466aa7044a132e2488d71b11"
+-                  "spdlog-1")
+-
+ # Find standard libraries
+ find_package(Socket REQUIRED)
+ find_package(Threads REQUIRED)


### PR DESCRIPTION
###### Motivation for this change

LizardFS 3.12.0 is out. Also, Berkeley DB is a nice name caching system that reduces the memory usage of the master server a little.

I have been using these commits for a while in a private fork of Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

