### PR TITLE
libselinux: fix cross compilation

### DIFF
--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python ];
-  buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ swig python ];
+  buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ python ];
 
   # drop fortify here since package uses it by default, leading to compile error:
   # command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]

--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -19,9 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "0mwcq78v6ngbq06xmb9dvilpg0jnl2vs9fgrpakhmmiskdvc1znh";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libsepol pcre fts ]
-             ++ optionals enablePython [ swig python ];
+  nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python ];
+  buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ swig python ];
 
   # drop fortify here since package uses it by default, leading to compile error:
   # command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]


### PR DESCRIPTION
###### Motivation for this change

Fixes the following:
```
  9981 make[1]: Leaving directory '/build/libselinux-2.7/man'
  9982 make -C src install-pywrap install-pywrap
  9983 make[1]: Entering directory '/build/libselinux-2.7/src'
  9984 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9985 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9986 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9987 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9988 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9989 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9990 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: python: command not found
  9991 bash -e exception.sh > selinuxswig_python_exception.i || (rm -f selinuxswig_python_exception.i ; false)
  9992 swig -Wall -python -o selinuxswig_wrap.c -outdir ./  -DNO_ANDROID_BACKEND selinuxswig_python.i
  9993 /nix/store/06vmwfva8phjx2s8a53xvq0p062kyqsf-bash-4.4-p23/bin/bash: swig: command not found
  9994 make[1]: *** [Makefile:169: selinuxswig_wrap.c] Error 127
  9995 make[1]: Leaving directory '/build/libselinux-2.7/src'
  9996 make: *** [Makefile:57: install-pywrap] Error 2
  9997 builder for '/nix/store/4dl2jxsfcapgkaz99ddi35bvm1b6w7a7-libselinux-2.7-armv7l-unknown-linux-gnueabihf.drv' failed with exit code 2
  9998 error: build of '/nix/store/4dl2jxsfcapgkaz99ddi35bvm1b6w7a7-libselinux-2.7-armv7l-unknown-linux-gnueabihf.drv' failed
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

