### PR TITLE
libinput: fix docs & libinput command

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -2,15 +2,26 @@
 , libevdev, mtdev, udev, libwacom
 , documentationSupport ? false, doxygen ? null, graphviz ? null # Documentation
 , eventGUISupport ? false, cairo ? null, glib ? null, gtk3 ? null # GUI event viewer support
-, testsSupport ? false, check ? null, valgrind ? null, python3Packages ? null
+, testsSupport ? false, check ? null, valgrind ? null, python3 ? null
 }:
 
-assert documentationSupport -> doxygen != null && graphviz != null;
+assert documentationSupport -> doxygen != null && graphviz != null && python3 != null;
 assert eventGUISupport -> cairo != null && glib != null && gtk3 != null;
-assert testsSupport -> check != null && valgrind != null && python3Packages != null;
+assert testsSupport -> check != null && valgrind != null && python3 != null;
 
 let
   mkFlag = optSet: flag: "-D${flag}=${stdenv.lib.boolToString optSet}";
+
+  sphinx-build = if documentationSupport then
+    python3.pkgs.sphinx.overrideAttrs (super: {
+      propagatedBuildInputs = super.propagatedBuildInputs ++ (with python3.pkgs; [ recommonmark sphinx_rtd_theme ]);
+
+      postFixup = super.postFixup or "" + ''
+        # Do not propagate Python
+        rm $out/nix-support/propagated-build-inputs
+      '';
+    })
+  else null;
 in
 
 with stdenv.lib;
@@ -32,18 +43,25 @@ stdenv.mkDerivation rec {
     "--libexecdir=${placeholder "bin"}/libexec"
   ];
 
-  nativeBuildInputs = [ pkgconfig meson ninja python3Packages.python ]
-    ++ optionals documentationSupport [ doxygen graphviz ]
-    ++ optionals testsSupport [ check valgrind python3Packages.pyparsing ];
+  nativeBuildInputs = [ pkgconfig meson ninja ]
+    ++ optionals documentationSupport [ doxygen graphviz sphinx-build ]
+    ++ optionals testsSupport [ valgrind ];
 
-  buildInputs = [ libevdev mtdev libwacom ]
-    ++ optionals eventGUISupport [ cairo glib gtk3 ];
+  buildInputs = [ libevdev mtdev libwacom (python3.withPackages (pkgs: with pkgs; [ evdev ])) ]
+    ++ optionals eventGUISupport [ cairo glib gtk3 ]
+    ++ optionals testsSupport [ check ];
 
   propagatedBuildInputs = [ udev ];
 
   patches = [ ./udev-absolute-path.patch ];
 
-  doCheck = testsSupport;
+  postPatch = ''
+    patchShebangs tools/helper-copy-and-exec-from-tmp.sh
+    patchShebangs test/symbols-leak-test
+    patchShebangs test/check-leftover-udev-rules.sh
+  '';
+
+  doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = {
     description = "Handles input devices in Wayland compositors and provides a generic X.Org input driver";


### PR DESCRIPTION
###### Motivation for this change
libinput switched from Doxygen to Sphinx for user docs. Since Sphinx is a Python
module, it propagates Python. And because it is listed in nativeBuildInputs,
its python binary takes precedence over the one added in buildInputs.
This results in a wrong interpreter being substituted into shebangs.

The contamination occurred previously too but libinput does not use pyparsing
dependency since 1.12.0, so it could be removed.

I prevented Sphinx from propagating Python and added some additional
dependencies to it. In the future we might want something more reusable.

While at it, I also fixed the tests.

Closes: https://github.com/NixOS/nixpkgs/issues/48252

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh for sealing Python modules (sphinx)