### PR TITLE
[NOT READY TO MERGE] perceptualdiff: 1.2 -> 2.1

### DIFF
--- a/pkgs/tools/graphics/perceptualdiff/default.nix
+++ b/pkgs/tools/graphics/perceptualdiff/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, freeimage }:
+
+stdenv.mkDerivation rec {
+  pname = "perceptualdiff";
+  name = "${pname}-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "myint";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12sx2alidfba07v281jrvr5dxxsalp263x92lag6r9swj5nbbgn2";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ freeimage ];
+
+  meta = with stdenv.lib; {
+    description = "A program that compares two images using a perceptually based image metric";
+    homepage = "https://github.com/myint/perceptualdiff";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ uri-canva ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/graphics/perceptualdiff/default.nix
+++ b/pkgs/tools/graphics/perceptualdiff/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   pname = "perceptualdiff";
   name = "${pname}-${version}";
-  version = "1.2";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "myint";
     repo = pname;
     rev = "v${version}";
-    sha256 = "12sx2alidfba07v281jrvr5dxxsalp263x92lag6r9swj5nbbgn2";
+    sha256 = "176n518xv0pczf1yyz9r5a8zw5r6sh5ym596kmvw30qznp8n4a8j";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4662,6 +4662,8 @@ with pkgs;
 
   pepper = callPackage ../tools/admin/salt/pepper { };
 
+  perceptualdiff = callPackage ../tools/graphics/perceptualdiff { };
+
   percona-xtrabackup = callPackage ../tools/backup/percona-xtrabackup {
     boost = boost159;
   };


### PR DESCRIPTION
###### Motivation for this change

Based on https://github.com/NixOS/nixpkgs/pull/51244

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
