### PR TITLE
fix: gperf 3.0 cross compilation

### DIFF
--- a/pkgs/development/tools/misc/gperf/3.0.x.nix
+++ b/pkgs/development/tools/misc/gperf/3.0.x.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{stdenv, fetchurl, autoreconfHook, autoconf }:
 
 stdenv.mkDerivation rec {
   name = "gperf-3.0.4";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0gnnm8iqcl52m8iha3sxrzrl9mcyhg7lfrhhqgdn4zj00ji14wbn";
   };
 
+  nativeBuildInputs = [ autoreconfHook ];
+  patches = [ ./gperf-ar-fix.patch ];
   meta = {
     description = "Perfect hash function generator";
 

--- a/pkgs/development/tools/misc/gperf/3.0.x.nix
+++ b/pkgs/development/tools/misc/gperf/3.0.x.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, autoreconfHook, autoconf }:
+{stdenv, fetchurl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "gperf-3.0.4";

--- a/pkgs/development/tools/misc/gperf/gperf-ar-fix.patch
+++ b/pkgs/development/tools/misc/gperf/gperf-ar-fix.patch
@@ -1,0 +1,46 @@
+--- gperf-3.0.4/lib/configure.ac	2009-01-15 02:24:31.000000000 +0200
++++ gperf-3.0.4.patched/lib/configure.ac	2018-11-29 06:37:20.968627533 +0300
+@@ -21,10 +21,12 @@
+ 
+ AC_PREREQ([2.60])
+ AC_INIT([hash.cc])
++m4_include([../aclocal.m4])
+ AC_PROG_MAKE_SET
+ dnl
+ dnl           checks for programs
+ dnl
++AC_SUBST([AR])
+ AC_PROG_CC
+                       dnl sets variable CC
+ AC_PROG_CPP
+--- gperf-3.0.4/lib/Makefile.in	2008-08-23 21:52:48.000000000 +0300
++++ gperf-3.0.4.patched/lib/Makefile.in	2018-11-29 06:36:43.161998888 +0300
+@@ -41,7 +41,7 @@
+ # Both C and C++ compiler
+ OBJEXT = @OBJEXT@
+ # Other
+-AR = ar
++AR = @AR@
+ AR_FLAGS = rc
+ RANLIB = @RANLIB@
+ MV = mv
+--- gperf-3.0.4/doc/configure.ac	2009-01-15 02:24:31.000000000 +0200
++++ gperf-3.0.4.patched/doc/configure.ac	2018-11-29 06:36:00.961288421 +0300
+@@ -21,6 +21,7 @@
+ 
+ AC_PREREQ([2.60])
+ AC_INIT([gperf.1])
++m4_include([../aclocal.m4])
+ PACKAGE=gperf
+ AC_SUBST([PACKAGE])
+ AC_PROG_MAKE_SET
+--- gperf-3.0.4/src/configure.ac	2009-01-15 02:24:30.000000000 +0200
++++ gperf-3.0.4.patched/src/configure.ac	2018-11-29 06:34:21.718576658 +0300
+@@ -21,6 +21,7 @@
+ 
+ AC_PREREQ([2.60])
+ AC_INIT([main.cc])
++m4_include([../aclocal.m4])
+ AC_CONFIG_HEADER([config.h])
+ AC_PROG_MAKE_SET
+ dnl


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/50749

This one is old and doesn't use automake so I had to resort to older methods of trade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

