### PR TITLE
pythonPackages.uarray: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/astunparse/default.nix
+++ b/pkgs/development/python-modules/astunparse/default.nix
@@ -1,16 +1,27 @@
-{ stdenv, fetchPypi, buildPythonPackage, six }:
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, six
+, wheel
+ }:
 
 buildPythonPackage rec {
   pname = "astunparse";
-  version =  "1.5.0";
+  version =  "1.6.1";
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1kc9lm2jvfcip3z8snj04dar5a9jh857a704m6lvcv4xclm3rpsm";
+    sha256 = "d27b16fb33dea0778c5a2c01801554eae0d3f8a8d6f604f15627589c3d6f11ca";
   };
-  propagatedBuildInputs = [ six ];
-  doCheck = false; # no tests
+
+  propagatedBuildInputs = [ six wheel ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
   meta = with stdenv.lib; {
     description = "This is a factored out version of unparse found in the Python source distribution";
+    homepage = https://github.com/simonpercivall/astunparse;
     license = licenses.bsd3;
     maintainers = with maintainers; [ jyp ];
   };

--- a/pkgs/development/python-modules/hopcroftkarp/default.nix
+++ b/pkgs/development/python-modules/hopcroftkarp/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "hopcroftkarp";
+  version = "1.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cc6fc7ad348bbe5c9451f8116845c46ae26290c92b2dd14690aae2d55ba5e3a6";
+  };
+
+  # tests fail due to bad package name
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Implementation of HopcroftKarp's algorithm";
+    homepage = https://github.com/sofiat-olaosebikan/hopcroftkarp;
+    license = licenses.gpl1;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/matchpy/default.nix
+++ b/pkgs/development/python-modules/matchpy/default.nix
@@ -7,11 +7,13 @@
 , pytestrunner
 , hypothesis
 , setuptools_scm
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "matchpy";
   version = "0.4.6";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/matchpy/default.nix
+++ b/pkgs/development/python-modules/matchpy/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, hopcroftkarp
+, multiset
+, pytest
+, pytestrunner
+, hypothesis
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "matchpy";
+  version = "0.4.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "eefa1e50a10e1255db61bc2522a6768ad0701f8854859f293ebaa442286faadd";
+  };
+
+  buildInputs = [ setuptools_scm pytestrunner ];
+  checkInputs = [ pytest hypothesis ];
+  propagatedBuildInputs = [ hopcroftkarp multiset ];
+
+  meta = with lib; {
+    description = "A library for pattern matching on symbolic expressions";
+    homepage = https://github.com/HPAC/matchpy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/multiset/default.nix
+++ b/pkgs/development/python-modules/multiset/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pytestrunner
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "multiset";
+  version = "2.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4801569c08bfcecfe7b0927b17f079c90f8607aca8fecaf42ded92b737162bc7";
+  };
+
+  buildInputs = [ setuptools_scm pytestrunner ];
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "An implementation of a multiset";
+    homepage = https://github.com/wheerd/multiset;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/nbval/default.nix
+++ b/pkgs/development/python-modules/nbval/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, coverage
+, ipykernel
+, jupyter_client
+, nbformat
+, pytest
+, six
+, glibcLocales
+, matplotlib
+, sympy
+, pytestcov
+}:
+
+buildPythonPackage rec {
+  pname = "nbval";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3f18b87af4e94ccd073263dd58cd3eebabe9f5e4d6ab535b39d3af64811c7eda";
+  };
+
+  LC_ALL = "en_US.UTF-8";
+
+  buildInputs = [ glibcLocales ];
+  checkInputs = [ matplotlib sympy pytestcov ];
+  propagatedBuildInputs = [ coverage ipykernel jupyter_client nbformat pytest six ];
+
+  checkPhase = ''
+    pytest tests --current-env --ignore tests/test_timeouts.py
+  '';
+
+  meta = with lib; {
+    description = "A py.test plugin to validate Jupyter notebooks";
+    homepage = https://github.com/computationalmodelling/nbval;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/perf/default.nix
+++ b/pkgs/development/python-modules/perf/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, statistics
+, pythonOlder
+, nose
+, psutil
+, contextlib2
+, mock
+, unittest2
+, isPy27
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "perf";
+  version = "1.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5aae76e58bd3edd0c50adcc7c16926ebb9ed8c0e5058b435a30d58c6bb0394a8";
+  };
+
+  checkInputs = [ nose psutil ] ++
+    lib.optionals isPy27 [ contextlib2 mock unittest2 ];
+  propagatedBuildInputs = [ six ] ++
+    lib.optionals (pythonOlder "3.4") [ statistics ];
+
+  # tests not included in pypi repository
+  doCheck = false;
+
+  checkPhase = ''
+    ${python.interpreter} -m nose
+  '';
+
+  meta = with lib; {
+    description = "Python module to generate and modify perf";
+    homepage = https://github.com/vstinner/perf;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-mypy/default.nix
+++ b/pkgs/development/python-modules/pytest-mypy/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, mypy
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-mypy";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "acc653210e7d8d5c72845a5248f00fd33f4f3379ca13fe56cfc7b749b5655c3e";
+  };
+
+  propagatedBuildInputs = [ pytest mypy ];
+
+  meta = with lib; {
+    description = "Mypy static type checker plugin for Pytest";
+    homepage = https://github.com/dbader/pytest-mypy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/uarray/default.nix
+++ b/pkgs/development/python-modules/uarray/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, matchpy
+, numpy
+, astunparse
+, typing-extensions
+, black
+, pytest
+, pytestcov
+, numba
+, nbval
+, python
+, isPy37
+}:
+
+buildPythonPackage rec {
+  pname = "uarray";
+  version = "0.4";
+  format = "flit";
+  # will have support soon see
+  # https://github.com/Quansight-Labs/uarray/pull/64
+  disabled = isPy37;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4ec88f477d803a914d58fdf83aeedfb1986305355775cf55525348c62cce9aa4";
+  };
+
+  checkInputs = [ pytest nbval pytestcov numba ];
+  propagatedBuildInputs = [ matchpy numpy astunparse typing-extensions black ];
+
+  checkPhase = ''
+    ${python.interpreter} extract_readme_tests.py
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Universal array library";
+    homepage = https://github.com/Quansight-Labs/uarray;
+    license = licenses.bsd0;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -398,6 +398,8 @@ in {
     inherit python;
   });
 
+  hopcroftkarp = callPackage ../development/python-modules/hopcroftkarp { };
+
   httpsig = callPackage ../development/python-modules/httpsig { };
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3961,6 +3961,8 @@ in {
 
   ua-parser = callPackage ../development/python-modules/ua-parser { };
 
+  uarray = callPackage ../development/python-modules/uarray { };
+
   ukpostcodeparser = callPackage ../development/python-modules/ukpostcodeparser { };
 
   umemcache = callPackage ../development/python-modules/umemcache {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -623,6 +623,8 @@ in {
 
   pytesseract = callPackage ../development/python-modules/pytesseract { };
 
+  pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
+
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
   python-binance = callPackage ../development/python-modules/python-binance { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -430,6 +430,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  multiset = callPackage ../development/python-modules/multiset { };
+
   mwclient = callPackage ../development/python-modules/mwclient { };
 
   mwoauth = callPackage ../development/python-modules/mwoauth { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -488,6 +488,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  perf = callPackage ../development/python-modules/perf { };
+
   phonopy = callPackage ../development/python-modules/phonopy { };
 
   pims = callPackage ../development/python-modules/pims { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -434,6 +434,8 @@ in {
 
   mwoauth = callPackage ../development/python-modules/mwoauth { };
 
+  nbval = callPackage ../development/python-modules/nbval { };
+
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
 
   neuron = pkgs.neuron.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -422,6 +422,8 @@ in {
 
   markerlib = callPackage ../development/python-modules/markerlib { };
 
+  matchpy = callPackage ../development/python-modules/matchpy { };
+
   monty = callPackage ../development/python-modules/monty { };
 
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;


### PR DESCRIPTION
###### Motivation for this change

Will be working on uarray and want support in nixpkgs

###### Things done

- pythonPackages.astunparse: 1.5.0 -> 1.6.1 
- pythonPackages.nbval: init at 0.9.1 
- pythonPackages.multiset: init at 2.1.1 
- pythonPackages.matchpy: init at 0.4.6 
- pythonPackages.hopcroftkarp: init at 1.2.4 
- pythonPackages.uarray: init at 0.4 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

