### PR TITLE
python.pkgs.docutils: set LANG in case of darwin and python3

### DIFF
--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , fetchurl
 , buildPythonPackage
 , isPy3k
@@ -14,11 +15,13 @@ buildPythonPackage rec {
     sha256 = "0x22fs3pdmr42kvz6c654756wja305qv6cx1zbhwlagvxgr4xrji";
   };
 
-  checkPhase = if isPy3k then ''
+  # Only Darwin needs LANG, but we could set it in general.
+  # It's done here conditionally to prevent mass-rebuilds.
+  checkPhase = lib.optionalString (isPy3k && stdenv.isDarwin) ''LANG="en_US.UTF-8" '' + (if isPy3k then ''
     ${python.interpreter} test3/alltests.py
   '' else ''
     ${python.interpreter} test/alltests.py
-  '';
+  '');
 
   # Create symlinks lacking a ".py" suffix, many programs depend on these names
   postFixup = ''


### PR DESCRIPTION
This should allow the Python3 version to be built while preventing mass-rebuilds.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

