### PR TITLE
tabbed: 20160425 -> 20180310

### DIFF
--- a/pkgs/applications/window-managers/tabbed/default.nix
+++ b/pkgs/applications/window-managers/tabbed/default.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "tabbed-20160425";
+  name = "tabbed-20180310";
 
   src = fetchgit {
     url = https://git.suckless.org/tabbed;
-    rev = "bc236142fa72d2f9d6b5c790d3f3a9a9168a7164";
-    sha256 = "1fiv57g3jnlhnb6zrzl3n6lnpn2s9s0sd7bcv7r1nb3grwy7icri";
+    rev = "b5f9ec647aae2d9a1d3bd586eb7523a4e0a329a3";
+    sha256 = "0frj2yjaf0mfjwgyfappksfir52mx2xxd3cdg5533m5d88vbmxss";
   };
 
   inherit patches;


### PR DESCRIPTION
###### Motivation for this change

I meant to look more into this,
but only updated and checked the binaries superficially.

Quick test of functionality would be good.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---