### PR TITLE
sysdig: 0.23.1 -> 0.24.1

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -1,19 +1,22 @@
-{stdenv, fetchFromGitHub, cmake, luajit, kernel, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils}:
+{ stdenv, fetchFromGitHub, cmake, kernel
+, luajit, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils, tbb
+}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "sysdig-${version}";
-  version = "0.23.1";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "draios";
     repo = "sysdig";
     rev = version;
-    sha256 = "0q52yfag97n6cvrnzgx7inx11zdg7bgwkvqn2idsg9874fd2wkzh";
+    sha256 = "04y6cqi2j0qpr5bgxyn6zz9f33v5v4lmkcl21c3sg5hmpjwibg3w";
   };
 
+  nativeBuildInputs = [ cmake perl ];
   buildInputs = [
-    cmake zlib luajit ncurses perl jsoncpp libb64 openssl curl jq gcc elfutils
+    zlib luajit ncurses jsoncpp libb64 openssl curl jq gcc elfutils tbb
   ] ++ optional (kernel != null) kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
@@ -51,9 +54,11 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A tracepoint-based system tracing tool for Linux (with clients for other OSes)";
-    license = licenses.gpl2;
+    license = with licenses; [ asl20 gpl2 mit ];
     maintainers = [maintainers.raskin];
     platforms = ["x86_64-linux"] ++ platforms.darwin;
+    broken = kernel != null && (versionOlder kernel.version "4.14" || versionAtLeast kernel.version "4.20");
+    homepage = "https://sysdig.com/opensource/";
     downloadPage = "https://github.com/draios/sysdig/releases";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

* support kernels 4.14.0 to 4.19.x

Minimum supported version [defined in quirks.h](https://github.com/draios/sysdig/blob/0.24.1/driver/bpf/quirks.h#L15)
Compatibility with 4.19 introduced in https://github.com/draios/sysdig/commit/4f433df34dbea0e4bd7dbd94a806aaedd36c2db5 and https://github.com/draios/sysdig/commit/d32e5c5fc92b8ef4ea9e3306024649159c29129e

* move cmake and perl into native build inputs

* licensing change:
  - userspace programs are now licensed under Apache 2.0
  - kernel module is now licensed under both MIT and GPLv2

See https://github.com/draios/sysdig/commit/e404c50c346ce1a2750446aeaac59f4062f33b0a

---
/cc @7c6f434c @Mic92 

I haven't tested booting with the module loaded, but it builds fine for 4.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

