### PR TITLE
uriparser: Enable cross-compilation

### DIFF
--- a/pkgs/development/libraries/uriparser/default.nix
+++ b/pkgs/development/libraries/uriparser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtest, pkgconfig, doxygen, graphviz }:
+{ lib, stdenv, fetchurl, gtest, pkgconfig, doxygen, graphviz }:
 
 stdenv.mkDerivation rec {
   name = "uriparser-${version}";
@@ -10,9 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "0b2yagxzhq9ghpszci6a9xlqg0yl7vq9j5r8dwbar3nszqsfnrzc";
   };
 
-  nativeBuildInputs = [ pkgconfig gtest doxygen graphviz ];
+  nativeBuildInputs = [ pkgconfig doxygen graphviz ];
+  buildInputs = lib.optional doCheck gtest;
+  configureFlags = lib.optional (!doCheck) "--disable-tests";
 
-  doCheck = true;
+  doCheck = stdenv.targetPlatform.system == stdenv.hostPlatform.system;
 
   meta = with stdenv.lib; {
     homepage = https://uriparser.github.io/;


### PR DESCRIPTION
###### Motivation for this change

uriparser needs some extra options to enable cross-compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

