### PR TITLE
lighttpd: enable cross-compilation

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -3,6 +3,7 @@
 , enableMysql ? false, mysql ? null
 , enableLdap ? false, openldap ? null
 , enableWebDAV ? true, sqlite ? null, libuuid ? null
+, buildPackages
 , perl
 }:
 
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
     patchShebangs tests
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.pkgconfig ];
   buildInputs = [ pcre libxml2 zlib attr bzip2 which file openssl ]
              ++ stdenv.lib.optional enableMagnet lua5_1
              ++ stdenv.lib.optional enableMysql mysql.connector-c
@@ -32,7 +33,8 @@ stdenv.mkDerivation rec {
              ++ stdenv.lib.optional enableWebDAV sqlite
              ++ stdenv.lib.optional enableWebDAV libuuid;
 
-  configureFlags = [ "--with-openssl" ]
+  configureFlags = [ "--with-openssl"
+                     "--with-pcre=${pcre.dev}" ]
                 ++ stdenv.lib.optional enableMagnet "--with-lua"
                 ++ stdenv.lib.optional enableMysql "--with-mysql"
                 ++ stdenv.lib.optional enableLdap "--with-ldap"


### PR DESCRIPTION
###### Motivation for this change

Lighttpd needs some extra configure flags to build a working cross-compiler. I'm not sure if this makes it work with all combinations of options, and I'm not sure if there's an easier way to make the configure script pick up the host pkgconfig deps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

