### PR TITLE
Fix FAT32 partition issues on sd-image-based images

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -134,7 +134,7 @@ in
         ${config.sdImage.populateBootCommands}
 
         # Copy the populated /boot into the SD image
-        (cd boot; mcopy -bpsvm -i ../bootpart.img ./* ::)
+        (cd boot; mcopy -psvm -i ../bootpart.img ./* ::)
         # Verify the FAT partition before copying it.
         fsck.vfat -vn bootpart.img
         dd conv=notrunc if=bootpart.img of=$img seek=$START count=$SECTORS

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -135,6 +135,8 @@ in
 
         # Copy the populated /boot into the SD image
         (cd boot; mcopy -bpsvm -i ../bootpart.img ./* ::)
+        # Verify the FAT partition before copying it.
+        fsck.vfat -vn bootpart.img
         dd conv=notrunc if=bootpart.img of=$img seek=$START count=$SECTORS
       '';
     }) {};


### PR DESCRIPTION
###### Motivation for this change

Fixes #51150.

The main issue:

```
[...]
  Bad short file name (.).
  Auto-renaming it.
  Renamed to FSCK0000.000
```

Is already fixed using `mtools-4.0.21`. For `release-18.09` its update will need to be backported (#51159).

* * *

This fixes the seemingly-always-existing issue where the FAT32 partition was subtly broken by `mtools`. It wouldn't pass an `fsck`, even when freshly made. See #51150 for investigation details, and see commit messages for fixes details.

To ensure no regression with regards to the integrity of the boot partition, an `fsck` pass is now made just after copying the files. This will add a negligible amount of time to the whole build process, but will ensure tools will be able to manipulate the boot partition with success.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


cc @dezgeg @tilpner @bennofs 
