### PR TITLE
pqiv: 2.10.4 -> 2.11

### DIFF
--- a/pkgs/applications/graphics/pqiv/default.nix
+++ b/pkgs/applications/graphics/pqiv/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation (rec {
   name = "pqiv-${version}";
-  version = "2.10.4";
+  version = "2.11";
 
   src = fetchFromGitHub {
     owner = "phillipberndt";
     repo = "pqiv";
     rev = version;
-    sha256 = "04fawc3sd625y1bbgfgwmak56pq28sm58dwn5db4h183iy3awdl9";
+    sha256 = "06cwm28b7j1skwp21s5snmj1pqh3xh6y2i5v4w3pz0b8k3053h9i";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
https://github.com/phillipberndt/pqiv/releases/tag/2.11


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---