### PR TITLE
sky: init at 2.1.7369

### DIFF
--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, fetchurl, file, lib, libX11, libXScrnSaver
+, gcc-unwrapped, libGL, qt5, SDL, libpulseaudio
+, libXrandr, libXext, libXcursor, libXinerama, libXi
+, ffmpeg-full, curl, sqlite, openssl_1_1_0
+, libuuid, openh264, libv4l, libxkbfile, libXv, zlib, libXmu
+, libXtst, libXdamage, pam, patchelfUnstable, libXfixes, libXrender, libjpeg_original
+}:
+ let
+   # Sky is linked to the libjpeg 8 version and checks for the version number in the code.
+   libjpeg_original_fix = libjpeg_original.overrideAttrs (oldAttrs: {
+    src = fetchurl{
+      url = http://www.ijg.org/files/jpegsrc.v8d.tar.gz;
+      sha256 = "1cz0dy05mgxqdgjf52p54yxpyy95rgl30cnazdrfmw7hfca9n0h0";
+    };
+  });
+in
+stdenv.mkDerivation rec {
+  version_major = "2.1.7300";
+  version_minor = "1";
+  version = version_major + "." + version_minor;
+  name = "sky-${version}";
+  src = fetchurl {
+    url = "https://tel.red/repos/archlinux/sky-archlinux-${version_major + "-" + version_minor}-x86_64.pkg.tar.xz";
+    sha256 = "1423d4c091faa56fcda5ccf53c87a151a8fe7f1cc8cda748c4198cb51f7b7143";
+  };
+  buildInputs = [ 
+    stdenv
+    file
+    gcc-unwrapped
+    qt5.qtbase
+    SDL
+    ffmpeg-full
+    sqlite
+    openssl_1_1_0
+    openh264
+    pam
+    curl
+    libX11 libXScrnSaver libGL libpulseaudio libXrandr
+    libXext libXcursor libXinerama libXi libuuid libv4l
+    libxkbfile libXv zlib libXmu libXtst libXdamage
+    libXfixes libXrender
+    libjpeg_original_fix
+];
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/lib" "$out/share"
+    cp -a lib/sky/lib/* "$out/lib/"
+    cp -a lib/sky/sky "$out/bin"
+    cp -a lib/sky/man.sh "$out/bin"
+    cp -a share/* "$out/share"
+    chmod +x $out/bin/sky
+  '';
+
+  postFixup = ''
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-client.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-server.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-shadow.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libopenh264.so.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/librdtk.so.1.1.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libSDL-1.3.so.0.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libsipw.so.1.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libwinpr.so.1.1.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libxfreerdp-client.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/sky
+    sed -i "s#/usr/bin/sky#$out/bin/sky#g" $out/share/applications/sky.desktop
+    sed -i "s#/usr/lib/sky#$out/bin/#g" $out/share/applications/sky.desktop
+  '';
+
+  meta = with stdenv.lib;{
+    description = "Skype for business";
+    longDescription = ''
+      Lync & Skype for business on linux
+    '';
+    homepage = https://tel.red/;
+    license = licenses.unfree;
+    maintainers = [ maintainers.Scriptkiddi ];
+    platforms = intersectLists platforms.unix platforms.x86_64;
+  };
+}
+

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   unpackCmd = "ar x $curSrc; tar -xf data.tar.xz";
   src = fetchurl {
     url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+xenial_amd64.deb";
-    sha256 = "18s22jghrwckw0rqj8zc6w0v9mwvl6c7q4bcyrd6yz3wpszb7j7w";
+    sha256 = "0b3j90km3rp5bgaklxw881g0gcy09mqzbhjdfrq4s2np026ql3d9";
   };
   buildInputs = [ 
     file

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   name = "sky-${version}";
   unpackCmd = "ar x $curSrc; tar -xf data.tar.xz";
   src = fetchurl {
-    url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+artful_amd64.deb";
+    url = "https://tel.red/repos/ubuntu/pool/non-free/sky_${version_major + "-" + version_minor}ubuntu+xenial_amd64.deb";
     sha256 = "18s22jghrwckw0rqj8zc6w0v9mwvl6c7q4bcyrd6yz3wpszb7j7w";
   };
   buildInputs = [ 

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -1,0 +1,76 @@
+{ stdenv, fetchurl, file, lib, libX11, libXScrnSaver,
+  gcc-unwrapped, libGL, qt5, SDL, libpulseaudio,
+  libXrandr, libXext, libXcursor, libXinerama, libXi,
+  ffmpeg-full, curl, sqlite, openssl_1_1_0,
+  libuuid, openh264, libv4l, libxkbfile, libXv, zlib, libXmu,
+  libXtst, libXdamage, pam, patchelfUnstable, libXfixes, libXrender, libjpeg_original
+}:
+ let
+   libjpeg_original_fix = libjpeg_original.overrideAttrs (oldAttrs: {
+    src = fetchurl{
+      url = http://www.ijg.org/files/jpegsrc.v8d.tar.gz;
+      sha256 = "1cz0dy05mgxqdgjf52p54yxpyy95rgl30cnazdrfmw7hfca9n0h0";
+    };
+  });
+in
+stdenv.mkDerivation rec {
+  version = "2.1.7300.1";
+  name = "sky-${version}";
+  src = fetchurl {
+    url = "https://tel.red/repos/archlinux/sky-archlinux-${(lib.concatStringsSep "." (lib.take 3 (lib.splitString "." version))) + "-" + (lib.last (lib.splitString "." version))}-x86_64.pkg.tar.xz";
+    sha256 = "1423d4c091faa56fcda5ccf53c87a151a8fe7f1cc8cda748c4198cb51f7b7143";
+  };
+  buildInputs = [ 
+    stdenv
+    file
+    gcc-unwrapped
+    qt5.qtbase
+    SDL
+    ffmpeg-full
+    sqlite
+    openssl_1_1_0
+    openh264
+    pam
+    curl
+    libX11 libXScrnSaver libGL libpulseaudio libXrandr libXext libXcursor libXinerama libXi libuuid libv4l libxkbfile libXv zlib libXmu libXtst libXdamage libXfixes libXrender
+    libjpeg_original_fix
+];
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/lib" "$out/share"
+    cp -a lib/sky/lib/* "$out/lib/"
+    cp -a lib/sky/sky "$out/bin"
+    cp -a lib/sky/man.sh "$out/bin"
+    cp -a share/* "$out/share"
+    chmod +x $out/bin/sky
+  '';
+
+  postFixup = ''
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-client.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-server.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp-shadow.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libfreerdp.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libopenh264.so.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/librdtk.so.1.1.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libSDL-1.3.so.0.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libsipw.so.1.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libwinpr.so.1.1.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} $out/lib/libxfreerdp-client.so.2.0.0
+    patchelf --set-rpath $out/lib:${stdenv.lib.makeLibraryPath buildInputs} --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/sky
+    sed -i "s#/usr/bin/sky#$out/bin/sky#g" $out/share/applications/sky.desktop
+    sed -i "s#/usr/lib/sky#$out/bin/#g" $out/share/applications/sky.desktop
+  '';
+
+  meta = with stdenv.lib;{
+    description = "Skype for business";
+    longDescription = ''
+      Lync & Skype for business on linux
+    '';
+    homepage = https://tel.red/;
+    license = licenses.unfree;
+    maintainers = [ maintainers.Scriptkiddi ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -16,7 +16,7 @@
   });
 in
 stdenv.mkDerivation rec {
-  version_major = "2.1.7295";
+  version_major = "2.1.7369";
   version_minor = "1";
   version = version_major + "." + version_minor;
   name = "sky-${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5042,6 +5042,8 @@ with pkgs;
 
   sks = callPackage ../servers/sks { inherit (ocamlPackages_4_02) ocaml camlp4; };
 
+  sky = callPackage ../applications/networking/instant-messengers/sky { };
+
   skydns = callPackage ../servers/skydns { };
 
   sipcalc = callPackage ../tools/networking/sipcalc { };


### PR DESCRIPTION
###### Motivation for this change
To use a NixOs at work I need to use skype buisness

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

