### PR TITLE
deskew: init at 1.25

### DIFF
--- a/pkgs/applications/graphics/deskew/default.nix
+++ b/pkgs/applications/graphics/deskew/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromBitbucket, libtiff, fpc }:
+
+stdenv.mkDerivation rec {
+
+  name = "deskew-${version}";
+  version = "1.25";
+
+  src = fetchFromBitbucket {
+    owner = "galfar";
+    repo = "app-deskew";
+    rev = "v${version}";
+    sha256 = "0zjjj66qhgqkmfxl3q7p78dv4xl4ci918pgl4d5259pqdj1bfgc8";
+  };
+
+  nativeBuildInputs = [ fpc ];
+  buildInputs = [ libtiff ];
+
+  buildPhase = ''
+    rm -r Bin # Remove pre-compiled binary
+    mkdir Bin
+    chmod +x compile.sh
+    ./compile.sh
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin Bin/*
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A command line tool for deskewing scanned text documents.";
+    homepage = https://bitbucket.org/galfar/app-deskew/overview;
+    license = licenses.mit;
+    maintainers = with maintainers; [ryantm];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/applications/graphics/deskew/default.nix
+++ b/pkgs/applications/graphics/deskew/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A command line tool for deskewing scanned text documents.";
+    description = "A command line tool for deskewing scanned text documents";
     homepage = https://bitbucket.org/galfar/app-deskew/overview;
     license = licenses.mit;
     maintainers = with maintainers; [ryantm];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -681,6 +681,8 @@ with pkgs;
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  deskew = callPackage ../applications/graphics/deskew { };
+
   diskus = callPackage ../tools/misc/diskus { };
 
   djmount = callPackage ../tools/filesystems/djmount { };


### PR DESCRIPTION
###### Motivation for this change

package not in nixpkgs that is useful for auto-rotating images

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

