### PR TITLE
Minor doc fixes

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests-interactively.xml
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.xml
@@ -19,7 +19,7 @@ starting VDE switch for network 1
 &gt; startAll
 &gt; testScript
 &gt; $machine->succeed("touch /tmp/foo")
-&gt; print($machine->succeed("pwd"), "\n") # Show stdout of command
+&gt; print($machine->succeed("pwd")) # Show stdout of command
 </screen>
   The function <command>testScript</command> executes the entire test script
   and drops you back into the test driver command line upon its completion.

--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -108,7 +108,7 @@ xlink:href="https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualis
 <programlisting>
 $machine->start;
 $machine->waitForUnit("default.target");
-die unless $machine->succeed("uname") =~ /Linux/;
+$machine->succeed("uname") =~ /Linux/ or die;
 </programlisting>
   The first line is actually unnecessary; machines are implicitly started when
   you first execute an action on them (such as <literal>waitForUnit</literal>


### PR DESCRIPTION
This fixes some quirks I introduced in previous commits.

1. No need for an extra newline when printing the output of shell commands.
2. 'or die' is what's already used in the NixOS test sources, while
   'die unless' has no occurrences.