### PR TITLE
valgrind: Disable parallel building

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   # GDB is needed to provide a sane default for `--db-command'.
   buildInputs = [ perl gdb ]  ++ stdenv.lib.optionals (stdenv.isDarwin) [ bootstrap_cmds xnu ];
 
-  enableParallelBuilding = true;
+  enableParallelBuilding = false;
   separateDebugInfo = stdenv.isLinux;
 
   preConfigure = stdenv.lib.optionalString stdenv.isDarwin (


### PR DESCRIPTION
###### Motivation for this change
Valgrind appears to have a race condition with an unspecified dependency somewhere in the Makefile. I'll see about contacting upstream about this as well, but in the meantime, we can unblock ourselves.

https://github.com/NixOS/nixpkgs/pull/50876#issuecomment-441717798

```
rm -f libcoregrind-amd64-linux.a
ar cru libcoregrind-amd64-linux.a libcoregrind_amd64_linux_a-m_addrinfo.o libcoregrind_amd64_linux_a-m_cache.o libcoregrind_amd64_linux_a-m_commandline.o libcoregrind_amd64_linux_a-m_compiler.o libcoregrind_amd64_linux_a-m_clientstate.o libcoregrind_amd64_linux_a-m_cpuid.o libcoregrind_amd64_linux_a-m_deduppoolalloc.o libcoregrind_amd64_linux_a-m_debuglog.o libcoregrind_amd64_linux_a-m_errormgr.o libcoregrind_amd64_linux_a-m_execontext.o libcoregrind_amd64_linux_a-m_hashtable.o libcoregrind_amd64_linux_a-m_libcbase.o libcoregrind_amd64_linux_a-m_libcassert.o libcoregrind_amd64_linux_a-m_libcfile.o libcoregrind_amd64_linux_a-m_libcprint.o libcoregrind_amd64_linux_a-m_libcproc.o libcoregrind_amd64_linux_a-m_libcsignal.o libcoregrind_amd64_linux_a-m_machine.o libcoregrind_amd64_linux_a-m_mallocfree.o libcoregrind_amd64_linux_a-m_options.o libcoregrind_amd64_linux_a-m_oset.o libcoregrind_amd64_linux_a-m_poolalloc.o libcoregrind_amd64_linux_a-m_rangemap.o libcoregrind_amd64_linux_a-m_redir.o libcoregrind_amd64_linux_a-m_sbprofile.o libcoregrind_amd64_linux_a-m_seqmatch.o libcoregrind_amd64_linux_a-m_signals.o libcoregrind_amd64_linux_a-m_sparsewa.o libcoregrind_amd64_linux_a-m_stacks.o libcoregrind_amd64_linux_a-m_stacktrace.o libcoregrind_amd64_linux_a-m_syscall.o libcoregrind_amd64_linux_a-m_threadstate.o libcoregrind_amd64_linux_a-m_tooliface.o libcoregrind_amd64_linux_a-m_trampoline.o libcoregrind_amd64_linux_a-m_translate.o libcoregrind_amd64_linux_a-m_transtab.o libcoregrind_amd64_linux_a-m_vki.o libcoregrind_amd64_linux_a-m_vkiscnums.o libcoregrind_amd64_linux_a-m_wordfm.o libcoregrind_amd64_linux_a-m_xarray.o libcoregrind_amd64_linux_a-m_xtree.o libcoregrind_amd64_linux_a-m_xtmemory.o libcoregrind_amd64_linux_a-m_aspacehl.o m_aspacemgr/libcoregrind_amd64_linux_a-aspacemgr-common.o m_aspacemgr/libcoregrind_amd64_linux_a-aspacemgr-linux.o m_aspacemgr/libcoregrind_amd64_linux_a-aspacemgr-segnames.o m_coredump/libcoregrind_amd64_linux_a-coredump-elf.o m_coredump/libcoregrind_amd64_linux_a-coredump-macho.o m_coredump/libcoregrind_amd64_linux_a-coredump-solaris.o m_debuginfo/libcoregrind_amd64_linux_a-misc.o m_debuginfo/libcoregrind_amd64_linux_a-d3basics.o m_debuginfo/libcoregrind_amd64_linux_a-debuginfo.o m_debuginfo/libcoregrind_amd64_linux_a-image.o m_debuginfo/libcoregrind_amd64_linux_a-minilzo-inl.o m_debuginfo/libcoregrind_amd64_linux_a-readdwarf.o m_debuginfo/libcoregrind_amd64_linux_a-readdwarf3.o m_debuginfo/libcoregrind_amd64_linux_a-readelf.o m_debuginfo/libcoregrind_amd64_linux_a-readexidx.o m_debuginfo/libcoregrind_amd64_linux_a-readmacho.o m_debuginfo/libcoregrind_amd64_linux_a-readpdb.o m_debuginfo/libcoregrind_amd64_linux_a-storage.o m_debuginfo/libcoregrind_amd64_linux_a-tinfl.o m_debuginfo/libcoregrind_amd64_linux_a-tytypes.o m_demangle/libcoregrind_amd64_linux_a-cp-demangle.o m_demangle/libcoregrind_amd64_linux_a-cplus-dem.o m_demangle/libcoregrind_amd64_linux_a-demangle.o m_demangle/libcoregrind_amd64_linux_a-dyn-string.o m_demangle/libcoregrind_amd64_linux_a-d-demangle.o m_demangle/libcoregrind_amd64_linux_a-rust-demangle.o m_demangle/libcoregrind_amd64_linux_a-safe-ctype.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-x86-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-amd64-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-ppc32-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-ppc64be-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-ppc64le-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-arm-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-arm64-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-s390x-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-mips32-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-mips64-linux.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-x86-darwin.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-amd64-darwin.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-x86-solaris.o m_dispatch/libcoregrind_amd64_linux_a-dispatch-amd64-solaris.o m_gdbserver/libcoregrind_amd64_linux_a-inferiors.o m_gdbserver/libcoregrind_amd64_linux_a-m_gdbserver.o m_gdbserver/libcoregrind_amd64_linux_a-regcache.o m_gdbserver/libcoregrind_amd64_linux_a-remote-utils.o m_gdbserver/libcoregrind_amd64_linux_a-server.o m_gdbserver/libcoregrind_amd64_linux_a-signals.o m_gdbserver/libcoregrind_amd64_linux_a-target.o m_gdbserver/libcoregrind_amd64_linux_a-utils.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-x86.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-amd64.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-arm.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-arm64.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-ppc32.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-ppc64.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-s390x.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-mips32.o m_gdbserver/libcoregrind_amd64_linux_a-valgrind-low-mips64.o m_gdbserver/libcoregrind_amd64_linux_a-version.o m_initimg/libcoregrind_amd64_linux_a-initimg-linux.o m_initimg/libcoregrind_amd64_linux_a-initimg-darwin.o m_initimg/libcoregrind_amd64_linux_a-initimg-solaris.o m_initimg/libcoregrind_amd64_linux_a-initimg-pathscan.o m_mach/libcoregrind_amd64_linux_a-mach_basics.o m_mach/libcoregrind_amd64_linux_a-mach_msg.o m_mach/libcoregrind_amd64_linux_a-mach_traps-x86-darwin.o m_mach/libcoregrind_amd64_linux_a-mach_traps-amd64-darwin.o m_replacemalloc/libcoregrind_amd64_linux_a-replacemalloc_core.o m_scheduler/libcoregrind_amd64_linux_a-sched-lock.o m_scheduler/libcoregrind_amd64_linux_a-sched-lock-generic.o m_scheduler/libcoregrind_amd64_linux_a-scheduler.o m_scheduler/libcoregrind_amd64_linux_a-sema.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-common.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-x86-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-amd64-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-ppc32-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-ppc64-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-arm-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-arm64-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-s390x-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-mips32-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-mips64-linux.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-x86-darwin.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-amd64-darwin.o m_sigframe/libcoregrind_amd64_linux_a-sigframe-solaris.o m_syswrap/libcoregrind_amd64_linux_a-syscall-x86-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-amd64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-ppc32-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-ppc64be-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-ppc64le-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-arm-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-arm64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-s390x-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-mips32-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-mips64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syscall-x86-darwin.o m_syswrap/libcoregrind_amd64_linux_a-syscall-amd64-darwin.o m_syswrap/libcoregrind_amd64_linux_a-syscall-x86-solaris.o m_syswrap/libcoregrind_amd64_linux_a-syscall-amd64-solaris.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-main.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-generic.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-linux-variants.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-darwin.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-solaris.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-x86-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-amd64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-ppc32-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-ppc64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-arm-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-arm64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-s390x-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-mips32-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-mips64-linux.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-x86-darwin.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-amd64-darwin.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-xen.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-x86-solaris.o m_syswrap/libcoregrind_amd64_linux_a-syswrap-amd64-solaris.o m_ume/libcoregrind_amd64_linux_a-elf.o m_ume/libcoregrind_amd64_linux_a-macho.o m_ume/libcoregrind_amd64_linux_a-main.o m_ume/libcoregrind_amd64_linux_a-script.o m_scheduler/libcoregrind_amd64_linux_a-ticket-lock-linux.o   libnolto_coregrind_amd64_linux_a-m_libcsetjmp.o libnolto_coregrind_amd64_linux_a-m_main.o
ar: `u' modifier ignored since `D' is the default (see `U')
ar: libnolto_coregrind_amd64_linux_a-m_main.o: No such file or directory
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

