### PR TITLE
networkmanager: 1.12.2 -> 1.14.4

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -9,11 +9,11 @@ let
   pname = "NetworkManager";
 in stdenv.mkDerivation rec {
   name = "network-manager-${version}";
-  version = "1.12.2";
+  version = "1.14.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "09hsh34m8hg4m402pw5n11f29vsfjw6lm3p5m56yxwq57bwnzq3b";
+    sha256 = "064cgj9za0kzarks0lrv0qw2ysdphb5l97iw0c964bfiqzjfv8rm";
   };
 
   outputs = [ "out" "dev" ];
@@ -70,10 +70,6 @@ in stdenv.mkDerivation rec {
     (fetchpatch {
       url = https://bugzilla.gnome.org/attachment.cgi?id=372953;
       sha256 = "0xg7bzs6dvkbv2qp67i7mi1c5yrmfd471xgmlkn15b33pqkzy3mc";
-    })
-    (fetchpatch {
-      url = https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/0a3755c1799d3a4dc1875d4c59c7c568a64c8456.patch;
-      sha256 = "0r7338q3za7mf419a244vi65b1q497rg84avijybmv6w4x6p1ksd";
     })
     (substituteAll {
       src = ./fix-paths.patch;

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -25,8 +25,6 @@ in stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace configure --replace /usr/bin/uname ${coreutils}/bin/uname
     substituteInPlace configure --replace /usr/bin/file ${file}/bin/file
-    # to enable link-local connections
-    configureFlags="$configureFlags --with-udev-dir=$out/lib/udev"
 
     # Fixes: error: po/Makefile.in.in was not created by intltoolize.
     intltoolize --automake --copy --force
@@ -42,10 +40,11 @@ in stdenv.mkDerivation rec {
     "--with-dhcpcd=no"
     "--with-pppd=${ppp}/bin/pppd"
     "--with-iptables=${iptables}/bin/iptables"
-    #"--with-udev-dir=$(out)/lib/udev"
+    # to enable link-local connections
+    "--with-udev-dir=${placeholder "out"}/lib/udev"
     "--with-resolvconf=${openresolv}/sbin/resolvconf"
     "--sysconfdir=/etc" "--localstatedir=/var"
-    "--with-dbus-sys-dir=\${out}/etc/dbus-1/system.d"
+    "--with-dbus-sys-dir=${placeholder "out"}/etc/dbus-1/system.d"
     "--with-crypto=gnutls" "--disable-more-warnings"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-kernel-firmware-dir=/run/current-system/firmware"
@@ -77,9 +76,11 @@ in stdenv.mkDerivation rec {
 
   doCheck = false; # requires /sys, the net
 
-  preInstall = ''
-    installFlagsArray=( "sysconfdir=$out/etc" "localstatedir=$out/var" "runstatedir=$out/var/run" )
-  '';
+  installFlags = [
+    "sysconfdir=${placeholder "out"}/etc"
+    "localstatedir=${placeholder "out"}/var"
+    "runstatedir=${placeholder "out"}/var/run"
+  ];
 
   postInstall = ''
     mkdir -p $out/lib/NetworkManager

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, substituteAll, intltool, pkgconfig, dbus-glib
+{ stdenv, fetchurl, substituteAll, intltool, pkgconfig, dbus, dbus-glib
 , gnome3, systemd, libuuid, polkit, gnutls, ppp, dhcp, iptables
 , libgcrypt, dnsmasq, bluez5, readline
 , gobject-introspection, modemmanager, openresolv, libndp, newt, libsoup
@@ -25,14 +25,6 @@ in stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace configure --replace /usr/bin/uname ${coreutils}/bin/uname
     substituteInPlace configure --replace /usr/bin/file ${file}/bin/file
-    substituteInPlace data/84-nm-drivers.rules \
-      --replace /bin/sh ${stdenv.shell}
-    substituteInPlace data/85-nm-unmanaged.rules \
-      --replace /bin/sh ${stdenv.shell} \
-      --replace /usr/sbin/ethtool ${ethtool}/sbin/ethtool \
-      --replace /bin/sed ${gnused}/bin/sed
-    substituteInPlace data/NetworkManager.service.in \
-      --replace /bin/kill ${coreutils}/bin/kill
     # to enable link-local connections
     configureFlags="$configureFlags --with-udev-dir=$out/lib/udev"
 
@@ -66,14 +58,10 @@ in stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # https://bugzilla.gnome.org/show_bug.cgi?id=796751
-    (fetchpatch {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=372953;
-      sha256 = "0xg7bzs6dvkbv2qp67i7mi1c5yrmfd471xgmlkn15b33pqkzy3mc";
-    })
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit inetutils kmod openconnect;
+      inherit inetutils kmod openconnect ethtool coreutils dbus;
+      inherit (stdenv) shell;
     })
 
   ];

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -1,17 +1,52 @@
 --- a/clients/common/nm-vpn-helpers.c
 +++ b/clients/common/nm-vpn-helpers.c
-@@ -205,7 +205,7 @@
- 	char *argv[4];
- 	const char *path;
+@@ -214,10 +214,7 @@
+ 		NULL,
+ 	};
  
--	path = nm_utils_find_helper ("openconnect", "/usr/sbin/openconnect", error);
+-	path = nm_utils_file_search_in_paths ("openconnect", "/usr/sbin/openconnect", DEFAULT_PATHS,
+-	                                      G_FILE_TEST_IS_EXECUTABLE, NULL, NULL, error);
+-	if (!path)
+-		return FALSE;
 +	path = "@openconnect@/bin/openconnect";
- 	if (!path)
- 		return FALSE;
  
+ 	argv[0] = (char *) path;
+ 	argv[1] = "--authenticate";
+--- a/data/84-nm-drivers.rules
++++ b/data/84-nm-drivers.rules
+@@ -7,6 +7,6 @@
+ # Determine ID_NET_DRIVER if there's no ID_NET_DRIVER or DRIVERS (old udev?)
+ ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
+ DRIVERS=="?*", GOTO="nm_drivers_end"
+-PROGRAM="/bin/sh -c 'ethtool -i $1 | sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
++PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @coreutils@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
+ 
+ LABEL="nm_drivers_end"
+--- a/data/90-nm-thunderbolt.rules
++++ b/data/90-nm-thunderbolt.rules
+@@ -5,7 +5,7 @@
+ 
+ # Load he thunderbolt-net driver if we a device of type thunderbolt_xdomain
+ # is added.
+-SUBSYSTEM=="thunderbolt", ENV{DEVTYPE}=="thunderbolt_xdomain", RUN{builtin}+="kmod load thunderbolt-net"
++SUBSYSTEM=="thunderbolt", ENV{DEVTYPE}=="thunderbolt_xdomain", RUN{builtin}+="@kmod@/bin/kmod load thunderbolt-net"
+ 
+ # For all thunderbolt network devices, we want to enable link-local configuration
+ SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="thunderbolt-net", ENV{NM_AUTO_DEFAULT_LINK_LOCAL_ONLY}="1"
+--- a/data/NetworkManager.service.in
++++ b/data/NetworkManager.service.in
+@@ -8,7 +8,7 @@
+ [Service]
+ Type=dbus
+ BusName=org.freedesktop.NetworkManager
+-ExecReload=/usr/bin/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager.Reload uint32:0
++ExecReload=@dbus@/bin/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager.Reload uint32:0
+ #ExecReload=/bin/kill -HUP $MAINPID
+ ExecStart=@sbindir@/NetworkManager --no-daemon
+ Restart=on-failure
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -11828,14 +11828,14 @@
+@@ -12350,14 +12350,14 @@
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
@@ -30,7 +65,7 @@
  		}
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
-@@ -428,7 +428,7 @@
+@@ -421,7 +421,7 @@
  
  	/* construct the argument list */
  	argv = g_ptr_array_sized_new (4);


### PR DESCRIPTION
###### Motivation for this change

* https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.14.4/NEWS

1.12.4 info:
* https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.12.4/NEWS
* https://gitlab.freedesktop.org/NetworkManager/NetworkManager/tags/1.12.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---