### PR TITLE
aiohttp: move idna-ssl into propogatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -29,8 +29,8 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest gunicorn pytest-mock async_generator pytestrunner pytest-timeout ];
 
-  propagatedBuildInputs = [ attrs chardet multidict async-timeout yarl ]
-    ++ lib.optional (pythonOlder "3.7") idna-ssl;
+  propagatedBuildInputs = [ attrs chardet multidict async-timeout yarl idna-ssl ];
+    #++ lib.optional (pythonOlder "3.7") idna-ssl;
 
 
   # Several test failures. Need to be looked into.


### PR DESCRIPTION
###### Motivation for this change

Fixes #51009 

I have no idea what the side effects may be of this change, but it does seem to solve the issue. If I need to do more testing, or my commit format is not correct, please let me know.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

