### PR TITLE
tesseract_4: 4.00.00alpha-git-20170410 -> 4.0.0

### DIFF
--- a/pkgs/applications/graphics/tesseract/4.x.nix
+++ b/pkgs/applications/graphics/tesseract/4.x.nix
@@ -7,20 +7,20 @@
 
 stdenv.mkDerivation rec {
   name = "tesseract-${version}";
-  version = "4.00.00alpha-git-20170410";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "tesseract-ocr";
     repo = "tesseract";
-    rev = "36a995bdc92eb2dd8bc5a63205708944a3f990a1";
-    sha256 = "0xz3krvap8sdm27v1dyb34lcdmx11wzvxyszpppfsfmjgkvg19bq";
+    rev = version;
+    sha256 = "1b5fi2vibc4kk9b30kkk4ais4bw8fbbv24bzr5709194hb81cav8";
   };
 
   tessdata = fetchFromGitHub {
     owner = "tesseract-ocr";
     repo = "tessdata";
-    rev = "8bf2e7ad08db9ca174ae2b0b3a7498c9f1f71d40";
-    sha256 = "0idwkv4qsmmqhrxcgyhy32yldl3vk054m7dkv4fjswfnalgsx794";
+    rev = version;
+    sha256 = "1chw1ya5zf8aaj2ixr9x013x7vwwwjjmx6f2ag0d6i14lypygy28";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook autoconf-archive ];


### PR DESCRIPTION
The 4.0.0 stable release is out.

Changelog: https://github.com/tesseract-ocr/tesseract/wiki/4.0x-Changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

