### PR TITLE
quantomatic: init at 0.7

### DIFF
--- a/pkgs/applications/science/physics/quantomatic/default.nix
+++ b/pkgs/applications/science/physics/quantomatic/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "quantomatic-${version}";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://github.com/Quantomatic/quantomatic/releases/download/v${version}/Quantomatic-v${version}.jar";
+    sha256 = "04dd5p73a7plb4l4x2balam8j7mxs8df06rjkalxycrr1id52q4r";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/libexec/quantomatic
+    cp $src $out/libexec/quantomatic/quantomatic.jar
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/quantomatic --add-flags "-jar $out/libexec/quantomatic/quantomatic.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A piece of software for reasoning about monoidal theories; in particular, quantum information processing";
+    license = licenses.gpl3;
+    homepage = https://quantomatic.github.io/;
+    maintainers = with maintainers; [ nickhu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18704,6 +18704,8 @@ with pkgs;
 
   qtscrobbler = callPackage ../applications/audio/qtscrobbler { };
 
+  quantomatic = callPackage ../applications/science/physics/quantomatic { };
+
   quassel = libsForQt5.callPackage ../applications/networking/irc/quassel {
     monolithic = true;
     daemon = false;


### PR DESCRIPTION
###### Motivation for this change

Introduce an expression for the [Quantomatic](https://quantomatic.github.io/) tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---