### PR TITLE
nsjail: 2.7 -> 2.8

### DIFF
--- a/pkgs/tools/security/nsjail/default.nix
+++ b/pkgs/tools/security/nsjail/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   name = "nsjail-${version}";
-  version = "2.7";
+  version = "2.8";
 
   src = fetchFromGitHub {
     owner           = "google";
     repo            = "nsjail";
     rev             = version;
     fetchSubmodules = true;
-    sha256          = "13s1bi2b80rlwrgls1bx4bk140qhncwdamm9q51jd677s0i3xg3s";
+    sha256          = "0cgycj0cz74plmz4asxryqprg6mkzpmnxzqbfsp1wwackinxq5fq";
   };
 
   nativeBuildInputs = [ autoconf bison flex libtool pkgconfig which ];


### PR DESCRIPTION
###### Motivation for this change

Changelog: https://github.com/google/nsjail/releases/tag/2.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```ini
$ ./result/bin/nsjail -Mo --chroot / -- /run/current-system/sw/bin/echo "ABC"
[2018-11-24T00:23:06+0100] Mode: STANDALONE_ONCE
[2018-11-24T00:23:06+0100] Jail parameters: hostname:'NSJAIL', chroot:'/', process:'/run/current-system/sw/bin/echo', bind:[::]:0, max_conns_per_ip:0, time_limit:0, personality:0, daemonize:false, clone_newnet:true, clone_newuser:true, clone_newns:true, clone_newpid:true, clone_newipc:true, clonew_newuts:true, clone_newcgroup:true, keep_caps:false, disable_no_new_privs:false, max_cpus:0
[2018-11-24T00:23:06+0100] Mount point: '/' -> '/' flags:MS_RDONLY|MS_BIND|MS_REC|MS_PRIVATE type:'' options:'' is_dir:true
[2018-11-24T00:23:06+0100] Mount point: '/proc' flags:MS_RDONLY type:'proc' options:'' is_dir:true
[2018-11-24T00:23:06+0100] Uid map: inside_uid:1000 outside_uid:1000 count:1 newuidmap:false
[2018-11-24T00:23:06+0100] Gid map: inside_gid:100 outside_gid:100 count:1 newgidmap:false
[2018-11-24T00:23:06+0100] Executing '/run/current-system/sw/bin/echo' for '[STANDALONE MODE]'
ABC
[2018-11-24T00:23:06+0100] PID: 3365 ([STANDALONE MODE]) exited with status: 0, (PIDs left: 0)
```