### PR TITLE
dropbox: add mesa and libxshmfence

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -36,7 +36,7 @@ buildFHSUserEnv {
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
     libXxf86vm libxcb xkeyboardconfig
     curl dbus firefox-bin fontconfig freetype gcc glib gnutar libxml2 libxslt
-    procps zlib
+    procps zlib mesa libxshmfence libpthreadstubs
   ];
 
   extraInstallCommands = ''


### PR DESCRIPTION
###### Motivation for this change

The `dropbox-cli` package crashes on startup failing to load some libraries.

Dropbox somehow still fails after the initial sync with:

```
/home/markus/.dropbox-dist/dropbox-lnx.x86_64-62.4.103/dropbox: error while loading shared libraries: libpthread.so.0: cannot open shared object file: No such file or directory                                   
```

But given that I'm okay as long as it syncs once, I didn't investigate further and this pr leaves it at least in a working state.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

