### PR TITLE
(18.09) postgresql: Enable systemd integration for 9.6+

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -238,6 +238,9 @@ in
             User = "postgres";
             Group = "postgres";
             PermissionsStartOnly = true;
+            Type = if lib.versionAtLeast cfg.package.version "9.6"
+                   then "notify"
+                   else "simple";
 
             # Shut down Postgres using SIGINT ("Fast Shutdown mode").  See
             # http://www.postgresql.org/docs/current/static/server-shutdown.html

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -16,7 +16,8 @@ let
     setOutputFlags = false; # $out retains configureFlags :-/
 
     buildInputs =
-      [ zlib readline openssl libxml2 makeWrapper systemd ]
+      [ zlib readline openssl libxml2 makeWrapper ]
+      ++ lib.optionals (atLeast "9.6" && !stdenv.isDarwin) [ systemd ]
       ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
 
     enableParallelBuilding = true;


### PR DESCRIPTION
I'd really like to backport this one to 18.09 as it improves reliability.

I ran PostgreSQL nixos tests and will run this from today on in production (on top of 18.09). So give it a day or so.

EDIT: sorry for mass spam :(