### PR TITLE
Treewide: use HTTPS for repo.or.cz and SF.net

### DIFF
--- a/pkgs/applications/audio/a2jmidid/default.nix
+++ b/pkgs/applications/audio/a2jmidid/default.nix
@@ -9,12 +9,12 @@ in stdenv.mkDerivation rec {
   version = "8";
 
   src = fetchurl {
-    url = "http://repo.or.cz/a2jmidid.git/snapshot/7383d268c4bfe85df9f10df6351677659211d1ca.tar.gz";
+    url = "https://repo.or.cz/a2jmidid.git/snapshot/7383d268c4bfe85df9f10df6351677659211d1ca.tar.gz";
     sha256 = "06dgf5655znbvrd7fhrv8msv6zw8vk0hjqglcqkh90960mnnmwz7";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ makeWrapper alsaLib dbus libjack2 python dbus-python ];
+  nativeBuildInputs = [ pkgconfig makeWrapper wafHook ];
+  buildInputs = [ alsaLib dbus libjack2 python dbus-python ];
 
   postInstall = ''
     wrapProgram $out/bin/a2j_control --set PYTHONPATH $PYTHONPATH

--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://repo.or.cz/w/llpp.git;
+    homepage = https://repo.or.cz/w/llpp.git;
     description = "A MuPDF based PDF pager written in OCaml";
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/applications/networking/mailreaders/realpine/default.nix
+++ b/pkgs/applications/networking/mailreaders/realpine/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.asl20;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    homepage = http://re-alpine.sf.net/;
-    downloadPage = "http://sourceforge.net/projects/re-alpine/files/";
+    homepage = https://sourceforge.net/projects/re-alpine/;
+    downloadPage = "https://sourceforge.net/projects/re-alpine/files/";
   };
 }

--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -6,7 +6,7 @@ let version = "2.48"; in
 stdenv.mkDerivation {
   name = "gwyddion-${version}";
   src = fetchurl {
-    url = "http://sourceforge.net/projects/gwyddion/files/gwyddion/${version}/gwyddion-${version}.tar.xz";
+    url = "mirror://sourceforge/gwyddion/files/gwyddion/${version}/gwyddion-${version}.tar.xz";
     sha256 = "119iw58ac2wn4cas6js8m7r1n4gmmkga6b1y711xzcyjp9hshgwx";
   };
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/science/math/fricas/default.nix
+++ b/pkgs/applications/science/math/fricas/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
-    url    = "http://sourceforge.net/projects/fricas/files/fricas/${version}/${name}-full.tar.bz2";
+    url    = "mirror://sourceforge/fricas/files/fricas/${version}/${name}-full.tar.bz2";
     sha256 = "156k9az1623y5808j845c56z2nvvdrm48dzg1v0ivpplyl7vp57x";
   };
 

--- a/pkgs/applications/science/misc/golly/beta.nix
+++ b/pkgs/applications/science/misc/golly/beta.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    downloadPage = "http://sourceforge.net/projects/golly/files/golly";
+    downloadPage = "https://sourceforge.net/projects/golly/files/golly";
   };
 }

--- a/pkgs/applications/science/misc/golly/default.nix
+++ b/pkgs/applications/science/misc/golly/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
-    downloadPage = "http://sourceforge.net/projects/golly/files/golly";
+    downloadPage = "https://sourceforge.net/projects/golly/files/golly";
   };
 }

--- a/pkgs/applications/science/misc/golly/default.upstream
+++ b/pkgs/applications/science/misc/golly/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/golly/files/golly/
+url https://sourceforge.net/projects/golly/files/golly/
 version_link '[-][0-9.]+/$'
 SF_version_tarball 'src'
 SF_redirect

--- a/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Import svn, mercurial into git";
-    homepage = http://repo.or.cz/w/fast-export.git;
+    homepage = https://repo.or.cz/w/fast-export.git;
     license = licenses.gpl2;
     maintainers = [ maintainers.koral ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/window-managers/stalonetray/default.nix
+++ b/pkgs/applications/window-managers/stalonetray/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateInfo = {
-      downloadPage = "http://sourceforge.net/projects/stalonetray/files/";
+      downloadPage = "https://sourceforge.net/projects/stalonetray/files/";
     };
   };
 }

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     ./missing-size_t.patch # https://bugzilla.redhat.com/show_bug.cgi?id=906519
     (fetchpatch {
       name = "CVE-2013-4122.patch";
-      url = "http://sourceforge.net/projects/miscellaneouspa/files/glibc217/cyrus-sasl-2.1.26-glibc217-crypt.diff";
+      url = "mirror://sourceforge/miscellaneouspa/files/glibc217/cyrus-sasl-2.1.26-glibc217-crypt.diff";
       sha256 = "05l7dh1w9d5fvzg0pjwzqh0fy4ah8y5cv6v67s4ssbq8xwd4pkf2";
     })
   ] ++ lib.optional stdenv.isFreeBSD (

--- a/pkgs/development/libraries/dssi/default.nix
+++ b/pkgs/development/libraries/dssi/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux;
     license = licenses.lgpl21;
-    downloadPage = "http://sourceforge.net/projects/dssi/files/dssi/";
+    downloadPage = "https://sourceforge.net/projects/dssi/files/dssi/";
   };
 }

--- a/pkgs/development/libraries/libipfix/default.nix
+++ b/pkgs/development/libraries/libipfix/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libipfix-${version}";
   version = "110209";
   src = fetchurl {
-    url = "http://sourceforge.net/projects/libipfix/files/libipfix/libipfix_110209.tgz";
+    url = "mirror://sourceforge/libipfix/files/libipfix/libipfix_110209.tgz";
     sha256 = "0h7v0sxjjdc41hl5vq2x0yhyn04bczl11bqm97825mivrvfymhn6";
   };
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libtar/default.nix
+++ b/pkgs/development/libraries/libtar/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = let
     fp =  name: sha256:
       fetchpatch {
-        url = "http://sources.debian.net/data/main/libt/libtar/1.2.20-4/debian/patches/${name}.patch";
+        url = "https://sources.debian.net/data/main/libt/libtar/1.2.20-4/debian/patches/${name}.patch";
         inherit sha256;
       };
     in [
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C library for manipulating POSIX tar files";
-    homepage = http://repo.or.cz/libtar;
+    homepage = https://repo.or.cz/libtar;
     license = licenses.bsd3;
     platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/games/blobby/default.nix
+++ b/pkgs/games/blobby/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "blobby-volley-${version}";
 
   src = fetchurl {
-    url = "http://softlayer-ams.dl.sourceforge.net/project/blobby/Blobby%20Volley%202%20%28Linux%29/1.0/blobby2-linux-1.0.tar.gz";
+    url = "mirror://sourceforge/blobby/Blobby%20Volley%202%20%28Linux%29/1.0/blobby2-linux-1.0.tar.gz";
     sha256 = "1qpmbdlyhfbrdsq4vkb6cb3b8mh27fpizb71q4a21ala56g08yms";
   };
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [raskin];
     homepage = http://blobby.sourceforge.net/;
-    downloadPage = "http://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/";
+    downloadPage = "https://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/";
     inherit version;
   };
 }

--- a/pkgs/games/blobby/default.upstream
+++ b/pkgs/games/blobby/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/
+url https://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/
 SF_version_dir
 version_link '[.]tar[.][^.]+/download$'
 SF_redirect

--- a/pkgs/games/tennix/fix_FTBFS.patch
+++ b/pkgs/games/tennix/fix_FTBFS.patch
@@ -1,7 +1,7 @@
 From: Thomas Perl <m@thp.io>
 Description: Fix FTBFS 
-Origin: upstream, http://repo.or.cz/w/tennix.git/commitdiff/6144cb7626dfdc0820a0036af83a531e8e68bae6
-Bug-Debian:  http://bugs.debian.org/664907
+Origin: upstream, https://repo.or.cz/w/tennix.git/commitdiff/6144cb7626dfdc0820a0036af83a531e8e68bae6
+Bug-Debian:  https://bugs.debian.org/664907
 
 --- tennix-1.1.orig/archivetool.cc
 +++ tennix-1.1/archivetool.cc

--- a/pkgs/os-specific/linux/bridge-utils/default.nix
+++ b/pkgs/os-specific/linux/bridge-utils/default.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "http://sourceforge.net/projects/bridge/";
-    homepage = http://www.linux-foundation.org/en/Net:Bridge/;
-    license = "GPL";
+    description = "https://sourceforge.net/projects/bridge/";
+    homepage = https://wiki.linuxfoundation.org/networking/bridge;
+    license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation {
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
     homepage = https://l3net.wordpress.com/projects/firejail/;
-    downloadPage = "http://sourceforge.net/projects/firejail/files/firejail/";
+    downloadPage = "https://sourceforge.net/projects/firejail/files/firejail/";
   };
 }

--- a/pkgs/os-specific/linux/firejail/default.upstream
+++ b/pkgs/os-specific/linux/firejail/default.upstream
@@ -1,3 +1,3 @@
-url http://sourceforge.net/projects/firejail/files/firejail/
+url https://sourceforge.net/projects/firejail/files/firejail/
 version_link '[-][0-9.]+[.]tar[.][a-z0-9]+/download$'
 SF_redirect

--- a/pkgs/tools/filesystems/smbnetfs/default.nix
+++ b/pkgs/tools/filesystems/smbnetfs/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
     license = licenses.gpl2;
-    downloadPage = "http://sourceforge.net/projects/smbnetfs/files/smbnetfs";
+    downloadPage = "https://sourceforge.net/projects/smbnetfs/files/smbnetfs";
     updateWalker = true;
     inherit version;
     homepage = https://sourceforge.net/projects/smbnetfs/;

--- a/pkgs/tools/filesystems/smbnetfs/default.upstream
+++ b/pkgs/tools/filesystems/smbnetfs/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/smbnetfs/files/smbnetfs/
+url https://sourceforge.net/projects/smbnetfs/files/smbnetfs/
 version_link '[-][0-9.]+[a-z]*/$'
 version_link '[.]tar[.][a-z0-9]+/download$'
 SF_redirect

--- a/pkgs/tools/misc/yad/default.nix
+++ b/pkgs/tools/misc/yad/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "yad-0.40.0";
 
   src = fetchurl {
-    url = "http://sourceforge.net/projects/yad-dialog/files/${name}.tar.xz";
+    url = "mirror://sourceforge/yad-dialog/files/${name}.tar.xz";
     sha256 = "1x0fsv8nfkm8lchdawnf3zw79jaqbnvhv87sk5r8g86knv8vgl62";
   };
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://yad-dialog.sourceforge.net/;
+    homepage = https://sourceforge.net/projects/yad-dialog/;
     description = "GUI dialog tool for shell scripts";
     longDescription = ''
       Yad (yet another dialog) is a GUI dialog tool for shell scripts. It is a

--- a/pkgs/tools/system/ipmiutil/default.nix
+++ b/pkgs/tools/system/ipmiutil/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
     license = licenses.bsd3;
-    downloadPage = "http://sourceforge.net/projects/ipmiutil/files/ipmiutil/";
+    downloadPage = "https://sourceforge.net/projects/ipmiutil/files/ipmiutil/";
     inherit version;
   };
 }

--- a/pkgs/tools/system/ipmiutil/default.upstream
+++ b/pkgs/tools/system/ipmiutil/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/ipmiutil/files/
+url https://sourceforge.net/projects/ipmiutil/files/
 SF_version_tarball
 SF_redirect
 minimize_overwrite

--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -7,7 +7,7 @@ let
   dbrev = "4548";
   drivedbBranch = "RELEASE_${builtins.replaceStrings ["."] ["_"] version}_DRIVEDB";
   driverdb = fetchurl {
-    url    = "http://sourceforge.net/p/smartmontools/code/${dbrev}/tree/branches/${drivedbBranch}/smartmontools/drivedb.h?format=raw";
+    url    = "https://sourceforge.net/p/smartmontools/code/${dbrev}/tree/branches/${drivedbBranch}/smartmontools/drivedb.h?format=raw";
     sha256 = "0nwk4ir0c40b01frqm7a0lvljh5k9yhslc3j4485zjsx3v5w269f";
     name   = "smartmontools-drivedb.h";
   };
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tools for monitoring the health of hard drives";
-    homepage    = http://smartmontools.sourceforge.net/;
+    homepage    = https://www.smartmontools.org/;
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ peti ];
     platforms   = with platforms; linux ++ darwin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -314,8 +314,8 @@ with pkgs;
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
-    url = "http://repo.or.cz/${repo}.git/snapshot/${rev}.tar.gz";
-    meta.homepage = "http://repo.or.cz/${repo}.git/";
+    url = "https://repo.or.cz/${repo}.git/snapshot/${rev}.tar.gz";
+    meta.homepage = "https://repo.or.cz/${repo}.git/";
   } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; };
 
   fetchNuGet = callPackage ../build-support/fetchnuget { };


### PR DESCRIPTION
###### Motivation for this change

https://repo.or.cz/ repo now uses a trusted Let's Encrypt certificate and http:// redirects to https://

\+ replaced links to SourceForge still using `http://`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

