### PR TITLE
insomnia: 6.0.2 -> 6.2.0

### DIFF
--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -1,30 +1,70 @@
-{ stdenv, lib, makeWrapper, fetchurl, dpkg
+{ stdenv, makeWrapper, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
-, gdk_pixbuf, glib, gnome2, gtk2-x11, nspr, nss
+, gdk_pixbuf, glib, gnome2, nspr, nss, gtk3, gtk2, at-spi2-atk 
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, nghttp2
-, libudev0-shim, glibc, curl, openssl
+, libudev0-shim, glibc, curl, openssl, autoPatchelfHook
 }:
 
 let
-  libPath = lib.makeLibraryPath [
-    alsaLib atk cairo cups dbus expat fontconfig freetype gdk_pixbuf glib gnome2.GConf gnome2.pango
-    gtk2-x11 nspr nss stdenv.cc.cc libX11 libXScrnSaver libXcomposite libXcursor libXdamage libXext libXfixes
-    libXi libXrandr libXrender libXtst libxcb
+  runtimeLibs = stdenv.lib.makeLibraryPath [
+    curl
+    glibc
+    libudev0-shim
+    nghttp2
+    openssl
+    stdenv.cc.cc
   ];
-  runtimeLibs = lib.makeLibraryPath [ libudev0-shim glibc curl openssl nghttp2 ];
 in stdenv.mkDerivation rec {
   name = "insomnia-${version}";
-  version = "6.0.2";
+  version = "6.2.0";
 
   src = fetchurl {
     url = "https://github.com/getinsomnia/insomnia/releases/download/v${version}/insomnia_${version}_amd64.deb";
-    sha256 = "18xspbaal945bmrwjnsz1sjba53040wxrzvig40nnclwj8h671ms";
+    sha256 = "1wxgcriszsbgpicaj4h1ycyykgwsjr8m7x5xi02y5bs5k6l7gcva";
   };
 
-  nativeBuildInputs = [ makeWrapper dpkg ];
+  nativeBuildInputs = [ 
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+  
+  buildInputs = [
+    alsaLib
+    at-spi2-atk
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gnome2.pango
+    gtk2
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+  ];
 
-  buildPhase = ":";
+  dontBuild = true;
+  dontConfigure = true;
 
   unpackPhase = "dpkg-deb -x $src .";
 
@@ -39,23 +79,13 @@ in stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    for lib in $out/lib/*.so; do
-      patchelf --set-rpath "$out/lib:${libPath}" $lib
-    done
-
-    for bin in $out/bin/insomnia; do
-      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-               --set-rpath "$out/lib:${libPath}" \
-               $bin
-    done
-
     wrapProgram "$out/bin/insomnia" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
   '';
 
   meta = with stdenv.lib; {
     homepage = https://insomnia.rest/;
     description = "The most intuitive cross-platform REST API Client";
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ markus1189 ];
   };


### PR DESCRIPTION
###### Motivation for this change
Fixes  #50724 

We needed a few more dependencies to have it working.

In particular the application wouldn't function without `stdenv.cc.cc` in `LD_LIBRARY_PATH`.
![screenshot from 2018-11-21 22 04 41](https://user-images.githubusercontent.com/28888242/48881026-fe664900-ee0a-11e8-8eba-fe29df04953c.png)

Also switch to using `autoPatchelfHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

