### PR TITLE
nixos/sway-beta: pass arguments from wrapper to sway

### DIFF
--- a/nixos/modules/programs/sway-beta.nix
+++ b/nixos/modules/programs/sway-beta.nix
@@ -8,7 +8,7 @@ let
 
   swayWrapped = pkgs.writeShellScriptBin "sway" ''
     ${cfg.extraSessionCommands}
-    exec ${pkgs.dbus.dbus-launch} --exit-with-session ${swayPackage}/bin/sway
+    exec ${pkgs.dbus.dbus-launch} --exit-with-session ${swayPackage}/bin/sway "$@"
   '';
   swayJoined = pkgs.symlinkJoin {
     name = "sway-joined";


### PR DESCRIPTION
###### Motivation for this change

The sway-beta wrapper doesn't pass the arguments like the stable sway wrapper do.

Note that I'm not doing it the same way as in the sway.nix file. Which is:

https://github.com/NixOS/nixpkgs/blob/128a446c59872f1df38070655a903b885293b995/nixos/modules/programs/sway.nix#L9-L16

I'm not sure which way is better. My way seems to work. I can launch sway using `sway` and check the config using `sway -C`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

