### PR TITLE
mailcap: init at 2.1.48

### DIFF
--- a/pkgs/data/misc/mailcap/default.nix
+++ b/pkgs/data/misc/mailcap/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchzip }:
+
+let
+  version = "2.1.48";
+
+in fetchzip {
+  name = "mailcap-${version}";
+
+  url = "https://releases.pagure.org/mailcap/mailcap-${version}.tar.xz";
+  sha256 = "0m1rls4z85aby9fggwx2x70b4y6l0jjyiqdv30p8g91nv8hrq9fw";
+
+  postFetch = ''
+    tar -xavf $downloadedFile --strip-components=1
+    substituteInPlace mailcap --replace "/usr/bin/" ""
+    gzip mailcap.4
+
+    install -D -m0644 -t $out/etc mailcap mime.types
+    install -D -m0644 -t $out/share/man/man4 mailcap.4.gz
+  '';
+
+  meta = with lib; {
+    description = "Helper application and MIME type associations for file types";
+    homepage = "https://pagure.io/mailcap";
+    license = licenses.mit;
+    maintainers = with maintainers; [ c0bw3b ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15395,6 +15395,8 @@ with pkgs;
 
   maia-icon-theme = callPackage ../data/icons/maia-icon-theme { };
 
+  mailcap = callPackage ../data/misc/mailcap { };
+
   marathi-cursive = callPackage ../data/fonts/marathi-cursive { };
 
   man-pages = callPackage ../data/documentation/man-pages { };


### PR DESCRIPTION
###### Motivation for this change

Helper application and MIME type associations for file types (made to be fixed-output).
Provides a fresher `mime.types` than pkg `mime-types` v9 which dates back to 2012-10-05
It lives under `${mailcap.out}/etc/`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

