### PR TITLE
echoip: Init at unstable-2018-11-20

### DIFF
--- a/pkgs/servers/echoip/default.nix
+++ b/pkgs/servers/echoip/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "echoip-${version}";
+  version = "unstable-2018-11-20";
+
+  goPackagePath = "github.com/mpolden/echoip";
+
+  src = fetchFromGitHub {
+    owner = "mpolden";
+    repo = "echoip";
+    rev = "4bfaf671b9f75a7b2b37543b2991401cbf57f1f0";
+    sha256 = "0n5d9i8cc5lqgy5apqd3zhyl3h1xjacf612z8xpvbm75jnllcvxy";
+  };
+
+  goDeps = ./deps.nix;
+
+  outputs = [ "bin" "out" ];
+
+  postInstall = ''
+    mkdir -p $out
+    cp $src/index.html $out/index.html
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/mpolden/echoip;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/servers/echoip/deps.nix
+++ b/pkgs/servers/echoip/deps.nix
@@ -1,0 +1,73 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/jessevdk/go-flags";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jessevdk/go-flags";
+      rev = "v1.4.0";
+      sha256 = "0algnnigph27spgn655zm4723yfjxjjvlf4k14z9drj3682df25a";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/oschwald/geoip2-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oschwald/geoip2-golang";
+      rev = "v1.2.1";
+      sha256 = "0zpgpz577rghvgis6ji9l99pq87z5izbgzmnbyn3dy533bayrgpw";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/oschwald/maxminddb-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oschwald/maxminddb-golang";
+      rev = "v1.2.1";
+      sha256 = "1x5famcyw3iadx8hd5lz0vrli6v6zdy8bcir2fy2km76a85yvixj";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.2.2";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "37707fdb30a5";
+      sha256 = "1abrr2507a737hdqv4q7pw7hv6ls9pdiq9crhdi52r3gcz6hvizg";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16360,6 +16360,8 @@ with pkgs;
 
   eaglemode = callPackage ../applications/misc/eaglemode { };
 
+  echoip = callPackage ../servers/echoip { };
+
   eclipses = recurseIntoAttrs (callPackage ../applications/editors/eclipse {
     jdk = jdk11;
   });


### PR DESCRIPTION
###### Motivation for this change
The power behind https://ifconfig.co now in `nixpkgs` :tada: 
~The project uses go modules - I did not find an automated solution to convert the go module files into `deps.nix`, so I first converted it to use `dep`, then used `dep2nix` to generate the `deps.nix`.
Still had to do some manual tweaking to make it build, however, as `golang.org/x/sys` was not included in `deps.nix` by some reason.~
Turns out https://github.com/adisbladis/vgo2nix exists, so I just used the tool to generate `deps.nix`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

