### PR TITLE
pythonPackages.rpy2: various fixes

### DIFF
--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -1,10 +1,13 @@
 { lib
+, python
 , buildPythonPackage
 , fetchPypi
 , isPyPy
 , isPy27
 , readline
 , R
+, rWrapper
+, rPackages
 , pcre
 , lzma
 , bzip2
@@ -13,7 +16,11 @@
 , singledispatch
 , six
 , jinja2
+, pytz
+, numpy
 , pytest
+, mock
+, extraRPackages ? []
 }:
 
 buildPythonPackage rec {
@@ -38,18 +45,54 @@ buildPythonPackage rec {
       bzip2
       zlib
       icu
+    ] ++ (with rPackages; [
+      # packages expected by the test framework
+      ggplot2
+      dplyr
+      RSQLite
+      broom
+      DBI
+      dbplyr
+      hexbin
+      lme4
+      tidyr
+    ]) ++ extraRPackages ++ rWrapper.recommendedPackages;
+
+    patches = [
+      # R_LIBS_SITE is used by the nix r package to point to the installed R libraries.
+      # This patch sets R_LIBS_SITE when rpy2 is imported.
+      ./r-libs-site.patch
     ];
+    postPatch = ''
+      substituteInPlace rpy/rinterface/__init__.py --replace '@NIX_R_LIBS_SITE@' "$R_LIBS_SITE"
+    '';
+
     propagatedBuildInputs = [
       singledispatch
       six
       jinja2
+      pytz
+      numpy
     ];
-    checkInputs = [ pytest ];
-    # Tests fail with `assert not _relpath.startswith('..'), "Path must be within the project"`
-    # in the unittest `loader.py`. I don't know what causes this.
+
+    checkInputs = [
+      pytest
+      mock
+    ];
+    # One remaining test failure caused by different unicode encoding.
+    # https://bitbucket.org/rpy2/rpy2/issues/488
     doCheck = false;
-    # without this tests fail when looking for libreadline.so
-    LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+    checkPhase = ''
+      ${python.interpreter} -m 'rpy2.tests'
+    '';
+
+    # For some reason libreadline.so is not found. Curiously `ldd _rinterface.so | grep readline` shows two readline entries:
+    # libreadline.so.6 => not found
+    # libreadline.so.6 => /nix/store/z2zhmrg6jcrn5iq2779mav0nnq4vm2q6-readline-6.3p08/lib/libreadline.so.6 (0x00007f333ac43000)
+    # There must be a better way to fix this, but I don't know it.
+    postFixup = ''
+      patchelf --add-needed ${readline}/lib/libreadline.so "$out/${python.sitePackages}/rpy2/rinterface/"_rinterface*.so
+    '';
 
     meta = {
       homepage = http://rpy.sourceforge.net/rpy2;

--- a/pkgs/development/python-modules/rpy2/r-libs-site.patch
+++ b/pkgs/development/python-modules/rpy2/r-libs-site.patch
@@ -1,0 +1,20 @@
+diff --git a/rpy/rinterface/__init__.py b/rpy/rinterface/__init__.py
+index 9362e57..1af258e 100644
+--- a/rpy/rinterface/__init__.py
++++ b/rpy/rinterface/__init__.py
+@@ -43,6 +43,15 @@ if not R_HOME:
+ if not os.environ.get("R_HOME"):
+     os.environ['R_HOME'] = R_HOME
+ 
++# path to libraries
++existing = os.environ.get('R_LIBS_SITE')
++if existing is not None:
++    prefix = existing + ':'
++else:
++    prefix = ''
++additional = '@NIX_R_LIBS_SITE@'
++os.environ['R_LIBS_SITE'] = prefix + additional
++
+ if sys.platform == 'win32':
+     _load_r_dll(R_HOME)
+ 

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -5,6 +5,9 @@ stdenv.mkDerivation {
 
   buildInputs = [makeWrapper R] ++ recommendedPackages ++ packages;
 
+  # Make the list of recommended R packages accessible to other packages such as rpy2
+  passthru.recommendedPackages = recommendedPackages;
+
   unpackPhase = ":";
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

- make sure libreadline is found at runtime
- make sure python libraries are found at runtime
- add libraries necessary to pass the testsuite and standard libraries

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

