### PR TITLE
libpcap: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.tcpdump.org/release/${name}.tar.gz";
-    sha256 = "18sw7nr97gfjr2rg0k82zlcllpy0ymqdknh3a2kf8qaqg100h7m4";
+    sha256 = "06bhydl4vr4z9c3vahl76f2j96z1fbrcl7wwismgs4sris08inrf";
   };
 
   nativeBuildInputs = [ flex bison ];

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, flex, bison }:
+{ stdenv, fetchurl, flex, bison }:
 
 stdenv.mkDerivation rec {
   name = "libpcap-1.9.0";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   preInstall = ''mkdir -p $out/bin'';
 
   meta = with stdenv.lib; {
-    homepage = http://www.tcpdump.org;
+    homepage = https://www.tcpdump.org;
     description = "Packet Capture Library";
     platforms = platforms.unix;
     maintainers = with maintainers; [ fpletz ];

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, fetchpatch, flex, bison }:
 
 stdenv.mkDerivation rec {
-  name = "libpcap-1.8.1";
+  name = "libpcap-1.9.0";
 
   src = fetchurl {
     url = "https://www.tcpdump.org/release/${name}.tar.gz";
-    sha256 = "07jlhc66z76dipj4j5v3dig8x6h3k6cb36kmnmpsixf3zmlvqgb7";
+    sha256 = "18sw7nr97gfjr2rg0k82zlcllpy0ymqdknh3a2kf8qaqg100h7m4";
   };
 
   nativeBuildInputs = [ flex bison ];
@@ -26,22 +26,6 @@ stdenv.mkDerivation rec {
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
   '';
-
-  patches = [
-    (fetchpatch {
-      url    = "https://sources.debian.net/data/main/libp/libpcap/1.8.1-3/debian/patches/disable-remote.diff";
-      sha256 = "0dvjax9c0spvq8cdjnkbnm65wlzaml259yragf95kzg611vszfmj";
-    })
-    # See https://github.com/wjt/bustle/commit/f62cf6bfa662af4ae39effbbd4891bc619e3b4e9
-    (fetchpatch {
-      url    = "https://github.com/the-tcpdump-group/libpcap/commit/2be9c29d45fb1fab8e9549342a30c160b7dea3e1.patch";
-      sha256 = "1g8mh942vr0abn48g0bdvi4gmhq1bz0l80276603y7064qhy3wq5";
-    })
-    (fetchpatch {
-      url    = "https://github.com/the-tcpdump-group/libpcap/commit/1a6b088a88886eac782008f37a7219a32b86da45.patch";
-      sha256 = "1n5ylm7ch3i1lh4y2q16b0vabgym8g8mqiqxpqcdkjdn05c1wflr";
-    })
-  ];
 
   preInstall = ''mkdir -p $out/bin'';
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

