### PR TITLE
vdirsyncer: fix build

### DIFF
--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3Packages, glibcLocales, rustPlatform, pkgconfig, openssl }:
+{ stdenv, python3Packages, fetchpatch, glibcLocales, rustPlatform, pkgconfig, openssl, Security }:
 
 # Packaging documentation at:
 # https://github.com/untitaker/vdirsyncer/blob/master/docs/packaging.rst
@@ -16,7 +16,7 @@ let
     inherit src;
     sourceRoot = name + "/rust";
     cargoSha256 = "08xq9q5fx37azzkqqgwcnds1yd8687gh26dsl3ivql5h13fa2w3q";
-    buildInputs = [ pkgconfig openssl ];
+    buildInputs = [ pkgconfig openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
   };
 in pythonPackages.buildPythonApplication rec {
   inherit version pname src native;
@@ -34,6 +34,21 @@ in pythonPackages.buildPythonApplication rec {
   buildInputs = with pythonPackages; [ setuptools_scm ];
 
   checkInputs = with pythonPackages; [ hypothesis pytest pytest-localserver pytest-subtesthack ] ++ [ glibcLocales ];
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/pimutils/vdirsyncer/commit/80a42e4c6c18ca4db737bc6700c50a3866832bbb.patch;
+      sha256 = "1vrhn0ma3y08w6f5abhl3r5rq30g60h1bp3wmyszw909hyvyzp5l";
+    })
+    (fetchpatch {
+      url = https://github.com/pimutils/vdirsyncer/commit/22ad88a6b18b0979c5d1f1d610c1d2f8f87f4b89.patch;
+      sha256 = "0dbzj6jlxhdidnm3i21a758z83sdiwzhpd45pbkhycfhgmqmhjpl";
+    })
+    (fetchpatch {
+      url = https://github.com/pimutils/vdirsyncer/commit/29417235321c249c65904bc7948b066ef5683aee.patch;
+      sha256 = "0zvr0y88gm3vprjcdzs4m151laa9qhkyi61rvrfdjmf42fwhbm80";
+    })
+  ];
 
   postPatch = ''
     sed -i 's/spec.add_external_build(cmd=cmd/spec.add_external_build(cmd="true"/g' setup.py

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19502,7 +19502,9 @@ with pkgs;
 
   vcv-rack = callPackage ../applications/audio/vcv-rack { };
 
-  vdirsyncer = callPackage ../tools/misc/vdirsyncer { };
+  vdirsyncer = callPackage ../tools/misc/vdirsyncer {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 


### PR DESCRIPTION
###### Motivation for this change
Disabled vdirsyncer tests, because our version of hypothesis is a bit new https://github.com/pimutils/vdirsyncer/pull/779

Closes https://github.com/NixOS/nixpkgs/issues/51241

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

