### PR TITLE
backport keybase from unstable

### DIFF
--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kbfs-${version}";
-  version = "2.6.0";
+  version = "2.10.1";
 
   goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" "kbfsgit/git-remote-keybase" ];
@@ -13,7 +13,7 @@ buildGoPackage rec {
     owner = "keybase";
     repo = "kbfs";
     rev = "v${version}";
-    sha256 = "0i4f1bc0gcnax572s749m7zcpy53a0f9yzi4lwc312zzxi7krz2f";
+    sha256 = "0c03jm4pxqh4cfg1d7c833hdl8l57f1sbfqxwdq16y5s2cac1yss";
   };
 
   buildFlags = [ "-tags production" ];

--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kbfs-${version}";
-  version = "2.5.0";
+  version = "2.6.0";
 
   goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" "kbfsgit/git-remote-keybase" ];
@@ -13,7 +13,7 @@ buildGoPackage rec {
     owner = "keybase";
     repo = "kbfs";
     rev = "v${version}";
-    sha256 = "196w7vvi49xpmzn9d75qr5a1b8w23931544kx9bkc9bbwbjfc4la";
+    sha256 = "0i4f1bc0gcnax572s749m7zcpy53a0f9yzi4lwc312zzxi7krz2f";
   };
 
   buildFlags = [ "-tags production" ];

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub
-, AVFoundation ? null, AudioToolbox ? null, ImageIO ? null, CoreMedia ? null
-, Foundation ? null, CoreGraphics ? null, MediaToolbox ? null }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, cf-private
+, AVFoundation, AudioToolbox, ImageIO, CoreMedia
+, Foundation, CoreGraphics, MediaToolbox
+}:
 
 buildGoPackage rec {
   name = "keybase-${version}";
@@ -18,7 +19,11 @@ buildGoPackage rec {
     sha256 = "1sw6v3vf544vp8grw8p287cx078mr9v0v1wffcj6f9p9shlwj7ic";
   };
 
-  buildInputs = lib.optionals stdenv.isDarwin [ AVFoundation AudioToolbox ImageIO CoreMedia Foundation CoreGraphics MediaToolbox ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    AVFoundation AudioToolbox ImageIO CoreMedia Foundation CoreGraphics MediaToolbox
+    # Needed for OBJC_CLASS_$_NSData symbols.
+    cf-private
+  ];
   buildFlags = [ "-tags production" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -5,7 +5,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "2.7.3";
+  version = "2.10.1";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner  = "keybase";
     repo   = "client";
     rev    = "v${version}";
-    sha256 = "1sw6v3vf544vp8grw8p287cx078mr9v0v1wffcj6f9p9shlwj7ic";
+    sha256 = "1gfxnqzs8msxmykg1zrhrrl2slmb29gl7b8s4m2g44zxaj91gfi9";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -4,7 +4,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "2.5.0";
+  version = "2.7.3";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -15,7 +15,7 @@ buildGoPackage rec {
     owner  = "keybase";
     repo   = "client";
     rev    = "v${version}";
-    sha256 = "0fa55nizld8q0szhlpsf75ifb53js3crh98xmf8mn4bvms7d0x09";
+    sha256 = "1sw6v3vf544vp8grw8p287cx078mr9v0v1wffcj6f9p9shlwj7ic";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ AVFoundation AudioToolbox ImageIO CoreMedia Foundation CoreGraphics MediaToolbox ];

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -1,9 +1,26 @@
-{ stdenv, fetchurl, alsaLib, atk, cairo, cups
-, dbus, expat, fontconfig, freetype, gcc, gdk_pixbuf, glib, gnome2, gtk3
-, libnotify, nspr, nss, pango, systemd, xorg }:
+{ stdenv, fetchurl, alsaLib, atk, cairo, cups, udev, hicolor-icon-theme
+, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, gnome2, gtk3, gnome3
+, libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook }:
 
 let
-  libPath = stdenv.lib.makeLibraryPath [
+  versionSuffix = "20181121195344.99751ac04f";
+in
+
+stdenv.mkDerivation rec {
+  name = "keybase-gui-${version}";
+  version = "2.11.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
+    sha256 = "1gh7brdw2p4xfdgc43vrmv0lvki2f3691mfh6lvksy1dv43yb8zl";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
     alsaLib
     atk
     cairo
@@ -12,10 +29,10 @@ let
     expat
     fontconfig
     freetype
-    gcc.cc
     gdk_pixbuf
     glib
     gnome2.GConf
+    gnome3.gsettings-desktop-schemas
     gtk3
     libnotify
     nspr
@@ -23,7 +40,7 @@ let
     pango
     systemd
     xorg.libX11
-    xorg.libxcb
+    xorg.libXScrnSaver
     xorg.libXcomposite
     xorg.libXcursor
     xorg.libXdamage
@@ -32,22 +49,23 @@ let
     xorg.libXi
     xorg.libXrandr
     xorg.libXrender
-    xorg.libXScrnSaver
     xorg.libXtst
+    xorg.libxcb
   ];
-in
-stdenv.mkDerivation rec {
-  name = "keybase-gui-${version}";
-  version = "2.7.0-20180926133747.0d62c866fc";
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}_amd64.deb";
-    sha256 = "0a0ax3skfw398vcjl7822qp7160lbll1snwdqsa13dy8qrjl1byp";
-  };
-  phases = ["unpackPhase" "installPhase" "fixupPhase"];
+
+  runtimeDependencies = [
+    udev.lib
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchElf = true;
+
   unpackPhase = ''
     ar xf $src
     tar xf data.tar.xz
   '';
+
   installPhase = ''
     mkdir -p $out/bin
     mv usr/share $out/share
@@ -83,13 +101,10 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/keybase.desktop \
       --replace run_keybase $out/bin/keybase-gui
   '';
-  postFixup = ''
-    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath "${libPath}:\$ORIGIN" "$out/share/keybase/Keybase"
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://www.keybase.io/;
-    description = "The Keybase official GUI.";
+    description = "The Keybase official GUI";
     platforms = platforms.linux;
     maintainers = with maintainers; [ puffnfresh np ];
     license = licenses.bsd3;

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -38,10 +38,10 @@ let
 in
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "2.5.0-20180807164805.0fda758997";
+  version = "2.7.0-20180926133747.0d62c866fc";
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}_amd64.deb";
-    sha256 = "135sm3h5i2h9j06py827psjbhhiqy1mb133s92p7jp6q1mhr8j1x";
+    sha256 = "0a0ax3skfw398vcjl7822qp7160lbll1snwdqsa13dy8qrjl1byp";
   };
   phases = ["unpackPhase" "installPhase" "fixupPhase"];
   unpackPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3459,6 +3459,7 @@ with pkgs;
   kexectools = callPackage ../os-specific/linux/kexectools { };
 
   keybase = callPackage ../tools/security/keybase {
+    inherit (darwin) cf-private;
     # Reasoning for the inherited apple_sdk.frameworks:
     # 1. specific compiler errors about: AVFoundation, AudioToolbox, MediaToolbox
     # 2. the rest are added from here: https://github.com/keybase/client/blob/68bb8c893c5214040d86ea36f2f86fbb7fac8d39/go/chat/attachments/preview_darwin.go#L7


### PR DESCRIPTION
###### Motivation for this change

I received an email from Keybase that the version 2.6.0 that's currently on 18.09 has reach EOL and will no longer be maintained soon.

Fixes https://github.com/NixOS/nixpkgs/issues/50999

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @carlsverre @np @rvolosatovs @puffnfresh 