### PR TITLE
Adding xnd packages: libndtypes, ndtypes, libxnd, xnd, libgumath, gumath

### DIFF
--- a/pkgs/development/libraries/libgumath/default.nix
+++ b/pkgs/development/libraries/libgumath/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitHub
+, libndtypes
+, libxnd
+}:
+
+stdenv.mkDerivation rec {
+  name = "libgumath-${version}";
+  version = "unstable-2018-11-27";
+
+  src = fetchFromGitHub {
+    owner = "plures";
+    repo = "gumath";
+    rev = "5a9d27883b40432246d6a93cd6133157267fd166";
+    sha256 = "0w2qzp7anxd1wzkvv5r2pdkkpgrnqzgrq47lrvpqc1i1wqzcwf0w";
+  };
+
+  buildInputs = [ libndtypes libxnd ];
+
+  # Override linker with cc (symlink to either gcc or clang)
+  # Library expects to use cc for linking
+  configureFlags = [
+    "LD=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Library supporting function dispatch on general data containers. C base and Python wrapper";
+    homepage = https://xnd.io/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/libraries/libndtypes/default.nix
+++ b/pkgs/development/libraries/libndtypes/default.nix
@@ -1,27 +1,28 @@
-{ lib
-, stdenv
+{ stdenv
 , fetchFromGitHub
 }:
 
 stdenv.mkDerivation rec {
   name = "libndtypes-${version}";
-  version = "0.2.0dev3";
+  version = "unstable-2018-11-27";
 
   src = fetchFromGitHub {
     owner = "plures";
     repo = "ndtypes";
-    rev = "v${version}";
-    sha256 = "0dpvv13mrid8l5zkjlz18qvirz3nr0v98agx9bcvkqbiahlfgjli";
+    rev = "4d810d0c4d54c81a7136f313f0ae6623853d574a";
+    sha256 = "1kk1sa7f17ffh49jc1qlizlsj536fr3s4flb6x4rjyi81rp7psb9";
   };
 
   # Override linker with cc (symlink to either gcc or clang)
   # Library expects to use cc for linking
   configureFlags = [ "LD=${stdenv.cc.targetPrefix}cc" ];
 
-  meta = {
+  doCheck = true;
+
+  meta = with stdenv.lib; {
     description = "Dynamic types for data description and in-memory computations";
     homepage = https://xnd.io/;
-    license = lib.licenses.bsdOriginal;
-    maintainers = with lib.maintainers; [ costrouc ];
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
   };
 }

--- a/pkgs/development/libraries/libxnd/default.nix
+++ b/pkgs/development/libraries/libxnd/default.nix
@@ -6,23 +6,32 @@
 
 stdenv.mkDerivation rec {
   name = "libxnd-${version}";
-  version = "0.2.0dev3";
+  version = "unstable-2018-11-27";
 
   src = fetchFromGitHub {
     owner = "plures";
     repo = "xnd";
-    rev = "v${version}";
-    sha256 = "0byq7jspyr2wxrhihw4q7nf0y4sb6j5ax0ndd5dnq5dz88c7qqm2";
+    rev = "8a9f3bd1d01d872828b40bc9dbd0bc0184524da3";
+    sha256 = "10jh2kqvhpzwy50adayh9az7z2lm16yxy4flrh99alzzbqdyls44";
   };
 
   buildInputs = [ libndtypes ];
 
   # Override linker with cc (symlink to either gcc or clang)
   # Library expects to use cc for linking
-  configureFlags = [ "LD=${stdenv.cc.targetPrefix}cc" ];
+  configureFlags = [
+      # Override linker with cc (symlink to either gcc or clang)
+      # Library expects to use cc for linking
+      "LD=${stdenv.cc.targetPrefix}cc"
+      # needed for tests
+      "--with-includes=${libndtypes}/include"
+      "--with-libs=${libndtypes}/lib"
+  ];
+
+  doCheck = true;
 
   meta = {
-    description = "General container that maps a wide range of Python values directly to memory";
+    description = "C library for managing typed memory blocks and Python container module";
     homepage = https://xnd.io/;
     license = lib.licenses.bsdOriginal;
     maintainers = with lib.maintainers; [ costrouc ];

--- a/pkgs/development/python-modules/gumath/default.nix
+++ b/pkgs/development/python-modules/gumath/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, numba
+, ndtypes
+, xnd
+, libndtypes
+, libxnd
+, libgumath
+, isPy27
+}:
+
+buildPythonPackage {
+  pname = "gumath";
+  disabled = isPy27;
+  inherit (libgumath) src version meta;
+
+  checkInputs = [ numba ];
+  propagatedBuildInputs = [ ndtypes xnd ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'add_include_dirs = [".", "libgumath", "ndtypes/python/ndtypes", "xnd/python/xnd"] + INCLUDES' \
+                'add_include_dirs = [".", "${libndtypes}/include", "${libxnd}/include", "${libgumath}/include"]' \
+      --replace 'add_library_dirs = ["libgumath", "ndtypes/libndtypes", "xnd/libxnd"] + LIBS' \
+                'add_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib", "${libgumath}/lib"]' \
+      --replace 'add_runtime_library_dirs = ["$ORIGIN"]' \
+                'add_runtime_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib", "${libgumath}/lib"]'
+  '';
+}

--- a/pkgs/development/python-modules/ndtypes/default.nix
+++ b/pkgs/development/python-modules/ndtypes/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, libndtypes
+, isPy27
+}:
+
+buildPythonPackage {
+  pname = "ndtypes";
+  disabled = isPy27;
+  inherit (libndtypes) version src meta;
+
+  propagatedBuildInputs = [ numpy ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'include_dirs = ["libndtypes"]' \
+                'include_dirs = ["${libndtypes}/include"]' \
+      --replace 'library_dirs = ["libndtypes"]' \
+                'library_dirs = ["${libndtypes}/lib"]' \
+      --replace 'runtime_library_dirs = ["$ORIGIN"]' \
+                'runtime_library_dirs = ["${libndtypes}/lib"]'
+  '';
+
+  postInstall = ''
+    mkdir $out/include
+    cp python/ndtypes/*.h $out/include
+  '';
+}

--- a/pkgs/development/python-modules/xnd/default.nix
+++ b/pkgs/development/python-modules/xnd/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, ndtypes
+, libndtypes
+, libxnd
+, isPy27
+}:
+
+buildPythonPackage {
+  pname = "xnd";
+  disabled = isPy27;
+  inherit (libxnd) version src meta;
+
+  propagatedBuildInputs = [ ndtypes ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'include_dirs = ["libxnd", "ndtypes/python/ndtypes"] + INCLUDES' \
+                'include_dirs = ["${libndtypes}/include", "${ndtypes}/include", "${libxnd}/include"]' \
+      --replace 'library_dirs = ["libxnd", "ndtypes/libndtypes"] + LIBS' \
+                'library_dirs = ["${libndtypes}/lib", "${libxnd}/lib"]' \
+      --replace 'runtime_library_dirs = ["$ORIGIN"]' \
+                'runtime_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib"]' \
+  '';
+
+  postInstall = ''
+    mkdir $out/include
+    cp python/xnd/*.h $out/include
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3964,6 +3964,8 @@ in
 
   libhandy = callPackage ../development/libraries/libhandy { };
 
+  libgumath = callPackage ../development/libraries/libgumath { };
+
   libipfix = callPackage ../development/libraries/libipfix { };
 
   libircclient = callPackage ../development/libraries/libircclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -496,6 +496,8 @@ in {
 
   nbval = callPackage ../development/python-modules/nbval { };
 
+  ndtypes = callPackage ../development/python-modules/ndtypes { };
+
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
 
   neuron = pkgs.neuron.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2786,6 +2786,8 @@ in {
 
   xdis = callPackage ../development/python-modules/xdis { };
 
+  xnd = callPackage ../development/python-modules/xnd { };
+
   uncompyle6 = callPackage ../development/python-modules/uncompyle6 { };
 
   lsi = callPackage ../development/python-modules/lsi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -418,6 +418,8 @@ in {
 
   guestfs = callPackage ../development/python-modules/guestfs { };
 
+  gumath = callPackage ../development/python-modules/gumath { };
+
   h5py = callPackage ../development/python-modules/h5py {
     hdf5 = pkgs.hdf5;
   };


### PR DESCRIPTION
###### Motivation for this change

Packages that have hopes of being a future replacement for numpy.

###### Things done


libgumath: init at unstable-2018-11-27 

libxnd: 0.2.0dev3 -> unstable-2018-11-27 

libndtypes: 0.2.0dev3 -> unstable-2018-11-27 

pythonPackages.ndtypes: init at unstable-2018-11-27 

pythonPackages.xnd: init at unstable-2018-11-27 

pythonPackages.gumath: init at unstable-2018-11-27 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

