### PR TITLE
stdenv/generic/setup.sh: More robust unpacking

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -810,12 +810,12 @@ _defaultUnpack() {
         case "$fn" in
             *.tar.xz | *.tar.lzma | *.txz)
                 # Don't rely on tar knowing about .xz.
-                xz -d < "$fn" | tar xf -
+                xz -d < "$fn" | tar --delay-directory-restore -xf -
                 ;;
             *.tar | *.tar.* | *.tgz | *.tbz2 | *.tbz)
                 # GNU tar can automatically select the decompression method
                 # (info "(tar) gzip").
-                tar xf "$fn"
+                tar --delay-directory-restore -xf "$fn"
                 ;;
             *)
                 return 1
@@ -895,6 +895,11 @@ unpackPhase() {
     fi
 
     echo "source root is $sourceRoot"
+
+    # Make all directories enterable. This is required for archives that contain
+    # directories that do not have their execute bit set. This seems to occur
+    # most often when a tar is created in Windows.
+    find "$sourceRoot" -type d -exec chmod u+x {} \;
 
     # By default, add write permission to the sources.  This is often
     # necessary when sources have been copied from other store


### PR DESCRIPTION
###### Motivation for this change

This commit makes it so the unpack phase can unpack tar files containing directories that do not have their execute bit set. This most commonly seems to happen to archives created on Windows. Two changes are required to make this work:
1) The `--delay-directory-restore` flag needs to be set on the tar command, otherwise tar cannot enter newly created directories (that don't have their x bit set) and fails.
2) After tar is run, directories need their execute bit set because tar restores the permissions once the extraction is complete.

The --mode flag of tar isn't used because that would affect every file instead of only directories. I'm not a tar expert, but the other flag that seems like it might help (--no-same-permissions), applies the user's umask, thus doesn't set the x bit.

I've rebuilt my entire NixOS system with this change successfully. Please let me know what other testing is required and I'll be happy to run it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

