### PR TITLE
gitAndTools.git-reparent: init at 2018-11-27

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -94,6 +94,8 @@ let
 
   git-remote-hg = callPackage ./git-remote-hg { };
 
+  git-reparent = callPackage ./git-reparent { };
+
   git-secret = callPackage ./git-secret { };
 
   git-secrets = callPackage ./git-secrets { };

--- a/pkgs/applications/version-management/git-and-tools/git-reparent/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-reparent/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, makeWrapper, git, gnused }:
+
+stdenv.mkDerivation rec {
+  name = "git-reparent-${version}";
+  version = "2017-09-03";
+
+  src = fetchFromGitHub {
+    owner  = "MarkLodato";
+    repo   = "git-reparent";
+    rev    = "a99554a32524a86421659d0f61af2a6c784b7715";
+    sha256 = "0v0yxydpw6r4awy0hb7sbnh520zsk86ibzh1xjf3983yhsvkfk5v";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -m755 -Dt $out/bin git-reparent
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/git-reparent --prefix PATH : "${stdenv.lib.makeBinPath [ git gnused ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Git command to recommit HEAD with a new set of parents";
+    maintainers = [ maintainers.marsam ];
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

