### PR TITLE
slither: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi, makeWrapper, prettytable, pythonOlder, solc }:
+
+buildPythonPackage rec {
+  pname = "slither-analyzer";
+  version = "0.3.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10vrcqm371kqmf702xmqmzimv3xgrn3k3ip06nr1l6gnj3jk138g";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ prettytable ];
+
+  postFixup = ''
+    wrapProgram $out/bin/slither \
+      --prefix PATH : "${lib.makeBinPath [ solc ]}"
+  '';
+
+  meta = with lib; {
+    description = "Static Analyzer for Solidity";
+    longDescription = ''
+      Slither is a Solidity static analysis framework written in Python 3. It
+      runs a suite of vulnerability detectors, prints visual information about
+      contract details, and provides an API to easily write custom analyses.
+    '';
+    homepage = https://github.com/trailofbits/slither;
+    license = licenses.agpl3;
+    maintainers = [ maintainers.asymmetric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5357,6 +5357,8 @@ with pkgs;
 
   signal-desktop = callPackage ../applications/networking/instant-messengers/signal-desktop { };
 
+  slither-analyzer = with python3Packages; toPythonApplication slither-analyzer;
+
   signify = callPackage ../tools/security/signify { };
 
   # aka., pgp-tools

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -688,6 +688,8 @@ in {
 
   slicerator = callPackage ../development/python-modules/slicerator { };
 
+  slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };
+
   snapcast = callPackage ../development/python-modules/snapcast { };
 
   spglib = callPackage ../development/python-modules/spglib { };


### PR DESCRIPTION
###### Motivation for this change

Adds [slither](https://github.com/trailofbits/slither), which has both a [library](https://github.com/trailofbits/slither/wiki/API-examples) and a CLI component.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
