### PR TITLE
nixos: allow overriding lib

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,4 +1,13 @@
+let
+  looks-like-nixos-lib = { path, prefix }:
+    prefix == "nixos-lib" ||
+    (prefix == "" && builtins.pathExists "${path}/nixos-lib");
+in
+
 { configuration ? import ./lib/from-env.nix "NIXOS_CONFIG" <nixos-config>
+, lib ? if builtins.any looks-like-nixos-lib builtins.nixPath
+          then import <nixos-lib>
+          else import ../lib
 , system ? builtins.currentSystem
 }:
 
@@ -7,12 +16,18 @@ let
   eval = import ./lib/eval-config.nix {
     inherit system;
     modules = [ configuration ];
+    specialArgs = {
+      inherit lib;
+    };
   };
 
   # This is for `nixos-rebuild build-vm'.
   vmConfig = (import ./lib/eval-config.nix {
     inherit system;
     modules = [ configuration ./modules/virtualisation/qemu-vm.nix ];
+    specialArgs = {
+      inherit lib;
+    };
   }).config;
 
   # This is for `nixos-rebuild build-vm-with-bootloader'.
@@ -23,6 +38,9 @@ let
         ./modules/virtualisation/qemu-vm.nix
         { virtualisation.useBootLoader = true; }
       ];
+    specialArgs = {
+      inherit lib;
+    };
   }).config;
 
 in


### PR DESCRIPTION
###### Motivation for this change

Allows overriding the `lib` argument used in configurations, which in turn allows using library functions while working with imports, like e.g.:

```
{ lib, ... }: {
  imports = lib.my-imports-generator;
}
```

The same wouldn't be possible with `pkgs.lib`, as it would cause an infinite recursion.

I'm not sure this is the best way to implement this feature.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

