### PR TITLE
spdlog: 0.14.0 -> 0.17.0 & 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -15,7 +15,7 @@ let
 
       nativeBuildInputs = [ cmake ];
 
-      # cmakeFlags = [ "-DSPDLOG_BUILD_EXAMPLES=ON" ];
+      cmakeFlags = [ "-DSPDLOG_BUILD_EXAMPLES=OFF" ];
 
       outputs = [ "out" "doc" ];
 
@@ -35,12 +35,12 @@ let
 in
 {
   spdlog_1 = generic {
-    version = "1.1.0";
-    sha256 = "0yckz5w02v8193jhxihk9v4i8f6jafyg2a33amql0iclhk17da8f";
+    version = "1.2.1";
+    sha256 = "0gdj8arfz4r9419zbcxk9y9nv47qr7kyjjzw9m3ijgmn2pmxk88n";
   };
 
   spdlog_0 = generic {
-    version = "0.14.0";
-    sha256 = "13730429gwlabi432ilpnja3sfvy0nn2719vnhhmii34xcdyc57q";
+    version = "0.17.0";
+    sha256 = "112kfh4fbpm5cvrmgbgz4d8s802db91mhyjpg7cwhlywffnzkwr9";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

