### PR TITLE
sqlcheck: init at 1.2

### DIFF
--- a/pkgs/development/tools/database/sqlcheck/default.nix
+++ b/pkgs/development/tools/database/sqlcheck/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "sqlcheck-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "jarulraj";
+    repo = "sqlcheck";
+    rev = "v${version}";
+    sha256 = "0v8idyhwhbphxzmh03lih3wd9gdq317zn7wsf01infih7b6l0k69";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Automatically identify anti-patterns in SQL queries";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8977,6 +8977,8 @@ with pkgs;
 
   spoofer-gui = callPackage ../tools/networking/spoofer { withGUI = true; };
 
+  sqlcheck = callPackage ../development/tools/database/sqlcheck { };
+
   sqlitebrowser = libsForQt5.callPackage ../development/tools/database/sqlitebrowser { };
 
   sqlite-web = callPackage ../development/tools/database/sqlite-web { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

