### PR TITLE
aminal: init at 0.7.4

### DIFF
--- a/pkgs/applications/misc/aminal/default.nix
+++ b/pkgs/applications/misc/aminal/default.nix
@@ -1,0 +1,75 @@
+{ buildGoPackage
+, Carbon
+, Cocoa
+, Kernel
+, cf-private
+, fetchFromGitHub
+, lib
+, mesa_glu
+, stdenv
+, xorg
+}:
+
+buildGoPackage rec {
+  name = "aminal-${version}";
+  version = "0.7.4";
+
+  goPackagePath = "github.com/liamg/aminal";
+
+  buildInputs =
+    lib.optionals stdenv.isLinux [
+      mesa_glu
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXi
+      xorg.libXinerama
+      xorg.libXrandr
+      xorg.libXxf86vm
+    ] ++ lib.optionals stdenv.isDarwin [
+      Carbon
+      Cocoa
+      Kernel
+      cf-private  /* Needed for NSDefaultRunLoopMode */
+    ];
+
+  src = fetchFromGitHub {
+    owner = "liamg";
+    repo = "aminal";
+    rev = "v${version}";
+    sha256 = "0wnzxjlv98pi3gy4hp3d19pwpa4kf1h5rqy03s9bcqdbpb1v1b7v";
+  };
+
+  preBuild = ''
+    buildFlagsArray=("-ldflags=-X ${goPackagePath}/version.Version=${version}")
+  '';
+
+  meta = with lib; {
+    description = "Golang terminal emulator from scratch";
+    longDescription = ''
+      Aminal is a modern terminal emulator for Mac/Linux implemented in Golang
+      and utilising OpenGL.
+
+      The project is experimental at the moment, so you probably won't want to
+      rely on Aminal as your main terminal for a while.
+
+      Features:
+      - Unicode support
+      - OpenGL rendering
+      - Customisation options
+      - True colour support
+      - Support for common ANSI escape sequences a la xterm
+      - Scrollback buffer
+      - Clipboard access
+      - Clickable URLs
+      - Multi platform support (Windows coming soon...)
+      - Sixel support
+      - Hints/overlays
+      - Built-in patched fonts for powerline
+      - Retina display support
+    '';
+    homepage = https://github.com/liamg/aminal;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19319,6 +19319,11 @@ with pkgs;
     vte = gnome3.vte;
   };
 
+  aminal = callPackage ../applications/misc/aminal {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa Kernel;
+    inherit (darwin) cf-private;
+  };
+
   termite-unwrapped = callPackage ../applications/misc/termite {
     vte = gnome3.vte-ng;
   };


### PR DESCRIPTION
###### Motivation for this change

Nice terminal emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build aminal