### PR TITLE
rclone: 1.44 -> 1.45

### DIFF
--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -2,15 +2,16 @@
 
 buildGoPackage rec {
   name = "rclone-${version}";
-  version = "1.44";
+  version = "1.45";
 
   goPackagePath = "github.com/ncw/rclone";
+  subPackages = [ "." ];
 
   src = fetchFromGitHub {
     owner = "ncw";
     repo = "rclone";
     rev = "v${version}";
-    sha256 = "0kpx9r4kksscsvia7r79z9h8ghph25ay9dgpqrnp599fq1bqky61";
+    sha256 = "06xg0ibv9pnrnmabh1kblvxx1pk8h5rmkr9mjbymv497sx3zgz26";
   };
 
   outputs = [ "bin" "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change
Updated to latest version. See https://rclone.org/changelog/

Also added `subPackages = [ "." ]` since otherwise we end up with a binary called `test_all` in the output.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

