### PR TITLE
git-secrets: install manpage

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
@@ -1,40 +1,32 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, git }:
+{ stdenv, fetchFromGitHub, makeWrapper, git, coreutils }:
 
-let
+stdenv.mkDerivation rec {
+  name = "git-secrets-${version}";
   version = "1.2.1";
-  repo = "git-secrets";
-
-in stdenv.mkDerivation {
-  name = "${repo}-${version}";
 
   src = fetchFromGitHub {
-    inherit repo;
     owner = "awslabs";
+    repo = "git-secrets";
     rev = "${version}";
     sha256 = "14jsm4ks3k5d9iq3jr23829izw040pqpmv7dz8fhmvx6qz8fybzg";
   };
 
-  buildInputs = [ makeWrapper git];
+  nativeBuildInputs = [ makeWrapper ];
 
-  # buildPhase = ''
-  #  make man # TODO: need rst2man.py
-  # '';
-  
+  dontBuild = true;
+
   installPhase = ''
-    install -D git-secrets $out/bin/git-secrets
+    install -m755 -Dt $out/bin git-secrets
+    install -m444 -Dt $out/share/man/man1 git-secrets.1
 
     wrapProgram $out/bin/git-secrets \
-      --prefix PATH : "${lib.makeBinPath [ git ]}"
-
-    # TODO: see above note on rst2man.py
-    # mkdir $out/share
-    # cp -r man $out/share
+      --prefix PATH : "${stdenv.lib.makeBinPath [ git coreutils ]}"
   '';
 
-  meta = {
-    description = "Prevents you from committing passwords and other sensitive information to a git repository";
+  meta = with stdenv.lib; {
+    description = "Prevents you from committing secrets and credentials into git repositories";
     homepage = https://github.com/awslabs/git-secrets;
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.asl20;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

