### PR TITLE
crack-attack: enable custom sounds

### DIFF
--- a/pkgs/games/crack-attack/default.nix
+++ b/pkgs/games/crack-attack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, freeglut, SDL, libGLU_combined, libXi, libXmu}:
+{ stdenv, fetchurl, pkgconfig, gtk2, freeglut, SDL, SDL_mixer, libGLU_combined, libXi, libXmu }:
 
 stdenv.mkDerivation {
   name = "crack-attack-1.1.14";
@@ -8,10 +8,18 @@ stdenv.mkDerivation {
     sha256 = "1sakj9a2q05brpd7lkqxi8q30bccycdzd96ns00s6jbxrzjlijkm";
   };
 
+  patches = [
+    ./crack-attack-1.1.14-gcc43.patch
+    ./crack-attack-1.1.14-glut.patch
+  ];
+
+  configureFlags = [ "--enable-sound=yes" ];
+
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 freeglut SDL libGLU_combined libXi libXmu ];
+  buildInputs = [ gtk2 freeglut SDL SDL_mixer libGLU_combined libXi libXmu ];
 
   hardeningDisable = [ "format" ];
+  enableParallelBuilding = true;
 
   meta = {
     description = "A fast-paced puzzle game inspired by the classic Super NES title Tetris Attack!";
@@ -20,9 +28,4 @@ stdenv.mkDerivation {
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.piotr ];
   };
-
-  patches = [
-    ./crack-attack-1.1.14-gcc43.patch
-    ./crack-attack-1.1.14-glut.patch
-  ];
 }


### PR DESCRIPTION
###### Motivation for this change

Closes #22905
crack-attack will search for user-provided musics and sounds
under ~/.crack-attack/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

