### PR TITLE
mpd: 0.20.21 -> 0.20.23

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -36,7 +36,7 @@ let
   opt = stdenv.lib.optional;
   mkFlag = c: f: if c then "--enable-${f}" else "--disable-${f}";
   major = "0.20";
-  minor = "21";
+  minor = "23";
 
 in stdenv.mkDerivation rec {
   name = "mpd-${version}";
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
     owner  = "MusicPlayerDaemon";
     repo   = "MPD";
     rev    = "v${version}";
-    sha256 = "0qchvycwiai5gwkvvf44nc1jw16yhpcjmlppqlrlvicgzsanhmy3";
+    sha256 = "1z1pdgiddimnmck0ardrpxkvgk1wn9zxri5wfv5ppasbb7kfm350";
   };
 
   patches = [ ./x86.patch ];


### PR DESCRIPTION
https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/v0.20.23/NEWS

Includes a fix for the build failure:
https://hydra.nixos.org/build/85119443/nixlog/1

###### Motivation for this change

Closes #51298.

Do note this is not the most up to date release however update to 0.21.x release series seemed rather non-trivial. Not quite sure what's the policy on updates like this one but at the very least it unblocks the build and seems rather safe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

