### PR TITLE
go_1_11: check if we still need to set CC

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -148,10 +148,6 @@ stdenv.mkDerivation rec {
   # Hopefully avoids test timeouts on Hydra
   GO_TEST_TIMEOUT_SCALE = 3;
 
-  # The go build actually checks for CC=*/clang and does something different, so we don't
-  # just want the generic `cc` here.
-  CC = if stdenv.isDarwin then "clang" else "cc";
-
   configurePhase = ''
     # Indicate that we are running on build infrastructure
     # Some tests assume things like home directories and users exists


### PR DESCRIPTION
###### Motivation for this change

DO NOT MERGE: this pull request is purely for testing with ofBorg.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

