### PR TITLE
vimb: 3.1.0 -> 3.3.0

### DIFF
--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libsoup, webkit, gtk2, glib-networking
+{ stdenv, fetchFromGitHub, pkgconfig, libsoup, webkit, gtk3, glib-networking
 , gsettings-desktop-schemas, makeWrapper
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
-  buildInputs = [ gtk2 libsoup webkit gsettings-desktop-schemas ];
+  buildInputs = [ gtk3 libsoup webkit gsettings-desktop-schemas ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "vimb-${version}";
-  version = "3.1.0";
+  version = "3.3.0";
 
   src = fetchurl {
     url = "https://github.com/fanglingsu/vimb/archive/${version}.tar.gz";
-    sha256 = "1gws028c2v1zh6r142hmjvi2m447lwqqh65m6z3dzcar2yw35z3f";
+    sha256 = "0v3daxs10nndxvcpvx8377aylfdismzkys5n5cs8m89c3fdy6vsw";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, libsoup, webkit, gtk3, glib-networking
-, gsettings-desktop-schemas, makeWrapper
+, gsettings-desktop-schemas, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -13,16 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "1qg18z2gnsli9qgrqfhqfrsi6g9mcgr90w8yab28nxrq4aha6brf";
   };
 
-  nativeBuildInputs = [ makeWrapper pkgconfig ];
-  buildInputs = [ gtk3 libsoup webkit gsettings-desktop-schemas ];
+  nativeBuildInputs = [ wrapGAppsHook pkgconfig ];
+  buildInputs = [ gtk3 libsoup webkit glib-networking gsettings-desktop-schemas ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/vimb" \
-      --prefix GIO_EXTRA_MODULES : "${glib-networking.out}/lib/gio/modules" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-  '';
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = {
     description = "A Vim-like browser";

--- a/pkgs/applications/networking/browsers/vimb/default.nix
+++ b/pkgs/applications/networking/browsers/vimb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libsoup, webkit, gtk2, glib-networking
+{ stdenv, fetchFromGitHub, pkgconfig, libsoup, webkit, gtk2, glib-networking
 , gsettings-desktop-schemas, makeWrapper
 }:
 
@@ -6,13 +6,15 @@ stdenv.mkDerivation rec {
   name = "vimb-${version}";
   version = "3.3.0";
 
-  src = fetchurl {
-    url = "https://github.com/fanglingsu/vimb/archive/${version}.tar.gz";
-    sha256 = "0v3daxs10nndxvcpvx8377aylfdismzkys5n5cs8m89c3fdy6vsw";
+  src = fetchFromGitHub {
+    owner = "fanglingsu";
+    repo = "vimb";
+    rev = version;
+    sha256 = "1qg18z2gnsli9qgrqfhqfrsi6g9mcgr90w8yab28nxrq4aha6brf";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ makeWrapper gtk2 libsoup webkit gsettings-desktop-schemas ];
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
+  buildInputs = [ gtk2 libsoup webkit gsettings-desktop-schemas ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
https://github.com/fanglingsu/vimb/releases/tag/3.2.0

https://github.com/fanglingsu/vimb/releases/tag/3.3.0


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---