### PR TITLE
containers: simplify env var definition

### DIFF
--- a/nixos/modules/virtualisation/container-config.nix
+++ b/nixos/modules/virtualisation/container-config.nix
@@ -22,12 +22,8 @@ with lib;
     # Not supported in systemd-nspawn containers.
     security.audit.enable = false;
 
-    # Make sure that root user in container will talk to host nix-daemon
-    environment.etc."profile".text = ''
-    export NIX_REMOTE=daemon
-    '';
-
-
+    # Use the host's nix-daemon.
+    environment.variables.NIX_REMOTE = "daemon";
 
   };
 


### PR DESCRIPTION
Also clear up the misleading comment: This env var isn't root-specific, it's needed for all users.