### PR TITLE
jemalloc: add option disable-initial-exec-tls

### DIFF
--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -1,11 +1,15 @@
 { version, sha256 }:
-{ stdenv, fetchurl,
+{ stdenv, fetchurl
 # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
 # then stops downstream builds (mariadb in particular) from detecting it. This
 # option should remove the prefix and give us a working jemalloc.
 # Causes segfaults with some software (ex. rustc), but defaults to true for backward
 # compatibility. Ignored on non OSX.
-stripPrefix ? true }:
+, stripPrefix ? true
+, disableInitExecTls ? false
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "jemalloc-${version}";
@@ -17,7 +21,11 @@ stdenv.mkDerivation rec {
   };
 
   # see the comment on stripPrefix
-  configureFlags = stdenv.lib.optional (stdenv.isDarwin && stripPrefix) "--with-jemalloc-prefix=";
+  configureFlags = []
+    ++ optional (stdenv.isDarwin && stripPrefix) [ "--with-jemalloc-prefix=" ]
+    ++ optional disableInitExecTls [ "--disable-initial-exec-tls" ]
+  ;
+
   doCheck = true;
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13588,6 +13588,7 @@ with pkgs;
 
   mariadb = callPackage ../servers/sql/mariadb {
     asio = asio_1_10;
+    jemalloc = jemalloc.override ({ disableInitExecTls = true; });
     inherit (darwin) cctools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change
Add default build option --disable-initial-exec-tls
This option fix error - cannot allocate memory in static TLS block - https://github.com/jemalloc/jemalloc/issues/1237
Need to normal work MariaDB plugin TokuDB

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

