### PR TITLE
scilab-bin: adding bin/scilab symlink

### DIFF
--- a/pkgs/applications/science/math/scilab-bin/default.nix
+++ b/pkgs/applications/science/math/scilab-bin/default.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
     cp -r . "$out/opt/scilab-${ver}/"
     mkdir "$out/bin"
     ln -s "$out/opt/scilab-${ver}/bin/scilab" "$out/bin/scilab-${ver}"
+    ln -s "$out/opt/scilab-${ver}/bin/scilab" "$out/bin/scilab"
     ln -s "scilab-${ver}" "$out/bin/scilab-${majorVer}"
   '';
 


### PR DESCRIPTION
Should fix #51343; merely adding a scilab symlink within the bin/ directory, so that it can be detected by SageMath.

###### Motivation for this change
Desire to fix #51343, plus this sounds like it might save a little work for users that wish to launch the app from the command-line. 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS) (I built on NixOS and as ` = true;` is apparently the default this must have been used).
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).