### PR TITLE
buildRustPackage: write cargo config to temporary file instead of source dir

### DIFF
--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -38,18 +38,19 @@ stdenv.mkDerivation {
     fi
 
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
+    CARGO_CONFIG=$(mktemp cargo-config.XXXX)
 
     ${cargoUpdateHook}
 
     mkdir -p $out
-    cargo vendor $out | cargo-vendor-normalise > config
+    cargo vendor $out | cargo-vendor-normalise > $CARGO_CONFIG
     # fetchcargo used to never keep the config output by cargo vendor
     # and instead hardcode the config in ./fetchcargo-default-config.toml.
     # This broke on packages needing git dependencies, so now we keep the config.
     # But not to break old cargoSha256, if the previous behavior was enough,
     # we don't store the config.
-    if ! cmp config ${./fetchcargo-default-config.toml} > /dev/null; then
-      install -Dt $out/.cargo config;
+    if ! cmp $CARGO_CONFIG ${./fetchcargo-default-config.toml} > /dev/null; then
+      install -Dt $out/.cargo $CARGO_CONFIG;
     fi;
   '';
 


### PR DESCRIPTION
... as this fails if the source dir contains a "config" directory.

###### Motivation for this change
I want to build https://github.com/mimblewimble/grin/ which has a "config" dir.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

