### PR TITLE
doc: tweak the coding conventions

### DIFF
--- a/doc/coding-conventions.xml
+++ b/doc/coding-conventions.xml
@@ -56,25 +56,30 @@ foo { arg = ...; }
      or list elements should be aligned:
 <programlisting>
 # A long list.
-list =
-  [ elem1
-    elem2
-    elem3
-  ];
+list = [
+  elem1
+  elem2
+  elem3
+];
 
 # A long attribute set.
-attrs =
-  { attr1 = short_expr;
-    attr2 =
-      if true then big_expr else big_expr;
-  };
-
-# Alternatively:
 attrs = {
   attr1 = short_expr;
   attr2 =
     if true then big_expr else big_expr;
 };
+
+# Combined
+listOfAttrs = [
+  {
+    attr1 = 3;
+    attr2 = "fff";
+  }
+  {
+    attr1 = 5;
+    attr2 = "ggg";
+  }
+];
 </programlisting>
     </para>
    </listitem>


### PR DESCRIPTION
Tweaks the coding style guide to encourage putting container elements on their own lines.

This minimizes diffs, merge conflicts and makes re-ordering of those elements easier.

Nix doesn't suffer the restrictions of other languages where commas are
used to separate list items.

###### Motivation for this change

Discussion at https://discourse.nixos.org/t/on-nix-expression-formatting/1521/15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

