### PR TITLE
rtl8821a: init at 5.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3404,6 +3404,11 @@
     github = "pkmx";
     name = "Chih-Mao Chen";
   };
+  plchldr = {
+    email = "mail@oddco.de";
+    github = "plchldr";
+    name = "Jonas Beyer";
+  };
   plcplc = {
     email = "plcplc@gmail.com";
     github = "plcplc";

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, kernel, bc }:
+
+stdenv.mkDerivation rec {
+  name = "rtl8821au-${kernel.version}-${version}";
+  version = "5.1.5";
+
+  src = fetchFromGitHub {
+    owner = "zebulon2";
+    repo = "rtl8812au";
+    rev = "61d0cd95afc01eae64da0c446515803910de1a00";
+    sha256 = "0dlzyiaa3hmb2qj3lik52px88n4mgrx7nblbm4s0hn36g19ylssw";
+  };
+
+  nativeBuildInputs = [ bc ];
+  buildInputs = kernel.moduleBuildDependencies;
+
+  hardeningDisable = [ "pic" "format" ];
+
+  NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
+
+  prePatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace /sbin/depmod \# \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "rtl8821AU, rtl8812AU and rtl8811AU chipset driver with firmware";
+    homepage = https://github.com/zebulon2/rtl8812au;
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ plchldr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14481,6 +14481,8 @@ with pkgs;
 
     rtl8814au = callPackage ../os-specific/linux/rtl8814au { };
 
+    rtl8821au = callPackage ../os-specific/linux/rtl8821au { };
+
     rtlwifi_new = callPackage ../os-specific/linux/rtlwifi_new { };
 
     openafs = callPackage ../servers/openafs/1.6/module.nix { };


### PR DESCRIPTION
###### Motivation for this change
I needed this driver for my new USB WLAN adapter (rtl8811au).

###### Things done
For this I've merged together
- https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rtl8821au-dkms-git
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/rtl8812au/default.nix
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/rtl8814au/default.nix
And the result works fine for me.

I guess there's an argument to be made to add a make flag  `CONFIG_RTL8812A=n`, so the resulting module is named "8821a" instead of "8812a" and so doesn't conflict with the better suited driver for this chipset.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

