### PR TITLE
llpp: 2018-03-02 -> 30

### DIFF
--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -1,33 +1,36 @@
-{ stdenv, lib, makeWrapper, fetchgit, pkgconfig, ninja, ocaml, findlib, mupdf
-, gtk3, openjpeg, jbig2dec, mujs, xsel, openssl, freetype, ncurses }:
+{ stdenv, lib, substituteAll, makeWrapper, fetchgit, ocaml, mupdf, libX11,
+libGLU_combined, freetype, xclip }:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "4.02";
+assert lib.versionAtLeast (lib.getVersion ocaml) "4.07";
 
 stdenv.mkDerivation rec {
   name = "llpp-${version}";
-  version = "2018-03-02";
+  version = "30";
 
   src = fetchgit {
     url = "git://repo.or.cz/llpp.git";
-    rev = "0ab1fbbf142b6df6d6bae782e3af2ec50f32dec9";
-    sha256 = "1h0hrmxwm7ripgp051788p8ad0q38dc9nvjx87mdwlkwk9qc0dis";
+    rev = "v${version}";
+    sha256 = "0iilpzf12hs0zky58j55l4y5dvzv7fc53nsrg324n9vka92mppvd";
     fetchSubmodules = false;
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ninja ];
-  buildInputs = [ ocaml findlib mupdf gtk3 jbig2dec openjpeg mujs openssl freetype ncurses ];
+  patches = (substituteAll {
+    inherit version;
+    src = ./fix-build-bash.patch;
+  });
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ ocaml mupdf libX11 libGLU_combined freetype ];
 
   dontStrip = true;
 
   configurePhase = ''
-    sed -i -e 's+ocamlc --version+ocamlc -version+' build.sh
-    sed -i -e 's+-I \$srcdir/mupdf/include -I \$srcdir/mupdf/thirdparty/freetype/include+-I ${freetype.dev}/include+' build.sh
-    sed -i -e 's+-lmupdf +-lfreetype -lz -lharfbuzz -ljbig2dec -lopenjp2 -ljpeg -lmupdf +' build.sh
-    sed -i -e 's+-L\$srcdir/mupdf/build/native ++' build.sh
+    mkdir -p build/mupdf/thirdparty
+    ln -s ${freetype.dev} build/mupdf/thirdparty/freetype
   '';
 
   buildPhase = ''
-    sh ./build.sh build
+    bash ./build.bash build
   '';
 
   installPhase = ''
@@ -35,14 +38,14 @@ stdenv.mkDerivation rec {
     install build/llpp $out/bin
     wrapProgram $out/bin/llpp \
         --prefix CAML_LD_LIBRARY_PATH ":" "$out/lib" \
-        --prefix PATH ":" "${xsel}/bin"
+        --prefix PATH ":" "${xclip}/bin"
   '';
 
   meta = with stdenv.lib; {
     homepage = https://repo.or.cz/w/llpp.git;
     description = "A MuPDF based PDF pager written in OCaml";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [ pSub enzime ];
     license = licenses.gpl3;
   };
 }

--- a/pkgs/applications/misc/llpp/fix-build-bash.patch
+++ b/pkgs/applications/misc/llpp/fix-build-bash.patch
@@ -1,0 +1,88 @@
+From cccadedfbcb6764a38382154838113a6b2fd4dee Mon Sep 17 00:00:00 2001
+From: Michael Hoang <enzime@users.noreply.github.com>
+Date: Mon, 10 Dec 2018 15:08:01 +1100
+Subject: [PATCH] Patch build.bash for nixpkgs
+
+---
+ build.bash | 37 ++-----------------------------------
+ 1 file changed, 2 insertions(+), 35 deletions(-)
+
+diff --git a/build.bash b/build.bash
+index 1588011..72117d9 100755
+--- a/build.bash
++++ b/build.bash
+@@ -29,7 +29,6 @@ srcd="$(dirname $0)"
+ mudir=$outd/mupdf
+ muinc="-I $mudir/include -I $mudir/thirdparty/freetype/include"
+ 
+-test -d "$mudir" || die muPDF not found, consult $(dirname $0)/BUILDING
+ 
+ mkdir -p $outd/{$wsid,lablGL}
+ :>$outd/ordered
+@@ -39,12 +38,6 @@ isfresh() { test -r "$1.past" && . "$1.past" && test "$k" = "$2"; }
+ mbt=native
+ mulibs="$mudir/build/$mbt/libmupdf.a" # $mudir/build/$mbt/libmupdf-third.a
+ 
+-keycmd="(cd $mudir && git describe --tags --dirty); digest $mulibs"
+-isfresh "$mulibs" "$(eval $keycmd)" || (
+-    make -C "$mudir" build=$mbt -j $mjobs libs
+-    echo "k='$(eval $keycmd)'" >$mudir/build/$mbt/libmupdf.a.past
+-) && vecho "fresh mupdf"
+-
+ oincs() {
+     local i=
+     local incs1=
+@@ -90,32 +83,6 @@ mflags() {
+ }
+ 
+ overs="$(ocamlc -vnum 2>/dev/null)" || overs=""
+-test "$overs" = "4.07.0" || {
+-    url=https://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.0.tar.xz
+-    txz=$outd/$(basename $url)
+-    isfresh $txz $url || {
+-        executable_p() { command -v "$1" >/dev/null 2>&1; }
+-        if executable_p wget; then dl() { wget -q "$1" -O "$2"; }
+-        elif executable_p curl; then dl() { curl -L "$1" -o "$2"; }
+-        else die "no program to fetch remote urls found"
+-        fi
+-        dl $url $txz
+-        echo "k=$url" >$txz.past
+-    } && vecho "fresh $txz"
+-    absprefix=$(cd $outd &>/dev/null; pwd -P)
+-    export PATH=$absprefix/bin:$PATH
+-    isfresh $absprefix/bin/ocamlc "$url" || (
+-        tar xf $txz -C $outd
+-        bn=$(basename $url)
+-        cd $outd/${bn%.tar.xz}
+-        ./configure -prefix $absprefix                                      \
+-                    -no-graph -no-debugger -no-ocamldoc -no-native-compiler
+-        make -j $mjobs world
+-        make install
+-        echo "k='$url'" >$absprefix/bin/ocamlc.past
+-    ) && vecho "fresh ocamlc"
+-    overs=$(ocamlc -vnum 2>/dev/null)
+-}
+ 
+ bocaml1() {
+     grep -q "$3" $outd/ordered || {
+@@ -224,7 +191,7 @@ bobjc() {
+     } && vecho "fresh $o"
+ }
+ 
+-ver=$(cd $srcd && git describe --tags --dirty) || ver=unknown
++ver=@version@
+ 
+ cmd="(. $srcd/genconfstr.sh >$outd/confstruct.ml)"
+ keycmd="digest $srcd/genconfstr.sh $outd/confstruct.ml"
+@@ -278,7 +245,7 @@ for m in ml_gl ml_glarray ml_raw; do
+ done
+ 
+ libs="str.cma unix.cma"
+-clibs="-L$mudir/build/$mbt -lmupdf -lmupdf-third -lpthread"
++clibs="-lmupdf -lfreetype -lpthread"
+ if $darwin; then
+     mcomp=$(ocamlc -config | grep bytecomp_c_co | { read _ c; echo $c; })
+     clibs="$clibs -framework Cocoa -framework OpenGL"
+-- 
+2.19.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17844,7 +17844,7 @@ in
 
   linuxsampler = callPackage ../applications/audio/linuxsampler { };
 
-  llpp = ocaml-ng.ocamlPackages_4_04.callPackage ../applications/misc/llpp { };
+  llpp = ocaml-ng.ocamlPackages_4_07.callPackage ../applications/misc/llpp { };
 
   lmms = libsForQt5.callPackage ../applications/audio/lmms {
     lame = null;


### PR DESCRIPTION
Remove unnecessary packages from derivation as well as fix sed commands
to rewrite build.bash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

