### PR TITLE
pythonPackages.pyproj: 1.9.5.1 -> unstable-2018-11-13

### DIFF
--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -1,21 +1,26 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , python
 , nose2
+, cython
 , proj ? null
 }:
 
 buildPythonPackage (rec {
   pname = "pyproj";
-  version = "1.9.5.1";
+  version = "unstable-2018-11-13";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "53fa54c8fa8a1dfcd6af4bf09ce1aae5d4d949da63b90570ac5ec849efaf3ea8";
+  src = fetchFromGitHub {
+    owner = "jswhit";
+    repo = pname;
+    rev = "78540f5ff40da92160f80860416c91ee74b7643c";
+    sha256 = "1vq5smxmpdjxialxxglsfh48wx8kaq9sc5mqqxn4fgv1r5n1m3n9";
   };
 
-  buildInputs = [ nose2 ];
+  buildInputs = [ cython ];
+
+  checkInputs = [ nose2 ];
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
###### Motivation for this change
Allow us to build pyproj with python3.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

