### PR TITLE
libgpiod: init at 2018-10-07

### DIFF
--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoconf, autoconf-archive, automake, libtool, pkgconfig, kmod, enable-tools ? true }:
+{ stdenv, fetchgit, autoreconfHook, autoconf-archive, pkgconfig, kmod, enable-tools ? true }:
 
 stdenv.mkDerivation rec {
   name = "libgpiod-${version}";
@@ -12,19 +12,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ kmod ];
   nativeBuildInputs = [
-    autoconf
     autoconf-archive
-    automake
-    libtool
     pkgconfig
+    autoreconfHook
   ];
 
-  configurePhase = ''
-    ./autogen.sh \
-      --enable-tools=${if enable-tools then "yes" else "no"} \
-      --enable-bindings-cxx \
-      --prefix="$out"
-  '';
+  configureFlags = [
+    "--enable-tools=${if enable-tools then "yes" else "no"}"
+    "--enable-bindings-cxx"
+    "--prefix=$(out)"
+  ];
 
   meta = with stdenv.lib; {
     description = "C library and tools for interacting with the linux GPIO character device";

--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchgit, autoconf, autoconf-archive, automake, libtool, pkgconfig, kmod, enable-tools ? true }:
+
+stdenv.mkDerivation rec {
+  name = "libgpiod-${version}";
+  version = "2018-10-07";
+
+  src = fetchgit {
+    url = "git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git";
+    rev = "4bf402d3a49336eacd33654441d575bd267780b8";
+    sha256 = "01f3jzb133z189sxdiz9qiy65p0bjqhynfllidbpxdr0cxkyyc1d";
+  };
+
+  buildInputs = [ kmod ];
+  nativeBuildInputs = [
+    autoconf
+    autoconf-archive
+    automake
+    libtool
+    pkgconfig
+  ];
+
+  configurePhase = ''
+    ./autogen.sh \
+      --enable-tools=${if enable-tools then "yes" else "no"} \
+      --enable-bindings-cxx \
+      --prefix="$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C library and tools for interacting with the linux GPIO character device";
+    longDescription = ''
+      Since linux 4.8 the GPIO sysfs interface is deprecated. User space should use
+      the character device instead. This library encapsulates the ioctl calls and
+      data structures behind a straightforward API.
+    '';
+    homepage = https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/;
+    license = licenses.lgpl2;
+    maintainers = [ maintainers.expipiplus1 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2018-10-07";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git";
+    url = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git";
     rev = "4bf402d3a49336eacd33654441d575bd267780b8";
     sha256 = "01f3jzb133z189sxdiz9qiy65p0bjqhynfllidbpxdr0cxkyyc1d";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10729,6 +10729,8 @@ with pkgs;
 
   libgphoto2 = callPackage ../development/libraries/libgphoto2 { };
 
+  libgpiod = callPackage ../development/libraries/libgpiod { };
+
   libgpod = callPackage ../development/libraries/libgpod {
     inherit (pkgs.pythonPackages) mutagen;
     monoSupport = false;


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---