### PR TITLE
scilab-bin: adding application launchers

### DIFF
--- a/pkgs/applications/science/math/scilab-bin/default.nix
+++ b/pkgs/applications/science/math/scilab-bin/default.nix
@@ -61,10 +61,40 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/opt/scilab-${ver}"
     cp -r . "$out/opt/scilab-${ver}/"
+
+    # Create bin/ dir
     mkdir "$out/bin"
-    ln -s "$out/opt/scilab-${ver}/bin/scilab" "$out/bin/scilab-${ver}"
+
+    # Creating executable symlinks
     ln -s "$out/opt/scilab-${ver}/bin/scilab" "$out/bin/scilab"
-    ln -s "scilab-${ver}" "$out/bin/scilab-${majorVer}"
+    ln -s "$out/opt/scilab-${ver}/bin/scilab-cli" "$out/bin/scilab-cli"
+    ln -s "$out/opt/scilab-${ver}/bin/scilab-adv-cli" "$out/bin/scilab-adv-cli"
+
+    # Creating desktop config dir
+    mkdir -p "$out/share/applications"
+
+    # Moving desktop config files
+    mv $out/opt/scilab-${ver}/share/applications/*.desktop $out/share/applications
+
+    # Fixing Exec paths and launching each app with a terminal
+    sed -i -e "s|Exec=|Exec=$out/opt/scilab-${ver}/bin/|g" \
+           -e "s|Terminal=.*$|Terminal=true|g" $out/share/applications/*.desktop
+
+    # Moving icons to the appropriate locations
+    for path in $out/opt/scilab-${ver}/share/icons/hicolor/*/*/*
+    do
+      newpath=$(echo $path | sed 's|/opt/scilab-${ver}||g')
+      filename=$(echo $path | sed 's|.*/||g')
+      dir=$(echo $newpath | sed "s|$filename||g")
+      mkdir -p $dir
+      mv $path $newpath
+    done
+
+    # Removing emptied folders
+    rm -rf $out/opt/scilab-${ver}/share/{applications,icons}
+
+    # Moving other share/ folders
+    mv $out/opt/scilab-${ver}/share/{appdata,locale,mime} $out/share
   '';
 
   meta = {


### PR DESCRIPTION
Moving the desktop configuration files from `opt/scilab-$ver/share/applications` to `share/applications`, making the required changes, and moving the icons in `opt/scilab-$ver/share/icons` to `share/icons`.

###### Motivation for this change
Presently the scilab-bin package provides no application launchers for the Scilab, Scinotes and Xcos apps. In this PR I am adding these launchers. 

On lines 76, 79 and 82 I am replacing `Terminal=false` with `Terminal=true` in the Scilab, Scinotes and Xcos desktop config files, as I've tried launching these apps using these launchers, without the `Terminal=true` change, and they always crash on start up. Changing to `Terminal=true` fixes this problem for all three apps. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

