### PR TITLE
[staging-18.09] backport nss, libpng & sqlite updates

### DIFF
--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -3,20 +3,20 @@
 assert zlib != null;
 
 let
-  patchVersion = "1.6.34";
+  patchVersion = "1.6.35";
   patch_src = fetchurl {
     url = "mirror://sourceforge/libpng-apng/libpng-${patchVersion}-apng.patch.gz";
-    sha256 = "1ha4npf9mfrzp0srg8a5amks5ww84xzfpjbsj8k3yjjpai798qg6";
+    sha256 = "011fq5wgyz07pfrqs9albixbiksx3agx5nkcf3535gbvhlwv5khq";
   };
   whenPatched = stdenv.lib.optionalString apngSupport;
 
 in stdenv.mkDerivation rec {
   name = "libpng" + whenPatched "-apng" + "-${version}";
-  version = "1.6.34";
+  version = "1.6.35";
 
   src = fetchurl {
     url = "mirror://sourceforge/libpng/libpng-${version}.tar.xz";
-    sha256 = "1xjr0v34fyjgnhvaa1zixcpx5yvxcg4zwvfh0fyklfyfj86rc7ig";
+    sha256 = "1mxwjf5cdzk7g0y51gl9w3f0j5ypcls05i89kgnifjaqr742x493";
   };
   postPatch = whenPatched "gunzip < ${patch_src} | patch -Np1";
 

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -8,11 +8,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "nss-${version}";
-  version = "3.39";
+  version = "3.40";
 
   src = fetchurl {
-    url = "mirror://mozilla/security/nss/releases/NSS_3_39_RTM/src/${name}.tar.gz";
-    sha256 = "0jw6qlfl2g47hhx056nvnj6h92bk3sn46hy3ig61a911dzblvrkb";
+    url = "mirror://mozilla/security/nss/releases/NSS_3_40_RTM/src/${name}.tar.gz";
+    sha256 = "1p9jidi3nysirf3lhkrqkjjrf2cw3y2wz2jgjvsjn1ysidxhhqh5";
   };
 
   buildInputs = [ perl zlib sqlite ]

--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  version = "3.25.0";
+  version = "3.25.1";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "020dyfd948l4zdw2izirjaw90pq4668ihms0c9kqj5rmzhk88n81";
+    sha256 = "1bkz5n8zshh51brcxvyfysdy6mmx6zy4xhhdnwvsavnynk042bz6";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  version = "3.25.2";
+  version = "3.25.3";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "0n7lzp671x1xz6fx138xa1jhi4vfwib3awaxac5skw6fv9q61940";
+    sha256 = "08b4fs9mrah5gxl1865smlqs2ba6g7k7d6pfa084i6d78342p4n7";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  version = "3.25.1";
+  version = "3.25.2";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "1bkz5n8zshh51brcxvyfysdy6mmx6zy4xhhdnwvsavnynk042bz6";
+    sha256 = "0n7lzp671x1xz6fx138xa1jhi4vfwib3awaxac5skw6fv9q61940";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  version = "3.24.0";
+  version = "3.25.0";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "19ck2sg13i6ga5vapxak42jn6050vpfid0zrmah7jh32mksh58vj";
+    sha256 = "020dyfd948l4zdw2izirjaw90pq4668ihms0c9kqj5rmzhk88n81";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-${version}";
-  version = "3.24.0";
+  version = "3.25.0";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2018/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "0jmprv2vpggzhy7ma4ynmv1jzn3pfiwzkld0kkg6hvgvqs44xlfr";
+    sha256 = "0wbz638p1q8fxr2rdhi5dy9wvffh8x1zwh2lx0zdj8zaq7gr66ny";
   };
 
   outputs = [ "bin" "dev" "out" ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-${version}";
-  version = "3.25.2";
+  version = "3.25.3";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2018/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "109i1sfryghrdaynkqq9s9aq4347vy653bwkqwx4slix8a2196ns";
+    sha256 = "1pgkja0d13qp5p79ik9kh9lm5y79cwyxwwfc80cr8a1rw5xzksq0";
   };
 
   outputs = [ "bin" "dev" "out" ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-${version}";
-  version = "3.25.0";
+  version = "3.25.1";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2018/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "0wbz638p1q8fxr2rdhi5dy9wvffh8x1zwh2lx0zdj8zaq7gr66ny";
+    sha256 = "1lbgxhrdjjy2gcwrzj0inq4p117g1l117mmgm0y0g4zhhyyldvcn";
   };
 
   outputs = [ "bin" "dev" "out" ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-${version}";
-  version = "3.25.1";
+  version = "3.25.2";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2018/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "1lbgxhrdjjy2gcwrzj0inq4p117g1l117mmgm0y0g4zhhyyldvcn";
+    sha256 = "109i1sfryghrdaynkqq9s9aq4347vy653bwkqwx4slix8a2196ns";
   };
 
   outputs = [ "bin" "dev" "out" ];

--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchPypi
+, fetchpatch
 , buildPythonPackage
 , pytest
 , mock
@@ -9,12 +10,22 @@
 
 buildPythonPackage rec {
   pname = "SQLAlchemy";
-  version = "1.2.11";
+  version = "1.2.13";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524";
+    sha256 = "84412de3794acee05630e7788f25e80e81f78eb4837e7b71d0499129f660486a";
   };
+
+  patches = [
+    # fix for failing doc tests
+    # https://bitbucket.org/zzzeek/sqlalchemy/issues/4370/sqlite-325x-docs-tutorialrst-doctests-fail
+    (fetchpatch {
+      name = "doc-test-fixes.patch";
+      url = https://bitbucket.org/zzzeek/sqlalchemy/commits/63279a69e2b9277df5e97ace161fa3a1bb4f29cd/raw;
+      sha256 = "1x25aj5hqmgjdak4hllya0rf0srr937k1hwaxb24i9ban607hjri";
+    })
+  ];
 
   checkInputs = [
     pytest


### PR DESCRIPTION
This is the backport of the PRs #50374 & #46852.

Both of which will be required in a few weeks from now for the firefox bump.

As previously discussed with @vcunat in https://github.com/NixOS/nixpkgs/pull/50374#issuecomment-438994359 we should wait until those changes arrive in unstable/passed initial testing.

Feel free to merge whenever you feel the time is right. Preferably in time for the Firefox release ;)

/cc @dtzWill (since he dealt with the sqlite upgrade)
/cc @samueldr (the other release manager of 18.09)
