### PR TITLE
fped: init at unstable-2017-05-11

### DIFF
--- a/pkgs/applications/science/electronics/fped/default.nix
+++ b/pkgs/applications/science/electronics/fped/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchgit
+, flex, bison, fig2dev, imagemagick, netpbm, gtk2
+, pkgconfig
+}:
+
+with lib;
+stdenv.mkDerivation rec {
+  name = "fped-${version}";
+  version = "unstable-2017-05-11";
+
+  src = fetchgit {
+    url = "git://projects.qi-hardware.com/fped.git";
+    rev = "fa98e58157b6f68396d302c32421e882ac87f45b";
+    sha256 = "0xv364a00zwxhd9kg1z9sch5y0cxnrhk546asspyb9bh58sdzfy7";
+  };
+
+  # This uses '/bin/bash', '/usr/local' and 'lex' by default
+  makeFlags = [
+    "PREFIX=${placeholder ''out''}"
+    "LEX=flex"
+    "RGBDEF=${netpbm}/share/netpbm/misc/rgb.txt"
+  ];
+
+  nativeBuildInputs = [
+    flex
+    bison
+    pkgconfig
+    imagemagick
+    fig2dev
+    netpbm
+  ];
+
+  buildInputs = [
+    gtk2
+  ];
+
+  meta = {
+    description = "An editor that allows the interactive creation of footprints electronic components";
+    homepage = http://projects.qi-hardware.com/index.php/p/fped/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ expipiplus1 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22314,6 +22314,8 @@ in
 
   gtkwave = callPackage ../applications/science/electronics/gtkwave { };
 
+  fped = callPackage ../applications/science/electronics/fped { };
+
   kicad = callPackage ../applications/science/electronics/kicad {
     wxGTK = wxGTK30;
     boost = boost160;


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---