### PR TITLE
oxipng: 2.1.6 -> 2.1.8

### DIFF
--- a/pkgs/tools/graphics/oxipng/default.nix
+++ b/pkgs/tools/graphics/oxipng/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  version = "2.1.6";
+  version = "2.1.8";
   name = "oxipng-${version}";
 
   src = fetchFromGitHub {
     owner = "shssoichiro";
     repo = "oxipng";
     rev = "v${version}";
-    sha256 = "0n3v2dxybfkf07hb4p2hbhhkwx907b85wzj8wa4whwil89igyrdm";
+    sha256 = "18ld65vm58s6x918g6bhfkrg7lw2lca8daidv88ff14wm5khjvik";
   };
 
-  cargoSha256 = "1ycacwhwbn27i81jpp55m1446b9a50knlqv0kzkjcv8yf27213y9";
+  cargoSha256 = "034i8hgi0zgv085bimlja1hl3nd096rqpi167pw6rda5aj18c625";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/shssoichiro/oxipng;


### PR DESCRIPTION
[Version 2.1.8](https://github.com/shssoichiro/oxipng/blob/master/CHANGELOG.md#version-218)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

