### PR TITLE
php: 7.2.11 -> 7.2.12, 7.1.23 -> 7.1.24 (CVE-2018-17082)

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,5 +1,5 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-{ lib, stdenv, fetchurl, flex, bison
+{ lib, stdenv, fetchurl, flex, bison, autoconf
 , mysql, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pkgconfig, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
@@ -12,6 +12,7 @@ let
   generic =
   { version
   , sha256
+  , extraPatches ? []
   , imapSupport ? config.php.imap or (!stdenv.isDarwin)
   , ldapSupport ? config.php.ldap or true
   , mhashSupport ? config.php.mhash or true
@@ -65,7 +66,7 @@ let
 
       enableParallelBuilding = true;
 
-      nativeBuildInputs = [ pkgconfig ];
+      nativeBuildInputs = [ pkgconfig autoconf ];
       buildInputs = [ flex bison pcre ]
         ++ optional stdenv.isLinux systemd
         ++ optionals imapSupport [ uwimap openssl pam ]
@@ -182,6 +183,8 @@ let
 
         configureFlags+=(--with-config-file-path=$out/etc \
           --includedir=$dev/include)
+
+        ./buildconf --force
       '';
 
       postInstall = ''
@@ -210,7 +213,7 @@ let
         outputsToInstall = [ "out" "dev" ];
       };
 
-      patches = [ ./fix-paths-php7.patch ];
+      patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
 
       postPatch = optional stdenv.isDarwin ''
         substituteInPlace configure --replace "-lstdc++" "-lc++"
@@ -223,35 +226,19 @@ let
     };
 
 in {
-  # Because of an upstream bug: https://bugs.php.net/bug.php?id=76826
-  # We can't update the darwin versions because they simply don't compile at
-  # all due to a bug in the intl extensions.
-  #
-  # The bug so far is present in 7.1.21, 7.1.22, 7.1.23, 7.2.9, 7.2.10, 7.2.11.
+  php71 = generic {
+    version = "7.1.23";
+    sha256 = "0jyc5q666xh808sgy78cfylkhy5ma2zdg88jlxhagyphv23aly9d";
 
-  php71 = generic (
-    if stdenv.isDarwin then
-      {
-        version = "7.1.20";
-        sha256 = "0i8xd6p4zdg8fl6f0j430raanlshsshr3s3jlm72b0gvi1n4f6rs";
-      }
-    else
-      {
-        version = "7.1.23";
-        sha256 = "0jyc5q666xh808sgy78cfylkhy5ma2zdg88jlxhagyphv23aly9d";
-      }
-  );
+    # https://bugs.php.net/bug.php?id=76826
+    extraPatches = optional stdenv.isDarwin ./php71-darwin-isfinite.patch;
+  };
 
-  php72 = generic (
-    if stdenv.isDarwin then
-      {
-        version = "7.2.8";
-        sha256 = "1rky321gcvjm0npbfd4bznh36an0y14viqcvn4yzy3x643sni00z";
-      }
-    else
-      {
-        version = "7.2.11";
-        sha256 = "1idlv04j1l2d0bn5nvfrapcpjh6ayj1n4y80lqvnp5h75m07y3aa";
-      }
-  );
+  php72 = generic {
+    version = "7.2.11";
+    sha256 = "1idlv04j1l2d0bn5nvfrapcpjh6ayj1n4y80lqvnp5h75m07y3aa";
+
+    # https://bugs.php.net/bug.php?id=76826
+    extraPatches = optional stdenv.isDarwin ./php72-darwin-isfinite.patch;
+  };
 }

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -227,8 +227,8 @@ let
 
 in {
   php71 = generic {
-    version = "7.1.23";
-    sha256 = "0jyc5q666xh808sgy78cfylkhy5ma2zdg88jlxhagyphv23aly9d";
+    version = "7.1.24";
+    sha256 = "02qy76krbdhlbkzs9k1sa5mgmj0qnbb8gcf1j3q0cq3z7kkj9pk6";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = optional stdenv.isDarwin ./php71-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -235,8 +235,8 @@ in {
   };
 
   php72 = generic {
-    version = "7.2.11";
-    sha256 = "1idlv04j1l2d0bn5nvfrapcpjh6ayj1n4y80lqvnp5h75m07y3aa";
+    version = "7.2.12";
+    sha256 = "1dpnbsv4bdlc5v40ddddi971f456jp1qrn89w5di1dj70g1c895p";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = optional stdenv.isDarwin ./php72-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/fix-paths-php7.patch
+++ b/pkgs/development/interpreters/php/fix-paths-php7.patch
@@ -1,16 +1,8 @@
---- php-7.0.0beta1/configure	    2015-07-10 12:11:41.810045613 +0000
-+++ php-7.0.0beta1-new/configure	2015-07-17 16:10:21.775528267 +0000
-@@ -6172,7 +6172,7 @@
-     as_fn_error $? "Please note that Apache version >= 2.0.44 is required" "$LINENO" 5
-   fi
- 
--  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
-+  APXS_LIBEXECDIR="$prefix/modules"
-   if test -z `$APXS -q SYSCONFDIR`; then
-     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
-                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
-@@ -37303,9 +37303,7 @@
- 
+diff -ru a/ext/gettext/config.m4 b/ext/gettext/config.m4
+--- a/ext/gettext/config.m4	2018-11-07 15:35:26.000000000 +0000
++++ b/ext/gettext/config.m4	2018-11-27 00:33:07.000000000 +0000
+@@ -6,9 +6,7 @@
+ [  --with-gettext[=DIR]      Include GNU gettext support])
  
  if test "$PHP_GETTEXT" != "no"; then
 -  for i in $PHP_GETTEXT /usr/local /usr; do
@@ -19,5 +11,16 @@
 +  GETTEXT_DIR=$PHP_GETTEXT
  
    if test -z "$GETTEXT_DIR"; then
-     as_fn_error $? "Cannot locate header file libintl.h" "$LINENO" 5
-
+     AC_MSG_ERROR(Cannot locate header file libintl.h)
+diff -ru a/sapi/apache2handler/config.m4 b/sapi/apache2handler/config.m4
+--- a/sapi/apache2handler/config.m4	2018-11-07 15:35:23.000000000 +0000
++++ b/sapi/apache2handler/config.m4	2018-11-27 00:32:28.000000000 +0000
+@@ -66,7 +66,7 @@
+     AC_MSG_ERROR([Please note that Apache version >= 2.0.44 is required])
+   fi
+ 
+-  APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
++  APXS_LIBEXECDIR="$prefix/modules"
+   if test -z `$APXS -q SYSCONFDIR`; then
+     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \

--- a/pkgs/development/interpreters/php/php71-darwin-isfinite.patch
+++ b/pkgs/development/interpreters/php/php71-darwin-isfinite.patch
@@ -1,0 +1,60 @@
+diff -ru a/Zend/configure.in b/Zend/configure.in
+--- a/Zend/configure.in	2018-11-07 15:35:26.000000000 +0000
++++ b/Zend/configure.in	2018-11-27 00:28:48.000000000 +0000
+@@ -70,7 +70,7 @@
+ #endif
+ 
+ #ifndef zend_isnan
+-#if HAVE_DECL_ISNAN && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISNAN && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isnan(a) isnan(a)
+ #elif defined(HAVE_FPCLASS)
+ #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
+@@ -79,7 +79,7 @@
+ #endif
+ #endif
+ 
+-#if HAVE_DECL_ISINF && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISINF && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isinf(a) isinf(a)
+ #elif defined(INFINITY)
+ /* Might not work, but is required by ISO C99 */
+@@ -90,7 +90,7 @@
+ #define zend_isinf(a) 0
+ #endif
+ 
+-#if HAVE_DECL_ISFINITE && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISFINITE && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_finite(a) isfinite(a)
+ #elif defined(HAVE_FINITE)
+ #define zend_finite(a) finite(a)
+diff -ru a/configure.in b/configure.in
+--- a/configure.in	2018-11-07 15:35:26.000000000 +0000
++++ b/configure.in	2018-11-27 00:28:48.000000000 +0000
+@@ -75,7 +75,7 @@
+ #endif
+ 
+ #ifndef zend_isnan
+-#if HAVE_DECL_ISNAN && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISNAN && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isnan(a) isnan(a)
+ #elif defined(HAVE_FPCLASS)
+ #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
+@@ -84,7 +84,7 @@
+ #endif
+ #endif
+ 
+-#if HAVE_DECL_ISINF && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISINF && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isinf(a) isinf(a)
+ #elif defined(INFINITY)
+ /* Might not work, but is required by ISO C99 */
+@@ -95,7 +95,7 @@
+ #define zend_isinf(a) 0
+ #endif
+ 
+-#if HAVE_DECL_ISFINITE && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISFINITE && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_finite(a) isfinite(a)
+ #elif defined(HAVE_FINITE)
+ #define zend_finite(a) finite(a)

--- a/pkgs/development/interpreters/php/php72-darwin-isfinite.patch
+++ b/pkgs/development/interpreters/php/php72-darwin-isfinite.patch
@@ -1,0 +1,62 @@
+diff --git a/Zend/configure.ac b/Zend/configure.ac
+index b95c1360b8..fe16c86007 100644
+--- a/Zend/configure.ac
++++ b/Zend/configure.ac
+@@ -60,7 +60,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #include <math.h>
+ 
+ #ifndef zend_isnan
+-#if HAVE_DECL_ISNAN && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISNAN && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isnan(a) isnan(a)
+ #elif defined(HAVE_FPCLASS)
+ #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
+@@ -69,7 +69,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #endif
+ #endif
+ 
+-#if HAVE_DECL_ISINF && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISINF && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isinf(a) isinf(a)
+ #elif defined(INFINITY)
+ /* Might not work, but is required by ISO C99 */
+@@ -80,7 +80,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #define zend_isinf(a) 0
+ #endif
+ 
+-#if HAVE_DECL_ISFINITE && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISFINITE && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_finite(a) isfinite(a)
+ #elif defined(HAVE_FINITE)
+ #define zend_finite(a) finite(a)
+diff --git a/configure.ac b/configure.ac
+index d3f3cacd07..ddbf712ba2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -68,7 +68,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #include <math.h>
+ 
+ #ifndef zend_isnan
+-#if HAVE_DECL_ISNAN && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISNAN && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isnan(a) isnan(a)
+ #elif defined(HAVE_FPCLASS)
+ #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
+@@ -77,7 +77,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #endif
+ #endif
+ 
+-#if HAVE_DECL_ISINF && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISINF && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isinf(a) isinf(a)
+ #elif defined(INFINITY)
+ /* Might not work, but is required by ISO C99 */
+@@ -88,7 +88,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #define zend_isinf(a) 0
+ #endif
+ 
+-#if HAVE_DECL_ISFINITE && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISFINITE && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_finite(a) isfinite(a)
+ #elif defined(HAVE_FINITE)
+ #define zend_finite(a) finite(a)


### PR DESCRIPTION
Also align Darwin with Linux versions by introducing some trivial configure.ac
patches. This requires running autoconf/autoheader (through ./buildconf), which
also made a change to fix-paths-php7.patch necessary since it patched ./configure
directly instead of the .m4 inputs.

Supersedes #50511 with backwards compatibility on Darwin. @Ekleog @etu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

