### PR TITLE
iptables: 1.6.2 -> 1.8.2

### DIFF
--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,18 +1,38 @@
-{ stdenv, fetchurl, bison, flex, pkgconfig
-, libnetfilter_conntrack, libnftnl, libmnl }:
+{ stdenv, fetchurl, fetchpatch, bison, flex, pkgconfig
+, libnetfilter_conntrack, libnftnl, libmnl, libpcap }:
 
 stdenv.mkDerivation rec {
   name = "iptables-${version}";
-  version = "1.6.2";
+  version = "1.8.2";
 
   src = fetchurl {
     url = "https://www.netfilter.org/projects/iptables/files/${name}.tar.bz2";
-    sha256 = "0crp0lvh5m2f15pr8cw97h8yb8zjj10x95zj06j46cr68vx2vl2m";
+    sha256 = "1bqj9hf3szy9r0w14iy23w00ir8448nfhpcprbwmcchsxm88nxx3";
   };
+
+  patches = [
+    # Adds missing bits to extensions' libipt_icmp.c and libip6t_icmp6.c that were causing build to fail
+    (fetchpatch {
+      url = "https://git.netfilter.org/iptables/patch/?id=907e429d7548157016cd51aba4adc5d0c7d9f816";
+      sha256 = "0vc7ljcglz5152lc3jx4p44vjfi6ipvxdrgkdb5dmkhlb5v93i2h";
+    })
+    # Build with musl libc fails because of conflicting struct ethhdr definitions
+    (fetchpatch {
+      url = "https://git.netfilter.org/iptables/patch/?id=51d374ba41ae4f1bb851228c06b030b83dd2092f";
+      sha256 = "05fwrq03f9sm0v2bfwshbrg7pi2p978w1460arnmpay3135gj266";
+    })
+    # extensions: libip6t_mh: fix bogus translation error
+    (fetchpatch {
+      url = "https://git.netfilter.org/iptables/patch/?id=5839d7fe62ff667af7132fc7d589b386951f27b3";
+      sha256 = "0578jn1ip710z9kijwg9g2vjq2kfrbafl03m1rgi4fasz215gvkf";
+    })
+    # Prevent headers collisions between linux and netfilter (in.h and in6.h)
+    (./netinet-headers-collision.patch)
+  ];
 
   nativeBuildInputs = [ bison flex pkgconfig ];
 
-  buildInputs = [ libnetfilter_conntrack libnftnl libmnl ];
+  buildInputs = [ libnetfilter_conntrack libnftnl libmnl libpcap ];
 
   preConfigure = ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -lmnl -lnftnl"
@@ -21,17 +41,18 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-devel"
     "--enable-shared"
+    "--enable-bpf-compiler"
   ];
 
   outputs = [ "out" "dev" ];
 
   meta = with stdenv.lib; {
     description = "A program to configure the Linux IP packet filtering ruleset";
-    homepage = http://www.netfilter.org/projects/iptables/index.html;
+    homepage = https://www.netfilter.org/projects/iptables/index.html;
     platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz ];
     license = licenses.gpl2;
-    downloadPage = "http://www.netfilter.org/projects/iptables/files/";
+    downloadPage = "https://www.netfilter.org/projects/iptables/files/";
     updateWalker = true;
     inherit version;
   };

--- a/pkgs/os-specific/linux/iptables/netinet-headers-collision.patch
+++ b/pkgs/os-specific/linux/iptables/netinet-headers-collision.patch
@@ -1,0 +1,11 @@
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -3,7 +3,9 @@
+ 
+ #include <linux/types.h>
+ 
++#ifndef _NETINET_IN_H
+ #include <linux/in.h>
+ #include <linux/in6.h>
++#endif
+ #include <limits.h>


### PR DESCRIPTION
###### Motivation for this change
Version bump
\+ enabled BPF compiler by default since BPF is the future of Linux packet filtering.
It adds the `nfbpf_compile` command which compiles a PCAP expression into a BPF bytecode that can then be used in a rule.

Changelog 1.8.0:
https://www.netfilter.org/projects/iptables/files/changes-iptables-1.8.0.txt

Changelog 1.8.1:
https://www.netfilter.org/projects/iptables/files/changes-iptables-1.8.1.txt

Changelog 1.8.2:
https://www.netfilter.org/projects/iptables/files/changes-iptables-1.8.2.txt

/cc @fpletz as maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```shell
$ nix path-info -sS /nix/store/mdm7f4mka3dqdkvj1nz8gckzzad1hqqq-iptables-1.6.2
/nix/store/mdm7f4mka3dqdkvj1nz8gckzzad1hqqq-iptables-1.6.2          2289496        27871656

$ nix path-info -sS /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2
/nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2          2475784        30194448

$ /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2/bin/iptables --version
iptables v1.8.2 (legacy)

$ /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2/bin/iptables-nft --version
iptables v1.8.2 (nf_tables)

$ /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2/bin/nfbpf_compile 
Usage:    /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2/bin/nfbpf_compile [link] '<program>'

          link is a pcap linklayer type:
          one of EN10MB, RAW, SLIP, ...

Examples: /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2/bin/nfbpf_compile RAW 'tcp and greater 100'
          /nix/store/5wnbybbm1nifhh4a931vb9lnrf40hz08-iptables-1.8.2/bin/nfbpf_compile EN10MB 'ip proto 47'
```