### PR TITLE
nixos/sway-beta: Improve the wrapper

### DIFF
--- a/nixos/modules/programs/sway-beta.nix
+++ b/nixos/modules/programs/sway-beta.nix
@@ -7,8 +7,19 @@ let
   swayPackage = cfg.package;
 
   swayWrapped = pkgs.writeShellScriptBin "sway" ''
-    ${cfg.extraSessionCommands}
-    exec ${pkgs.dbus.dbus-launch} --exit-with-session ${swayPackage}/bin/sway "$@"
+    set -o errexit
+
+    if [ ! "$_SWAY_WRAPPER_ALREADY_EXECUTED" ]; then
+      export _SWAY_WRAPPER_ALREADY_EXECUTED=1
+      ${cfg.extraSessionCommands}
+    fi
+
+    if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
+      export DBUS_SESSION_BUS_ADDRESS
+      exec ${swayPackage}/bin/sway "$@"
+    else
+      exec ${pkgs.dbus}/bin/dbus-run-session ${swayPackage}/bin/sway "$@"
+    fi
   '';
   swayJoined = pkgs.symlinkJoin {
     name = "sway-joined";


### PR DESCRIPTION
According to the dbus-launch documentation [0] "--exit-with-session"
shouldn't be used: "This option is not recommended, since it will
consume input from the terminal where it was started; it is mainly
provided for backwards compatibility." And it also states: "To start a
D-Bus session within a text-mode session, do not use dbus-launch.
Instead, see dbus-run-session(1)."

The new wrapper also avoids starting an additional D-Bus session if
DBUS_SESSION_BUS_ADDRESS is already set.

Fix #51303.

[0]: https://dbus.freedesktop.org/doc/dbus-launch.1.html
[1]: https://dbus.freedesktop.org/doc/dbus-run-session.1.html

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

