### PR TITLE
reptyr: enable on 32-bit ARM Linux and x86 FreeBSD

### DIFF
--- a/pkgs/os-specific/linux/reptyr/default.nix
+++ b/pkgs/os-specific/linux/reptyr/default.nix
@@ -29,5 +29,6 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [raskin];
     license = lib.licenses.mit;
     description = "Reparent a running program to a new terminal";
+    homepage = https://github.com/nelhage/reptyr;
   };
 }

--- a/pkgs/os-specific/linux/reptyr/default.nix
+++ b/pkgs/os-specific/linux/reptyr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   version = "0.6.2";
@@ -20,9 +20,14 @@ stdenv.mkDerivation rec {
 
   makeFlags = ["PREFIX=$(out)"];
   meta = {
-    platforms = [ "i686-linux" "x86_64-linux" ];
-    maintainers = with stdenv.lib.maintainers; [raskin];
-    license = stdenv.lib.licenses.mit;
-    description = ''A Linux tool to change controlling pty of a process'';
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+      "i686-freebsd"
+      "x86_64-freebsd"
+    ] ++ lib.platforms.arm;
+    maintainers = with lib.maintainers; [raskin];
+    license = lib.licenses.mit;
+    description = "Reparent a running program to a new terminal";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Reptyr should not restricted to specific architectures. I tested it and it works fine on armv7l.

###### Things done

Made the platforms less restrictive, allowing it to run on all Linux architectures. MacOS is not supported.

cc @7c6f434c

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

