### PR TITLE
pythonPackages.nvchecker: 1.1 -> 1.2.7

### DIFF
--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -1,16 +1,15 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pytest, setuptools, structlog, pytest-asyncio, pytest_xdist, flaky, tornado }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, pytest, setuptools, structlog, pytest-asyncio, pytest_xdist, flaky, tornado, pycurl }:
 
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "1.1";
+  version = "1.2.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1nk9ff26s5r6v5v7w4l9110qi5kmhllvwk5kh20zyyhdvxv72m3i";
+    sha256 = "19qc2wwkdr701mx94r75ayq5h2jz3q620hcqaj2ng9qdgxm90940";
   };
 
-  # tornado is not present in the tarball setup.py but is required by the executable
-  propagatedBuildInputs = [ setuptools structlog tornado ];
+  propagatedBuildInputs = [ setuptools structlog tornado pycurl ];
   checkInputs = [ pytest pytest-asyncio pytest_xdist flaky ];
 
   # Disable tests for now, because our version of pytest seems to be too new


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

