### PR TITLE
gandi-cli: 0.19 -> 1.3

### DIFF
--- a/pkgs/tools/networking/gandi-cli/default.nix
+++ b/pkgs/tools/networking/gandi-cli/default.nix
@@ -1,17 +1,16 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python3Packages, fetchFromGitHub }:
 
-with pythonPackages;
+with python3Packages;
 
-buildPythonPackage rec {
-  namePrefix = "";
-  name = "gandi-cli-${version}";
-  version = "0.19";
+buildPythonApplication rec {
+  pname = "gandi-cli";
+  version = "1.3";
 
   src = fetchFromGitHub {
-    sha256 = "0xbf97p75zl6sjxqcgmaa4p5rax2h6ixn8srwdr4rsx2zz9dpwgp";
-    rev = version;
-    repo = "gandi.cli";
     owner = "Gandi";
+    repo = "gandi.cli";
+    rev = version;
+    sha256 = "07i1y88j5awsw7qadk7gnmax8mi7vgh1nflnc8j54z53fjyamlcs";
   };
 
   propagatedBuildInputs = [ click ipy pyyaml requests ];
@@ -22,6 +21,6 @@ buildPythonPackage rec {
     description = "Command-line interface to the public Gandi.net API";
     homepage = http://cli.gandi.net/;
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ckampka ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

gandi-cli 0.19 is hopelessly out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

