### PR TITLE
 thunderbird, thunderbird-bin: 60.3.0 -> 60.3.2 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "60.3.1";
+  version = "60.3.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ar/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ar/thunderbird-60.3.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "57b092a02666d2ca2d2b13b04bc00114b7e14b8b23b82f0af53f0d53485a8db117eea3408affcebff6431133bf337f07ecc111cdd8c5f50b4a93594ad07c0a29";
+      sha512 = "c051155472deab805e0e689d45ab82a952aecd19f91b2373cdfab3925a6b9fdebcd9a147c06e6ff491e1d1374cb03e2091220187801ab7f07f9d787c4fc4c269";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ast/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ast/thunderbird-60.3.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "a0635e9006beec03cc5a6fb298cfc1f4bfce342bb537f1834d02f452e82285ac5853ea520c1275140ea812c742fcf19d5f6e662b7eba58bcf7e80d796236ca39";
+      sha512 = "099d5a43e4e037f33f9ae4f89c1958d9e7016cc5f5673eed74d3c37bde6590fc2e47bb832784561bcf9c4ed53decbde51372a83019e3c72bf09745b95aeaf74a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/be/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/be/thunderbird-60.3.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "f2860e9508278895198d87b54ac2984d961221fa0bac20dba505d01d762ea7041127323c67cd2288d2372f37d82e0870c6a832ff4113fe914927a377e22ced99";
+      sha512 = "7e55877c3f75d9907e5cca8f7f423edc79d1bb072f96acf227fffe37375528dd5c40bf8b3d39151ac79ff510ad3e50f1940ea4df32a6cbb32a0afb085640aaba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/bg/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/bg/thunderbird-60.3.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "1d0070daf743b1c9e2b0a3471ff4f8bfd992279a422bb58daf6b7f96a6238adf654bfdf74d8414e758af2f033703a73cb0e1f71c0c72e0b7e61e62b6180ea185";
+      sha512 = "6230c26a960e962db8a0c4f8302df3ae471aa6b663bd7819da1b3ccd1b2f6db1fa207936502f7b8cf2eb47032efca7e6d0e1275223007758588df290ba9a9ac8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/br/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/br/thunderbird-60.3.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "f2bb792417855409c993a2d2e9ae627b800ef3dfc7a78fd82f3af400c2c4c964757662659a32b039e20e0330b7f16b502d011a104798c2dcc47235a8c561b9a3";
+      sha512 = "8005b6b605d8a863a4b2b312a0126ffcd09a25072d11731eaab9f096f5e0b22e4fc8142d86d39505c48b6f73f96cf2d6ac4c2158d148338cbfa8c587b238063a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ca/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ca/thunderbird-60.3.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "e5ae4dbe02b38042ed64f399ea531203fd04d6358b70ddb2c67d29ccea45019a4226ea1719692ea48120c30af240d4d5470e4f64f09239dbfff2607569ad9bb7";
+      sha512 = "98be5d8e71110d4de311e15c448b71cceec37fce5b50b689ecdad0322c093a7e7d96caab9919a83b48af784bf4da7269274125cd5d351870dcb775c0453237ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/cs/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/cs/thunderbird-60.3.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "b0f1440db8a329103f873a57988bc6fa66e36336752b7c215a952079f77182d91c6fdacc7815f74c18a4fe7c8a648e7aaf58cbb2fdabfda5b76daac81a602559";
+      sha512 = "35863fc6513dec41b256150a7a9c3bb9e45cc72ae869da422b8550986148c8de0de14d985a5bba50af030263c0480a709d2a9755aac73b7e60e40939db7f9f31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/cy/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/cy/thunderbird-60.3.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "191f2113ffce94d1ebff5619aa84caea262f424217bf17882189f40f772704aa07ce4ac232292742493d1b1be564558907a418c0104be656ec1441bcaee7ebe0";
+      sha512 = "3e3813449095eea1c7715d98d9198c63001b46b1aae463c6cfa1622b3808659d8a71d3cbac4264fa0fdb6264c1de738a2c79503b0629e062e949616ba0208f7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/da/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/da/thunderbird-60.3.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "54611a769b3f06860a3d61519b992dc5e4605b13d8d7069031155a23b590230c003dde720dbaf161f6dee87d96df057f01d55e195ec34bb4fb55f1423b166ee2";
+      sha512 = "dc51279ead50553ef8e8345635925b45dd8be63fdd99e3aa1499d2cc2996d084931c00b7b942935d00914c78f56b8bef13a7545d6bbf47a51a16ab26a30132cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/de/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/de/thunderbird-60.3.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "d1ea83e5402e68a93800491e091daf7bd9951be2de8e3c4e786061c57fe850cdd12bba4a35a24e4df44432a2124dc3b8c5732271a9a1c71f7fe2deebbfe94d88";
+      sha512 = "117a1c2a930c8c5a3c5a96dd6e28e7e167fb6cbe06f607211aeb1af427b47bc3b75d0431ea38ddf3812f5899d690f9c7a6dc8341c124249836bd0ab0da3147c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/dsb/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/dsb/thunderbird-60.3.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "5f1d459902e2ed9eb6cfa10a0ea05068bda0eb3146e5bb9b20ca2c93d85521ff465d596e9348421dda839ebd0e55c480e277ae66ba10236533f9aba7c3c317cb";
+      sha512 = "a717e0d4e57b354c4eb331f01de97267d0616fdf9a47dc8e51acadc4966ee21323a97c59b902e2b315079174acfb896c658cb07ee62f6f04959116961837d92f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/el/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/el/thunderbird-60.3.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "5f1702a2b78373f0cb408363621bbfaa377f1ca38eb17bc6dfbac582115a795c2d22220725378f67b49f8f7554a37a5af5f0a18f7584e54c7f62128fba3dec33";
+      sha512 = "4e4d0df91c563cf21c83617529751cfe26ddd6d0c3952fffd5ef03d40d622da9dc84e1dc861239cbfb345d87a99e2fbe0afe4fd7975bb589201bef8d70da092e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/en-GB/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/en-GB/thunderbird-60.3.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "754d330a04178aa68c15c6212a04dcd5547af820f82b55d7d36910b5c85fc3d28310fe24864dcf7e4ab21838589350a752dc220c9409307ea6059d3e9adc02f3";
+      sha512 = "6a7c42efe472950daa603462de76b57bfcf97810e4c4a2fa38f07aeff8a6729939ddd35b7348deab357c723c6a20b71d25da3e2fa05502ebac1d74fb9c6498c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/en-US/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/en-US/thunderbird-60.3.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "3f8dd135299243996182ab9b8f38e5f7d6d486468b1afbeb52d481d8ad943cb9fec899cd56002ecb5f55f7b22e3184c4a5d114f55734b8e39debbe4ac4060b68";
+      sha512 = "6c549e9cb1a4de1f73b26332c933cb96da841f75afc54511e3d6ed459b3f1439e7febe72337e8b24d825a8fa82b1b1520248c8551bfd8446812abedd3df516b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/es-AR/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/es-AR/thunderbird-60.3.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "cbe6bbd993f84e583b3d399ac45626384969d6823ef21da84034f3bb3b26b1f86e4ba65a1bee73438ca75d8aeb9f61a75f1b8747b23f1ed5059796d7ec14adac";
+      sha512 = "4465e400726d550d06fd36e8baf3c96445123f2b8c78c1d5c701d9175038878d52e304adb1cd5a6fee3be274605448916a8512b9fbda452852aaf63c8aeca242";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/es-ES/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/es-ES/thunderbird-60.3.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "3c7c4b4cd9cfc2d867ed895adbcef4e1af487b5fe6bad6c5931ce055f2fa656de9b51d1008cfa9a342f7b8360ee6d39529d4e81dc773721157bd42841cde2d95";
+      sha512 = "4629ac510525f6af9f287bad685f696f130607eaab020bfec8bb46c2b816b7b8a3df1d0cf45e98446e13b8d219add30b751935ba5d08d5fd426da9346f9292de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/et/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/et/thunderbird-60.3.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "ba2b2a7970a87d41c85aa5fea1cebed55755356fed7a82a08b0945e6311b410df25511e4886e6c066f43b31774fbd35fc65c10b155bab2aac5eb1918cdec8e3c";
+      sha512 = "fbb8b9e90ab0e3160e8b48ad788ec31ebc2c82b2839f64deb2d28c2377debb666bd94a7b081748f11d9eaa10af026693a25d9ac121754d8e2c333330984f97cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/eu/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/eu/thunderbird-60.3.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "3398a2c1a2fed97b8e17822d7b6048af686b67f91d2b096f1e0d58dc5d29c2eac60aed39b62b80788634c3996adb0bcb93cb07e5bfe7eb2d2a88e58e1cdfe8fb";
+      sha512 = "8c2e3da06c2ce5768e23d2a0e29e186d31be925c9fd2e7479978ee8a190113d753c80ca059126b1d28bc828f732c517ba6f28647402be5284948fbe7939ea98a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/fi/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/fi/thunderbird-60.3.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "e7be730f994829e55a51754b569b8148cfc871fbf6dc28962f3d23400ed68105d813ead1612974f5f27148a57bfe099e4fd63ed4111eb877485314111fc046ea";
+      sha512 = "05c7516c48e1574055ef56575e7c7f0315bf307dddee786758b5c49fc8acb41462fad1064fb1255d4b8c2f714da7ebd6070d4d5248c6078bfc587457b51b0f2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/fr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/fr/thunderbird-60.3.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "710a1da3b50dd50d01f29685c6bbb6a39849a5d0daf1c98c2722c5f823b501b9679f53ed72a0335143582e10d01605d57e474936278063254f01f41cc211d92d";
+      sha512 = "5a11368521eeff68cacf8ed353b12d9d17f134871739e0c1d25a6103e4c8b917b19179978940075905e5dbac51cc13ff8bdae6185222ceb6eaa5fdd3dfab16ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/fy-NL/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/fy-NL/thunderbird-60.3.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "dd08b6a9e99b2f639139bd8b2f83406229dc8470a66381bd625a15f17093f7996777d35c05bf8cfae930c1379e547236197f73620750a99c27cc2adf0b7688c4";
+      sha512 = "003561a27b2ff7b484fe0ddf37fc539055ca8e302f0daea64c1932c0a9e2fb3a66809cef707ec3feb2dfbea5e57cb1d8aa957d4584a33f0465d252398dcad512";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ga-IE/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ga-IE/thunderbird-60.3.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "ef38f8713a7e792d7ccc62e360954c29675ce208e51c06dc3679869487059e5d768f803e751fd008c369a2e438f5c54d95f4b48d042deeb88b0c6e7c84bab213";
+      sha512 = "17db64205a0d56a90c61ab63326986054a3b162bacc01a5ae5cbfc5c6015b47a64886663418b10f1da779556b5730411bae6515e903af96c1d2f0bc51399067d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/gd/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/gd/thunderbird-60.3.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "9ea6406dbdca47e031af25139707707b9bc56957180ac73682b55c324980c6df0dc8b0ec4618cb175dfd489d7941f8f61f71551c9d221383698eaa6b300826e0";
+      sha512 = "9c09193e9a24b7a34a5e247cb9bac9b1913a4bd7549a396a4c723c83de716b3e7d055588c926d6bb08e7b6a223515764b8ba51f6d013229f40da848a401f3b01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/gl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/gl/thunderbird-60.3.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "6ed22b1fe889a1b8109c180c90e35acabe3ce904a0d57824fdfc83f703814635123aa2fcc2f8a6edf50a33111698537ee284911a7eb3ce7f1dc8ec77819ee61f";
+      sha512 = "a303ff6bd6fe3659ef2d09aa58cd911b7b8148ea5c925b82ca7a68f3b16534e13149e03f6fb15c5f93242d6e61d4e1448a1ff27b146de9adf586f01d8d32dfbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/he/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/he/thunderbird-60.3.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "08c9923c10248b3b6e0c33b75dde8de66377404c979924c29ce602798ddec564fdb3e978a1345d9f2f734768301a262f8ce309bf002f7c7cf9434087e2439266";
+      sha512 = "ea72e43f7b1de708de898dd8351cf4837f97c1a28a71648cbfb76986bb2a87cdb747437e8b9358577685c38c9f5ec80e9982442521065a8c0e412e19cfdccdb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/hr/thunderbird-60.3.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "95cb5f4d35174dffbf341d2d8986ae0b5248ca7e447aebb13d27915ac7968dc1454ee8fdad201b0de7fa6b9af0cd632c951a2aa9d43fc5f6aa6f7f205ec42cb4";
+      sha512 = "a48ac47c5c04fcdc532e983559fbd2967539250d242f84f2599883c068c67e9c72d73b6355f7f6756d80ed9a54bff5a36929928398acd080e04675b552bcffec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hsb/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/hsb/thunderbird-60.3.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "903be2c67851f112092a09110b7abde2d05d1964e8c573962709b902a5335be3eda0f2c687e6cad67d42339e58559d633768d5b203ad482c1de6f31ba3b13a94";
+      sha512 = "cef96f079261d53092d2fb7e8f93f72caebb3aaff910264188e8b3532de1ec4fa0f43ed45a60f80bc9ba5eac69cd17f2a415b70700d7bfd6ed8c873f2fadfdd8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hu/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/hu/thunderbird-60.3.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "83a65776921962cc84f6c932e471d8a1532aeaae6edf95a9d8f68e301ad4383d0cfdb35469a51393c45628e89142c63af3886d1bfb31cb37eef188a07f96f352";
+      sha512 = "45245ae609216cb307e07b33ebc531c900e51634a6eba57bffcdbb4e0d72dd7466e399d0f5fff42a06973c3f2fde61d5e59a608985a513786819dde443cd2e3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/hy-AM/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/hy-AM/thunderbird-60.3.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "42469e3b613321906f2573706a523af032e93abea2e579b1e768d75898a504c4ab5280d7f9ec1a2e25257ca4fd877d53092fd85813d59c6dc4e5eca058aad6b4";
+      sha512 = "d9b56f551997ba6d2413ce6847ab6af4bcf9d633bef2fea7a0fa8e8bf37fd87ce497134a7f58c31d647f781d07977be58449485c13212eff2996e3ebd34a3be7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/id/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/id/thunderbird-60.3.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "008e9b2949f55a400209440e6eefc6144b71f76589ce18c022e2fdfb203d75f97a93ec3f06a9810a72e0b5b0566d2403b16baee25a46dbaf77eaf36a1ad0bbf2";
+      sha512 = "8d09a5e23191f454b628c3bbd1b95045b201dce34ce5ee78e35d4e03ab3e2f686a1be2683332d1fde5bccbffec1e878c851bbebe019b8e62634f64eae344e2df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/is/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/is/thunderbird-60.3.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "130432feebe93be2c2d87febbf3a45be16c118a980d3fbb20a8d0fa42ea1898e70f60d758ce407df461ef6984a2e55d67594e50edcc4b9445468bb1ef5421889";
+      sha512 = "bd38c11eeecc90df111917e8d6d4c68882c24b40b1c7171f366c795dcaf4709fcd47aa1d81d76c7db549b054b3705330ce389bd8445dd48350c8cd3a22bdd9e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/it/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/it/thunderbird-60.3.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "1887f49727e3116bfecba4b084fe550b1b9b82f90b620ada9baa81825ab200489dbedab2f465cb52a0e22eb130069bc639eb54ab48b6e708c264bbc5bc076fbb";
+      sha512 = "ad3fef3fc1414a98e7c24abd31b0fa0796e326c141ec5896b29feac7c3955c807ebdf01e7d099f37b31e32f3267cf8052ee8d4f324ef974ccbce38f13ae432d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ja/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ja/thunderbird-60.3.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "c60a6e44368387f424c9881702dcb4f3dcfe439bcef92a5e6791c7619f3fb71a36a83e6ec2142cfa556e36b0582070f1aee9973261afc1fdae55a6d5f5b808d9";
+      sha512 = "880df6180766953da20c8917da020750431b5463879aa1803a6a4b9437a650f918a69e75804c267c1cfcc959a18edae1936f5059fa165cb9a5721937b3aa68af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/kab/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/kab/thunderbird-60.3.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "1db688c67904b1f930133c5e711390d2fa1498e48db450f3ca41e6b039fd7cce4b68298ecfe5a47c20eda9ae0464ab9fe8d0907b28a59bb3fd95a7d895c02665";
+      sha512 = "285a5054b19e155905f0a29478b4cbb3694499d798ec009dcf4c3cf5d44510c5468d6119fcfd5d2e4ca4e4d1abd83ddc1d9fbdfc68499534e42040e2b8a27463";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/kk/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/kk/thunderbird-60.3.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "e24f8f451e39bf945e51dc9afc4f40f3e5239616cb838e977ab74151f64dc07c246dcded50976a721261a01d9de0d55b802077de18f7682bbd892c2282f7969d";
+      sha512 = "fe77320d7228c623bab6eed15466bb31b64955dd885728728000e03ebd368c666b825bfce8a5ae9b9f17e74a519d74ae26c636e8451fa3df91a7b5b5e2ff3d05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ko/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ko/thunderbird-60.3.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "52296e8ba959fd82b29b8cd7eb57812955d2078fc7b8aeccab80b8a4d917a6459072a2a317feee41bf649c1806797767a85fcf81af656eb51dee70352b57ec17";
+      sha512 = "f3cbb3fe94d44f4c4334041ff53983829c783ba1cb23bdf73d07a35f3b59dbff8c4a584f159441b142e1ceae3e768e4b20316a870033603db8987bf4f1b04d53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/lt/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/lt/thunderbird-60.3.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "b5a1a8ce67d441e0d919e808a9f7b0e9dedbcdd7af105a372f071430ad1426847087b53ab2b7bb455d161216287e2c0a7e2639d80a0161f7a92a8e87337deb8d";
+      sha512 = "977aeda9dfaa83b1abf844d40199382f5ab8be2466064b4258fe46b6821b333db027c2f45355c6655a7173ca369e5329b269bb456ab964ec38e3e5a878cb8054";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ms/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ms/thunderbird-60.3.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "8ebbee14a1c2b540baac19f6b154e74e3c39a3178b1ea32b55f35edaf2cf41f4e6096be3075b54c37f8b01e7e424dbc2f9d6b3fd04afd366ed854684e276f302";
+      sha512 = "f5e4ec77934a66ee22d8d8bc2d0c238d020a0843da562ac6ad344818ab0ed32497ca00eaf96c252392d3923151ecbe9f7a0c90d3dee7e558bbe75da278547549";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/nb-NO/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/nb-NO/thunderbird-60.3.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "8e9ae2aa4572e247ecf9d1715d0733bdf7123dc1fab7804a2dfb4f27aac589aecfa86824597e1efa218dfec4807730a697e36a813008b0b208c9181ae20592dc";
+      sha512 = "4d3723af7503ef508ea269f44185eefb33894a989461a22a742cfd369d0a2d93d6c3bce61711ce2a5de868b3d7f7c612a8a596718609068950b32d1bca7f1c55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/nl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/nl/thunderbird-60.3.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "a910555ed33fe721de624b591fa0a4aa769e8c8e3d78253eca907e0ad2f4ebe541e2b72ca3434d79aee9a59dde219c5b24d5b406f0dbafa0b1a8f080cd3f6e9d";
+      sha512 = "0a95e88ecaa1b3af514bdfcaab648f3cba9b280e5eb4c9efb371309cdaf0dd1215cd74d2d3af203e0547c1bab4b2480c4a3e9f81e2d1c301322497aa990af281";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/nn-NO/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/nn-NO/thunderbird-60.3.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "9fb084d5ddaf22cd282b3ba001b39d926ef49a03c9ceb5624cf11bc637af5dbe3ad90d0282f6b90f794010f69104e5bb126ff5c8aafd7cbed82cae0834563e20";
+      sha512 = "d4c112319b8df0e377cdca82b33f55b0e949d3b2f2cdc3bfc5b5eb0c0a0e98470452b231e8c82f2cf303f1e75b512c5097f5988bf10efc57cb2362f7711dfae2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/pl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/pl/thunderbird-60.3.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "c5c4590b177775b559acd89d3aa2c4555fa4c8c564ed426cad567b68e2508560d6a8bf55c9b3665819be3ce9b42ef94b795082f18e27559d6f1087a51c26bd5d";
+      sha512 = "94829eaf23916a0ff5273b38594a9a10ba9b178c0103deffcef0eb2015e4a2c51dba341644252b86430f18f4a2e526307f45ae5515f6d47832b74438dc798ea9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/pt-BR/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/pt-BR/thunderbird-60.3.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "4d66d1774fea6fcf2c81bebb5035b4544ae6795077c8d12cfddd05257149a56ae91b280a28488483ddaa444533b253297f7e6d9c2314111db8013e0f8f0c234a";
+      sha512 = "55148505771d65796766e6ce0b46ae9787dffda5a3176f249092f9f446fa5cb9d7dffbca0774865bfe000e79cb8b9e7704e4f095117172b3a2b8fc661b4e21d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/pt-PT/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/pt-PT/thunderbird-60.3.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "1e24124c69e5c8b0293ea79c499329b0075fa795d87e8ebc78f322859bfb6e76f977daaaf1cb187bcff5239767fd55dd5e53884a785cc60bbf4c1180543c8c5b";
+      sha512 = "9d7c6f004afec887f06e7b08c344727dd8310390511f454e18a93ef618830bb68df5ef60129659a31c33ef6b57d3c0e7693ccb5d4c9452eed1ef1404c6f83956";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/rm/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/rm/thunderbird-60.3.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "f2f6174e337010075ab78b88f9de1fb10d213fe1329ac185a64bde7c2efd9f5ad6a0151a42e0745694bb1f426246fba34cea5627316e17fa41bdc292ad692fc1";
+      sha512 = "f7dc1d5981d98f38c13c840e71b542dd3aad096d8dea8add79ebf756129a0a83316eb42b9018d47ab694c190384658cfb243dc96d4522a84a7f35ce82e79fa00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ro/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ro/thunderbird-60.3.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "25daf13a075591ef46295b44c0977c8e159612862953e7c22a053a3958b765b8a5693e8aef691590031285605101024142a42922faafdf9c0c998554e154dd74";
+      sha512 = "97f7f674e4a858ee9c03bf1661071c6d0990b5018de9f69ac46a98c82db53c67d2589d91ec9db2c1f6361a700d47779f6f4015214d8010da490fd69fbe065764";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/ru/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/ru/thunderbird-60.3.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "a187abec0708338f7a0f593a2054fc20f4f018d1e2ceead6778c616450a2cb3fd2f959f4c7e6018ecefd07a984828efa2da3f91b34104dd62fbf5a5a97310082";
+      sha512 = "de481909f670659bbb3c227aa97780ceb54683b5ce47135e480fb95f89663b2fd9ce176d7507913f31417f66fbe8d4f8af08481bbfbac6468f7ebdc5b0bdcfa8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/si/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/si/thunderbird-60.3.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "076c69137e6d4067f553efde45d1676b386277c904f452ee1880a52ead9cc40a1bceab33a895886c32a203dc8aa6d2735b5f81b21b969ccccfd2d5e75a2db289";
+      sha512 = "07ebf67fa8673dc7bfcf5563591e4ef5c4736e3844b31a4e6662098d15dc05a437e3d5eab544cd09c010628a20f15ead8185e149560e0526dc1379f0a9202f56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sk/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/sk/thunderbird-60.3.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "669bf299926fb9f4b0201c9fbbb593eebe127ff64d9c3cd12f79aa56b2e9d8a9b68c34e8ee42b9cc1287972c1a3d28c080945c1f17f4fbf672bc90c1f86425e1";
+      sha512 = "deb6291ba941743956603f6a91c0a19a2c56960bc91869ca7201f7a3eccfc630300987ce5b7bba51856bc16cbad2e34cd7ee645a22d692c12e8b4f66553c6a1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/sl/thunderbird-60.3.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "0d22ef11e347caa3e03b4a83c19dc1a230be3ed2e561ce84284b752abc7d64720e2d68d2fbdec19da73cdc13c5e90983179197e512f7db4f52c341539b8c1329";
+      sha512 = "b07617d113b7c3ac75cd4b3f8fbd098bbbf5cc2b8f06317da410ce534a93013671519c9e0698809add4c14fe131b6273dafdbdb8a8ed56922a68978cd20a094f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sq/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/sq/thunderbird-60.3.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "ac5e98dc1660efc255bc07a545e47f2141a8468e8bb911ad1b42143e5e048a82d5771f32718983ab80695b357b3b2d08897cf98f791f466edfa57d75579920c0";
+      sha512 = "b22bdf2bf3b8cb3c1a5e63360652ac34bcc63499a02a8a5af7e2c6987b310d5d4a18495b17c2f7ce9f509be08b8b5ea1beefc241958d75c4c6be26bc5a02532d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/sr/thunderbird-60.3.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "2215af6e62448949dbb89cc66a52c9f83eabf1074ad8cff437953123d53ad403537b5655509bcdbbdf239da32e5b9d689b02cd625e225ce74a0c22f07318ba1f";
+      sha512 = "5d5139a8f9405b4ced928bb9241c0a4b3502421c8329b2da4d582022c2f57b7c599b48428ceb6601799448ad40d52270429891b7a637f9a913b47ef15a3d296c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/sv-SE/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/sv-SE/thunderbird-60.3.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "c72db6a8ed31e7348df9a0fc3931c5b1520f7bc03ea47e92eab343acd58c3fb4574beb91fc932733bc52e670451a04a88262e6e29ad7c0dacbcb37da522537b6";
+      sha512 = "2b8d2962846a7a0ef0c8f77cfb51e26da417de7a808bccc97ae3087dde1f4f0d38f770a3e14c26f5081af6c57dbd175ef81ff82992430bcc5fdfba2c2948c9ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/tr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/tr/thunderbird-60.3.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "249d2320607100ec397556619872b701dea16142ee3ca0599fd17d66e5581d4753326a0aa9e2fff4b38c9a91ab8e923abeb0115cd8ad9e82cc871116d670cd4e";
+      sha512 = "e37b98fca81ceb022d95e6b23260a22ae0dde8f48753c6dcab96a3aadc8a68c852c2c6e105ee7da8733402561435357b0d70524aac419604a13964894a88671c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/uk/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/uk/thunderbird-60.3.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "439d7018c6a6cb3544ec26fdf6bb93d6be2a7a4a6a19d6d5de40e7bcaf0281e42af6fbad23d4640959fae84ea4bf487c19fe07bb50334cd593a20c7c5db999e9";
+      sha512 = "9d1f38ed783b36f4312ce701dc8da3bf9facbff9874b08bf5730995a2fec3a060cd55aa395919b03ae12fd9f941e5f2fd329e5d836e1f722bfea97387e07be92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/vi/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/vi/thunderbird-60.3.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "0f7e6cc139cba5223fb75b0fff6b60e26d2783e6a78f22f3d8d1ec518f950856ecdef9b2aa31346aadbadcc08ee9b9a251e2fbdc5bc9655395fa2015530de050";
+      sha512 = "e70d087dcdfc0e5f6791b1c5e1483ffe6891b64792823b400d79fd9ed8bba10e5c21cb14a11cc2e020d8c91ef5f82455793595dc7143956d0d1a99f673125253";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/zh-CN/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/zh-CN/thunderbird-60.3.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "3280a8085855b25b88e485581d3f275873c4c01f1ea9608d98b01553a0dacfa7226d405d055028b2a45daf6316004b12ccd8637deeffb30724540df1ee480773";
+      sha512 = "28c4d992ce79d3f62984a1a0c009a742709c4d5dc1be3e9e05da6b4e232e269b04f548b67b1e0af85c51f7f4470cb3bb9a79d5bb2ab5c55f27806bbd27f5611d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-x86_64/zh-TW/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-x86_64/zh-TW/thunderbird-60.3.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "194cd71fd722d2f8f47ada2fcb02c018cace495d6d72c7eacfff38c6e5f30b7749dad41f2e28af8e935703c4033fcd5f7264ff828240008bb17a86e6894fedd8";
+      sha512 = "444524e9be27bc5a37d06cf7f9496d75ae524a27c97577066cf6bfcb2923369cf11a949d8712433345f04fd2ed7423c45497a51a50c058b7910216d9f0986350";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ar/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ar/thunderbird-60.3.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "56a8a07096fb29db87dc2633aff725612ff8255991674c590dfff51970778bb6b118a2f025097bb139086cfb949d0f53b1a6b1e9670c4b3cb0fc9ecfe35f6065";
+      sha512 = "5e147d4087d5b3f92f3f62e4f889bf1a38851f038ecaf9957bdc9ba8a7c52905ef74788a6879285836bf780177ea785b0ff65074eead4a1ba2442ad2466ef82b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ast/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ast/thunderbird-60.3.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "9475397f31e227e6a83b9572b82d7067fc633fde9a271fa68be5922f860346abb2bc879b14f489b54c3e518cd2d917b5e5ea2a03da3ab554607356cb7236f4b9";
+      sha512 = "29066ad291416e4cb1e778effb807b3427d74285ca5edc4ae84c27e39e4b033eaa665ca22ebd603b7d1f7347e6d21874c1be6b00df56e6a4c93aa60fdf613b07";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/be/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/be/thunderbird-60.3.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "488cf4396202882d4499b0bf6a3c5fe636fd162c767c5344ccb033ad57c90f544fb1e4daf348f08863c990eed0a07bb543c8b9f648786535a3db2887e77a6823";
+      sha512 = "535a84a7943a1da9117829e9cc9aa0f1fef1e3eda0ee61d356a4f2e10dbf2a61da899fef2d0b858674a4e54f574bb0aa5db628b5dab52fccf2a0eca06b9695cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/bg/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/bg/thunderbird-60.3.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "62bd4387ede66078250b1a462ddd487c97addd044b8c04858de922b60b88823880869f7eee0cf618b51ef1de956007d4fc9a6ce05ffae209284104cec4557bb1";
+      sha512 = "83c925fc5164146c24447835229cd1abe4d9eb89adababa68057d90906ee6b1fa51549311dfae934eb1faf36f5d10118a1d4cb7338019dd41a6d563fcfafafa7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/br/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/br/thunderbird-60.3.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "39fd9e5b42000c9b1e37f7a0bdf03681a3372166cf90750495f7e2a0e10f45465b3eb7d68454022634ffa8dd7a280d0ba98fee9367fa6058223fb87c06349e75";
+      sha512 = "b9c0e4cd14a3c745f506c303e2cad6357890f7b9dda91de43d4bddf5bf45c0247120f6c824189721512536e3cfed4b3a1d32a1767b2cac64f20349f158c10acc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ca/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ca/thunderbird-60.3.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "9cde54a64916448a776de3c197851576c5d9e395bc90da1f18abc0f5f1bb27d267bfcda33cde51fb06c80277caf35a7b9f1fad6853f8d053d95abb8ed2e95f5f";
+      sha512 = "5d45160609b49ef060d7d6a92c5ca24b4dd6f02397103cd66a76796ac72c2ce8f9be6445b09489d8aa96ef0156ec31a734e7091d0134176593a488905370d81a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/cs/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/cs/thunderbird-60.3.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "1b5b8633a6502e731e9d187b0c3977db8338c3aac9d4b07c12468b143a11488c5c4b46b898f3ced8637b16abeacde0c0482b74d0c67c04bb4e1e40bce66d8151";
+      sha512 = "659431aa61b6221543bb7e59b7b5361ac2011ffad65ece1046df3869b54c1cd39fda0998108f9c72f1dc4f5151496962b73e31ba1d3a2bf9bd6bd3186f7ed0a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/cy/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/cy/thunderbird-60.3.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "a4636852813f271fe7ded7665d386d34120f664e5e2c18bd923efb4f3ff4cc273fa6ce952b243a2e25840f96baa4ac28979201d6f9a99ce8ce2bd18be41f1f82";
+      sha512 = "4a488557f0f64d4d4a4aa33ab385754f89bd1d1f2d7d39b64e75ef8a6a2d2f55bacfe9fcdad7901e44f9f2c69acb76d595ae379dbd3dee07bdf299a4dfa08a3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/da/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/da/thunderbird-60.3.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "fb4b302ac628b6b84ee8c537ec533200421c0fa4ce5af2efbc92e1f62e23761f5a64e11ed004ebbada8c0f31a4576d8a006571470896470547622aefb27af4dd";
+      sha512 = "39b46247bc1f83c1f2d3470421411cc931beef1087089110aaffa4b604c102048771069c833db85a3c3b070b9586e45a6eeeaeb5b3fe9ee1e77daf5e6e7aaf0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/de/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/de/thunderbird-60.3.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "76a213f0ee3fc1611d88d82639bdd3a90fb0cae0ef9c938087da3cc14c2802c6ab2bb5c73eb27e370fa45dcf25c075c27c86fc1b8f38b32aeaf76b796269293e";
+      sha512 = "fd29518af52080217b38733f5babac66e7dfb17742b67be2ad962c541ac31e27bb162303474acb3c320a4a33c1e589c4f826b66b16df2296647e499051b540d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/dsb/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/dsb/thunderbird-60.3.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "34e0fdc2179d4edd61044eb43f9fb4653e3a34e424ca68e549f430dd2398c6e8890b1ab5dc1aa08a1f93ce5e73774eb465e75ac13c6ec56ffe25de5e41b308bd";
+      sha512 = "4f0c47c2757a5ef641f1618a7276a9a171cd681c517db130886a1569c7e00542be05fab2062fce21b5c3f8df60e3c521b25292f7bfe1c437b7c1a779c9165510";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/el/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/el/thunderbird-60.3.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "c09cb6653d9bace2767c25fd7a2d8a0100c36a5f029e2950872a13cd2f2cdc56f4e4c5a53af36d1667cd23a0ed405e529d470b0405a0f615c4a1e78e08cc6c90";
+      sha512 = "fb6f80d1a7a8e465fc49e38d986bdcbfd962b3c99c45629ac188e58ff3cc63cc97da4529fb67566705ed3c4e682598e0089e826d015b0dddcf60d359faece400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/en-GB/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/en-GB/thunderbird-60.3.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "df3b0c6e90fb683d7b67db078c4052be3066072032a99e9b1ec2bd1bc9f5f7a95952788c754efbfce9c5ca89a43d6b59953a3c5283eaef134457b79f7fa0c538";
+      sha512 = "7e2301e76e4be208256bcec9237c39b30cf49075c46d27a243005c39289e1ae26a1ee41a294c8d5389279b21749fda4f490c2fd1b3ee4b8bd9f1170f2efffcec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/en-US/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/en-US/thunderbird-60.3.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "18794d71c1d904caa1959feeaeceee38c86bca0faa84438ac1e1355879ae832fd509d2124a6d9ecbac7242eef334793357caed871713a139511ae77107168933";
+      sha512 = "0132ce8050a45246919e5fe538b84eb158cbf40401d487ffb7bf72d04a2bc3371d7606523dc6776dc3b6dd4c1930d56f6b47197385cf580d7b51c926c69eae99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/es-AR/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/es-AR/thunderbird-60.3.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "69825a80a98ecaed860c5f31c63928f215736fd9eefeadd7be1d88659c17afa58d7975f0ceec26040a21ca048da7b06154a44798069092c0a4e2e6816e847aba";
+      sha512 = "bccb7704f8bd0f09054e48c54bd4ebeb4718667aaf46c55a7cca3e351181e09760fdcbca4e1e1948746b74f2c7ae46cf0d565f4a9c00430225e6f2c2849ea459";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/es-ES/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/es-ES/thunderbird-60.3.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "673b4d55bf3691cf972a1f1369486cd205d7c6e8bc91cd826050fa28dd6c313f872aca399191305320289962f93495ea6316ae2f2b29313d8b61c175ae0640cb";
+      sha512 = "81359edf957802660c0f92f8894a9087acb2ee6b08906de1fbf4be2145911c30b6de27b11b66ee8b7ad8cafeb09e00f336649537829f82cb7f204c834b1e585f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/et/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/et/thunderbird-60.3.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "1dd9ac5e292fdec230189de90fe5ca923351b98a95d72d302bbc2c838e48cda46bc2e8e4ac2f08d2356b7a596dc2210fb9f24c15319fbb519b29dab78e29f2c1";
+      sha512 = "4039a1680551f03a17225cb8b2cb9e0fbf554ce3956e89700655cf010483c61e7b29070aba4a0fb7395b93838f9fab6542fb006b9c14f0a013b6eb587329d7c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/eu/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/eu/thunderbird-60.3.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "acfa8190d55223752cd3c65fa87bff86b7f1f38d86365bba23190c4f16519feb8acc37e1a47497e69279a312e57d39a5830ba8d9c4391a1503024f125ab72b18";
+      sha512 = "d7a5c40069541615ff8479a8eb48d5a199d9bf9f834661af833b65d68fce93d8b433fd45e0175bf29c8322a402136f8b4b174b7c85329659bfaaaa3430bab574";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/fi/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/fi/thunderbird-60.3.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "8a95970bd4fb56ff80324a743f02e9dfa21df698f761096ee5d425663e87590ca8d38ab62ccc97298f4d935f4713ded1e0acf01afbcea1d378ed2c065cee637d";
+      sha512 = "10c1d2e0a3d3d0dd2bc6166e4dd3ffc273f97e7b7a03d5148a8475411357eba8733ef33380cb79d813b65fe128e2bc07ac2eef30139e3d6c69af77003cee8950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/fr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/fr/thunderbird-60.3.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "51111b8da2823523bdce77d9807535e09b54f1ca7e1621f3447c9e4bf44522a176263a843875a3f55602b7b53d60ae00fd5a59f22fb3119a792064ebb9ace209";
+      sha512 = "31b8463352704d1ac6640a07bd0131f683f4baa2faed799f91de956a083f184539186f0a1bd061c0e1793cc97f22a32b275c5e60994cce93f441181f2120ceaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/fy-NL/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/fy-NL/thunderbird-60.3.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "144cf86e32fdad0f4eed95b461de9dc0713c3bc70ccd77c1db94ea53762bffe7a5254f3f898228347e7b1d26df0055dc04b0192d3b1a3653a8109ff8f4f712c1";
+      sha512 = "80831dcef438c2737d38df2822223632030d62efd84361925f06caa7a108cc966848184403d8422a8a1c43fd1df52a77dc4b561dd2733de73d2c8aa0e0d5978e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ga-IE/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ga-IE/thunderbird-60.3.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "7f411ee0f9b518dcf122eff2eb0b70fc1c7a71d2ccddb73482a17c9508f084ff0df6aa6d9a1555c576b0fbd32c9d65e106b8f98c7d603907c7a7189de034bbca";
+      sha512 = "7ceb9363d331fe9a0c3ed4b052cce765e2ef735b8a869ba3a08e83ed5195d073c1f4d9ca4578140b195cf25e3ae8771da8e061efb3e14bf5e9d875362babb713";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/gd/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/gd/thunderbird-60.3.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "116e72b7f9759576077d3d11b9913b78dc6356e98995f0ee1ce152d04da9d0d5db6d32218a8e3a9403ee64405c95413fda8f86c6fef85336f799324179896fb2";
+      sha512 = "292a67e214ab6392e7c6eb80a576fa130b9c22620c8c2ae5ae5eecddecb823526f39a0f16d7df3c4cb80b35325b907708083fd45efb845d40ab89bc3cf5d0374";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/gl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/gl/thunderbird-60.3.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "1d06ad862128b2ecb38b885c868c153b78a2246cdc635a066634f8b1a9e08fcff83d30806f9906b8f2a5a929e702be51ebec7fec54f7b80d4544f20cd2ab84b6";
+      sha512 = "df9f2a24a70facdaaa8c1b3831994fa2f5f14df92cc85dfdafa4fd4a28e7f331ae220ae08a4938755738f01e5f6fa1bbd62a558780a5444afe07e201d6c34f5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/he/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/he/thunderbird-60.3.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "6858b78aa38171194ee1821f7266924301859921591d84ab057a52ffaced7665adaaeb1ba536f9f0a7b8cd79ccc253631ff1a3d205c43c2c08d161e520ce7a60";
+      sha512 = "f1f527e5ec325fe9df177b172061dbfd205c307ea275f732b31ab460801dc49a18cd41625caca0c118f62d2642e4494e961b85b3058e2909445203d7b69ce6c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/hr/thunderbird-60.3.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "eb3f16f0000ea85e420c8bc60abe7b509ba0d125b8f95fdfc67d4c0fcf87b6c0db86a0297e8ee2e7fcb419951fcb0ba42a7e59005742145ae6067be5e85f6e93";
+      sha512 = "dd5b62e71c708db2dfbaa59bf860b4dcff951607277605193ff084943f4ba7be9f458310a2a3c047d4e29b7ba432bfce1ee2dcb5217c460d90816b17c2232824";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hsb/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/hsb/thunderbird-60.3.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "55ee75a0158ef072c1698cefa5b6725da36e9286c6da004ceb58f2aec109609f7ca9937d8825b92ae2731ef156e562249093fd551064388bc73905fc9ad2545f";
+      sha512 = "30374f1750facbd5d96e9b38aa2f237a7424e278df6e8ceaa622d119866b10859b594622438c8299d92bdb6baee2ddd7e45498e6fbdb13a0b0d8bf2304454501";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hu/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/hu/thunderbird-60.3.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "6b9fee4d7747af8b6d39654fcbd0c14e7762a1ab4fb7e7e133598fded0295020b39009e028ffb3d8db502811bd5ca9889abf5004cb01ff995bf9c13b871e11bc";
+      sha512 = "7a1a955704d4fe5220f039a6fca68f87995f654a59f51df832970607809db76f1cf480df90893ffa88fe87c5cabfa0733ff307393e22c78318c379db963cb26e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/hy-AM/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/hy-AM/thunderbird-60.3.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "e0aa3adb175fd1562e6292526f6512d5f6a9e6584d521aae3c97cc0143946a49e41e1914e9ba6d87f29409ab8b17f84cac9bd4a815e29f7c9ece1729d302881c";
+      sha512 = "8393a86a9217a4c387cc92b4c61ea552c7115549dba0ee02afac065757fcae4f79b67ef8fdd1559b942f674f6804bba7804d54696ffa71338de42bca7f12cf83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/id/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/id/thunderbird-60.3.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "7839db4bb937e699688d1e2fd387cbfb25a0402529b183f09897535341324f4d92e774c3bf517ba3a51c86f74854508b5bd6a5560bc153bf3720ea8191c119ca";
+      sha512 = "fafd7a26288b951d179657f99c72581e4bb5299e8db775b7a086f3481f700dde031137e2cc7370e308c943a0a874c5985c6b9e36c7af1b60c4553779a4653d85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/is/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/is/thunderbird-60.3.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "29b069bcad1cc668f65a3749a1d87b6582ad32400905bf446f8ccb86cf42100d7034bdb4c0d22a66b8f5ccf95659a5ee4c058f7c5a5ee2222dd0a93cd6236a9d";
+      sha512 = "3aa276ee0ee8f2613ec7ef1543ba5938658fdd5c1ea24b42d39c5fff4f016325daaa701f89c65a32f04c85fd066f3bef75dd0d5d28ffdeb29618fc16435f046d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/it/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/it/thunderbird-60.3.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "fdc47d3462cc3db49a8208423c19b0d74b65eeefaad2eca873eb194cc8c9691adfba7e87bbbc7c4a472423eff91ff8e21d78fafef18a4e841e922c72eb53d78b";
+      sha512 = "696b5bd5c93fa5a174b04f2501e46c6334cbbdba43073015962e7ae17cbf577f0e64d016b7f892513a3a07b6867e8419cb16fc82b915d09695d5a84f3d904bad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ja/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ja/thunderbird-60.3.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "068a15c6913a556c1c9d0deeb96c75087f68e62c0dd2eef3445c4460e08c314d457f799e82f96dfe00fabf9ce4cf7a7c379d08e7a7ebb2969c39ae87082bdef4";
+      sha512 = "588e5c6dfbb40cf355d62f000b5561c6a2a4e0b5c43c7dd2136fab11ee4763cd9cbea89e958f3959aae0570c694aa067d77ed7cca818147cf51a28efb304ab72";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/kab/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/kab/thunderbird-60.3.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "d11ef24a47ff39eab178ad448ea2d1457978b31dbe5ab0da2b87011d351d92ba54245891a1c6be3ed7424ea9f5743093e1cd6eeaadfe016405ad53252b7d5590";
+      sha512 = "aa58f8a4309ca122d8517042c9a8c8a92b90087001ae4552de6b660bae082565ae1d80aacd3e506f8582a145132a482fb8c22eab033d7afd4a3959653d00f1d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/kk/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/kk/thunderbird-60.3.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "e4bb916f3e04136b470d46b04d7d2ba4c3d9d703dc8fda44e7611ec51af06af4bf73ab30f4d4b578560a27a34adb6950534d0554573a21210bf825f2aec4ea73";
+      sha512 = "6081c78fe6febdc6c1c0ef2d102755760c9b137d117c0ad5b8adbf1a50769c3198a703abbb5a826ddd723cb128d535d2f075359e7300d763d8e0a769e3bd5897";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ko/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ko/thunderbird-60.3.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "9453426d6bb088af4bc4e0e2eea7dd163d434fbb7a29993b82faea9e79a11aca95214aefbac6278a44b90356eaca050ba081dccbb0e57bf5eadfddb992251ee4";
+      sha512 = "980b2fe49c2f705296ff9036e6714f2039a81ca8c591dd8a0567ba2171196f188be647a3aab1bab25fd48c7f3a02b75307f0a35edb36c534785d51c207fd7203";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/lt/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/lt/thunderbird-60.3.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "a0a3580444318c1bae14d8123cb215c37c32ef4e7f0db87e118054c34d7c3fb9b4d3659241379a23360680ddef6bbaec9fd3a514790efd6cd5f43d58de2fab30";
+      sha512 = "e3b37725dcc8f97f36c7e57450b911ba4547b2f34720f27cd89b7f2be92bcc0ee20f1e3426e623a53125013b447ea90df138da53c68de535620f548c955915f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ms/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ms/thunderbird-60.3.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "8295bef9738e4808fe0e72fdc27f772f493ef8ec0ba1ee66923a51e45088152bf61ef0dc1539af7de6e6c637dae1b9ea70ea89912e621a27083550f7abb47c70";
+      sha512 = "a27ab9c7c524f7dbeb6dde32f36c4cd0f3fe20026e90793bf6fb6396f9a7816aee99c48574224c72be8aba5922dd3d7a21b6c05cbbf8caf1e7b956af50018f2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/nb-NO/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/nb-NO/thunderbird-60.3.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "3311340af28fe81452c27c704420a9e30ca9c1ff1dc3b7ce2a49210e83149c0fdea1014f546109704f14cd467963624f8634568df7764085a88e078a58cf8af4";
+      sha512 = "45135f0d62b03919b754b2b95329dd4a60ad7a2ad1ed4fdff5f174df5d1391111c9f3acd1a0b4ee71b340327b06180619fe84740b43fa8d6fa5d70ea6bcba0da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/nl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/nl/thunderbird-60.3.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "7b6ebfa8c12da1e73769f74ea15fbd339e0886783bf4a51fb1c612d7d7372cddd0abdfe654760880c4bdbee6930349b6290c3d52d886915445110449cdef8d6f";
+      sha512 = "be4fd59d184fd161aa2afa1d2a13a11e54adad4329991b588d373a206b5f2e41bd03d51c1270d6bfc6c84a83c520cd3859eea8f5dbe71b0d2fbfe4bdac2a862e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/nn-NO/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/nn-NO/thunderbird-60.3.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "d89fabc6c2bf7b64eeca36b4b0b20e64e8e317764c24c9b4cf9430c54635e81ddf66879a3bd1748c295d3b52c523b63d4871823d98e86e1be68c953e0639fe6e";
+      sha512 = "896c6bfef19af9dc5cf48829869d47a7fcc2daeb9ce2f0a86a959fd6d656b6d721b024830f03230b9bf35a300b21dcb603d5e7aacb36666c33ff80bf5babf1a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/pl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/pl/thunderbird-60.3.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "5ee0bf77ccbf7f57fd4b4c7cc71befa785590d68c67141e135ef5f399e73a7e3cf2b5256f9420963c63b27a680168308772b313fea8a29c6aa322b8eaa46f059";
+      sha512 = "fb5f412f4bee2af9fed61f310306b883e78b4d64934643cfa0418b69a54e29f746b427e97f58aa94031bf1428d959e3c7e7605dc98c3658163f34217e87ed051";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/pt-BR/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/pt-BR/thunderbird-60.3.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "2243bfd560aff648ffe73cc9e7c6218bf6a1dc81e9970a097742a37aef6becdb93e5226d7340d7b69ee7a7a74785f7c06d93d0da726869ad339a715c265dbd5e";
+      sha512 = "d1cfa631a3491f1015b8182ef5beb8046cebb0d2a0f541a31dfaac88b2f54586c8a6ad15a23ad17aac0c1ff9ec3b5a214002f0aa46dea37698093ca9f71ad288";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/pt-PT/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/pt-PT/thunderbird-60.3.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "06a4caf81f561fd943050bfbb36b2f9190790f407aaecd8f20a3dcaca82bd037edd70622ace1dcf41fa4be1109ad9e80fd40332e45034895dc3fec148fd334aa";
+      sha512 = "5d63808463b829f6bffea85d0c07119ba8d33f09f39fd7494f84d12dcf205286df6e87ff1dbbeac8a6961403060f0f23b148c2ebe0329e47ec8dbab3b94267c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/rm/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/rm/thunderbird-60.3.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "4664931159370d114a50f075d7fd0cec7fa0bb3e91b96d7778b206ed5e748bbe71a9f30ec1a3a7a41849b524b409e024346c5c5344d18b5eb94aa939b86f59e2";
+      sha512 = "b8c0b360b47ab9d43fa2ec3fa0fde1cacc8cc7d2f47e43eda2b4f973991d2df247520d0a10972777ce78d87887e0ace82844aec5955d122cef3119328367c862";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ro/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ro/thunderbird-60.3.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "f0b19356c5917e16edeb8f120b0765f948010198a1bb8fa45e4bf7965553677f01920cf34b816d0dc3ba9190a11b6fb72ee33f0239e2e5974c60bd2929924a7b";
+      sha512 = "3a696c7bcf2ee63ca797579d5a196659cc00ebba9ccbd7f41450aa5f8352260cd7cece56b43722ff09dafeafa2e11e76bd51f6863a7badd15f550ef1e38c6ce5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/ru/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/ru/thunderbird-60.3.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "b79517c780485098ae0aa91d275e8f314b8914a1a84400646963e0a23bd9179fe9dd3b63b80e45cc102296364bed639ab45841932d0bf93142e38850764125e7";
+      sha512 = "897df974fdda8f9c68091a15ddaaf36261b4d68183c3f09442fff486c2a86249e24744187cf85cfcd3217f54340a7c51f14ecc618373101ecd264ae767a387e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/si/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/si/thunderbird-60.3.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "d7a4a804c0122a902d513e6bbde37fb75b35a6a49300992aa81f6590becff6315d757c095f35505dce48b1e4d6b4963f7484f636c0d87d5ecf0cdfc1b9f44464";
+      sha512 = "35b16423c41886f28a9aab9e9b5ebcc811ac03424a89b9e6f7ca494f8cc43a1c51668854d9c479fde8f977306290cf0b5bd2eb4c0c60fc98fc6522333624890e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sk/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/sk/thunderbird-60.3.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "f50653801aff3f8596cfcdaf53755b5557e69aa237a76bd5598bc349839616a18b2a7703ce79094b6719d7e544f66a114b5d61ac9ef65f20c4f10a2e7b2cbe45";
+      sha512 = "5e4855121d4d36dc639a85986d5ccef62c7eff28008d7d2c5150becd75ebe6f95a5ae54a280e35e50c5f2cbc27665a709e1fdc55860d17b893b2fc2e48d0e56b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sl/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/sl/thunderbird-60.3.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "d98731420605736ec5ba1df75a38b8a44ebe2a29c307fb7e63f51db0b2f8d2fab0bde2c8e4d9778bba82545f04f42a80bff1659cf49f3a1db5ad5418cfe9c34f";
+      sha512 = "93ca3fb5eec8edeb050d8c293446f44c975f5b206de5ceac7cf9a7feb3699c90c1e85848fb22108ec757960d6a686d68ffba61644b20d1e0c8ffd0a126dadd17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sq/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/sq/thunderbird-60.3.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "8973e874151efb48343dec2c192e98015740d160dff902d1c07f6f1a5e770344ed07260bb4986892615f31b5c06f56a59406def6d7af20cab04edcba2e5b6003";
+      sha512 = "891a6a103eb05b84af59c76cee7742d5ad04aa51beb955a7023852879e2853b5ac2b79af2dd45f87cefbcd176ab7d6bda9773f9af8e624435ac228d0c04ce298";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/sr/thunderbird-60.3.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "354706cac183b91067d55d49b16f525aef6c5abbedb729d321e615d8e29c05976ec8e33c905600584bf2e64ba8fb27472fe14a9390e2188fb2b236df0cf7d39e";
+      sha512 = "14d84a42a89b84d2aeca1e4b4f2b2ecb30dd5e940ccb77a7b6337df88d0c73e4cfdaae0c6fdc055e6cbe213ad4652361c3b5f37680e09506da354bcc492cc155";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/sv-SE/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/sv-SE/thunderbird-60.3.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "8714ecbaf368d5c405224163bc1f0047b498770167dc6ffd53cc1bb0828228cd48933a5ff7e5116634e1c50218d08d27fa667942878a19fa2f0a4398ab0fa458";
+      sha512 = "4a51fbca27bb37b556fd3aaaca45ba0f18129089da8d69d796ea6c13fcf8e65138db7d3f87d355777ce325c7f0e7b7b643d7a0c6067f71ca63e1c37c052d34ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/tr/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/tr/thunderbird-60.3.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "e8e62fdc8704f91754be9a97f288d113577039bbca1ed69c01e577cc8813e4302f9cd1842f38a91cb8d9899a7a9317b59e931e65f492e619b6b6c2a736117366";
+      sha512 = "332deb7803f935e67bc3d3e8ff55255f5ac8a6a7f128fef924c78aeb8b4023f0f562b9957dbdf84ba25c4b65a55028a8b341a0764ec4aced8fb127b05c083029";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/uk/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/uk/thunderbird-60.3.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "d948efc3e6bd4c9392fed77f52e77998f5b1a202945a6e4bd3b3bcc8332925c6d8de5d48c9737401e94ac701ee7d9e334819fd3718b600914650ee57bef5a5bc";
+      sha512 = "0c96360839e9e72848b1574c389cd29d71e3225cfaca7292c83f9835c4c9d59cb324b390acb00666861f7a060eedc233ac84dc475536e9b206af75e9fa4edf49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/vi/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/vi/thunderbird-60.3.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "929f5c94418de4df462356e0321088482e1e7ece9fe1838123c12f7649c2762e53d20de75bb77f77bc54add23985653ba77b63502b19912b6bc82f2b0ef1dfa0";
+      sha512 = "b0421b6a3ee1dd95d3282c69d618eadf8f1fb69f72d61bec63fa82544d387780b2f80b2531c48c853fcfb4e9a50d14a79b145d3fe3f9ca0919582876385d63af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/zh-CN/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/zh-CN/thunderbird-60.3.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "b746273c7ad7651521d6072f211351c3b585d25ebd48027be3b93a3ce0e09abdaae2a63e97eca013dba046dbadf97f5d4a38fd08bf4a9304c7622881367af73a";
+      sha512 = "22197ee9de592ea02894cf3cffda12267a4999b3fba31a6f90c621aec502834753f09834ed80901f156a385f7af6c1ff4a3d6558a47b2e489f153d1d727d0bd6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.1/linux-i686/zh-TW/thunderbird-60.3.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.2/linux-i686/zh-TW/thunderbird-60.3.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "9251b5688967e87f521bc283b0000194eb98c2ce157aa8befe624146d5dcbf4e7237944d3ae8c0045a0667172fd68616e179fb3ecf6e0f848f7e15a6a2b21f00";
+      sha512 = "8e7e3d7063ef9b5e56f000cfada185ad31951b3ccf7dd9f84455fde7490e3cafef934f0b3501b70d7746464aa5b41180f6f9eeecc7b580d07823bf2ec97d11e8";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -24,11 +24,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "60.3.1";
+  version = "60.3.2";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "266m4kwxiwh1zi60z4gcs54k4w903aximafngmmqaa5nkxnsxh6sp62j1mazdh52g40pzdy9sqb8zkcjsm7dp937kpcl2lvw778lanm";
+    sha512 = "27hdv1c0jgwk6lkkdfy1rx7r29s2girikbbrriwr9v1gvmf7j3vgdldk7wqijjcp185dbp714wh3n5kp1p9f3sa8mf7z6321xby0mf7";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
###### Motivation for this change

- Bug fixes

https://www.thunderbird.net/en-US/thunderbird/60.3.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

