### PR TITLE
lit: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/tools/misc/lit/default.nix
+++ b/pkgs/development/tools/misc/lit/default.nix
@@ -1,10 +1,10 @@
-{ lib, python }:
+{ lib, python2 }:
 
-python.pkgs.buildPythonApplication rec {
+python2.pkgs.buildPythonApplication rec {
   pname = "lit";
   version = "0.7.0";
 
-  src = python.pkgs.fetchPypi {
+  src = python2.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "13b32f1f1b3912bbf2bda91e9d1609abc92c0b4ce83276fe13a340516252e4b0";
   };

--- a/pkgs/development/tools/misc/lit/default.nix
+++ b/pkgs/development/tools/misc/lit/default.nix
@@ -1,12 +1,12 @@
-{ lib, python2 }:
+{ lib, python }:
 
-python2.pkgs.buildPythonApplication rec {
+python.pkgs.buildPythonApplication rec {
   pname = "lit";
-  version = "0.6.0";
+  version = "0.7.0";
 
-  src = python2.pkgs.fetchPypi {
+  src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "1png3jgbhrw8a602gy6rnzvjcrj8w2p2kk6szdg9lz42zr090lgb";
+    sha256 = "13b32f1f1b3912bbf2bda91e9d1609abc92c0b4ce83276fe13a340516252e4b0";
   };
 
   # Non-standard test suite. Needs custom checkPhase.


### PR DESCRIPTION
(LLVM6 -> LLVM7)


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---