### PR TITLE
dragonfly-reverb: 0.9.4 -> 1.0.0

### DIFF
--- a/pkgs/applications/audio/dragonfly-reverb/default.nix
+++ b/pkgs/applications/audio/dragonfly-reverb/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "michaelwillis";
     repo = "dragonfly-reverb";
-    rev = "0.9.4";
-    sha256 = "0lc45jybjwg4wrcz4s9lvzpvqawgj825rkqhz2xxvalfbvjazi53";
+    rev = "1.0.0";
+    sha256 = "05m4hd8lg0a7iiia6cbiw5qmc4p8vbkxp2qh7ywaabawiwa9r24x";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

