### PR TITLE
Treewide: use more HTTPS-enabled sources

### DIFF
--- a/nixos/modules/hardware/raid/hpsa.nix
+++ b/nixos/modules/hardware/raid/hpsa.nix
@@ -8,7 +8,7 @@ let
     version = "2.40-13.0";
 
     src = pkgs.fetchurl {
-      url = "http://downloads.linux.hpe.com/SDR/downloads/MCP/Ubuntu/pool/non-free/${name}_amd64.deb";
+      url = "https://downloads.linux.hpe.com/SDR/downloads/MCP/Ubuntu/pool/non-free/${name}_amd64.deb";
       sha256 = "11w7fwk93lmfw0yya4jpjwdmgjimqxx6412sqa166g1pz4jil4sw";
     };
 
@@ -34,7 +34,7 @@ let
 
     meta = with lib; {
       description = "HP Smart Array CLI";
-      homepage = http://downloads.linux.hpe.com/SDR/downloads/MCP/Ubuntu/pool/non-free/;
+      homepage = https://downloads.linux.hpe.com/SDR/downloads/MCP/Ubuntu/pool/non-free/;
       license = licenses.unfreeRedistributable;
       platforms = [ "x86_64-linux" ];
       maintainers = with maintainers; [ volth ];

--- a/nixos/modules/services/monitoring/systemhealth.nix
+++ b/nixos/modules/services/monitoring/systemhealth.nix
@@ -8,7 +8,7 @@ let
   systemhealth = with pkgs; stdenv.mkDerivation {
     name = "systemhealth-1.0";
     src = fetchurl {
-      url = "http://www.brianlane.com/static/downloads/systemhealth/systemhealth-1.0.tar.bz2";
+      url = "https://www.brianlane.com/downloads/systemhealth/systemhealth-1.0.tar.bz2";
       sha256 = "1q69lz7hmpbdpbz36zb06nzfkj651413n9icx0njmyr3xzq1j9qy";
     };
     buildInputs = [ python ];

--- a/nixos/modules/services/networking/flashpolicyd.nix
+++ b/nixos/modules/services/networking/flashpolicyd.nix
@@ -11,7 +11,7 @@ let
 
     src = pkgs.fetchurl {
       name = "flashpolicyd_v0.6.zip";
-      url = "http://www.adobe.com/content/dotcom/en/devnet/flashplayer/articles/socket_policy_files/_jcr_content/articlePrerequistes/multiplefiles/node_1277808777771/file.res/flashpolicyd_v0.6%5B1%5D.zip";
+      url = "https://download.adobe.com/pub/adobe/devnet/flashplayer/articles/socket_policy_files/flashpolicyd_v0.6.zip";
       sha256 = "16zk237233npwfq1m4ksy4g5lzy1z9fp95w7pz0cdlpmv0fv9sm3";
     };
 
@@ -35,9 +35,9 @@ in
   ###### interface
 
   options = {
-  
+
     services.flashpolicyd = {
-    
+
       enable = mkOption {
         default = false;
         description =
@@ -47,13 +47,13 @@ in
             connections to your server.
           '';
       };
-      
+
       policy = mkOption {
         default =
           ''
             <?xml version="1.0"?>
             <!DOCTYPE cross-domain-policy SYSTEM "/xml/dtds/cross-domain-policy.dtd">
-            <cross-domain-policy> 
+            <cross-domain-policy>
               <site-control permitted-cross-domain-policies="master-only"/>
               <allow-access-from domain="*" to-ports="*" />
             </cross-domain-policy>

--- a/nixos/modules/services/web-servers/apache-httpd/mediawiki.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/mediawiki.nix
@@ -86,7 +86,7 @@ let
     name= "mediawiki-1.29.1";
 
     src = pkgs.fetchurl {
-      url = "http://download.wikimedia.org/mediawiki/1.29/${name}.tar.gz";
+      url = "https://releases.wikimedia.org/mediawiki/1.29/${name}.tar.gz";
       sha256 = "03mpazbxvb011s2nmlw5p6dc43yjgl5yrsilmj1imyykm57bwb3m";
     };
 
@@ -311,7 +311,7 @@ in
       description = ''
         Any additional text to be appended to MediaWiki's
         configuration file.  This is a PHP script.  For configuration
-        settings, see <link xlink:href='http://www.mediawiki.org/wiki/Manual:Configuration_settings'/>.
+        settings, see <link xlink:href='https://www.mediawiki.org/wiki/Manual:Configuration_settings'/>.
       '';
     };
 

--- a/pkgs/applications/audio/seq24/default.nix
+++ b/pkgs/applications/audio/seq24/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation  rec {
   version = "0.9.3";
 
   src = fetchurl {
-    url = "http://launchpad.net/seq24/trunk/${version}/+download/${name}.tar.gz";
+    url = "https://launchpad.net/seq24/trunk/${version}/+download/${name}.tar.gz";
     sha256 = "1qpyb7355s21sgy6gibkybxpzx4ikha57a8w644lca6qy9mhcwi3";
   };
 

--- a/pkgs/applications/editors/monodevelop/default.nix
+++ b/pkgs/applications/editors/monodevelop/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nunit2510 = fetchurl {
-    url = "http://launchpad.net/nunitv2/2.5/2.5.10/+download/NUnit-2.5.10.11092.zip";
+    url = "https://launchpad.net/nunitv2/2.5/2.5.10/+download/NUnit-2.5.10.11092.zip";
     sha256 = "0k5h5bz1p2v3d0w0hpkpbpvdkcszgp8sr9ik498r1bs72w5qlwnc";
   };
 

--- a/pkgs/applications/misc/pinfo/default.nix
+++ b/pkgs/applications/misc/pinfo/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     # homepage needed you to login to download the tarball
-    url = "http://src.fedoraproject.org/repo/pkgs/pinfo/pinfo-0.6.10.tar.bz2"
+    url = "https://src.fedoraproject.org/repo/pkgs/pinfo/pinfo-0.6.10.tar.bz2"
       + "/fe3d3da50371b1773dfe29bf870dbc5b/pinfo-0.6.10.tar.bz2";
     sha256 = "0p8wyrpz9npjcbx6c973jspm4c3xz4zxx939nngbq49xqah8088j";
   };

--- a/pkgs/applications/misc/sakura/default.nix
+++ b/pkgs/applications/misc/sakura/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.6.0";
 
   src = fetchurl {
-    url = "http://launchpad.net/sakura/trunk/${version}/+download/${name}.tar.bz2";
+    url = "https://launchpad.net/sakura/trunk/${version}/+download/${name}.tar.bz2";
     sha256 = "1q463qm41ym7jb3kbzjz7b6x549vmgkb70arpkhsf86yxly1y5m1";
   };
 

--- a/pkgs/applications/version-management/bazaar/tools.nix
+++ b/pkgs/applications/version-management/bazaar/tools.nix
@@ -5,7 +5,7 @@ python2Packages.buildPythonApplication rec {
   version = "2.6.0";
 
   src = fetchurl {
-    url = "http://launchpad.net/bzrtools/stable/${version}/+download/bzrtools-${version}.tar.gz";
+    url = "https://launchpad.net/bzrtools/stable/${version}/+download/bzrtools-${version}.tar.gz";
     sha256 = "0n3zzc6jf5866kfhmrnya1vdr2ja137a45qrzsz8vz6sc6xgn5wb";
   };
 

--- a/pkgs/applications/version-management/monotone-viz/default.nix
+++ b/pkgs/applications/version-management/monotone-viz/default.nix
@@ -22,15 +22,15 @@ stdenv.mkDerivation rec {
   patchFlags = ["-p0"];
   patches = [
     (fetchurl {
-      url = "http://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-dot.patch";
+      url = "https://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-dot.patch";
       sha256 = "0risfy8iqmkr209hmnvpv57ywbd3rvchzzd0jy2lfyqrrrm6zknw";
     })
     (fetchurl {
-      url = "http://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-new-stdio.patch";
+      url = "https://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-new-stdio.patch";
       sha256 = "16bj0ppzqd45an154dr7sifjra7lv4m9anxfw3c56y763jq7fafa";
     })
     (fetchurl {
-      url = "http://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-typefix.patch";
+      url = "https://src.fedoraproject.org/cgit/rpms/monotone-viz.git/plain/monotone-viz-1.0.2-typefix.patch";
       sha256 = "1gfp82rc7pawb5x4hh2wf7xh1l1l54ib75930xgd1y437la4703r";
     })
   ];

--- a/pkgs/applications/virtualization/driver/win-spice/default.nix
+++ b/pkgs/applications/virtualization/driver/win-spice/default.nix
@@ -2,12 +2,12 @@
 
 let
   src_usbdk_x86 = fetchurl {
-    url = "http://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.4_x86.msi";
+    url = "https://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.4_x86.msi";
     sha256 = "17hv8034wk1xqnanm5jxs4741nl7asps1fdz6lhnrpp6gvj6yg9y";
   };
 
   src_usbdk_amd64 = fetchurl {
-    url = "http://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.4_x64.msi";
+    url = "https://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.4_x64.msi";
     sha256 = "0alcqsivp33pm8sy0lmkvq7m5yh6mmcmxdl39zjxjra67kw8r2sd";
   };
 
@@ -17,12 +17,12 @@ let
   };
 
   src_vdagent_x86 = fetchurl {
-    url = "http://www.spice-space.org/download/windows/vdagent/vdagent-win-0.7.3/vdagent_0_7_3_x86.zip";
+    url = "https://www.spice-space.org/download/windows/vdagent/vdagent-win-0.7.3/vdagent_0_7_3_x86.zip";
     sha256 = "0d928g49rf4dl79jmvnqh6g864hp1flw1f0384sfp82himm3bxjs";
   };
 
   src_vdagent_amd64 = fetchurl {
-    url = "http://www.spice-space.org/download/windows/vdagent/vdagent-win-0.7.3/vdagent_0_7_3_x64.zip";
+    url = "https://www.spice-space.org/download/windows/vdagent/vdagent-win-0.7.3/vdagent_0_7_3_x64.zip";
     sha256 = "0djmvm66jcmcyhhbjppccbai45nqpva7vyvry6w8nyc0fwi1vm9l";
   };
 in
@@ -62,7 +62,7 @@ stdenv.mkDerivation  {
 
   meta = with stdenv.lib; {
     description = ''Windows SPICE Drivers'';
-    homepage = http://www.spice-space.org;
+    homepage = https://www.spice-space.org;
     maintainers = [ maintainers.tstrobel ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/virtualization/driver/win-spice/default.nix
+++ b/pkgs/applications/virtualization/driver/win-spice/default.nix
@@ -61,8 +61,9 @@ stdenv.mkDerivation  {
       (copy "amd64" "w8.1") + (copy "x86" "w8.1");
 
   meta = with stdenv.lib; {
-    description = ''Windows SPICE Drivers'';
-    homepage = https://www.spice-space.org;
+    description = "Windows SPICE Drivers";
+    homepage = https://www.spice-space.org/;
+    license = [ licenses.asl20 ]; # See https://github.com/vrozenfe/qxl-dod
     maintainers = [ maintainers.tstrobel ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/virtualization/driver/win-spice/default.nix
+++ b/pkgs/applications/virtualization/driver/win-spice/default.nix
@@ -12,7 +12,7 @@ let
   };
 
   src_qxlwddm = fetchurl {
-    url = "http://people.redhat.com/~vrozenfe/qxlwddm/qxlwddm-0.11.zip";
+    url = "https://people.redhat.com/~vrozenfe/qxlwddm/qxlwddm-0.11.zip";
     sha256 = "082zdpbh9i3bq2ds8g33rcbcw390jsm7cqf46rrlx02x8r03dm98";
   };
 

--- a/pkgs/applications/virtualization/spice-vdagent/default.nix
+++ b/pkgs/applications/virtualization/spice-vdagent/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
          to the client resolution
        * Multiple displays
     '';
-    homepage = http://www.spice-space.org/home.html;
+    homepage = https://www.spice-space.org/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.aboseley ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
     # Ticket: https://bugs.freedesktop.org/show_bug.cgi?id=27222
     (fetchpatch {
       name = "SDL_SetGamma.patch";
-      url = "http://src.fedoraproject.org/cgit/rpms/SDL.git/plain/SDL-1.2.15-x11-Bypass-SetGammaRamp-when-changing-gamma.patch?id=04a3a7b1bd88c2d5502292fad27e0e02d084698d";
+      url = "https://src.fedoraproject.org/cgit/rpms/SDL.git/plain/SDL-1.2.15-x11-Bypass-SetGammaRamp-when-changing-gamma.patch?id=04a3a7b1bd88c2d5502292fad27e0e02d084698d";
       sha256 = "0x52s4328kilyq43i7psqkqg7chsfwh0aawr50j566nzd7j51dlv";
     })
     # Fix a build failure on OS X Mavericks

--- a/pkgs/development/libraries/kyotocabinet/default.nix
+++ b/pkgs/development/libraries/kyotocabinet/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   patches = [(fetchurl {
     name = "gcc6.patch";
-    url = "http://src.fedoraproject.org/rpms/kyotocabinet/raw/master/f/kyotocabinet-1.2.76-gcc6.patch";
+    url = "https://src.fedoraproject.org/rpms/kyotocabinet/raw/master/f/kyotocabinet-1.2.76-gcc6.patch";
     sha256 = "1h5k38mkiq7lz8nd2gbn7yvimcz49g3z7phn1cr560bzjih8rz23";
   })];
 

--- a/pkgs/development/libraries/libmatheval/default.nix
+++ b/pkgs/development/libraries/libmatheval/default.nix
@@ -15,26 +15,26 @@ stdenv.mkDerivation rec {
   # Patches coming from debian package
   # https://packages.debian.org/source/sid/libs/libmatheval
   patches = [ (fetchpatch {
-                url = "http://anonscm.debian.org/cgit/debian-science/packages/libmatheval.git/plain/debian/patches/002-skip-docs.patch";
+                url = "https://salsa.debian.org/science-team/libmatheval/raw/debian/1.1.11+dfsg-3/debian/patches/002-skip-docs.patch";
                 sha256 = "1nnkk9aw4jj6nql46zhwq6vx74zrmr1xq5ix0xyvpawhabhgjg62";
               } )
               (fetchpatch {
-                url = "http://anonscm.debian.org/cgit/debian-science/packages/libmatheval.git/plain/debian/patches/003-guile2.0.patch";
+                url = "https://salsa.debian.org/science-team/libmatheval/raw/debian/1.1.11+dfsg-3/debian/patches/003-guile2.0.patch";
                 sha256 = "1xgfw4finfvr20kjbpr4yl2djxmyr4lmvfa11pxirfvhrdi602qj";
                } )
               (fetchpatch {
-                url = "http://anonscm.debian.org/cgit/debian-science/packages/libmatheval.git/plain/debian/patches/disable_coth_test.patch";
+                url = "https://salsa.debian.org/science-team/libmatheval/raw/debian/1.1.11+dfsg-3/debian/patches/disable_coth_test.patch";
                 sha256 = "0bai8jrd5azfz5afmjixlvifk34liq58qb7p9kb45k6kc1fqqxzm";
                } )
             ];
-  
+
   meta = {
     description = "A library to parse and evaluate symbolic expressions input as text";
     longDescription = ''
-      GNU libmatheval is a library (callable from C and Fortran) to parse and evaluate symbolic 
-      expressions input as text. It supports expressions in any number of variables of arbitrary 
-      names, decimal and symbolic constants, basic unary and binary operators, and elementary 
-      mathematical functions. In addition to parsing and evaluation, libmatheval can also compute 
+      GNU libmatheval is a library (callable from C and Fortran) to parse and evaluate symbolic
+      expressions input as text. It supports expressions in any number of variables of arbitrary
+      names, decimal and symbolic constants, basic unary and binary operators, and elementary
+      mathematical functions. In addition to parsing and evaluation, libmatheval can also compute
       symbolic derivatives and output expressions to strings.
     '';
     homepage = https://www.gnu.org/software/libmatheval/;

--- a/pkgs/development/libraries/ntrack/default.nix
+++ b/pkgs/development/libraries/ntrack/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   name = "ntrack-${version}";
 
   src = fetchurl {
-    url = "http://launchpad.net/ntrack/main/${version}/+download/${name}.tar.gz";
+    url = "https://launchpad.net/ntrack/main/${version}/+download/${name}.tar.gz";
     sha256 = "037ig5y0mp327m0hh4pnfr3vmsk3wrxgfjy3645q4ws9vdhx807w";
   };
 

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -74,7 +74,7 @@ in stdenv.mkDerivation rec {
       Python bindings are available too.
     '';
 
-    homepage = http://www.spice-space.org/;
+    homepage = https://www.spice-space.org/;
     license = licenses.lgpl21;
     maintainers = [ maintainers.xeji ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/spice-protocol/default.nix
+++ b/pkgs/development/libraries/spice-protocol/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Protocol headers for the SPICE protocol";
-    homepage = http://www.spice-space.org;
+    homepage = https://www.spice-space.org/;
     license = licenses.bsd3;
     maintainers = with maintainers; [ bluescreen303 ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       VD-Interfaces. The VD-Interfaces (VDI) enable both ends of the solution to be easily
       utilized by a third-party component.
     '';
-    homepage = http://www.spice-space.org/;
+    homepage = https://www.spice-space.org/;
     license = licenses.lgpl21;
 
     maintainers = [ maintainers.bluescreen303 ];

--- a/pkgs/development/python-modules/distutils_extra/default.nix
+++ b/pkgs/development/python-modules/distutils_extra/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   version = "2.39";
 
   src = fetchurl {
-    url = "http://launchpad.net/python-distutils-extra/trunk/${version}/+download/python-${pname}-${version}.tar.gz";
+    url = "https://launchpad.net/python-distutils-extra/trunk/${version}/+download/python-${pname}-${version}.tar.gz";
     sha256 = "1bv3h2p9ffbzyddhi5sccsfwrm3i6yxzn0m06fdxkj2zsvs28gvj";
   };
 

--- a/pkgs/development/python-modules/notify/default.nix
+++ b/pkgs/development/python-modules/notify/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.singleton (fetchurl {
     name = "libnotify07.patch";
-    url = "http://src.fedoraproject.org/cgit/notify-python.git/plain/"
+    url = "https://src.fedoraproject.org/cgit/notify-python.git/plain/"
         + "libnotify07.patch?id2=289573d50ae4838a1658d573d2c9f4c75e86db0c";
     sha256 = "1lqdli13mfb59xxbq4rbq1f0znh6xr17ljjhwmzqb79jl3dig12z";
   });

--- a/pkgs/development/python-modules/pyblock/default.nix
+++ b/pkgs/development/python-modules/pyblock/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   md5_path = "f6d33a8362dee358517d0a9e2ebdd044";
 
   src = pkgs.fetchurl rec {
-    url = "http://src.fedoraproject.org/repo/pkgs/python-pyblock/"
+    url = "https://src.fedoraproject.org/repo/pkgs/python-pyblock/"
         + "${name}.tar.bz2/${md5_path}/${name}.tar.bz2";
     sha256 = "f6cef88969300a6564498557eeea1d8da58acceae238077852ff261a2cb1d815";
   };

--- a/pkgs/development/python-modules/pyexiv2/default.nix
+++ b/pkgs/development/python-modules/pyexiv2/default.nix
@@ -6,7 +6,7 @@ buildPythonPackage rec {
   format = "other";
 
   src = fetchurl {
-    url = "http://launchpad.net/pyexiv2/0.3.x/0.3.2/+download/${pname}-${version}.tar.bz2";
+    url = "https://launchpad.net/pyexiv2/0.3.x/0.3.2/+download/${pname}-${version}.tar.bz2";
     sha256 = "09r1ga6kj5cnmrldpkqzvdhh7xi7aad9g4fbcr1gawgsd9y13g0a";
   };
 

--- a/pkgs/development/python-modules/pykickstart/default.nix
+++ b/pkgs/development/python-modules/pykickstart/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   md5_path = "d249f60aa89b1b4facd63f776925116d";
 
   src = fetchurl rec {
-    url = "http://src.fedoraproject.org/repo/pkgs/pykickstart/"
+    url = "https://src.fedoraproject.org/repo/pkgs/pykickstart/"
     + "${pname}-${version}.tar.gz/${md5_path}/${pname}-${version}.tar.gz";
     sha256 = "e0d0f98ac4c5607e6a48d5c1fba2d50cc804de1081043f9da68cbfc69cad957a";
   };

--- a/pkgs/development/tools/misc/prelink/default.nix
+++ b/pkgs/development/tools/misc/prelink/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = http://people.redhat.com/jakub/prelink/;
+    homepage = https://people.redhat.com/jakub/prelink/;
     license = "GPL";
     description = "ELF prelinking utility to speed up dynamic linking";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://src.fedoraproject.org/repo/pkgs/ocaml-omake/${pname}-${version}.tar.gz/fe39a476ef4e33b7ba2ca77a6bcaded2/${pname}-${version}.tar.gz";
+    url = "https://src.fedoraproject.org/repo/pkgs/ocaml-omake/${pname}-${version}.tar.gz/fe39a476ef4e33b7ba2ca77a6bcaded2/${pname}-${version}.tar.gz";
     sha256 = "1sas02pbj56m7wi5vf3vqrrpr4ynxymw2a8ybvfj2dkjf7q9ii13";
   };
   patchFlags = "-p0";

--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "http://launchpad.net/widelands/build${version}/build${version}/+download/widelands-build${version}-src-gcc7.tar.bz2";
+    url = "https://launchpad.net/widelands/build${version}/build${version}/+download/widelands-build${version}-src-gcc7.tar.bz2";
     sha256 = "0n2lb1c2dix32j90nir96zfqivn63izr1pmabjnhns3wbb7vhwzg";
   };
 

--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   '';
   meta = {
     description = "Audit Library";
-    homepage = http://people.redhat.com/sgrubb/audit/;
+    homepage = https://people.redhat.com/sgrubb/audit/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];

--- a/pkgs/os-specific/linux/fatrace/default.nix
+++ b/pkgs/os-specific/linux/fatrace/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.13";
 
   src = fetchurl {
-    url = "http://launchpad.net/fatrace/trunk/${version}/+download/${name}.tar.bz2";
+    url = "https://launchpad.net/fatrace/trunk/${version}/+download/${name}.tar.bz2";
     sha256 = "0hrh45bpzncw0jkxw3x2smh748r65k2yxvfai466043bi5q0d2vx";
   };
 

--- a/pkgs/os-specific/linux/gogoclient/default.nix
+++ b/pkgs/os-specific/linux/gogoclient/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     #url = http://gogo6.com/downloads/gogoc-1_2-RELEASE.tar.gz;
-    url = http://src.fedoraproject.org/repo/pkgs/gogoc/gogoc-1_2-RELEASE.tar.gz/41177ed683cf511cc206c7782c37baa9/gogoc-1_2-RELEASE.tar.gz;
+    url = https://src.fedoraproject.org/repo/pkgs/gogoc/gogoc-1_2-RELEASE.tar.gz/41177ed683cf511cc206c7782c37baa9/gogoc-1_2-RELEASE.tar.gz;
     sha256 = "a0ef45c0bd1fc9964dc8ac059b7d78c12674bf67ef641740554e166fa99a2f49";
   };
   patches = [./gcc46-include-fix.patch ./config-paths.patch ];

--- a/pkgs/os-specific/linux/ioport/default.nix
+++ b/pkgs/os-specific/linux/ioport/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   buildInputs = [ perl ];
   meta = with stdenv.lib; {
     description = "Direct access to I/O ports from the command line";
-    homepage = http://people.redhat.com/rjones/ioport/;
+    homepage = https://people.redhat.com/rjones/ioport/;
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = [ maintainers.cleverca22 ];

--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://people.redhat.com/dhowells/keyutils/;
+    homepage = https://people.redhat.com/dhowells/keyutils/;
     description = "Tools used to control the Linux kernel key management system";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/libcap-ng/default.nix
+++ b/pkgs/os-specific/linux/libcap-ng/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = let inherit (stdenv.lib) platforms licenses maintainers; in {
     description = "Library for working with POSIX capabilities";
-    homepage = http://people.redhat.com/sgrubb/libcap-ng/;
+    homepage = https://people.redhat.com/sgrubb/libcap-ng/;
     platforms = platforms.linux;
     license = licenses.lgpl21;
     maintainers = with maintainers; [ wkennington ];

--- a/pkgs/os-specific/linux/tiptop/default.nix
+++ b/pkgs/os-specific/linux/tiptop/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = [(fetchpatch {
     name = "reproducibility.patch";
-    url = "http://anonscm.debian.org/cgit/collab-maint/tiptop.git/plain/debian/"
-      + "patches/0001-fix-reproducibility-of-build-process.patch?id=c777d0d5803";
+    url = "https://salsa.debian.org/debian/tiptop/raw/debian/2.3.1-1/debian/patches/0001-fix-reproducibility-of-build-process.patch";
     sha256 = "116l7n3nl9lj691i7j8x0d0za1i6zpqgghw5d70qfpb17c04cblp";
   })];
 

--- a/pkgs/tools/filesystems/nixpart/0.4/dmraid.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/dmraid.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "dmraid-1.0.0.rc15";
 
   src = fetchurl {
-    url = "http://people.redhat.com/~heinzm/sw/dmraid/src/old/${name}.tar.bz2";
+    url = "https://people.redhat.com/~heinzm/sw/dmraid/src/old/${name}.tar.bz2";
     sha256 = "01bcaq0sc329ghgj7f182xws7jgjpdc41bvris8fsiprnxc7511h";
   };
 

--- a/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   md5_path = "f6d33a8362dee358517d0a9e2ebdd044";
 
   src = fetchurl rec {
-    url = "http://src.fedoraproject.org/repo/pkgs/python-pyblock/"
+    url = "https://src.fedoraproject.org/repo/pkgs/python-pyblock/"
         + "${name}.tar.bz2/${md5_path}/${name}.tar.bz2";
     sha256 = "f6cef88969300a6564498557eeea1d8da58acceae238077852ff261a2cb1d815";
   };

--- a/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
@@ -6,7 +6,7 @@ buildPythonApplication rec {
   md5_path = "d249f60aa89b1b4facd63f776925116d";
 
   src = fetchurl rec {
-    url = "http://src.fedoraproject.org/repo/pkgs/pykickstart/"
+    url = "https://src.fedoraproject.org/repo/pkgs/pykickstart/"
         + "${name}.tar.gz/${md5_path}/${name}.tar.gz";
     sha256 = "e0d0f98ac4c5607e6a48d5c1fba2d50cc804de1081043f9da68cbfc69cad957a";
   };

--- a/pkgs/tools/security/ecryptfs/default.nix
+++ b/pkgs/tools/security/ecryptfs/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "111";
 
   src = fetchurl {
-    url = "http://launchpad.net/ecryptfs/trunk/${version}/+download/ecryptfs-utils_${version}.orig.tar.gz";
+    url = "https://launchpad.net/ecryptfs/trunk/${version}/+download/ecryptfs-utils_${version}.orig.tar.gz";
     sha256 = "0zwq19siiwf09h7lwa7n7mgmrr8cxifp45lmwgcfr8c1gviv6b0i";
   };
 

--- a/pkgs/tools/security/super/default.nix
+++ b/pkgs/tools/security/super/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-   (fetchpatch { url = http://anonscm.debian.org/cgit/users/robert/super.git/plain/debian/patches/14-Fix-unchecked-setuid-call.patch;
+   (fetchpatch { url = https://salsa.debian.org/debian/super/raw/debian/3.30.0-7/debian/patches/14-Fix-unchecked-setuid-call.patch;
                  sha256 = "08m9hw4kyfjv0kqns1cqha4v5hkgp4s4z0q1rgif1fnk14xh7wqh";
                })
   ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   installFlags = "sysconfdir=$(out)/etc localstatedir=$(TMPDIR)";
 
   meta = {
-    homepage = http://www.ucolick.org/~will/;
+    homepage = "https://www.ucolick.org/~will/#super";
     description = "Allows users to execute scripts as if they were root";
     longDescription =
       ''

--- a/pkgs/tools/system/hardlink/default.nix
+++ b/pkgs/tools/system/hardlink/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Consolidate duplicate files via hardlinks";
     homepage = https://pagure.io/hardlink;
-    repositories.git = http://src.fedoraproject.org/cgit/rpms/hardlink.git;
+    repositories.git = https://src.fedoraproject.org/cgit/rpms/hardlink.git;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

More usage of HTTPS-enabled upstream sources :

- updated 4 modules to fetch over https and from URLs that are not dead ;
- http://launchpad.net -> https://launchpad.net
- http://src.fedoraproject.org -> https://src.fedoraproject.org
- http://people.redhat.com -> https://people.redhat.com
- http://www.spice-space.org -> https://www.spice-space.org
- http://anonscm.debian.org/ is not available anymore -> fetch some patches from https://salsa.debian.org now

Related: #13809

/cc @markuskowa @Infinisil @ryantm 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

