### PR TITLE
coqPackages.math-classes: 1.0.7 -> 8.8.1

### DIFF
--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
 
   name = "coq${coq.coq-version}-math-classes-${version}";
-  version = "1.0.7";
+  version = "8.8.1";
 
   src = fetchFromGitHub {
-    owner = "math-classes";
+    owner = "coq-community";
     repo = "math-classes";
     rev = version;
-    sha256 = "0wgnczacvkb2pc3vjbni9bwjijfyd5jcdnyyjg8185hkf9zzabgi";
+    sha256 = "05vlrrwnlfhd7l3xwn4zwpnkwvziw84zpd9775c6ffb83z48ri1r";
   };
 
   buildInputs = [ coq bignums ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

