### PR TITLE
Fix breaking changes to make-derivation

### DIFF
--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./setup.patch;
-      version_ = "3${stdenv.lib.versions.minor python.version}";
+      version = "3${stdenv.lib.versions.minor python.version}";
     })
   ];
 

--- a/pkgs/development/python-modules/py3exiv2/setup.patch
+++ b/pkgs/development/python-modules/py3exiv2/setup.patch
@@ -3,9 +3,9 @@
 @@ -39,7 +39,7 @@
                  if '3' in l[2:]:
                      return l.replace('libboost', 'boost')
-
+ 
 -libboost = get_libboost_name()
-+libboost = 'boost_python@version_@'
-
++libboost = 'boost_python@version@'
+ 
  setup(
      name='py3exiv2',

--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -23,7 +23,7 @@ let
   };
 
   hplipState = substituteAll {
-    version_ = version;
+    inherit version;
     src = ./hplip.state;
   };
 

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -25,7 +25,7 @@ let
   };
 
   hplipState = substituteAll {
-    version_ = version;
+    inherit version;
     src = ./hplip.state;
   };
 

--- a/pkgs/misc/drivers/hplip/hplip.state
+++ b/pkgs/misc/drivers/hplip/hplip.state
@@ -1,4 +1,4 @@
 [plugin]
 installed=1
 eula=1
-version=@version_@
+version=@version@

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -96,7 +96,7 @@ rec {
                                       ++ depsHostHost ++ depsHostHostPropagated
                                       ++ buildInputs ++ propagatedBuildInputs
                                       ++ depsTargetTarget ++ depsTargetTargetPropagated) == 0;
-      runtimeSensativeIfFixedOutput = fixedOutputDrv -> !noNonNativeDeps;
+      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || stdenv.cc == null;
       supportedHardeningFlags = [ "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro" "bindnow" ];
       defaultHardeningFlags = if stdenv.targetPlatform.isMusl
                               then supportedHardeningFlags
@@ -187,7 +187,7 @@ rec {
             # suffix. But we have some weird ones with run-time deps that are
             # just used for their side-affects. Those might as well since the
             # hash can't be the same. See #32986.
-            (stdenv.hostPlatform != stdenv.buildPlatform && runtimeSensativeIfFixedOutput)
+            (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)
             ("-" + stdenv.hostPlatform.config);
 
           builder = attrs.realBuilder or stdenv.shell;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -88,7 +88,8 @@ rec {
       doCheck' = doCheck && stdenv.hostPlatform == stdenv.buildPlatform;
       doInstallCheck' = doInstallCheck && stdenv.hostPlatform == stdenv.buildPlatform;
 
-      outputs' = outputs ++ lib.optional separateDebugInfo "debug";
+      separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux;
+      outputs' = outputs ++ lib.optional separateDebugInfo' "debug";
 
       fixedOutputDrv = attrs ? outputHash;
       noNonNativeDeps = builtins.length (depsBuildTarget ++ depsBuildTargetPropagated
@@ -123,7 +124,7 @@ rec {
         [
           (map (drv: drv.__spliced.buildBuild or drv) depsBuildBuild)
           (map (drv: drv.nativeDrv or drv) nativeBuildInputs
-             ++ lib.optional separateDebugInfo ../../build-support/setup-hooks/separate-debug-info.sh
+             ++ lib.optional separateDebugInfo' ../../build-support/setup-hooks/separate-debug-info.sh
              ++ lib.optional stdenv.hostPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh)
           (map (drv: drv.__spliced.buildTarget or drv) depsBuildTarget)
         ]
@@ -181,7 +182,7 @@ rec {
         // {
           # A hack to make `nix-env -qa` and `nix search` ignore broken packages.
           # TODO(@oxij): remove this assert when something like NixOS/nix#1771 gets merged into nix.
-          name = assert validity.handled && (separateDebugInfo -> stdenv.hostPlatform.isLinux); computedName + lib.optionalString
+          name = assert validity.handled; computedName + lib.optionalString
             # Fixed-output derivations like source tarballs shouldn't get a host
             # suffix. But we have some weird ones with run-time deps that are
             # just used for their side-affects. Those might as well since the

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -81,13 +81,6 @@ rec {
     , ... } @ attrs:
 
     let
-      # Check that the name is consistent with pname and version:
-      selfConsistent = (with attrs; attrs ? "name" ->
-        (lib.assertMsg (attrs ? "version" -> lib.strings.hasInfix version name)
-          "version ${version} does not appear in name ${name}" &&
-        lib.assertMsg (attrs ? "pname" -> lib.strings.hasInfix pname name)
-          "pname ${pname} does not appear in name ${name}"));
-
       computedName = if name != "" then name else "${attrs.pname}-${attrs.version}";
 
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
@@ -188,7 +181,7 @@ rec {
         // {
           # A hack to make `nix-env -qa` and `nix search` ignore broken packages.
           # TODO(@oxij): remove this assert when something like NixOS/nix#1771 gets merged into nix.
-          name = assert selfConsistent && validity.handled && (separateDebugInfo -> stdenv.hostPlatform.isLinux); computedName + lib.optionalString
+          name = assert validity.handled && (separateDebugInfo -> stdenv.hostPlatform.isLinux); computedName + lib.optionalString
             # Fixed-output derivations like source tarballs shouldn't get a host
             # suffix. But we have some weird ones with run-time deps that are
             # just used for their side-affects. Those might as well since the


### PR DESCRIPTION
###### Motivation for this change

A few breaking changes have been introduced to make-derivation recently. IMO make-derivation shouldn't ever change in what it accepts from release to release. There's too many places where this is used both internally and externally.

So this restores a few things:

- Automatic adding host suffixes to name when a cross system exists. This should not happen with simple things like ```substituteAll``` where ```name``` is often used for things like binary names. Try cross compiling nixos-install for example.
- Don't assert when version is set but pname isn't. Again lots of places use ```substituteAll``` and the ```version``` attr. No reason to assert here.
- Don't assert when separateDebugInfo is on and we aren't on Linux. While the separate debug info only works on Linux, that doesn't mean that non-Linux stuff is "broken". You just can't generate debug outputs in this way.
