### PR TITLE
kube-prompt: 1.0.4 -> 1.0.5

### DIFF
--- a/pkgs/development/tools/kube-prompt/default.nix
+++ b/pkgs/development/tools/kube-prompt/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kube-prompt-${version}";
-  version = "1.0.4";
+  version = "1.0.5";
   rev = "v${version}";
 
   goPackagePath = "github.com/c-bata/kube-prompt";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "c-bata";
     repo = "kube-prompt";
-    sha256 = "09c2kjsk8cl7qgxbr1s7qd9br5shf7gccxvbf7nyi6wjiass9yg5";
+    sha256 = "1c1y0n1yxcaxvhlsj7b0wvhi934b5g0s1mi46hh5amb9j3dhgq1c";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/development/tools/kube-prompt/deps.nix
+++ b/pkgs/development/tools/kube-prompt/deps.nix
@@ -14,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/c-bata/go-prompt";
-      rev =  "c52492ff1b386e5c0ba5271b5eaad165fab09eca";
-      sha256 = "14k8anchf0rcpxfbb2acrajdqrfspscbkn47m4py1zh5rkk6b9p9";
+      rev =  "09daf6ae57865e436aab9ede6b66b490036e87de";
+      sha256 = "1s58y0i67x2yvi3iisdhj2qqrbl4kz0viy06caip8ykhxpvvkq30";
     };
   }
   {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

