### PR TITLE
linuxPackages.nvidia_x11_legacy304: mark as broken on 4.18

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -75,5 +75,6 @@ rec {
         '';
     in applyPatches [ "fix-typos" ];
     patches = maybePatch_drm_legacy;
+    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -10,6 +10,7 @@
 
 , prePatch ? ""
 , patches ? []
+, broken ? false
 }:
 
 { stdenv, callPackage, pkgsi686Linux, fetchurl
@@ -91,6 +92,7 @@ let
       platforms = [ "i686-linux" "x86_64-linux" ];
       maintainers = [ maintainers.vcunat ];
       priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
+      inherit broken;
     };
   };
 


### PR DESCRIPTION
cc @volth 

related to https://github.com/NixOS/nixpkgs/pull/51220
