### PR TITLE
set-source-date-epoch-to-latest: fix warning

### DIFF
--- a/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
+++ b/pkgs/build-support/setup-hooks/set-source-date-epoch-to-latest.sh
@@ -10,7 +10,7 @@ updateSourceDateEpoch() {
     local newestFile="${res[1]}"
 
     # Update $SOURCE_DATE_EPOCH if the most recent file we found is newer.
-    if [ "$time" -gt "$SOURCE_DATE_EPOCH" ]; then
+    if [ "${time:-0}" -gt "$SOURCE_DATE_EPOCH" ]; then
         echo "setting SOURCE_DATE_EPOCH to timestamp $time of file $newestFile"
         export SOURCE_DATE_EPOCH="$time"
 


### PR DESCRIPTION
###### Motivation for this change

If there was no older file than $NIX_BUILD_TOP this would result in a
warning, e.g. with nix-info.

```
/nix/store/15kgcm8hnd99p7plqzx7p4lcr2jni4df-set-source-date-epoch-to-latest.sh: line 13: [: : integer expression expected
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

