### PR TITLE
yubikey-manager: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -2,11 +2,11 @@
   yubikey-personalization, libu2f-host, libusb1 }:
 
 pythonPackages.buildPythonPackage rec {
-  name = "yubikey-manager-1.0.0";
+  name = "yubikey-manager-1.0.1";
 
   srcs = fetchurl {
     url = "https://developers.yubico.com/yubikey-manager/Releases/${name}.tar.gz";
-    sha256 = "1qdb2b3mv4wafghnmv3sxw4fh7cjc06hnkdimfnwmqcjafzvbawd";
+    sha256 = "0i7w1f89hqlw7g800fjhbb6yvq9wjmj5d7w7p6v8bkyvk645v48z";
   };
 
   propagatedBuildInputs =
@@ -40,6 +40,7 @@ pythonPackages.buildPythonPackage rec {
   meta = with lib; {
     homepage = https://developers.yubico.com/yubikey-manager;
     description = "Command line tool for configuring any YubiKey over all USB transports.";
+
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ benley ];

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -26,12 +26,13 @@ pythonPackages.buildPythonPackage rec {
     ];
 
   makeWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${libu2f-host}/lib:${libusb1}/lib:${yubikey-personalization}/lib"
+    "--prefix" "LD_LIBRARY_PATH" ":"
+    (lib.makeLibraryPath [ libu2f-host libusb1 yubikey-personalization ])
   ];
 
   postInstall = ''
-    mkdir -p $out/etc/bash_completion.d
-    _YKMAN_COMPLETE=source $out/bin/ykman > $out/etc/bash_completion.d/ykman.sh ||true
+    mkdir -p $out/share/bash-completion/completions
+    _YKMAN_COMPLETE=source $out/bin/ykman > $out/share/bash-completion/completions/ykman || :
   '';
 
   # See https://github.com/NixOS/nixpkgs/issues/29169


### PR DESCRIPTION
###### Motivation for this change

https://developers.yubico.com/yubikey-manager/Release_Notes.html

https://github.com/Yubico/yubikey-manager/releases/tag/yubikey-manager-1.0.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---