### PR TITLE
Backport: Ghc 8.4.4 default 18.09

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -1,6 +1,6 @@
 # pkgs/development/haskell-modules/configuration-hackage2nix.yaml
 
-compiler: ghc-8.4.3
+compiler: ghc-8.4.4
 
 core-packages:
   - array-0.5.2.0
@@ -12,12 +12,12 @@ core-packages:
   - deepseq-1.4.3.0
   - directory-1.3.1.5
   - filepath-1.4.2
-  - ghc-8.4.3
-  - ghc-boot-8.4.3
-  - ghc-boot-th-8.4.3
+  - ghc-8.4.4
+  - ghc-boot-8.4.4
+  - ghc-boot-th-8.4.4
   - ghc-compact-0.1.0.0
   - ghc-prim-0.5.2.0
-  - ghci-8.4.3
+  - ghci-8.4.4
   - haskeline-0.7.4.2
   - hpc-0.6.0.3
   - integer-gmp-1.0.2.0
@@ -26,10 +26,10 @@ core-packages:
   - pretty-1.1.3.6
   - process-1.6.3.0
   - rts-1.0
-  - stm-2.4.5.0
+  - stm-2.4.5.1
   - template-haskell-2.13.0.0
   - terminfo-0.4.1.1
-  - text-1.2.3.0
+  - text-1.2.3.1
   - time-1.8.0.2
   - transformers-0.5.5.0
   - unix-2.7.2.2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6717,7 +6717,7 @@ with pkgs;
 
   haskell = callPackage ./haskell-packages.nix { };
 
-  haskellPackages = haskell.packages.ghc843.override {
+  haskellPackages = haskell.packages.ghc844.override {
     overrides = config.haskellPackageOverrides or haskell.packageOverrides;
   };
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -108,7 +108,7 @@ in {
       stage0 = ../development/compilers/ghcjs-ng/8.2/stage0.nix;
     };
     ghcjs84 = callPackage ../development/compilers/ghcjs-ng {
-      bootPkgs = packages.ghc843;
+      bootPkgs = packages.ghc844;
       ghcjsSrcJson = ../development/compilers/ghcjs-ng/8.4/git.json;
       stage0 = ../development/compilers/ghcjs-ng/8.4/stage0.nix;
       ghcjsDepOverrides = callPackage ../development/compilers/ghcjs-ng/8.4/dep-overrides.nix {};


### PR DESCRIPTION
###### Motivation for this change

Backporting the minor update to GHC 8.4.4 as the default to 18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

