### PR TITLE
hound: 20170324 -> 2018-11-02

### DIFF
--- a/pkgs/development/tools/misc/hound/default.nix
+++ b/pkgs/development/tools/misc/hound/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "hound-unstable-${version}";
-  version = "20170324";
-  rev = "effbe5873f329fcdf982e906b756b535e2804ebc";
+  version = "2018-11-02";
+  rev = "74ec7448a234d8d09e800b92e52c92e378c07742";
 
   goPackagePath = "github.com/etsy/hound";
 
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "etsy";
     repo = "hound";
-    sha256 = "0zc769lygad5an63z5mivaggbmm07d9ynngi2jx3f7651wpji4aw";
+    sha256 = "0g6nvgqjabprcl9z5ci5frhbam1dzq978h1d6aanf8vvzslfgdpq";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change
Newer upstream version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `nixos/tests/hound.nix`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).