### PR TITLE
antibody: 4.0.0 -> 4.0.2

### DIFF
--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -2,24 +2,23 @@
 
 buildGoPackage rec {
   name = "antibody-${version}";
-  version = "4.0.0";
-  rev = "v${version}";
+  version = "4.0.2";
 
   goPackagePath = "github.com/getantibody/antibody";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner  = "getantibody";
     repo   = "antibody";
-    sha256 = "0iq3dfwwh39hmk8qmhrfgkn8pcabxf67c03s7vh18n7w9aay4jfz";
+    rev = "v${version}";
+    sha256 = "1lq0bd2l928bgwqiq3fa5ippjhnsfgwdqn6nd3hfis8bijrwc5jv";
   };
 
   goDeps = ./deps.nix;
 
   meta = with lib; {
     description = "The fastest shell plugin manager";
-    homepage    = https://github.com/getantibody/antibody;
-    license     = licenses.mit;
+    homepage = https://github.com/getantibody/antibody;
+    license = licenses.mit;
     maintainers = with maintainers; [ worldofpeace ];
   };
 }

--- a/pkgs/shells/zsh/antibody/deps.nix
+++ b/pkgs/shells/zsh/antibody/deps.nix
@@ -1,110 +1,73 @@
-[
-  {
-    goPackagePath  = "github.com/alecthomas/kingpin";
-    fetch = {
-      type = "git";
-      url = "https://github.com/alecthomas/kingpin";
-      rev =  "a39589180ebd6bbf43076e514b55f20a95d43086";
-      sha256 = "0b00bfiwl76qflnmnk3cnlaii6wxgzzdnby99cxdych4f8qmzlv3";
-    };
-  }
-  {
-    goPackagePath  = "github.com/alecthomas/template";
-    fetch = {
-      type = "git";
-      url = "https://github.com/alecthomas/template";
-      rev =  "a0175ee3bccc567396460bf5acd36800cb10c49c";
-      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
-    };
-  }
-  {
-    goPackagePath  = "github.com/alecthomas/units";
-    fetch = {
-      type = "git";
-      url = "https://github.com/alecthomas/units";
-      rev =  "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
-      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
-    };
-  }
-  {
-    goPackagePath  = "github.com/caarlos0/gohome";
-    fetch = {
-      type = "git";
-      url = "https://github.com/caarlos0/gohome";
-      rev =  "c08fdebe2a8b9b92637a423c66ac5d4a8f4e91e8";
-      sha256 = "1wpg7dpi44kic4y20bk6fjwpanm65h1hj4762dsp41kbdfzc8322";
-    };
-  }
-  {
-    goPackagePath  = "github.com/davecgh/go-spew";
-    fetch = {
-      type = "git";
-      url = "https://github.com/davecgh/go-spew";
-      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
-      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
-    };
-  }
-  {
-    goPackagePath  = "github.com/getantibody/folder";
-    fetch = {
-      type = "git";
-      url = "https://github.com/getantibody/folder";
-      rev =  "479aa91767d47bc27599e6ebc7fd07945dd38132";
-      sha256 = "0mzc2x7897f17kj2v807d8cqzgclq9bsz2xqz81j1k85g53l513j";
-    };
-  }
-  {
-    goPackagePath  = "github.com/pmezard/go-difflib";
-    fetch = {
-      type = "git";
-      url = "https://github.com/pmezard/go-difflib";
-      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
-      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
-    };
-  }
-  {
-    goPackagePath  = "github.com/stretchr/testify";
-    fetch = {
-      type = "git";
-      url = "https://github.com/stretchr/testify";
-      rev =  "12b6f73e6084dad08a7c6e575284b177ecafbc71";
-      sha256 = "01f80s0q64pw5drfgqwwk1wfwwkvd2lhbs56lhhkff4ni83k73fd";
-    };
-  }
-  {
-    goPackagePath  = "golang.org/x/crypto";
-    fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/crypto";
-      rev =  "1a580b3eff7814fc9b40602fd35256c63b50f491";
-      sha256 = "11adgxc6fzcb3dxr5v2g4nk6ggrz04qnx633hzgmzfh2wv3blgv7";
-    };
-  }
-  {
-    goPackagePath  = "golang.org/x/net";
-    fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/net";
-      rev =  "2491c5de3490fced2f6cff376127c667efeed857";
-      sha256 = "1wmijnrxi9p2rv8g6clqkzdihn5ncv29j0s4s1bz9ksncdr36ll3";
-    };
-  }
-  {
-    goPackagePath  = "golang.org/x/sync";
-    fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/sync";
-      rev =  "1d60e4601c6fd243af51cc01ddf169918a5407ca";
-      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
-    };
-  }
-  {
-    goPackagePath  = "golang.org/x/sys";
-    fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/sys";
-      rev =  "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b";
-      sha256 = "03fhkng37rczqwfgah5hd7d373jps3hcfx79dmky2fh62yvpcyn3";
-    };
-  }
-]
+[{
+  goPackagePath = "github.com/getantibody/folder";
+  fetch = {
+    type = "git";
+    url = "https://github.com/getantibody/folder";
+    rev = "479aa91767d47bc27599e6ebc7fd07945dd38132";
+    sha256 = "0mzc2x7897f17kj2v807d8cqzgclq9bsz2xqz81j1k85g53l513j";
+  };
+}{
+  goPackagePath = "github.com/alecthomas/units";
+  fetch = {
+    type = "git";
+    url = "https://github.com/alecthomas/units";
+    rev = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
+    sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+  };
+}{
+  goPackagePath = "github.com/alecthomas/template";
+  fetch = {
+    type = "git";
+    url = "https://github.com/alecthomas/template";
+    rev = "a0175ee3bccc567396460bf5acd36800cb10c49c";
+    sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+  };
+}{
+  goPackagePath = "github.com/caarlos0/gohome";
+  fetch = {
+    type = "git";
+    url = "https://github.com/caarlos0/gohome";
+    rev = "75f08ebc60b144c5c3178115baedce176fdcfe99";
+    sha256 = "04950r9lzhgkksgqbnlfx0m3n7zqfif3l8fixwb7f271a880i4gz";
+  };
+}{
+  goPackagePath = "github.com/alecthomas/kingpin";
+  fetch = {
+    type = "git";
+    url = "https://github.com/alecthomas/kingpin";
+    rev = "a39589180ebd6bbf43076e514b55f20a95d43086";
+    sha256 = "0b00bfiwl76qflnmnk3cnlaii6wxgzzdnby99cxdych4f8qmzlv3";
+  };
+}{
+  goPackagePath = "golang.org/x/sync";
+  fetch = {
+    type = "git";
+    url = "https://go.googlesource.com/sync";
+    rev = "1d60e4601c6fd243af51cc01ddf169918a5407ca";
+    sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+  };
+}{
+  goPackagePath = "golang.org/x/crypto";
+  fetch = {
+    type = "git";
+    url = "https://go.googlesource.com/crypto";
+    rev = "1a580b3eff7814fc9b40602fd35256c63b50f491";
+    sha256 = "11adgxc6fzcb3dxr5v2g4nk6ggrz04qnx633hzgmzfh2wv3blgv7";
+  };
+}{
+  goPackagePath = "golang.org/x/sys";
+  fetch = {
+    type = "git";
+    url = "https://go.googlesource.com/sys";
+    rev = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b";
+    sha256 = "03fhkng37rczqwfgah5hd7d373jps3hcfx79dmky2fh62yvpcyn3";
+  };
+}{
+  goPackagePath = "golang.org/x/net";
+  fetch = {
+    type = "git";
+    url = "https://go.googlesource.com/net";
+    rev = "2491c5de3490fced2f6cff376127c667efeed857";
+    sha256 = "1wmijnrxi9p2rv8g6clqkzdihn5ncv29j0s4s1bz9ksncdr36ll3";
+  };
+}]


### PR DESCRIPTION
###### Motivation for this change
Usual updates.

https://github.com/getantibody/antibody/releases/tag/v4.0.1
https://github.com/getantibody/antibody/releases/tag/v4.0.2

Mostly switched to using go modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

