### PR TITLE
mkpasswd: fix cross compilation

### DIFF
--- a/pkgs/tools/security/mkpasswd/default.nix
+++ b/pkgs/tools/security/mkpasswd/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
   src = whois.src;
 
-  buildInputs = [ perl ];
+  nativeBuildInputs = [ perl ];
 
   preConfigure = whois.preConfigure;
   buildPhase = "make mkpasswd";


### PR DESCRIPTION
###### Motivation for this change

Fixes #51112 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

