### PR TITLE
pythonPackages.sure: 1.2.24 -> 1.4.11

### DIFF
--- a/pkgs/development/python-modules/sure/default.nix
+++ b/pkgs/development/python-modules/sure/default.nix
@@ -1,31 +1,28 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, nose
+, rednose
 , six
 , mock
-, pkgs
 , isPyPy
 }:
 
 buildPythonPackage rec {
   pname = "sure";
-  version = "1.2.24";
+  version = "1.4.11";
   disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1lyjq0rvkbv585dppjdq90lbkm6gyvag3wgrggjzyh7cpyh5c12w";
+    sha256 = "3c8d5271fb18e2c69e2613af1ad400d8df090f1456081635bd3171847303cdaa";
   };
 
-  LC_ALL="en_US.UTF-8";
-
-  buildInputs = [ nose pkgs.glibcLocales ];
+  buildInputs = [ rednose ];
   propagatedBuildInputs = [ six mock ];
 
   meta = with stdenv.lib; {
     description = "Utility belt for automated testing";
-    homepage = https://falcao.it/sure/;
+    homepage = https://sure.readthedocs.io/en/latest/;
     license = licenses.gpl3Plus;
   };
 


### PR DESCRIPTION
Fix broken python package `sure`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

