### PR TITLE
dune/jbuilder: 1.0.1 -> 1.5.1

### DIFF
--- a/pkgs/development/tools/ocaml/jbuilder/default.nix
+++ b/pkgs/development/tools/ocaml/jbuilder/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "jbuilder-${version}";
-  version = "1.0.1";
+  version = "1.5.1";
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = "dune";
     rev = "${version}";
-    sha256 = "0k6r9qrbwlnb4rqwqys5fr7khwza7n7d8wpgl9jbb3xpag2zl3q9";
+    sha256 = "abc45a0b5c49795d564bf3b201a224a3c416021bde8e4c051dff011ad2db89eb";
   };
 
   buildInputs = with ocamlPackages; [ ocaml findlib ];


### PR DESCRIPTION
###### Motivation for this change

Bumped dune to version 1.5.1.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

