### PR TITLE
balsa: switch from enchant to gtkspell3

### DIFF
--- a/pkgs/applications/networking/mailreaders/balsa/default.nix
+++ b/pkgs/applications/networking/mailreaders/balsa/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, gtk3, gmime, gnutls,
-  webkitgtk, libesmtp, openssl, libnotify, enchant, gpgme,
+  webkitgtk, libesmtp, openssl, libnotify, gtkspell3, gpgme,
   libcanberra-gtk3, libsecret, gtksourceview, gobjectIntrospection,
   hicolor-icon-theme, wrapGAppsHook
 }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     webkitgtk
     openssl
     libnotify
-    enchant
+    gtkspell3
     gpgme
     libcanberra-gtk3
     gtksourceview
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     "--with-ssl"
     "--with-unique"
     "--without-gnome"
+    "--with-spell-checker=gtkspell"
   ];
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";


### PR DESCRIPTION

###### Motivation for this change

The build fails with enchant-1.6.1 (upgrade is in #50876) and enchant2. use gtkspell3 instead.

cc maintainer @romildo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

