### PR TITLE
doc: add example usage for breakpointHook

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2458,7 +2458,7 @@ addEnvHooks "$hostOffset" myBashFunction
        <command>cntr</command> is only supported on Linux-based platforms. To
        use it first add <literal>cntr</literal> to your
        <literal>environment.systemPackages</literal> on NixOS or alternatively to
-       the root user on non-nixos systems. Then in the package that is supposed
+       the root user on non-NixOS systems. Then in the package that is supposed
        to be inspected, add <literal>cntr</literal> to
        <literal>nativeBuildInputs</literal>.
 <programlisting>

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2459,7 +2459,7 @@ addEnvHooks "$hostOffset" myBashFunction
        use it first add <literal>cntr</literal> to your
        <literal>environment.systemPackages</literal> on NixOS or alternatively to
        the root user on non-NixOS systems. Then in the package that is supposed
-       to be inspected, add <literal>cntr</literal> to
+       to be inspected, add <literal>breakpointHook</literal> to
        <literal>nativeBuildInputs</literal>.
 <programlisting>
          nativeBuildInputs = [ breakpointHook ];

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2455,7 +2455,7 @@ addEnvHooks "$hostOffset" myBashFunction
        use the cntr exec subcommand. Note that <command>cntr</command> also
        needs to be executed on the machine that is doing the build, which might
        be not the case when remote builders are enabled.
-       <command>cntr</command> is only supported on linux based platforms. To
+       <command>cntr</command> is only supported on Linux-based platforms. To
        use it first add <literal>cntr</literal> to your
        <literal>environment.systemPackaes</literal> on NixOS or alternativly to
        the root user on non-nixos systems. Then in the package that is supposed

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2455,7 +2455,17 @@ addEnvHooks "$hostOffset" myBashFunction
        use the cntr exec subcommand. Note that <command>cntr</command> also
        needs to be executed on the machine that is doing the build, which might
        be not the case when remote builders are enabled.
-       <command>cntr</command> is only supported on linux based platforms.
+       <command>cntr</command> is only supported on linux based platforms. To
+       use it first add <literal>cntr</literal> to your
+       <literal>environment.systemPackaes</literal> on NixOS or alternativly to
+       the root user on non-nixos systems. Then in the package that is supposed
+       to be inspected, add <literal>cntr</literal> to
+       <literal>nativeBuildInputs</literal>.
+<programlisting>
+         nativeBuildInputs = [ breakpointHook ];
+       </programlisting>
+       When a build failure happens there will be an instruction printed that
+       shows how to attach with <literal>cntr</literal> to the build sandbox.
       </para>
      </listitem>
     </varlistentry>

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2457,7 +2457,7 @@ addEnvHooks "$hostOffset" myBashFunction
        be not the case when remote builders are enabled.
        <command>cntr</command> is only supported on Linux-based platforms. To
        use it first add <literal>cntr</literal> to your
-       <literal>environment.systemPackaes</literal> on NixOS or alternativly to
+       <literal>environment.systemPackages</literal> on NixOS or alternatively to
        the root user on non-nixos systems. Then in the package that is supposed
        to be inspected, add <literal>cntr</literal> to
        <literal>nativeBuildInputs</literal>.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

