### PR TITLE
cups-toshiba-estudio: fix homepage

### DIFF
--- a/pkgs/misc/cups/drivers/estudio/default.nix
+++ b/pkgs/misc/cups/drivers/estudio/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       TOSHIBA e-STUDIO6540C, TOSHIBA e-STUDIO6550C, TOSHIBA e-STUDIO6560C,
       TOSHIBA e-STUDIO6570C and TOSHIBA e-STUDIO7506AC.
     '';
-    homepage = https://www.toshiba-business.com.au/support/drivers;
+    homepage = http://business.toshiba.com/support/downloads/index.html;
     license = licenses.unfree;
     maintainers = [ maintainers.jpotier ];
   };


### PR DESCRIPTION
Provide an URL that works.

###### Motivation for this change

The URL in `homepage` attribute does not work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

