### PR TITLE
ckbcomp: 1.133 -> 1.187

### DIFF
--- a/pkgs/tools/X11/ckbcomp/default.nix
+++ b/pkgs/tools/X11/ckbcomp/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchgit, perl, xkeyboard_config }:
+{ stdenv, fetchFromGitLab, perl, xkeyboard_config }:
 
 stdenv.mkDerivation rec {
   name = "ckbcomp-${version}";
-  version = "1.133";
+  version = "1.187";
 
-  src = fetchgit {
-    url = "git://anonscm.debian.org/d-i/console-setup.git";
-    rev = "refs/tags/${version}";
-    sha256 = "1whli40ik5izyfs0m8d08gq8zcsdjscnxbsvxyxvdnkrvzw4izdz";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "installer-team";
+    repo = "console-setup";
+    rev = version;
+    sha256 = "1dcsgdai5lm1r0bhlcfwh01s9k11iwgnd0111gpgbv568rs5isqh";
   };
 
   buildInputs = [ perl ];
@@ -20,15 +22,13 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p "$out"/bin
-    cp Keyboard/ckbcomp "$out"/bin/
-    mkdir -p "$out"/share/man/man1
-    cp man/ckbcomp.1 "$out"/share/man/man1
+    install -Dm0555 -t $out/bin Keyboard/ckbcomp
+    install -Dm0444 -t $out/share/man/man1 man/ckbcomp.1
   '';
 
   meta = with stdenv.lib; {
     description = "Compiles a XKB keyboard description to a keymap suitable for loadkeys";
-    homepage = http://anonscm.debian.org/cgit/d-i/console-setup.git;
+    homepage = https://salsa.debian.org/installer-team/console-setup;
     license = licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ dezgeg ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Package update and remove the last reference to `anonscm.debian.org` which is now closed.
/cc @dezgeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

