### PR TITLE
ocamlPackages.buildDunePackage: fix meta.platforms

### DIFF
--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -25,12 +25,12 @@ stdenv.mkDerivation ({
     runHook postInstall
   '';
 
-  meta.platform = ocaml.meta.platform;
-
 } // args // {
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
   buildInputs = [ ocaml dune findlib ] ++ buildInputs;
+
+  meta = (args.meta or {}) // { platforms = args.meta.platforms or ocaml.meta.platforms; };
 
 })


### PR DESCRIPTION
###### Motivation for this change

The standard `meta` attribute is spelled `platforms` (https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes).

Also, `//` does not merge nested attribute sets (https://nixos.org/nix/manual/#sec-language-operators).

cc/@Zimmi48, author.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

