### PR TITLE
yaru: init at 18.10.7

### DIFF
--- a/pkgs/misc/themes/yaru/default.nix
+++ b/pkgs/misc/themes/yaru/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, meson, ninja, sassc, gtk3, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "yaru-theme-${version}";
+  version = "18.10.7";
+
+  src = fetchFromGitHub {
+    owner = "ubuntu";
+    repo = "yaru";
+    rev = version;
+    sha256 = "1aryri3jk16yrgrhr6c16lfci16cknra28h4k02kfxb51xx7ih60";
+  };
+
+  nativeBuildInputs = [ meson ninja sassc python3 ];
+  buildInputs = [ gtk3 ];
+
+  postPatch = ''
+    for x in icons/meson/post_install.py sessions/meson/{compile-schemas,install-dock-override}; do
+      chmod +x $x
+      patchShebangs $x
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ubuntu community theme";
+    homepage = https://github.com/ubuntu/yaru;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.dtzWill ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22822,6 +22822,8 @@ with pkgs;
 
   yara = callPackage ../tools/security/yara { };
 
+  yaru-theme = callPackage ../misc/themes/yaru { };
+
   yaxg = callPackage ../tools/graphics/yaxg {};
 
   zap = callPackage ../tools/networking/zap { };


### PR DESCRIPTION
###### Motivation for this change

Community theme(s) from Ubuntu.

GTK and icon themes (Saru?) appear to work.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---