### PR TITLE
nixos: make the nixpkgs symlink permanent

### DIFF
--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -22,7 +22,6 @@ pkgs.releaseTools.makeSourceTarball {
     mkdir -p $out/tarballs
     cp -prd . ../$releaseName
     chmod -R u+w ../$releaseName
-    ln -s . ../$releaseName/nixpkgs # hack to make ‘<nixpkgs>’ work
     NIX_STATE_DIR=$TMPDIR nix-env -f ../$releaseName/default.nix -qaP --meta --xml \* > /dev/null
     cd ..
     chmod -R u+w $releaseName

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -86,9 +86,6 @@ let format' = format; in let
     mkdir -p $out
     cp -prd ${nixpkgs} $out/nixos
     chmod -R u+w $out/nixos
-    if [ ! -e $out/nixos/nixpkgs ]; then
-      ln -s . $out/nixos/nixpkgs
-    fi
     rm -rf $out/nixos/.git
     echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
   '';

--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -18,9 +18,6 @@ let
       mkdir -p $out
       cp -prd ${nixpkgs} $out/nixos
       chmod -R u+w $out/nixos
-      if [ ! -e $out/nixos/nixpkgs ]; then
-        ln -s . $out/nixos/nixpkgs
-      fi
       echo -n ${config.system.nixos.revision} > $out/nixos/.git-revision
       echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
       echo ${config.system.nixos.versionSuffix} | sed -e s/pre// > $out/nixos/svn-revision

--- a/nixpkgs
+++ b/nixpkgs
@@ -1,0 +1,1 @@
+nixpkgs


### PR DESCRIPTION
###### Motivation for this change

This change allows to set `NIX_PATH=/path/to/nixpkgs` and still have a working
`<nixpkgs>`.

The `./nixpkgs -> .` symlink was initially introduced as a way to allow
backward-compatibility. Instead of generating it on channel creation,
add it to the repository directly. That way even a git checkout will
work the same way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

