### PR TITLE
linux_rpi: enable aarch64 build on hydra

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -25,7 +25,7 @@ lib.overrideDerivation (buildLinux (args // rec {
     efiBootStub = false;
   } // (args.features or {});
 
-  extraMeta.hydraPlatforms = [];
+  extraMeta.hydraPlatforms = with stdenv.lib.platforms; [ aarch64 ];
 })) (oldAttrs: {
   postConfigure = ''
     # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.


### PR DESCRIPTION
I think this makes sense to build for AArch64.