### PR TITLE
brave: 0.56.12 -> 0.56.15 (70.0.3538.77 -> 70.0.3538.110)

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -74,11 +74,11 @@ let rpath = lib.makeLibraryPath [
 
 in stdenv.mkDerivation rec {
     name = "brave-${version}";
-    version = "0.56.12";
+    version = "0.56.15";
 
     src = fetchurl {
         url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-        sha256 = "1pvablwchpsm1fdhfp9kr2912yv4812r8prv5fn799qpflzxvyai";
+        sha256 = "1d18fgnxcgl95bhkgfqjyv4p81q6fciqibd3ss4vwh1ljjy1fv76";
     };
 
     dontConfigure = true;


### PR DESCRIPTION
###### Motivation for this change

TODO: incorporate https://github.com/NixOS/nixpkgs/pull/49797 later on for v0.57.x (v71 base build).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

