### PR TITLE
Favor HTTPS URLs - the GNU edition

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -935,7 +935,7 @@ The implementation can be found in the
 [integer-gmp](http://hackage.haskell.org/package/integer-gmp) package.
 
 A potential problem with this is that GMP is licensed under the
-[GNU Lesser General Public License (LGPL)](http://www.gnu.org/copyleft/lesser.html),
+[GNU Lesser General Public License (LGPL)](https://www.gnu.org/copyleft/lesser.html),
 a kind of "copyleft" license. According to the terms of the LGPL, paragraph 5,
 you may distribute a program that is designed to be compiled and dynamically
 linked with the library under the terms of your choice (i.e., commercially) but

--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -14,7 +14,7 @@ meta = with stdenv.lib; {
     GNU Hello is a program that prints "Hello, world!" when you run it.
     It is fully customizable.
   '';
-  homepage = http://www.gnu.org/software/hello/manual/;
+  homepage = https://www.gnu.org/software/hello/manual/;
   license = licenses.gpl3Plus;
   maintainers = [ maintainers.eelco ];
   platforms = platforms.all;
@@ -35,7 +35,7 @@ $ nix-env -qa hello --json
     "hello": {
         "meta": {
             "description": "A program that produces a familiar, friendly greeting",
-            "homepage": "http://www.gnu.org/software/hello/manual/",
+            "homepage": "https://www.gnu.org/software/hello/manual/",
             "license": {
                 "fullName": "GNU General Public License version 3 or later",
                 "shortName": "GPLv3+",
@@ -135,7 +135,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
     <listitem>
      <para>
       The package’s homepage. Example:
-      <literal>http://www.gnu.org/software/hello/manual/</literal>
+      <literal>https://www.gnu.org/software/hello/manual/</literal>
      </para>
     </listitem>
    </varlistentry>
@@ -146,7 +146,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
     <listitem>
      <para>
       The page where a link to the current version can be found. Example:
-      <literal>http://ftp.gnu.org/gnu/hello/</literal>
+      <literal>https://ftp.gnu.org/gnu/hello/</literal>
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/doc/manual/configuration/adding-custom-packages.xml
+++ b/nixos/doc/manual/configuration/adding-custom-packages.xml
@@ -31,7 +31,7 @@ $ cd nixpkgs
  <para>
   The second possibility is to add the package outside of the Nixpkgs tree. For
   instance, here is how you specify a build of the
-  <link xlink:href="http://www.gnu.org/software/hello/">GNU Hello</link>
+  <link xlink:href="https://www.gnu.org/software/hello/">GNU Hello</link>
   package directly in <filename>configuration.nix</filename>:
 <programlisting>
 <xref linkend="opt-environment.systemPackages"/> =

--- a/nixos/modules/services/editors/emacs.xml
+++ b/nixos/modules/services/editors/emacs.xml
@@ -11,7 +11,7 @@
       Rodney Lorrimar @rvl
   -->
  <para>
-  <link xlink:href="http://www.gnu.org/software/emacs/">Emacs</link> is an
+  <link xlink:href="https://www.gnu.org/software/emacs/">Emacs</link> is an
   extensible, customizable, self-documenting real-time display editor — and
   more. At its core is an interpreter for Emacs Lisp, a dialect of the Lisp
   programming language with extensions to support text editing.

--- a/pkgs/applications/audio/faust/faust1.nix
+++ b/pkgs/applications/audio/faust/faust1.nix
@@ -18,7 +18,7 @@ let
 
   meta = with stdenv.lib; {
     homepage = http://faust.grame.fr/;
-    downloadPage = http://sourceforge.net/projects/faudiostream/files/;
+    downloadPage = https://sourceforge.net/projects/faudiostream/files/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ magnetophon pmahoney ];

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -27,7 +27,7 @@ let
 
   meta = with stdenv.lib; {
     homepage = http://faust.grame.fr/;
-    downloadPage = http://sourceforge.net/projects/faudiostream/files/;
+    downloadPage = https://sourceforge.net/projects/faudiostream/files/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ magnetophon pmahoney ];

--- a/pkgs/applications/audio/lash/default.nix
+++ b/pkgs/applications/audio/lash/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation  rec {
     longDescription = ''
       Session management system for GNU/Linux audio applications.
     '';
-    homepage = http://www.nongnu.org/lash;
+    homepage = https://www.nongnu.org/lash;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/audio/lingot/default.nix
+++ b/pkgs/applications/audio/lingot/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Not a Guitar-Only tuner";
-    homepage = http://www.nongnu.org/lingot/;
+    homepage = https://www.nongnu.org/lingot/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/applications/audio/mi2ly/default.nix
+++ b/pkgs/applications/audio/mi2ly/default.nix
@@ -6,7 +6,7 @@ let
     version="0.12";
     name="${baseName}-${version}";
     hash="1b14zcwlvnxhjxr3ymyzg0mg4sbijkinzpxm641s859jxcgylmll";
-    url="http://download.savannah.gnu.org/releases/mi2ly/mi2ly.0.12.tar.bz2";
+    url="https://download.savannah.gnu.org/releases/mi2ly/mi2ly.0.12.tar.bz2";
     sha256="1b14zcwlvnxhjxr3ymyzg0mg4sbijkinzpxm641s859jxcgylmll";
   };
   buildInputs = [

--- a/pkgs/applications/audio/mi2ly/default.upstream
+++ b/pkgs/applications/audio/mi2ly/default.upstream
@@ -1,3 +1,3 @@
-url http://download.savannah.gnu.org/releases/mi2ly/
+url https://download.savannah.gnu.org/releases/mi2ly/
 ensure_choice
 version '.*/mi2ly[.]([0-9.]+)[.]tar.*' '\1'

--- a/pkgs/applications/audio/mimms/default.nix
+++ b/pkgs/applications/audio/mimms/default.nix
@@ -5,7 +5,7 @@ pythonPackages.buildPythonApplication rec {
   version = "3.2";
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/mimms/mimms-${version}.tar.bz2";
+    url = "https://download.savannah.gnu.org/releases/mimms/mimms-${version}.tar.bz2";
     sha256 = "0zmcd670mpq85cs3nvdq3i805ba0d1alqahfy1m9cpf7kxrivfml";
   };
 

--- a/pkgs/applications/audio/normalize/default.nix
+++ b/pkgs/applications/audio/normalize/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libmad ];
 
   meta = with stdenv.lib; {
-    homepage = http://normalize.nongnu.org/;
+    homepage = https://www.nongnu.org/normalize/;
     description = "Audio file normalizer";
     license = licenses.gpl2;
     platforms = platforms.unix;

--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -61,7 +61,7 @@ in buildPythonApplication rec {
        - Commandline control
        - Available in 24 languages
     '';
-    homepage = http://www.nongnu.org/sonata/;
+    homepage = https://www.nongnu.org/sonata/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.rvl ];

--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/ed/;
+    homepage = https://www.gnu.org/software/ed/;
 
     maintainers = [ ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/editors/emacs-modes/bbdb/3.nix
+++ b/pkgs/applications/editors/emacs-modes/bbdb/3.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://savannah.nongnu.org/projects/bbdb/;
+    homepage = https://savannah.nongnu.org/projects/bbdb/;
     description = "The Insidious Big Brother Database (BBDB), a contact management utility for Emacs, version 3";
     license = "GPL";
   };

--- a/pkgs/applications/editors/emacs-modes/bbdb/3.nix
+++ b/pkgs/applications/editors/emacs-modes/bbdb/3.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "bbdb-3.1.2";
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/bbdb/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/bbdb/${name}.tar.gz";
     sha256 = "1gs16bbpiiy01w9pyg12868r57kx1v3hnw04gmqsmpc40l1hyy05";
   };
 

--- a/pkgs/applications/editors/emacs-modes/color-theme/default.nix
+++ b/pkgs/applications/editors/emacs-modes/color-theme/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Emacs-lisp mode for skinning your Emacs";
-    homepage = http://www.nongnu.org/color-theme;
+    homepage = https://www.nongnu.org/color-theme;
     license = stdenv.lib.licenses.gpl2Plus;
 
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/applications/editors/emacs-modes/emms/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emms/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     # These guys don't use ftp.gnu.org...
-    url = "http://www.gnu.org/software/emms/download/${name}.tar.gz";
+    url = "https://www.gnu.org/software/emms/download/${name}.tar.gz";
     sha256 = "151mfx97x15lfpd1qc2sqbvhwhvg46axgh15qyqmdy42vh906xav";
   };
 
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
       support, with no effort from your side.
     '';
 
-    homepage = http://www.gnu.org/software/emms/;
+    homepage = https://www.gnu.org/software/emms/;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/applications/editors/emacs-modes/let-alist/default.nix
+++ b/pkgs/applications/editors/emacs-modes/let-alist/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "let-alist-1.0.3";
 
   src = fetchurl {
-    url = "http://elpa.gnu.org/packages/let-alist-1.0.3.el";
+    url = "https://elpa.gnu.org/packages/let-alist-1.0.3.el";
     sha256 = "12n1cmjc7hzyy0jmsdxqz1hqzg4ri4nvvi0p9mw1d6v44xzfm0mx";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://elpa.gnu.org/packages/let-alist.html;
+    homepage = https://elpa.gnu.org/packages/let-alist.html;
     description = "Easily let-bind values of an assoc-list by their names";
     license = stdenv.lib.licenses.gpl3Plus;
   };

--- a/pkgs/applications/editors/emacs/25.nix
+++ b/pkgs/applications/editors/emacs/25.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The extensible, customizable GNU text editor";
-    homepage    = http://www.gnu.org/software/emacs/;
+    homepage    = https://www.gnu.org/software/emacs/;
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ chaoflow lovek323 peti the-kenny jwiegley ];
     platforms   = platforms.all;

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The extensible, customizable GNU text editor";
-    homepage    = http://www.gnu.org/software/emacs/;
+    homepage    = https://www.gnu.org/software/emacs/;
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ chaoflow lovek323 peti the-kenny jwiegley ];
     platforms   = platforms.all;

--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The extensible, customizable text editor";
-    homepage    = http://www.gnu.org/software/emacs/;
+    homepage    = https://www.gnu.org/software/emacs/;
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ jwiegley matthewbauer ];
     platforms   = platforms.darwin;

--- a/pkgs/applications/editors/leafpad/default.nix
+++ b/pkgs/applications/editors/leafpad/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   version = "0.8.18.1";
   name = "leafpad-${version}";
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/leafpad/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/leafpad/${name}.tar.gz";
     sha256 = "0b0az2wvqgvam7w0ns1j8xp2llslm1rx6h7zcsy06a7j0yp257cm";
   };
 

--- a/pkgs/applications/editors/moe/default.nix
+++ b/pkgs/applications/editors/moe/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       completion, directory browser, duplicate removal from prompt histories,
       delimiter matching, text conversion from/to UTF-8, romanization, etc.
     '';
-    homepage = http://www.gnu.org/software/moe/;
+    homepage = https://www.gnu.org/software/moe/;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.unix;

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -64,7 +64,7 @@ let
   gtdialog_url   = "http://foicica.com/gtdialog/download/" + gtdialog_zip;
   lspawn_url     = "http://foicica.com/lspawn/download/" + lspawn_zip;
 
-  scintilla_url  = "http://prdownloads.sourceforge.net/scintilla/" + scintilla_tgz;
+  scintilla_url  = "mirror://sourceforge/scintilla/" + scintilla_tgz;
   lua_url        = "http://www.lua.org/ftp/" + lua_tgz;
   lpeg_url       = "http://www.inf.puc-rio.br/~roberto/lpeg/" + lpeg_tgz;
   lfs_url        = "https://github.com/keplerproject/luafilesystem/archive/" + lfs_zip;

--- a/pkgs/applications/editors/zile/default.nix
+++ b/pkgs/applications/editors/zile/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       compiles to about 130Kb.
     '';
 
-    homepage = http://www.gnu.org/software/zile/;
+    homepage = https://www.gnu.org/software/zile/;
 
     license = licenses.gpl3Plus;
 

--- a/pkgs/applications/misc/devilspie2/default.nix
+++ b/pkgs/applications/misc/devilspie2/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.43";
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/devilspie2/devilspie2_${version}-src.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/devilspie2/devilspie2_${version}-src.tar.gz";
     sha256 = "0a7qjl2qd4099kkkbwa1y2fk48s21jlr409lf9mij7mlc9yc3zzc";
   };
 

--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   # trick on NIX_LDFLAGS and dontPatchELF to make it find them.
   # I use 'yes y' to skip a build error linking with xineLib,
   # because xine stopped exporting "_x_vo_new_port"
-  #  http://sourceforge.net/projects/eaglemode/forums/forum/808824/topic/5115261
+  #  https://sourceforge.net/projects/eaglemode/forums/forum/808824/topic/5115261
   buildPhase = ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -lXxf86vm -lXext"
     perl make.pl build

--- a/pkgs/applications/misc/gksu/default.nix
+++ b/pkgs/applications/misc/gksu/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
       programs that need to ask a user's password to run another program
       as another user.
     '';
-    homepage = http://www.nongnu.org/gksu/;
+    homepage = https://www.nongnu.org/gksu/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.romildo ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/misc/gtk2fontsel/default.nix
+++ b/pkgs/applications/misc/gtk2fontsel/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       Trivial, but useful nonetheless.
     '';
     homepage = http://gtk2fontsel.sourceforge.net/;
-    downloadPage = http://sourceforge.net/projects/gtk2fontsel/;
+    downloadPage = https://sourceforge.net/projects/gtk2fontsel/;
     license = licenses.gpl2;
     maintainers = [ maintainers.prikhi ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/gv/default.nix
+++ b/pkgs/applications/misc/gv/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   doCheck = true;
 
   meta = {
-    homepage = http://www.gnu.org/software/gv/;
+    homepage = https://www.gnu.org/software/gv/;
     description = "PostScript/PDF document viewer";
 
     longDescription = ''

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       GNU Hello is a program that prints "Hello, world!" when you run it.
       It is fully customizable.
     '';
-    homepage = http://www.gnu.org/software/hello/manual/;
+    homepage = https://www.gnu.org/software/hello/manual/;
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/xlog/default.nix
+++ b/pkgs/applications/misc/xlog/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   version = "2.0.15";
   
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/xlog/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/xlog/${name}.tar.gz";
     sha256 = "0an883wqw3zwpw8nqinm9cb17hp2xw9vf603k4l2345p61jqdw2j";
   };
 

--- a/pkgs/applications/misc/xlog/default.nix
+++ b/pkgs/applications/misc/xlog/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
          location in latitude and longitude and distance and heading in kilometers or miles,
          both for short and long path. 
       '';
-    homepage = http://www.nongnu.org/xlog;
+    homepage = https://www.nongnu.org/xlog;
     maintainers = [ maintainers.mafo ];
     license = licenses.gpl3;
     platforms = platforms.unix;

--- a/pkgs/applications/networking/esniper/default.nix
+++ b/pkgs/applications/networking/esniper/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl curl ];
 
   # Add support for CURL_CA_BUNDLE variable.
-  # Fix <http://sourceforge.net/p/esniper/bugs/648/>.
+  # Fix <https://sourceforge.net/p/esniper/bugs/648/>.
   patches = [ ./find-ca-bundle.patch ];
 
   postInstall = ''

--- a/pkgs/applications/networking/instant-messengers/freetalk/default.nix
+++ b/pkgs/applications/networking/instant-messengers/freetalk/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus ;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
-    downloadPage = "http://www.gnu.org/software/freetalk/";
+    downloadPage = "https://www.gnu.org/software/freetalk/";
   };
 }

--- a/pkgs/applications/science/electronics/archimedes/default.nix
+++ b/pkgs/applications/science/electronics/archimedes/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU package for semiconductor device simulations";
-    homepage = http://www.gnu.org/software/archimedes;
+    homepage = https://www.gnu.org/software/archimedes;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = with stdenv.lib.platforms; linux;
   };

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation ({
 
   # Failures in the regression test suite won't abort the build process. We run
   # the suite only so that potential errors show up in the build log. See also:
-  # http://sourceforge.net/tracker/?func=detail&aid=3365831&group_id=4933&atid=104933.
+  # https://sourceforge.net/tracker/?func=detail&aid=3365831&group_id=4933&atid=104933.
   doCheck = true;
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/math/pspp/default.nix
+++ b/pkgs/applications/science/math/pspp/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.gnu.org/software/pspp/;
+    homepage = https://www.gnu.org/software/pspp/;
     description = "A free replacement for SPSS, a program for statistical analysis of sampled data";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/applications/science/misc/motu-client/default.nix
+++ b/pkgs/applications/science/misc/motu-client/default.nix
@@ -12,10 +12,10 @@ python27Packages.buildPythonApplication rec {
     homepage = https://github.com/quiet-oceans/motuclient-setuptools;
     description = "CLI to query oceanographic data to Motu servers";
     longDescription = ''
-      Access data from (motu)[http://sourceforge.net/projects/cls-motu/] servers.
+      Access data from (motu)[https://sourceforge.net/projects/cls-motu/] servers.
       This is a refactored fork of the original release in order to simplify integration,
       deployment and packaging. Upstream code can be found at
-      http://sourceforge.net/projects/cls-motu/ .
+      https://sourceforge.net/projects/cls-motu/ .
     '';
     license = licenses.lgpl3Plus;
     maintainers = [ maintainers.lsix ];

--- a/pkgs/applications/version-management/arch/default.nix
+++ b/pkgs/applications/version-management/arch/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU Arch (aka. `tla'), a distributed revision control system";
-    homepage = http://www.gnu.org/software/gnu-arch/;
+    homepage = https://www.gnu.org/software/gnu-arch/;
     license = "GPL";
   };
 }

--- a/pkgs/applications/version-management/rcs/default.nix
+++ b/pkgs/applications/version-management/rcs/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-std=c99" ];
 
   meta = {
-    homepage = http://www.gnu.org/software/rcs/;
+    homepage = https://www.gnu.org/software/rcs/;
     description = "Revision control system";
     longDescription =
       '' The GNU Revision Control System (RCS) manages multiple revisions of

--- a/pkgs/applications/window-managers/ratpoison/default.nix
+++ b/pkgs/applications/window-managers/ratpoison/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.nongnu.org/ratpoison/;
+    homepage = https://www.nongnu.org/ratpoison/;
     description = "Simple mouse-free tiling window manager";
     license = licenses.gpl2Plus;
 

--- a/pkgs/data/documentation/std-man-pages/default.nix
+++ b/pkgs/data/documentation/std-man-pages/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "C++ STD manual pages";
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = "GPL/LGPL";
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/data/fonts/freefont-ttf/default.nix
+++ b/pkgs/data/fonts/freefont-ttf/default.nix
@@ -19,7 +19,7 @@ fetchzip rec {
       (PostScript Type0, TrueType, OpenType...) fonts covering the ISO
       10646/Unicode UCS (Universal Character Set).
     '';
-    homepage = http://www.gnu.org/software/freefont/;
+    homepage = https://www.gnu.org/software/freefont/;
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.all;
     maintainers = [];

--- a/pkgs/data/misc/miscfiles/default.nix
+++ b/pkgs/data/misc/miscfiles/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/miscfiles/;
+    homepage = https://www.gnu.org/software/miscfiles/;
     license = licenses.gpl2Plus;
     description = "Collection of files not of crucial importance for sysadmins";
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/desktops/gnome-2/desktop/mail-notification/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/mail-notification/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tray status icon, which notifies us when new email arrives";
-    homepage = http://www.nongnu.org/mailnotify/;
+    homepage = https://www.nongnu.org/mailnotify/;
     license = with licenses; [ gpl3 ];
     platforms = platforms.unix;
     maintainers = [ maintainers.eleanor ];

--- a/pkgs/development/compilers/fpc/default.upstream
+++ b/pkgs/development/compilers/fpc/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/freepascal/files/Source/
+url https://sourceforge.net/projects/freepascal/files/Source/
 SF_version_dir
 version_link 'fpcbuild-[0-9.]+[.]tar[.]gz/download$'
 SF_redirect

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -335,7 +335,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -397,7 +397,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -348,7 +348,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -409,7 +409,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -353,7 +353,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -414,7 +414,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -355,7 +355,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -416,7 +416,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -319,7 +319,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -367,7 +367,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -304,7 +304,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -345,7 +345,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -269,7 +269,7 @@ stdenv.mkDerivation ({
     then "install-strip"
     else "install";
 
-  # http://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
+  # https://gcc.gnu.org/install/specific.html#x86-64-x-solaris210
   ${if hostPlatform.system == "x86_64-solaris" then "CC" else null} = "gcc -m64";
 
   # Setting $CPATH and $LIBRARY_PATH to make sure both `gcc' and `xgcc' find the
@@ -317,7 +317,7 @@ stdenv.mkDerivation ({
   inherit (stdenv) is64bit;
 
   meta = {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = stdenv.lib.licenses.gpl3Plus;  # runtime support libraries are typically LGPLv3+
     description = "GNU Compiler Collection, version ${version}"
       + (if stripped then "" else " (with debugging info)");

--- a/pkgs/development/compilers/gcl/2.6.13-pre.nix
+++ b/pkgs/development/compilers/gcl/2.6.13-pre.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     sha256 = "0vpxb6z5g9fjavrgx8gz8fsjvskfz64f63qibh5s00fvvndlwi88";
-    url = "http://git.savannah.gnu.org/r/gcl.git";
+    url = "https://git.savannah.gnu.org/r/gcl.git";
     rev = "refs/tags/Version_2_6_13pre50";
   };
 

--- a/pkgs/development/compilers/gprolog/default.nix
+++ b/pkgs/development/compilers/gprolog/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = http://www.gnu.org/software/gprolog/;
+    homepage = https://www.gnu.org/software/gprolog/;
     description = "GNU Prolog, a free Prolog compiler with constraint solving over finite domains";
     license = stdenv.lib.licenses.lgpl3Plus;
 

--- a/pkgs/development/compilers/mit-scheme/default.nix
+++ b/pkgs/development/compilers/mit-scheme/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation {
          development cycle.
       '';
 
-    homepage = http://www.gnu.org/software/mit-scheme/;
+    homepage = https://www.gnu.org/software/mit-scheme/;
 
     license = licenses.gpl2Plus;
 

--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       guile-gnome a comprehensive environment for developing modern
       applications.
     '';
-    homepage = "http://www.gnu.org/software/guile-gnome/";
+    homepage = "https://www.gnu.org/software/guile-gnome/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;

--- a/pkgs/development/guile-modules/guile-lib/default.nix
+++ b/pkgs/development/guile-modules/guile-lib/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation {
       modules into a coherent library.  Think "a down-scaled, limited-scope CPAN
       for Guile".
     '';
-    homepage = "http://www.nongnu.org/guile-lib/";
+    homepage = "https://www.nongnu.org/guile-lib/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.gnu ++ platforms.linux;

--- a/pkgs/development/guile-modules/guile-opengl/default.nix
+++ b/pkgs/development/guile-modules/guile-opengl/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Guile bindings for the OpenGL graphics API";
-    homepage = "http://gnu.org/s/guile-opengl";
+    homepage = "https://www.gnu.org/software/guile-opengl/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;

--- a/pkgs/development/guile-modules/guile-sdl/default.nix
+++ b/pkgs/development/guile-modules/guile-sdl/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Guile bindings for SDL";
-    homepage = "http://gnu.org/s/guile-sdl";
+    homepage = "https://www.gnu.org/software/guile-sdl/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;

--- a/pkgs/development/interpreters/gnu-apl/default.nix
+++ b/pkgs/development/interpreters/gnu-apl/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Free interpreter for the APL programming language";
-    homepage    = http://www.gnu.org/software/apl/;
+    homepage    = https://www.gnu.org/software/apl/;
     license     = licenses.gpl3Plus;
     maintainers = [ maintainers.kovirobi ];
     platforms   = with platforms; linux ++ darwin;

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Embeddable Scheme implementation";
-    homepage    = http://www.gnu.org/software/guile/;
+    homepage    = https://www.gnu.org/software/guile/;
     license     = stdenv.lib.licenses.lgpl2Plus;
     maintainers = [ stdenv.lib.maintainers.ludo ];
     platforms   = stdenv.lib.platforms.unix;

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   # One test fails.
   # ERROR: file: "libtest-asmobs", message: "file not found"
   # This is fixed here:
-  # <http://git.savannah.gnu.org/cgit/guile.git/commit/?h=branch_release-1-8&id=a0aa1e5b69d6ef0311aeea8e4b9a94eae18a1aaf>.
+  # <https://git.savannah.gnu.org/cgit/guile.git/commit/?h=branch_release-1-8&id=a0aa1e5b69d6ef0311aeea8e4b9a94eae18a1aaf>.
   doCheck = false;
   doInstallCheck = doCheck;
 

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -41,7 +41,7 @@
   patches = [ ./disable-gc-sensitive-tests.patch ./eai_system.patch ./clang.patch
     (fetchpatch {
       # Fixes stability issues with 00-repl-server.test
-      url = "http://git.savannah.gnu.org/cgit/guile.git/patch/?id=2fbde7f02adb8c6585e9baf6e293ee49cd23d4c4";
+      url = "https://git.savannah.gnu.org/cgit/guile.git/patch/?id=2fbde7f02adb8c6585e9baf6e293ee49cd23d4c4";
       sha256 = "0p6c1lmw1iniq03z7x5m65kg3lq543kgvdb4nrxsaxjqf3zhl77v";
     })
     ./riscv.patch

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -94,7 +94,7 @@
 
   meta = {
     description = "Embeddable Scheme implementation";
-    homepage    = http://www.gnu.org/software/guile/;
+    homepage    = https://www.gnu.org/software/guile/;
     license     = stdenv.lib.licenses.lgpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ ludo lovek323 ];
     platforms   = stdenv.lib.platforms.all;
@@ -114,7 +114,7 @@
 //
 
 (stdenv.lib.optionalAttrs (!stdenv.isLinux) {
-  # Work around <http://bugs.gnu.org/14201>.
+  # Work around <https://bugs.gnu.org/14201>.
   SHELL = "/bin/sh";
   CONFIG_SHELL = "/bin/sh";
 })

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -90,7 +90,7 @@
 
   meta = {
     description = "Embeddable Scheme implementation";
-    homepage    = http://www.gnu.org/software/guile/;
+    homepage    = https://www.gnu.org/software/guile/;
     license     = stdenv.lib.licenses.lgpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ ludo lovek323 vrthra ];
     platforms   = stdenv.lib.platforms.all;

--- a/pkgs/development/interpreters/lush/default.upstream
+++ b/pkgs/development/interpreters/lush/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/lush/files/lush2/
+url https://sourceforge.net/projects/lush/files/lush2/
 version_link '[.]tar[.]gz/download$'
 SF_redirect
 minimize_overwrite

--- a/pkgs/development/interpreters/regina/default.upstream
+++ b/pkgs/development/interpreters/regina/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/regina-rexx/files/regina-rexx/
+url https://sourceforge.net/projects/regina-rexx/files/regina-rexx/
 SF_version_dir
 SF_version_tarball
 SF_redirect

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   installTargets = [ "install" "install-lib" "install-dev" ];
 
   meta = with stdenv.lib; {
-    homepage = "http://savannah.nongnu.org/projects/acl";
+    homepage = "https://savannah.nongnu.org/projects/acl";
     description = "Library and tools for manipulating access control lists";
     platforms = platforms.linux;
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://savannah.nongnu.org/projects/attr/";
+    homepage = "https://savannah.nongnu.org/projects/attr/";
     description = "Library and tools for manipulating extended attributes";
     platforms = platforms.linux;
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/ccrtp/1.8.nix
+++ b/pkgs/development/libraries/ccrtp/1.8.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "GNU ccRTP is an implementation of RTP, the real-time transport protocol from the IETF";
-    homepage = http://www.gnu.org/software/ccrtp/;
+    homepage = https://www.gnu.org/software/ccrtp/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/ccrtp/default.nix
+++ b/pkgs/development/libraries/ccrtp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An implementation of the IETF real-time transport protocol (RTP)";
-    homepage = http://www.gnu.org/software/ccrtp/;
+    homepage = https://www.gnu.org/software/ccrtp/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ marcweber ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/commoncpp2/default.nix
+++ b/pkgs/development/libraries/commoncpp2/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
          to build native threading applications for Microsoft Windows.
       '';
 
-    homepage = http://www.gnu.org/software/commoncpp/;
+    homepage = https://www.gnu.org/software/commoncpp/;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/development/libraries/gcc/libstdc++/5.nix
+++ b/pkgs/development/libraries/gcc/libstdc++/5.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = licenses.lgpl3Plus;
     description = "GNU Compiler Collection, version ${version} -- C++ standard library";
     platforms = platforms.linux;

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
          package also provides traditional dbm and ndbm interfaces.
       '';
 
-    homepage = http://www.gnu.org/software/gdbm/;
+    homepage = https://www.gnu.org/software/gdbm/;
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.vrthra ];

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
       GNU packages produce multi-lingual messages.
     '';
 
-    homepage = http://www.gnu.org/software/gettext/;
+    homepage = https://www.gnu.org/software/gettext/;
 
     maintainers = with maintainers; [ zimbatm vrthra ];
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -187,7 +187,7 @@ stdenv.mkDerivation ({
   doCheck = false; # fails
 
   meta = {
-    homepage = http://www.gnu.org/software/libc/;
+    homepage = https://www.gnu.org/software/libc/;
     description = "The GNU C Library";
 
     longDescription =

--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
          programming language and organized in the form of a library.
       '';
 
-    homepage = http://www.gnu.org/software/glpk/;
+    homepage = https://www.gnu.org/software/glpk/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = with stdenv.lib.maintainers; [ bjg timokau ];

--- a/pkgs/development/libraries/gnu-config/default.nix
+++ b/pkgs/development/libraries/gnu-config/default.nix
@@ -5,11 +5,11 @@ let
 
   # Don't use fetchgit as this is needed during Aarch64 bootstrapping
   configGuess = fetchurl {
-    url = "http://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=${rev}";
+    url = "https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=${rev}";
     sha256 = "1bb8z1wzjs81p9qrvji4bc2a8zyxjinz90k8xq7sxxdp6zrmq1sv";
   };
   configSub = fetchurl {
-    url = "http://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=${rev}";
+    url = "https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=${rev}";
     sha256 = "00dn5i2cp4iqap5vr368r5ifrgcjfq5pr97i4dkkdbha1han5hsc";
   };
 in
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Attempt to guess a canonical system name";
-    homepage = http://savannah.gnu.org/projects/config;
+    homepage = https://savannah.gnu.org/projects/config;
     license = licenses.gpl3;
     # In addition to GPLv3:
     #   As a special exception to the GNU General Public License, if you

--- a/pkgs/development/libraries/gnutls-kdh/generic.nix
+++ b/pkgs/development/libraries/gnutls-kdh/generic.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     [ "--enable-guile" "--with-guile-site-dir=\${out}/share/guile/site" ];
 
   # Build of the Guile bindings is not parallel-safe.  See
-  # <http://git.savannah.gnu.org/cgit/gnutls.git/commit/?id=330995a920037b6030ec0282b51dde3f8b493cad>
+  # <https://github.com/arpa2/gnutls-kdh/commit/330995a920037b6030ec0282b51dde3f8b493cad>
   # for the actual fix.  Also an apparent race in the generation of
   # systemkey-args.h.
   enableParallelBuilding = false;

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation {
        tampering, or message forgery."
     '';
 
-    homepage = http://www.gnu.org/software/gnutls/;
+    homepage = https://www.gnu.org/software/gnutls/;
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ eelco wkennington fpletz ];
     platforms = platforms.all;

--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
          (e.g. IMAP, SMTP, etc.) to authenticate peers. 
        '';
 
-    homepage = http://www.gnu.org/software/gsasl/;
+    homepage = https://www.gnu.org/software/gsasl/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = with stdenv.lib.maintainers; [ shlevy ];

--- a/pkgs/development/libraries/gsl/default.nix
+++ b/pkgs/development/libraries/gsl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # ToDo: there might be more impurities than FMA support check
-    ./disable-fma.patch # http://lists.gnu.org/archive/html/bug-gsl/2011-11/msg00019.html
+    ./disable-fma.patch # https://lists.gnu.org/archive/html/bug-gsl/2011-11/msg00019.html
   ];
 
   # https://lists.gnu.org/archive/html/bug-gsl/2015-11/msg00012.html
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "The GNU Scientific Library, a large numerical library";
-    homepage = http://www.gnu.org/software/gsl/;
+    homepage = https://www.gnu.org/software/gsl/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     longDescription = ''

--- a/pkgs/development/libraries/gsl/gsl-1_16.nix
+++ b/pkgs/development/libraries/gsl/gsl-1_16.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # ToDo: there might be more impurities than FMA support check
-    ./disable-fma.patch # http://lists.gnu.org/archive/html/bug-gsl/2011-11/msg00019.html
+    ./disable-fma.patch # https://lists.gnu.org/archive/html/bug-gsl/2011-11/msg00019.html
     (fetchpatch {
       name = "bug-39055.patch";
       url = "https://git.savannah.gnu.org/cgit/gsl.git/patch/?id=9cc12d";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "The GNU Scientific Library, a large numerical library";
-    homepage = http://www.gnu.org/software/gsl/;
+    homepage = https://www.gnu.org/software/gsl/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     longDescription = ''

--- a/pkgs/development/libraries/gsl/gsl-1_16.nix
+++ b/pkgs/development/libraries/gsl/gsl-1_16.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     ./disable-fma.patch # http://lists.gnu.org/archive/html/bug-gsl/2011-11/msg00019.html
     (fetchpatch {
       name = "bug-39055.patch";
-      url = "http://git.savannah.gnu.org/cgit/gsl.git/patch/?id=9cc12d";
+      url = "https://git.savannah.gnu.org/cgit/gsl.git/patch/?id=9cc12d";
       sha256 = "1bmrmihi28cly9g9pq54kkix2jy59y7cd7h5fw4v1c7h5rc2qvs8";
     })
   ];

--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/gss/;
+    homepage = https://www.gnu.org/software/gss/;
     description = "Generic Security Service";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ bjg wkennington ];

--- a/pkgs/development/libraries/judy/default.nix
+++ b/pkgs/development/libraries/judy/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   # gcc 4.8 optimisations break judy.
-  # http://sourceforge.net/p/judy/mailman/message/31995144/
+  # https://sourceforge.net/p/judy/mailman/message/31995144/
   preConfigure = stdenv.lib.optionalString stdenv.cc.isGNU ''
     configureFlagsArray+=("CFLAGS=-fno-strict-aliasing -fno-aggressive-loop-optimizations")
   '';

--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       It is associated with GNU Binutils, and elsewhere often distributed with
       it.
     '';
-    homepage = http://www.gnu.org/software/binutils/;
+    homepage = https://www.gnu.org/software/binutils/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ericson2314 ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libcdio/default.nix
+++ b/pkgs/development/libraries/libcdio/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       ISO-9660 filesystems (libiso9660), as well as utility
       programs such as an audio CD player and an extractor.
     '';
-    homepage = http://www.gnu.org/software/libcdio/;
+    homepage = https://www.gnu.org/software/libcdio/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/development/libraries/libchop/default.nix
+++ b/pkgs/development/libraries/libchop/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = [ ./gets-undeclared.patch ./size_t.patch ];
 
   nativeBuildInputs = [ pkgconfig gperf ];
-  
+
   buildInputs =
     [ zlib bzip2 lzo
       libgcrypt
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
          line.  It is written in C and has Guile (Scheme) bindings.
       '';
 
-    homepage = http://nongnu.org/libchop/;
+    homepage = https://www.nongnu.org/libchop/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ];
     platforms = platforms.gnu ++ platforms.linux;

--- a/pkgs/development/libraries/libe-book/default.upstream
+++ b/pkgs/development/libraries/libe-book/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/libebook/files/
+url https://sourceforge.net/projects/libebook/files/
 SF_version_dir libe-book-
 version_link '[.]tar.xz/download$'
 SF_redirect

--- a/pkgs/development/libraries/libgksu/default.nix
+++ b/pkgs/development/libraries/libgksu/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
       user.  It provides X authentication facilities for running
       programs in an X session.
     '';
-    homepage = http://www.nongnu.org/gksu/;
+    homepage = https://www.nongnu.org/gksu/;
     license = stdenv.lib.licenses.lgpl2;
     maintainers = [ stdenv.lib.maintainers.romildo ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/libiberty/default.nix
+++ b/pkgs/development/libraries/libiberty/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://gcc.gnu.org/;
+    homepage = https://gcc.gnu.org/;
     license = licenses.lgpl2;
     description = "Collection of subroutines used by various GNU programs";
     maintainers = with maintainers; [ abbradar ericson2314 ];

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
       applications.
     '';
 
-    homepage = http://www.gnu.org/software/libiconv/;
+    homepage = https://www.gnu.org/software/libiconv/;
     license = lib.licenses.lgpl2Plus;
 
     maintainers = [ ];

--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails
 
   meta = {
-    homepage = http://www.gnu.org/software/libidn/;
+    homepage = https://www.gnu.org/software/libidn/;
     description = "Library for internationalized domain names";
 
     longDescription = ''

--- a/pkgs/development/libraries/libmicrohttpd/default.nix
+++ b/pkgs/development/libraries/libmicrohttpd/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.lgpl2Plus;
 
-    homepage = http://www.gnu.org/software/libmicrohttpd/;
+    homepage = https://www.gnu.org/software/libmicrohttpd/;
 
     maintainers = with maintainers; [ eelco vrthra fpletz ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libmwaw/default.upstream
+++ b/pkgs/development/libraries/libmwaw/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/libmwaw/files/libmwaw/
+url https://sourceforge.net/projects/libmwaw/files/libmwaw/
 SF_version_dir libmwaw-
 version_link '[.]tar.xz/download$'
 SF_redirect

--- a/pkgs/development/libraries/libnih/default.nix
+++ b/pkgs/development/libraries/libnih/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   name = "libnih-${version}";
 
   src = fetchurl {
-    url = "http://code.launchpad.net/libnih/1.0/${version}/+download/libnih-${version}.tar.gz";
+    url = "https://code.launchpad.net/libnih/1.0/${version}/+download/libnih-${version}.tar.gz";
     sha256 = "01glc6y7z1g726zwpvp2zm79pyb37ki729jkh45akh35fpgp4xc9";
   };
 

--- a/pkgs/development/libraries/libodfgen/default.upstream
+++ b/pkgs/development/libraries/libodfgen/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/libwpd/files/libodfgen/
+url https://sourceforge.net/projects/libwpd/files/libodfgen/
 SF_version_dir libodfgen-
 version_link '[.]tar.xz/download$'
 SF_redirect

--- a/pkgs/development/libraries/libopcodes/default.nix
+++ b/pkgs/development/libraries/libopcodes/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library from binutils for manipulating machine code";
-    homepage = http://www.gnu.org/software/binutils/;
+    homepage = https://www.gnu.org/software/binutils/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ericson2314 ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/librevenge/default.upstream
+++ b/pkgs/development/libraries/librevenge/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/libwpd/files/librevenge/
+url https://sourceforge.net/projects/libwpd/files/librevenge/
 SF_version_dir librevenge-
 version_link '[.]tar.xz/download$'
 SF_redirect

--- a/pkgs/development/libraries/libsigsegv/default.nix
+++ b/pkgs/development/libraries/libsigsegv/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   doCheck = true; # not cross;
 
   meta = {
-    homepage = http://www.gnu.org/software/libsigsegv/;
+    homepage = https://www.gnu.org/software/libsigsegv/;
     description = "Library to handle page faults in user mode";
 
     longDescription = ''

--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/libtasn1/;
+    homepage = https://www.gnu.org/software/libtasn1/;
     description = "An ASN.1 library";
     longDescription = ''
       Libtasn1 is the ASN.1 library used by GnuTLS, GNU Shishi and some

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   meta = {
-    homepage = http://www.gnu.org/software/libunistring/;
+    homepage = https://www.gnu.org/software/libunistring/;
 
     description = "Unicode string library";
 

--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails
 
   meta = with stdenv.lib; {
-    homepage = http://www.nongnu.org/libunwind;
+    homepage = https://www.nongnu.org/libunwind;
     description = "A portable and efficient API to determine the call-chain of a program";
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libxmi/default.nix
+++ b/pkgs/development/libraries/libxmi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Library for rasterizing 2-D vector graphics";
-    homepage = http://www.gnu.org/software/libxmi/;
+    homepage = https://www.gnu.org/software/libxmi/;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
     maintainers = [ ];

--- a/pkgs/development/libraries/lightning/default.nix
+++ b/pkgs/development/libraries/lightning/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = http://www.gnu.org/software/lightning/;
+    homepage = https://www.gnu.org/software/lightning/;
     description = "Run-time code generation library";
     longDescription = ''
       GNU lightning is a library that generates assembly language code

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -159,7 +159,7 @@ stdenv.mkDerivation rec {
       ported to OS/2 Warp!
     '';
 
-    homepage = http://www.gnu.org/software/ncurses/;
+    homepage = https://www.gnu.org/software/ncurses/;
 
     license = lib.licenses.mit;
     platforms = lib.platforms.all;

--- a/pkgs/development/libraries/osip/default.nix
+++ b/pkgs/development/libraries/osip/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     license = stdenv.lib.licenses.lgpl21Plus;
-    homepage = http://www.gnu.org/software/osip/;
+    homepage = https://www.gnu.org/software/osip/;
     description = "The GNU oSIP library, an implementation of the Session Initiation Protocol (SIP)";
     maintainers = with stdenv.lib.maintainers; [ raskin ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/png++/default.nix
+++ b/pkgs/development/libraries/png++/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.nongnu.org/pngpp/;
+    homepage = https://www.nongnu.org/pngpp/;
     description = "C++ wrapper for libpng library";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/pth/default.nix
+++ b/pkgs/development/libraries/pth/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The GNU Portable Threads library";
-    homepage = http://www.gnu.org/software/pth;
+    homepage = https://www.gnu.org/software/pth;
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/readline/6.2.nix
+++ b/pkgs/development/libraries/readline/6.2.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (rec {
       desire its capabilities.
     '';
 
-    homepage = http://savannah.gnu.org/projects/readline/;
+    homepage = https://savannah.gnu.org/projects/readline/;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
       desire its capabilities.
     '';
 
-    homepage = http://savannah.gnu.org/projects/readline/;
+    homepage = https://savannah.gnu.org/projects/readline/;
 
     license = licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/readline/7.0.nix
+++ b/pkgs/development/libraries/readline/7.0.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       desire its capabilities.
     '';
 
-    homepage = http://savannah.gnu.org/projects/readline/;
+    homepage = https://savannah.gnu.org/projects/readline/;
 
     license = licenses.gpl3Plus;
 

--- a/pkgs/development/libraries/tinyxml/2.6.2.nix
+++ b/pkgs/development/libraries/tinyxml/2.6.2.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
     # add pkgconfig file
     ./2.6.2-add-pkgconfig.patch
 
-    # http://sourceforge.net/tracker/index.php?func=detail&aid=3031828&group_id=13559&atid=313559
+    # https://sourceforge.net/tracker/index.php?func=detail&aid=3031828&group_id=13559&atid=313559
     ./2.6.2-entity.patch
 
     # Use CC, CXX, and LD from environment

--- a/pkgs/development/libraries/ucommon/default.nix
+++ b/pkgs/development/libraries/ucommon/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "C++ library to facilitate using C++ design patterns";
-    homepage = http://www.gnu.org/software/commoncpp/;
+    homepage = https://www.gnu.org/software/commoncpp/;
     license = stdenv.lib.licenses.lgpl3Plus;
 
     maintainers = with stdenv.lib.maintainers; [ ];

--- a/pkgs/development/libraries/vcdimager/default.nix
+++ b/pkgs/development/libraries/vcdimager/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libcdio ];
 
   meta = with lib; {
-    homepage = http://www.gnu.org/software/vcdimager/;
+    homepage = https://www.gnu.org/software/vcdimager/;
     description = "Full-featured mastering suite for authoring, disassembling and analyzing Video CDs and Super Video CDs";
     platforms = platforms.unix;
     license = licenses.gpl2;

--- a/pkgs/development/misc/avr/libc/default.nix
+++ b/pkgs/development/misc/avr/libc/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "a C runtime library for AVR microcontrollers";
-    homepage = http://savannah.nongnu.org/projects/avr-libc/;
+    homepage = https://savannah.nongnu.org/projects/avr-libc/;
     license = licenses.bsd3;
     platforms = [ "avr-none" ];
     maintainers = with maintainers; [ mguentner ];

--- a/pkgs/development/misc/avr/libc/default.nix
+++ b/pkgs/development/misc/avr/libc/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   name = "avr-libc-${version}";
 
   src = fetchurl {
-    url = http://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2;
+    url = https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2;
     sha256 = "15svr2fx8j6prql2il2fc0ppwlv50rpmyckaxx38d3gxxv97zpdj";
   };
 

--- a/pkgs/development/python-modules/mmpython/default.nix
+++ b/pkgs/development/python-modules/mmpython/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   pname = "mmpython";
 
   src = fetchurl {
-    url = http://sourceforge.net/projects/mmpython/files/latest/download;
+    url = https://sourceforge.net/projects/mmpython/files/latest/download;
     sha256 = "1b7qfad3shgakj37gcj1b9h78j1hxlz6wp9k7h76pb4sq4bfyihy";
     name = "${pname}-${version}.tar.gz";
   };

--- a/pkgs/development/python-modules/pycdio/default.nix
+++ b/pkgs/development/python-modules/pycdio/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/libcdio/;
+    homepage = https://www.gnu.org/software/libcdio/;
     description = "Wrapper around libcdio (CD Input and Control library)";
     maintainers = with maintainers; [ rycee ];
     license = licenses.gpl3Plus;

--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   outputs = [ "out" "man" "info" ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/make/;
+    homepage = https://www.gnu.org/software/make/;
     description = "A tool to control the generation of non-source files from sources";
     license = licenses.gpl3Plus;
 

--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "gnulib-20180226";
 
   src = fetchgit {
-    url = "http://git.savannah.gnu.org/r/gnulib.git";
+    url = "https://git.savannah.gnu.org/r/gnulib.git";
     rev = "0bec5d56c6938c2f28417bb5fd1c4b05ea2e7d28";
     sha256 = "0sifr3bkmhyr5s6ljgfyr0fw6w49ajf11rlp1r797f3r3r6j9w4k";
   };

--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://www.gnu.org/software/gnulib/;
+    homepage = https://www.gnu.org/software/gnulib/;
     description = "Central location for code to be shared among GNU packages";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/tools/guile/g-wrap/default.nix
+++ b/pkgs/development/tools/guile/g-wrap/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       inter-language calls.  It currently only supports generating Guile
       wrappers for C functions.
     '';
-    homepage = "http://www.nongnu.org/g-wrap/";
+    homepage = "https://www.nongnu.org/g-wrap/";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ vyp ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/java/fastjar/default.nix
+++ b/pkgs/development/tools/java/fastjar/default.nix
@@ -5,7 +5,7 @@ let version = "0.98"; in
     name = "fastjar-${version}";
 
     src = fetchurl {
-      url = "http://download.savannah.gnu.org/releases/fastjar/fastjar-${version}.tar.gz";
+      url = "https://download.savannah.gnu.org/releases/fastjar/fastjar-${version}.tar.gz";
       sha256 = "0iginbz2m15hcsa3x4y7v3mhk54gr1r7m3ghx0pg4n46vv2snmpi";
     };
 

--- a/pkgs/development/tools/java/fastjar/default.nix
+++ b/pkgs/development/tools/java/fastjar/default.nix
@@ -22,7 +22,7 @@ let version = "0.98"; in
         the stock `jar' program running without a JIT.
       '';
 
-      homepage = http://savannah.nongnu.org/projects/fastjar/;
+      homepage = https://savannah.nongnu.org/projects/fastjar/;
 
       license = stdenv.lib.licenses.gpl2Plus;
       platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/tools/misc/autoconf-archive/default.nix
+++ b/pkgs/development/tools/misc/autoconf-archive/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Archive of autoconf m4 macros";
-    homepage = http://www.gnu.org/software/autoconf-archive/;
+    homepage = https://www.gnu.org/software/autoconf-archive/;
     license = licenses.gpl3;
     platforms = platforms.unix;
   };

--- a/pkgs/development/tools/misc/autoconf/2.13.nix
+++ b/pkgs/development/tools/misc/autoconf/2.13.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   postInstall = ''ln -s autoconf "$out"/bin/autoconf-2.13'';
 
   meta = {
-    homepage = http://www.gnu.org/software/autoconf/;
+    homepage = https://www.gnu.org/software/autoconf/;
     description = "Part of the GNU Build System";
     branch = "2.13";
 

--- a/pkgs/development/tools/misc/autoconf/2.64.nix
+++ b/pkgs/development/tools/misc/autoconf/2.64.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = false; # fails
 
   meta = {
-    homepage = http://www.gnu.org/software/autoconf/;
+    homepage = https://www.gnu.org/software/autoconf/;
     description = "Part of the GNU Build System";
 
     longDescription = ''

--- a/pkgs/development/tools/misc/autoconf/default.nix
+++ b/pkgs/development/tools/misc/autoconf/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = false; # fails
 
   meta = {
-    homepage = http://www.gnu.org/software/autoconf/;
+    homepage = https://www.gnu.org/software/autoconf/;
     description = "Part of the GNU Build System";
 
     longDescription = ''

--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Automated text and program generation tool";
     license = with licenses; [ gpl3Plus lgpl3Plus ];
-    homepage = http://www.gnu.org/software/autogen/;
+    homepage = https://www.gnu.org/software/autogen/;
     platforms = platforms.all;
     maintainers = [ ];
   };

--- a/pkgs/development/tools/misc/automake/automake-1.11.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.11.x.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   # TODO: Remove the `aclocal' wrapper when $ACLOCAL_PATH support is
   # available upstream; see
-  # <http://debbugs.gnu.org/cgi/bugreport.cgi?bug=9026>.
+  # <https://debbugs.gnu.org/cgi/bugreport.cgi?bug=9026>.
   builder = ./builder.sh;
 
   setupHook = ./setup-hook.sh;
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     branch = "1.11";
-    homepage = http://www.gnu.org/software/automake/;
+    homepage = https://www.gnu.org/software/automake/;
     description = "GNU standard-compliant makefile generator";
 
     longDescription = ''

--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     branch = "1.15";
-    homepage = http://www.gnu.org/software/automake/;
+    homepage = https://www.gnu.org/software/automake/;
     description = "GNU standard-compliant makefile generator";
     license = stdenv.lib.licenses.gpl2Plus;
 

--- a/pkgs/development/tools/misc/avrdude/default.nix
+++ b/pkgs/development/tools/misc/avrdude/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       download/upload/manipulate the ROM and EEPROM contents of AVR
       microcontrollers using the in-system programming technique (ISP).
     '';
-    homepage = http://www.nongnu.org/avrdude/;
+    homepage = https://www.nongnu.org/avrdude/;
     license = licenses.gpl2Plus;
     platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation rec {
       They also include the BFD (Binary File Descriptor) library,
       `gprof', `nm', `strip', etc.
     '';
-    homepage = http://www.gnu.org/software/binutils/;
+    homepage = https://www.gnu.org/software/binutils/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ericson2314 ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/misc/cflow/default.nix
+++ b/pkgs/development/tools/misc/cflow/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/cflow/;
+    homepage = https://www.gnu.org/software/cflow/;
 
     maintainers = [ maintainers.vrthra ];
 

--- a/pkgs/development/tools/misc/complexity/default.nix
+++ b/pkgs/development/tools/misc/complexity/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/complexity/;
+    homepage = https://www.gnu.org/software/complexity/;
 
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/development/tools/misc/cppi/default.nix
+++ b/pkgs/development/tools/misc/cppi/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = http://savannah.gnu.org/projects/cppi/;
+    homepage = https://savannah.gnu.org/projects/cppi/;
 
     description = "A C preprocessor directive indenter";
 

--- a/pkgs/development/tools/misc/ddd/default.nix
+++ b/pkgs/development/tools/misc/ddd/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   patches = [ ./gcc44.patch ];
 
   meta = {
-    homepage = http://www.gnu.org/software/ddd;
+    homepage = https://www.gnu.org/software/ddd;
     description = "Graphical front-end for command-line debuggers";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/tools/misc/dejagnu/default.nix
+++ b/pkgs/development/tools/misc/dejagnu/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   # details.
 
   # The test-suite needs to have a non-empty stdin:
-  #   http://lists.gnu.org/archive/html/bug-dejagnu/2003-06/msg00002.html
+  #   https://lists.gnu.org/archive/html/bug-dejagnu/2003-06/msg00002.html
   checkPhase = ''
     # Provide `runtest' with a log name, otherwise it tries to run
     # `whoami', which fails when in a chroot.
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       Tool command language.
     '';
 
-    homepage = http://www.gnu.org/software/dejagnu/;
+    homepage = https://www.gnu.org/software/dejagnu/;
     license = licenses.gpl2Plus;
 
     platforms = platforms.unix;

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
       program was doing at the moment it crashed.
     '';
 
-    homepage = http://www.gnu.org/software/gdb/;
+    homepage = https://www.gnu.org/software/gdb/;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/tools/misc/gengetopt/default.nix
+++ b/pkgs/development/tools/misc/gengetopt/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
          fills a struct
       '';
 
-    homepage = http://www.gnu.org/software/gengetopt/;
+    homepage = https://www.gnu.org/software/gengetopt/;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       independence of any editor.  It runs on a UNIX (POSIX) compatible
       operating system like GNU and BSD.
     '';
-    homepage = http://www.gnu.org/software/global/;
+    homepage = https://www.gnu.org/software/global/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ pSub peterhoeg ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = [ ./s_isdir.patch ] ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin stdenv.secure-format-patch;
 
   meta = {
-    homepage = http://www.gnu.org/software/m4/;
+    homepage = https://www.gnu.org/software/m4/;
     description = "GNU M4, a macro processor";
 
     longDescription = ''

--- a/pkgs/development/tools/misc/gperf/3.0.x.nix
+++ b/pkgs/development/tools/misc/gperf/3.0.x.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/gperf/;
+    homepage = https://www.gnu.org/software/gperf/;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/gperf/default.nix
+++ b/pkgs/development/tools/misc/gperf/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/gperf/;
+    homepage = https://www.gnu.org/software/gperf/;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
          ‘--version’ output of other commands.
       '';
 
-    homepage = http://www.gnu.org/software/help2man/;
+    homepage = https://www.gnu.org/software/help2man/;
 
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/development/tools/misc/libtool/default.nix
+++ b/pkgs/development/tools/misc/libtool/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       documentation for details.
     '';
 
-    homepage = http://www.gnu.org/software/libtool/;
+    homepage = https://www.gnu.org/software/libtool/;
 
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       documentation for details.
     '';
 
-    homepage = http://www.gnu.org/software/libtool/;
+    homepage = https://www.gnu.org/software/libtool/;
 
     license = stdenv.lib.licenses.gpl2Plus;
 

--- a/pkgs/development/tools/misc/texi2html/default.nix
+++ b/pkgs/development/tools/misc/texi2html/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = { 
     description = "Perl script which converts Texinfo source files to HTML output";
-    homepage = http://www.nongnu.org/texi2html/;
+    homepage = https://www.nongnu.org/texi2html/;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     && !stdenv.isSunOS; # flaky
 
   meta = {
-    homepage = http://www.gnu.org/software/texinfo/;
+    homepage = https://www.gnu.org/software/texinfo/;
     description = "The GNU documentation system";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/development/tools/misc/uisp/default.nix
+++ b/pkgs/development/tools/misc/uisp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Tool for AVR microcontrollers which can interface to many hardware in-system programmers";
     license = stdenv.lib.licenses.gpl2;
-    homepage = http://savannah.nongnu.org/projects/uisp;
+    homepage = https://savannah.nongnu.org/projects/uisp;
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/tools/parsing/bison/2.x.nix
+++ b/pkgs/development/tools/parsing/bison/2.x.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   # M4 = "${m4}/bin/m4";
 
   meta = {
-    homepage = http://www.gnu.org/software/bison/;
+    homepage = https://www.gnu.org/software/bison/;
     description = "Yacc-compatible parser generator";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/tools/parsing/bison/3.x.nix
+++ b/pkgs/development/tools/parsing/bison/3.x.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = false; # fails
 
   meta = {
-    homepage = http://www.gnu.org/software/bison/;
+    homepage = https://www.gnu.org/software/bison/;
     description = "Yacc-compatible parser generator";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/development/tools/quilt/default.nix
+++ b/pkgs/development/tools/quilt/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://savannah.nongnu.org/projects/quilt;
+    homepage = https://savannah.nongnu.org/projects/quilt;
     description = "Easily manage large numbers of patches";
 
     longDescription = ''

--- a/pkgs/games/ball-and-paddle/default.nix
+++ b/pkgs/games/ball-and-paddle/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/ballandpaddle/;
+    homepage = https://www.gnu.org/software/ballandpaddle/;
 
     maintainers = [ ];
 

--- a/pkgs/games/crack-attack/default.nix
+++ b/pkgs/games/crack-attack/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A fast-paced puzzle game inspired by the classic Super NES title Tetris Attack!";
-    homepage = http://www.nongnu.org/crack-attack/;
+    homepage = https://www.nongnu.org/crack-attack/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.piotr ];

--- a/pkgs/games/cuyo/default.nix
+++ b/pkgs/games/cuyo/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.1.0";
   
   src = fetchurl {
-     url = http://download.savannah.gnu.org/releases/cuyo/cuyo-2.1.0.tar.gz;
+     url = https://download.savannah.gnu.org/releases/cuyo/cuyo-2.1.0.tar.gz;
      sha256 = "17yqv924x7yvwix7yz9jdhgyar8lzdhqvmpvv0any8rdkajhj23c";
      };
 

--- a/pkgs/games/gltron/default.nix
+++ b/pkgs/games/gltron/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   patches = [ ./gentoo-prototypes.patch ];
 
   postPatch = ''
-     # Fix http://sourceforge.net/p/gltron/bugs/15
+     # Fix https://sourceforge.net/p/gltron/bugs/15
      sed -i /__USE_MISC/d lua/src/lib/liolib.c
   '';
 

--- a/pkgs/games/gnuchess/default.upstream
+++ b/pkgs/games/gnuchess/default.upstream
@@ -1,1 +1,1 @@
-url http://ftp.gnu.org/gnu/chess/
+url https://ftp.gnu.org/gnu/chess/

--- a/pkgs/games/gnugo/default.nix
+++ b/pkgs/games/gnugo/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU Go - A computer go player";
-    homepage = http://www.gnu.org/software/gnugo/;
+    homepage = https://www.gnu.org/software/gnugo/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/games/gtypist/default.nix
+++ b/pkgs/games/gtypist/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/gtypist;
+    homepage = https://www.gnu.org/software/gtypist;
     description = "Universal typing tutor";
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/games/liquidwar/5.nix
+++ b/pkgs/games/liquidwar/5.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
   version = "5.6.4";
   name = "liquidwar5-${version}";
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/liquidwar/liquidwar-${version}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/liquidwar/liquidwar-${version}.tar.gz";
     sha256 = "18wkbfzp07yckg05b5gjy67rw06z9lxp0hzg0zwj7rz8i12jxi9j";
   };
 

--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Quick tactics game";
-    homepage = http://www.gnu.org/software/liquidwar6/;
+    homepage = https://www.gnu.org/software/liquidwar6/;
     maintainers = [ maintainers.raskin ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;

--- a/pkgs/games/quantumminigolf/default.upstream
+++ b/pkgs/games/quantumminigolf/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/quantumminigolf/files/quantumminigolf/
+url https://sourceforge.net/projects/quantumminigolf/files/quantumminigolf/
 SF_version_dir
 version_link '[.]tar[.][^.]+/download$'
 SF_redirect

--- a/pkgs/games/soi/default.nix
+++ b/pkgs/games/soi/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
     license = licenses.free;
-    downloadPage = http://sourceforge.net/projects/soi/files/;
+    downloadPage = https://sourceforge.net/projects/soi/files/;
   };
 }

--- a/pkgs/games/xboard/default.nix
+++ b/pkgs/games/xboard/default.nix
@@ -9,12 +9,12 @@ let
     version="4.9.1";
     name="${baseName}-${version}";
     hash="1mkh36xnnacnz9r00b5f9ld9309k32jv6mcavklbdnca8bl56bib";
-    url="http://ftp.gnu.org/gnu/xboard/xboard-4.9.1.tar.gz";
+    url="https://ftp.gnu.org/gnu/xboard/xboard-4.9.1.tar.gz";
     sha256="1mkh36xnnacnz9r00b5f9ld9309k32jv6mcavklbdnca8bl56bib";
   };
   buildInputs = [
-    libX11 xproto libXt libXaw libSM libICE libXmu 
-    libXext gnuchess texinfo libXpm pkgconfig librsvg 
+    libX11 xproto libXt libXaw libSM libICE libXmu
+    libXext gnuchess texinfo libXpm pkgconfig librsvg
     cairo pango gtk2
   ];
 in
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
   meta = {
     inherit (s) version;
     description = ''GUI for chess engines'';
+    homepage = https://www.gnu.org/software/xboard/;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.gpl3Plus;

--- a/pkgs/games/xboard/default.upstream
+++ b/pkgs/games/xboard/default.upstream
@@ -1,1 +1,1 @@
-url http://ftp.gnu.org/gnu/xboard/
+url https://ftp.gnu.org/gnu/xboard/

--- a/pkgs/os-specific/linux/conspy/default.upstream
+++ b/pkgs/os-specific/linux/conspy/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/conspy/files/
+url https://sourceforge.net/projects/conspy/files/
 version_link 'conspy-[-0-9.]+/$'
 version_link '[-0-9.]+[.]tar[.][a-z0-9]+/download$'
 SF_redirect

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   makeFlags = "prefix=$(out)";
 
   meta = with stdenv.lib; {
-    homepage = http://www.nongnu.org/dmidecode/;
+    homepage = https://www.nongnu.org/dmidecode/;
     description = "A tool that reads information about your system's hardware from the BIOS according to the SMBIOS/DMI standard";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/sysvinit/default.nix
+++ b/pkgs/os-specific/linux/sysvinit/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     '';
 
   meta = {
-    homepage = http://www.nongnu.org/sysvinit/;
+    homepage = https://www.nongnu.org/sysvinit/;
     description = "Utilities related to booting and shutdown";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Flexible dictionary server and client implementing RFC 2229";
-    homepage    = http://www.gnu.org/software/dico/;
+    homepage    = https://www.gnu.org/software/dico/;
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.linux;

--- a/pkgs/servers/dict/dictd-db.nix
+++ b/pkgs/servers/dict/dictd-db.nix
@@ -29,15 +29,15 @@ let
    };
 in rec {
   deu2eng = makeDictdDBFreedict (fetchurl {
-    url = http://prdownloads.sourceforge.net/freedict/deu-eng.tar.gz;
+    url = mirror://sourceforge/freedict/deu-eng.tar.gz;
     sha256 = "0dqrhv04g4f5s84nbgisgcfwk5x0rpincif0yfhfh4sc1bsvzsrb";
   }) "deu-eng" "de_DE";
   eng2deu = makeDictdDBFreedict (fetchurl {
-    url = http://prdownloads.sourceforge.net/freedict/eng-deu.tar.gz;
+    url = mirror://sourceforge/freedict/eng-deu.tar.gz;
     sha256 = "01x12p72sa3071iff3jhzga8588440f07zr56r3x98bspvdlz73r";
   }) "eng-deu" "en_EN";
   nld2eng = makeDictdDBFreedict (fetchurl {
-    url = http://prdownloads.sourceforge.net/freedict/nld-eng.tar.gz;
+    url = mirror://sourceforge/freedict/nld-eng.tar.gz;
     sha256 = "1vhw81pphb64fzsjvpzsnnyr34ka2fxizfwilnxyjcmpn9360h07";
   }) "nld-eng" "nl_NL";
   eng2nld =  makeDictdDBFreedict (fetchurl {

--- a/pkgs/servers/http/myserver/default.nix
+++ b/pkgs/servers/http/myserver/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       built-in features.  Share your files in minutes!
     '';
 
-    homepage = http://www.gnu.org/software/myserver/;
+    homepage = https://www.gnu.org/software/myserver/;
 
     license = lib.licenses.gpl3Plus;
 

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "DIRSETGID=:" ];
 
   meta = {
-    homepage = http://www.gnu.org/software/mailman/;
+    homepage = https://www.gnu.org/software/mailman/;
     description = "Free software for managing electronic mail discussion and e-newsletter lists";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/servers/p910nd/default.nix
+++ b/pkgs/servers/p910nd/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       this protocol and the syntax is lp=remotehost%9100 in /etc/printcap.
     '';
     homepage = http://p910nd.sourceforge.net/;
-    downloadPage = http://sourceforge.net/projects/p910nd/;
+    downloadPage = https://sourceforge.net/projects/p910nd/;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/servers/pies/default.nix
+++ b/pkgs/servers/pies/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/pies/;
+    homepage = https://www.gnu.org/software/pies/;
 
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/servers/quagga/default.nix
+++ b/pkgs/servers/quagga/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
       It is more than a routed replacement, it can be used as a Route Server and
       a Route Reflector.
     '';
-    homepage = http://www.nongnu.org/quagga/;
+    homepage = https://www.nongnu.org/quagga/;
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ tavyc ];

--- a/pkgs/servers/shishi/default.nix
+++ b/pkgs/servers/shishi/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage    = http://www.gnu.org/software/shishi/;
+    homepage    = https://www.gnu.org/software/shishi/;
     description = "An implementation of the Kerberos 5 network security system";
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ bjg lovek323 wkennington ];

--- a/pkgs/servers/sip/sipwitch/default.nix
+++ b/pkgs/servers/sip/sipwitch/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Secure peer-to-peer VoIP server that uses the SIP protocol";
-    homepage = http://www.gnu.org/software/sipwitch/;
+    homepage = https://www.gnu.org/software/sipwitch/;
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux;

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/bash/;
+    homepage = https://www.gnu.org/software/bash/;
     description =
       "GNU Bourne-Again Shell, the de facto standard shell on Linux" +
         (if interactive then " (for interactive use)" else "");

--- a/pkgs/shells/rush/default.nix
+++ b/pkgs/shells/rush/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
          sftp-server or scp, that lack this ability.
       '';
 
-    homepage = http://www.gnu.org/software/rush/;
+    homepage = https://www.gnu.org/software/rush/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [ stdenv.lib.maintainers.bjg ];

--- a/pkgs/tools/X11/autocutsel/default.nix
+++ b/pkgs/tools/X11/autocutsel/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     inherit version;
-    homepage = http://www.nongnu.org/autocutsel/;
+    homepage = https://www.nongnu.org/autocutsel/;
     description = "Tracks changes in the server's cutbuffer and CLIPBOARD selection";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = with stdenv.lib.platforms; all;

--- a/pkgs/tools/X11/xbindkeys/default.nix
+++ b/pkgs/tools/X11/xbindkeys/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   buildInputs = [ libX11 guile ];
 
   meta = {
-    homepage = http://www.nongnu.org/xbindkeys/xbindkeys.html;
+    homepage = https://www.nongnu.org/xbindkeys/xbindkeys.html;
     description = "Launch shell commands with your keyboard or your mouse under X Window";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/tools/X11/xnee/default.nix
+++ b/pkgs/tools/X11/xnee/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/xnee/;
+    homepage = https://www.gnu.org/software/xnee/;
 
     maintainers = with stdenv.lib.maintainers; [ fuuzetsu ];
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice

--- a/pkgs/tools/archivers/atool/default.nix
+++ b/pkgs/tools/archivers/atool/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   configureScript = "${bash}/bin/bash configure";
 
   meta = {
-    homepage = http://www.nongnu.org/atool;
+    homepage = https://www.nongnu.org/atool;
     description = "Archive command line helper";
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.gpl3;

--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/cpio/;
+    homepage = https://www.gnu.org/software/cpio/;
     description = "A program to create or extract from cpio archives";
     license = licenses.gpl3;
     platforms = platforms.all;

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = false; # fails
 
   meta = {
-    homepage = http://www.gnu.org/software/tar/;
+    homepage = https://www.gnu.org/software/tar/;
     description = "GNU implementation of the `tar' archiver";
 
     longDescription = ''

--- a/pkgs/tools/archivers/sharutils/default.nix
+++ b/pkgs/tools/archivers/sharutils/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
          by a copy of the shell. unshar may also process files containing
          concatenated shell archives.
       '';
-    homepage = http://www.gnu.org/software/sharutils/;
+    homepage = https://www.gnu.org/software/sharutils/;
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.ndowens ];
     platforms = platforms.all;

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -5,7 +5,7 @@ python2Packages.buildPythonApplication rec {
   version = "0.7.18.2";
 
   src = fetchurl {
-    url = "http://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${name}.tar.gz";
+    url = "https://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${name}.tar.gz";
     sha256 = "0j37dgyji36hvb5dbzlmh5rj83jwhni02yq16g6rd3hj8f7qhdn2";
   };
 
@@ -35,7 +35,7 @@ python2Packages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "Encrypted bandwidth-efficient backup using the rsync algorithm";
-    homepage = http://www.nongnu.org/duplicity;
+    homepage = https://www.nongnu.org/duplicity;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ peti ];
     platforms = platforms.unix;

--- a/pkgs/tools/backup/duply/default.nix
+++ b/pkgs/tools/backup/duply/default.nix
@@ -28,11 +28,11 @@ stdenv.mkDerivation rec {
     description = "Shell front end for the duplicity backup tool";
     longDescription = ''
       Duply is a shell front end for the duplicity backup tool
-      http://duplicity.nongnu.org/. It greatly simplifies it's usage by
+      https://www.nongnu.org/duplicity. It greatly simplifies its usage by
       implementing backup job profiles, batch commands and more. Who says
       secure backups on non-trusted spaces are no child's play?
     '';
-    homepage = http://duply.net/;
+    homepage = https://duply.net/;
     license = licenses.gpl2;
     maintainers = [ maintainers.bjornfor ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/backup/store-backup/default.nix
+++ b/pkgs/tools/backup/store-backup/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl makeWrapper ];
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/storebackup/storeBackup-${version}.tar.bz2";
+    url = "https://download.savannah.gnu.org/releases/storebackup/storeBackup-${version}.tar.bz2";
     sha256 = "0y4gzssc93x6y93mjsxm5b5cdh68d7ffa43jf6np7s7c99xxxz78";
   };
 

--- a/pkgs/tools/backup/store-backup/default.nix
+++ b/pkgs/tools/backup/store-backup/default.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A backup suite that stores files on other disks";
-    homepage = http://savannah.nongnu.org/projects/storebackup;
+    homepage = https://savannah.nongnu.org/projects/storebackup;
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [stdenv.lib.maintainers.marcweber];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/cd-dvd/xorriso/default.nix
+++ b/pkgs/tools/cd-dvd/xorriso/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/xorriso/;
+    homepage = https://www.gnu.org/software/xorriso/;
 
     maintainers = [ maintainers.vrthra ];
     platforms = platforms.unix;

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.nongnu.org/lzip/lzip.html;
+    homepage = https://www.nongnu.org/lzip/lzip.html;
     description = "A lossless data compressor based on the LZMA algorithm";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   makeFlags = ["sbindir=$(out)/sbin" "ssbindir=$(out)/sbin"];
 
   meta = {
-    homepage = http://savannah.nongnu.org/projects/davfs2;
+    homepage = https://savannah.nongnu.org/projects/davfs2;
     description = "Mount WebDAV shares like a typical filesystem";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/tools/filesystems/nixpart/0.4/parted.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/parted.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       which also serves as a sample implementation and script backend.
     '';
 
-    homepage = http://www.gnu.org/software/parted/;
+    homepage = https://www.gnu.org/software/parted/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [

--- a/pkgs/tools/graphics/asymptote/default.upstream
+++ b/pkgs/tools/graphics/asymptote/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/asymptote/files/
+url https://sourceforge.net/projects/asymptote/files/
 SF_version_dir
 version_link 'src[.]tgz/download$'
 SF_redirect

--- a/pkgs/tools/graphics/barcode/default.nix
+++ b/pkgs/tools/graphics/barcode/default.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
     description = "GNU barcode generator";
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux; # Maybe other non-darwin Unix
-    downloadPage = "http://ftp.gnu.org/gnu/barcode/";
+    downloadPage = "https://ftp.gnu.org/gnu/barcode/";
     updateWalker = true;
-    homepage = http://ftp.gnu.org/gnu/barcode/;
+    homepage = https://www.gnu.org/software/barcode/;
     license = licenses.gpl3;
   };
 }

--- a/pkgs/tools/graphics/dmtx-utils/default.upstream
+++ b/pkgs/tools/graphics/dmtx-utils/default.upstream
@@ -1,4 +1,4 @@
-url http://sourceforge.net/projects/libdmtx/files/libdmtx/
+url https://sourceforge.net/projects/libdmtx/files/libdmtx/
 SF_version_dir
 version_link 'dmtx-utils-.*[.]tar[.][a-z0-9]+/download$'
 SF_redirect

--- a/pkgs/tools/graphics/fim/default.nix
+++ b/pkgs/tools/graphics/fim/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       to be a highly customizable and scriptable for users who are comfortable
       with software like the VIM text editor or the Mutt mail user agent.
     '';
-    homepage = http://www.nongnu.org/fbi-improved/;
+    homepage = https://www.nongnu.org/fbi-improved/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ primeos ];

--- a/pkgs/tools/graphics/icoutils/default.nix
+++ b/pkgs/tools/graphics/icoutils/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.nongnu.org/icoutils/;
+    homepage = https://www.nongnu.org/icoutils/;
     description = "Set of programs to deal with Microsoft Windows(R) icon and cursor files";
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = with stdenv.lib.platforms; linux ++ darwin;

--- a/pkgs/tools/graphics/plotutils/default.nix
+++ b/pkgs/tools/graphics/plotutils/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
          graphics.
       '';
 
-    homepage = http://www.gnu.org/software/plotutils/;
+    homepage = https://www.gnu.org/software/plotutils/;
 
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.marcweber ];

--- a/pkgs/tools/graphics/scanbd/default.nix
+++ b/pkgs/tools/graphics/scanbd/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       scanbuttond project. 
     '';
     homepage = http://scanbd.sourceforge.net/;
-    downloadPage = http://sourceforge.net/projects/scanbd/;
+    downloadPage = https://sourceforge.net/projects/scanbd/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/inputmethods/m17n-db/default.nix
+++ b/pkgs/tools/inputmethods/m17n-db/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "m17n-db-1.8.0";
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
     sha256 = "0vfw7z9i2s9np6nmx1d4dlsywm044rkaqarn7akffmb6bf1j6zv5";
   };
 

--- a/pkgs/tools/inputmethods/m17n-db/default.nix
+++ b/pkgs/tools/inputmethods/m17n-db/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   ;
 
   meta = {
-    homepage = http://www.nongnu.org/m17n/;
+    homepage = https://www.nongnu.org/m17n/;
     description = "Multilingual text processing library (database)";
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
   name = "m17n-lib-1.8.0";
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
     sha256 = "0jp61y09xqj10mclpip48qlfhniw8gwy8b28cbzxy8hq8pkwmfkq";
   };
 

--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ m17n_db ];
 
   meta = {
-    homepage = http://www.nongnu.org/m17n/;
+    homepage = https://www.nongnu.org/m17n/;
     description = "Multilingual text processing library (runtime)";
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    homepage = http://www.nongnu.org/m17n/;
+    homepage = https://www.nongnu.org/m17n/;
     description = "Multilingual text processing library (libotf)";
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "libotf-0.9.16";
 
   src = fetchurl {
-    url = "http://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
+    url = "https://download.savannah.gnu.org/releases/m17n/${name}.tar.gz";
     sha256 = "0sq6g3xaxw388akws6qrllp3kp2sxgk2dv4j79k6mm52rnihrnv8";
   };
 

--- a/pkgs/tools/misc/bc/default.nix
+++ b/pkgs/tools/misc/bc/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU software calculator";
-    homepage = http://www.gnu.org/software/bc/;
+    homepage = https://www.gnu.org/software/bc/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.gnu.org/software/coreutils/;
+    homepage = https://www.gnu.org/software/coreutils/;
     description = "The basic file, shell and text manipulation utilities of the GNU operating system";
 
     longDescription = ''

--- a/pkgs/tools/misc/datamash/default.nix
+++ b/pkgs/tools/misc/datamash/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A command-line program which performs basic numeric,textual and statistical operations on input textual data files";
-    homepage = http://www.gnu.org/software/datamash/;
+    homepage = https://www.gnu.org/software/datamash/;
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ pSub vrthra ];

--- a/pkgs/tools/misc/fileschanged/default.nix
+++ b/pkgs/tools/misc/fileschanged/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = http://www.nongnu.org/fileschanged/;
+    homepage = https://www.nongnu.org/fileschanged/;
     description = "A command-line utility that reports when files have been altered";
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://www.gnu.org/software/findutils/;
+    homepage = https://www.gnu.org/software/findutils/;
     description = "GNU Find Utilities, the basic directory searching utilities of the GNU operating system";
 
     longDescription = ''

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
          operating system (e.g., GNU).
       '';
 
-    homepage = http://www.gnu.org/software/grub/;
+    homepage = https://www.gnu.org/software/grub/;
 
     license = licenses.gpl3Plus;
 

--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -21,7 +21,7 @@ let
 
   po_src = fetchurl {
     name = "grub-2.02-beta2.tar.gz";
-    url = "http://alpha.gnu.org/gnu/grub/grub-2.02~beta2.tar.gz";
+    url = "https://alpha.gnu.org/gnu/grub/grub-2.02~beta2.tar.gz";
     sha256 = "1lr9h3xcx0wwrnkxdnkfjwy08j7g7mdlmmbdip2db4zfgi69h0rm";
 
   };

--- a/pkgs/tools/misc/idutils/default.nix
+++ b/pkgs/tools/misc/idutils/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       contents of certain character strings.
     '';
 
-    homepage = http://www.gnu.org/software/idutils/;
+    homepage = https://www.gnu.org/software/idutils/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [ ];

--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
          it possible to use output from GNU Parallel as input for other
          programs.
       '';
-    homepage = http://www.gnu.org/software/parallel/;
+    homepage = https://www.gnu.org/software/parallel/;
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ pSub vrthra ];

--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
       which also serves as a sample implementation and script backend.
     '';
 
-    homepage = http://www.gnu.org/software/parted/;
+    homepage = https://www.gnu.org/software/parted/;
     license = stdenv.lib.licenses.gpl3Plus;
 
     maintainers = [

--- a/pkgs/tools/misc/recutils/default.nix
+++ b/pkgs/tools/misc/recutils/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
          number of named fields.
       '';
 
-    homepage = http://www.gnu.org/software/recutils/;
+    homepage = https://www.gnu.org/software/recutils/;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/tools/misc/renameutils/default.nix
+++ b/pkgs/tools/misc/renameutils/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ readline ];
 
   meta = {
-    homepage = http://www.nongnu.org/renameutils/;
+    homepage = https://www.nongnu.org/renameutils/;
     description = "A set of programs to make renaming of files faster";
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/screen/;
+    homepage = https://www.gnu.org/software/screen/;
     description = "A window manager that multiplexes a physical terminal";
     license = licenses.gpl2Plus;
 

--- a/pkgs/tools/misc/stow/default.nix
+++ b/pkgs/tools/misc/stow/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     '';
 
     license = stdenv.lib.licenses.gpl3Plus;
-    homepage = http://www.gnu.org/software/stow/;
+    homepage = https://www.gnu.org/software/stow/;
 
     maintainers = with stdenv.lib.maintainers; [ the-kenny jgeerds ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/tools/misc/time/default.nix
+++ b/pkgs/tools/misc/time/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     '';
 
     license = stdenv.lib.licenses.gpl3Plus;
-    homepage = http://www.gnu.org/software/time/;
+    homepage = https://www.gnu.org/software/time/;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/misc/uucp/default.nix
+++ b/pkgs/tools/misc/uucp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
          just found one of the finest UUCP implementations available.
       '';
 
-    homepage = http://www.gnu.org/software/uucp/uucp.html;
+    homepage = https://www.gnu.org/software/uucp/uucp.html;
 
     license = stdenv.lib.licenses.gpl2Plus;
 

--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   CFLAGS = "-DSFTPSERVER_PATH=\\\"${sftpPath}\\\"";
 
-  # http://www.gnu.org/software/make/manual/html_node/Libraries_002fSearch.html
+  # https://www.gnu.org/software/make/manual/html_node/Libraries_002fSearch.html
   preConfigure = ''
     makeFlags=VPATH=`cat $NIX_CC/nix-support/orig-libc`/lib
   '';

--- a/pkgs/tools/networking/flvstreamer/default.nix
+++ b/pkgs/tools/networking/flvstreamer/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl2Plus;
 
-    homepage = http://savannah.nongnu.org/projects/flvstreamer;
+    homepage = https://savannah.nongnu.org/projects/flvstreamer;
 
     maintainers = [ stdenv.lib.maintainers.thammers ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
          traceroute, uucpd, and whois.
       '';
 
-    homepage = http://www.gnu.org/software/inetutils/;
+    homepage = https://www.gnu.org/software/inetutils/;
     license = licenses.gpl3Plus;
 
     maintainers = with maintainers; [ matthewbauer ];

--- a/pkgs/tools/networking/jwhois/default.nix
+++ b/pkgs/tools/networking/jwhois/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A client for the WHOIS protocol allowing you to query the owner of a domain name";
-    homepage = http://www.gnu.org/software/jwhois/;
+    homepage = https://www.gnu.org/software/jwhois/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
 
     maintainers = with maintainers; [ orivej vrthra ];
 
-    homepage = http://www.gnu.org/software/mailutils/;
+    homepage = https://www.gnu.org/software/mailutils/;
 
     # Some of the dependencies fail to build on {cyg,dar}win.
     platforms = platforms.gnu ++ platforms.linux;

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/wget/;
+    homepage = https://www.gnu.org/software/wget/;
 
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.all;

--- a/pkgs/tools/security/gnu-pw-mgr/default.nix
+++ b/pkgs/tools/security/gnu-pw-mgr/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "gnu-pw-mgr-${version}";
   version = "2.4.2";
   src = fetchurl {
-    url = "http://ftp.gnu.org/gnu/gnu-pw-mgr/${name}.tar.xz";
+    url = "https://ftp.gnu.org/gnu/gnu-pw-mgr/${name}.tar.xz";
     sha256 = "1yvdzc5w37qrjrkby5699ygj9bhkvgi3zk9k9jcjry1j6b7wdl17";
   };
 

--- a/pkgs/tools/security/oath-toolkit/default.nix
+++ b/pkgs/tools/security/oath-toolkit/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Components for building one-time password authentication systems";
-    homepage = http://www.nongnu.org/oath-toolkit/;
+    homepage = https://www.nongnu.org/oath-toolkit/;
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/system/acct/default.nix
+++ b/pkgs/tools/system/acct/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/acct/;
+    homepage = https://www.gnu.org/software/acct/;
 
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.linux;

--- a/pkgs/tools/system/ddrescue/default.nix
+++ b/pkgs/tools/system/ddrescue/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
          second and successive copies.
       '';
 
-    homepage = http://www.gnu.org/software/ddrescue/ddrescue.html;
+    homepage = https://www.gnu.org/software/ddrescue/ddrescue.html;
 
     license = licenses.gpl3Plus;
 

--- a/pkgs/tools/system/fdisk/default.nix
+++ b/pkgs/tools/system/fdisk/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, parted, libuuid, gettext, guile }:
 
 stdenv.mkDerivation rec {
-  name = "gnufdisk-2.0.0a"; # .0a1 seems broken, see http://lists.gnu.org/archive/html/bug-fdisk/2012-09/msg00000.html
+  name = "gnufdisk-2.0.0a"; # .0a1 seems broken, see https://lists.gnu.org/archive/html/bug-fdisk/2012-09/msg00000.html
 
   src = fetchurl {
     url = "mirror://gnu/fdisk/${name}.tar.gz";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/fdisk/;
+    homepage = https://www.gnu.org/software/fdisk/;
 
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/tools/system/freeipmi/default.nix
+++ b/pkgs/tools/system/freeipmi/default.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
          info.
       '';
 
-    homepage = http://www.gnu.org/software/freeipmi/;
-    downloadPage = "http://www.gnu.org/software/freeipmi/download.html";
+    homepage = https://www.gnu.org/software/freeipmi/;
+    downloadPage = "https://www.gnu.org/software/freeipmi/download.html";
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/tools/system/mcron/default.nix
+++ b/pkgs/tools/system/mcron/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       when jobs should be run.  Mcron was written by Dale Mellor.
     '';
 
-    homepage = http://www.gnu.org/software/mcron/;
+    homepage = https://www.gnu.org/software/mcron/;
 
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://ftp.gnu.org/gnu/which/;
+    homepage = https://www.gnu.org/software/which/;
     platforms = platforms.all;
     license = licenses.gpl3;
   };

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/diffutils/diffutils.html;
+    homepage = https://www.gnu.org/software/diffutils/diffutils.html;
     description = "Commands for showing the differences between files (diff, cmp, etc.)";
     license = licenses.gpl3;
     platforms = platforms.unix;

--- a/pkgs/tools/text/enscript/default.nix
+++ b/pkgs/tools/text/enscript/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
     license = stdenv.lib.licenses.gpl3Plus;
 
-    homepage = http://www.gnu.org/software/enscript/;
+    homepage = https://www.gnu.org/software/enscript/;
 
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/gawk/;
+    homepage = https://www.gnu.org/software/gawk/;
     description = "GNU implementation of the Awk programming language";
 
     longDescription = ''

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/grep/;
+    homepage = https://www.gnu.org/software/grep/;
     description = "GNU implementation of the Unix grep command";
 
     longDescription = ''

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
          more original files, producing patched versions.
       '';
 
-    homepage = http://savannah.gnu.org/projects/patch;
+    homepage = https://savannah.gnu.org/projects/patch;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/tools/text/gnused/422.nix
+++ b/pkgs/tools/text/gnused/422.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   outputs = [ "out" "info" ];
 
   meta = {
-    homepage = http://www.gnu.org/software/sed/;
+    homepage = https://www.gnu.org/software/sed/;
     description = "GNU sed, a batch stream editor";
 
     longDescription = ''

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   PERL = if stdenv.hostPlatform == stdenv.buildPlatform then null else "missing";
 
   meta = {
-    homepage = http://www.gnu.org/software/sed/;
+    homepage = https://www.gnu.org/software/sed/;
     description = "GNU sed, a batch stream editor";
 
     longDescription = ''

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.gnu.org/software/groff/;
+    homepage = https://www.gnu.org/software/groff/;
     description = "GNU Troff, a typesetting package that reads plain text and produces formatted output";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/tools/text/numdiff/default.nix
+++ b/pkgs/tools/text/numdiff/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
       line by line and field by field, ignoring small numeric differences
       or/and different numeric formats
     '';
-    homepage = http://www.nongnu.org/numdiff/;
+    homepage = https://www.nongnu.org/numdiff/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ndowens ];
     platforms = platforms.gnu ++ platforms.linux;

--- a/pkgs/tools/text/poedit/default.nix
+++ b/pkgs/tools/text/poedit/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "poedit-1.5.7";
 
   src = fetchurl {
-    url = "http://prdownloads.sourceforge.net/poedit/${name}.tar.gz";
+    url = "mirror://sourceforge/poedit/${name}.tar.gz";
     sha256 = "0y0gbkb1jvp61qhh8sh7ar8849mwirizc42pk57zpxy84an5qlr4";
   };
 

--- a/pkgs/tools/text/recode/default.nix
+++ b/pkgs/tools/text/recode/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.gnu.org/software/recode/;
+    homepage = https://www.gnu.org/software/recode/;
     description = "Converts files between various character sets and usages";
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Source code renderer with syntax highlighting";
-    homepage = http://www.gnu.org/software/src-highlite/;
+    homepage = https://www.gnu.org/software/src-highlite/;
     license = stdenv.lib.licenses.gpl3Plus;
     platforms = with stdenv.lib.platforms; linux ++ darwin;
     longDescription =

--- a/pkgs/tools/text/wdiff/default.nix
+++ b/pkgs/tools/text/wdiff/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   checkInputs = [ which ];
 
   meta = {
-    homepage = http://www.gnu.org/software/wdiff/;
+    homepage = https://www.gnu.org/software/wdiff/;
     description = "Comparing files on a word by word basis";
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [ stdenv.lib.maintainers.eelco ];

--- a/pkgs/tools/typesetting/lout/default.nix
+++ b/pkgs/tools/typesetting/lout/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
       "mirror://savannah/lout/${name}.tar.gz"      # new!
       "mirror://sourceforge/lout/${name}.tar.gz"   # to be phased out
       # XXX: We could add the CTAN mirrors
-      # (see http://www.ctan.org/tex-archive/support/lout/).
+      # (see https://www.ctan.org/tex-archive/support/lout/).
     ];
     sha256 = "1gb8vb1wl7ikn269dd1c7ihqhkyrwk19jwx5kd0rdvbk6g7g25ix";
   };
@@ -40,9 +40,9 @@ stdenv.mkDerivation rec {
       went back to the beginning.
     '';
 
-    # Author's page: http://www.cs.usyd.edu.au/~jeff/
-    # Wiki: http://lout.wiki.sourceforge.net/
-    homepage = http://savannah.nongnu.org/projects/lout/;
+    # Author's page: http://jeffreykingston.id.au/lout/
+    # Wiki: https://sourceforge.net/p/lout/wiki/
+    homepage = https://savannah.nongnu.org/projects/lout/;
 
     license = stdenv.lib.licenses.gpl3Plus;
 

--- a/pkgs/tools/typesetting/tex/auctex/default.nix
+++ b/pkgs/tools/typesetting/tex/auctex/default.nix
@@ -30,7 +30,7 @@ let auctex = stdenv.mkDerivation ( rec {
 
   meta = {
     description = "Extensible package for writing and formatting TeX files in GNU Emacs and XEmacs";
-    homepage = http://www.gnu.org/software/auctex;
+    homepage = https://www.gnu.org/software/auctex;
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.gpl3;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -294,8 +294,8 @@ with pkgs;
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
-    url = "http://git.savannah.gnu.org/cgit/${repo}.git/snapshot/${repo}-${rev}.tar.gz";
-    meta.homepage = "http://git.savannah.gnu.org/cgit/${repo}.git/";
+    url = "https://git.savannah.gnu.org/cgit/${repo}.git/snapshot/${repo}-${rev}.tar.gz";
+    meta.homepage = "https://git.savannah.gnu.org/cgit/${repo}.git/";
   } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; };
 
   # gitlab example


### PR DESCRIPTION
###### Motivation for this change

GNU / Savannah / NonGNU domains always offers HTTPS and often there is even a redirect from plain http to https. So let's save a redirect to users (and Hydra) when following a link to an homepage or to a source tarball. It also updates links in the doc.
More details in the commit messages.

\+ a bonus on a small number of SourceForge URLs that were left before

Related: #13809 / #50989
/cc @markuskowa @Infinisil @ryantm 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

