### PR TITLE
sunxi-tools: 20171130 -> 20181113

### DIFF
--- a/pkgs/development/tools/sunxi-tools/default.nix
+++ b/pkgs/development/tools/sunxi-tools/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, pkgconfig, libusb, zlib }:
 
 stdenv.mkDerivation {
-  name = "sunxi-tools-20171130";
+  name = "sunxi-tools-20181113";
 
   src = fetchFromGitHub {
     owner = "linux-sunxi";
     repo = "sunxi-tools";
-    rev = "5c1971040c6c44caefb98e371bfca9e18d511da9";
-    sha256 = "0qzm515i3dfn82a6sf7372080zb02d365z52bh0b1q711r4dvjgp";
+    rev = "6d598a0ed714201380e78130213500be6512942b";
+    sha256 = "1yhl6jfl2cws596ymkyhm8h9qkcvp67v8hlh081lsaqv1i8j9yig";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   installTargets = [ "install-tools" "install-misc" ];
 
   meta = with stdenv.lib; {
-    description = "Tools for Allwinner A10 devices";
+    description = "Tools for Allwinner SoC devices";
     homepage = http://linux-sunxi.org/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

The update is necessary [to flash the SPI NOR flash](https://nixos.wiki/wiki/NixOS_on_ARM/PINE_A64-LTS#SPI_NOR_flash) available on some AllWinner devices.

The revision chosen is the current tip of `master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This was verified as working, as the instructions on the NixOS wiki were followed using that build.