### PR TITLE
Remove reference to unpackaged GHC version

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-head.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-head.nix
@@ -40,7 +40,7 @@ self: super: {
   xhtml = null;
 
   # jailbreak-cabal can use the native Cabal library.
-  jailbreak-cabal = pkgs.haskell.packages.ghc802.jailbreak-cabal;
+  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = null; };
 
   # haddock: No input file(s).
   nats = dontHaddock super.nats;


### PR DESCRIPTION
This reverts https://github.com/NixOS/nixpkgs/pull/28827.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/51042

ghc802 is no longer in Nixpkgs as of 2f0de54ddbfdb03540128f8d2abcc47221d42b25.

The Cabal bug that ghc802 was a workaround for was fixed in Cabal 2.2, though, so this shouldn't be necessary any more.

Upstream bugs:
https://github.com/peti/jailbreak-cabal/issues/13
https://github.com/haskell/cabal/issues/4719

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---