### PR TITLE
pythonPackages.affine: init at 2.2.1

### DIFF
--- a/pkgs/development/python-modules/affine/default.nix
+++ b/pkgs/development/python-modules/affine/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage, pytest, lib, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "affine";
+  version = "2.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0j3mvcnmgjvvm0znqyf7xylq7i89zjf4dq0g8280xs6bwbl5cvih";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = "py.test";
+
+  meta = with lib; {
+    description = "Matrices describing affine transformation of the plane";
+    license = licenses.bsd3;
+    homepage = https://github.com/sgillies/affine;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+
+}

--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -1,0 +1,46 @@
+{ buildPythonPackage, lib, fetchPypi
+, pytest, filelock, mock, pep8
+, cython, isPy37, glibcLocales
+, six, pyshp, shapely, geos, proj, numpy
+, gdal, pillow, matplotlib, pyepsg, pykdtree, scipy, owslib, fiona
+}:
+
+buildPythonPackage rec {
+  pname = "cartopy";
+  version = "0.17.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Cartopy";
+    sha256 = "0q9ckfi37cxj7jwnqnzij62vwcf4krccx576vv5lhvpgvplxjjs2";
+  };
+
+  checkInputs = [ filelock mock pytest pep8 ];
+
+  # several tests require network connectivity: we disable them
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    pytest --pyargs cartopy \
+      -m "not network and not natural_earth" \
+      -k "not test_nightshade_image"
+  '';
+
+  buildInputs = [ cython glibcLocales ];
+  LC_ALL = "en_US.UTF-8";
+
+  propagatedBuildInputs = [
+    # required
+    six pyshp shapely geos proj numpy
+
+    # optional
+    gdal pillow matplotlib pyepsg pykdtree scipy fiona owslib
+  ];
+
+  meta = with lib; {
+    description = "Process geospatial data to create maps and perform analyses";
+    license = licenses.lgpl3;
+    homepage = https://scitools.org.uk/cartopy/docs/latest/;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+
+}

--- a/pkgs/development/python-modules/gentools/default.nix
+++ b/pkgs/development/python-modules/gentools/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage, lib, fetchFromGitHub, pytest
+, typing, funcsigs, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "gentools";
+  version = "1.1.0";
+
+  # Pypi doesn't ship the tests, so we fetch directly from GitHub
+  src = fetchFromGitHub {
+    owner = "ariebovenberg";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1sm6cqi7fv2k3pc68r7wvvjjz8y6cjmz8bvxgqfa4v4wxibwnwrl";
+  };
+
+  propagatedBuildInputs =
+    lib.optionals (pythonOlder "3.5") [ typing ] ++
+    lib.optionals (pythonOlder "3.4") [ funcsigs ];
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  meta = with lib; {
+    description = "Tools for generators, generator functions, and generator-based coroutines";
+    license = licenses.mit;
+    homepage = http://gentools.readthedocs.io/;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+
+}

--- a/pkgs/development/python-modules/pyepsg/default.nix
+++ b/pkgs/development/python-modules/pyepsg/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, lib, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "pyepsg";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ng0k140kzq3xcffi4vy10py4cmwzfy8anccysw3vgn1x30ghzjr";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Simple Python interface to epsg.io";
+    license = licenses.lgpl3;
+    homepage = https://pyepsg.readthedocs.io/en/latest/;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+
+}

--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, lib, fetchFromGitHub
+, cython
+, numpy, affine, attrs, cligj, click-plugins, snuggs, gdal
+, pytest, pytestcov, packaging, hypothesis, boto3
+}:
+
+buildPythonPackage rec {
+  pname = "rasterio";
+  version = "1.0.10";
+
+  # Pypi doesn't ship the tests, so we fetch directly from GitHub
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = "rasterio";
+    rev = version;
+    sha256 = "0gnck9y3n31nnazlrw54swab8wql9qjx5r5x9r7hrmzy72xlzjqq";
+  };
+
+  checkInputs = [ boto3 pytest pytestcov packaging hypothesis ];
+  buildInputs = [ cython ];
+  propagatedBuildInputs = [ gdal numpy attrs affine cligj click-plugins snuggs ];
+
+  meta = with lib; {
+    description = "Python package to read and write geospatial raster data";
+    license = licenses.bsd3;
+    homepage = https://rasterio.readthedocs.io/en/latest/;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/development/python-modules/snug/default.nix
+++ b/pkgs/development/python-modules/snug/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage, lib, fetchFromGitHub, glibcLocales
+, pytest, pytest-mock, gentools
+, typing, singledispatch, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "snug";
+  version = "1.3.4";
+
+  # Pypi doesn't ship the tests, so we fetch directly from GitHub
+  src = fetchFromGitHub {
+    owner = "ariebovenberg";
+    repo = "snug";
+    rev = "v${version}";
+    sha256 = "0jmg0sivz9ljazlnsrrqaizrb3r7asy5pa0dj3idx49gbig4589i";
+  };
+
+  # Prevent unicode decoding error in setup.py
+  # while reading README.rst and HISTORY.rst
+  buildInputs = [ glibcLocales ];
+  LC_ALL = "en_US.UTF-8";
+
+  propagatedBuildInputs =
+    lib.optionals (pythonOlder "3.4") [ singledispatch ] ++
+    lib.optionals (pythonOlder "3.5") [ typing ];
+
+  checkInputs = [ pytest pytest-mock gentools ];
+  checkPhase = "pytest";
+
+  meta = with lib; {
+    description = "Tiny toolkit for writing reusable interactions with web APIs";
+    license = licenses.mit;
+    homepage = https://snug.readthedocs.io/en/latest/;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+
+}

--- a/pkgs/development/python-modules/snuggs/default.nix
+++ b/pkgs/development/python-modules/snuggs/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, lib, fetchFromGitHub
+, click, numpy, pyparsing
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "snuggs";
+  version = "1.4.2";
+
+  # Pypi doesn't ship the tests, so we fetch directly from GitHub
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = pname;
+    rev = version;
+    sha256 = "1q6jqwai4qgghdjgwhyx3yz8mlrm7p1vvnwc339lfl028hrgb5kb";
+  };
+
+  propagatedBuildInputs = [ click numpy pyparsing ];
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest test_snuggs.py";
+
+  meta = with lib; {
+    description = "S-expressions for Numpy";
+    license = licenses.mit;
+    homepage = https://github.com/mapbox/snuggs;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1053,6 +1053,8 @@ in {
 
   pyechonest = callPackage ../development/python-modules/pyechonest { };
 
+  pyepsg = callPackage ../development/python-modules/pyepsg { };
+
   pyezminc = callPackage ../development/python-modules/pyezminc { };
 
   billiard = callPackage ../development/python-modules/billiard { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3661,6 +3661,8 @@ in {
 
   rabbitpy = callPackage ../development/python-modules/rabbitpy { };
 
+  rasterio = callPackage ../development/python-modules/rasterio { };
+
   radicale_infcloud = callPackage ../development/python-modules/radicale_infcloud {};
 
   recaptcha_client = callPackage ../development/python-modules/recaptcha_client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -744,6 +744,8 @@ in {
 
   adal = callPackage ../development/python-modules/adal { };
 
+  affine = callPackage ../development/python-modules/affine { };
+
   aioconsole = callPackage ../development/python-modules/aioconsole { };
 
   aiodns = callPackage ../development/python-modules/aiodns { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2417,6 +2417,8 @@ in {
 
   genshi = callPackage ../development/python-modules/genshi { };
 
+  gentools = callPackage ../development/python-modules/gentools { };
+
   gevent = callPackage ../development/python-modules/gevent { };
 
   geventhttpclient = callPackage ../development/python-modules/geventhttpclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1136,6 +1136,8 @@ in {
 
   carrot = callPackage ../development/python-modules/carrot {};
 
+  cartopy = callPackage ../development/python-modules/cartopy {};
+
   case = callPackage ../development/python-modules/case {};
 
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3841,6 +3841,8 @@ in {
 
   snug = callPackage ../development/python-modules/snug { };
 
+  snuggs = callPackage ../development/python-modules/snuggs { };
+
   spake2 = callPackage ../development/python-modules/spake2 { };
 
   sphfile = callPackage ../development/python-modules/sphfile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3839,6 +3839,8 @@ in {
 
   snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
 
+  snug = callPackage ../development/python-modules/snug { };
+
   spake2 = callPackage ../development/python-modules/spake2 { };
 
   sphfile = callPackage ../development/python-modules/sphfile { };


### PR DESCRIPTION
cartopy: init at 0.17.0
pyepsg: init at 0.3.2
rasterio: init at 0.34.0
snug: init at 1.3.4
snuggs: init at 1.4.2

A few libraries related to geospatial data analysis

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

