### PR TITLE
s-tui: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/tools/system/s-tui/default.nix
+++ b/pkgs/tools/system/s-tui/default.nix
@@ -3,11 +3,11 @@
 pythonPackages.buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "s-tui";
-  version = "0.8.2";
+  version = "0.8.3";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "18bn0bpnrljx11gj95m2x5hlsnb8jkivlm6b1xx035ldgj1svgzh";
+    sha256 = "00lsh2v4i8rwfyjyxx5lijd6rnk9smcfffhzg5sv94ijpcnh216m";
   };
 
   propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/amanusk/s-tui/releases/tag/v0.8.3

Drop patch, including it was the reason for this release :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---