### PR TITLE
ocamlPackages.opti: init at 1.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2052,6 +2052,11 @@
     github = "jluttine";
     name = "Jaakko Luttinen";
   };
+  jmagnusj = {
+    email = "jmagnusj@gmail.com";
+    github = "magnusjonsson";
+    name = "Johan Magnus Jonsson";
+  };
   jmettes = {
     email = "jonathan@jmettes.com";
     github = "jmettes";

--- a/pkgs/development/ocaml-modules/opti/default.nix
+++ b/pkgs/development/ocaml-modules/opti/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "opti";
+  version = "1.0.3";
+
+  src = fetchurl {
+    url = "https://github.com/magnusjonsson/opti/releases/download/${version}/opti-${version}.tbz";
+    sha256 = "ed9ba56dc06e9d2b1bf097964cc65ea37db787d4f239c13d0dd74693f5b50a1e";
+  };
+
+  meta = with stdenv.lib; {
+    description = "DSL to generate fast incremental C code from declarative specifications";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jmagnusj ];
+    homepage = https://github.com/magnusjonsson/opti;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -552,6 +552,8 @@ let
 
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
 
+    opti = callPackage ../development/ocaml-modules/opti { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otr = callPackage ../development/ocaml-modules/otr { };


### PR DESCRIPTION
###### Motivation for this change

Help promote nix at work by making this package available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

