### PR TITLE
minizinc: 2.2.1 -> 2.2.3

### DIFF
--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, flex, bison }:
 let
-  version = "2.2.1";
+  version = "2.2.3";
 in
 stdenv.mkDerivation {
   name = "minizinc-${version}";
@@ -8,13 +8,12 @@ stdenv.mkDerivation {
   buildInputs = [ cmake flex bison ];
 
   src = fetchFromGitHub {
-    rev = "${version}";
     owner = "MiniZinc";
     repo = "libminizinc";
-    sha256 = "1i11lan7fqs3lg0s6jfr8sflzwn5nk1ln5j6afjrkrdb08291dr7";
+    rev = "3d66971a0cad6edbe796f4dd940229d38e5bfe3d"; # tags on the repo are disappearing: See https://github.com/MiniZinc/libminizinc/issues/257
+    sha256 = "1q31y9131aj2lsm34srm8i1s0271qcaaknzvym3r8awynm14saq5";
   };
 
-  # meta is all the information about the package..
   meta = with stdenv.lib; {
     homepage = http://www.minizinc.org/;
     description = "MiniZinc is a medium-level constraint modelling language.";


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/pull/50684

Fetch would fail because all of their recent tags disappeared.
So we'll just use a git rev.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

