### PR TITLE
python3Packages.datrie: fix build

### DIFF
--- a/pkgs/development/python-modules/datrie/default.nix
+++ b/pkgs/development/python-modules/datrie/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest, pytestrunner, hypothesis}:
+, cython, pytest, pytestrunner, hypothesis }:
 
 buildPythonPackage rec {
   pname = "datrie";
@@ -10,7 +10,14 @@ buildPythonPackage rec {
     sha256 = "08r0if7dry2q7p34gf7ffyrlnf4bdvnprxgydlfxgfnvq8f3f4bs";
   };
 
+  nativeBuildInputs = [ cython ];
   buildInputs = [ pytest pytestrunner hypothesis ];
+
+  # recompile pxd and pyx for python37
+  # https://github.com/pytries/datrie/issues/52
+  preBuild = ''
+    ./update_c.sh
+  '';
 
   meta = with stdenv.lib; {
     description = "Super-fast, efficiently stored Trie for Python";


### PR DESCRIPTION
###### Motivation for this change

python3Packages.datrie is broken: https://hydra.nixos.org/build/84807067
Need to fix it for snakemake to build for #50900

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
