### PR TITLE
roundcube: 1.3.7 -> 1.3.8

### DIFF
--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchzip }:
 let
-  version = "1.3.7";
+  version = "1.3.8";
 in
 fetchzip rec {
   name= "roundcube-${version}";
 
-  url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz"; 
-  sha256 = "0xwqy0adynx7066a0cvz9vyg85waax1i4p70kcdkz7q5jnw4jzhf";
- 
+  url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
+  sha256 = "1lhwr13bglm8rqgamnb480b07wpqhw9bskjj2xxb0x8kdjly29ks";
+
   extraPostFetch = ''
     ln -sf /etc/roundcube/config.inc.php $out/config/config.inc.php
     rm -rf $out/installer


### PR DESCRIPTION
This is a service release to update the stable version 1.3 of Roundcube
Webmail.  It contains fixes to several bugs backported from the master
branch including a security fix for a reported XSS vulnerability plus
updates to ensure compatibility with PHP 7.3 and recent versions of
Courier-IMAP, Dovecot and MySQL 8. See the complete changelog at
https://github.com/roundcube/roundcubemail/releases/tag/1.3.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

