### PR TITLE
pythonPackages.nanoleaf: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1319,6 +1319,11 @@
     github = "ellis";
     name = "Ellis Whitehead";
   };
+  elseym = {
+    email = "elseym@me.com";
+    github = "elseym";
+    name = "Simon Waibl";
+  };
   elvishjerricco = {
     email = "elvishjerricco@gmail.com";
     github = "ElvishJerricco";

--- a/pkgs/development/python-modules/nanoleaf/default.nix
+++ b/pkgs/development/python-modules/nanoleaf/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "nanoleaf";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17dmxibfjmwnrs6ng5cmvfis3cv6iw267xb8n1pijy15y9dz0s8s";
+  };
+
+  prePatch = ''
+    sed -i '/^gitVersion =/d' setup.py
+    substituteInPlace setup.py --replace 'gitVersion' '"${version}"'
+  '';
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = with stdenv.lib; {
+    description = "A python interface for Nanoleaf Aurora lighting";
+    homepage = https://github.com/software-2/nanoleaf;
+    license = licenses.mit;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -562,7 +562,7 @@
     "light.mqtt_template" = ps: with ps; [ paho-mqtt ];
     "light.mysensors" = ps: with ps; [  ];
     "light.mystrom" = ps: with ps; [  ];
-    "light.nanoleaf_aurora" = ps: with ps; [  ];
+    "light.nanoleaf_aurora" = ps: with ps; [ nanoleaf ];
     "light.opple" = ps: with ps; [  ];
     "light.osramlightify" = ps: with ps; [  ];
     "light.piglow" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4996,6 +4996,8 @@ in {
 
   pymssql = callPackage ../development/python-modules/pymssql { };
 
+  nanoleaf = callPackage ../development/python-modules/nanoleaf { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
nanoleaf connectivity for home-assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

