### PR TITLE
scss_lint: init at 0.57.1

### DIFF
--- a/pkgs/development/tools/scss-lint/Gemfile
+++ b/pkgs/development/tools/scss-lint/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem "scss_lint"

--- a/pkgs/development/tools/scss-lint/Gemfile.lock
+++ b/pkgs/development/tools/scss-lint/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.9.25)
+    rake (12.3.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    sass (3.7.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    scss_lint (0.57.1)
+      rake (>= 0.9, < 13)
+      sass (~> 3.5, >= 3.5.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  scss_lint
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/development/tools/scss-lint/default.nix
+++ b/pkgs/development/tools/scss-lint/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "scss_lint";
+  gemdir = ./.;
+  exes = [ "scss-lint" ];
+
+  meta = with lib; {
+    description = "A tool to help keep your SCSS files clean and readable";
+    homepage    = https://github.com/brigade/scss-lint;
+    license     = licenses.mit;
+    maintainers = [ maintainers.lovek323 ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/scss-lint/gemset.nix
+++ b/pkgs/development/tools/scss-lint/gemset.nix
@@ -1,0 +1,62 @@
+{
+  ffi = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jpm2dis1j7zvvy3lg7axz9jml316zrn7s0j59vyq3qr127z0m7q";
+      type = "gem";
+    };
+    version = "1.9.25";
+  };
+  rake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1idi53jay34ba9j68c3mfr9wwkg3cd9qh0fn9cg42hv72c6q8dyg";
+      type = "gem";
+    };
+    version = "12.3.1";
+  };
+  rb-fsevent = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lm1k7wpz69jx7jrc92w3ggczkjyjbfziq5mg62vjnxmzs383xx8";
+      type = "gem";
+    };
+    version = "0.10.3";
+  };
+  rb-inotify = {
+    dependencies = ["ffi"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yfsgw5n7pkpyky6a9wkf1g9jafxb0ja7gz0qw0y14fd2jnzfh71";
+      type = "gem";
+    };
+    version = "0.9.10";
+  };
+  sass = {
+    dependencies = ["sass-listen"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1phs6hnd8b95m7n5wbh5bsclmwaajd1sqlgw9fmj72bfqldbmcqa";
+      type = "gem";
+    };
+    version = "3.7.2";
+  };
+  sass-listen = {
+    dependencies = ["rb-fsevent" "rb-inotify"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xw3q46cmahkgyldid5hwyiwacp590zj2vmswlll68ryvmvcp7df";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  scss_lint = {
+    dependencies = ["rake" "sass"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dv4ff1lqbgqdx99nwg059c983dhw67kvvjd21f6vf62cjx09lpn";
+      type = "gem";
+    };
+    version = "0.57.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8919,6 +8919,8 @@ with pkgs;
 
   sbt-extras = callPackage ../development/tools/build-managers/sbt-extras { };
 
+  scss-lint = callPackage ../development/tools/scss-lint { };
+
   shallot = callPackage ../tools/misc/shallot { };
 
   shards = callPackage ../development/tools/build-managers/shards { };


### PR DESCRIPTION
###### Motivation for this change

I needed this program.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

