### PR TITLE
solargraph: 0.28.2 -> 0.29.1

### DIFF
--- a/pkgs/development/ruby-modules/solargraph/Gemfile.lock
+++ b/pkgs/development/ruby-modules/solargraph/Gemfile.lock
@@ -2,7 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    coderay (1.1.2)
     eventmachine (1.2.7)
     htmlentities (4.3.4)
     jaro_winkler (1.5.1)
@@ -11,34 +10,33 @@ GEM
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
     reverse_markdown (1.1.0)
       nokogiri
-    rubocop (0.59.2)
+    rubocop (0.60.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    solargraph (0.28.2)
-      coderay (~> 1.1)
+    solargraph (0.29.1)
       eventmachine (~> 1.2, >= 1.2.5)
       htmlentities (~> 4.3, >= 4.3.4)
       kramdown (~> 1.16)
-      parser (~> 2.4)
+      parser (~> 2.3)
       reverse_markdown (~> 1.0, >= 1.0.5)
       rubocop (~> 0.52)
       thor (~> 0.19, >= 0.19.4)
       tilt (~> 2.0)
       yard (~> 0.9)
-    thor (0.20.0)
-    tilt (2.0.8)
+    thor (0.20.3)
+    tilt (2.0.9)
     unicode-display_width (1.4.0)
     yard (0.9.16)
 
@@ -49,4 +47,4 @@ DEPENDENCIES
   solargraph!
 
 BUNDLED WITH
-   1.16.3
+   1.17.1

--- a/pkgs/development/ruby-modules/solargraph/default.nix
+++ b/pkgs/development/ruby-modules/solargraph/default.nix
@@ -7,9 +7,9 @@ bundlerApp rec {
 
   meta = with lib; {
     description = "IDE tools for the Ruby language";
-    homepage    = http://www.github.com/castwide/solargraph;
-    license     = licenses.mit;
+    homepage = http://www.github.com/castwide/solargraph;
+    license = licenses.mit;
     maintainers = with maintainers; [ worldofpeace ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/ruby-modules/solargraph/gemset.nix
+++ b/pkgs/development/ruby-modules/solargraph/gemset.nix
@@ -7,14 +7,6 @@
     };
     version = "2.4.0";
   };
-  coderay = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "15vav4bhcc2x3jmi3izb11l4d9f3xv8hp2fszb7iqmpsccv1pz4y";
-      type = "gem";
-    };
-    version = "1.1.2";
-  };
   eventmachine = {
     source = {
       remotes = ["https://rubygems.org"];
@@ -76,10 +68,10 @@
     dependencies = ["ast"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1zp89zg7iypncszxsjp8kiccrpbdf728jl449g6cnfkz990fyb5k";
+      sha256 = "1zjk0w1kjj3xk8ymy1430aa4gg0k8ckphfj88br6il4pm83f0n1f";
       type = "gem";
     };
-    version = "2.5.1.2";
+    version = "2.5.3.0";
   };
   powerpack = {
     source = {
@@ -110,10 +102,10 @@
     dependencies = ["jaro_winkler" "parallel" "parser" "powerpack" "rainbow" "ruby-progressbar" "unicode-display_width"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0110r4yqi6nn97bp2myah76plv6a7daxnm9k04k64n1y4zpqm256";
+      sha256 = "1ivk049z3mp12nc6v1wn35bsq1g7nz1i2r4xwzqf0v25hm2v7n1i";
       type = "gem";
     };
-    version = "0.59.2";
+    version = "0.60.0";
   };
   ruby-progressbar = {
     source = {
@@ -124,29 +116,29 @@
     version = "1.10.0";
   };
   solargraph = {
-    dependencies = ["coderay" "eventmachine" "htmlentities" "kramdown" "parser" "reverse_markdown" "rubocop" "thor" "tilt" "yard"];
+    dependencies = ["eventmachine" "htmlentities" "kramdown" "parser" "reverse_markdown" "rubocop" "thor" "tilt" "yard"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0xvxifq5871fh2c34hjvsqn38nw4s63d599vbs5mlrrvdl3c5s01";
+      sha256 = "12sy1rdz2fk3aba43701qp1250xm8w26rlizypd6h5rnmmqm5q54";
       type = "gem";
     };
-    version = "0.28.2";
+    version = "0.29.1";
   };
   thor = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0nmqpyj642sk4g16nkbq6pj856adpv91lp4krwhqkh2iw63aszdl";
+      sha256 = "1yhrnp9x8qcy5vc7g438amd5j9sw83ih7c30dr6g6slgw9zj3g29";
       type = "gem";
     };
-    version = "0.20.0";
+    version = "0.20.3";
   };
   tilt = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0020mrgdf11q23hm1ddd6fv691l51vi10af00f137ilcdb2ycfra";
+      sha256 = "0ca4k0clwf0rkvy7726x4nxpjxkpv67w043i39saxgldxd97zmwz";
       type = "gem";
     };
-    version = "2.0.8";
+    version = "2.0.9";
   };
   unicode-display_width = {
     source = {


### PR DESCRIPTION
###### Motivation for this change
The usual.

##### [Changelogs](https://github.com/castwide/solargraph/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

