### PR TITLE
rpm-ostree: 2018.5 → 2019.1

### DIFF
--- a/pkgs/tools/misc/ostree/default.nix
+++ b/pkgs/tools/misc/ostree/default.nix
@@ -1,34 +1,17 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, gtk-doc, gobject-introspection, gnome3
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gtk-doc, gobject-introspection, gnome3
 , glib, systemd, xz, e2fsprogs, libsoup, gpgme, which, autoconf, automake, libtool, fuse, utillinuxMinimal, libselinux
 , libarchive, libcap, bzip2, yacc, libxslt, docbook_xsl, docbook_xml_dtd_42, python3
 }:
 
-let
-  version = "2018.9";
-
-  libglnx-src = fetchFromGitHub {
-    owner = "GNOME";
-    repo = "libglnx";
-    rev = "470af8763ff7b99bec950a6ae0a957c1dcfc8edd";
-    sha256 = "1fwik38i6w3r6pn4qkizradcqp1m83n7ljh9jg0y3p3kvrbfxh15";
-  };
-
-  bsdiff-src = fetchFromGitHub {
-    owner = "mendsley";
-    repo = "bsdiff";
-    rev = "1edf9f656850c0c64dae260960fabd8249ea9c60";
-    sha256 = "1h71d2h2d3anp4msvpaff445rnzdxii3id2yglqk7af9i43kdsn1";
-  };
-in stdenv.mkDerivation {
-  name = "ostree-${version}";
+stdenv.mkDerivation rec {
+  pname = "ostree";
+  version = "2019.1";
 
   outputs = [ "out" "dev" "man" "installedTests" ];
 
-  src = fetchFromGitHub {
-    rev = "v${version}";
-    owner = "ostreedev";
-    repo = "ostree";
-    sha256 = "0a8gr4qqxcvz3fqv9w4dxy6iq0rq4kdzf08rzv8xg4gic3ldgyvj";
+  src = fetchurl {
+    url = "https://github.com/ostreedev/ostree/releases/download/v${version}/libostree-${version}.tar.xz";
+    sha256 = "08y7nsxl305dnlfak4kyj88lld848y4kg6bvjqngcxaqqvkk9xqm";
   };
 
   patches = [
@@ -57,13 +40,6 @@ in stdenv.mkDerivation {
     (python3.withPackages (p: with p; [ pyyaml ])) gnome3.gjs # for tests
   ];
 
-  prePatch = ''
-    rmdir libglnx bsdiff
-    cp --no-preserve=mode -r ${libglnx-src} libglnx
-    cp --no-preserve=mode -r ${bsdiff-src} bsdiff
-  '';
-
-
   preConfigure = ''
     env NOCONFIGURE=1 ./autogen.sh
   '';
@@ -71,16 +47,15 @@ in stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   configureFlags = [
-    "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
-    "--with-systemdsystemgeneratordir=$(out)/lib/systemd/system-generators"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-systemdsystemgeneratordir=${placeholder "out"}/lib/systemd/system-generators"
     "--enable-installed-tests"
   ];
 
   makeFlags = [
-    "installed_testdir=$(installedTests)/libexec/installed-tests/libostree"
-    "installed_test_metadir=$(installedTests)/share/installed-tests/libostree"
+    "installed_testdir=${placeholder "installedTests"}/libexec/installed-tests/libostree"
+    "installed_test_metadir=${placeholder "installedTests"}/share/installed-tests/libostree"
   ];
-
 
   meta = with stdenv.lib; {
     description = "Git for operating system binaries";

--- a/pkgs/tools/misc/rpm-ostree/default.nix
+++ b/pkgs/tools/misc/rpm-ostree/default.nix
@@ -1,52 +1,33 @@
-{ stdenv, fetchpatch, fetchFromGitHub, ostree, rpm, which, autoconf, automake, libtool, pkgconfig,
-  gobject-introspection, gtk-doc, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, gperf, cmake,
+{ stdenv, fetchurl, ostree, rpm, which, autoconf, automake, libtool, pkgconfig, cargo, rustc,
+  gobject-introspection, gtk-doc, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gperf, cmake,
   libcap, glib, systemd, json-glib, libarchive, libsolv, librepo, polkit,
   bubblewrap, pcre, check, python }:
 
-let
-  libglnx-src = fetchFromGitHub {
-    owner = "GNOME";
-    repo = "libglnx";
-    rev = "97b5c08d2f93dc93ba296a84bbd2a5ab9bd8fc97";
-    sha256 = "0cz4x63f6ys7dln54g6mrr7hksvqwz78wdc8qb7zr1h2cp1azcvs";
+stdenv.mkDerivation rec {
+  pname = "rpm-ostree";
+  version = "2019.1";
+
+  src = fetchurl {
+    url = "https://github.com/projectatomic/${pname}/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "14qk8mq5yc67j3wl3fa9xnhh8ii8x5qdiavf7ybw7mp4ma4lwa8k";
   };
 
-  libdnf-src = fetchFromGitHub {
-    owner = "rpm-software-management";
-    repo = "libdnf";
-    rev = "b3fcc53f6f3baf4f51f836f5e1eb54eb82d5df49";
-    sha256 = "15nl9x4blyc9922rvz7iq56yy8hxhpsf31cs3ag7aypqpfx3czci";
-  };
-
-  version = "2018.5";
-in stdenv.mkDerivation {
-  name = "rpm-ostree-${version}";
+  patches = [
+    # gobject-introspection requires curl in cflags
+    # https://github.com/NixOS/nixpkgs/pull/50953#issuecomment-449777169
+    # https://github.com/NixOS/nixpkgs/pull/50953#issuecomment-452177080
+    ./fix-introspection-build.patch
+  ];
 
   outputs = [ "out" "dev" "man" "devdoc" ];
-
-  src = fetchFromGitHub {
-    rev = "v${version}";
-    owner = "projectatomic";
-    repo = "rpm-ostree";
-    sha256 = "0y37hr8mmrsww4ka2hlqmz7wp57ibzhah4j87yg8q8dks5hxcbsx";
-  };
-
   nativeBuildInputs = [
-    pkgconfig which autoconf automake libtool cmake gperf
-    gobject-introspection gtk-doc libxml2 libxslt docbook_xsl docbook_xml_dtd_42
+    pkgconfig which autoconf automake libtool cmake gperf cargo rustc
+    gobject-introspection gtk-doc libxml2 libxslt docbook_xsl docbook_xml_dtd_42 docbook_xml_dtd_43
   ];
   buildInputs = [
     libcap ostree rpm glib systemd polkit bubblewrap
     json-glib libarchive libsolv librepo
     pcre check python
-  ];
-
-  patches = [
-    # Use gdbus-codegen from PATH
-    (fetchpatch {
-      url = https://github.com/projectatomic/rpm-ostree/commit/315406d8cd0937e786723986e88d376c88806c60.patch;
-      sha256 = "073yfa62515kyf58s0sz56w0a40062lh761y2y4assqipybwxbvp";
-    })
   ];
 
   configureFlags = [
@@ -57,15 +38,8 @@ in stdenv.mkDerivation {
   dontUseCmakeConfigure = true;
 
   prePatch = ''
-    rmdir libglnx libdnf
-    cp --no-preserve=mode -r ${libglnx-src} libglnx
-    cp --no-preserve=mode -r ${libdnf-src} libdnf
-
     # According to #cmake on freenode, libdnf should bundle the FindLibSolv.cmake module
     cp ${libsolv}/share/cmake/Modules/FindLibSolv.cmake libdnf/cmake/modules/
-
-    # libdnf normally wants sphinx to build its hawkey manpages, but we don't care about those manpages since we don't use hawkey
-    substituteInPlace configure.ac --replace 'cmake \' 'cmake -DWITH_MAN=off \'
 
     # Let's not hardcode the rpm-gpg path...
     substituteInPlace libdnf/libdnf/dnf-keyring.cpp \
@@ -84,4 +58,3 @@ in stdenv.mkDerivation {
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/tools/misc/rpm-ostree/fix-introspection-build.patch
+++ b/pkgs/tools/misc/rpm-ostree/fix-introspection-build.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -103,7 +103,7 @@
+ 				     ostree-1 >= 2018.9
+ 				     libsystemd
+ 				     polkit-gobject-1
+-				     rpm librepo libsolv
++				     rpm librepo libsolv libcurl
+ 				     libarchive])
+ 
+ dnl -ldl: https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c


### PR DESCRIPTION
###### Motivation for this change
Update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

