### PR TITLE
dejsonlz4: init at 1.1

### DIFF
--- a/pkgs/tools/compression/dejsonlz4/default.nix
+++ b/pkgs/tools/compression/dejsonlz4/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
       homepage = https://github.com/avih/dejsonlz4;
       license = licenses.bsd2;
       maintainers = with maintainers; [ mt-caret ];
-      platforms = platforms.all;
+      platforms = platforms.linux;
     };
   }

--- a/pkgs/tools/compression/dejsonlz4/default.nix
+++ b/pkgs/tools/compression/dejsonlz4/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+    name = "${pname}-${version}";
+    pname = "dejsonlz4";
+    version = "1.1";
+    src = fetchFromGitHub {
+      owner = "avih";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "0ggs69qamaama5mid07mhp95m1x42wljdb953lrwfr7p8p6f8czh";
+    };
+
+    buildPhase = ''
+      gcc -Wall -o dejsonlz4 src/dejsonlz4.c src/lz4.c
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin/
+      cp dejsonlz4 $out/bin/
+    '';
+
+    meta = with stdenv.lib; {
+      description = " Decompress Mozilla Firefox bookmarks backup files";
+      homepage = https://github.com/avih/dejsonlz4;
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ mt-caret ];
+      platforms = platforms.all;
+    };
+  }

--- a/pkgs/tools/compression/dejsonlz4/default.nix
+++ b/pkgs/tools/compression/dejsonlz4/default.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchFromGitHub }:
 stdenv.mkDerivation rec {
-    name = "${pname}-${version}";
     pname = "dejsonlz4";
     version = "1.1";
     src = fetchFromGitHub {

--- a/pkgs/tools/compression/dejsonlz4/default.nix
+++ b/pkgs/tools/compression/dejsonlz4/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     '';
 
     meta = with stdenv.lib; {
-      description = " Decompress Mozilla Firefox bookmarks backup files";
+      description = "Decompress Mozilla Firefox bookmarks backup files";
       homepage = https://github.com/avih/dejsonlz4;
       license = licenses.bsd2;
       maintainers = with maintainers; [ mt-caret ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1247,6 +1247,8 @@ with pkgs;
 
   deja-dup = callPackage ../applications/backup/deja-dup { };
 
+  dejsonlz4 = callPackage ../tools/compression/dejsonlz4 { };
+
   desync = callPackage ../applications/networking/sync/desync { };
 
   devmem2 = callPackage ../os-specific/linux/devmem2 { };


### PR DESCRIPTION
###### Motivation for this change

Adds dejsonlz4, a small tool that helps decompress jsonlz4 files used by the Firefox browser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

