### PR TITLE
emacsPackagesNg.trivialBuild: cleanup and standardize function

### DIFF
--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -61,19 +61,18 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
     ln -s "$NIX_BUILD_TOP/$sourceRoot" "$NIX_BUILD_TOP/working/$ename"
   '';
 
-  buildPhase =
-    ''
-      runHook preBuild
+  buildPhase = ''
+    runHook preBuild
 
-      cd "$NIX_BUILD_TOP"
+    cd "$NIX_BUILD_TOP"
 
-      emacs --batch -Q \
-          -L "$melpa/package-build" \
-          -l "$melpa2nix" \
-          -f melpa2nix-build-package \
-          $ename $version
+    emacs --batch -Q \
+        -L "$melpa/package-build" \
+        -l "$melpa2nix" \
+        -f melpa2nix-build-package \
+        $ename $version
 
-      runHook postBuild
+    runHook postBuild
     '';
 
   installPhase = ''

--- a/pkgs/build-support/emacs/trivial.nix
+++ b/pkgs/build-support/emacs/trivial.nix
@@ -7,27 +7,22 @@ with lib;
 args:
 
 import ./generic.nix envargs ({
-  #preConfigure = ''
-  #  export LISPDIR=$out/share/emacs/site-lisp
-  #  export VERSION_SPECIFIC_LISPDIR=$out/share/emacs/site-lisp
-  #'';
-
   buildPhase = ''
-    eval "$preBuild"
+    runHook preBuild
 
     emacs -L . --batch -f batch-byte-compile *.el
 
-    eval "$postBuild"
+    runHook postBuild
   '';
 
   installPhase = ''
-    eval "$preInstall"
+    runHook preInstall
 
     LISPDIR=$out/share/emacs/site-lisp
     install -d $LISPDIR
     install *.el *.elc $LISPDIR
 
-    eval "$postInstall"
+    runHook postInstall
   '';
 }
 


### PR DESCRIPTION
No real function change here, but this updates the trivial and melpa builders to
be formatted more consistently with the rest of the builders, and swaps
`eval "$preBuild"` for the more standard `runHook preBuild`.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

