### PR TITLE
Add the tychus application

### DIFF
--- a/pkgs/development/tools/tychus/default.nix
+++ b/pkgs/development/tools/tychus/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, buildGoPackage, CoreFoundation }:
+
+buildGoPackage rec {
+  name = "tychus-${version}";
+  version = "0.6.3";
+
+  goPackagePath = "github.com/devlocker/tychus";
+  goDeps = ./deps.nix;
+  subPackages = [];
+
+  src = fetchFromGitHub {
+    owner = "devlocker";
+    repo = "tychus";
+    rev = "v${version}";
+    sha256 = "02ybxjsfga89gpg0k21zmykhhnpx1vy3ny8fcwj0qsg73i11alvw";
+  };
+
+  buildInputs = stdenv.lib.optionals stdenv.hostPlatform.isDarwin [ CoreFoundation ];
+
+  buildFlags = "--tags release";
+
+  meta = {
+    description = "Command line utility to live-reload your application.";
+    homepage = https://github.com/devlocker/tychus;
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/tools/tychus/deps.nix
+++ b/pkgs/development/tools/tychus/deps.nix
@@ -1,0 +1,30 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "f91529fc609202eededff4de2dc0ba2f662240a3";
+      sha256 = "10c3d5dp98rys134dnsl19ldj8bca183z91lj8rkbsy78qzrr9af";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "e57e3eeb33f795204c1ca35f56c44f83227c6e66";
+      sha256 = "13mhx4i913jil32j295m3a36jzvq1y64xig0naadiz7q9ja011r2";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9009,6 +9009,10 @@ with pkgs;
 
   tweak = callPackage ../applications/editors/tweak { };
 
+  tychus = callPackage ../development/tools/tychus {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation;
+  };
+
   uhd = callPackage ../development/tools/misc/uhd { };
 
   uisp = callPackage ../development/tools/misc/uisp { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the [tychus](https://github.com/devlocker/tychus) package which is a really neat go program which restarts servers during development. Its main trick is to keep around http requests as long the server restarts, so "reloads" always work.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
  Fails with 
```
dyld: Library not loaded: @rpath/CoreFoundation.framework/Versions/A/CoreFoundation
  Referenced from: /nix/store/317hbs85qqygc903idn8gvgg2yx9xqbl-go-1.11/bin/go
  Reason: no suitable image found.  Did find:
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation: file system sandbox blocked sta
``` 
though.
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

