### PR TITLE
valgrind: Apply upstream patch for Makefile race in coregrind

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/coregrind-makefile-race.patch
+++ b/pkgs/development/tools/analysis/valgrind/coregrind-makefile-race.patch
@@ -1,0 +1,41 @@
+From 7820fc268fae4353118b6355f1d4b9e1b7eeebec Mon Sep 17 00:00:00 2001
+From: Philippe Waroquiers <philippe.waroquiers@skynet.be>
+Date: Sun, 28 Oct 2018 18:35:11 +0100
+Subject: [PATCH 1/1] Fix dependencies between libcoregrind*.a and
+ *m_main.o/*m_libcsetjmp.o
+
+The primary and secondary coregrind libraries must be updated
+when m_main.c or m_libcsetjmp.c are changed.
+
+A dependency was missing between libcoregrind*.a and libnolto_coregrind*.a,
+and so tools were not relinked when m_main.c or m_libcsetjmp.c were
+changed.
+---
+ coregrind/Makefile.am | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/coregrind/Makefile.am b/coregrind/Makefile.am
+index 914a270..8de1996 100644
+--- a/coregrind/Makefile.am
++++ b/coregrind/Makefile.am
+@@ -511,6 +511,8 @@ libcoregrind_@VGCONF_ARCH_PRI@_@VGCONF_OS@_a_CFLAGS += \
+ endif
+ libcoregrind_@VGCONF_ARCH_PRI@_@VGCONF_OS@_a_LIBADD = \
+     $(libnolto_coregrind_@VGCONF_ARCH_PRI@_@VGCONF_OS@_a_OBJECTS)
++libcoregrind_@VGCONF_ARCH_PRI@_@VGCONF_OS@_a_DEPENDENCIES = \
++    libnolto_coregrind-@VGCONF_ARCH_PRI@-@VGCONF_OS@.a
+ 
+ if VGCONF_HAVE_PLATFORM_SEC
+ libcoregrind_@VGCONF_ARCH_SEC@_@VGCONF_OS@_a_SOURCES = \
+@@ -531,6 +533,8 @@ libcoregrind_@VGCONF_ARCH_SEC@_@VGCONF_OS@_a_CFLAGS += \
+ endif
+ libcoregrind_@VGCONF_ARCH_SEC@_@VGCONF_OS@_a_LIBADD = \
+     $(libnolto_coregrind_@VGCONF_ARCH_SEC@_@VGCONF_OS@_a_OBJECTS)
++libcoregrind_@VGCONF_ARCH_SEC@_@VGCONF_OS@_a_DEPENDENCIES = \
++    libnolto_coregrind-@VGCONF_ARCH_SEC@-@VGCONF_OS@.a
+ endif
+ 
+ #----------------------------------------------------------------------------
+-- 
+2.9.3
+

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "19ds42jwd89zrsjb94g7gizkkzipn8xik3xykrpcqxylxyzi2z03";
   };
 
+  patches = [ ./coregrind-makefile-race.patch ];
+
   outputs = [ "out" "dev" "man" "doc" ];
 
   hardeningDisable = [ "stackprotector" ];


### PR DESCRIPTION
###### Motivation for this change
Supercedes #51082
Thanks @delroth for noticing the commit upstream. :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

