### PR TITLE
kubetail: install completions

### DIFF
--- a/pkgs/applications/networking/cluster/kubetail/default.nix
+++ b/pkgs/applications/networking/cluster/kubetail/default.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    install -Dm755 kubetail $out/bin/kubetail
+    install -Dm755 kubetail                 "$out/bin/kubetail"
+    install -Dm755 completion/kubetail.bash "$out/share/bash-completion/completions/kubetail"
+    install -Dm755 completion/kubetail.fish "$out/share/fish/vendor_completions.d/kubetail.fish"
+    install -Dm755 completion/kubetail.zsh  "$out/share/zsh/site-functions/_kubetail"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Install completions for kubetail. N.B. I tested fish completions. YMMV with bash and zsh.. I've seen some confusion re: {ba,z}sh on Nix lately..

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

