### PR TITLE
usbutils: patch hashbang of lsusb.py

### DIFF
--- a/pkgs/os-specific/linux/usbutils/default.nix
+++ b/pkgs/os-specific/linux/usbutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, autoreconfHook, pkgconfig, libusb1, hwdata }:
+{ stdenv, fetchurl, substituteAll, autoreconfHook, pkgconfig, libusb1, hwdata , python3 }:
 
 stdenv.mkDerivation rec {
   name = "usbutils-010";
@@ -16,7 +16,12 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ libusb1 ];
+  buildInputs = [ libusb1 python3 ];
+
+  outputs = [ "out" "man" "python" ];
+  postInstall = ''
+    moveToOutput "bin/lsusb.py" "$python"
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://www.linux-usb.org/;


### PR DESCRIPTION
###### Motivation for this change
The `lsusb.py` script in the `usbutils` package is written in the Python3 programming language and requires `python3` being available in the `PATH`. If one does not have `python3` installed, the script could not be executed.
This PR changes the hashbang/shebang of this script to point to the `python3` interpreter. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

