### PR TITLE
jfsutils: fix cross compilation

### DIFF
--- a/pkgs/tools/filesystems/jfsutils/ar-fix.patch
+++ b/pkgs/tools/filesystems/jfsutils/ar-fix.patch
@@ -1,0 +1,10 @@
+--- jfsutils-1.1.15/configure.in.orig	2018-11-27 20:46:55.830242385 +0300
++++ jfsutils-1.1.15/configure.in	2018-11-27 20:47:00.596307630 +0300
+@@ -15,6 +15,7 @@
+ AC_PATH_PROG(LN, ln, ln)
+ AC_PROG_LN_S
+ AC_PROG_RANLIB
++AM_PROG_AR
+ 
+ dnl Checks for header files.
+ AC_HEADER_STDC

--- a/pkgs/tools/filesystems/jfsutils/default.nix
+++ b/pkgs/tools/filesystems/jfsutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libuuid }:
+{ stdenv, fetchurl, libuuid, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "jfsutils-1.1.15";
@@ -8,8 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "0kbsy2sk1jv4m82rxyl25gwrlkzvl3hzdga9gshkxkhm83v1aji4";
   };
 
-  patches = [ ./types.patch ./hardening-format.patch ];
+  patches = [ ./types.patch ./hardening-format.patch ./ar-fix.patch ];
 
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libuuid ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/51126

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

