### PR TITLE
libmtp: 1.1.15 -> 1.1.16

### DIFF
--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libusb1, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "libmtp-1.1.15";
+  name = "libmtp-1.1.16";
 
   src = fetchurl {
     url = "mirror://sourceforge/libmtp/${name}.tar.gz";
-    sha256 = "089h79nkz7wcr3lbqi7025l8p75hbp0aigxk3wdk2zkm8q5r0h6h";
+    sha256 = "185vh9bds6dcy00ycggg69g4v7m3api40zv8vrcfb3fk3vfzjs2v";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
This fixes the problem of connecting android phones via MTP in kde/dolphin.

Original Bug description: https://bugs.kde.org/show_bug.cgi?id=387454

(cherry picked from commit 79f148c2e0c12a41f377dcf6b5e74022de28857c)

see #49411