### PR TITLE
semver-tool: init at 2.1.0

### DIFF
--- a/pkgs/development/tools/misc/semver-tool/default.nix
+++ b/pkgs/development/tools/misc/semver-tool/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0lpwsa86qb5w6vbnsn892nb3qpxxx9ifxch8pw3ahzx2dqhdgnrr";
   };
 
+  postPatch = ''
+    patchShebangs .
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     install src/semver $out/bin

--- a/pkgs/development/tools/misc/semver-tool/default.nix
+++ b/pkgs/development/tools/misc/semver-tool/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "semver-tool-${version}";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "fsaintjacques";
+    repo = "semver-tool";
+    rev = version;
+    sha256 = "0lpwsa86qb5w6vbnsn892nb3qpxxx9ifxch8pw3ahzx2dqhdgnrr";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install src/semver $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/fsaintjacques/semver-tool;
+    description = "semver bash implementation";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.qyliss ];
+  };
+}

--- a/pkgs/development/tools/misc/semver-tool/default.nix
+++ b/pkgs/development/tools/misc/semver-tool/default.nix
@@ -16,8 +16,10 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install src/semver $out/bin
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8897,6 +8897,8 @@ with pkgs;
 
   selendroid = callPackage ../development/tools/selenium/selendroid { };
 
+  semver-tool = callPackage ../development/tools/misc/semver-tool { };
+
   sconsPackages = callPackage ../development/tools/build-managers/scons { };
   scons = sconsPackages.scons_3_0_1;
   scons_2_5_1 = sconsPackages.scons_2_5_1;


### PR DESCRIPTION
###### Motivation for this change

Requested by @coretemp in https://github.com/NixOS/nixpkgs/issues/50945.

I chose "semver-tool" as the path for this package because "semver" is extremely generic, and probably more rightly belongs to [node-semver][1] (at least judging by GitHub stars), and because "semver-tool" is the name of this project's GitHub repository, and because it was the name used in the [package request][2].

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[1]: https://github.com/npm/node-semver
[2]: https://github.com/NixOS/nixpkgs/issues/50945