### PR TITLE
postgresql: Fix variable spelling in NixOS module

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -248,7 +248,7 @@ in
             # receiving systemd's SIGINT.
             TimeoutSec = 120;
 
-            Type = if versionAtLeast postgresqlPackage.psqlSchema "9.6" then "notify" else "simple";
+            Type = if versionAtLeast cfg.package.psqlSchema "9.6" then "notify" else "simple";
           };
 
         # Wait for PostgreSQL to be ready to accept connections.


### PR DESCRIPTION
Current build of nixos-18.09-small (nixos-18.09.1473.c1acb5ce6d8) fails
with

error: undefined variable 'postgresqlPackage' at […]/nixos/modules/services/databases/postgresql.nix:251:38

The right variable name should be cfg.package; fix.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

