### PR TITLE
melpaBuild: Get package-build from melpa/package-build

### DIFF
--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -35,11 +35,11 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
     then pname
     else ename;
 
-  melpa = fetchFromGitHub {
+  packageBuild = fetchFromGitHub {
     owner = "melpa";
-    repo = "melpa";
-    rev = "7103313a7c31bb1ebb71419e365cd2e279ee4609";
-    sha256 = "0m10f83ix0mzjk0vjd4kkb1m1p4b8ha0ll2yjsgk9bqjd7fwapqb";
+    repo = "package-build";
+    rev = "0a22c3fbbf661822ec1791739953b937a12fa623";
+    sha256 = "0dpy5p34il600sc8ic5jdgb3glya9si3lrvhxab0swks8fdydjgs";
   };
 
   elpa2nix = ./elpa2nix.el;
@@ -51,7 +51,7 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
       cp "$recipe" "$NIX_BUILD_TOP/recipes/$ename"
     fi
 
-    ln -s "$melpa/package-build" "$NIX_BUILD_TOP/package-build"
+    ln -s "$packageBuild" "$NIX_BUILD_TOP/package-build"
 
     mkdir -p "$NIX_BUILD_TOP/packages"
   '';
@@ -67,7 +67,7 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
     cd "$NIX_BUILD_TOP"
 
     emacs --batch -Q \
-        -L "$melpa/package-build" \
+        -L "$NIX_BUILD_TOP/package-build" \
         -l "$melpa2nix" \
         -f melpa2nix-build-package \
         $ename $version


### PR DESCRIPTION
This commit causes melpaBuild to use package-build from melpa/package-build
instead of melpa/melpa. Development of package-build happens in the former
repository whereas the latter is much larger, containing also the MELPA
recipes. We do not need to fetch the MELPA recipes from melpa/melpa, as we fetch
them one-by-one for Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

