### PR TITLE
Fix 4 broken builds in python-unstable

### DIFF
--- a/pkgs/development/python-modules/gidgethub/default.nix
+++ b/pkgs/development/python-modules/gidgethub/default.nix
@@ -16,6 +16,7 @@
 buildPythonPackage rec {
   pname = "gidgethub";
   version = "3.0.0";
+  format = "flit";
 
   disabled = pythonOlder "3.6";
 

--- a/pkgs/development/python-modules/github3_py/default.nix
+++ b/pkgs/development/python-modules/github3_py/default.nix
@@ -9,10 +9,10 @@
 , dateutil
 , requests
 , pyopenssl
-, uritemplate_py
+, uritemplate
 , ndg-httpsclient
-, requests_toolbelt
 , pyasn1
+, jwcrypto
 }:
 
 buildPythonPackage rec {
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ unittest2 pytest mock betamax betamax-matchers dateutil ];
-  propagatedBuildInputs = [ requests pyopenssl uritemplate_py ndg-httpsclient requests_toolbelt pyasn1 ];
+  propagatedBuildInputs = [ requests uritemplate dateutil jwcrypto pyopenssl ndg-httpsclient pyasn1 ];
 
   postPatch = ''
     sed -i -e 's/mock ==1.0.1/mock>=1.0.1/' setup.py

--- a/pkgs/development/python-modules/jwcrypto/default.nix
+++ b/pkgs/development/python-modules/jwcrypto/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "jwcrypto";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a87ac0922d09d9a65011f76d99849f1fbad3d95439c7452cebf4ab0871c2b665";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+  ];
+
+  meta = with lib; {
+    description = "Implementation of JOSE Web standards";
+    homepage = https://github.com/latchset/jwcrypto;
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/lz4/default.nix
+++ b/pkgs/development/python-modules/lz4/default.nix
@@ -1,7 +1,11 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, nose
+, pytestrunner
+, pytest
+, psutil
+, pkgconfig
+, setuptools_scm
 }:
 
 buildPythonPackage rec {
@@ -13,7 +17,8 @@ buildPythonPackage rec {
     sha256 = "ec265f7c3fc3df706e9579bde632ceeef9278858d7ae87c376a2954d11e9ea39";
   };
 
-  buildInputs = [ nose ];
+  buildInputs = [ setuptools_scm pytestrunner pkgconfig ];
+  checkInputs = [ pytest psutil ];
 
   meta = with stdenv.lib; {
     description = "Compression library";

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -3,11 +3,14 @@
 
 buildPythonPackage rec {
   pname = "tifffile";
-  version = "2018.10.18";
+  # 2018.10.18 and 2018.11.6 are not releases...?
+  # https://github.com/blink1073/tifffile/issues/54
+  # anaconda uses 0.15.1
+  version = "0.15.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9ca8ee9a54d10d2b38ec262cc65abb687f38c34aa9cda23bb22077cd48a9b1ff";
+    sha256 = "1fbb2cfd57fd8e42e417bc29001a17f319701f1be00e0b8a0004a52da93f1b08";
   };
 
   checkInputs = [ nose ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -410,6 +410,8 @@ in {
 
   jira = callPackage ../development/python-modules/jira { };
 
+  jwcrypto = callPackage ../development/python-modules/jwcrypto { };
+
   lammps-cython = callPackage ../development/python-modules/lammps-cython {
     mpi = pkgs.openmpi;
   };


### PR DESCRIPTION
###### Motivation for this change

Fixing several broken builds. Thanks to https://discourse.nixos.org/t/where-to-find-current-failed-hydra-builds-in-master/1545 for showing me how to easily find broken builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

