### PR TITLE
kubernetes-helm: tell Helm what version it is

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   # Thsese are the original flags from the helm makefile
   buildFlagsArray = ''
-    -ldflags=
+    -ldflags=-X k8s.io/helm/pkg/version.Version=v${version}
     -w
     -s
   '';


### PR DESCRIPTION
###### Motivation for this change

Helm uses its version to determine what version of Tiller (the server
component) to install. Without this patch it thinks it is `v2.11+unreleased` and
tries to download `gcr.io/kubernetes-helm/tiller:v2.11`. After the patch it
correctly downloads `gcr.io/kubernetes-helm/tiller:v2.11.0`. Fixes #49120.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

