### PR TITLE
curl: cherry-pick upstream patch for ipv6 url parsing

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -34,6 +34,11 @@ stdenv.mkDerivation rec {
     sha256 = "084niy7cin13ba65p8x38w2xcyc54n3fgzbin40fa2shfr0ca0kq";
   };
 
+  patches = [
+    # Cherry picked fix for https://github.com/curl/curl/issues/3218
+    ./fix-ipv6-url-parsing.patch
+  ];
+
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
   separateDebugInfo = stdenv.isLinux;
 

--- a/pkgs/tools/networking/curl/fix-ipv6-url-parsing.patch
+++ b/pkgs/tools/networking/curl/fix-ipv6-url-parsing.patch
@@ -1,0 +1,54 @@
+From b28094833a971870fd8c07960b3b12bf6fbbaad3 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 2 Nov 2018 15:11:16 +0100
+Subject: [PATCH] URL: fix IPv6 numeral address parser
+
+Regression from 46e164069d1a52. Extended test 1560 to verify.
+
+Reported-by: tpaukrt on github
+Fixes #3218
+Closes #3219
+---
+ lib/urlapi.c            | 8 ++++++--
+ tests/libtest/lib1560.c | 9 +++++++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/lib/urlapi.c b/lib/urlapi.c
+index c53e523434..18a6076fff 100644
+--- a/lib/urlapi.c
++++ b/lib/urlapi.c
+@@ -499,8 +499,12 @@ static CURLUcode parse_port(struct Curl_URL *u, char *hostname)
+      (']' == endbracket)) {
+     /* this is a RFC2732-style specified IP-address */
+     portptr = &hostname[len];
+-    if (*portptr != ':')
+-      return CURLUE_MALFORMED_INPUT;
++    if(*portptr) {
++      if(*portptr != ':')
++        return CURLUE_MALFORMED_INPUT;
++    }
++    else
++      portptr = NULL;
+   }
+   else
+     portptr = strchr(hostname, ':');
+diff --git a/tests/libtest/lib1560.c b/tests/libtest/lib1560.c
+index e0faa12b29..57469a9063 100644
+--- a/tests/libtest/lib1560.c
++++ b/tests/libtest/lib1560.c
+@@ -128,6 +128,15 @@ struct querycase {
+ };
+ 
+ static struct testcase get_parts_list[] ={
++  {"http://[fd00:a41::50]:8080",
++   "http | [11] | [12] | [13] | [fd00:a41::50] | 8080 | / | [16] | [17]",
++   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
++  {"http://[fd00:a41::50]/",
++   "http | [11] | [12] | [13] | [fd00:a41::50] | [15] | / | [16] | [17]",
++   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
++  {"http://[fd00:a41::50]",
++   "http | [11] | [12] | [13] | [fd00:a41::50] | [15] | / | [16] | [17]",
++   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
+   {"https://[::1%252]:1234",
+    "https | [11] | [12] | [13] | [::1%252] | 1234 | / | [16] | [17]",
+    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},


### PR DESCRIPTION
###### Motivation for this change

Upstream bug: curl/curl#3218.

This causes nixos/tests/ipv6.nix to fix since the last staging merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

