### PR TITLE
sarasa-gothic: rewrite: TTC and fixed-output

### DIFF
--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -1,23 +1,22 @@
 { stdenv, fetchurl, p7zip }:
 
-stdenv.mkDerivation rec {
+let
   version = "0.6.0";
+  sha256 = "08g3kzplp3v8kvni1vzl73fgh03xgfl8pwqyj7vwjihjdr1xfjyz";
+in fetchurl rec {
+  inherit sha256;
+
   name = "sarasa-gothic-${version}";
 
-  package = fetchurl {
-    url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttf-${version}.7z";
-    sha256 = "00kyx03lpgycxaw0cyx96hhrx8gwkcmy3qs35q7r09y60vg5i0nv";
-  };
+  url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
 
-  nativeBuildInputs = [ p7zip ];
+  recursiveHash = true;
+  downloadToTemp = true;
 
-  unpackPhase = ''
-    7z x $package
-  '';
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
+  postFetch = ''
+    ${p7zip}/bin/7z x $downloadedFile
+    mkdir -p $out/share/fonts
+    install -m644 *.ttc $out/share/fonts/
   '';
 
   meta = with stdenv.lib; {
@@ -26,7 +25,5 @@ stdenv.mkDerivation rec {
     license = licenses.ofl;
     maintainers = [ maintainers.ChengCat ];
     platforms = platforms.all;
-    # large package, mainly i/o bound
-    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
Rewritten to use TTC archive instead of the TTF one. It's also now fixed-output.

###### Motivation for this change

The current sarasa-gothic font takes up 2.2GB in the Nix store. This can be reduced to 212MB by using the TTC archive instead of the TTF one, which shares data between individual fonts and has a much smaller size than the sum of individual fonts.

It was written like `wqy_zenhei`. It, as it has been, does not use `fetchzip` because `p7zip` is needed.

Also I've made it fixed-output like `wqy_zenhei`. This should avoid unnecessary re-builds.

I have not kept `hydraPlatforms = []` due to the size having drastically decreased. Is this acceptable? (cc @Mic92)

`nix path-info -S` output showing the improvement:

```
/nix/store/i7sjfwhxxlp197063avdyhqql7pydyrl-sarasa-gothic-0.6.0  2288735488         # 2.2GB
/nix/store/z2x9q54rdyjicpf61yg0nn2wap9vr0fv-sarasa-gothic-0.6.0   212067152         # 212MB
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
