### PR TITLE
slang: respect TERMINFO_DIRS and ignore FHS paths

### DIFF
--- a/pkgs/development/libraries/slang/default.nix
+++ b/pkgs/development/libraries/slang/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "man" "doc" ];
 
+  patches = [ ./terminfo-dirs.patch ];
+
   # Fix some wrong hardcoded paths
   preConfigure = ''
     sed -i -e "s|/usr/lib/terminfo|${ncurses.out}/lib/terminfo|" configure

--- a/pkgs/development/libraries/slang/terminfo-dirs.patch
+++ b/pkgs/development/libraries/slang/terminfo-dirs.patch
@@ -1,0 +1,172 @@
+commit c7aa0c07b6522fbbb47ef47bd22f47f1611e7423
+Author: John E. Davis <jed@jedsoft.org>
+Date:   Wed Nov 28 00:46:28 2018 -0500
+
+    pre2.3.3-5: Added support for TERMINFO_DIRS env var
+
+Modified: removed changes to changelog and version number.
+
+diff --git a/src/sltermin.c b/src/sltermin.c
+index a06d0e4..65d3bbc 100644
+--- a/src/sltermin.c
++++ b/src/sltermin.c
+@@ -133,6 +133,9 @@ static FILE *open_terminfo (char *file, SLterminfo_Type *h)
+    unsigned char buf[12];
+    int magic;
+ 
++#ifdef SLANG_UNTIC
++   (void) fprintf (stdout,"# Trying %s\n", file);
++#endif
+    /* Alan Cox reported a security problem here if the application using the
+     * library is setuid.  So, I need to make sure open the file as a normal
+     * user.  Unfortunately, there does not appear to be a portable way of
+@@ -269,10 +272,73 @@ static char *read_string_table (FILE *fp, SLterminfo_Type *t)
+  * are implemented by multiple links to the same compiled file.
+  */
+ 
++static FILE *try_open_tidir (SLterminfo_Type *ti, const char *tidir, const char *term)
++{
++   char file[1024];
++
++   if (sizeof (file) > strlen (tidir) + 5 + strlen (term))
++     {
++	FILE *fp;
++
++	sprintf (file, "%s/%c/%s", tidir, *term, term);
++	if (NULL != (fp = open_terminfo (file, ti)))
++	  return fp;
++
++	sprintf (file, "%s/%02x/%s", tidir, (unsigned char)*term, term);
++	if (NULL != (fp = open_terminfo (file, ti)))
++	  return fp;
++     }
++
++   return NULL;
++}
++
++static FILE *try_open_env (SLterminfo_Type *ti, const char *term, const char *envvar)
++{
++   char *tidir;
++
++   if (NULL == (tidir = _pSLsecure_getenv (envvar)))
++     return NULL;
++
++   return try_open_tidir (ti, tidir, term);
++}
++
++static FILE *try_open_home (SLterminfo_Type *ti, const char *term)
++{
++   char home_ti[1024];
++   char *env;
++
++   if (NULL == (env = _pSLsecure_getenv ("HOME")))
++     return NULL;
++
++   strncpy (home_ti, env, sizeof (home_ti) - 11);
++   home_ti [sizeof(home_ti) - 11] = 0;
++   strcat (home_ti, "/.terminfo");
++
++   return try_open_tidir (ti, home_ti, term);
++}
++
++static FILE *try_open_env_path (SLterminfo_Type *ti, const char *term, const char *envvar)
++{
++   char tidir[1024];
++   char *env;
++   unsigned int i;
++
++   if (NULL == (env = _pSLsecure_getenv (envvar)))
++     return NULL;
++
++   i = 0;
++   while (-1 != SLextract_list_element (env, i, ':', tidir, sizeof(tidir)))
++     {
++	FILE *fp = try_open_tidir (ti, tidir, term);
++	if (fp != NULL) return fp;
++	i++;
++     }
++
++   return NULL;
++}
++
+ static SLCONST char *Terminfo_Dirs [] =
+ {
+-   "", /* $TERMINFO */
+-   "", /* $HOME/.terminfo */
+ #ifdef MISC_TERMINFO_DIRS
+    MISC_TERMINFO_DIRS,
+ #endif
+@@ -287,6 +353,23 @@ static SLCONST char *Terminfo_Dirs [] =
+    NULL,
+ };
+ 
++static FILE *try_open_hardcoded (SLterminfo_Type *ti, const char *term)
++{
++   const char *tidir, **tidirs;
++
++   tidirs = Terminfo_Dirs;
++   while (NULL != (tidir = *tidirs++))
++     {
++	FILE *fp;
++
++	if ((*tidir != 0)
++	    && (NULL != (fp = try_open_tidir (ti, tidir, term))))
++	  return fp;
++     }
++
++   return NULL;
++}
++
+ void _pSLtt_tifreeent (SLterminfo_Type *t)
+ {
+    if (t == NULL)
+@@ -305,11 +388,7 @@ void _pSLtt_tifreeent (SLterminfo_Type *t)
+ 
+ SLterminfo_Type *_pSLtt_tigetent (SLCONST char *term)
+ {
+-   SLCONST char **tidirs, *tidir;
+    FILE *fp = NULL;
+-   char file[1024];
+-   static char home_ti [1024];
+-   char *env;
+    SLterminfo_Type *ti;
+ 
+    if (
+@@ -341,33 +420,10 @@ SLterminfo_Type *_pSLtt_tigetent (SLCONST char *term)
+    /* If we are on a termcap based system, use termcap */
+    if (0 == tcap_getent (term, ti)) return ti;
+ 
+-   if (NULL != (env = _pSLsecure_getenv ("TERMINFO")))
+-     Terminfo_Dirs[0] = env;
+-
+-   if (NULL != (env = _pSLsecure_getenv ("HOME")))
+-     {
+-	strncpy (home_ti, env, sizeof (home_ti) - 11);
+-	home_ti [sizeof(home_ti) - 11] = 0;
+-	strcat (home_ti, "/.terminfo");
+-	Terminfo_Dirs [1] = home_ti;
+-     }
+-
+-   tidirs = Terminfo_Dirs;
+-   while (NULL != (tidir = *tidirs++))
+-     {
+-	if (*tidir == 0)
+-	  continue;
+-
+-	if (sizeof (file) > strlen (tidir) + 5 + strlen (term))
+-	  {
+-	     sprintf (file, "%s/%c/%s", tidir, *term, term);
+-	     if (NULL != (fp = open_terminfo (file, ti)))
+-	       break;
+-	     sprintf (file, "%s/%02x/%s", tidir, (unsigned char)*term, term);
+-	     if (NULL != (fp = open_terminfo (file, ti)))
+-	       break;
+-	  }
+-     }
++   fp = try_open_env_path (ti, term, "TERMINFO_DIRS");
++   if (fp == NULL) fp = try_open_env (ti, term, "TERMINFO");
++   if (fp == NULL) fp = try_open_home (ti, term);
++   if (fp == NULL) fp = try_open_hardcoded (ti, term);
+ 
+ #ifdef SLANG_UNTIC
+    fp_open_label:


### PR DESCRIPTION
###### Motivation for this change
Makes whiptail, nmtui and others work correctly in nonstandard terminals like alacritty.

cc @tilpner who was complaining about this not working, @Fuuzetsu maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

