### PR TITLE
audit-tmpdir hook: use abspath matching on RPATH entries 

### DIFF
--- a/pkgs/build-support/setup-hooks/audit-tmpdir.sh
+++ b/pkgs/build-support/setup-hooks/audit-tmpdir.sh
@@ -26,7 +26,7 @@ auditTmpdir() {
             fi
         fi
 
-        if  isScript "$i"; then
+        if isScript "$i"; then
             if [ -e "$(dirname "$i")/.$(basename "$i")-wrapped" ]; then
                 if grep -q -F "$TMPDIR/" "$i"; then
                     echo "wrapper script $i contains a forbidden reference to $TMPDIR/"

--- a/pkgs/build-support/setup-hooks/audit-tmpdir.sh
+++ b/pkgs/build-support/setup-hooks/audit-tmpdir.sh
@@ -20,7 +20,7 @@ auditTmpdir() {
         if [[ "$i" =~ .build-id ]]; then continue; fi
 
         if isELF "$i"; then
-            if patchelf --print-rpath "$i" | grep -q -F "$TMPDIR/"; then
+            if { printf :; patchelf --print-rpath "$i"; } | grep -q -F ":$TMPDIR/"; then
                 echo "RPATH of binary $i contains a forbidden reference to $TMPDIR/"
                 exit 1
             fi


### PR DESCRIPTION
###### Motivation for this change
This ensures that RPATH entries like "/foo/build" doesn't trigger a match when TMPDIR is "/build. (I've had this problem with a prebuilt package.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

