### PR TITLE
minizincide: init at 2.2.3

### DIFF
--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     sha256 = "1hanq7c6li59awlwghgvpd8w93a7zb6iw7p4062nphnbd1dmg92f";
   };
 
-  postUnpack = ''export sourceRoot="$sourceRoot/MiniZincIDE"'';
+  sourceRoot = "source/MiniZincIDE";
 
   enableParallelBuilding = true;
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     homepage = https://www.minizinc.org/;
-    description = "IDE for MiniZinc, a medium-level constraint modelling language.";
+    description = "IDE for MiniZinc, a medium-level constraint modelling language";
 
     longDescription = ''
       MiniZinc is a medium-level constraint modelling

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "MiniZinc";
     repo = "MiniZincIDE";
-    rev = version; # XXX chance it//revisit: "3d66971a0cad6edbe797f4dd940229d38e5bfe3d"; # tags on the repo are disappearing: See https://github.com/MiniZinc/libminizinc/issues/257
+    rev = version;
     sha256 = "1hanq7c6li59awlwghgvpd8w93a7zb6iw7p4062nphnbd1dmg92f";
   };
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.minizinc.org/;
+    homepage = https://www.minizinc.org/;
     description = "IDE for MiniZinc, a medium-level constraint modelling language.";
 
     longDescription = ''
@@ -37,6 +37,6 @@ stdenv.mkDerivation {
 
     license = licenses.mpl20;
     platforms = platforms.linux;
-    maintainers = [ maintainers.sheenobu ];
+    maintainers = [ maintainers.dtzWill ];
   };
 }

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, qtbase, qtwebengine, qtwebkit, qmake, makeWrapper, minizinc }:
+let
+  version = "2.2.3";
+in
+stdenv.mkDerivation {
+  name = "minizinc-ide-${version}";
+
+  nativeBuildInputs = [ qmake makeWrapper ];
+  buildInputs = [ qtbase qtwebengine qtwebkit ];
+
+  src = fetchFromGitHub {
+    owner = "MiniZinc";
+    repo = "MiniZincIDE";
+    rev = version; # XXX chance it//revisit: "3d66971a0cad6edbe797f4dd940229d38e5bfe3d"; # tags on the repo are disappearing: See https://github.com/MiniZinc/libminizinc/issues/257
+    sha256 = "1hanq7c6li59awlwghgvpd8w93a7zb6iw7p4062nphnbd1dmg92f";
+  };
+
+  postUnpack = ''export sourceRoot="$sourceRoot/MiniZincIDE"'';
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/MiniZincIDE --prefix PATH ":" ${stdenv.lib.makeBinPath [ minizinc ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.minizinc.org/;
+    description = "IDE for MiniZinc, a medium-level constraint modelling language.";
+
+    longDescription = ''
+      MiniZinc is a medium-level constraint modelling
+      language. It is high-level enough to express most
+      constraint problems easily, but low-level enough
+      that it can be mapped onto existing solvers easily and consistently.
+      It is a subset of the higher-level language Zinc.
+    '';
+
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheenobu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8725,6 +8725,7 @@ with pkgs;
   minify = callPackage ../development/web/minify { };
 
   minizinc = callPackage ../development/tools/minizinc { };
+  minizincide = qt5.callPackage ../development/tools/minizinc/ide.nix { };
 
   mk = callPackage ../development/tools/build-managers/mk { };
 


### PR DESCRIPTION
* wrap so minizinc on PATH
  (to ensure it's avail/found)


###### Motivation for this change

Wanted to try, still looking into it but packaging as first step :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---