### PR TITLE
nixos/test/ipv6: Specify port in curl

### DIFF
--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -70,8 +70,8 @@ import ./make-test.nix ({ pkgs, ...} : {
           my $serverIp = waitForAddress $server, "eth1", "global";
           $client->succeed("ping -c 1 $clientIp >&2");
           $client->succeed("ping -c 1 $serverIp >&2");
-          $client->succeed("curl --fail -g http://[$serverIp]");
-          $client->fail("curl --fail -g http://[$clientIp]");
+          $client->succeed("curl --fail -g http://[$serverIp]:80");
+          $client->fail("curl --fail -g http://[$clientIp]:80");
       };
 
       # TODO: test reachability of a machine on another network.


### PR DESCRIPTION
###### Motivation for this change

A curl update has recently broken the IPv6 test. #50905 fixes curl and eventually the test, but the commits are on staging-next and I would like the IPv6 test to test IPv6 functionality only, so I propose to make the curl commands more defined anyway, i.e. to include the port number.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

