### PR TITLE
gist: 4.6.2 -> 5.0.0, simplify

### DIFF
--- a/pkgs/tools/text/gist/default.nix
+++ b/pkgs/tools/text/gist/default.nix
@@ -1,21 +1,11 @@
-{ buildRubyGem, lib, ruby, makeWrapper }:
+{ buildRubyGem, lib, ruby }:
 
 buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "gist";
-  version = "4.6.2";
-  source.sha256 = "0zrw84k2982aiansmv2aj3101d3giwa58221n6aisvg5jq5kmiib";
-
-  buildInputs = [ makeWrapper ];
-
-  postInstall = ''
-    # Fix the default ruby wrapper
-    makeWrapper $out/${ruby.gemPath}/bin/gist $out/bin/gist \
-      --set GEM_PATH $out/${ruby.gemPath}:${ruby}/${ruby.gemPath}
-  '';
-
-  dontStrip = true;
+  version = "5.0.0";
+  source.sha256 = "1i0a73mzcjv4mj5vjqwkrx815ydsppx3v812lxxd9mk2s7cj1vyd";
 
   meta = with lib; {
     description = "Upload code to https://gist.github.com (or github enterprise)";


### PR DESCRIPTION
* default wrapper works fine now AFAICT
* Not sure that 'dontStrip' does anything here
  (regardless doesn't seem to be useful any longer)

###### Motivation for this change

Apologies for not linking changelog-- didn't find one but probably
could have searched more thoroughly O:).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---