### PR TITLE
powershell: 6.1.0 -> 6.1.1

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -4,8 +4,8 @@
 let platformString = if stdenv.isDarwin then "osx"
                      else if stdenv.isLinux then "linux"
                      else throw "unsupported platform";
-    platformSha = if stdenv.isDarwin then "0jngmqxjiiz5dpgky027wl0s3nn321rxs6kxab27kmp031j65x8g"
-                     else if stdenv.isLinux then "0nmqv32mck16b7zljfpb9ydg3h2jvcqrid9ga2i5wac26x3ix531"
+    platformSha = if stdenv.isDarwin then "1zm5q25ny2x6wvdqfrc380467zq0nbrzh2rzldwdkdpkb6wbvpj8"
+                     else if stdenv.isLinux then "0wh5vvh8pk75fy37bm5av4xvp76slqyjhb6a0al55vw9rlg5q3xw"
                      else throw "unsupported platform";
     platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
                      else if stdenv.isLinux then "LD_LIBRARY_PATH"
@@ -14,7 +14,7 @@ let platformString = if stdenv.isDarwin then "osx"
 in
 stdenv.mkDerivation rec {
   name = "powershell-${version}";
-  version = "6.1.0";
+  version = "6.1.1";
 
   src = fetchzip {
     url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-${platformString}-x64.tar.gz";
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "Cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework";
     homepage = https://github.com/PowerShell/PowerShell;
     maintainers = [ maintainers.yrashk ];
-    platforms = platforms.unix;
+    platforms = with platforms; unix ++ darwin;
     license = with licenses; [ mit ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fixes #50644 by updating the darwin hash as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

