### PR TITLE
Bump android sdk backport in 18.09

### DIFF
--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
         # The monitor requires some more patching
 
         cd lib/monitor-x86
-        patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux.so.2 monitor
+        patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 monitor
         patchelf --set-rpath ${makeLibraryPath [ libX11 libXext libXrender freetype fontconfig ]} libcairo-swt.so
 
         wrapProgram `pwd`/monitor \

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -41,10 +41,16 @@ stdenv.mkDerivation rec {
     }
     else throw "platform not ${stdenv.hostPlatform.system} supported!";
 
+  emulator = fetchurl {
+     url = "https://dl.google.com/android/repository/emulator-linux-4969155.zip";
+     sha256 = "0iw0j6j3w9zpfalsa7xq2czz4vzgq96zk2zddjhanwwx4p8fhrfd";
+  };
+
   buildCommand = ''
     mkdir -p $out/libexec
     cd $out/libexec
     unpackFile $src
+    unpackFile $emulator
     cd tools
 
     for f in monitor bin/monkeyrunner bin/uiautomatorviewer
@@ -76,13 +82,16 @@ stdenv.mkDerivation rec {
       # The emulators need additional libraries, which are dynamically loaded => let's wrap them
 
       ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        for i in emulator emulator-check
+        cd ..
+        for i in emulator/emulator* emulator/qemu/linux-x86_64/qemu-system-*
         do
+            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
             wrapProgram `pwd`/$i \
               --prefix PATH : ${stdenv.lib.makeBinPath [ file glxinfo ]} \
               --suffix LD_LIBRARY_PATH : `pwd`/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \
               --suffix QT_XKB_CONFIG_ROOT : ${xkeyboardconfig}/share/X11/xkb
         done
+        cd tools
       ''}
     ''}
 
@@ -256,6 +265,14 @@ stdenv.mkDerivation rec {
     done
 
     for i in $out/libexec/build-tools/*/*
+    do
+        if [ ! -d $i ] && [ -x $i ]
+        then
+            ln -sf $i $out/bin/$(basename $i)
+        fi
+    done
+
+    for i in $out/libexec/emulator/*
     do
         if [ ! -d $i ] && [ -x $i ]
         then

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -6,7 +6,7 @@
 , includeSources
 , licenseAccepted
 }:
-{ platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false
+{ platformVersions, abiVersions, useGoogleAPIs, buildToolsVersions ? [], useExtraSupportLibs ? false
 , useGooglePlayServices ? false, useInstantApps ? false }:
 
 if !licenseAccepted then throw ''
@@ -120,8 +120,16 @@ stdenv.mkDerivation rec {
 
     cd ..
     ln -s ${platformTools}/platform-tools
-    ln -s ${buildTools}/build-tools
     ln -s ${support}/support
+
+    mkdir -p build-tools
+    cd build-tools
+
+    ${stdenv.lib.concatMapStrings
+       (v: "ln -s ${builtins.getAttr "v${builtins.replaceStrings ["."] ["_"] v}" buildTools}/build-tools/*")
+       (if (builtins.length buildToolsVersions) == 0 then platformVersions else buildToolsVersions)}
+
+    cd ..
 
     # Symlink required Google API add-ons
 

--- a/pkgs/development/mobile/androidenv/androidsdk.nix
+++ b/pkgs/development/mobile/androidenv/androidsdk.nix
@@ -4,9 +4,17 @@
 , freetype, fontconfig, glib, gtk2, atk, file, jdk, coreutils, libpulseaudio, dbus
 , zlib, glxinfo, xkeyboardconfig
 , includeSources
+, licenseAccepted
 }:
 { platformVersions, abiVersions, useGoogleAPIs, useExtraSupportLibs ? false
 , useGooglePlayServices ? false, useInstantApps ? false }:
+
+if !licenseAccepted then throw ''
+    You must accept the Android Software Development Kit License Agreement at
+    https://developer.android.com/studio/terms
+    by setting nixpkgs config option 'android_sdk.accept_license = true;'
+  ''
+else assert licenseAccepted;
 
 let inherit (stdenv.lib) makeLibraryPath;
 
@@ -20,16 +28,16 @@ in
 
 stdenv.mkDerivation rec {
   name = "android-sdk-${version}";
-  version = "25.2.5";
+  version = "26.1.1";
 
   src = if (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
     then fetchurl {
-      url = "https://dl.google.com/android/repository/tools_r${version}-linux.zip";
-      sha256 = "0gnk49pkwy4m0nqwm1xnf3w4mfpi9w0kk7841xlawpwbkj0icxap";
+      url = "https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip";
+      sha256 = "1yfy0qqxz1ixpsci1pizls1nrncmi8p16wcb9rimdn4q3mdfxzwj";
     }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then fetchurl {
-      url = "http://dl.google.com/android/repository/tools_r${version}-macosx.zip";
-      sha256 = "0yg7wjmyw70xsh8k4hgbqb5rilam2a94yc8dwbh7fjwqcmpxgwqb";
+      url = "https://dl.google.com/android/repository/sdk-tools-darwin-4333796.zip";
+      sha256 = "0gl5c30m40kx0vvrpbaa8cw8wq2vb89r14hgzb1df4qgpic97cpc";
     }
     else throw "platform not ${stdenv.hostPlatform.system} supported!";
 
@@ -39,7 +47,7 @@ stdenv.mkDerivation rec {
     unpackFile $src
     cd tools
 
-    for f in android traceview draw9patch hierarchyviewer monitor ddms screenshot2 uiautomatorviewer monkeyrunner jobb lint
+    for f in monitor bin/monkeyrunner bin/uiautomatorviewer
     do
         sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
     done
@@ -54,24 +62,6 @@ stdenv.mkDerivation rec {
           patchelf --set-rpath ${stdenv_32bit.cc.cc.lib}/lib $i
       done
 
-      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        for i in bin64/{mkfs.ext4,fsck.ext4,e2fsck,tune2fs,resize2fs}
-        do
-            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
-            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64 $i
-        done
-      ''}
-
-      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        # We must also patch the 64-bit emulator instances, if needed
-
-        for i in emulator emulator64-arm emulator64-mips emulator64-x86 emulator64-crash-service emulator-check qemu/linux-x86_64/qemu-system-*
-        do
-            patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
-            patchelf --set-rpath ${stdenv.cc.cc.lib}/lib64 $i
-        done
-      ''}
-
       # The following scripts used SWT and wants to dynamically load some GTK+ stuff.
       # Creating these wrappers ensure that they can be found:
 
@@ -79,22 +69,18 @@ stdenv.mkDerivation rec {
         --prefix PATH : ${jdk}/bin \
         --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ glib gtk2 libXtst ]}
 
-      wrapProgram `pwd`/uiautomatorviewer \
-        --prefix PATH : ${jdk}/bin \
-        --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
-
-      wrapProgram `pwd`/hierarchyviewer \
+      wrapProgram `pwd`/bin/uiautomatorviewer \
         --prefix PATH : ${jdk}/bin \
         --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
 
       # The emulators need additional libraries, which are dynamically loaded => let's wrap them
 
       ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
-        for i in emulator emulator64-arm emulator64-mips emulator64-x86 emulator64-crash-service
+        for i in emulator emulator-check
         do
             wrapProgram `pwd`/$i \
               --prefix PATH : ${stdenv.lib.makeBinPath [ file glxinfo ]} \
-              --suffix LD_LIBRARY_PATH : `pwd`/lib64:`pwd`/lib64/qt/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \
+              --suffix LD_LIBRARY_PATH : `pwd`/lib:${makeLibraryPath [ stdenv.cc.cc libX11 libxcb libXau libXdmcp libXext libGLU_combined alsaLib zlib libpulseaudio dbus.lib ]} \
               --suffix QT_XKB_CONFIG_ROOT : ${xkeyboardconfig}/share/X11/xkb
         done
       ''}
@@ -245,6 +231,14 @@ stdenv.mkDerivation rec {
         fi
     done
 
+    for i in $out/libexec/tools/bin/*
+    do
+        if [ ! -d $i ] && [ -x $i ]
+        then
+            ln -sf $i $out/bin/$(basename $i)
+        fi
+    done
+
     for i in $out/libexec/platform-tools/*
     do
         if [ ! -d $i ] && [ -x $i ]
@@ -260,6 +254,11 @@ stdenv.mkDerivation rec {
             ln -sf $i $out/bin/$(basename $i)
         fi
     done
+
+    wrapProgram $out/bin/sdkmanager \
+      --set JAVA_HOME ${jdk}
+
+    yes | ANDROID_SDK_HOME=$(mktemp -d) $out/bin/sdkmanager --licenses || true
   '';
 
   buildInputs = [ unzip makeWrapper ];

--- a/pkgs/development/mobile/androidenv/build-tools-srcs-linux.nix
+++ b/pkgs/development/mobile/androidenv/build-tools-srcs-linux.nix
@@ -1,0 +1,376 @@
+
+# This file is generated from generate-tools.sh. DO NOT EDIT.
+# Execute generate-tools.sh or fetch.sh to update the file.
+{ fetchurl }:
+
+{
+    
+  v17 = {
+    version = "17.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r17-linux.zip;
+      sha1 = "2c2872bc3806aabf16a12e3959c2183ddc866e6d";
+    };
+  };
+
+  v18_0_1 = {
+    version = "18.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.0.1-linux.zip;
+      sha1 = "f11618492b0d2270c332325d45d752d3656a9640";
+    };
+  };
+
+  v18_1_0 = {
+    version = "18.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1-linux.zip;
+      sha1 = "f314a0599e51397f0886fe888b50dd98f2f050d8";
+    };
+  };
+
+  v18_1_1 = {
+    version = "18.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1.1-linux.zip;
+      sha1 = "68c9acbfc0cec2d51b19efaed39831a17055d998";
+    };
+  };
+
+  v19 = {
+    version = "19.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19-linux.zip;
+      sha1 = "55c1a6cf632e7d346f0002b275ec41fd3137fd83";
+    };
+  };
+
+  v19_0_1 = {
+    version = "19.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.1-linux.zip;
+      sha1 = "18d2312dc4368858914213087f4e61445aca4517";
+    };
+  };
+
+  v19_0_2 = {
+    version = "19.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.2-linux.zip;
+      sha1 = "a03a6bdea0091aea32e1b35b90a7294c9f04e3dd";
+    };
+  };
+
+  v19_0_3 = {
+    version = "19.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.3-linux.zip;
+      sha1 = "c2d6055478e9d2d4fba476ee85f99181ddd1160c";
+    };
+  };
+
+  v19_1_0 = {
+    version = "19.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.1-linux.zip;
+      sha1 = "1ff20ac15fa47a75d00346ec12f180d531b3ca89";
+    };
+  };
+
+  v20 = {
+    version = "20.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r20-linux.zip;
+      sha1 = "b688905526a5584d1327a662d871a635ff502758";
+    };
+  };
+
+  v21 = {
+    version = "21.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21-linux.zip;
+      sha1 = "4933328fdeecbd554a29528f254f4993468e1cf4";
+    };
+  };
+
+  v21_0_1 = {
+    version = "21.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.1-linux.zip;
+      sha1 = "e573069eea3e5255e7a65bedeb767f4fd0a5f49a";
+    };
+  };
+
+  v21_0_2 = {
+    version = "21.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.2-linux.zip;
+      sha1 = "e1236ab8897b62b57414adcf04c132567b2612a5";
+    };
+  };
+
+  v21_1_0 = {
+    version = "21.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1-linux.zip;
+      sha1 = "b7455e543784d52a8925f960bc880493ed1478cb";
+    };
+  };
+
+  v21_1_1 = {
+    version = "21.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.1-linux.zip;
+      sha1 = "1c712ee3a1ba5a8b0548f9c32f17d4a0ddfd727d";
+    };
+  };
+
+  v21_1_2 = {
+    version = "21.1.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.2-linux.zip;
+      sha1 = "5e35259843bf2926113a38368b08458735479658";
+    };
+  };
+
+  v22 = {
+    version = "22.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22-linux.zip;
+      sha1 = "a8a1619dd090e44fac957bce6842e62abf87965b";
+    };
+  };
+
+  v22_0_1 = {
+    version = "22.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22.0.1-linux.zip;
+      sha1 = "da8b9c5c3ede39298e6cf0283c000c2ee9029646";
+    };
+  };
+
+  v23 = {
+    version = "23.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23-linux.zip;
+      sha1 = "c1d6209212b01469f80fa804e0c1d39a06bc9060";
+    };
+  };
+
+  v23_0_1 = {
+    version = "23.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.1-linux.zip;
+      sha1 = "b6ba7c399d5fa487d95289d8832e4ad943aed556";
+    };
+  };
+
+  v23_0_2 = {
+    version = "23.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.2-linux.zip;
+      sha1 = "8a9f2b37f6fcf7a9fa784dc21aeaeb41bbb9f2c3";
+    };
+  };
+
+  v23_0_3 = {
+    version = "23.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.3-linux.zip;
+      sha1 = "368f2600feac7e9b511b82f53d1f2240ae4a91a3";
+    };
+  };
+
+  v24 = {
+    version = "24.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24-linux.zip;
+      sha1 = "c6271c4d78a5612ea6c7150688bcd5b7313de8d1";
+    };
+  };
+
+  v24_0_1 = {
+    version = "24.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.1-linux.zip;
+      sha1 = "84f18c392919a074fcbb9b1d967984e6b2fef8b4";
+    };
+  };
+
+  v24_0_2 = {
+    version = "24.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.2-linux.zip;
+      sha1 = "f199a7a788c3fefbed102eea34d6007737b803cf";
+    };
+  };
+
+  v24_0_3 = {
+    version = "24.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.3-linux.zip;
+      sha1 = "9e8cc49d66e03fa1a8ecc1ac3e58f1324f5da304";
+    };
+  };
+
+  v25 = {
+    version = "25.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25-linux.zip;
+      sha1 = "f2bbda60403e75cabd0f238598c3b4dfca56ea44";
+    };
+  };
+
+  v25_0_1 = {
+    version = "25.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.1-linux.zip;
+      sha1 = "ff063d252ab750d339f5947d06ff782836f22bac";
+    };
+  };
+
+  v25_0_2 = {
+    version = "25.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.2-linux.zip;
+      sha1 = "ff953c0177e317618fda40516f3e9d95fd43c7ae";
+    };
+  };
+
+  v25_0_3 = {
+    version = "25.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.3-linux.zip;
+      sha1 = "db95f3a0ae376534d4d69f4cdb6fad20649f3509";
+    };
+  };
+
+  v26 = {
+    version = "26.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-linux.zip;
+      sha1 = "1cbe72929876f8a872ab1f1b1040a9f720261f59";
+    };
+  };
+
+  v26_rc1 = {
+    version = "26.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc1-linux.zip;
+      sha1 = "8cd6388dc96db2d7a49d06159cf990d3bbc78d04";
+    };
+  };
+
+  v26_rc2 = {
+    version = "26.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc2-linux.zip;
+      sha1 = "629bbd8d2e415bf64871fb0b4c0540fd6d0347a0";
+    };
+  };
+
+  v26_0_1 = {
+    version = "26.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.1-linux.zip;
+      sha1 = "5378c2c78091b414d0eac40a6bd37f2faa31a365";
+    };
+  };
+
+  v26_0_2 = {
+    version = "26.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.2-linux.zip;
+      sha1 = "5b2b7b66c7bf2151f2af183b5b50a17808850592";
+    };
+  };
+
+  v26_0_3 = {
+    version = "26.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.3-linux.zip;
+      sha1 = "8a2e6c1bcd845844523a68aa17e5442f0dce328c";
+    };
+  };
+
+  v27 = {
+    version = "27.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27-linux.zip;
+      sha1 = "28542332ba97cf4a08c3eddfcf5edd70e3cf1260";
+    };
+  };
+
+  v27_0_1 = {
+    version = "27.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.1-linux.zip;
+      sha1 = "7f4eedb1077ef948b848040dcd15de9e8a759f4a";
+    };
+  };
+
+  v27_0_2 = {
+    version = "27.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.2-linux.zip;
+      sha1 = "b687ddf6be84f11607871138aad32cf857d0b837";
+    };
+  };
+
+  v27_0_3 = {
+    version = "27.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.3-linux.zip;
+      sha1 = "d85e7a6320eddffe7eeace3437605079dac938ca";
+    };
+  };
+
+  v28 = {
+    version = "28.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-linux.zip;
+      sha1 = "d9f8a754d833ccd334f56fcc6089c5925cd82abb";
+    };
+  };
+
+  v28_rc1 = {
+    version = "28.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc1-linux.zip;
+      sha1 = "1601977fae25fd478bcfaa0481ca5ea3c609d840";
+    };
+  };
+
+  v28_rc2 = {
+    version = "28.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc2-linux.zip;
+      sha1 = "efe9c0dde0646a07544c864276390ca6e96b24dc";
+    };
+  };
+
+  v28_0_1 = {
+    version = "28.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.1-linux.zip;
+      sha1 = "ee70dfa1fccb58b37cebc9544830511f36a137a0";
+    };
+  };
+
+  v28_0_2 = {
+    version = "28.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.2-linux.zip;
+      sha1 = "b4492209810a3fd48deaa982f9852fef12433d55";
+    };
+  };
+
+  v28_0_3 = {
+    version = "28.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.3-linux.zip;
+      sha1 = "ea6f2f7103cd9da9ff0bdf6e37fbbba548fa4165";
+    };
+  };
+
+}

--- a/pkgs/development/mobile/androidenv/build-tools-srcs-macosx.nix
+++ b/pkgs/development/mobile/androidenv/build-tools-srcs-macosx.nix
@@ -1,0 +1,376 @@
+
+# This file is generated from generate-tools.sh. DO NOT EDIT.
+# Execute generate-tools.sh or fetch.sh to update the file.
+{ fetchurl }:
+
+{
+    
+  v17 = {
+    version = "17.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r17-macosx.zip;
+      sha1 = "602ee709be9dbb8f179b1e4075148a57f9419930";
+    };
+  };
+
+  v18_0_1 = {
+    version = "18.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.0.1-macosx.zip;
+      sha1 = "d84f5692fb44d60fc53e5b2507cebf9f24626902";
+    };
+  };
+
+  v18_1_0 = {
+    version = "18.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1-macosx.zip;
+      sha1 = "16ddb299b8b43063e5bb3387ec17147c5053dfd8";
+    };
+  };
+
+  v18_1_1 = {
+    version = "18.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r18.1.1-macosx.zip;
+      sha1 = "a9d9d37f6ddf859e57abc78802a77aaa166e48d4";
+    };
+  };
+
+  v19 = {
+    version = "19.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19-macosx.zip;
+      sha1 = "86ec1c12db1bc446b7bcaefc5cc14eb361044e90";
+    };
+  };
+
+  v19_0_1 = {
+    version = "19.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.1-macosx.zip;
+      sha1 = "efaf50fb19a3edb8d03efbff76f89a249ad2920b";
+    };
+  };
+
+  v19_0_2 = {
+    version = "19.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.2-macosx.zip;
+      sha1 = "145bc43065d45f756d99d87329d899052b9a9288";
+    };
+  };
+
+  v19_0_3 = {
+    version = "19.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.0.3-macosx.zip;
+      sha1 = "651cf8754373b2d52e7f6aab2c52eabffe4e9ea4";
+    };
+  };
+
+  v19_1_0 = {
+    version = "19.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r19.1-macosx.zip;
+      sha1 = "0d11aae3417de1efb4b9a0e0a7855904a61bcec1";
+    };
+  };
+
+  v20 = {
+    version = "20.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r20-macosx.zip;
+      sha1 = "1240f629411c108a714c4ddd756937c7fab93f83";
+    };
+  };
+
+  v21 = {
+    version = "21.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21-macosx.zip;
+      sha1 = "9bef7989b51436bd4e5114d8a0330359f077cbfa";
+    };
+  };
+
+  v21_0_1 = {
+    version = "21.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.1-macosx.zip;
+      sha1 = "b60c8f9b810c980abafa04896706f3911be1ade7";
+    };
+  };
+
+  v21_0_2 = {
+    version = "21.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.0.2-macosx.zip;
+      sha1 = "f17471c154058f3734729ef3cc363399b1cd3de1";
+    };
+  };
+
+  v21_1_0 = {
+    version = "21.1.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1-macosx.zip;
+      sha1 = "df619356c2359aa5eacdd48699d15b335d9bd246";
+    };
+  };
+
+  v21_1_1 = {
+    version = "21.1.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.1-macosx.zip;
+      sha1 = "836a146eab0504aa9387a5132e986fe7c7381571";
+    };
+  };
+
+  v21_1_2 = {
+    version = "21.1.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r21.1.2-macosx.zip;
+      sha1 = "e7c906b4ba0eea93b32ba36c610dbd6b204bff48";
+    };
+  };
+
+  v22 = {
+    version = "22.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22-macosx.zip;
+      sha1 = "af95429b24088d704bc5db9bd606e34ac1b82c0d";
+    };
+  };
+
+  v22_0_1 = {
+    version = "22.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r22.0.1-macosx.zip;
+      sha1 = "53dad7f608e01d53b17176ba11165acbfccc5bbf";
+    };
+  };
+
+  v23 = {
+    version = "23.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23-macosx.zip;
+      sha1 = "90ba6e716f7703a236cd44b2e71c5ff430855a03";
+    };
+  };
+
+  v23_0_1 = {
+    version = "23.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.1-macosx.zip;
+      sha1 = "d96ec1522721e9a179ae2c591c99f75d31d39718";
+    };
+  };
+
+  v23_0_2 = {
+    version = "23.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.2-macosx.zip;
+      sha1 = "482c4cbceef8ff58aefd92d8155a38610158fdaf";
+    };
+  };
+
+  v23_0_3 = {
+    version = "23.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r23.0.3-macosx.zip;
+      sha1 = "fbc98cd303fd15a31d472de6c03bd707829f00b0";
+    };
+  };
+
+  v24 = {
+    version = "24.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24-macosx.zip;
+      sha1 = "97fc4ed442f23989cc488d02c1d1de9bdde241de";
+    };
+  };
+
+  v24_0_1 = {
+    version = "24.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.1-macosx.zip;
+      sha1 = "5c6457fcdfa07724fb086d8ff4e8316fc0742848";
+    };
+  };
+
+  v24_0_2 = {
+    version = "24.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.2-macosx.zip;
+      sha1 = "8bb8fc575477491d5957de743089df412de55cda";
+    };
+  };
+
+  v24_0_3 = {
+    version = "24.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r24.0.3-macosx.zip;
+      sha1 = "a01c15f1b105c34595681075e1895d58b3fff48c";
+    };
+  };
+
+  v25 = {
+    version = "25.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25-macosx.zip;
+      sha1 = "273c5c29a65cbed00e44f3aa470bbd7dce556606";
+    };
+  };
+
+  v25_0_1 = {
+    version = "25.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.1-macosx.zip;
+      sha1 = "7bf7f22d7d48ef20b6ab0e3d7a2912e5c088340f";
+    };
+  };
+
+  v25_0_2 = {
+    version = "25.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.2-macosx.zip;
+      sha1 = "12a5204bb3b6e39437535469fde7ddf42da46b16";
+    };
+  };
+
+  v25_0_3 = {
+    version = "25.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r25.0.3-macosx.zip;
+      sha1 = "160d2fefb5ce68e443427fc30a793a703b63e26e";
+    };
+  };
+
+  v26 = {
+    version = "26.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-macosx.zip;
+      sha1 = "d01a1aeca03747245f1f5936b3cb01759c66d086";
+    };
+  };
+
+  v26_rc1 = {
+    version = "26.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc1-macosx.zip;
+      sha1 = "5c5a1de7d5f4f000d36ae349229fe0be846d6137";
+    };
+  };
+
+  v26_rc2 = {
+    version = "26.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26-rc2-macosx.zip;
+      sha1 = "cb1eb738a1f7003025af267a9b8cc2d259533c70";
+    };
+  };
+
+  v26_0_1 = {
+    version = "26.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.1-macosx.zip;
+      sha1 = "cbde59de198916b390777dd0227921bfa2120832";
+    };
+  };
+
+  v26_0_2 = {
+    version = "26.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.2-macosx.zip;
+      sha1 = "d9ed7c7f149ce38be5dc08979aea8acec1459ca0";
+    };
+  };
+
+  v26_0_3 = {
+    version = "26.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r26.0.3-macosx.zip;
+      sha1 = "5bb90ed935d99e5bc90686f43b852e68c5ad40df";
+    };
+  };
+
+  v27 = {
+    version = "27.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27-macosx.zip;
+      sha1 = "fb4e8d7e6b8d29a77090e34024077a80458d5ae1";
+    };
+  };
+
+  v27_0_1 = {
+    version = "27.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.1-macosx.zip;
+      sha1 = "1edd07bfdbadd95652d093040e16d858f7489594";
+    };
+  };
+
+  v27_0_2 = {
+    version = "27.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.2-macosx.zip;
+      sha1 = "6d5d9cf2a47877f273f4b742b19e712a051a31be";
+    };
+  };
+
+  v27_0_3 = {
+    version = "27.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r27.0.3-macosx.zip;
+      sha1 = "61d9fb18790c68d66ff73bf1e7ad56bc1f1eef2d";
+    };
+  };
+
+  v28 = {
+    version = "28.0.0";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-macosx.zip;
+      sha1 = "72088d32d1d82cc3c2cf7cf6618b6130c0c84ade";
+    };
+  };
+
+  v28_rc1 = {
+    version = "28.0.0-rc1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc1-macosx.zip;
+      sha1 = "2c77821967a2330b7b227072d0b1c02ef19fe2fc";
+    };
+  };
+
+  v28_rc2 = {
+    version = "28.0.0-rc2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28-rc2-macosx.zip;
+      sha1 = "0d0314b353589feb10e528b44c5a685b6658d797";
+    };
+  };
+
+  v28_0_1 = {
+    version = "28.0.1";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.1-macosx.zip;
+      sha1 = "aeef42ad953f1630dd6f5d71eefdc0b825211462";
+    };
+  };
+
+  v28_0_2 = {
+    version = "28.0.2";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.2-macosx.zip;
+      sha1 = "c10dd5a7825578622fb362a8a34f76eb3ba0c0a9";
+    };
+  };
+
+  v28_0_3 = {
+    version = "28.0.3";
+    src = fetchurl {
+      url = https://dl.google.com/android/repository/build-tools_r28.0.3-macosx.zip;
+      sha1 = "f8c333a2991b1ab05a671bc6248b78e00edcd83a";
+    };
+  };
+
+}

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,56 +1,53 @@
-{stdenv, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses}:
+{stdenv, lib, stdenv_32bit, fetchurl, unzip, zlib_32bit, ncurses_32bit, file, zlib, ncurses, coreutils, buildToolsSources}:
 
-stdenv.mkDerivation rec {
-  version = "26.0.2";
-  name = "android-build-tools-r${version}";
-  src = if (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
-    then fetchurl {
-      url = "https://dl.google.com/android/repository/build-tools_r${version}-linux.zip";
-      sha256 = "1kii880bwhjkc343zwx1ysxyisxhczrwhphnxbwsgi45mjgq8lm7";
-    }
-    else if stdenv.hostPlatform.system == "x86_64-darwin" then fetchurl {
-      url = "https://dl.google.com/android/repository/build-tools_r${version}-macosx.zip";
-      sha256 = "1x0ycprl6hgsm23kck5ind7x00hzydc5k3h3ch4a13407xbpvzvx";
-    }
-    else throw "System ${stdenv.hostPlatform.system} not supported!";
+let buildBuildTools = name: { version, src }:
+  stdenv.mkDerivation rec {
+    inherit version src;
+    name = "android-build-tools-r${version}";
+    buildCommand = ''
+      mkdir -p $out/build-tools
+      cd $out/build-tools
+      unzip $src
+      mv android-* ${version}
 
-  buildCommand = ''
-    mkdir -p $out/build-tools
-    cd $out/build-tools
-    unzip $src
-    mv android-* ${version}
+      cd ${version}
 
-    ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
-      ''
-        cd ${version}
+      for f in $(grep -Rl /bin/ls .); do
+        sed -i -e "s|/bin/ls|${coreutils}/bin/ls|" "$f"
+      done
 
-        ln -s ${ncurses.out}/lib/libncurses.so.5 `pwd`/lib64/libtinfo.so.5
+      ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
+        ''
 
-        find . -type f -print0 | while IFS= read -r -d "" file
-        do
-          type=$(file "$file")
-          ## Patch 64-bit binaries
-          if grep -q "ELF 64-bit" <<< "$type"
-          then
-            if grep -q "interpreter" <<< "$type"
+          ln -s ${ncurses.out}/lib/libncurses.so.5 `pwd`/lib64/libtinfo.so.5
+
+          find . -type f -print0 | while IFS= read -r -d "" file
+          do
+            type=$(file "$file")
+            ## Patch 64-bit binaries
+            if grep -q "ELF 64-bit" <<< "$type"
             then
-              patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 "$file"
-            fi
-            patchelf --set-rpath `pwd`/lib64:${stdenv.cc.cc.lib.out}/lib:${zlib.out}/lib:${ncurses.out}/lib "$file"
-          ## Patch 32-bit binaries
-          elif grep -q "ELF 32-bit" <<< "$type"
-          then
-            if grep -q "interpreter" <<< "$type"
+              if grep -q "interpreter" <<< "$type"
+              then
+                patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 "$file"
+              fi
+              patchelf --set-rpath `pwd`/lib64:${stdenv.cc.cc.lib.out}/lib:${zlib.out}/lib:${ncurses.out}/lib "$file"
+            ## Patch 32-bit binaries
+            elif grep -q "ELF 32-bit" <<< "$type"
             then
-              patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 "$file"
+              if grep -q "interpreter" <<< "$type"
+              then
+                patchelf --set-interpreter ${stdenv_32bit.cc.libc.out}/lib/ld-linux.so.2 "$file"
+              fi
+              patchelf --set-rpath ${stdenv_32bit.cc.cc.lib.out}/lib:${zlib_32bit.out}/lib:${ncurses_32bit.out}/lib "$file"
             fi
-            patchelf --set-rpath ${stdenv_32bit.cc.cc.lib.out}/lib:${zlib_32bit.out}/lib:${ncurses_32bit.out}/lib "$file"
-          fi
-        done
-      ''}
+          done
+        ''}
 
-      patchShebangs .
-  '';
+        patchShebangs .
+    '';
 
-  buildInputs = [ unzip file ];
-}
+    buildInputs = [ unzip file ];
+  };
+in
+  lib.mapAttrs buildBuildTools buildToolsSources

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -9,8 +9,19 @@ rec {
     inherit buildPackages pkgs;
   };
 
+  buildToolsSources = let
+    system = pkgs.stdenv.hostPlatform.system;
+    path = if (system == "i686-linux" || system == "x86_64-linux")
+      then ./build-tools-srcs-linux.nix
+      else if system == "x86_64-darwin"
+      then ./build-tools-srcs-macosx.nix
+      else throw "System: ${system} not supported!";
+  in
+    import path { inherit (pkgs) fetchurl; };
+
   buildTools = import ./build-tools.nix {
-    inherit (pkgs) stdenv fetchurl unzip zlib file;
+    inherit (pkgs) stdenv lib fetchurl unzip zlib file coreutils;
+    inherit buildToolsSources;
     stdenv_32bit = pkgs_i686.stdenv;
     zlib_32bit = pkgs_i686.zlib;
     ncurses_32bit = pkgs_i686.ncurses5;

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,5 +1,5 @@
 { buildPackages, pkgs, pkgs_i686, targetPackages
-, includeSources ? true
+, includeSources ? true, licenseAccepted ? false
 }:
 
 # TODO: use callPackage instead of import to avoid so many inherits
@@ -57,7 +57,7 @@ rec {
 
     inherit platformTools buildTools support
             supportRepository platforms sysimages
-            addons sources includeSources;
+            addons sources includeSources licenseAccepted;
 
     stdenv_32bit = pkgs_i686.stdenv;
   };

--- a/pkgs/development/mobile/androidenv/fetch.sh
+++ b/pkgs/development/mobile/androidenv/fetch.sh
@@ -14,3 +14,4 @@ curl -o sys-img.xml       https://dl.google.com/android/repository/sys-img/andro
 ./generate-platforms.sh
 ./generate-sysimages.sh
 ./generate-sources.sh
+./generate-tools.sh

--- a/pkgs/development/mobile/androidenv/generate-tools.sh
+++ b/pkgs/development/mobile/androidenv/generate-tools.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+xsltproc --stringparam os linux generate-tools.xsl repository-11.xml > build-tools-srcs-linux.nix
+xsltproc --stringparam os macosx generate-tools.xsl repository-11.xml > build-tools-srcs-macosx.nix

--- a/pkgs/development/mobile/androidenv/generate-tools.xsl
+++ b/pkgs/development/mobile/androidenv/generate-tools.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:sdk="http://schemas.android.com/sdk/android/repository/11">
+
+  <xsl:param name="os" />
+  <xsl:output omit-xml-declaration="yes" indent="no" />
+
+  <xsl:template name="repository-url">
+    <xsl:variable name="raw-url" select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:url"/>
+    <xsl:choose>
+      <xsl:when test="starts-with($raw-url, 'http')">
+        <xsl:value-of select="$raw-url"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>https://dl.google.com/android/repository/</xsl:text>
+        <xsl:value-of select="$raw-url"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="/sdk:sdk-repository">
+# This file is generated from generate-tools.sh. DO NOT EDIT.
+# Execute generate-tools.sh or fetch.sh to update the file.
+{ fetchurl }:
+
+{
+    <xsl:for-each select="sdk:build-tool">
+      <xsl:sort select="sdk:revision/sdk:major" data-type="number"/>
+      <xsl:sort select="sdk:revision/sdk:minor" data-type="number"/>
+      <xsl:sort select="sdk:revision/sdk:micro" data-type="number"/>
+      <xsl:sort select="sdk:revision/sdk:preview" data-type="number"/>
+  v<xsl:value-of select="sdk:revision/sdk:major"/><xsl:if test="sdk:revision/sdk:minor + sdk:revision/sdk:micro > 0">_<xsl:value-of select="sdk:revision/sdk:minor" />_<xsl:value-of select="sdk:revision/sdk:micro"/></xsl:if><xsl:if test="sdk:revision/sdk:preview > 0">_rc<xsl:value-of select="sdk:revision/sdk:preview"/></xsl:if> = {
+    version = "<xsl:value-of select="sdk:revision/sdk:major"/>.<xsl:value-of select="sdk:revision/sdk:minor" />.<xsl:value-of select="sdk:revision/sdk:micro"/><xsl:if test="sdk:revision/sdk:preview > 0">-rc<xsl:value-of select="sdk:revision/sdk:preview"/></xsl:if>";
+    src = fetchurl {
+      url = <xsl:call-template name="repository-url"/>;
+      sha1 = "<xsl:value-of select="sdk:archives/sdk:archive[sdk:host-os=$os or count(sdk:host-os) = 0]/sdk:checksum[@type='sha1']" />";
+    };
+  };
+</xsl:for-each>
+}
+</xsl:template>
+</xsl:stylesheet>

--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
     makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
         --add-flags "-jar $out/libexec/apktool/apktool.jar" \
-        --prefix PATH : "${buildTools}/build-tools/25.0.1/"
+        --prefix PATH : "${buildTools.v25_0_1}/build-tools/25.0.1/"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -756,6 +756,7 @@ with pkgs;
 
   androidenv = callPackage ../development/mobile/androidenv {
     pkgs_i686 = pkgsi686Linux;
+    licenseAccepted = (config.android_sdk.accept_license or false);
   };
 
   inherit (androidenv) androidndk;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

