### PR TITLE
ffmpeg: enable subtitles filter

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -126,6 +126,7 @@ stdenv.mkDerivation rec {
       (ifMinVer "1.0" "--enable-fontconfig")
       (ifMinVer "0.7" "--enable-libfreetype")
       "--enable-libmp3lame"
+      (ifMinVer "0.9" "--enable-libass")
       (ifMinVer "1.2" "--enable-iconv")
       "--enable-libtheora"
       (ifMinVer "2.1" "--enable-libssh")


### PR DESCRIPTION
FFmpeg does not autodetect `libass`, it has to be enabled manually. Doing so enables for example the subtitles filter. Interestingly, `libass` is already a build dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).