### PR TITLE
cht-sh: init at unstable-2018-11-02

### DIFF
--- a/pkgs/tools/misc/cht.sh/default.nix
+++ b/pkgs/tools/misc/cht.sh/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+, curl
+, ncurses
+, rlwrap
+, xsel
+}:
+
+stdenv.mkDerivation rec {
+  name = "cht.sh-${version}";
+  version = "unstable-2018-11-02";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = fetchFromGitHub {
+    owner = "chubin";
+    repo = "cheat.sh";
+    rev = "9595805ac68b3c096f7c51fa024dcb97a7dfac44";
+    sha256 = "11g8say5fksg0zg0bqrgl92rprn4lwp20g9rz1i0r38f0jy3nyrf";
+  };
+
+  # Fix ".cht.sh-wrapped" in the help message
+  postPatch = "substituteInPlace share/cht.sh.txt --replace '\${0##*/}' cht.sh";
+
+  installPhase = ''
+    install -m755 -D share/cht.sh.txt "$out/bin/cht.sh"
+    wrapProgram "$out/bin/cht.sh" \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ curl rlwrap ncurses xsel ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CLI client for cheat.sh, a community driven cheat sheet";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+    homepage = https://github.com/chubin/cheat.sh;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1168,6 +1168,8 @@ in
 
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
+  cht-sh = callPackage ../tools/misc/cht.sh { };
+
   ckbcomp = callPackage ../tools/X11/ckbcomp { };
 
   clac = callPackage ../tools/misc/clac {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

