### PR TITLE
mutt/neomutt: work around S/MIME issues with `application/pgp-encrypted`

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = optional smimeSupport (fetchpatch {
-    url    = "https://sources.debian.net/src/mutt/1.7.2-1/debian/patches/misc/smime.rc.patch";
-    sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+    url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
+    sha256 = "1rl27qqwl4nw321ll5jcvfmkmz4fkvcsh5vihjcrhzzyf6vz8wmj";
   });
 
   buildInputs =

--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, gettext, makeWrapper, tcl, which, writeScript
 , ncurses, perl , cyrus_sasl, gss, gpgme, kerberos, libidn, libxml2, notmuch, openssl
-, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, mime-types }:
+, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, mailcap
+}:
 
 let
   muttWrapper = writeScript "mutt" ''
@@ -28,7 +29,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     cyrus_sasl gss gpgme kerberos libidn ncurses
     notmuch openssl perl lmdb
-    mime-types
+    mailcap
   ];
 
   nativeBuildInputs = [
@@ -47,10 +48,11 @@ in stdenv.mkDerivation rec {
         --replace http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd ${docbook_xml_dtd_42}/xml/dtd/docbook/docbookx.dtd
     done
 
+
     # allow neomutt to map attachments to their proper mime.types if specified wrongly
     # and use a far more comprehensive list than the one shipped with neomutt
     substituteInPlace sendlib.c \
-      --replace /etc/mime.types ${mime-types}/etc/mime.types
+      --replace /etc/mime.types ${mailcap}/etc/mime.types
 
     # The string conversion tests all fail with the first version of neomutt
     # that has tests (20180223) as well as 20180716 so we disable them for now.


### PR DESCRIPTION
###### Motivation for this change

The original issue can be reproduced when sending with an unpatched
`mutt` or `neomutt` an email with an attachement which as han `.asc`
extension. This will be interpreted as `application/pgp-encrypted` which
experiences special logic, in the end the attachement will contain
"Version: 1"[1][2][3]

Right now, there are the following issues in the {,neo}mutt packages:

* `mutt.override { smimeSupport = true }` fails to build since the
  Debian patch results in a 404. Debian moved their packages to
  `salsa.debian.org`.

  However we can't use a versioned URL for this as Debian only tracks
  the Mutt versions that are available in their releases. The patch
  doesn't touch Mutt's core and is therefore simple to rebase, so
  sticking to the 1.10.2 patch for now should be sufficient.

* The original issue was never fixed in NeoMutt, currently we use the
  S/MIME database from `pkgs.mime-types` which contains the issue with
  `application/pgp-encrypted` as well.

  It seems as it's more reliable to use the default `neomutt` database
  for now which lives in `doc/mime.types` and place it into `PKGDATADIR`
  ($out/share/neomutt).

[1] https://bugs.archlinux.org/task/43319
[2] https://bugs.gentoo.org/534658
[3] https://github.com/neomutt/neomutt/blob/neomutt-20180716/sendlib.c#L490-L496

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

