### PR TITLE
f2fs-tools: fix cross compilation

### DIFF
--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libselinux libuuid ];
 
+  patches = [ ./f2fs-tools-cross-fix.patch ];
+
   meta = with stdenv.lib; {
     homepage = http://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/;
     description = "Userland tools for the f2fs filesystem";

--- a/pkgs/tools/filesystems/f2fs-tools/f2fs-tools-cross-fix.patch
+++ b/pkgs/tools/filesystems/f2fs-tools/f2fs-tools-cross-fix.patch
@@ -1,0 +1,27 @@
+--- f2fs-tools/configure.ac.orig	2018-11-29 05:05:57.154988687 +0300
++++ f2fs-tools/configure.ac	2018-11-29 05:06:12.667316101 +0300
+@@ -20,14 +20,16 @@
+ 				[\([0-9]*\).\([0-9]*\)\(\w\|\W\)*], [\2]),
+ 				[Minor version for f2fs-tools])
+ 
+-AC_CHECK_FILE(.git,
+-	AC_DEFINE([F2FS_TOOLS_DATE],
+-		"m4_bpatsubst(f2fs_tools_gitdate,
+-		[\([0-9-]*\)\(\w\|\W\)*], [\1])",
+-		[f2fs-tools date based on Git commits]),
+-	AC_DEFINE([F2FS_TOOLS_DATE],
+-		"f2fs_tools_date",
+-		[f2fs-tools date based on Source releases]))
++dnl AC_CHECK_FILE(.git,
++dnl 	AC_DEFINE([F2FS_TOOLS_DATE],
++dnl 		"m4_bpatsubst(f2fs_tools_gitdate,
++dnl 		[\([0-9-]*\)\(\w\|\W\)*], [\1])",
++dnl 		[f2fs-tools date based on Git commits]),
++dnl 	AC_DEFINE([F2FS_TOOLS_DATE],
++dnl 		"f2fs_tools_date",
++dnl 		[f2fs-tools date based on Source releases]))
++
++AC_DEFINE([F2FS_TOOLS_DATE], "f2fs_tools_date", [f2fs-tools date based on Source releases])
+ 
+ AC_CONFIG_SRCDIR([config.h.in])
+ AC_CONFIG_HEADER([config.h])


### PR DESCRIPTION
###### Motivation for this change

Fixes:
```
 8469 configuring
 8470 fixing libtool script ./build-aux/ltmain.sh
 8471 configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/hqz4nqa2gpmhh57zwqyidgvxdxcncz5l-f2fs-tools-1.11.0-armv7l-unknown-linux-gnueabihf --build=x86_64-unknown-linux-gnu --host=armv7l-unknown-linux-gnuea\
      bihf
 8472 checking for .git... configure: error: cannot check for file existence when cross compiling
 8473 builder for '/nix/store/sp97qpr6qy1mvr05149nd9lb66zsqdy2-f2fs-tools-1.11.0-armv7l-unknown-linux-gnueabihf.drv' failed with exit code 1
 8474 error: build of '/nix/store/sp97qpr6qy1mvr05149nd9lb66zsqdy2-f2fs-tools-1.11.0-armv7l-unknown-linux-gnueabihf.drv' failed
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have disabled an autoconf macro that inserts tool date from git. This doesn't implicate any source code change.