### PR TITLE
pythonPackages.yattag: init at 1.10.1

### DIFF
--- a/pkgs/development/python-modules/yattag/default.nix
+++ b/pkgs/development/python-modules/yattag/default.nix
@@ -11,6 +11,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Generate HTML or XML in a pythonic way. Pure python alternative to web template engines. Can fill HTML forms with default values and error messages.";
+    license = [ licenses.lgpl21 ];
     homepage = http://www.yattag.org/;
   };
 }

--- a/pkgs/development/python-modules/yattag/default.nix
+++ b/pkgs/development/python-modules/yattag/default.nix
@@ -1,0 +1,16 @@
+{ lib, stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "yattag";
+  version = "1.10.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r3pwfygvpkgc0hzxc6z8dl56g6brlh52r0x8kcjhywr1biahqb2";
+  };
+
+  meta = with lib; {
+    description = "Generate HTML or XML in a pythonic way. Pure python alternative to web template engines. Can fill HTML forms with default values and error messages.";
+    homepage = http://www.yattag.org/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4980,6 +4980,8 @@ in {
 
   simpy = callPackage ../development/python-modules/simpy { };
 
+  yattag = callPackage ../development/python-modules/yattag { };
+
   z3 = (toPythonModule (pkgs.z3.override {
     inherit python;
   })).python;


### PR DESCRIPTION
###### Motivation for this change
Adding an HTML generation library I'm using for a project

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions - gentoo with nix2.0.4
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

