### PR TITLE
gecode: 6.0.0 -> 6.1.0, deps, Gist support

### DIFF
--- a/pkgs/development/libraries/gecode/default.nix
+++ b/pkgs/development/libraries/gecode/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchFromGitHub, perl }:
 
 stdenv.mkDerivation rec {
   name = "gecode-${version}";
-  version = "6.0.0";
+  version = "6.1.0";
 
-  src = fetchurl {
-    url = "http://www.gecode.org/download/${name}.tar.gz";
-    sha256 = "0dp7bm6k790jx669y4jr0ffi5cdfpwsqm1ykj2c0zh56jsgs6hfs";
+  src = fetchFromGitHub {
+    owner = "Gecode";
+    repo = "gecode";
+    rev = "release-${version}";
+    sha256 = "1ijjy8ppx7djnkrkawsd00rmlf24qh1z13aap0h1azailw1pbrg4";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/gecode/default.nix
+++ b/pkgs/development/libraries/gecode/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gecode.org;
     description = "Toolkit for developing constraint-based systems";
     platforms = platforms.all;
-    maintainers = [ maintainers.manveru ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/gecode/default.nix
+++ b/pkgs/development/libraries/gecode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl }:
+{ stdenv, fetchFromGitHub, bison, flex, perl, gmp, mpfr, enableGist ? true, qtbase }:
 
 stdenv.mkDerivation rec {
   name = "gecode-${version}";
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
-  buildInputs = [ perl ];
+  nativeBuildInputs = [ bison flex ];
+  buildInputs = [ perl gmp mpfr ]
+    ++ stdenv.lib.optional enableGist qtbase;
 
   meta = with stdenv.lib; {
     license = licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9714,8 +9714,8 @@ with pkgs;
   gdbm = callPackage ../development/libraries/gdbm { };
 
   gecode_3 = callPackage ../development/libraries/gecode/3.nix { };
-  gecode_4 = callPackage ../development/libraries/gecode { };
-  gecode = gecode_4;
+  gecode_6 = qt5.callPackage ../development/libraries/gecode { };
+  gecode = gecode_6;
 
   gephi = callPackage ../applications/science/misc/gephi { };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/Gecode/gecode/releases/tag/release-6.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---