### PR TITLE
[18.09] minecraft: Fix versions <1.13

### DIFF
--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeDesktopItem, makeWrapper
-, jdk, jre, libpulseaudio
+, jdk, jre, libpulseaudio, libXxf86vm
 }:
 
 let
@@ -12,6 +12,11 @@ let
     genericName = "minecraft";
     categories = "Game;";
   };
+
+  libPath = stdenv.lib.makeLibraryPath [
+    libpulseaudio
+    libXxf86vm # Needed only for versions <1.13
+  ];
 
 in stdenv.mkDerivation {
   name = "minecraft-2015-07-24";
@@ -30,7 +35,7 @@ in stdenv.mkDerivation {
 
     makeWrapper ${jre}/bin/java $out/bin/minecraft \
       --add-flags "-jar $out/share/minecraft/minecraft.jar" \
-      --suffix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ libpulseaudio ]}
+      --suffix LD_LIBRARY_PATH : ${libPath}
 
     cp $src $out/share/minecraft/minecraft.jar
     cp -r ${desktopItem}/share/applications $out/share


### PR DESCRIPTION
###### Motivation for this change
Backport of https://github.com/NixOS/nixpkgs/pull/51350

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

