### PR TITLE
systemd timeout arguments to use infinity instead of 0

### DIFF
--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -180,7 +180,7 @@ in
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${pkgs.apcupsd}/bin/apcupsd --killpower -f ${configFile}";
-        TimeoutSec = 0;
+        TimeoutSec = "infinity";
         StandardOutput = "tty";
         RemainAfterExit = "yes";
       };

--- a/nixos/modules/services/monitoring/osquery.nix
+++ b/nixos/modules/services/monitoring/osquery.nix
@@ -78,7 +78,7 @@ in
         mkdir -p "$(dirname ${escapeShellArg cfg.databasePath})"
       '';
       serviceConfig = {
-        TimeoutStartSec = 0;
+        TimeoutStartSec = "infinity";
         ExecStart = "${pkgs.osquery}/bin/osqueryd --logger_path ${escapeShellArg cfg.loggerPath} --pidfile ${escapeShellArg cfg.pidfile} --database_path ${escapeShellArg cfg.databasePath}";
         KillMode = "process";
         KillSignal = "SIGTERM";

--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -185,7 +185,7 @@ in
           PermissionsStartOnly = true;
           User = if cfg.dropPrivileges then "consul" else null;
           Restart = "on-failure";
-          TimeoutStartSec = "0";
+          TimeoutStartSec = "infinity";
         } // (optionalAttrs (cfg.leaveOnStop) {
           ExecStop = "${cfg.package.bin}/bin/consul leave";
         });

--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -119,7 +119,7 @@ in
           { Type = "oneshot";
             ExecStart = "${pkgs.cloud-init}/bin/cloud-init init --local";
             RemainAfterExit = "yes";
-            TimeoutSec = "0";
+            TimeoutSec = "infinity";
             StandardOutput = "journal+console";
           };
       };
@@ -137,7 +137,7 @@ in
           { Type = "oneshot";
             ExecStart = "${pkgs.cloud-init}/bin/cloud-init init";
             RemainAfterExit = "yes";
-            TimeoutSec = "0";
+            TimeoutSec = "infinity";
             StandardOutput = "journal+console";
           };
       };
@@ -153,7 +153,7 @@ in
           { Type = "oneshot";
             ExecStart = "${pkgs.cloud-init}/bin/cloud-init modules --mode=config";
             RemainAfterExit = "yes";
-            TimeoutSec = "0";
+            TimeoutSec = "infinity";
             StandardOutput = "journal+console";
           };
       };
@@ -169,7 +169,7 @@ in
           { Type = "oneshot";
             ExecStart = "${pkgs.cloud-init}/bin/cloud-init modules --mode=final";
             RemainAfterExit = "yes";
-            TimeoutSec = "0";
+            TimeoutSec = "infinity";
             StandardOutput = "journal+console";
           };
       };

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -165,7 +165,7 @@ in
       ExecStop = "${gce}/bin/google_metadata_script_runner --debug --script-type shutdown";
       Type = "oneshot";
       RemainAfterExit = true;
-      TimeoutStopSec = 0;
+      TimeoutStopSec = "infinity";
     };
   };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/49700

###### Motivation for this change

systemd changed the behavior for TimeoutStartSec in 229. `infinity` is now the preferred argument to disable timeouts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

