### PR TITLE
or-tools: v6.9.1 -> v6.10, touchups

### DIFF
--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, google-gflags, which
-, lsb-release, glog, protobuf, cbc, zlib }:
+, lsb-release, glog, protobuf, cbc, zlib, python3 }:
 
 stdenv.mkDerivation rec {
   name = "or-tools-${version}";
@@ -28,10 +28,13 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=${placeholder "out"}" ];
   buildFlags = [ "cc" ];
 
+  checkTarget = "test_cc";
+  doCheck = true;
+
   installTargets = [ "install_cc" ];
 
   nativeBuildInputs = [
-    cmake lsb-release which zlib
+    cmake lsb-release which zlib python3
   ];
   propagatedBuildInputs = [
     google-gflags glog protobuf cbc

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     google-gflags glog protobuf cbc
   ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = https://github.com/google/or-tools;
     license = licenses.asl20;

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -25,13 +25,10 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  buildPhase = ''
-    make cc
-  '';
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+  buildFlags = [ "cc" ];
 
-  installPhase = ''
-    make install_cc prefix=$out
-  '';
+  installTargets = [ "install_cc" ];
 
   nativeBuildInputs = [
     cmake lsb-release which zlib

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "or-tools-${version}";
-  version = "v6.9.1";
+  version = "v6.10";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "or-tools";
     rev = version;
-    sha256 = "099j1mc7vvry0a2fiz9zvk6divivglzphv48wbw0c6nd5w8hb27c";
+    sha256 = "11k3671rpv968dsglc6bgarr9yi8ijaaqm2wq3m0rn4wy8fj7za2";
   };
 
   # The original build system uses cmake which does things like pull
@@ -32,17 +32,6 @@ stdenv.mkDerivation rec {
   installPhase = ''
     make install_cc prefix=$out
   '';
-
-  patches = [
-    # In "expected" way of compilation, the glog package is compiled
-    # with gflags support which then makes gflags header transitively
-    # included through glog. However in nixpkgs we don't compile glog
-    # with gflags so we have to include it ourselves. Upstream should
-    # always include gflags to support both ways I think.
-    #
-    # Upstream ticket: https://github.com/google/or-tools/issues/902
-    ./gflags-include.patch
-  ];
 
   nativeBuildInputs = [
     cmake lsb-release which zlib


### PR DESCRIPTION
###### Motivation for this change

Note there are no 'bins' before or after this,
hopefully that's the expected behavior.

Haven't tested-- have these on my "to watch" list
but don't recall how they're used :innocent:.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---