### PR TITLE
swig: fix cross compilation

### DIFF
--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre, buildPackages }:
 
 stdenv.mkDerivation rec {
   name = "swig-${version}";
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1wyffskbkzj5zyhjnnpip80xzsjcr3p0q5486z3wdwabnysnhn8n";
   };
 
+  # for cross-compiling we need pcre.dev in nativeBuildInputs to get pcre-config
   nativeBuildInputs = [ autoconf automake libtool bison pcre.dev ];
+  disallowedReferences = [ buildPackages.pcre.dev ];
+
   buildInputs = [ pcre ];
 
   configureFlags = [ "--without-tcl" ];

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wyffskbkzj5zyhjnnpip80xzsjcr3p0q5486z3wdwabnysnhn8n";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool bison ];
+  nativeBuildInputs = [ autoconf automake libtool bison pcre.dev ];
   buildInputs = [ pcre ];
 
   configureFlags = [ "--without-tcl" ];


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/51171

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

