### PR TITLE
treewide: cross-fixes

### DIFF
--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 
 , meson
 , ninja
@@ -20,6 +21,13 @@ stdenv.mkDerivation rec {
     url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${name}.tar.bz2";
     sha256 = "1kp4b1hpx2ky20ixgy2xhj5iygfl7ps5k9kglh1z5i7mhykg4r3a";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/fribidi/fribidi/pull/88.patch";
+      sha256 = "1n4l6333vhbxfckwg101flmvq6bbygg66fjp69ddcjqaqb6gh9k9";
+    })
+  ];
 
   postPatch = ''
     patchShebangs test

--- a/pkgs/development/libraries/ilmbase/cross.patch
+++ b/pkgs/development/libraries/ilmbase/cross.patch
@@ -1,0 +1,35 @@
+From: Helmut Grohne <>
+Subject: compile build tools with the build architecture compiler
+
+Patch-Source: https://github.com/openexr/openexr/issues/221
+
+Index: ilmbase-2.2.0/configure.ac
+===================================================================
+--- ilmbase-2.2.0.orig/configure.ac
++++ ilmbase-2.2.0/configure.ac
+@@ -28,6 +28,7 @@
+ AC_PROG_LN_S
+ AC_PROG_LIBTOOL
+ AC_PROG_MAKE_SET
++AX_PROG_CXX_FOR_BUILD
+ 
+ dnl
+ dnl PKGCONFIG preparations
+Index: ilmbase-2.2.0/Half/Makefile.am
+===================================================================
+--- ilmbase-2.2.0.orig/Half/Makefile.am
++++ ilmbase-2.2.0/Half/Makefile.am
+@@ -17,9 +17,11 @@
+ 
+ CLEANFILES = eLut eLut.h toFloat toFloat.h
+ 
+-eLut_SOURCES = eLut.cpp
++eLut$(EXEEXT): eLut.cpp
++	$(CXX_FOR_BUILD) $(CXXFLAGS_FOR_BUILD) $< -o $@
+ 
+-toFloat_SOURCES = toFloat.cpp
++toFloat$(EXEEXT): toFloat.cpp
++	$(CXX_FOR_BUILD) $(CXXFLAGS_FOR_BUILD) $< -o $@
+ 
+ eLut.h:	eLut
+ 	./eLut > eLut.h

--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, automake, autoconf, libtool, which }:
+{ stdenv, fetchurl, buildPackages, automake, autoconf, libtool, which }:
 
 stdenv.mkDerivation rec {
   name = "ilmbase-${version}";
@@ -16,11 +16,12 @@ stdenv.mkDerivation rec {
     ./bootstrap
   '';
 
-  buildInputs = [ automake autoconf libtool which ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ automake autoconf libtool which ];
 
   NIX_CFLAGS_LINK = [ "-pthread" ];
 
-  patches = [ ./bootstrap.patch ];
+  patches = [ ./bootstrap.patch ./cross.patch ];
 
   # fails 1 out of 1 tests with
   # "lt-ImathTest: testBoxAlgo.cpp:892: void {anonymous}::boxMatrixTransform(): Assertion `b21 == b2' failed"

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -60,7 +60,9 @@ stdenv.mkDerivation rec {
     ++ optional (libpaper != null) "--enable-libpaper"
     ++ optional stdenv.isDarwin "--disable-launchd";
 
+  # AR has to be an absolute path
   preConfigure = ''
+    export AR="${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
     configureFlagsArray+=(
       # Put just lib/* and locale into $lib; this didn't work directly.
       # lib/cups is moved back to $out in postInstall.

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1248,7 +1248,7 @@ lib.makeScope newScope (self: with self; {
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
 
-  libxcb = callPackage ({ stdenv, pkgconfig, fetchurl, libxslt, libpthreadstubs, python, libXau, xcbproto, libXdmcp }: stdenv.mkDerivation {
+  libxcb = callPackage ({ stdenv, pkgconfig, fetchurl, libxslt, libpthreadstubs, libXau, xcbproto, libXdmcp, python }: stdenv.mkDerivation {
     name = "libxcb-1.13.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1256,8 +1256,8 @@ lib.makeScope newScope (self: with self; {
       sha256 = "1i27lvrcsygims1pddpl5c4qqs6z715lm12ax0n3vx0igapvg7x8";
     };
     hardeningDisable = [ "bindnow" "relro" ];
-    nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ libxslt libpthreadstubs python libXau xcbproto libXdmcp ];
+    nativeBuildInputs = [ pkgconfig python ];
+    buildInputs = [ libxslt libpthreadstubs libXau xcbproto libXdmcp ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
 
@@ -1594,8 +1594,8 @@ lib.makeScope newScope (self: with self; {
       sha256 = "1qdxw9syhbvswiqj5dvj278lrmfhs81apzmvx6205s4vcqg7563v";
     };
     hardeningDisable = [ "bindnow" "relro" ];
-    nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ python ];
+    nativeBuildInputs = [ pkgconfig python ];
+    buildInputs = [ ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -23,6 +23,7 @@ my %pkgURLs;
 my %pkgHashes;
 my %pkgNames;
 my %pkgRequires;
+my %pkgNativeRequires;
 
 my %pcMap;
 
@@ -106,6 +107,7 @@ while (<>) {
     my $provides = `find $pkgDir -name "*.pc.in"`;
     my @provides2 = split '\n', $provides;
     my @requires = ();
+    my @nativeRequires = ();
 
     foreach my $pcFile (@provides2) {
         my $pc = $pcFile;
@@ -163,7 +165,7 @@ while (<>) {
     }
 
     if ($file =~ /AM_PATH_PYTHON/) {
-        push @requires, "python";
+        push @nativeRequires, "python";
     }
 
     if ($file =~ /AC_PATH_PROG\(FCCACHE/) {
@@ -230,7 +232,9 @@ while (<>) {
     push @requires, "gperf", "m4", "xproto" if $pkg =~ /xcbutil/;
 
     print "REQUIRES $pkg => @requires\n";
+    print "NATIVE_REQUIRES $pkg => @nativeRequires\n";
     $pkgRequires{$pkg} = \@requires;
+    $pkgNativeRequires{$pkg} = \@nativeRequires;
 
     print "done\n";
 }
@@ -255,6 +259,20 @@ EOF
 foreach my $pkg (sort (keys %pkgURLs)) {
     print "$pkg\n";
 
+    my %nativeRequires = ();
+    my @nativeBuildInputs;
+    foreach my $req (sort @{$pkgNativeRequires{$pkg}}) {
+        if (defined $pcMap{$req}) {
+            # Some packages have .pc that depends on itself.
+            next if $pcMap{$req} eq $pkg;
+            if (!defined $nativeRequires{$pcMap{$req}}) {
+                push @nativeBuildInputs, $pcMap{$req};
+                $nativeRequires{$pcMap{$req}} = 1;
+            }
+        } else {
+            print "  NOT FOUND: $req\n";
+        }
+    }
     my %requires = ();
     my @buildInputs;
     foreach my $req (sort @{$pkgRequires{$pkg}}) {
@@ -270,9 +288,11 @@ foreach my $pkg (sort (keys %pkgURLs)) {
         }
     }
 
+    my $nativeBuildInputsStr = join "", map { $_ . " " } @nativeBuildInputs;
     my $buildInputsStr = join "", map { $_ . " " } @buildInputs;
 
     my @arguments = @buildInputs;
+    push @arguments, @nativeBuildInputs;
     unshift @arguments, "stdenv", "pkgconfig", "fetchurl";
     my $argumentsStr = join ", ", @arguments;
 
@@ -290,7 +310,7 @@ foreach my $pkg (sort (keys %pkgURLs)) {
       sha256 = "$pkgHashes{$pkg}";
     };
     hardeningDisable = [ "bindnow" "relro" ];
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkgconfig $nativeBuildInputsStr];
     buildInputs = [ $buildInputsStr];$extraAttrsStr
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,5 +1,5 @@
 { abiCompat ? null,
-  stdenv, makeWrapper, lib, fetchurl, fetchpatch,
+  stdenv, makeWrapper, lib, fetchurl, fetchpatch, buildPackages,
 
   automake, autoconf, libtool, intltool, mtdev, libevdev, libinput,
   python, freetype, tradcpp, fontconfig,
@@ -98,6 +98,7 @@ self: super:
     outputs = [ "out" "dev" "man" ];
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
     preConfigure = ''
       sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure
     '';

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -245,6 +245,8 @@ self: super:
 
   libXv = super.libXv.overrideAttrs (attrs: {
     outputs = [ "out" "dev" "devdoc" ];
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
   });
 
   libXvMC = super.libXvMC.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -2,7 +2,7 @@
   stdenv, makeWrapper, lib, fetchurl, fetchpatch, buildPackages,
 
   automake, autoconf, libtool, intltool, mtdev, libevdev, libinput,
-  python, freetype, tradcpp, fontconfig,
+  freetype, tradcpp, fontconfig,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm,
   mesa_noglu, udev, bootstrap_cmds, bison, flex, clangStdenv, autoreconfHook,
   mcpp, epoxy, openssl, pkgconfig, llvm_6,
@@ -85,13 +85,8 @@ self: super:
   });
 
   libxcb = super.libxcb.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [ python ];
     configureFlags = [ "--enable-xkb" "--enable-xinput" ];
     outputs = [ "out" "dev" "man" "doc" ];
-  });
-
-  xcbproto = super.xcbproto.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [ python ];
   });
 
   libX11 = super.libX11.overrideAttrs (attrs: {

--- a/pkgs/tools/networking/ssmtp/default.nix
+++ b/pkgs/tools/networking/ssmtp/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation {
       sed -e '/INSTALLED_CONFIGURATION_FILE/d' \
           -e 's|/lib/sendmail|$(TMPDIR)/sendmail|' \
           -i Makefile
+      substituteInPlace Makefile \
+        --replace '$(INSTALL) -s' '$(INSTALL) -s --strip-program $(STRIP)'
     '';
 
   installFlags = "etcdir=$(out)/etc";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13941,7 +13941,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa;
     inherit (darwin.apple_sdk.libs) Xplugin;
     bootstrap_cmds = if stdenv.isDarwin then darwin.bootstrap_cmds else null;
-    python = python2; # Incompatible with Python 3x
     udev = if stdenv.isLinux then udev else null;
     libdrm = if stdenv.isLinux then libdrm else null;
     abiCompat = config.xorg.abiCompat # `config` because we have no `xorg.override`

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -596,7 +596,7 @@ let
     };
 
     patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
-      substituteInPlace src/makefile --replace gcc cc \
+      substituteInPlace src/makefile \
         --replace 10.3 10.5
     '';
 
@@ -604,6 +604,8 @@ let
       makeFlagsArray=(
         LUAV=${lua.luaversion}
         PLAT=${platformString}
+        CC=''${CC}
+        LD=''${CC}
         prefix=$out
       );
     '';


### PR DESCRIPTION
###### Motivation for this change

Fixes xorg and luasocket cross builds.

Perl code could be deduplicated but not sure if worth the hassle.

Fixes #51178

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

