### PR TITLE
pixman: 0.34.0 -> 0.36.0

### DIFF
--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, autoconf, automake, libtool, autoreconfHook, pkgconfig, libpng, glib /*just passthru*/ }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libpng, glib /*just passthru*/ }:
 
 stdenv.mkDerivation rec {
   name = "pixman-${version}";

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -2,23 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "pixman-${version}";
-  version = "0.34.0";
+  version = "0.36.0";
 
   src = fetchurl {
     url = "mirror://xorg/individual/lib/${name}.tar.bz2";
-    sha256 = "184lazwdpv67zrlxxswpxrdap85wminh1gmq1i5lcz6iycw39fir";
+    sha256 = "1p40fygy9lcn6ypkzh14azksi570brcpr3979bjpff8qk76c14px";
   };
 
-  patches = stdenv.lib.optionals stdenv.cc.isClang [
-    (fetchpatch {
-      name = "builtin-shuffle.patch";
-      url = https://patchwork.freedesktop.org/patch/177506/raw;
-      sha256 = "0rvraq93769dy2im2m022rz99fcdxprgc2fbmasnddcwrqy1x3xr";
-    })
-  ];
-
-  nativeBuildInputs = [ pkgconfig ]
-    ++ stdenv.lib.optionals stdenv.cc.isClang [ autoconf automake libtool autoreconfHook ];
+  nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ libpng ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

