### PR TITLE
vale: 1.0.3 -> 1.2.6

### DIFF
--- a/pkgs/tools/text/vale/default.nix
+++ b/pkgs/tools/text/vale/default.nix
@@ -2,22 +2,21 @@
 
 buildGoPackage rec {
   name = "vale-${version}";
-  version = "1.0.3";
-  rev    = "v${version}";
+  version = "1.2.6";
 
   goPackagePath = "github.com/errata-ai/vale";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner  = "errata-ai";
     repo   = "vale";
-    sha256 = "132zzgry19alcdn3m3q62sp2lm3yxc4kil12lm309jl7b3n0850h";
+    rev    = "v${version}";
+    sha256 = "1mhynasikncwz9dkk9z27qvwk03j7q0vx0wjnqg69pd97lgrp7zp";
   };
 
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
-    homepage = https://errata.ai/vale/getting-started/;
+    homepage = https://errata-ai.github.io/vale/;
     description = "Vale is an open source linter for prose";
     license = licenses.mit;
     maintainers = [ maintainers.marsam ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

