### PR TITLE
sqlite-web: init at 0.3.5

### DIFF
--- a/pkgs/development/tools/database/sqlite-web/default.nix
+++ b/pkgs/development/tools/database/sqlite-web/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sqlite-web";
+  version = "0.3.5";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "9e0c8938434b0129423544162d4ca6975abf7042c131445f79661a4b9c885d47";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ flask peewee pygments ];
+
+  # no tests in repository
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Web-based SQLite database browser";
+    homepage = https://github.com/coleifer/sqlite-web;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8948,6 +8948,8 @@ with pkgs;
 
   sqlitebrowser = libsForQt5.callPackage ../development/tools/database/sqlitebrowser { };
 
+  sqlite-web = callPackage ../development/tools/database/sqlite-web { };
+
   sselp = callPackage ../tools/X11/sselp{ };
 
   stm32flash = callPackage ../development/tools/misc/stm32flash { };


### PR DESCRIPTION
###### Motivation for this change

Request for new python package sqlite-web
closes https://github.com/NixOS/nixpkgs/issues/50949

###### Things done

pythonPackages.sqlite-web: init at 0.3.5

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

