### PR TITLE
libtiff: 2018-11-04 -> 4.0.10

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -1,11 +1,7 @@
 { stdenv
-, fetchFromGitLab
+, fetchurl
 
 , pkgconfig
-, autogen
-, autoconf
-, automake
-, libtool
 
 , zlib
 , libjpeg
@@ -13,25 +9,21 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2018-11-04";
-  name = "libtiff-unstable-${version}";
+  version = "4.0.10";
+  name = "libtiff-${version}";
 
-  src = fetchFromGitLab {
-    owner = "libtiff";
-    repo = "libtiff";
-    rev = "779e54ca32b09155c10d398227a70038de399d7d";
-    sha256 = "029fmn0rdmb5gxhg83ff9j2zx3qk6wsiaiv554jq26pdc23achsp";
+  src = fetchurl {
+    url = "https://download.osgeo.org/libtiff/tiff-${version}.tar.gz";
+    sha256 = "1r4np635gr6zlc0bic38dzvxia6iqzcrary4n1ylarzpr8fd2lic";
   };
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
-  nativeBuildInputs = [ pkgconfig autogen autoconf automake libtool ];
+  nativeBuildInputs = [ pkgconfig ];
 
   propagatedBuildInputs = [ zlib libjpeg xz ]; #TODO: opengl support (bogus configure detection)
 
   enableParallelBuilding = true;
-
-  preConfigure = "./autogen.sh";
 
   doCheck = true; # not cross;
 


### PR DESCRIPTION
###### Motivation for this change
Security updates (#49786)

This is a followup to #49860 that switches back to a released version, and updates to 4.0.10 to fix `CVE-2018-18661`.  The Debian patchset that we applied prior to #49860 ([link][deb]) doesn't contain any security updates or bugfixes (just a typo fix, see [here][debpatches]), so I didn't re-add those. 

[deb]: https://github.com/andrew-d/nixpkgs/blob/4596251dd194cb34c83f02c152800deb7deb9f21/pkgs/development/libraries/libtiff/default.nix#L14-L24
[debpatches]: https://sources.debian.org/patches/tiff/4.0.10-2/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ckauhaus 