### PR TITLE
Rustfmt: 0.9.0 -> 0.99.5

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     chmod +x $out/bin/bindgen
   '';
 
-  doCheck = false; # half the tests fail because our rustfmt is not nightly enough
+  doCheck = true;
   checkInputs =
     let fakeRustup = writeScriptBin "rustup" ''
       #!${stdenv.shell}
@@ -42,6 +42,10 @@ rustPlatform.buildRustPackage rec {
     fakeRustup # the test suite insists in calling `rustup run nightly rustfmt`
     clang
   ];
+  preCheck = ''
+    # for the ci folder, notably
+    patchShebangs .
+  '';
 
   meta = with stdenv.lib; {
     description = "C and C++ binding generator";

--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform }:
+{ stdenv, fetchFromGitHub, rustPlatform, darwin }:
 
 rustPlatform.buildRustPackage rec {
   name = "rustfmt-${version}";
@@ -12,6 +12,9 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "1rs6jjm75ixxhrf8b3zn991xa5kfayxlf0b70zdx6wd4r6by7w2y";
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+
 
   # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
   RUSTC_BOOTSTRAP = 1;

--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -2,16 +2,25 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "0.9.0";
+  version = "0.99.5";
 
   src = fetchFromGitHub {
-    owner = "rust-lang-nursery";
+    owner = "rust-lang";
     repo = "rustfmt";
     rev = "${version}";
-    sha256 = "12l3ff0s0pzhcf5jbs8wqawjk4jghhhz8j6dq1n5201yvny12jlr";
+    sha256 = "1gx1bsyb0f94r3f88f1j3b4rcm2x6zppcfab1c5vgpsr2dr6ch28";
   };
 
-  cargoSha256 = "0gppki9mgx99xipapg36ydwk1bplygnz6sbyzbg46vhn10iggfwm";
+  cargoSha256 = "1rs6jjm75ixxhrf8b3zn991xa5kfayxlf0b70zdx6wd4r6by7w2y";
+
+  # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
+  RUSTC_BOOTSTRAP = 1;
+
+  # we run tests in debug mode so tests look for a debug build of
+  # rustfmt. Anyway this adds nearly no compilation time.
+  preCheck = ''
+    cargo build
+  '';
 
   meta = with stdenv.lib; {
     description = "A tool for formatting Rust code according to style guidelines";


### PR DESCRIPTION
###### Motivation for this change
the current version of rustfmt is unable to parse code accepted by our current version of rustc.
Also enable tests in `rustc-bindgen` (they were disabled because our version of rustfmt was too old)

cc @Ralith and @globin as maintainers.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`): tested `cargo fmt` and `rustfmt`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

