### PR TITLE
chromium: Add ungoogled flag to enable ungoogled-chromium patches

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -12,6 +12,7 @@
 , cupsSupport ? true
 , pulseSupport ? false
 , commandLineArgs ? ""
+, ungoogled ? false
 }:
 
 assert stdenv.cc.isClang -> (stdenv == llvmPackages.stdenv);
@@ -26,7 +27,7 @@ let
     mkChromiumDerivation = callPackage ./common.nix {
       inherit enableNaCl gnomeSupport gnome
               gnomeKeyringSupport proprietaryCodecs cupsSupport pulseSupport
-              enableWideVine;
+              enableWideVine ungoogled;
     };
 
     browser = callPackage ./browser.nix { inherit channel; };


### PR DESCRIPTION
###### Motivation for this change

Apply patches from https://github.com/Eloston/ungoogled-chromium.
~(Only one of the patches is applied for now for testing purpose)~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

