### PR TITLE
nixos-build-vms: fix eval

### DIFF
--- a/nixos/modules/installer/tools/nixos-build-vms/build-vms.nix
+++ b/nixos/modules/installer/tools/nixos-build-vms/build-vms.nix
@@ -7,7 +7,7 @@ let nodes = import networkExpr; in
 
 with import ../../../../lib/testing.nix {
   inherit system;
-  pkgs = import ../.. { inherit system config; };
+  pkgs = import ../../../../.. { inherit system config; };
 };
 
 (makeTest { inherit nodes; testScript = ""; }).driver


### PR DESCRIPTION
###### Motivation for this change

Previously I got the following error message:

```
error: opening file '/home/ma27/Projects/nixpkgs/nixos/modules/installer/default.nix': No such file or directory
```

Probably related to 6c68fbd4e1f8beac39cb1f499ff90c78256262d6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

