### PR TITLE
keynav: 0.20150730.0 -> 0.20180821.0

### DIFF
--- a/pkgs/tools/X11/keynav/default.nix
+++ b/pkgs/tools/X11/keynav/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchFromGitHub, pkgconfig, libX11, xextproto, libXtst, libXi, libXext
-, libXinerama, glib, cairo, xdotool }:
+, libXinerama, libXrandr, glib, cairo, xdotool }:
 
-let release = "20150730"; in
+let release = "20180821"; in
 stdenv.mkDerivation rec {
   name = "keynav-0.${release}.0";
 
   src = fetchFromGitHub {
     owner = "jordansissel";
     repo = "keynav";
-    rev = "4ae486db6697877e84b66583a0502afc7301ba16";
-    sha256 = "0v1m8w877fcrk918p6b6q3753dsz8i1f4mb9bi064cp11kh85nq5";
+    rev = "78f9e076a5618aba43b030fbb9344c415c30c1e5";
+    sha256 = "0hmc14fj612z5h7gjgk95zyqab3p35c4a99snnblzxfg0p3x2f1d";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libX11 xextproto libXtst libXi libXext libXinerama
+  buildInputs = [ libX11 xextproto libXtst libXi libXext libXinerama libXrandr
                   glib cairo xdotool ];
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

bump package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

