### PR TITLE
rstudio: fix qt plugins not found

### DIFF
--- a/pkgs/development/r-modules/wrapper-rstudio.nix
+++ b/pkgs/development/r-modules/wrapper-rstudio.nix
@@ -1,5 +1,8 @@
-{ stdenv, R, rstudio, makeWrapper, recommendedPackages, packages }:
+{ stdenv, R, rstudio, makeWrapper, recommendedPackages, packages, qtbase }:
 
+let
+  qtVersion = with stdenv.lib.versions; "${major qtbase.version}.${minor qtbase.version}";
+in
 stdenv.mkDerivation rec {
 
   name = rstudio.name + "-wrapper";
@@ -24,7 +27,8 @@ stdenv.mkDerivation rec {
     echo -n $R_LIBS_SITE | sed -e 's/:/", "/g' >> $out/${fixLibsR}
     echo -n "\"))" >> $out/${fixLibsR}
     echo >> $out/${fixLibsR}
-    makeWrapper ${rstudio}/bin/rstudio $out/bin/rstudio --set R_PROFILE_USER $out/${fixLibsR}
+    makeWrapper ${rstudio}/bin/rstudio $out/bin/rstudio --set R_PROFILE_USER $out/${fixLibsR} \
+      --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-${qtVersion}/plugins    
   '';
   
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13142,7 +13142,7 @@ with pkgs;
     packages = [];
   };
 
-  rstudioWrapper = callPackage ../development/r-modules/wrapper-rstudio.nix {
+  rstudioWrapper = libsForQt5.callPackage ../development/r-modules/wrapper-rstudio.nix {
     recommendedPackages = with rPackages; [
       boot class cluster codetools foreign KernSmooth lattice MASS
       Matrix mgcv nlme nnet rpart spatial survival


### PR DESCRIPTION
###### Motivation for this change

Fix #48826.

Thanks to @Ma27 .

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

