### PR TITLE
wpscan: init at 3.4.0

### DIFF
--- a/pkgs/tools/security/wpscan/Gemfile
+++ b/pkgs/tools/security/wpscan/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'wpscan', '= 3.4.0'

--- a/pkgs/tools/security/wpscan/Gemfile.lock
+++ b/pkgs/tools/security/wpscan/Gemfile.lock
@@ -1,0 +1,55 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    cms_scanner (0.0.41.0)
+      activesupport (~> 5.2)
+      addressable (~> 2.5)
+      nokogiri (~> 1.8.0)
+      opt_parse_validator (~> 0.0.16.4)
+      public_suffix (~> 3.0.0)
+      ruby-progressbar (~> 1.10.0)
+      typhoeus (~> 1.3.0)
+      xmlrpc (~> 0.3)
+      yajl-ruby (~> 1.4.1)
+    concurrent-ruby (1.1.3)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
+    ffi (1.9.25)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    opt_parse_validator (0.0.16.4)
+      activesupport (~> 5.2.1)
+      addressable (~> 2.5.0)
+    public_suffix (3.0.3)
+    ruby-progressbar (1.10.0)
+    thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    wpscan (3.4.0)
+      activesupport (~> 5.2)
+      cms_scanner (~> 0.0.41.0)
+      yajl-ruby (~> 1.3)
+    xmlrpc (0.3.0)
+    yajl-ruby (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  wpscan (= 3.4.0)
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/tools/security/wpscan/default.nix
+++ b/pkgs/tools/security/wpscan/default.nix
@@ -1,0 +1,15 @@
+{ bundlerApp, lib }:
+
+bundlerApp {
+  pname = "wpscan";
+  gemdir = ./.;
+  exes = [ "wpscan" ];
+
+  meta = with lib; {
+    description = "black box WordPress vulnerability scanner";
+    homepage    = https://wpscan.org/;
+    license     = licenses.unfreeRedistributable;
+    maintainers = [ maintainers.nyanloutre ];
+    platforms   = platforms.unix;
+};
+}

--- a/pkgs/tools/security/wpscan/default.nix
+++ b/pkgs/tools/security/wpscan/default.nix
@@ -6,7 +6,7 @@ bundlerApp {
   exes = [ "wpscan" ];
 
   meta = with lib; {
-    description = "black box WordPress vulnerability scanner";
+    description = "Black box WordPress vulnerability scanner";
     homepage    = https://wpscan.org/;
     license     = licenses.unfreeRedistributable;
     maintainers = [ maintainers.nyanloutre ];

--- a/pkgs/tools/security/wpscan/default.nix
+++ b/pkgs/tools/security/wpscan/default.nix
@@ -1,9 +1,15 @@
-{ bundlerApp, lib }:
+{ bundlerApp, lib, makeWrapper, curl }:
 
 bundlerApp {
   pname = "wpscan";
   gemdir = ./.;
   exes = [ "wpscan" ];
+
+  buildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram "$out/bin/wpscan" \
+      --prefix PATH : ${lib.makeBinPath [ curl ]}
+  '';
 
   meta = with lib; {
     description = "Black box WordPress vulnerability scanner";

--- a/pkgs/tools/security/wpscan/default.nix
+++ b/pkgs/tools/security/wpscan/default.nix
@@ -11,5 +11,5 @@ bundlerApp {
     license     = licenses.unfreeRedistributable;
     maintainers = [ maintainers.nyanloutre ];
     platforms   = platforms.unix;
-};
+  };
 }

--- a/pkgs/tools/security/wpscan/gemset.nix
+++ b/pkgs/tools/security/wpscan/gemset.nix
@@ -1,0 +1,164 @@
+{
+  activesupport = {
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ziy6xk31k4fs115cdkba1ys4i8nzcyri7a2jig7nx7k5h7li6l2";
+      type = "gem";
+    };
+    version = "5.2.1";
+  };
+  addressable = {
+    dependencies = ["public_suffix"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0viqszpkggqi8hq87pqp0xykhvz60g99nwmkwsb0v45kc2liwxvk";
+      type = "gem";
+    };
+    version = "2.5.2";
+  };
+  cms_scanner = {
+    dependencies = ["activesupport" "addressable" "nokogiri" "opt_parse_validator" "public_suffix" "ruby-progressbar" "typhoeus" "xmlrpc" "yajl-ruby"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1azsvgg070dng2jaz44zaqkvqyhf3pj131nqa7wdv3bsqp8y7kap";
+      type = "gem";
+    };
+    version = "0.0.41.0";
+  };
+  concurrent-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18q9skp5pfq4jwbxzmw8q2rn4cpw6mf4561i2hsjcl1nxdag2jvb";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  ethon = {
+    dependencies = ["ffi"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0y70szwm2p0b9qfvpqrzjrgm3jz0ig65vlbfr6ppc3z0m1h7kv48";
+      type = "gem";
+    };
+    version = "0.11.0";
+  };
+  ffi = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jpm2dis1j7zvvy3lg7axz9jml316zrn7s0j59vyq3qr127z0m7q";
+      type = "gem";
+    };
+    version = "1.9.25";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gcp1m1p6dpasycfz2sj82ci9ggz7lsskz9c9q6gvfwxrl8y9dx7";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  mini_portile2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13d32jjadpjj6d2wdhkfpsmy68zjx90p49bgf8f7nkpz86r1fr11";
+      type = "gem";
+    };
+    version = "2.3.0";
+  };
+  minitest = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0icglrhghgwdlnzzp4jf76b0mbc71s80njn5afyfjn4wqji8mqbq";
+      type = "gem";
+    };
+    version = "5.11.3";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0byyxrazkfm29ypcx5q4syrv126nvjnf7z6bqi01sqkv4llsi4qz";
+      type = "gem";
+    };
+    version = "1.8.5";
+  };
+  opt_parse_validator = {
+    dependencies = ["activesupport" "addressable"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1m3flpg1d7la1frip3vn0hgm6d91f0ys1jq2bhxr5va1vjbfvgbs";
+      type = "gem";
+    };
+    version = "0.0.16.4";
+  };
+  public_suffix = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
+      type = "gem";
+    };
+    version = "3.0.3";
+  };
+  ruby-progressbar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cv2ym3rl09svw8940ny67bav7b2db4ms39i4raaqzkf59jmhglk";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+  thread_safe = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nmhcgq6cgz44srylra07bmaw99f5271l0dpsvl5f75m44l0gmwy";
+      type = "gem";
+    };
+    version = "0.3.6";
+  };
+  typhoeus = {
+    dependencies = ["ethon"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cni8b1idcp0dk8kybmxydadhfpaj3lbs99w5kjibv8bsmip2zi5";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  tzinfo = {
+    dependencies = ["thread_safe"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fjx9j327xpkkdlxwmkl3a8wqj7i4l4jwlrv3z13mg95z9wl253z";
+      type = "gem";
+    };
+    version = "1.2.5";
+  };
+  wpscan = {
+    dependencies = ["activesupport" "cms_scanner" "yajl-ruby"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17mqqaiawp3apdfw4l6r2wp0a4f0rp8wdqd2426xkna7vsxgh8gs";
+      type = "gem";
+    };
+    version = "3.4.0";
+  };
+  xmlrpc = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1s744iwblw262gj357pky3d9fcx9hisvla7rnw29ysn5zsb6i683";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  yajl-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16v0w5749qjp13xhjgr2gcsvjv6mf35br7iqwycix1n2h7kfcckf";
+      type = "gem";
+    };
+    version = "1.4.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6032,6 +6032,8 @@ with pkgs;
 
   woof = callPackage ../tools/misc/woof { };
 
+  wpscan = callPackage ../tools/security/wpscan { };
+
   wsmancli = callPackage ../tools/system/wsmancli {};
 
   wolfebin = callPackage ../tools/networking/wolfebin {


### PR DESCRIPTION
###### Motivation for this change

This is my first attempt to bundle a Ruby application, so any comment is welcome

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

