### PR TITLE
Flexget: 2.16.2 -> 2.17.4

### DIFF
--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -14,18 +14,18 @@ let
 
   packageOverrides = self: super: {
     sqlalchemy = super.sqlalchemy.overridePythonAttrs (old: rec {
-      version = "1.1.10";
+      version = "1.2.6";
       src = old.src.override {
         inherit version;
-        sha256 = "1lvb14qclrx0qf6qqx8a8hkx5akk5lk3dvcqz8760v9hya52pnfv";
+        sha256 = "1nwylglh256mbwwnng6n6bzgxshyz18j12hw76sghbprp74hrc3w";
       };
     });
 
     guessit = super.guessit.overridePythonAttrs (old: rec {
-      version = "2.1.4";
+      version = "3.0.3";
       src = old.src.override {
         inherit version;
-        sha256 = "90e6f9fb49246ad27f34f8b9984357e22562ccc3059241cbc08b4fac1d401c56";
+        sha256 = "1q06b3k31bfb8cxjimpf1rkcrwnc596a9cppjw15minvdangl32r";
       };
     });
   };
@@ -36,11 +36,11 @@ with python'.pkgs;
 
 buildPythonApplication rec {
   pname = "FlexGet";
-  version = "2.16.2";
+  version = "2.17.14";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1b9nyrg1r69kmwhpmw9pxdrwa9pnw5mphpdlki85cpxiii2sms9j";
+    sha256 = "1wh12nspjzsgb0a7qp67s4k8wssbhhf500s8x8mx2smb1mgy4xzz";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Flexget: 2.16.2 -> 2.17.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

