### PR TITLE
gobject-introspection: rename package

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -35,7 +35,7 @@ with lib;
       networkmanager-vpnc = super.networkmanager-vpnc.override { withGnome = false; };
       networkmanager-iodine = super.networkmanager-iodine.override { withGnome = false; };
       pinentry = super.pinentry_ncurses;
-      gobjectIntrospection = super.gobjectIntrospection.override { x11Support = false; };
+      gobject-introspection = super.gobject-introspection.override { x11Support = false; };
     }));
   };
 }

--- a/pkgs/applications/audio/cozy-audiobooks/default.nix
+++ b/pkgs/applications/audio/cozy-audiobooks/default.nix
@@ -8,7 +8,7 @@
 , desktop-file-utils
 , gtk3
 , gst_all_1
-, gobjectIntrospection
+, gobject-introspection
 , python3Packages
 , file
 , cairo
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
     wrapGAppsHook
     appstream-glib
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, python3, python3Packages, intltool
 , glibcLocales, gnome3, gtk3, wrapGAppsHook
-, ipodSupport ? false, libgpod, gobjectIntrospection
+, ipodSupport ? false, libgpod, gobject-introspection
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
 
   buildInputs = [
     python3
-    gobjectIntrospection
+    gobject-introspection
     gnome3.defaultIconTheme
   ];
 

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, meson, ninja, pkgconfig
 , python3, gtk3, gst_all_1, libsecret, libsoup
 , appstream-glib, desktop-file-utils, gnome3
-, gobjectIntrospection, wrapGAppsHook }:
+, gobject-introspection, wrapGAppsHook }:
 
 python3.pkgs.buildPythonApplication rec  {
   version = "0.9.611";
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication rec  {
   nativeBuildInputs = with python3.pkgs; [
     appstream-glib
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pythonPackages, wrapGAppsHook
-, gst_all_1, glib-networking, gobjectIntrospection
+, gst_all_1, glib-networking, gobject-introspection
 }:
 
 pythonPackages.buildPythonApplication rec {
@@ -17,7 +17,7 @@ pythonPackages.buildPythonApplication rec {
 
   buildInputs = with gst_all_1; [
     gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad
-    glib-networking gobjectIntrospection
+    glib-networking gobject-introspection
   ];
 
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/applications/audio/mopidy/local-images.nix
+++ b/pkgs/applications/audio/mopidy/local-images.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy, gobjectIntrospection }:
+{ stdenv, fetchFromGitHub, pythonPackages, mopidy, gobject-introspection }:
 
 pythonPackages.buildPythonApplication rec {
   pname = "mopidy-local-images";
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0gdqxws0jish50mmi57mlqcs659wrllzv00czl18niz94vzvyc0d";
   };
 
-  buildInputs = [ gobjectIntrospection ];
+  buildInputs = [ gobject-introspection ];
 
   checkInputs = [
     pythonPackages.mock

--- a/pkgs/applications/audio/pithos/default.nix
+++ b/pkgs/applications/audio/pithos/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, pythonPackages, gtk3, gobjectIntrospection, libnotify
+{ fetchFromGitHub, stdenv, pythonPackages, gtk3, gobject-introspection, libnotify
 , gst_all_1, wrapGAppsHook }:
 
 pythonPackages.buildPythonApplication rec {
@@ -27,7 +27,7 @@ pythonPackages.buildPythonApplication rec {
   buildInputs = [ wrapGAppsHook ];
 
   propagatedBuildInputs =
-    [ gtk3 gobjectIntrospection libnotify ] ++
+    [ gtk3 gobject-introspection libnotify ] ++
     (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad ]) ++
     (with pythonPackages; [ pygobject3 pylast ]);
 

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python3, wrapGAppsHook, gettext, intltool, libsoup, gnome3, gtk3, gdk_pixbuf,
-  tag ? "", xvfb_run, dbus, glibcLocales, glib, glib-networking, gobjectIntrospection,
+  tag ? "", xvfb_run, dbus, glibcLocales, glib, glib-networking, gobject-introspection,
   gst_all_1, withGstPlugins ? true,
   xineBackend ? false, xineLib,
   withDbusPython ? false, withPyInotify ? false, withMusicBrainzNgs ? false, withPahoMqtt ? false,
@@ -24,7 +24,7 @@ python3.pkgs.buildPythonApplication rec {
 
   checkInputs = with python3.pkgs; [ pytest pytest_xdist pyflakes pycodestyle polib xvfb_run dbus.daemon glibcLocales ];
 
-  buildInputs = [ gnome3.defaultIconTheme libsoup glib glib-networking gtk3 webkitgtk gdk_pixbuf keybinder3 gtksourceview libmodplug libappindicator-gtk3 kakasi gobjectIntrospection ]
+  buildInputs = [ gnome3.defaultIconTheme libsoup glib glib-networking gtk3 webkitgtk gdk_pixbuf keybinder3 gtksourceview libmodplug libappindicator-gtk3 kakasi gobject-introspection ]
     ++ (if xineBackend then [ xineLib ] else with gst_all_1;
     [ gstreamer gst-plugins-base ] ++ optionals withGstPlugins [ gst-plugins-good gst-plugins-ugly gst-plugins-bad ]);
 

--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, intltool, wrapGAppsHook
-, python3Packages, gnome3, gtk3, gobjectIntrospection}:
+, python3Packages, gnome3, gtk3, gobject-introspection}:
 
 let
   inherit (python3Packages) buildPythonApplication isPy3k dbus-python pygobject3 mpd2;
@@ -29,7 +29,7 @@ in buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    gobjectIntrospection gtk3 pygobject3
+    gobject-introspection gtk3 pygobject3
   ];
 
   # The optional tagpy dependency (for editing metadata) is not yet

--- a/pkgs/applications/audio/vocal/default.nix
+++ b/pkgs/applications/audio/vocal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, vala_0_40, gtk3, libxml2, granite, webkitgtk, clutter-gtk
-, clutter-gst, libunity, libnotify, sqlite, gst_all_1, libsoup, json-glib, gnome3, gobjectIntrospection, wrapGAppsHook }:
+, clutter-gst, libunity, libnotify, sqlite, gst_all_1, libsoup, json-glib, gnome3, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "vocal";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    gobjectIntrospection
+    gobject-introspection
     libxml2
     ninja
     pkgconfig

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pam, pkgconfig, autoconf, automake, libtool, libxcb
 , glib, libXdmcp, itstool, intltool, libxklavier, libgcrypt, audit, busybox
-, polkit, accountsservice, gtk-doc, gnome3, gobjectIntrospection, vala
+, polkit, accountsservice, gtk-doc, gnome3, gobject-introspection, vala
 , withQt4 ? false, qt4
 , withQt5 ? false, qtbase
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     automake
     gnome3.yelp-tools
     gnome3.yelp-xsl
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     intltool
     itstool

--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -7,7 +7,7 @@
 , flatpak
 , glibcLocales
 , gnome3
-, gobjectIntrospection
+, gobject-introspection
 , gspell
 , gtk-doc
 , gtk3
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
     docbook_xsl
     docbook_xml_dtd_43
     glibcLocales # for Meson's gtkdochelper
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     hicolor-icon-theme
     meson

--- a/pkgs/applications/editors/quilter/default.nix
+++ b/pkgs/applications/editors/quilter/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, vala_0_40, pkgconfig, meson, ninja, python3
 , granite, gtk3, desktop-file-utils, gnome3, gtksourceview, webkitgtk, gtkspell3
-, discount, gobjectIntrospection, wrapGAppsHook }:
+, discount, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "quilter";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/editors/rednotebook/default.nix
+++ b/pkgs/applications/editors/rednotebook/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, fetchFromGitHub
-, gdk_pixbuf, glib, gobjectIntrospection, gtk3, gtksourceview, pango, webkitgtk
+, gdk_pixbuf, glib, gobject-introspection, gtk3, gtksourceview, pango, webkitgtk
 , pygobject3, pyyaml
 }:
 
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   # We have not packaged tests.
   doCheck = false;
 
-  nativeBuildInputs = [ gobjectIntrospection ];
+  nativeBuildInputs = [ gobject-introspection ];
 
   propagatedBuildInputs = [
     gdk_pixbuf glib gtk3 gtksourceview pango webkitgtk

--- a/pkgs/applications/graphics/mypaint/default.nix
+++ b/pkgs/applications/graphics/mypaint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, intltool, json_c, lcms2, libpng, librsvg, gobjectIntrospection, hicolor-icon-theme
+{ stdenv, fetchFromGitHub, gtk3, intltool, json_c, lcms2, libpng, librsvg, gobject-introspection, hicolor-icon-theme
 , gdk_pixbuf, pkgconfig, python2Packages, scons, swig, wrapGAppsHook }:
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     intltool pkgconfig scons swig wrapGAppsHook
-    gobjectIntrospection # for setup hook
+    gobject-introspection # for setup hook
   ];
 
   buildInputs = [

--- a/pkgs/applications/graphics/photoflow/default.nix
+++ b/pkgs/applications/graphics/photoflow/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gettext, glib, libxml2, pkgconfig, swig, automake, gobjectIntrospection, cmake, ninja, libtiff, libjpeg, fftw, exiv2, lensfun, gtkmm2, libraw, lcms2, libexif, vips, expat, pcre, pugixml }:
+{ stdenv, fetchFromGitHub, gettext, glib, libxml2, pkgconfig, swig, automake, gobject-introspection, cmake, ninja, libtiff, libjpeg, fftw, exiv2, lensfun, gtkmm2, libraw, lcms2, libexif, vips, expat, pcre, pugixml }:
 
 stdenv.mkDerivation {
   name = "photoflow-unstable-2018-08-28";
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     pkgconfig
     swig
     automake
-    gobjectIntrospection
+    gobject-introspection
     cmake
     ninja
   ];

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python3Packages
-, file, intltool, gobjectIntrospection, libgudev
+, file, intltool, gobject-introspection, libgudev
 , udisks, glib, gnome3, gst_all_1, libnotify
 , exiv2, exiftool, qt5, gdk_pixbuf
 }:
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication rec {
       --replace "import problemnotification" "import raphodo.problemnotification"
   '';
 
-  nativeBuildInputs = [ file intltool gobjectIntrospection ];
+  nativeBuildInputs = [ file intltool gobject-introspection ];
 
   buildInputs = [
     libgudev

--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, meson, ninja, gtk3, libexif, libgphoto2, libsoup, libxml2, vala, sqlite
 , webkitgtk, pkgconfig, gnome3, gst_all_1, libgudev, libraw, glib, json-glib
 , gettext, desktop-file-utils, gdk_pixbuf, librsvg, wrapGAppsHook
-, gobjectIntrospection, itstool, libgdata, python3 }:
+, gobject-introspection, itstool, libgdata, python3 }:
 
 # for dependencies see https://wiki.gnome.org/Apps/Shotwell/BuildingAndInstalling
 
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja vala pkgconfig itstool gettext desktop-file-utils python3 wrapGAppsHook gobjectIntrospection
+    meson ninja vala pkgconfig itstool gettext desktop-file-utils python3 wrapGAppsHook gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, automake, autoconf, libtool,
   pkgconfig, file, intltool, libxml2, json-glib , sqlite, itstool,
-  librsvg, vala, gnome3, wrapGAppsHook, gobjectIntrospection
+  librsvg, vala, gnome3, wrapGAppsHook, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     gnome3.yelp-tools
     wrapGAppsHook
     # For setup hook
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/gImageReader/default.nix
+++ b/pkgs/applications/misc/gImageReader/default.nix
@@ -6,7 +6,7 @@
 
 # Gtk deps
 # upstream gImagereader supports Qt too
-, gtk3, gobjectIntrospection, wrapGAppsHook
+, gtk3, gobject-introspection, wrapGAppsHook
 , gnome3, gtkspell3, gtkspellmm, cairomm
 }:
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
     # Gtk specific
     wrapGAppsHook
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, gtk3, pythonPackages, intltool, gnome3,
-  pango, gobjectIntrospection, wrapGAppsHook,
+  pango, gobject-introspection, wrapGAppsHook,
 # Optional packages:
  enableOSM ? true, osm-gps-map,
  enableGraphviz ? true, graphviz,
@@ -13,7 +13,7 @@ in buildPythonApplication rec {
   name = "gramps-${version}";
 
   nativeBuildInputs = [ wrapGAppsHook ];
-  buildInputs = [ intltool gtk3 gobjectIntrospection pango gnome3.gexiv2 ] 
+  buildInputs = [ intltool gtk3 gobject-introspection pango gnome3.gexiv2 ] 
     # Map support
     ++ stdenv.lib.optional enableOSM osm-gps-map
     # Graphviz support

--- a/pkgs/applications/misc/guake/default.nix
+++ b/pkgs/applications/misc/guake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3, gettext, gobjectIntrospection, wrapGAppsHook, glibcLocales
+{ stdenv, fetchFromGitHub, python3, gettext, gobject-introspection, wrapGAppsHook, glibcLocales
 , gtk3, keybinder3, libnotify, libutempter, vte }:
 
 let
@@ -14,7 +14,7 @@ in python3.pkgs.buildPythonApplication rec {
     sha256 = "1j38z968ha8ij6wrgbwvr8ad930nvhybm9g7pf4s4zv6d3vln0vm";
   };
 
-  nativeBuildInputs = [ gettext gobjectIntrospection wrapGAppsHook python3.pkgs.pip glibcLocales ];
+  nativeBuildInputs = [ gettext gobject-introspection wrapGAppsHook python3.pkgs.pip glibcLocales ];
 
   buildInputs = [ gtk3 keybinder3 libnotify python3 vte ];
 

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -2,7 +2,7 @@
 , fetchurl
 , intltool
 , python3Packages
-, gobjectIntrospection
+, gobject-introspection
 , gtk3
 , libwnck3
 , keybinder3
@@ -25,7 +25,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [
     wrapGAppsHook intltool
     # For setup hook
-    gobjectIntrospection wafHook
+    gobject-introspection wafHook
   ];
   buildInputs = [ hicolor-icon-theme docutils libwnck3 keybinder3 ];
   propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus-python pycairo ];

--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, vala_0_40, pkgconfig, meson, ninja, python3, granite
-, gtk3, gnome3, gtksourceview, json-glib, gobjectIntrospection, wrapGAppsHook }:
+, gtk3, gnome3, gtksourceview, json-glib, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "notejot";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/misc/onboard/default.nix
+++ b/pkgs/applications/misc/onboard/default.nix
@@ -7,7 +7,7 @@
 , glib
 , glibcLocales
 , gnome3
-, gobjectIntrospection
+, gobject-introspection
 , gsettings-desktop-schemas
 , gtk3
 , hunspell
@@ -88,7 +88,7 @@ in python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     glibcLocales
-    gobjectIntrospection # populate GI_TYPELIB_PATH
+    gobject-introspection # populate GI_TYPELIB_PATH
     intltool
     pkgconfig
   ];

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgconfig, fetchurl, buildPythonApplication
-, autoreconfHook, wrapGAppsHook, gobjectIntrospection
+, autoreconfHook, wrapGAppsHook, gobject-introspection
 , intltool, yelp-tools, itstool, libxmlxx3
 , python, pygobject3, gtk3, gnome3, substituteAll
 , at-spi2-atk, at-spi2-core, pyatspi, dbus, dbus-python, pyxdg
@@ -32,7 +32,7 @@ in buildPythonApplication rec {
 
   nativeBuildInputs = [
     autoreconfHook wrapGAppsHook pkgconfig libxmlxx3
-    intltool yelp-tools itstool gobjectIntrospection
+    intltool yelp-tools itstool gobject-introspection
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/misc/pdf-quench/default.nix
+++ b/pkgs/applications/misc/pdf-quench/default.nix
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication rec {
   nativeBuildInputs = [ wrapGAppsHook ];
   buildInputs = with pkgs; [
     gtk3
-    gobjectIntrospection
+    gobject-introspection
     goocanvas2
     poppler_gi
   ];

--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper, pkgconfig, vala, gtk3, libgee
-, poppler, libpthreadstubs, gstreamer, gst-plugins-base, librsvg, pcre, gobjectIntrospection }:
+, poppler, libpthreadstubs, gstreamer, gst-plugins-base, librsvg, pcre, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake pkgconfig vala
     # For setup hook
-    gobjectIntrospection
+    gobject-introspection
   ];
   buildInputs = [ gstreamer gst-plugins-base gtk3 libgee poppler
     libpthreadstubs makeWrapper librsvg pcre ];

--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, vala, atk, cairo, glib, gnome3, gtk3, libwnck3
 , libX11, libXfixes, libXi, pango, intltool, pkgconfig, libxml2
 , bamf, gdk_pixbuf, libdbusmenu-gtk3, file
-, wrapGAppsHook, autoreconfHook, gobjectIntrospection }:
+, wrapGAppsHook, autoreconfHook, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   pname = "plank";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     intltool
     libxml2 # xmllint
     wrapGAppsHook
-    gobjectIntrospection
+    gobject-introspection
     autoreconfHook
   ];
 

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf, automake, gettext, intltool
-, libtool, pkgconfig, wrapGAppsHook, wrapPython, gobjectIntrospection
+, libtool, pkgconfig, wrapGAppsHook, wrapPython, gobject-introspection
 , gtk3, python, pygobject3, hicolor-icon-theme, pyxdg
 
 , withQuartz ? stdenv.isDarwin, ApplicationServices
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     gtk3
     python
     hicolor-icon-theme

--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -9,7 +9,7 @@
 , gnome3
 , meson
 , ninja
-, gobjectIntrospection
+, gobject-introspection
 , gsettings-desktop-schemas
 , vala_0_40
 , wrapGAppsHook }:
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     gettext
-    gobjectIntrospection
+    gobject-introspection
     libxml2
     vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     wrapGAppsHook

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, gobjectIntrospection, libappindicator-gtk3, libnotify, gtk3, gnome3, xprintidle-ng, wrapGAppsHook, gdk_pixbuf, shared-mime-info, librsvg
+{ lib, python3Packages, gobject-introspection, libappindicator-gtk3, libnotify, gtk3, gnome3, xprintidle-ng, wrapGAppsHook, gdk_pixbuf, shared-mime-info, librsvg
 }:
 
 let inherit (python3Packages) python buildPythonApplication fetchPypi;
@@ -16,7 +16,7 @@ in buildPythonApplication rec {
 
   buildInputs = [
     gtk3
-    gobjectIntrospection
+    gobject-introspection
     gnome3.defaultIconTheme
     gnome3.adwaita-icon-theme
   ];

--- a/pkgs/applications/misc/sequeler/default.nix
+++ b/pkgs/applications/misc/sequeler/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, meson, ninja, pkgconfig, vala, gobjectIntrospection, gettext, wrapGAppsHook, python3, desktop-file-utils
+, meson, ninja, pkgconfig, vala, gobject-introspection, gettext, wrapGAppsHook, python3, desktop-file-utils
 , gtk3, glib, granite, libgee, libgda, gtksourceview, libxml2, libsecret }:
 
 
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     sha256 = "14a0i9y003m4pvdfp4ax7jfxvyzvyfg45zhln44rm08rfngb0f7k";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig vala gobjectIntrospection gettext wrapGAppsHook python3 desktop-file-utils ];
+  nativeBuildInputs = [ meson ninja pkgconfig vala gobject-introspection gettext wrapGAppsHook python3 desktop-file-utils ];
 
   buildInputs = [ gtk3 glib granite libgee sqlGda gtksourceview libxml2 libsecret ];
 

--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,4 +1,4 @@
-{fetchFromGitHub, stdenv, gtk3, pythonPackages, gobjectIntrospection}:
+{fetchFromGitHub, stdenv, gtk3, pythonPackages, gobject-introspection}:
 pythonPackages.buildPythonApplication rec {
   name = "solaar-unstable-${version}";
   version = "2018-02-02";
@@ -10,7 +10,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0zy5vmjzdybnjf0mpp8rny11sc43gmm8172svsm9s51h7x0v83y3";
   };
 
-  propagatedBuildInputs = [pythonPackages.pygobject3 pythonPackages.pyudev gobjectIntrospection gtk3];
+  propagatedBuildInputs = [pythonPackages.pygobject3 pythonPackages.pyudev gobject-introspection gtk3];
   postInstall = ''
     wrapProgram "$out/bin/solaar" \
       --prefix PYTHONPATH : "$PYTHONPATH" \

--- a/pkgs/applications/misc/synapse/default.nix
+++ b/pkgs/applications/misc/synapse/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gettext, pkgconfig, glib, libnotify, gtk3, libgee
-, keybinder3, json-glib, zeitgeist, vala_0_38, hicolor-icon-theme, gobjectIntrospection
+, keybinder3, json-glib, zeitgeist, vala_0_38, hicolor-icon-theme, gobject-introspection
 }:
 
 let
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig gettext vala_0_38
     # For setup hook
-    gobjectIntrospection
+    gobject-introspection
   ];
   buildInputs = [
     glib libnotify gtk3 libgee keybinder3 json-glib zeitgeist

--- a/pkgs/applications/misc/terminator/default.nix
+++ b/pkgs/applications/misc/terminator/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python2, keybinder3, intltool, file, gtk3, gobjectIntrospection
+{ stdenv, fetchurl, python2, keybinder3, intltool, file, gtk3, gobject-introspection
 , libnotify, wrapGAppsHook, gnome3
 }:
 
@@ -11,7 +11,7 @@ python2.pkgs.buildPythonApplication rec {
     sha256 = "95f76e3c0253956d19ceab2f8da709a496f1b9cf9b1c5b8d3cd0b6da3cc7be69";
   };
 
-  nativeBuildInputs = [ file intltool wrapGAppsHook gobjectIntrospection ];
+  nativeBuildInputs = [ file intltool wrapGAppsHook gobject-introspection ];
   buildInputs = [ gtk3 gnome3.vte libnotify keybinder3 ];
   propagatedBuildInputs = with python2.pkgs; [ pygobject3 psutil pycairo ];
 

--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , meson, ninja, pkgconfig, python3
-, gnome3, vala, gobjectIntrospection, wrapGAppsHook
+, gnome3, vala, gobject-introspection, wrapGAppsHook
 , gtk3, granite
 , json-glib, glib, glib-networking
 }:
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1z3wyx316nns6gi7vlvcfmalhvxncmvcmmlgclbv6b6hwl5x2ysi";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig python3 vala gobjectIntrospection wrapGAppsHook ];
+  nativeBuildInputs = [ meson ninja pkgconfig python3 vala gobject-introspection wrapGAppsHook ];
   buildInputs = [
     gtk3 granite json-glib glib glib-networking
     gnome3.libgee gnome3.libsoup gnome3.gsettings-desktop-schemas

--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, asciidoc-full, gettext
-, gobjectIntrospection, gtk3, hicolor-icon-theme, libappindicator-gtk3, libnotify, librsvg
+, gobject-introspection, gtk3, hicolor-icon-theme, libappindicator-gtk3, libnotify, librsvg
 , udisks2, wrapGAppsHook
 , buildPythonApplication
 , docopt
@@ -26,7 +26,7 @@ buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
-    gettext gobjectIntrospection gtk3 libnotify docopt
+    gettext gobject-introspection gtk3 libnotify docopt
     pygobject3 pyyaml udisks2 libappindicator-gtk3
   ];
 

--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, wrapGAppsHook
 , autoconf, autoconf-archive, automake, gettext, intltool, libtool, pkgconfig
 , libICE, libSM, libXScrnSaver, libXtst, cheetah
-, gobjectIntrospection, glib, glibmm, gtkmm3, atk, pango, pangomm, cairo
+, gobject-introspection, glib, glibmm, gtkmm3, atk, pango, pangomm, cairo
 , cairomm , dbus, dbus-glib, gdome2, gstreamer, gst-plugins-base
 , gst-plugins-good, libsigcxx }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     libICE libSM libXScrnSaver libXtst cheetah
-    gobjectIntrospection glib glibmm gtkmm3 atk pango pangomm cairo cairomm
+    gobject-introspection glib glibmm gtkmm3 atk pango pangomm cairo cairomm
     dbus dbus-glib gdome2 gstreamer gst-plugins-base gst-plugins-good libsigcxx
   ];
 

--- a/pkgs/applications/networking/browsers/eolie/default.nix
+++ b/pkgs/applications/networking/browsers/eolie/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, meson, ninja, pkgconfig
 , python3, gtk3, libsecret, gst_all_1, webkitgtk
 , glib-networking, gtkspell3, hunspell, desktop-file-utils
-, gobjectIntrospection, wrapGAppsHook }:
+, gobject-introspection, wrapGAppsHook }:
 
 python3.pkgs.buildPythonApplication rec {
   name = "eolie-${version}";
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/networking/corebird/default.nix
+++ b/pkgs/applications/networking/corebird/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, glib, gtk3, json-glib, sqlite, libsoup, gettext, vala_0_40
-, meson, ninja, pkgconfig, gnome3, gst_all_1, wrapGAppsHook, gobjectIntrospection
+, meson, ninja, pkgconfig, gnome3, gst_all_1, wrapGAppsHook, gobject-introspection
 , glib-networking, python3 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja vala_0_40 pkgconfig wrapGAppsHook python3
-    gobjectIntrospection # for setup hook
+    gobject-introspection # for setup hook
   ];
 
   buildInputs = [

--- a/pkgs/applications/networking/ftp/taxi/default.nix
+++ b/pkgs/applications/networking/ftp/taxi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, vala, pkgconfig, meson, ninja, python3, granite
-, gtk3, gnome3, libsoup, libsecret, gobjectIntrospection, wrapGAppsHook }:
+, gtk3, gnome3, libsoup, libsecret, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "taxi";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , vala, cmake, ninja, wrapGAppsHook, pkgconfig, gettext
-, gobjectIntrospection, gnome3, glib, gdk_pixbuf, gtk3, glib-networking
+, gobject-introspection, gnome3, glib, gdk_pixbuf, gtk3, glib-networking
 , xorg, libXdmcp, libxkbcommon
 , libnotify, libsoup
 , libgcrypt
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     qrencode
-    gobjectIntrospection
+    gobject-introspection
     glib-networking
     glib
     gnome3.libgee

--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -1,5 +1,5 @@
 { buildPythonApplication, lib, fetchurl, gettext, wrapGAppsHook
-, python, gtk3, gobjectIntrospection
+, python, gtk3, gobject-introspection
 , nbxmpp, pyasn1, pygobject3, gnome3, dbus-python, pillow
 , xvfb_run, dbus
 , enableJingle ? true, farstream, gstreamer, gst-plugins-base, gst-libav, gst-plugins-ugly
@@ -30,7 +30,7 @@ buildPythonApplication rec {
   '';
 
   buildInputs = [
-    gobjectIntrospection gtk3 gnome3.defaultIconTheme
+    gobject-introspection gtk3 gnome3.defaultIconTheme
   ] ++ optionals enableJingle [ farstream gstreamer gst-plugins-base gst-libav gst-plugins-ugly ]
     ++ optional enableSecrets libsecret
     ++ optional enableSpelling gspell

--- a/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, dbus-glib, libxml2, sqlite, telepathy-glib, pkgconfig
-, gnome3, makeWrapper, intltool, libxslt, gobjectIntrospection, dbus }:
+, gnome3, makeWrapper, intltool, libxslt, gobject-introspection, dbus }:
 
 stdenv.mkDerivation rec {
   project = "telepathy-logger";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    makeWrapper pkgconfig intltool libxslt gobjectIntrospection
+    makeWrapper pkgconfig intltool libxslt gobject-introspection
   ];
   buildInputs = [
     dbus-glib libxml2 sqlite telepathy-glib

--- a/pkgs/applications/networking/mailreaders/balsa/default.nix
+++ b/pkgs/applications/networking/mailreaders/balsa/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, gtk3, gmime, gnutls,
   webkitgtk, libesmtp, openssl, libnotify, enchant, gpgme,
-  libcanberra-gtk3, libsecret, gtksourceview, gobjectIntrospection,
+  libcanberra-gtk3, libsecret, gtksourceview, gobject-introspection,
   hicolor-icon-theme, wrapGAppsHook
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     intltool
-    gobjectIntrospection
+    gobject-introspection
     hicolor-icon-theme
     wrapGAppsHook
   ];

--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, python3Packages, wrapGAppsHook
 , glib, libxml2, libxslt, sqlite, libsoup , webkitgtk, json-glib, gst_all_1
 , libnotify, gtk3, gsettings-desktop-schemas, libpeas, dconf, librsvg
-, gobjectIntrospection, glib-networking, hicolor-icon-theme
+, gobject-introspection, glib-networking, hicolor-icon-theme
 }:
 
 let
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     glib gtk3 webkitgtk libxml2 libxslt sqlite libsoup gsettings-desktop-schemas
-    libpeas gsettings-desktop-schemas json-glib dconf gobjectIntrospection
+    libpeas gsettings-desktop-schemas json-glib dconf gobject-introspection
     librsvg glib-networking libnotify hicolor-icon-theme
   ] ++ (with gst_all_1; [
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad

--- a/pkgs/applications/networking/syncthing-gtk/default.nix
+++ b/pkgs/applications/networking/syncthing-gtk/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, libnotify, librsvg, killall
 , gtk3, libappindicator-gtk3, substituteAll, syncthing, wrapGAppsHook
 , gnome3, buildPythonApplication, dateutil, pyinotify, pygobject3
-, bcrypt, gobjectIntrospection }:
+, bcrypt, gobject-introspection }:
 
 buildPythonApplication rec {
   version = "0.9.4";
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [
     wrapGAppsHook
     # For setup hook populating GI_TYPELIB_PATH
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/applications/networking/transporter/default.nix
+++ b/pkgs/applications/networking/transporter/default.nix
@@ -9,7 +9,7 @@
 , gnome3
 , libxml2
 , gettext
-, gobjectIntrospection
+, gobject-introspection
 , appstream-glib
 , desktop-file-utils
 , magic-wormhole
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
     appstream-glib
     desktop-file-utils
     gettext
-    gobjectIntrospection # For setup hook
+    gobject-introspection # For setup hook
     libxml2
     meson
     ninja

--- a/pkgs/applications/networking/weather/meteo/default.nix
+++ b/pkgs/applications/networking/weather/meteo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitLab, vala, python3, pkgconfig, meson, ninja, granite, gtk3
 , gnome3, json-glib, libsoup, clutter, clutter-gtk, libchamplain, webkitgtk
-, libappindicator, desktop-file-utils, appstream, gobjectIntrospection, wrapGAppsHook }:
+, libappindicator, desktop-file-utils, appstream, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "meteo";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     appstream
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/office/aesop/default.nix
+++ b/pkgs/applications/office/aesop/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, vala_0_40, pkgconfig, meson, ninja, python3, granite, gtk3
-, gnome3, desktop-file-utils, json-glib, libsoup, poppler, gobjectIntrospection, wrapGAppsHook }:
+, gnome3, desktop-file-utils, json-glib, libsoup, poppler, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "aesop";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/office/autokey/default.nix
+++ b/pkgs/applications/office/autokey/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub, wrapGAppsHook, gobjectIntrospection
+{ lib, python3Packages, fetchFromGitHub, wrapGAppsHook, gobject-introspection
 , gnome3, libappindicator-gtk3, libnotify }:
 
 python3Packages.buildPythonApplication rec {
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
   # Note: no dependencies included for Qt GUI because Qt ui is poorly
   # maintained—see https://github.com/autokey/autokey/issues/51
 
-  buildInputs = [ wrapGAppsHook gobjectIntrospection gnome3.gtksourceview
+  buildInputs = [ wrapGAppsHook gobject-introspection gnome3.gtksourceview
     libappindicator-gtk3 libnotify ];
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, vala_0_40, python3, python2, pkgconfig, libxml2, meson, ninja, gtk3, granite, gnome3
-, gobjectIntrospection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook }:
+, gobject-introspection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "bookworm";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     bash
-    gobjectIntrospection
+    gobject-introspection
     libxml2
     meson
     ninja

--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -6,7 +6,7 @@
 , gtk3
 , granite
 , gnome3
-, gobjectIntrospection
+, gobject-introspection
 , json-glib
 , cmake
 , ninja
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     ninja
     gettext
     libxml2
-    gobjectIntrospection # For setup hook
+    gobject-introspection # For setup hook
   ];
   buildInputs = [
     gnome3.defaultIconTheme # should be `elementary.defaultIconTheme`when elementary attribute set is merged

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -2,7 +2,7 @@
 , python2Packages
 , pkgconfig
 , librsvg
-, gobjectIntrospection
+, gobject-introspection
 , atk
 , gtk3
 , gtkspell3
@@ -19,7 +19,7 @@ python2Packages.buildPythonApplication rec {
     inherit pname version;
     sha256 = "43759d22b061a7a392a534d19a045fafd442ce98a0e390ee830127367dcaf4b4";
   };
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
   propagatedBuildInputs = with python2Packages; [
     chardet
     dateutil

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -8,7 +8,7 @@
 , cmake
 , vala_0_40
 , libqalculate
-, gobjectIntrospection
+, gobject-introspection
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
     vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
     cmake
-    gobjectIntrospection # for setup-hook
+    gobject-introspection # for setup-hook
   ];
 
   buildInputs = [

--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, file, which, intltool, gobjectIntrospection,
+{ stdenv, fetchurl, file, which, intltool, gobject-introspection,
   findutils, xdg_utils, gnome3, pythonPackages, hicolor-icon-theme,
   wrapGAppsHook
 }:
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication rec {
     file
     which
     intltool
-    gobjectIntrospection
+    gobject-introspection
     wrapGAppsHook
   ];
 

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, itstool, python3Packages, intltool, wrapGAppsHook
-, libxml2, gobjectIntrospection, gtk3, gnome3, cairo, file
+, libxml2, gobject-introspection, gtk3, gnome3, cairo, file
 }:
 
 
@@ -20,7 +20,7 @@ in buildPythonApplication rec {
     gnome3.gtksourceview gnome3.gsettings-desktop-schemas pycairo cairo
     gnome3.defaultIconTheme gnome3.dconf file
   ];
-  propagatedBuildInputs = [ gobjectIntrospection pygobject3 gtk3 ];
+  propagatedBuildInputs = [ gobject-introspection pygobject3 gtk3 ];
 
   installPhase = ''
     mkdir -p "$out/lib/${python.libPrefix}/site-packages"

--- a/pkgs/applications/video/gnomecast/default.nix
+++ b/pkgs/applications/video/gnomecast/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, gtk3, gobjectIntrospection, ffmpeg, wrapGAppsHook }:
+{ lib, python3Packages, gtk3, gobject-introspection, ffmpeg, wrapGAppsHook }:
 
 with python3Packages;
 buildPythonApplication rec {
@@ -13,7 +13,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [ wrapGAppsHook ];
   propagatedBuildInputs = [
     PyChromecast bottle pycaption paste html5lib pygobject3 dbus-python
-    gtk3 gobjectIntrospection
+    gtk3 gobject-introspection
   ];
 
   preFixup = ''

--- a/pkgs/applications/video/kazam/default.nix
+++ b/pkgs/applications/video/kazam/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, python3, gst_all_1, wrapGAppsHook, gobjectIntrospection
+{ stdenv, fetchurl, substituteAll, python3, gst_all_1, wrapGAppsHook, gobject-introspection
 , gtk3, libwnck3, keybinder3, intltool, libcanberra-gtk3, libappindicator-gtk3, libpulseaudio }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "1qygnrvm6aqixbyivhssp70hs0llxwk7lh3j7idxa2jbkk06hj4f";
   };
 
-  nativeBuildInputs = [ gobjectIntrospection python3.pkgs.distutils_extra intltool wrapGAppsHook ];
+  nativeBuildInputs = [ gobject-introspection python3.pkgs.distutils_extra intltool wrapGAppsHook ];
   buildInputs = [
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gtk3 libwnck3
     keybinder3 libappindicator-gtk3

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gobjectIntrospection, mpv }:
+{ stdenv, fetchFromGitHub, pkgconfig, gobject-introspection, mpv }:
 
 stdenv.mkDerivation rec {
   name = "mpv-mpris-${version}.so";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ gobjectIntrospection mpv ];
+  buildInputs = [ gobject-introspection mpv ];
 
   installPhase = ''
     cp mpris.so $out

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig, intltool, itstool, python3, wrapGAppsHook
 , python3Packages, gst_all_1, gtk3
-, gobjectIntrospection, librsvg, gnome3, libnotify
+, gobject-introspection, librsvg, gnome3, libnotify
 , meson, ninja
 }:
 
@@ -19,7 +19,7 @@ let
       rev = version;
       sha256 = "16skiz9akavssii529v9nr8zd54w43livc14khdyzv164djg9q8f";
     };
-    nativeBuildInputs = [ pkgconfig meson ninja gobjectIntrospection python3 ];
+    nativeBuildInputs = [ pkgconfig meson ninja gobject-introspection python3 ];
     buildInputs = with gst_all_1; [ gstreamer gst-plugins-base ];
   };
 
@@ -47,7 +47,7 @@ in python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [ meson ninja pkgconfig intltool itstool python3 wrapGAppsHook ];
 
   buildInputs = [
-    gobjectIntrospection gtk3 librsvg gnome3.gnome-desktop gnome3.gsound
+    gobject-introspection gtk3 librsvg gnome3.gnome-desktop gnome3.gsound
     gnome3.defaultIconTheme
     gnome3.gsettings-desktop-schemas libnotify
     gst-transcoder

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python3Packages, intltool, file
 , wrapGAppsHook, gtk-vnc, vte, avahi, dconf
-, gobjectIntrospection, libvirt-glib, system-libvirt
+, gobject-introspection, libvirt-glib, system-libvirt
 , gsettings-desktop-schemas, glib, libosinfo, gnome3, gtk3
 , spiceSupport ? true, spice-gtk ? null
 , cpio, e2fsprogs, findutils, gzip
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     wrapGAppsHook intltool file
-    gobjectIntrospection # for setup hook populating GI_TYPELIB_PATH
+    gobject-introspection # for setup hook populating GI_TYPELIB_PATH
   ];
 
   buildInputs =

--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, luaPackages, cairo, librsvg, cmake, imagemagick, pkgconfig, gdk_pixbuf
 , xorg, libstartup_notification, libxdg_basedir, libpthreadstubs
-, xcb-util-cursor, makeWrapper, pango, gobjectIntrospection, unclutter
+, xcb-util-cursor, makeWrapper, pango, gobject-introspection, unclutter
 , compton, procps, iproute, coreutils, curl, alsaUtils, findutils, xterm
 , which, dbus, nettools, git, asciidoc, doxygen
 , xmlto, docbook_xml_dtd_45, docbook_xsl, findXMLCatalogs
@@ -30,7 +30,7 @@ with luaPackages; stdenv.mkDerivation rec {
   ];
 
   propagatedUserEnvPkgs = [ hicolor-icon-theme ];
-  buildInputs = [ cairo librsvg dbus gdk_pixbuf gobjectIntrospection
+  buildInputs = [ cairo librsvg dbus gdk_pixbuf gobject-introspection
                   git lgi libpthreadstubs libstartup_notification
                   libxdg_basedir lua nettools pango xcb-util-cursor
                   xorg.libXau xorg.libXdmcp xorg.libxcb xorg.libxshmfence

--- a/pkgs/applications/window-managers/i3/i3ipc-glib.nix
+++ b/pkgs/applications/window-managers/i3/i3ipc-glib.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pkgconfig, xproto, libxcb
 , autoreconfHook, json-glib, gtk-doc, which
-, gobjectIntrospection
+, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook which pkgconfig ];
 
-  buildInputs = [ libxcb json-glib gtk-doc xproto gobjectIntrospection ];
+  buildInputs = [ libxcb json-glib gtk-doc xproto gobject-introspection ];
 
 
   preAutoreconf = ''

--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchFromGitHub, pkgconfig, cmake, ninja, vala,
-  gettext, gobjectIntrospection, at-spi2-core, dbus, epoxy, expect,
+  gettext, gobject-introspection, at-spi2-core, dbus, epoxy, expect,
   gtk3, json-glib, libXdmcp, libgee, libpthreadstubs, librsvg,
   libsecret, libtasn1, libxcb, libxkbcommon, p11-kit, pcre, vte, wnck,
   deepin-menu, deepin-shortcut-viewer, deepin }:
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     ninja
     vala
     gettext
-    gobjectIntrospection # For setup hook
+    gobject-introspection # For setup hook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-gir-generator/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, go, gobjectIntrospection,
+{ stdenv, fetchFromGitHub, pkgconfig, go, gobject-introspection,
   libgudev, deepin, fetchurl }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     libgudev
   ];
 

--- a/pkgs/desktops/gnome-3/apps/accerciser/default.nix
+++ b/pkgs/desktops/gnome-3/apps/accerciser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gobjectIntrospection
+{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gobject-introspection
 , itstool, libxml2, python3Packages, at-spi2-core
 , dbus, intltool, libwnck3 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig wrapGAppsHook itstool intltool
-    gobjectIntrospection # For setup hook
+    gobject-introspection # For setup hook
   ];
   buildInputs = [
     gtk3 libxml2 python3Packages.python python3Packages.pyatspi

--- a/pkgs/desktops/gnome-3/apps/glade/default.nix
+++ b/pkgs/desktops/gnome-3/apps/glade/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, python3
-, pkgconfig, gtk3, glib, gobjectIntrospection
+, pkgconfig, gtk3, glib, gobject-introspection
 , wrapGAppsHook, itstool, libxml2, docbook_xsl
 , gnome3, gdk_pixbuf, libxslt }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig intltool itstool wrapGAppsHook docbook_xsl libxslt gobjectIntrospection
+    pkgconfig intltool itstool wrapGAppsHook docbook_xsl libxslt gobject-introspection
   ];
   buildInputs = [
     gtk3 glib libxml2 python3 python3.pkgs.pygobject3

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, wrapGAppsHook, pkgconfig, gettext, itstool, libvirt-glib
-, glib, gobjectIntrospection, libxml2, gtk3, gtk-vnc, freerdp, libvirt, spice-gtk, python3
+, glib, gobject-introspection, libxml2, gtk3, gtk-vnc, freerdp, libvirt, spice-gtk, python3
 , spice-protocol, libsoup, libosinfo, systemd, tracker, tracker-miners, vala
 , libcap, yajl, gmp, gdbm, cyrus_sasl, gnome3, librsvg, desktop-file-utils
 , mtools, cdrkit, libcdio, libusb, libarchive, acl, libgudev, qemu, libsecret
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   doCheck = true;
 
   nativeBuildInputs = [
-    meson ninja vala pkgconfig gettext itstool wrapGAppsHook gobjectIntrospection desktop-file-utils python3
+    meson ninja vala pkgconfig gettext itstool wrapGAppsHook gobject-introspection desktop-file-utils python3
   ];
 
   # Required for USB redirection PolicyKit rules file

--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gnome3, glib, gtk3, pango, wrapGAppsHook, python3
-, gobjectIntrospection, gjs, libunistring }:
+, gobject-introspection, gjs, libunistring }:
 
 stdenv.mkDerivation rec {
   name = "gnome-characters-${version}";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     };
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook python3 gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook python3 gobject-introspection ];
   buildInputs = [
     glib gtk3 gjs pango gnome3.gsettings-desktop-schemas
     gnome3.defaultIconTheme libunistring

--- a/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , meson, ninja, gettext, pkgconfig, wrapGAppsHook, itstool, desktop-file-utils
-, vala, gobjectIntrospection, libxml2, gtk3, glib, gsound, sound-theme-freedesktop
+, vala, gobject-introspection, libxml2, gtk3, glib, gsound, sound-theme-freedesktop
 , gnome3, gdk_pixbuf, geoclue2, libgweather }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     vala meson ninja pkgconfig gettext itstool wrapGAppsHook desktop-file-utils libxml2
-    gobjectIntrospection # for finding vapi files
+    gobject-introspection # for finding vapi files
   ];
   buildInputs = [
     gtk3 glib gnome3.gsettings-desktop-schemas gdk_pixbuf gnome3.defaultIconTheme

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -3,7 +3,7 @@
 , itstool, libxslt, webkitgtk, libgdata
 , gnome-desktop, libzapojit, libgepub
 , gnome3, gdk_pixbuf, libsoup, docbook_xsl, docbook_xml_dtd_42
-, gobjectIntrospection, inkscape, poppler_utils
+, gobject-introspection, inkscape, poppler_utils
 , desktop-file-utils, wrapGAppsHook, python3 }:
 
 stdenv.mkDerivation rec {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 glib gnome3.gsettings-desktop-schemas
     gdk_pixbuf gnome3.defaultIconTheme evince
-    libsoup webkitgtk gjs gobjectIntrospection
+    libsoup webkitgtk gjs gobject-introspection
     tracker tracker-miners libgdata
     gnome-desktop libzapojit libgepub
   ];

--- a/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, gettext, python3, pkgconfig, gnome3, gtk3
-, gobjectIntrospection, gdk_pixbuf, librsvg, libgweather
+, gobject-introspection, gdk_pixbuf, librsvg, libgweather
 , geoclue2, wrapGAppsHook, folks, libchamplain, gfbgraph, libsoup
 , webkitgtk, gjs, libgee, geocode-glib, evolution-data-server, gnome-online-accounts }:
 
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext python3 wrapGAppsHook ];
   buildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     gtk3 geoclue2 gjs libgee folks gfbgraph
     geocode-glib libchamplain libsoup
     gdk_pixbuf librsvg libgweather

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -1,6 +1,6 @@
 { stdenv, meson, ninja, gettext, fetchurl, gdk_pixbuf, tracker
 , libxml2, python3, libnotify, wrapGAppsHook, libmediaart
-, gobjectIntrospection, gnome-online-accounts, grilo, grilo-plugins
+, gobject-introspection, gnome-online-accounts, grilo, grilo-plugins
 , pkgconfig, gtk3, glib, desktop-file-utils, appstream-glib
 , itstool, gnome3, gst_all_1, libdazzle, libsoup }:
 
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "1d9gd9rqy71hibfrz4zglimvgv6yn1pw22cnrn7pbdz6k4yq209d";
   };
 
-  nativeBuildInputs = [ meson ninja gettext itstool pkgconfig libxml2 wrapGAppsHook desktop-file-utils appstream-glib gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja gettext itstool pkgconfig libxml2 wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
   buildInputs = with gst_all_1; [
     gtk3 glib libmediaart gnome-online-accounts
     gdk_pixbuf gnome3.defaultIconTheme python3

--- a/pkgs/desktops/gnome-3/apps/gnome-sound-recorder/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-sound-recorder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gobjectIntrospection, wrapGAppsHook, gjs, glib, gtk3, gdk_pixbuf, gst_all_1, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, intltool, gobject-introspection, wrapGAppsHook, gjs, glib, gtk3, gdk_pixbuf, gst_all_1, gnome3 }:
 
 let
   pname = "gnome-sound-recorder";
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
     sha256 = "0y0srj1hvr1waa35p6dj1r1mlgcsscc0i99jni50ijp4zb36fjqy";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig intltool gobject-introspection wrapGAppsHook ];
   buildInputs = [ gjs glib gtk3 gdk_pixbuf ] ++ (with gst_all_1; [ gstreamer.dev gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]);
 
   # TODO: fix this in gstreamer

--- a/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gjs, gobjectIntrospection
+{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gjs, gobject-introspection
 , libgweather, intltool, itstool, geoclue2, gnome-desktop }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
   buildInputs = [
-    gtk3 gjs gobjectIntrospection gnome-desktop
+    gtk3 gjs gobject-introspection gnome-desktop
     libgweather gnome3.defaultIconTheme geoclue2 gnome3.gsettings-desktop-schemas
   ];
 

--- a/pkgs/desktops/gnome-3/apps/polari/default.nix
+++ b/pkgs/desktops/gnome-3/apps/polari/default.nix
@@ -1,6 +1,6 @@
 { stdenv, itstool, fetchurl, gdk_pixbuf, adwaita-icon-theme
 , telepathy-glib, gjs, meson, ninja, gettext, telepathy-idle, libxml2, desktop-file-utils
-, pkgconfig, gtk3, glib, libsecret, libsoup, gobjectIntrospection, appstream-glib
+, pkgconfig, gtk3, glib, libsecret, libsoup, gobject-introspection, appstream-glib
 , gnome3, wrapGAppsHook, telepathy-logger, gspell }:
 
 let
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig itstool gettext wrapGAppsHook libxml2
-    desktop-file-utils gobjectIntrospection appstream-glib
+    desktop-file-utils gobject-introspection appstream-glib
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/apps/seahorse/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, vala, meson, ninja
-, pkgconfig, gtk3, glib, gobjectIntrospection
+, pkgconfig, gtk3, glib, gobject-introspection
 , wrapGAppsHook, itstool, gnupg, libsoup
 , gnome3, gpgme, python3, openldap
 , libsecret, avahi, p11-kit, openssh }:
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig vala itstool wrapGAppsHook
-    python3 gobjectIntrospection
+    python3 gobject-introspection
   ];
   buildInputs = [
     gtk3 glib gnome3.gcr

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, vala, libxslt, pkgconfig, glib, gtk3, gnome3, python3
-, libxml2, gettext, docbook_xsl, wrapGAppsHook, gobjectIntrospection }:
+, libxml2, gettext, docbook_xsl, wrapGAppsHook, gobject-introspection }:
 
 let
   pname = "dconf-editor";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
     sha256 = "06f736spn20s7qjsz00xw44v8r8bjhyrz1v3bix6v416jc5jp6ia";
   };
 
-  nativeBuildInputs = [ meson ninja vala libxslt pkgconfig wrapGAppsHook gettext docbook_xsl libxml2 gobjectIntrospection python3 ];
+  nativeBuildInputs = [ meson ninja vala libxslt pkgconfig wrapGAppsHook gettext docbook_xsl libxml2 gobject-introspection python3 ];
 
   buildInputs = [ glib gtk3 gnome3.dconf ];
 

--- a/pkgs/desktops/gnome-3/core/eog/default.nix
+++ b/pkgs/desktops/gnome-3/core/eog/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, meson, ninja, gettext, itstool, pkgconfig, libxml2, libjpeg, libpeas, gnome3
 , gtk3, glib, gsettings-desktop-schemas, adwaita-icon-theme, gnome-desktop, lcms2, gdk_pixbuf, exempi
-, shared-mime-info, wrapGAppsHook, librsvg, libexif, gobjectIntrospection, python3 }:
+, shared-mime-info, wrapGAppsHook, librsvg, libexif, gobject-introspection, python3 }:
 
 let
   pname = "eog";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1wrq3l3z0x6q0hnc1vqr2hnyb1b14qw6aqvc5dldfgbs0yys6p55";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook libxml2 gobjectIntrospection python3 ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook libxml2 gobject-introspection python3 ];
 
   buildInputs = [
     libjpeg gtk3 gdk_pixbuf glib libpeas librsvg lcms2 gnome-desktop libexif exempi

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, intltool, libxml2
 , glib, gtk3, pango, atk, gdk_pixbuf, shared-mime-info, itstool, gnome3
 , poppler, ghostscriptX, djvulibre, libspectre, libarchive, libsecret, wrapGAppsHook
-, librsvg, gobjectIntrospection, yelp-tools, gspell
+, librsvg, gobject-introspection, yelp-tools, gspell
 , recentListSize ? null # 5 is not enough, allow passing a different number
 , supportXPS ? false    # Open XML Paper Specification via libgxps
 , autoreconfHook
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig gobjectIntrospection intltool itstool wrapGAppsHook yelp-tools autoreconfHook
+    pkgconfig gobject-introspection intltool itstool wrapGAppsHook yelp-tools autoreconfHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, substituteAll, pkgconfig, gnome3, python3, gobjectIntrospection
+{ fetchurl, stdenv, substituteAll, pkgconfig, gnome3, python3, gobject-introspection
 , intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3
 , p11-kit, db, nspr, nss, libical, gperf, wrapGAppsHook, glib-networking, pcre
 , vala, cmake, ninja, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib }:
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cmake ninja pkgconfig intltool python3 gperf wrapGAppsHook gobjectIntrospection vala
+    cmake ninja pkgconfig intltool python3 gperf wrapGAppsHook gobject-introspection vala
   ];
   buildInputs = with gnome3; [
     glib libsoup libxml2 gtk gnome-online-accounts

--- a/pkgs/desktops/gnome-3/core/folks/default.nix
+++ b/pkgs/desktops/gnome-3/core/folks/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, glib, gnome3, nspr, intltool, gobjectIntrospection
+{ fetchurl, stdenv, pkgconfig, glib, gnome3, nspr, intltool, gobject-introspection
 , vala, sqlite, libxml2, dbus-glib, libsoup, nss, dbus
 , telepathy-glib, evolution-data-server, libsecret, db }:
 
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     dbus-glib telepathy-glib evolution-data-server dbus
     libsecret libxml2 libsoup nspr nss db
   ];
-  nativeBuildInputs = [ pkgconfig intltool vala gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig intltool vala gobject-introspection ];
 
   configureFlags = [ "--disable-fatal-warnings" ];
 

--- a/pkgs/desktops/gnome-3/core/gcr/default.nix
+++ b/pkgs/desktops/gnome-3/core/gcr/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnupg, p11-kit, glib
 , libgcrypt, libtasn1, dbus-glib, gtk, pango, gdk_pixbuf, atk
-, gobjectIntrospection, makeWrapper, libxslt, vala, gnome3
+, gobject-introspection, makeWrapper, libxslt, vala, gnome3
 , python2 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection libxslt makeWrapper vala ];
+  nativeBuildInputs = [ pkgconfig intltool gobject-introspection libxslt makeWrapper vala ];
 
   buildInputs = let
     gpg = gnupg.override { guiSupport = false; }; # prevent build cycle with pinentry_gnome

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, glib, itstool, libxml2, xorg
 , accountsservice, libX11, gnome3, systemd, autoreconfHook
-, gtk, libcanberra-gtk3, pam, libtool, gobjectIntrospection, plymouth
+, gtk, libcanberra-gtk3, pam, libtool, gobject-introspection, plymouth
 , librsvg, coreutils, xwayland, fetchpatch }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig libxml2 itstool autoreconfHook libtool gnome3.dconf ];
   buildInputs = [
     glib accountsservice systemd
-    gobjectIntrospection libX11 gtk
+    gobject-introspection libX11 gtk
     libcanberra-gtk3 pam plymouth librsvg
   ];
 

--- a/pkgs/desktops/gnome-3/core/geocode-glib/default.nix
+++ b/pkgs/desktops/gnome-3/core/geocode-glib/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, meson, ninja, pkgconfig, gettext, gtk-doc, docbook_xsl, gobjectIntrospection, gnome3, libsoup, json-glib }:
+{ fetchurl, stdenv, meson, ninja, pkgconfig, gettext, gtk-doc, docbook_xsl, gobject-introspection, gnome3, libsoup, json-glib }:
 
 stdenv.mkDerivation rec {
   name = "geocode-glib-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1vmydxs5xizcmaxpkfrq75xpj6pqrpdjizxyb30m00h54yqqch7a";
   };
 
-  nativeBuildInputs = with gnome3; [ meson ninja pkgconfig gettext gtk-doc docbook_xsl gobjectIntrospection ];
+  nativeBuildInputs = with gnome3; [ meson ninja pkgconfig gettext gtk-doc docbook_xsl gobject-introspection ];
   buildInputs = with gnome3; [ glib libsoup json-glib ];
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gjs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gjs/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gnome3, gtk3, atk, gobjectIntrospection
+{ fetchurl, stdenv, pkgconfig, gnome3, gtk3, atk, gobject-introspection
 , spidermonkey_60, pango, readline, glib, libxml2, dbus, gdk_pixbuf
 , makeWrapper }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "installedTests" ];
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
-  buildInputs = [ libxml2 gobjectIntrospection gtk3 glib pango readline dbus ];
+  buildInputs = [ libxml2 gobject-introspection gtk3 glib pango readline dbus ];
 
   propagatedBuildInputs = [ spidermonkey_60 ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gnome3, meson, ninja, pkgconfig, gtk3, intltool, glib
-, udev, itstool, libxml2, wrapGAppsHook, libnotify, libcanberra-gtk3, gobjectIntrospection
+, udev, itstool, libxml2, wrapGAppsHook, libnotify, libcanberra-gtk3, gobject-introspection
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43, python3 }:
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja intltool itstool pkgconfig libxml2 wrapGAppsHook gobjectIntrospection
+    meson ninja intltool itstool pkgconfig libxml2 wrapGAppsHook gobject-introspection
     gtk-doc docbook_xsl docbook_xml_dtd_43 python3
   ];
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-calculator/default.nix
@@ -1,5 +1,5 @@
 { stdenv, meson, ninja, vala, gettext, itstool, fetchurl, pkgconfig, libxml2
-, gtk3, glib, gtksourceview3, wrapGAppsHook, gobjectIntrospection, python3
+, gtk3, glib, gtksourceview3, wrapGAppsHook, gobject-introspection, python3
 , gnome3, mpfr, gmp, libsoup, libmpc }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig vala gettext itstool wrapGAppsHook python3
-    gobjectIntrospection # for finding vapi files
+    gobject-introspection # for finding vapi files
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, libxslt, which, libX11, gnome3, gtk3, glib
 , gettext, libxml2, xkeyboard_config, isocodes, itstool, wayland
-, libseccomp, bubblewrap, gobjectIntrospection, gtk-doc, docbook_xsl }:
+, libseccomp, bubblewrap, gobject-introspection, gtk-doc, docbook_xsl }:
 
 stdenv.mkDerivation rec {
   name = "gnome-desktop-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
-    pkgconfig which itstool gettext libxslt libxml2 gobjectIntrospection
+    pkgconfig which itstool gettext libxslt libxml2 gobject-introspection
     gtk-doc docbook_xsl
   ];
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-menus/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-menus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, glib, gobjectIntrospection }:
+{ stdenv, fetchurl, intltool, pkgconfig, glib, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gnome-menus-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   makeFlags = "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/ INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool glib gobjectIntrospection ];
+  buildInputs = [ intltool glib gobject-introspection ];
 
   meta = {
     homepage = https://www.gnome.org;

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk, wrapGAppsHook
-, webkitgtk, json-glib, rest, libsecret, gtk-doc, gobjectIntrospection
+, webkitgtk, json-glib, rest, libsecret, gtk-doc, gobject-introspection
 , gettext, icu, glib-networking
 , libsoup, docbook_xsl, docbook_xml_dtd_412, gnome3, gcr, kerberos
 }:
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
-    pkgconfig gobjectIntrospection vala gettext wrapGAppsHook
+    pkgconfig gobject-introspection vala gettext wrapGAppsHook
     libxslt docbook_xsl docbook_xml_dtd_412 gtk-doc
   ];
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -2,7 +2,7 @@
 , python3Packages, libsoup, polkit, clutter, networkmanager, docbook_xsl , docbook_xsl_ns, at-spi2-core
 , libstartup_notification, telepathy-glib, telepathy-logger, libXtst, unzip, glibcLocales, shared-mime-info
 , libgweather, libcanberra-gtk3, librsvg, geoclue2, perl, docbook_xml_dtd_42, desktop-file-utils
-, libpulseaudio, libical, gobjectIntrospection, gstreamer, wrapGAppsHook, libxslt
+, libpulseaudio, libical, gobject-introspection, gstreamer, wrapGAppsHook, libxslt
 , accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet
 , sassc, systemd, gst_all_1 }:
 
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
     gnome3.gnome-clocks # schemas needed
     at-spi2-core upower ibus gnome-desktop telepathy-logger gnome3.gnome-settings-daemon
     gst_all_1.gst-plugins-good # recording
-    gobjectIntrospection
+    gobject-introspection
 
     # not declared at build time, but typelib is needed at runtime
     libgweather networkmanagerapplet

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
-, glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobjectIntrospection, flatpak, fwupd
+, glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobject-introspection, flatpak, fwupd
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext wrapGAppsHook libxslt docbook_xml_dtd_42 docbook_xml_dtd_43
-    valgrind-light docbook_xsl gtk-doc desktop-file-utils gobjectIntrospection
+    valgrind-light docbook_xsl gtk-doc desktop-file-utils gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/grilo/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, vala, glib, liboauth, gtk3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43
-, libxml2, gnome3, gobjectIntrospection, libsoup }:
+, libxml2, gnome3, gobject-introspection, libsoup }:
 
 let
   pname = "grilo";
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext gobjectIntrospection vala
+    meson ninja pkgconfig gettext gobject-introspection vala
     gtk-doc docbook_xsl docbook_xml_dtd_43
   ];
   buildInputs = [ glib liboauth gtk3 libxml2 libsoup gnome3.totem-pl-parser ];

--- a/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
+++ b/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, gobjectIntrospection
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection
   # just for passthru
 , gnome3 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  buildInputs = [ glib gobjectIntrospection ];
+  buildInputs = [ glib gobject-introspection ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/desktops/gnome-3/core/gsound/default.nix
+++ b/pkgs/desktops/gnome-3/core/gsound/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libcanberra, gobjectIntrospection, libtool, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, glib, libcanberra, gobject-introspection, libtool, gnome3 }:
 
 let
   pname = "gsound";
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
     sha256 = "bba8ff30eea815037e53bee727bbd5f0b6a2e74d452a7711b819a7c444e78e53";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection libtool gnome3.vala ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection libtool gnome3.vala ];
   buildInputs = [ glib libcanberra ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gucharmap/default.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/default.nix
@@ -2,7 +2,7 @@
 , glib, desktop-file-utils, gtk-doc, autoconf, automake, libtool
 , wrapGAppsHook, gnome3, itstool, libxml2, yelp-tools
 , docbook_xsl, docbook_xml_dtd_412, gsettings-desktop-schemas
-, callPackage, unzip, gobjectIntrospection }:
+, callPackage, unzip, gobject-introspection }:
 
 let
   unicode-data = callPackage ./unicode-data.nix {};
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig wrapGAppsHook unzip intltool itstool
     autoconf automake libtool gtk-doc docbook_xsl docbook_xml_dtd_412
-    yelp-tools libxml2 desktop-file-utils gobjectIntrospection
+    yelp-tools libxml2 desktop-file-utils gobject-introspection
   ];
 
   buildInputs = [ gtk3 glib gsettings-desktop-schemas defaultIconTheme ];

--- a/pkgs/desktops/gnome-3/core/libgdata/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgdata/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, libxml2, glib, json-glib
-, gobjectIntrospection, liboauth, gnome3, p11-kit, openssl, uhttpmock }:
+, gobject-introspection, liboauth, gnome3, p11-kit, openssl, uhttpmock }:
 
 let
   pname = "libgdata";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${gnome3.libsoup.dev}/include/libsoup-gnome-2.4/ -I${gnome3.gcr}/include/gcr-3 -I${gnome3.gcr}/include/gck-1";
 
   buildInputs = with gnome3;
-    [ pkgconfig libsoup intltool libxml2 glib gobjectIntrospection
+    [ pkgconfig libsoup intltool libxml2 glib gobject-introspection
       liboauth gcr gnome-online-accounts p11-kit openssl uhttpmock ];
 
   propagatedBuildInputs = [ json-glib ];

--- a/pkgs/desktops/gnome-3/core/libgee/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgee/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, vala, pkgconfig, glib, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, autoconf, vala, pkgconfig, glib, gobject-introspection, gnome3 }:
 let
   pname = "libgee";
   version = "0.20.1";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  nativeBuildInputs = [ pkgconfig autoconf vala gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig autoconf vala gobject-introspection ];
   buildInputs = [ glib ];
 
   PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";

--- a/pkgs/desktops/gnome-3/core/libgepub/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgepub/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobjectIntrospection, gnome3
+{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobject-introspection, gnome3
 , webkitgtk, libsoup, libxml2, libarchive }:
 
 let
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
   buildInputs = [ glib webkitgtk libsoup libxml2 libarchive ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/libgnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgnome-keyring/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, dbus, libgcrypt, pkgconfig, intltool, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, glib, dbus, libgcrypt, pkgconfig, intltool, gobject-introspection, gnome3 }:
 
 let
   pname = "libgnome-keyring";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  propagatedBuildInputs = [ glib gobjectIntrospection dbus libgcrypt ];
+  propagatedBuildInputs = [ glib gobject-introspection dbus libgcrypt ];
   nativeBuildInputs = [ pkgconfig intltool ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/libgweather/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgweather/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, libxml2, glib, gtk, gettext, libsoup
-, gtk-doc, docbook_xsl, docbook_xml_dtd_43, gobjectIntrospection, python3, tzdata, geocode-glib, vala, gnome3 }:
+, gtk-doc, docbook_xsl, docbook_xml_dtd_43, gobject-introspection, python3, tzdata, geocode-glib, vala, gnome3 }:
 
 let
   pname = "libgweather";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
     sha256 = "0xfy5ghwvnz2g9074dy6512m4z2pv66pmja14vhi9imgacbfh708";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext vala gtk-doc docbook_xsl docbook_xml_dtd_43 gobjectIntrospection python3 ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext vala gtk-doc docbook_xsl docbook_xml_dtd_43 gobject-introspection python3 ];
   buildInputs = [ glib gtk libsoup libxml2 geocode-glib ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/libgxps/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgxps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobjectIntrospection, cairo
+{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobject-introspection, cairo
 , libarchive, freetype, libjpeg, libtiff, gnome3, fetchpatch
 }:
 
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
   buildInputs = [ glib cairo freetype libjpeg libtiff ];
   propagatedBuildInputs = [ libarchive ];
 

--- a/pkgs/desktops/gnome-3/core/libpeas/default.nix
+++ b/pkgs/desktops/gnome-3/core/libpeas/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnome3
-, glib, gtk3, gobjectIntrospection, python3Packages, ncurses
+, glib, gtk3, gobject-introspection, python3Packages, ncurses
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildInputs =  [ intltool glib gtk3 gnome3.defaultIconTheme ncurses python3Packages.python python3Packages.pygobject3 ];
   propagatedBuildInputs = [
     # Required by libpeas-1.0.pc
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/libzapojit/default.nix
+++ b/pkgs/desktops/gnome-3/core/libzapojit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, intltool, json-glib, rest, libsoup, gnome-online-accounts, gnome3, gobjectIntrospection }:
+{ stdenv, fetchurl, pkgconfig, glib, intltool, json-glib, rest, libsoup, gnome-online-accounts, gnome3, gobject-introspection }:
 let
   pname = "libzapojit";
   version = "0.0.3";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zn3s7ryjc3k1abj4k55dr2na844l451nrg9s6cvnnhh569zj99x";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
   propagatedBuildInputs = [ glib json-glib rest libsoup gnome-online-accounts ]; # zapojit-0.0.pc
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, fetchpatch, pkgconfig, gnome3, intltool, gobjectIntrospection, upower, cairo
+{ fetchurl, stdenv, fetchpatch, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
 
   buildInputs = with gnome3; [
-    glib gobjectIntrospection gtk gsettings-desktop-schemas upower
+    glib gobject-introspection gtk gsettings-desktop-schemas upower
     gnome-desktop cairo pango cogl clutter zenity libstartup_notification
     gnome3.geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, gnome3, intltool, gobjectIntrospection, upower, cairo
+{ fetchurl, stdenv, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
 
   buildInputs = with gnome3; [
-    glib gobjectIntrospection gtk gsettings-desktop-schemas upower
+    glib gobject-introspection gtk gsettings-desktop-schemas upower
     gnome-desktop cairo pango cogl clutter zenity libstartup_notification
     gnome3.geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile

--- a/pkgs/desktops/gnome-3/core/rest/default.nix
+++ b/pkgs/desktops/gnome-3/core/rest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, libsoup, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, glib, libsoup, gobject-introspection, gnome3 }:
 
 let
   pname = "rest";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libsoup gobjectIntrospection];
+  buildInputs = [ glib libsoup gobject-introspection];
 
   configureFlags = [ "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt" ];
 

--- a/pkgs/desktops/gnome-3/core/rygel/default.nix
+++ b/pkgs/desktops/gnome-3/core/rygel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, vala, gettext, libxml2, gobjectIntrospection, gtk-doc, wrapGAppsHook, glib, gssdp, gupnp, gupnp-av, gupnp-dlna, gst_all_1, libgee, libsoup, gtk3, libmediaart, sqlite, systemd, tracker, shared-mime-info, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, vala, gettext, libxml2, gobject-introspection, gtk-doc, wrapGAppsHook, glib, gssdp, gupnp, gupnp-av, gupnp-dlna, gst_all_1, libgee, libsoup, gtk3, libmediaart, sqlite, systemd, tracker, shared-mime-info, gnome3 }:
 
 let
   pname = "rygel";
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig vala gettext libxml2 gobjectIntrospection gtk-doc wrapGAppsHook
+    pkgconfig vala gettext libxml2 gobject-introspection gtk-doc wrapGAppsHook
   ];
   buildInputs = [
     glib gssdp gupnp gupnp-av gupnp-dlna libgee libsoup gtk3 libmediaart sqlite systemd tracker shared-mime-info

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, itstool, python3, wrapGAppsHook
 , cairo, gdk_pixbuf, colord, glib, gtk, gusb, packagekit, libwebp
-, libxml2, sane-backends, vala, gnome3, gobjectIntrospection }:
+, libxml2, sane-backends, vala, gnome3, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "simple-scan-${version}";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja gettext itstool pkgconfig python3 wrapGAppsHook libxml2
     # For setup hook
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/sushi/default.nix
+++ b/pkgs/desktops/gnome-3/core/sushi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, file, intltool, gobjectIntrospection, glib
+{ stdenv, fetchurl, pkgconfig, file, intltool, gobject-introspection, glib
 , clutter-gtk, clutter-gst, gnome3, aspell, hspell, gtksourceview, gjs
 , webkitgtk, libmusicbrainz5, icu, wrapGAppsHook, gst_all_1
 , gdk_pixbuf, librsvg, gtk3, harfbuzz }:
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zpaiw5r734fky3zq95a6szwn7srbkpixajqg2xvdivhhx4mbnnj";
   };
 
-  nativeBuildInputs = [ pkgconfig file intltool gobjectIntrospection wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig file intltool gobject-introspection wrapGAppsHook ];
   buildInputs = [
     glib gtk3 gnome3.evince icu harfbuzz
     clutter-gtk clutter-gst gjs gtksourceview gdk_pixbuf

--- a/pkgs/desktops/gnome-3/core/totem-pl-parser/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem-pl-parser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gmime, libxml2, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gmime, libxml2, gobject-introspection, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "totem-pl-parser-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript { packageName = "totem-pl-parser"; attrPath = "gnome3.totem-pl-parser"; };
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext gobject-introspection ];
   buildInputs = [ gmime libxml2 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, intltool, gst_all_1
 , clutter-gtk, clutter-gst, python3Packages, shared-mime-info
-, pkgconfig, gtk3, glib, gobjectIntrospection
+, pkgconfig, gtk3, glib, gobject-introspection
 , wrapGAppsHook, itstool, libxml2, vala, gnome3
 , gdk_pixbuf, tracker, nautilus }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
 
-  nativeBuildInputs = [ meson ninja vala pkgconfig intltool python3Packages.python itstool gobjectIntrospection wrapGAppsHook ];
+  nativeBuildInputs = [ meson ninja vala pkgconfig intltool python3Packages.python itstool gobject-introspection wrapGAppsHook ];
   buildInputs = [
     gtk3 glib gnome3.grilo clutter-gtk clutter-gst gnome3.totem-pl-parser gnome3.grilo-plugins
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad

--- a/pkgs/desktops/gnome-3/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitLab, intltool, meson, ninja, pkgconfig, gobjectIntrospection, python2
+{ stdenv, fetchurl, fetchFromGitLab, intltool, meson, ninja, pkgconfig, gobject-introspection, python2
 , gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_43, glibcLocales
 , libxml2, upower, glib, wrapGAppsHook, vala, sqlite, libxslt, libstemmer
 , gnome3, icu, libuuid, networkmanager, libsoup, json-glib }:
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja vala pkgconfig intltool libxslt wrapGAppsHook gobjectIntrospection
+    meson ninja vala pkgconfig intltool libxslt wrapGAppsHook gobject-introspection
     gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_43 glibcLocales
     python2 # for data-generators
   ];

--- a/pkgs/desktops/gnome-3/core/vte/2.90.nix
+++ b/pkgs/desktops/gnome-3/core/vte/2.90.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses, gobjectIntrospection }:
+{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   versionMajor = "0.36";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gobjectIntrospection intltool gnome3.glib gnome3.gtk3 ncurses ];
+  buildInputs = [ gobject-introspection intltool gnome3.glib gnome3.gtk3 ncurses ];
 
   configureFlags = [ "--enable-introspection" ];
 

--- a/pkgs/desktops/gnome-3/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/core/vte/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, pkgconfig
-, gnome3, ncurses, gobjectIntrospection, vala, libxml2, gnutls
+, gnome3, ncurses, gobject-introspection, vala, libxml2, gnutls
 , gperf, pcre2
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript { packageName = "vte"; attrPath = "gnome3.vte"; };
   };
 
-  nativeBuildInputs = [ gobjectIntrospection intltool pkgconfig vala gperf libxml2 ];
+  nativeBuildInputs = [ gobject-introspection intltool pkgconfig vala gperf libxml2 ];
   buildInputs = [ gnome3.glib gnome3.gtk3 ncurses ];
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -35,7 +35,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     hitori gnome-taquin
   ];
 
-  inherit (pkgs) atk glib gobjectIntrospection gspell webkitgtk gtk3 gtkmm3
+  inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
     clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle;

--- a/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, glib, amtk, appstream-glib, gobjectIntrospection, python3
+, glib, amtk, appstream-glib, gobject-introspection, python3
 , webkitgtk, gettext, itstool, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "036sddvhs0blqpc2ixmjdl9vxynvkn5jpgn0jxr1fxcm4rh3q07a";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook appstream-glib gobjectIntrospection python3 ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook appstream-glib gobject-introspection python3 ];
   buildInputs = [
     glib gtk3 webkitgtk amtk
     gnome3.defaultIconTheme gsettings-desktop-schemas

--- a/pkgs/desktops/gnome-3/games/gnome-chess/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-chess/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, vala, pkgconfig, wrapGAppsHook, gobjectIntrospection
+{ stdenv, fetchurl, meson, ninja, vala, pkgconfig, wrapGAppsHook, gobject-introspection
 , gettext, itstool, libxml2, python3, gnome3, glib, gtk3, librsvg }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "153wwh0861qfg53myyc3iwlqm989lbhdrlmsxaibmkxv3pgpl7ma";
   };
 
-  nativeBuildInputs = [ meson ninja vala pkgconfig gettext itstool libxml2 python3 wrapGAppsHook gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja vala pkgconfig gettext itstool libxml2 python3 wrapGAppsHook gobject-introspection ];
   buildInputs = [ glib gtk3 librsvg gnome3.defaultIconTheme ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, vala, gobjectIntrospection, pkgconfig, gnome3, gtk3, wrapGAppsHook
+{ stdenv, fetchurl, meson, ninja, vala, gobject-introspection, pkgconfig, gnome3, gtk3, wrapGAppsHook
 , librsvg, gettext, itstool, python3, libxml2, libgnome-games-support, libgee }:
 
 stdenv.mkDerivation rec {
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "08ddk400sg1g3q26gnm5mgv81vdqyix0yl7pd47p50vkc1w6f33z";
   };
 
-  # gobjectIntrospection for finding vapi files
-  nativeBuildInputs = [ meson ninja vala gobjectIntrospection pkgconfig gettext itstool python3 libxml2 wrapGAppsHook ];
+  # gobject-introspection for finding vapi files
+  nativeBuildInputs = [ meson ninja vala gobject-introspection pkgconfig gettext itstool python3 libxml2 wrapGAppsHook ];
   buildInputs = [ gtk3 librsvg gnome3.defaultIconTheme libgnome-games-support libgee ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/games/gnome-sudoku/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-sudoku/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, vala, pkgconfig, gobjectIntrospection, gettext, gtk3, gnome3, wrapGAppsHook
+{ stdenv, fetchurl, meson, ninja, vala, pkgconfig, gobject-introspection, gettext, gtk3, gnome3, wrapGAppsHook
 , json-glib, qqwing, itstool, libxml2, python3, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1xy986s51jnrcqwan2hy4bjdg6797yr9s7gxx2z2q4j4gkx3qa1f";
   };
 
-  nativeBuildInputs = [ meson ninja vala pkgconfig gobjectIntrospection gettext itstool libxml2 python3 desktop-file-utils wrapGAppsHook ];
+  nativeBuildInputs = [ meson ninja vala pkgconfig gobject-introspection gettext itstool libxml2 python3 desktop-file-utils wrapGAppsHook ];
   buildInputs = [ gtk3 gnome3.libgee json-glib qqwing ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/misc/california/default.nix
+++ b/pkgs/desktops/gnome-3/misc/california/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_34, libgee, wrapGAppsHook, itstool, gobjectIntrospection
+{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_34, libgee, wrapGAppsHook, itstool, gobject-introspection
 , gnome-online-accounts, evolution-data-server, gnome3, glib, libsoup, libgdata, sqlite, xdg_utils }:
 
 let
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1dky2kllv469k8966ilnf4xrr7z35pq8mdvs7kwziy59cdikapxj";
   };
 
-  nativeBuildInputs = [ intltool itstool vala_0_34 pkgconfig wrapGAppsHook gobjectIntrospection ];
+  nativeBuildInputs = [ intltool itstool vala_0_34 pkgconfig wrapGAppsHook gobject-introspection ];
   buildInputs = [ glib gtk3 libgee libsoup libgdata gnome-online-accounts evolution-data-server sqlite xdg_utils gnome3.gsettings-desktop-schemas ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_40, enchant
 , wrapGAppsHook, gdk_pixbuf, cmake, ninja, desktop-file-utils
 , libnotify, libcanberra-gtk3, libsecret, gmime, isocodes
-, gobjectIntrospection, libpthreadstubs, sqlite
+, gobject-introspection, libpthreadstubs, sqlite
 , gnome3, librsvg, gnome-doc-utils, webkitgtk, fetchpatch }:
 
 let
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobjectIntrospection ];
+  nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobject-introspection ];
   buildInputs = [
     gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
     libpthreadstubs gnome3.gsettings-desktop-schemas gnome3.gcr isocodes

--- a/pkgs/desktops/gnome-3/misc/gexiv2/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gexiv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, exiv2, glib, gnome3, gobjectIntrospection, vala }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, exiv2, glib, gnome3, gobject-introspection, vala }:
 
 let
   pname = "gexiv2";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection vala ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection vala ];
   buildInputs = [ glib ];
   propagatedBuildInputs = [ exiv2 ];
 

--- a/pkgs/desktops/gnome-3/misc/gfbgraph/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gfbgraph/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib
-, gnome3, libsoup, json-glib, gobjectIntrospection }:
+, gnome3, libsoup, json-glib, gobject-introspection }:
 
 let
   pname = "gfbgraph";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1dp0v8ia35fxs9yhnqpxj3ir5lh018jlbiwifjfn8ayy7h47j4fs";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
   buildInputs = [ glib gnome3.gnome-online-accounts ];
   propagatedBuildInputs = [ libsoup json-glib gnome3.rest ];
 

--- a/pkgs/desktops/gnome-3/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gitg/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, vala, intltool, pkgconfig, gtk3, glib
-, json-glib, wrapGAppsHook, libpeas, bash, gobjectIntrospection
+, json-glib, wrapGAppsHook, libpeas, bash, gobject-introspection
 , gnome3, gtkspell3, shared-mime-info, libgee, libgit2-glib, libsecret
 , meson, ninja, python3
  }:
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 glib json-glib libgee libpeas gnome3.libsoup
     libgit2-glib gtkspell3 gnome3.gtksourceview gnome3.gsettings-desktop-schemas
-    libsecret gobjectIntrospection gnome3.adwaita-icon-theme
+    libsecret gobject-introspection gnome3.adwaita-icon-theme
   ];
 
   nativeBuildInputs = [ meson ninja python3 vala wrapGAppsHook intltool pkgconfig ];

--- a/pkgs/desktops/gnome-3/misc/gnome-autoar/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-autoar/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gnome3
-, gtk3, glib, gobjectIntrospection, libarchive
+, gtk3, glib, gobject-introspection, libarchive
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtk3 glib ];
-  propagatedBuildInputs = [ libarchive gobjectIntrospection ];
+  propagatedBuildInputs = [ libarchive gobject-introspection ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
@@ -1,7 +1,7 @@
 { stdenv, meson, ninja, gettext, fetchurl
 , pkgconfig, gtk3, glib, libsoup
 , itstool, libxml2, python3Packages
-, gnome3, gdk_pixbuf, libnotify, gobjectIntrospection, wrapGAppsHook }:
+, gnome3, gdk_pixbuf, libnotify, gobject-introspection, wrapGAppsHook }:
 
 let
   pname = "gnome-tweaks";
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
     gdk_pixbuf gnome3.defaultIconTheme
     libnotify gnome3.gnome-shell python3Packages.pygobject3
     libsoup gnome3.gnome-settings-daemon gnome3.nautilus
-    gnome3.mutter gnome3.gnome-desktop gobjectIntrospection
+    gnome3.mutter gnome3.gnome-desktop gobject-introspection
     gnome3.nautilus
     # Makes it possible to select user themes through the `user-theme` extension
     gnome3.gnome-shell-extensions

--- a/pkgs/desktops/gnome-3/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gpaste/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, vala, glib, gjs, mutter
-, pango, gtk3, gnome3, dbus, clutter, appstream-glib, wrapGAppsHook, systemd, gobjectIntrospection }:
+, pango, gtk3, gnome3, dbus, clutter, appstream-glib, wrapGAppsHook, systemd, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   version = "3.30.2";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib gjs mutter gtk3 dbus
-    clutter pango gobjectIntrospection
+    clutter pango gobject-introspection
   ];
 
   configureFlags = [

--- a/pkgs/desktops/gnome-3/misc/libgit2-glib/default.nix
+++ b/pkgs/desktops/gnome-3/misc/libgit2-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gnome3, meson, ninja, pkgconfig, vala, libssh2
-, gtk-doc, gobjectIntrospection, libgit2, glib, python3 }:
+, gtk-doc, gobject-introspection, libgit2, glib, python3 }:
 
 stdenv.mkDerivation rec {
   name = "libgit2-glib-${version}";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig vala gtk-doc gobjectIntrospection
+    meson ninja pkgconfig vala gtk-doc gobject-introspection
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/libmediaart/default.nix
+++ b/pkgs/desktops/gnome-3/misc/libmediaart/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, gobject-introspection, gnome3 }:
 
 let
   pname = "libmediaart";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "a57be017257e4815389afe4f58fdacb6a50e74fd185452b23a652ee56b04813d";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
   buildInputs = [ glib gdk_pixbuf ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, autoconf-archive, appstream-glib, intltool, pkgconfig, libtool, wrapGAppsHook,
   dbus-glib, libcanberra, gst_all_1, vala, gnome3, gtk3, libxml2, autoreconfHook,
-  glib, gobjectIntrospection, libpeas
+  glib, gobject-introspection, libpeas
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    glib gobjectIntrospection libpeas
+    glib gobject-introspection libpeas
     dbus-glib libcanberra gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gnome3.gsettings-desktop-schemas

--- a/pkgs/desktops/mate/mate-menus/default.nix
+++ b/pkgs/desktops/mate/mate-menus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, gobjectIntrospection, python, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection, python, mate }:
 
 stdenv.mkDerivation rec {
   name = "mate-menus-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  buildInputs = [ glib gobjectIntrospection python ];
+  buildInputs = [ glib gobject-introspection python ];
 
   makeFlags = [
     "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/"

--- a/pkgs/desktops/mate/mate-polkit/default.nix
+++ b/pkgs/desktops/mate/mate-polkit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, gobjectIntrospection, libappindicator-gtk3, libindicator-gtk3, polkit, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, gobject-introspection, libappindicator-gtk3, libindicator-gtk3, polkit, mate }:
 
 stdenv.mkDerivation rec {
   name = "mate-polkit-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    gobjectIntrospection
+    gobject-introspection
     libappindicator-gtk3
     libindicator-gtk3
     polkit

--- a/pkgs/desktops/pantheon/apps/pantheon-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/pantheon-terminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, cmake, vala_0_38, pkgconfig, glib, gtk3, granite, gnome3, libnotify, gettext, wrapGAppsHook, gobjectIntrospection }:
+{ stdenv, fetchurl, perl, cmake, vala_0_38, pkgconfig, glib, gtk3, granite, gnome3, libnotify, gettext, wrapGAppsHook, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   majorVersion = "0.4";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     perl cmake vala_0_38 pkgconfig wrapGAppsHook
     # For setup hook
-    gobjectIntrospection
+    gobject-introspection
   ];
   buildInputs = with gnome3; [
     glib gtk3 granite libnotify gettext vte_290 libgee

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, substituteAll, callPackage, pkgconfig, cmake, vala, libxml2,
   glib, pcre, gtk2, gtk3, xorg, libxkbcommon, epoxy, at-spi2-core, dbus-glib, bamf,
-  xfce, libwnck3, libdbusmenu, gobjectIntrospection }:
+  xfce, libwnck3, libdbusmenu, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "xfce4-vala-panel-appmenu-plugin-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ (callPackage ./appmenu-gtk-module.nix {})
                   glib pcre gtk2 gtk3 xorg.libpthreadstubs xorg.libXdmcp libxkbcommon epoxy
                   at-spi2-core dbus-glib bamf xfce.xfce4panel_gtk3 xfce.libxfce4util xfce.xfconf
-                  libwnck3 libdbusmenu gobjectIntrospection ];
+                  libwnck3 libdbusmenu gobject-introspection ];
 
   patches = [
     (substituteAll {

--- a/pkgs/desktops/xfce4-13/libxfce4ui/default.nix
+++ b/pkgs/desktops/xfce4-13/libxfce4ui/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkXfceDerivation, gobjectIntrospection, gtk2, gtk3, libICE, libSM
+{ lib, mkXfceDerivation, gobject-introspection, gtk2, gtk3, libICE, libSM
 , libstartup_notification ? null, libxfce4util, xfconf }:
 
 mkXfceDerivation rec {
@@ -8,7 +8,7 @@ mkXfceDerivation rec {
 
   sha256 = "0m9h3kvkk2nx8pxxmsg9sjnyp6ajwjrz9djjxxvranjsdw3ilydy";
 
-  buildInputs =  [ gobjectIntrospection gtk2 gtk3 libstartup_notification xfconf ];
+  buildInputs =  [ gobject-introspection gtk2 gtk3 libstartup_notification xfconf ];
   propagatedBuildInputs = [ libxfce4util libICE libSM ];
 
   meta = with lib; {

--- a/pkgs/desktops/xfce4-13/libxfce4util/default.nix
+++ b/pkgs/desktops/xfce4-13/libxfce4util/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkXfceDerivation, gobjectIntrospection }:
+{ lib, mkXfceDerivation, gobject-introspection }:
 
 mkXfceDerivation rec {
   category = "xfce";
@@ -7,7 +7,7 @@ mkXfceDerivation rec {
 
   sha256 = "0sb6pzhmh0qzfdhixj1ard56zi68318k86z3a1h3f2fhqy7gyf98";
 
-  buildInputs = [ gobjectIntrospection ];
+  buildInputs = [ gobject-introspection ];
 
   meta = with lib; {
     description = "Extension library for Xfce";

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -474,7 +474,7 @@ self: super: builtins.intersectAttrs super {
   hapistrano = addBuildTool super.hapistrano pkgs.buildPackages.git;
 
   # This propagates this to everything depending on haskell-gi-base
-  haskell-gi-base = addBuildDepend super.haskell-gi-base pkgs.gobjectIntrospection;
+  haskell-gi-base = addBuildDepend super.haskell-gi-base pkgs.gobject-introspection;
 
   # requires valid, writeable $HOME
   hatex-guide = overrideCabal super.hatex-guide (drv: {

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, glib, intltool, makeWrapper, shadow
-, gobjectIntrospection, polkit, systemd, coreutils, meson, dbus
+, gobject-introspection, polkit, systemd, coreutils, meson, dbus
 , ninja, python3 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig makeWrapper meson ninja python3 ];
 
-  buildInputs = [ glib intltool gobjectIntrospection polkit systemd dbus ];
+  buildInputs = [ glib intltool gobject-introspection polkit systemd dbus ];
 
   mesonFlags = [ "-Dsystemdsystemunitdir=etc/systemd/system"
                  "-Dlocalstatedir=/var" ];

--- a/pkgs/development/libraries/appstream-glib/default.nix
+++ b/pkgs/development/libraries/appstream-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, substituteAll, pkgconfig, gettext, gtk3, glib
-, gtk-doc, libarchive, gobjectIntrospection, libxslt, pngquant
+, gtk-doc, libarchive, gobject-introspection, libxslt, pngquant
 , sqlite, libsoup, attr, acl, docbook_xsl, docbook_xml_dtd_42
 , libuuid, json-glib, meson, gperf, ninja
 }:
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib gettext sqlite libsoup
     attr acl libuuid json-glib
-    libarchive gobjectIntrospection gperf
+    libarchive gobject-introspection gperf
   ];
   propagatedBuildInputs = [ gtk3 ];
 

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchpatch, fetchFromGitHub, meson, ninja, pkgconfig, gettext
 , xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt
-, libstemmer, glib, xapian, libxml2, libyaml, gobjectIntrospection
+, libstemmer, glib, xapian, libxml2, libyaml, gobject-introspection
 , pcre, itstool, gperf, vala
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja pkgconfig gettext
     libxslt xmlto docbook_xsl docbook_xml_dtd_45
-    gobjectIntrospection itstool vala
+    gobject-introspection itstool vala
   ];
 
   buildInputs = [ libstemmer pcre glib xapian libxml2 libyaml gperf ];

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkgconfig
-, gobjectIntrospection
+, gobject-introspection
 
 , dbus
 , glib
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ]
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ]
     # Fixup rpaths because of meson, remove with meson-0.47
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [ dbus glib libX11 libXtst libXi ];

--- a/pkgs/development/libraries/atk/default.nix
+++ b/pkgs/development/libraries/atk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, gettext, pkgconfig, glib
-, fixDarwinDylibNames, gobjectIntrospection, gnome3
+, fixDarwinDylibNames, gobject-introspection, gnome3
 }:
 
 let
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext gobject-introspection ];
 
   propagatedBuildInputs = [
     # Required by atk.pc

--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoconf, automake, libtool, gnome3, which, fetchgit, libgtop, libwnck3, glib, vala, pkgconfig
-, libstartup_notification, gobjectIntrospection, gtk-doc, docbook_xsl
+, libstartup_notification, gobject-introspection, gtk-doc, docbook_xsl
 , xorgserver, dbus, python2 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     automake
     docbook_xsl
     gnome3.gnome-common
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     libtool
     pkgconfig

--- a/pkgs/development/libraries/clutter-gtk/default.nix
+++ b/pkgs/development/libraries/clutter-gtk/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, meson, ninja
-, gobjectIntrospection, clutter, gtk3, gnome3 }:
+, gobject-introspection, clutter, gtk3, gnome3 }:
 
 let
   pname = "clutter-gtk";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [ clutter gtk3 ];
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
 
   postBuild = "rm -rf $out/share/gtk-doc";
 

--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, libGLU_combined, libX11, libXext, libXfixes
 , libXdamage, libXcomposite, libXi, libxcb, cogl, pango, atk, json-glib
-, gobjectIntrospection, gtk3, gnome3, libinput, libgudev, libxkbcommon
+, gobject-introspection, gtk3, gnome3, libinput, libgudev, libxkbcommon
 }:
 
 let
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs =
     [ libX11 libGLU_combined libXext libXfixes libXdamage libXcomposite libXi cogl pango
-      atk json-glib gobjectIntrospection libxcb libinput libgudev libxkbcommon
+      atk json-glib gobject-introspection libxcb libinput libgudev libxkbcommon
     ];
 
   configureFlags = [ "--enable-introspection" ]; # needed by muffin AFAIK

--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, libGL, glib, gdk_pixbuf, xorg, libintl
-, pangoSupport ? true, pango, cairo, gobjectIntrospection, wayland, gnome3
+, pangoSupport ? true, pango, cairo, gobject-introspection, wayland, gnome3
 , mesa_noglu
 , gstreamerSupport ? true, gst_all_1 }:
 
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (!stdenv.isDarwin) [ "--enable-gles1" "--enable-gles2" ];
 
   propagatedBuildInputs = with xorg; [
-      glib gdk_pixbuf gobjectIntrospection wayland mesa_noglu
+      glib gdk_pixbuf gobject-introspection wayland mesa_noglu
       libGL libXrandr libXfixes libXcomposite libXdamage
     ]
     ++ stdenv.lib.optionals gstreamerSupport [ gst_all_1.gstreamer

--- a/pkgs/development/libraries/dee/default.nix
+++ b/pkgs/development/libraries/dee/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, pkgconfig
-, glib, icu, gobjectIntrospection }:
+, glib, icu, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "dee-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "12mzffk0lyd566y46x57jlvb9af152b4dqpasr40zal4wrn37w0v";
   };
 
-  buildInputs = [ glib gobjectIntrospection icu ];
+  buildInputs = [ glib gobject-introspection icu ];
   nativeBuildInputs = [ python pkgconfig ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=misleading-indentation" ]; # gcc-6

--- a/pkgs/development/libraries/farstream/default.nix
+++ b/pkgs/development/libraries/farstream/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libnice, pkgconfig, pythonPackages, gstreamer, gst-plugins-base
-, gst-python, gupnp-igd, gobjectIntrospection
+, gst-python, gupnp-igd, gobject-introspection
 , gst-plugins-good, gst-plugins-bad, gst-libav
 }:
 
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ libnice python pygobject2 gupnp-igd libnice ];
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
 
   propagatedBuildInputs = [
     gstreamer gst-plugins-base gst-python

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43, docbook_xsl, which, libxml2
-, gobjectIntrospection, gtk-doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc, xdg-dbus-proxy, p11-kit
+, gobject-introspection, gtk-doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc, xdg-dbus-proxy, p11-kit
 , bubblewrap, bzip2, dbus, glib, gpgme, json-glib, libarchive, libcap, libseccomp, coreutils, python2, hicolor-icon-theme
 , libsoup, lzma, ostree, polkit, python3, systemd, xorg, valgrind, glib-networking, makeWrapper, gnome3 }:
 
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    autoreconfHook libxml2 docbook_xml_dtd_412 docbook_xml_dtd_42 docbook_xml_dtd_43 docbook_xsl which gobjectIntrospection
+    autoreconfHook libxml2 docbook_xml_dtd_412 docbook_xml_dtd_42 docbook_xml_dtd_43 docbook_xsl which gobject-introspection
     gtk-doc intltool libxslt pkgconfig xmlto appstream-glib yacc makeWrapper
   ];
 

--- a/pkgs/development/libraries/gcab/default.nix
+++ b/pkgs/development/libraries/gcab/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gettext, gobjectIntrospection, pkgconfig
+{ stdenv, fetchurl, gettext, gobject-introspection, pkgconfig
 , meson, ninja, glibcLocales, git, vala, glib, zlib
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0l19sr6pg0cfcddmi5n79d08mjjbhn427ip5jlsy9zddq9r24aqr";
   };
 
-  nativeBuildInputs = [ meson ninja glibcLocales git pkgconfig vala gettext gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja glibcLocales git pkgconfig vala gettext gobject-introspection ];
 
   buildInputs = [ glib zlib ];
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, fixDarwinDylibNames, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
 , docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, jasper, gobjectIntrospection, doCheck ? false, makeWrapper }:
+, jasper, gobject-introspection, doCheck ? false, makeWrapper }:
 
 let
   pname = "gdk-pixbuf";
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext python3 libxml2 libxslt docbook_xsl docbook_xml_dtd_43
-    gtk-doc gobjectIntrospection makeWrapper
+    gtk-doc gobject-introspection makeWrapper
   ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
     "-Ddocs=true"
     "-Djasper=true"
     "-Dx11=true"
-    "-Dgir=${if gobjectIntrospection != null then "true" else "false"}"
+    "-Dgir=${if gobject-introspection != null then "true" else "false"}"
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/geis/default.nix
+++ b/pkgs/development/libraries/geis/default.nix
@@ -7,7 +7,7 @@
 , evemu
 , frame
 , gdk_pixbuf
-, gobjectIntrospection
+, gobject-introspection
 , grail
 , gtk3
 , libX11
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     [ pygobject3  ];
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook python3Packages.wrapPython];
-  buildInputs = [ atk dbus evemu frame gdk_pixbuf gobjectIntrospection grail
+  buildInputs = [ atk dbus evemu frame gdk_pixbuf gobject-introspection grail
     gtk3 libX11 libXext libXi libXtst pango python3Packages.python xorgserver
   ];
 

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, fetchpatch, intltool, pkgconfig, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, json-glib, libsoup, libnotify, gdk_pixbuf
-, modemmanager, avahi, glib-networking, wrapGAppsHook, gobjectIntrospection
+, modemmanager, avahi, glib-networking, wrapGAppsHook, gobject-introspection
 , withDemoAgent ? false
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
 
   nativeBuildInputs = [
-    pkgconfig intltool wrapGAppsHook gobjectIntrospection
+    pkgconfig intltool wrapGAppsHook gobject-introspection
     # devdoc
     gtk-doc docbook_xsl docbook_xml_dtd_412
   ];

--- a/pkgs/development/libraries/gmime/2.nix
+++ b/pkgs/development/libraries/gmime/2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, zlib, gnupg, libgpgerror, gobjectIntrospection }:
+{ stdenv, fetchurl, pkgconfig, glib, zlib, gnupg, libgpgerror, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   version = "2.6.23";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
   propagatedBuildInputs = [ glib zlib libgpgerror ];
   configureFlags = [ "--enable-introspection=yes" ];
 

--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, zlib, gnupg, gpgme, libidn2, libunistring, gobjectIntrospection }:
+{ stdenv, fetchurl, pkgconfig, glib, zlib, gnupg, gpgme, libidn2, libunistring, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   version = "3.2.3";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ gobjectIntrospection zlib gpgme libidn2 libunistring ];
+  buildInputs = [ gobject-introspection zlib gpgme libidn2 libunistring ];
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ glib ];
   configureFlags = [ "--enable-introspection=yes" ];

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -3,7 +3,7 @@
 , substituteAll, nixStoreDir ? builtins.storeDir
 , x11Support ? true
 }:
-# now that gobjectIntrospection creates large .gir files (eg gtk3 case)
+# now that gobject-introspection creates large .gir files (eg gtk3 case)
 # it may be worth thinking about using multiple derivation outputs
 # In that case its about 6MB which could be separated
 
@@ -60,7 +60,6 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;
-      attrPath = "gobjectIntrospection";
     };
   };
 

--- a/pkgs/development/libraries/goocanvas/2.x.nix
+++ b/pkgs/development/libraries/goocanvas/2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gettext, gtk-doc, gobjectIntrospection, python2, gtk3, cairo, glib }:
+{ stdenv, fetchurl, pkgconfig, gettext, gtk-doc, gobject-introspection, python2, gtk3, cairo, glib }:
 
 let
   version = "2.0.4";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig gettext gtk-doc python2 ];
-  buildInputs = [ gtk3 cairo glib gobjectIntrospection ];
+  buildInputs = [ gtk3 cairo glib gobject-introspection ];
 
   configureFlags = [
     "--disable-python"

--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, ninja, vala_0_40, pkgconfig, gobjectIntrospection, gnome3, gtk3, glib, gettext }:
+{ stdenv, fetchFromGitHub, cmake, ninja, vala_0_40, pkgconfig, gobject-introspection, gnome3, gtk3, glib, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "granite";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     gettext
-    gobjectIntrospection
+    gobject-introspection
     ninja
     pkgconfig
     vala_0_40 # should be `elementary.vala` when elementary attribute set is merged

--- a/pkgs/development/libraries/gsettings-qt/default.nix
+++ b/pkgs/development/libraries/gsettings-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchbzr, pkgconfig, qmake, qtbase, qtdeclarative, glib, gobjectIntrospection }:
+{ stdenv, fetchbzr, pkgconfig, qmake, qtbase, qtdeclarative, glib, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gsettings-qt-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     qmake
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gsignond/default.nix
+++ b/pkgs/development/libraries/gsignond/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, pkgconfig, meson, ninja, glib, glib-networking
-, sqlite, gobjectIntrospection, vala, gtk-doc, libsecret, docbook_xsl
+, sqlite, gobject-introspection, vala, gtk-doc, libsecret, docbook_xsl
 , docbook_xml_dtd_43, docbook_xml_dtd_45, glibcLocales, makeWrapper
 , symlinkJoin, gsignondPlugins, plugins }:
 
@@ -23,7 +23,7 @@ unwrapped = stdenv.mkDerivation rec {
     docbook_xml_dtd_45
     docbook_xsl
     glibcLocales
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     meson
     ninja

--- a/pkgs/development/libraries/gsignond/plugins/lastfm.nix
+++ b/pkgs/development/libraries/gsignond/plugins/lastfm.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, vala, glib, gsignond, json-glib, libsoup, gobjectIntrospection }:
+{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, vala, glib, gsignond, json-glib, libsoup, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gsignond-plugin-lastfm-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/development/libraries/gsignond/plugins/mail.nix
+++ b/pkgs/development/libraries/gsignond/plugins/mail.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, vala, glib, gsignond, gobjectIntrospection }:
+{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, vala, glib, gsignond, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gsignond-plugin-mail-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/development/libraries/gsignond/plugins/oauth.nix
+++ b/pkgs/development/libraries/gsignond/plugins/oauth.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitLab, fetchpatch, pkgconfig, meson, ninja, glib, gsignond, check
 , json-glib, libsoup, gnutls, gtk-doc, docbook_xml_dtd_43, docbook_xml_dtd_45
-, docbook_xsl, glibcLocales, gobjectIntrospection }:
+, docbook_xsl, glibcLocales, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gsignond-plugin-oauth-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_45
     docbook_xsl
     glibcLocales
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     meson
     ninja

--- a/pkgs/development/libraries/gsignond/plugins/sasl.nix
+++ b/pkgs/development/libraries/gsignond/plugins/sasl.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, fetchpatch, pkgconfig, meson, ninja, glib, gsignond, gsasl, check
-, gtk-doc, docbook_xml_dtd_43, docbook_xml_dtd_45, docbook_xsl, glibcLocales, gobjectIntrospection }:
+, gtk-doc, docbook_xml_dtd_43, docbook_xml_dtd_45, docbook_xsl, glibcLocales, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gsignond-plugin-sasl-${version}";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_45
     docbook_xsl
     glibcLocales
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     meson
     ninja

--- a/pkgs/development/libraries/gspell/default.nix
+++ b/pkgs/development/libraries/gspell/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, glib, gtk3, enchant2, isocodes, vala, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, libxml2, glib, gtk3, enchant2, isocodes, vala, gobject-introspection, gnome3 }:
 
 let
   pname = "gspell";
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ enchant2 ]; # required for pkgconfig
 
-  nativeBuildInputs = [ pkgconfig vala gobjectIntrospection libxml2 ];
+  nativeBuildInputs = [ pkgconfig vala gobject-introspection libxml2 ];
   buildInputs = [ glib gtk3 isocodes ];
 
   passthru = {

--- a/pkgs/development/libraries/gssdp/default.nix
+++ b/pkgs/development/libraries/gssdp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gobjectIntrospection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, libsoup, gtk3, glib }:
+{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, libsoup, gtk3, glib }:
 
 stdenv.mkDerivation rec {
   name = "gssdp-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1p1m2m3ndzr2whipqw4vfb6s6ia0g7rnzzc4pnq8b8g1qw4prqd1";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
   buildInputs = [ libsoup gtk3 ];
   propagatedBuildInputs = [ glib ];
 

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, lib
-, pkgconfig, meson, ninja, gettext, gobjectIntrospection
+, pkgconfig, meson, ninja, gettext, gobject-introspection
 , python3, gstreamer, orc, pango, libtheora
 , libintl, libopus
 , enableX11 ? stdenv.isLinux, libXv
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig python3 gettext gobjectIntrospection ]
+  nativeBuildInputs = [ pkgconfig python3 gettext gobject-introspection ]
 
   # Broken meson with Darwin. Should hopefully be fixed soon. Tracking
   # in https://bugzilla.gnome.org/show_bug.cgi?id=781148.

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, meson, ninja
-, pkgconfig, gettext, gobjectIntrospection
+, pkgconfig, gettext, gobject-introspection
 , bison, flex, python3, glib, makeWrapper
 , libcap,libunwind, darwin
 , lib
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev";
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext bison flex python3 makeWrapper gobjectIntrospection
+    meson ninja pkgconfig gettext bison flex python3 makeWrapper gobject-introspection
   ];
   buildInputs =
        lib.optionals stdenv.isLinux [ libcap libunwind ]

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, meson, ninja
 , pkgconfig, python, gst-plugins-base, libxml2
-, flex, perl, gettext, gobjectIntrospection
+, flex, perl, gettext, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection python flex perl ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext gobject-introspection python flex perl ];
 
   propagatedBuildInputs = [ gst-plugins-base libxml2 ];
 

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig
-, gst-plugins-base, gettext, gobjectIntrospection
+, gst-plugins-base, gettext, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja gettext gobjectIntrospection pkgconfig ];
+  nativeBuildInputs = [ meson ninja gettext gobject-introspection pkgconfig ];
 
   buildInputs = [ gst-plugins-base ];
 }

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gstreamer, gst-plugins-base
-, python, gobjectIntrospection, json-glib
+, python, gobject-introspection, json-glib
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
-    pkgconfig gobjectIntrospection
+    pkgconfig gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xorg
-, gdk_pixbuf, xlibsWrapper, gobjectIntrospection
+, gdk_pixbuf, xlibsWrapper, gobject-introspection
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? true, cups ? null
 , gdktarget ? if stdenv.isDarwin then "quartz" else "x11"
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  nativeBuildInputs = [ setupHook perl pkgconfig gettext gobjectIntrospection ];
+  nativeBuildInputs = [ setupHook perl pkgconfig gettext gobject-introspection ];
 
   patches = [
     ./2.0-immodules.cache.patch

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, gettext, perl, makeWrapper, shared-mime-info
-, expat, glib, cairo, pango, gdk_pixbuf, atk, at-spi2-atk, gobjectIntrospection
+, expat, glib, cairo, pango, gdk_pixbuf, atk, at-spi2-atk, gobject-introspection
 , xorg, epoxy, json-glib, libxkbcommon, gmp, gnome3
 , x11Support ? stdenv.isLinux
 , waylandSupport ? stdenv.isLinux, mesa_noglu, wayland, wayland-protocols
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
   outputBin = "dev";
 
-  nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection perl makeWrapper ];
+  nativeBuildInputs = [ pkgconfig gettext gobject-introspection perl makeWrapper ];
 
   patches = [
     ./3.0-immodules.cache.patch

--- a/pkgs/development/libraries/gtk-mac-integration/default.nix
+++ b/pkgs/development/libraries/gtk-mac-integration/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, glib, gtk-doc, gtk, gobjectIntrospection }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, glib, gtk-doc, gtk, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "gtk-mac-integration-2.0.8";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1fbhnvj0rqc3089ypvgnpkp6ad2rr37v5qk38008dgamb9h7f3qs";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig gtk-doc gobjectIntrospection ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig gtk-doc gobject-introspection ];
   buildInputs = [ glib ];
   propagatedBuildInputs = [ gtk ];
 

--- a/pkgs/development/libraries/gtksourceview/3.x.nix
+++ b/pkgs/development/libraries/gtksourceview/3.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala_0_40
-, libxml2, perl, intltool, gettext, gnome3, gobjectIntrospection, dbus, xvfb_run, shared-mime-info }:
+, libxml2, perl, intltool, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info }:
 
 let
   checkInputs = [ xvfb_run dbus ];
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig intltool perl gobjectIntrospection vala_0_40 ]
+  nativeBuildInputs = [ pkgconfig intltool perl gobject-introspection vala_0_40 ]
     ++ stdenv.lib.optionals doCheck checkInputs;
 
   buildInputs = [ atk cairo glib pango libxml2 gettext ];

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala_0_40
-, libxml2, perl, gettext, gnome3, gobjectIntrospection, dbus, xvfb_run, shared-mime-info }:
+, libxml2, perl, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info }:
 
 let
   checkInputs = [ xvfb_run dbus ];
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig gettext perl gobjectIntrospection vala_0_40 ]
+  nativeBuildInputs = [ pkgconfig gettext perl gobject-introspection vala_0_40 ]
     ++ stdenv.lib.optionals doCheck checkInputs;
 
   buildInputs = [ atk cairo glib pango libxml2 ];

--- a/pkgs/development/libraries/gtkspell/3.nix
+++ b/pkgs/development/libraries/gtkspell/3.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk3, aspell, pkgconfig, enchant2, isocodes, intltool, gobjectIntrospection, vala}:
+{stdenv, fetchurl, gtk3, aspell, pkgconfig, enchant2, isocodes, intltool, gobject-introspection, vala}:
 
 stdenv.mkDerivation rec {
   name = "gtkspell-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cjp6xdcnzh6kka42w9g0w2ihqjlq8yl8hjm9wsfnixk6qwgch5h";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection vala ];
+  nativeBuildInputs = [ pkgconfig intltool gobject-introspection vala ];
   buildInputs = [ aspell gtk3 enchant2 isocodes ];
   propagatedBuildInputs = [ enchant2 ];
 

--- a/pkgs/development/libraries/gupnp-av/default.nix
+++ b/pkgs/development/libraries/gupnp-av/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gobjectIntrospection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, gupnp, glib, libxml2 }:
+{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, gupnp, glib, libxml2 }:
 
 stdenv.mkDerivation rec {
   name = "gupnp-av-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nmq6wlbfsssanv3jgv2z0nhfkv8vzfr3gq5qa8svryvvn2fyf40";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
   buildInputs = [ gupnp glib libxml2 ];
 
   configureFlags = [

--- a/pkgs/development/libraries/gupnp-dlna/default.nix
+++ b/pkgs/development/libraries/gupnp-dlna/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gobjectIntrospection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, gupnp, gst_all_1 }:
+{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, gupnp, gst_all_1 }:
 
 stdenv.mkDerivation rec {
   name = "gupnp-dlna-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0spzd2saax7w776p5laixdam6d7smyynr9qszhbmq7f14y13cghj";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
   buildInputs = [ gupnp gst_all_1.gst-plugins-base ];
 
   configureFlags = [

--- a/pkgs/development/libraries/gupnp-igd/default.nix
+++ b/pkgs/development/libraries/gupnp-igd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gettext, gobjectIntrospection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, gupnp }:
+{ stdenv, fetchurl, pkgconfig, gettext, gobject-introspection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, gupnp }:
 
 stdenv.mkDerivation rec {
   name = "gupnp-igd-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "081v1vhkbz3wayv49xfiskvrmvnpx93k25am2wnarg5cifiiljlb";
   };
 
-  nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
+  nativeBuildInputs = [ pkgconfig gettext gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
   propagatedBuildInputs = [ glib gupnp ];
 
   configureFlags = [

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gobjectIntrospection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44, glib, gssdp, libsoup, libxml2, libuuid }:
+{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44, glib, gssdp, libsoup, libxml2, libuuid }:
 
 stdenv.mkDerivation rec {
   name = "gupnp-${version}";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ./fix-requires.patch
   ];
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection vala gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_44 ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_44 ];
   propagatedBuildInputs = [ glib gssdp libsoup libxml2 libuuid ];
 
   configureFlags = [

--- a/pkgs/development/libraries/gusb/default.nix
+++ b/pkgs/development/libraries/gusb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gobjectIntrospection
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gobject-introspection
 , gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44
 , glib, systemd, libusb1, vala, hwdata
 }:
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja pkgconfig gettext
     gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_44
-    gobjectIntrospection vala
+    gobject-introspection vala
   ];
   buildInputs = [ systemd glib ];
 

--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, meson, ninja, pkgconfig, gettext
-, gobjectIntrospection, fixDarwinDylibNames, gnome3
+, gobject-introspection, fixDarwinDylibNames, gnome3
 }:
 
 let
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ glib ];
-  nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext gobject-introspection ];
   buildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/jsonrpc-glib/default.nix
+++ b/pkgs/development/libraries/jsonrpc-glib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, glib, json-glib, pkgconfig, gobjectIntrospection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_43, gnome3 }:
+{ stdenv, fetchurl, meson, ninja, glib, json-glib, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_43, gnome3 }:
 let
   version = "3.30.0";
   pname = "jsonrpc-glib";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" "devdoc" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection vala gtk-doc docbook_xsl docbook_xml_dtd_43 ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_43 ];
   buildInputs = [ glib json-glib ];
 
   src = fetchurl {

--- a/pkgs/development/libraries/keybinder/default.nix
+++ b/pkgs/development/libraries/keybinder/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, gnome3
-, gtk-doc, gtk2, python2Packages, lua, gobjectIntrospection
+, gtk-doc, gtk2, python2Packages, lua, gobject-introspection
 }:
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     autoconf automake libtool gnome3.gnome-common gtk-doc gtk2
-    python pygtk lua gobjectIntrospection
+    python pygtk lua gobject-introspection
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/keybinder3/default.nix
+++ b/pkgs/development/libraries/keybinder3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, gnome3
-, gtk-doc, gtk3, libX11, libXext, libXrender, gobjectIntrospection
+, gtk-doc, gtk3, libX11, libXext, libXrender, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
   buildInputs = [
     gnome3.gnome-common gtk-doc gtk3
-    libX11 libXext libXrender gobjectIntrospection
+    libX11 libXext libXrender gobject-introspection
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/lasso/default.nix
+++ b/pkgs/development/libraries/lasso/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoconf, automake, autoreconfHook, fetchurl, glib, gobjectIntrospection, gtk-doc, libtool, libxml2, libxslt, openssl, pkgconfig, python27Packages, xmlsec, zlib }:
+{ stdenv, autoconf, automake, autoreconfHook, fetchurl, glib, gobject-introspection, gtk-doc, libtool, libxml2, libxslt, openssl, pkgconfig, python27Packages, xmlsec, zlib }:
 
 stdenv.mkDerivation rec {
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ autoconf automake glib gobjectIntrospection gtk-doc libtool libxml2 libxslt openssl python27Packages.six xmlsec zlib ];
+  buildInputs = [ autoconf automake glib gobject-introspection gtk-doc libtool libxml2 libxslt openssl python27Packages.six xmlsec zlib ];
 
   configurePhase = ''
     ./configure --with-pkg-config=$PKG_CONFIG_PATH \

--- a/pkgs/development/libraries/libaccounts-glib/default.nix
+++ b/pkgs/development/libraries/libaccounts-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, meson, ninja, glib, check, python3, vala, gtk-doc, glibcLocales
-, libxml2, libxslt, pkgconfig, sqlite, docbook_xsl, docbook_xml_dtd_43, gobjectIntrospection }:
+, libxml2, libxslt, pkgconfig, sqlite, docbook_xsl, docbook_xml_dtd_43, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "libaccounts-glib-${version}";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_43
     docbook_xsl
     glibcLocales
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     meson
     ninja

--- a/pkgs/development/libraries/libappindicator/default.nix
+++ b/pkgs/development/libraries/libappindicator/default.nix
@@ -5,7 +5,7 @@
 , glib, dbus-glib, gtkVersion ? "3"
 , gtk2 ? null, libindicator-gtk2 ? null, libdbusmenu-gtk2 ? null
 , gtk3 ? null, libindicator-gtk3 ? null, libdbusmenu-gtk3 ? null
-, python2Packages, gobjectIntrospection, vala
+, python2Packages, gobject-introspection, vala
 , monoSupport ? false, mono ? null, gtk-sharp-2_0 ? null
  }:
 
@@ -34,7 +34,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     glib dbus-glib
-    python pygobject2 pygtk gobjectIntrospection vala
+    python pygobject2 pygtk gobject-introspection vala
   ] ++ (if gtkVersion == "2"
     then [ libindicator-gtk2 ] ++ optionals monoSupport [ mono gtk-sharp-2_0 ]
     else [ libindicator-gtk3 ]);

--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk-doc, libxslt, docbook_xsl
-, docbook_xml_dtd_43, python3, gobjectIntrospection, glib, udev, kmod, parted, libyaml
+, docbook_xml_dtd_43, python3, gobject-introspection, glib, udev, kmod, parted, libyaml
 , cryptsetup, lvm2, dmraid, utillinux, libbytesize, libndctl, nss, volume_key
 }:
 
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    autoreconfHook pkgconfig gtk-doc libxslt docbook_xsl docbook_xml_dtd_43 python3 gobjectIntrospection
+    autoreconfHook pkgconfig gtk-doc libxslt docbook_xsl docbook_xml_dtd_43 python3 gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/libchamplain/default.nix
+++ b/pkgs/development/libraries/libchamplain/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, glib, gtk3, cairo, sqlite, gnome3
-, clutter-gtk, libsoup, gobjectIntrospection /*, libmemphis */ }:
+, clutter-gtk, libsoup, gobject-introspection /*, libmemphis */ }:
 
 let
   pname = "libchamplain";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
 
   propagatedBuildInputs = [ glib gtk3 cairo clutter-gtk sqlite libsoup ];
 

--- a/pkgs/development/libraries/libdazzle/default.nix
+++ b/pkgs/development/libraries/libdazzle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ninja, meson, pkgconfig, vala, gobjectIntrospection, libxml2
+{ stdenv, fetchurl, ninja, meson, pkgconfig, vala, gobject-introspection, libxml2
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43, glibcLocales, dbus, xvfb_run, glib, gtk3, gnome3 }:
 
 let
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     sha256 = "1m9n1gcxndly24rjkxzvmx02a2rkb6ad4cy7p6ncanm1kyp0wxvq";
   };
 
-  nativeBuildInputs = [ ninja meson pkgconfig vala gobjectIntrospection libxml2 gtk-doc docbook_xsl docbook_xml_dtd_43 glibcLocales dbus xvfb_run ];
+  nativeBuildInputs = [ ninja meson pkgconfig vala gobject-introspection libxml2 gtk-doc docbook_xsl docbook_xml_dtd_43 glibcLocales dbus xvfb_run ];
   buildInputs = [ glib gtk3 ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/libdbusmenu/default.nix
+++ b/pkgs/development/libraries/libdbusmenu/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, lib, file
 , pkgconfig, intltool
 , glib, dbus-glib, json-glib
-, gobjectIntrospection, vala_0_38, gnome-doc-utils
+, gobject-introspection, vala_0_38, gnome-doc-utils
 , gtkVersion ? null, gtk2 ? null, gtk3 ? null }:
 
 with lib;
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib dbus-glib json-glib
-    gobjectIntrospection vala_0_38 gnome-doc-utils
+    gobject-introspection vala_0_38 gnome-doc-utils
   ] ++ optional (gtkVersion != null) (if gtkVersion == "2" then gtk2 else gtk3);
 
   postPatch = ''

--- a/pkgs/development/libraries/libgrss/default.nix
+++ b/pkgs/development/libraries/libgrss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, vala, gobjectIntrospection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, libxml2, libsoup, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, vala, gobject-introspection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, libxml2, libsoup, gnome3 }:
 
 let
   version = "0.7.0";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "1nalslgyglvhpva3px06fj6lv5zgfg0qmj0sbxyyl5d963vc02b7";
   };
 
-  nativeBuildInputs = [ pkgconfig vala gobjectIntrospection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
+  nativeBuildInputs = [ pkgconfig vala gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
   buildInputs = [ glib libxml2 libsoup ];
 
   configureFlags = [

--- a/pkgs/development/libraries/libgtop/default.nix
+++ b/pkgs/development/libraries/libgtop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, glib, pkgconfig, perl, gettext, gobjectIntrospection, libtool, gnome3, gtk-doc }:
+{ stdenv, fetchurl, fetchpatch, glib, pkgconfig, perl, gettext, gobject-introspection, libtool, gnome3, gtk-doc }:
 let
   pname = "libgtop";
   version = "2.38.0";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [ glib ];
-  nativeBuildInputs = [ pkgconfig gnome3.gnome-common libtool gtk-doc perl gettext gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gnome3.gnome-common libtool gtk-doc perl gettext gobject-introspection ];
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, udev, glib, gobjectIntrospection, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, udev, glib, gobject-introspection, gnome3 }:
 
 let
   pname = "libgudev";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
     sha256 = "ee4cb2b9c573cdf354f6ed744f01b111d4b5bed3503ffa956cefff50489c7860";
   };
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
   buildInputs = [ udev glib ];
 
   # There's a dependency cycle with umockdev and the tests fail to LD_PRELOAD anyway.

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, meson, ninja, pkgconfig, gobjectIntrospection, vala
+{ stdenv, fetchFromGitLab, meson, ninja, pkgconfig, gobject-introspection, vala
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43
 , gtk3, gnome3
 , dbus, xvfb_run, libxml2
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gobjectIntrospection vala
+    meson ninja pkgconfig gobject-introspection vala
     gtk-doc docbook_xsl docbook_xml_dtd_43
   ];
   buildInputs = [ gnome3.gnome-desktop gtk3 gnome3.glade libxml2 ];

--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, meson, ninja, makeFontsConf, vala_0_40
-, gnome3, glib, json-glib, libarchive, libsoup, gobjectIntrospection }:
+, gnome3, glib, json-glib, libarchive, libsoup, gobject-introspection }:
 
 let
   pname = "libhttpseverywhere";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   };
 
   # Broken with newest Vala https://gitlab.gnome.org/GNOME/libhttpseverywhere/issues/1
-  nativeBuildInputs = [ vala_0_40 gobjectIntrospection meson ninja pkgconfig ];
+  nativeBuildInputs = [ vala_0_40 gobject-introspection meson ninja pkgconfig ];
   buildInputs = [ glib gnome3.libgee json-glib libsoup libarchive ];
 
   mesonFlags = [ "-Denable_valadoc=true" ];

--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, pkgconfig, cmake, ninja, vala, gobjectIntrospection
+{ stdenv, fetchFromGitHub, perl, pkgconfig, cmake, ninja, vala, gobject-introspection
 , python3, tzdata, gtk-doc, docbook_xsl, docbook_xml_dtd_43, glib, libxml2, icu }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    perl pkgconfig cmake ninja vala gobjectIntrospection
+    perl pkgconfig cmake ninja vala gobject-introspection
     (python3.withPackages (pkgs: with pkgs; [ pygobject3 ])) # running libical-glib tests
     gtk-doc docbook_xsl docbook_xml_dtd_43 # docs
   ];

--- a/pkgs/development/libraries/libindicate/default.nix
+++ b/pkgs/development/libraries/libindicate/default.nix
@@ -4,7 +4,7 @@
 , pkgconfig, autoconf
 , glib, dbus-glib, libdbusmenu
 , gtkVersion ? "3", gtk2 ? null, gtk3 ? null
-, pythonPackages, gobjectIntrospection, vala, gnome-doc-utils
+, pythonPackages, gobject-introspection, vala, gnome-doc-utils
 , monoSupport ? false, mono ? null, gtk-sharp-2_0 ? null
  }:
 
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
     sha256 = "10am0ymajx633b33anf6b79j37k61z30v9vaf5f9fwk1x5cw1q21";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf gobjectIntrospection vala gnome-doc-utils ];
+  nativeBuildInputs = [ pkgconfig autoconf gobject-introspection vala gnome-doc-utils ];
 
   buildInputs = [
     glib dbus-glib libdbusmenu

--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -1,7 +1,7 @@
 { gtkWidgets ? false # build GTK widgets for libinfinity
 , avahiSupport ? false # build support for Avahi in libinfinity
 , stdenv, fetchurl, pkgconfig, glib, libxml2, gnutls, gsasl
-, gobjectIntrospection
+, gobject-introspection
 , gtk3 ? null, gtk-doc, docbook_xsl, docbook_xml_dtd_412, avahi ? null, libdaemon, libidn, gss
 , libintl }:
 
@@ -21,7 +21,7 @@ let
 
     outputs = [ "bin" "out" "dev" "man" "devdoc" ];
 
-    nativeBuildInputs = [ pkgconfig gtk-doc docbook_xsl docbook_xml_dtd_412 gobjectIntrospection ];
+    nativeBuildInputs = [ pkgconfig gtk-doc docbook_xsl docbook_xml_dtd_412 gobject-introspection ];
     buildInputs = [ glib libxml2 gsasl libidn gss libintl libdaemon ]
       ++ stdenv.lib.optional gtkWidgets gtk3
       ++ stdenv.lib.optional avahiSupport avahi;

--- a/pkgs/development/libraries/liblangtag/default.nix
+++ b/pkgs/development/libraries/liblangtag/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, fetchFromBitbucket, autoreconfHook, gtkdoc, gettext
-, pkgconfig, glib, libxml2, gobjectIntrospection, gnome-common, unzip
+, pkgconfig, glib, libxml2, gobject-introspection, gnome-common, unzip
 }:
 
 stdenv.mkDerivation rec {
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     ''--with-locale-alias=${stdenv.cc.libc}/share/locale/locale.alias''
   ];
 
-  buildInputs = [ gettext glib libxml2 gobjectIntrospection gnome-common
+  buildInputs = [ gettext glib libxml2 gobject-introspection gnome-common
     unzip ];
   nativeBuildInputs = [ autoreconfHook gtkdoc gettext pkgconfig ];
 

--- a/pkgs/development/libraries/libmanette/default.nix
+++ b/pkgs/development/libraries/libmanette/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ninja, meson, pkgconfig, vala, gobjectIntrospection
+{ stdenv, fetchurl, ninja, meson, pkgconfig, vala, gobject-introspection
 , glib, libgudev, libevdev, gnome3 }:
 
 let
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     sha256 = "14vqz30p4693yy3yxs0gj858x25sl2kawib1g9lj8g5frgl0hd82";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig vala gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig vala gobject-introspection ];
   buildInputs = [ glib libgudev libevdev ];
 
   doCheck = true;

--- a/pkgs/development/libraries/libmx/default.nix
+++ b/pkgs/development/libraries/libmx/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , libtool, pkgconfig, automake, autoconf, intltool
-, glib, gobjectIntrospection, gtk2, gtk-doc
+, glib, gobject-introspection, gtk2, gtk-doc
 , clutter, clutter-gtk
 }:
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     automake autoconf libtool
     intltool
-    gobjectIntrospection glib
+    gobject-introspection glib
     gtk2 gtk-doc clutter clutter-gtk
   ];
 

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, autoreconfHook
-, glib, gdk_pixbuf, gobjectIntrospection }:
+, glib, gdk_pixbuf, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   ver_maj = "0.7";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   # disable tests as we don't need to depend on gtk+(2/3)
   configureFlags = [ "--disable-tests" ];
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook gobject-introspection ];
   buildInputs = [ glib gdk_pixbuf ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gobjectIntrospection, gtk-doc, docbook_xsl
+{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gobject-introspection, gtk-doc, docbook_xsl
 , glib, libsoup, libxml2, libxslt, check, curl, perl, hwdata, osinfo-db, vala ? null
 }:
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
 
   nativeBuildInputs = [
-    pkgconfig vala intltool gobjectIntrospection gtk-doc docbook_xsl
+    pkgconfig vala intltool gobject-introspection gtk-doc docbook_xsl
   ];
   buildInputs = [ glib libsoup libxml2 libxslt ];
   checkInputs = [ check curl perl ];

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, pkgconfig, glib, gdk_pixbuf, pango, cairo, libxml2, libgsf
 , bzip2, libcroco, libintl, darwin, rust, gnome3
 , withGTK ? false, gtk3 ? null
-, vala, gobjectIntrospection }:
+, vala, gobject-introspection }:
 
 let
   pname = "librsvg";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib gdk_pixbuf cairo ] ++ lib.optional withGTK gtk3;
 
-  nativeBuildInputs = [ pkgconfig rust.rustc rust.cargo vala gobjectIntrospection ]
+  nativeBuildInputs = [ pkgconfig rust.rustc rust.cargo vala gobject-introspection ]
     ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       ApplicationServices
     ]);

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, pkgconfig, intltool, libxslt, python3, docbook_xsl, docbook_xml_dtd_42
-, libgcrypt, gobjectIntrospection, vala, gtk-doc, gnome3, libintl, dbus, xvfb_run }:
+, libgcrypt, gobject-introspection, vala, gtk-doc, gnome3, libintl, dbus, xvfb_run }:
 
 stdenv.mkDerivation rec {
   pname = "libsecret";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
 
   propagatedBuildInputs = [ glib ];
-  nativeBuildInputs = [ pkgconfig intltool libxslt docbook_xsl docbook_xml_dtd_42 libintl gobjectIntrospection vala gtk-doc ];
+  nativeBuildInputs = [ pkgconfig intltool libxslt docbook_xsl docbook_xml_dtd_42 libintl gobject-introspection vala gtk-doc ];
   buildInputs = [ libgcrypt ];
   # optional: build docs with gtk-doc? (probably needs a flag as well)
 

--- a/pkgs/development/libraries/libsignon-glib/default.nix
+++ b/pkgs/development/libraries/libsignon-glib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, meson, ninja, vala, python3, gtk-doc, docbook_xsl, docbook_xml_dtd_43, docbook_xml_dtd_412, glib, check, gobjectIntrospection }:
+{ stdenv, fetchgit, pkgconfig, meson, ninja, vala, python3, gtk-doc, docbook_xsl, docbook_xml_dtd_43, docbook_xml_dtd_412, glib, check, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   pname = "libsignon-glib";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_412
     docbook_xml_dtd_43
     docbook_xsl
-    gobjectIntrospection
+    gobject-introspection
     gtk-doc
     meson
     ninja

--- a/pkgs/development/libraries/libskk/default.nix
+++ b/pkgs/development/libraries/libskk/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub,
   libtool, gettext, pkgconfig,
-  vala, gnome-common, gobjectIntrospection,
+  vala, gnome-common, gobject-introspection,
   libgee, json-glib, skk-dicts, libxkbcommon }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ skk-dicts libxkbcommon ];
-  nativeBuildInputs = [ vala gnome-common gobjectIntrospection libtool gettext pkgconfig ];
+  nativeBuildInputs = [ vala gnome-common gobject-introspection libtool gettext pkgconfig ];
   propagatedBuildInputs = [ libgee json-glib ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, libxml2, meson, ninja, pkgconfig, gnome3
-, gnomeSupport ? true, sqlite, glib-networking, gobjectIntrospection, vala
+, gnomeSupport ? true, sqlite, glib-networking, gobject-introspection, vala
 , libpsl, python3 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   buildInputs = [ python3 sqlite libpsl ];
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection vala ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection vala ];
   propagatedBuildInputs = [ glib libxml2 ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/libunique/3.x.nix
+++ b/pkgs/development/libraries/libunique/3.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig
-, dbus, dbus-glib, gtk3, gobjectIntrospection
+, dbus, dbus-glib, gtk3, gobject-introspection
 , gtkdoc, docbook_xml_dtd_45, docbook_xsl
 , libxslt, libxml2 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ dbus dbus-glib gtk3 gobjectIntrospection gtkdoc docbook_xml_dtd_45 docbook_xsl libxslt libxml2 ];
+  buildInputs = [ dbus dbus-glib gtk3 gobject-introspection gtkdoc docbook_xml_dtd_45 docbook_xsl libxslt libxml2 ];
 
   meta = {
     homepage = https://wiki.gnome.org/Attic/LibUnique;

--- a/pkgs/development/libraries/libunity/default.nix
+++ b/pkgs/development/libraries/libunity/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, automake, autoconf, libtool
-, glib, vala, dee, gobjectIntrospection, libdbusmenu
+, glib, vala, dee, gobject-introspection, libdbusmenu
 , gtk3, intltool, gnome-common, python3, icu }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     autoconf
     automake
     gnome-common
-    gobjectIntrospection
+    gobject-introspection
     intltool
     libtool
     pkgconfig

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libvirt, glib, libxml2, intltool, libtool, yajl
-, nettle, libgcrypt, pythonPackages, gobjectIntrospection, libcap_ng, numactl
+, nettle, libgcrypt, pythonPackages, gobject-introspection, libcap_ng, numactl
 , xen, libapparmor, vala
 }:
 
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig vala ];
   buildInputs = [
     libvirt glib libxml2 intltool libtool yajl nettle libgcrypt
-    python pygobject2 gobjectIntrospection libcap_ng numactl libapparmor
+    python pygobject2 gobject-introspection libcap_ng numactl libapparmor
   ] ++ stdenv.lib.optionals stdenv.isx86_64 [
     xen
   ];

--- a/pkgs/development/libraries/libwnck/3.x.nix
+++ b/pkgs/development/libraries/libwnck/3.x.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, pkgconfig, libX11, gtk3, intltool, gobjectIntrospection, gnome3}:
+{stdenv, fetchurl, pkgconfig, libX11, gtk3, intltool, gobject-introspection, gnome3}:
 
 let
   pname = "libwnck";
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec{
 
   configureFlags = [ "--enable-introspection" ];
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
   propagatedBuildInputs = [ libX11 gtk3 ];
 
   PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";

--- a/pkgs/development/libraries/libxklavier/default.nix
+++ b/pkgs/development/libraries/libxklavier/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, autoreconfHook, pkgconfig, gtk-doc, xkeyboard_config, libxml2, xorg, docbook_xsl
-, glib, isocodes, gobjectIntrospection }:
+, glib, isocodes, gobject-introspection }:
 
 let
   version = "5.4";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig gtk-doc docbook_xsl ];
 
-  buildInputs = [ gobjectIntrospection ];
+  buildInputs = [ gobject-introspection ];
 
   preAutoreconf = ''
     export NOCONFIGURE=1

--- a/pkgs/development/libraries/osm-gps-map/default.nix
+++ b/pkgs/development/libraries/osm-gps-map/default.nix
@@ -1,4 +1,4 @@
-{ cairo, fetchzip, glib, gnome3, gobjectIntrospection, pkgconfig, stdenv }:
+{ cairo, fetchzip, glib, gnome3, gobject-introspection, pkgconfig, stdenv }:
 
 stdenv.mkDerivation rec {
   name = "osm-gps-map-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [
-    cairo glib gobjectIntrospection
+    cairo glib gobject-introspection
   ] ++ (with gnome3; [
     gnome-common gtk libsoup
   ]);

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libXft, cairo, harfbuzz
-, libintl, gobjectIntrospection, darwin, fribidi, gnome3
+, libintl, gobject-introspection, darwin, fribidi, gnome3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43, makeFontsConf, freefont_ttf
 }:
 
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "devdoc" ];
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection gtk-doc docbook_xsl docbook_xml_dtd_43 ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_43 ];
   buildInputs = optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     Carbon
     CoreGraphics

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig, glib, expat, pam, perl
-, intltool, spidermonkey_52 , gobjectIntrospection, libxslt, docbook_xsl, dbus
+, intltool, spidermonkey_52 , gobject-introspection, libxslt, docbook_xsl, dbus
 , docbook_xml_dtd_412, gtk-doc, coreutils
 , useSystemd ? stdenv.isLinux, systemd
 , doCheck ? stdenv.isLinux
@@ -28,10 +28,10 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ]; # small man pages in $bin
 
   nativeBuildInputs =
-    [ gtk-doc pkgconfig autoreconfHook intltool gobjectIntrospection perl ]
+    [ gtk-doc pkgconfig autoreconfHook intltool gobject-introspection perl ]
     ++ [ libxslt docbook_xsl docbook_xml_dtd_412 ]; # man pages
   buildInputs =
-    [ glib expat pam spidermonkey_52 gobjectIntrospection ]
+    [ glib expat pam spidermonkey_52 gobject-introspection ]
     ++ stdenv.lib.optional useSystemd systemd;
 
   NIX_CFLAGS_COMPILE = " -Wno-deprecated-declarations "; # for polkit 0.114 and glib 2.56

--- a/pkgs/development/libraries/poppler/0.61.nix
+++ b/pkgs/development/libraries/poppler/0.61.nix
@@ -2,7 +2,7 @@
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg, fetchpatch
 , withData ? true, poppler_data
 , qt5Support ? false, qtbase ? null
-, introspectionSupport ? false, gobjectIntrospection ? null
+, introspectionSupport ? false, gobject-introspection ? null
 , utils ? false
 , minimal ? false, suffix ? "glib"
 }:
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     [ zlib freetype fontconfig libjpeg openjpeg ]
     ++ optionals (!minimal) [ cairo lcms curl ]
     ++ optional qt5Support qtbase
-    ++ optional introspectionSupport gobjectIntrospection;
+    ++ optional introspectionSupport gobject-introspection;
 
   nativeBuildInputs = [ cmake ninja pkgconfig ];
 

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -2,7 +2,7 @@
 , zlib, curl, cairo, freetype, fontconfig, lcms, libjpeg, openjpeg
 , withData ? true, poppler_data
 , qt5Support ? false, qtbase ? null
-, introspectionSupport ? false, gobjectIntrospection ? null
+, introspectionSupport ? false, gobject-introspection ? null
 , utils ? false, nss ? null
 , minimal ? false, suffix ? "glib"
 }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     ++ optionals (!minimal) [ cairo lcms curl ]
     ++ optional qt5Support qtbase
     ++ optional utils nss
-    ++ optional introspectionSupport gobjectIntrospection;
+    ++ optional introspectionSupport gobject-introspection;
 
   nativeBuildInputs = [ cmake ninja pkgconfig ];
 

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, spice-protocol, gettext, celt_0_5_1
-, openssl, libpulseaudio, pixman, gobjectIntrospection, libjpeg_turbo, zlib
+, openssl, libpulseaudio, pixman, gobject-introspection, libjpeg_turbo, zlib
 , cyrus_sasl, python2Packages, autoreconfHook, usbredir, libsoup
 , withPolkit ? true, polkit, acl, usbutils
 , vala, gtk3, epoxy, libdrm, gst_all_1, phodav, opusfile }:
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
     libjpeg_turbo zlib cyrus_sasl python pygtk usbredir gtk3 epoxy libdrm phodav opusfile
   ] ++ optionals withPolkit [ polkit acl usbutils ] ;
 
-  nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala gobject-introspection ];
 
   PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 

--- a/pkgs/development/libraries/telepathy/glib/default.nix
+++ b/pkgs/development/libraries/telepathy/glib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, dbus-glib, glib, python2, pkgconfig, libxslt
-, gobjectIntrospection, vala, glibcLocales }:
+, gobject-introspection, vala, glibcLocales }:
 
 stdenv.mkDerivation rec {
   name = "telepathy-glib-0.24.1";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   LC_ALL = "en_US.UTF-8";
   propagatedBuildInputs = [ dbus-glib glib ];
 
-  nativeBuildInputs = [ pkgconfig libxslt gobjectIntrospection vala ];
+  nativeBuildInputs = [ pkgconfig libxslt gobject-introspection vala ];
   buildInputs = [ glibcLocales python2 ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/template-glib/default.nix
+++ b/pkgs/development/libraries/template-glib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobjectIntrospection, flex, bison, vala, gettext, gnome3, gtk-doc, docbook_xsl, docbook_xml_dtd_43 }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobject-introspection, flex, bison, vala, gettext, gnome3, gtk-doc, docbook_xsl, docbook_xml_dtd_43 }:
 let
   version = "3.30.0";
   pname = "template-glib";
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ meson ninja pkgconfig gettext flex bison vala glib gtk-doc docbook_xsl docbook_xml_dtd_43 ];
-  nativeBuildInputs = [ glib gobjectIntrospection ];
+  nativeBuildInputs = [ glib gobject-introspection ];
 
   mesonFlags = [
     "-Denable_gtk_doc=true"

--- a/pkgs/development/libraries/uhttpmock/default.nix
+++ b/pkgs/development/libraries/uhttpmock/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitLab, autoconf, gtk-doc, automake, libtool, pkgconfig, glib, libsoup, gobjectIntrospection }:
+{ stdenv, lib, fetchFromGitLab, autoconf, gtk-doc, automake, libtool, pkgconfig, glib, libsoup, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   version="0.5.0";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf gtk-doc automake libtool glib libsoup gobjectIntrospection ];
+  buildInputs = [ autoconf gtk-doc automake libtool glib libsoup gobject-introspection ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, umockdev, gobjectIntrospection
+{ stdenv, fetchFromGitHub, autoreconfHook, umockdev, gobject-introspection
 , pkgconfig, glib, systemd, libgudev, vala }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib systemd libgudev ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig vala gobjectIntrospection ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig vala gobject-introspection ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/webkitgtk/2.4.nix
+++ b/pkgs/development/libraries/webkitgtk/2.4.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, perl, python, ruby, bison, gperf, flex
-, pkgconfig, which, gettext, gobjectIntrospection, pruneLibtoolFiles
+, pkgconfig, which, gettext, gobject-introspection, pruneLibtoolFiles
 , gtk2, gtk3, wayland, libwebp, enchant, sqlite
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, xorg
 , gst-plugins-base, libobjc
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     perl python ruby bison gperf flex
-    pkgconfig which gettext gobjectIntrospection pruneLibtoolFiles
+    pkgconfig which gettext gobject-introspection pruneLibtoolFiles
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, python2, ruby, bison, gperf, cmake, ninja
-, pkgconfig, gettext, gobjectIntrospection, libnotify, gnutls, libgcrypt
+, pkgconfig, gettext, gobject-introspection, libnotify, gnutls, libgcrypt
 , gtk3, wayland, libwebp, enchant2, xorg, libxkbcommon, epoxy, at-spi2-core
 , libxml2, libsoup, libsecret, libxslt, harfbuzz, libpthreadstubs, pcre, nettle, libtasn1, p11-kit
 , libidn, libedit, readline, libGLU_combined, libintl
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake ninja perl python2 ruby bison gperf
-    pkgconfig gettext gobjectIntrospection
+    pkgconfig gettext gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/zeitgeist/default.nix
+++ b/pkgs/development/libraries/zeitgeist/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, pkgconfig, glib, sqlite, gobjectIntrospection, vala
+{ stdenv, fetchFromGitLab, pkgconfig, glib, sqlite, gobject-introspection, vala
 , autoconf, automake, libtool, gettext, dbus, telepathy-glib
 , gtk3, json-glib, librdf_raptor2, dbus-glib
 , pythonSupport ? true, python2Packages
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-session-bus-services-dir=$(out)/share/dbus-1/services" ];
 
   nativeBuildInputs = [
-    autoconf automake libtool pkgconfig gettext gobjectIntrospection vala python2Packages.python
+    autoconf automake libtool pkgconfig gettext gobject-introspection vala python2Packages.python
   ];
   buildInputs = [
     glib sqlite dbus telepathy-glib dbus-glib

--- a/pkgs/development/python-modules/dogtail/default.nix
+++ b/pkgs/development/python-modules/dogtail/default.nix
@@ -5,7 +5,7 @@
 , pyatspi
 , pycairo
 , at-spi2-core
-, gobjectIntrospection
+, gobject-introspection
 , gtk3
 , gsettings-desktop-schemas
 , fetchurl
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     ./nix-support.patch
   ];
 
-  nativeBuildInputs = [ gobjectIntrospection dbus xvfb_run ]; # for setup hooks
+  nativeBuildInputs = [ gobject-introspection dbus xvfb_run ]; # for setup hooks
   propagatedBuildInputs = [ at-spi2-core gtk3 pygobject3 pyatspi pycairo ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/goocalendar/default.nix
+++ b/pkgs/development/python-modules/goocalendar/default.nix
@@ -3,7 +3,7 @@
 , buildPythonPackage
 , pkgconfig
 , gtk3
-, gobjectIntrospection
+, gobject-introspection
 , pygtk
 , pygobject3
 , goocanvas2
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "ca3950c2728916d9fb703c886f3940ac9b76739f99ec840b0e1c2c282510e1ab";
   };
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection ];
   propagatedBuildInputs = [
     pygtk
     pygobject3

--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, cairomm, sparsehash, pycairo, autoreconfHook,
 pkgconfig, boost, expat, scipy, cgal, gmp, mpfr,
-gobjectIntrospection, pygobject3, gtk3, matplotlib, ncurses,
+gobject-introspection, pygobject3, gtk3, matplotlib, ncurses,
 buildPythonPackage }:
 
 buildPythonPackage rec {
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     sparsehash
     # drawing
     cairomm
-    gobjectIntrospection
+    gobject-introspection
     gtk3
     pycairo
     matplotlib

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage, fetchurl, meson, ninja, stdenv, pkgconfig, python, pygobject3
-, gobjectIntrospection, gst-plugins-base, isPy3k
+, gobject-introspection, gst-plugins-base, isPy3k
 }:
 
 let
@@ -46,7 +46,7 @@ in buildPythonPackage rec {
     substituteInPlace meson.build --replace python3 python${if isPy3k then "3" else "2"}
   '';
 
-  nativeBuildInputs = [ meson ninja pkgconfig python gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig python gobject-introspection ];
 
   mesonFlags = [
     "-Dpython=python${if isPy3k then "3" else "2"}"

--- a/pkgs/development/python-modules/gtimelog/default.nix
+++ b/pkgs/development/python-modules/gtimelog/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   LC_ALL="en_US.UTF-8";
 
   # TODO: AppIndicator
-  propagatedBuildInputs = [ pkgs.gobjectIntrospection pygobject3 pkgs.makeWrapper pkgs.gtk3 ];
+  propagatedBuildInputs = [ pkgs.gobject-introspection pygobject3 pkgs.makeWrapper pkgs.gtk3 ];
 
   checkPhase = ''
     substituteInPlace runtests --replace "/usr/bin/env python" "${python}/bin/${python.executable}"

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -2,7 +2,7 @@
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
 , enableGhostscript ? false, ghostscript ? null, gtk3
-, enableGtk2 ? false, pygtk ? null, gobjectIntrospection
+, enableGtk2 ? false, pygtk ? null, gobject-introspection
 , enableGtk3 ? false, cairo
 , enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , enableQt ? false, pyqt4
@@ -42,7 +42,7 @@ buildPythonPackage rec {
       libpng pkgconfig mock pytz ]
     ++ stdenv.lib.optional (pythonOlder "3.3") backports_functools_lru_cache
     ++ stdenv.lib.optional enableGtk2 pygtk
-    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
+    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ stdenv.lib.optionals enableQt [ pyqt4 ]
     ++ stdenv.lib.optionals (builtins.hasAttr "isPy2" python) [ functools32 subprocess32 ];

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -2,7 +2,7 @@
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
 , enableGhostscript ? true, ghostscript ? null, gtk3
-, enableGtk2 ? false, pygtk ? null, gobjectIntrospection
+, enableGtk2 ? false, pygtk ? null, gobject-introspection
 , enableGtk3 ? false, cairo
 , enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , enableQt ? false, pyqt4
@@ -44,7 +44,7 @@ buildPythonPackage rec {
       libpng pkgconfig mock pytz ]
     ++ stdenv.lib.optional (pythonOlder "3.3") backports_functools_lru_cache
     ++ stdenv.lib.optional enableGtk2 pygtk
-    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobjectIntrospection pygobject3 ]
+    ++ stdenv.lib.optionals enableGtk3 [ cairo pycairo gtk3 gobject-introspection pygobject3 ]
     ++ stdenv.lib.optionals enableTk [ tcl tk tkinter libX11 ]
     ++ stdenv.lib.optionals enableQt [ pyqt4 ];
 

--- a/pkgs/development/python-modules/neovim_gui/default.nix
+++ b/pkgs/development/python-modules/neovim_gui/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     sha256 = "1vpvr3zm3f9sxg1z1cl7f7gi8v1xksjdvxj62qnw65aqj3zqxnkz";
   };
 
-  propagatedBuildInputs = [ neovim click pygobject3 pkgs.gobjectIntrospection pkgs.makeWrapper pkgs.gtk3 ];
+  propagatedBuildInputs = [ neovim click pygobject3 pkgs.gobject-introspection pkgs.makeWrapper pkgs.gtk3 ];
 
   patchPhase = ''
     sed -i -e "s|entry_points=entry_points,|entry_points=dict(console_scripts=['pynvim=neovim.ui.cli:main [GUI]']),|" setup.py

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPythonPackage, pkgconfig, glib, gobjectIntrospection,
+{ stdenv, fetchurl, buildPythonPackage, pkgconfig, glib, gobject-introspection,
 pycairo, cairo, which, ncurses, meson, ninja, isPy3k, gnome3 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [ pkgconfig meson ninja ];
-  buildInputs = [ glib gobjectIntrospection ]
+  buildInputs = [ glib gobject-introspection ]
                  ++ stdenv.lib.optionals stdenv.isDarwin [ which ncurses ];
   propagatedBuildInputs = [ pycairo cairo ];
 

--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k
-, wrapGAppsHook, gobjectIntrospection, pygobject3, graphviz, gnome3 }:
+, wrapGAppsHook, gobject-introspection, pygobject3, graphviz, gnome3 }:
 
 buildPythonPackage rec {
   pname = "xdot";
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   disabled = !isPy3k;
 
   nativeBuildInputs = [ wrapGAppsHook ];
-  propagatedBuildInputs = [ gobjectIntrospection pygobject3 graphviz gnome3.gtk ];
+  propagatedBuildInputs = [ gobject-introspection pygobject3 graphviz gnome3.gtk ];
 
   meta = with lib; {
     description = "xdot.py is an interactive viewer for graphs written in Graphviz's dot";

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -22,7 +22,7 @@
 , pkgconfig , ncurses, xapian_1_2_22, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
 , msgpack, qt59, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
-, cairo, re2, rake, gobjectIntrospection, gdk_pixbuf, zeromq, graphicsmagick, libcxx, file
+, cairo, re2, rake, gobject-introspection, gdk_pixbuf, zeromq, graphicsmagick, libcxx, file
 , libselinux ? null, libsepol ? null
 }@args:
 
@@ -157,7 +157,7 @@ in
 
   gio2 = attrs: {
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ gtk2 pcre gobjectIntrospection ] ++ lib.optionals stdenv.isLinux [ utillinux libselinux libsepol ];
+    buildInputs = [ gtk2 pcre gobject-introspection ] ++ lib.optionals stdenv.isLinux [ utillinux libselinux libsepol ];
   };
 
   gitlab-markup = attrs: { meta.priority = 1; };
@@ -176,7 +176,7 @@ in
 
   gobject-introspection = attrs: {
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ gobjectIntrospection gtk2 pcre ];
+    buildInputs = [ gobject-introspection gtk2 pcre ];
   };
 
   grpc = attrs: {

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgconfig, fetchurl, itstool, intltool, libxml2, glib, gtk3
-, python3Packages, wrapGAppsHook, gnome3, libwnck3, gobjectIntrospection }:
+, python3Packages, wrapGAppsHook, gnome3, libwnck3, gobject-introspection }:
 
 let
   pname = "d-feet";
@@ -14,7 +14,7 @@ in python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook libxml2 ];
-  buildInputs = [ glib gtk3 gnome3.defaultIconTheme libwnck3 gobjectIntrospection ];
+  buildInputs = [ glib gtk3 gnome3.defaultIconTheme libwnck3 gobject-introspection ];
 
   propagatedBuildInputs = with python3Packages; [ pygobject3 pep8 ];
 

--- a/pkgs/development/tools/valadoc/default.nix
+++ b/pkgs/development/tools/valadoc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gnome3, automake, autoconf, which, libtool, pkgconfig, graphviz, glib, gobjectIntrospection, expat}:
+{stdenv, fetchurl, gnome3, automake, autoconf, which, libtool, pkgconfig, graphviz, glib, gobject-introspection, expat}:
 stdenv.mkDerivation rec {
   version = "0.36.1";
   name = "valadoc-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "07501k2j9c016bd7rfr6xzaxdplq7j9sd18b5ixbqdbipvn6whnv";
   };
 
-  nativeBuildInputs = [ automake autoconf which gnome3.vala libtool pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ automake autoconf which gnome3.vala libtool pkgconfig gobject-introspection ];
   buildInputs = [ graphviz glib gnome3.libgee expat ];
 
   passthru = {

--- a/pkgs/games/gshogi/default.nix
+++ b/pkgs/games/gshogi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonApplication, fetchFromGitHub
-, gtk3, gobjectIntrospection
+, gtk3, gobject-introspection
 , wrapGAppsHook, python3Packages }:
 
 buildPythonApplication rec {
@@ -17,7 +17,7 @@ buildPythonApplication rec {
 
   buildInputs = [
     gtk3
-    gobjectIntrospection
+    gobject-introspection
   ];
 
   nativeBuildInputs = [ wrapGAppsHook ];

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonApplication, fetchFromGitHub, wrapGAppsHook
-, gtk3, gobjectIntrospection, libappindicator-gtk3, librsvg
+, gtk3, gobject-introspection, libappindicator-gtk3, librsvg
 , evdev, pygobject3, pylibacl, pytest, bluez
 , linuxHeaders
 , libX11, libXext, libXfixes, libusb1, udev
@@ -18,7 +18,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapGAppsHook ];
 
-  buildInputs = [ gtk3 gobjectIntrospection libappindicator-gtk3 librsvg ];
+  buildInputs = [ gtk3 gobject-introspection libappindicator-gtk3 librsvg ];
 
   propagatedBuildInputs = [ evdev pygobject3 pylibacl ];
 

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk-doc, pkgconfig, gobjectIntrospection, intltool
+{ stdenv, fetchurl, gtk-doc, pkgconfig, gobject-introspection, intltool
 , libgudev, polkit, appstream-glib, gusb, sqlite, libarchive, glib-networking
 , libsoup, help2man, gpgme, libxslt, elfutils, libsmbios, efivar, glibcLocales
 , gnu-efi, libyaml, valgrind, meson, libuuid, colord, docbook_xml_dtd_43, docbook_xsl
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
   outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
 
   nativeBuildInputs = [
-    meson ninja gtk-doc pkgconfig gobjectIntrospection intltool glibcLocales shared-mime-info
+    meson ninja gtk-doc pkgconfig gobject-introspection intltool glibcLocales shared-mime-info
     valgrind gcab docbook_xml_dtd_43 docbook_xsl help2man libxslt python wrapGAppsHook vala
   ];
   buildInputs = [

--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -1,6 +1,6 @@
 { stdenv, meson, ninja, pkgconfig, gettext, fetchFromGitHub, python3
 , wrapGAppsHook, gtk3, glib, desktop-file-utils, appstream-glib, gnome3
-, gobjectIntrospection }:
+, gobject-introspection }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "piper-${version}";
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "1ny0vf8ym9v040cb5h084k5wwn929fnhq9infbdq8f8vvy61magb";
   };
 
-  nativeBuildInputs = [ meson ninja gettext pkgconfig wrapGAppsHook desktop-file-utils appstream-glib gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja gettext pkgconfig wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
   buildInputs = [ gtk3 glib gnome3.defaultIconTheme python3 ];
   propagatedBuildInputs = with python3.pkgs; [ lxml evdev pygobject3 ];
 

--- a/pkgs/os-specific/linux/tiscamera/default.nix
+++ b/pkgs/os-specific/linux/tiscamera/default.nix
@@ -8,7 +8,7 @@
 , libusb1
 , libzip
 , glib
-, gobjectIntrospection
+, gobject-introspection
 , gst_all_1
 , libwebcam
 }:
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     libusb1
     libzip
     glib
-    gobjectIntrospection
+    gobject-introspection
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     libwebcam

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, substituteAll, libtool, pkgconfig, intltool, gnused
 , gnome3, gtk-doc, acl, systemd, glib, libatasmart, polkit, coreutils, bash
 , expat, libxslt, docbook_xsl, utillinux, mdadm, libgudev, libblockdev, parted
-, gobjectIntrospection, docbook_xml_dtd_412, docbook_xml_dtd_43
+, gobject-introspection, docbook_xml_dtd_412, docbook_xml_dtd_43
 , xfsprogs, f2fs-tools, dosfstools, e2fsprogs, btrfs-progs, exfat, nilfs-utils, ntfs3g
 }:
 
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    pkgconfig gnome3.gnome-common libtool intltool gobjectIntrospection
+    pkgconfig gnome3.gnome-common libtool intltool gobject-introspection
     gtk-doc libxslt docbook_xml_dtd_412 docbook_xml_dtd_43 docbook_xsl
   ];
 

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, dbus-glib
 , intltool, libxslt, docbook_xsl, udev, libgudev, libusb1
-, useSystemd ? true, systemd, gobjectIntrospection
+, useSystemd ? true, systemd, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ dbus-glib intltool libxslt docbook_xsl udev libgudev libusb1 gobjectIntrospection ]
+    [ dbus-glib intltool libxslt docbook_xsl udev libgudev libusb1 gobject-introspection ]
     ++ stdenv.lib.optional useSystemd systemd;
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/X11/wpgtk/default.nix
+++ b/pkgs/tools/X11/wpgtk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, python36Packages, fetchFromGitHub, pywal, feh, libxslt, imagemagick,
-  gobjectIntrospection, gtk3, wrapGAppsHook, gnome3 }:
+  gobject-introspection, gtk3, wrapGAppsHook, gnome3 }:
 
 python36Packages.buildPythonApplication rec {
   pname = "wpgtk";
@@ -22,7 +22,7 @@ python36Packages.buildPythonApplication rec {
   buildInputs = [
     wrapGAppsHook
     gtk3
-    gobjectIntrospection
+    gobject-introspection
     gnome3.adwaita-icon-theme
     libxslt
   ];

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -3,7 +3,7 @@
 , wrapGAppsHook, xorgserver, getopt, xauth, utillinux, which
 , ffmpeg, x264, libvpx, libwebp
 , libfakeXinerama
-, gst_all_1, pulseaudio, gobjectIntrospection
+, gst_all_1, pulseaudio, gobject-introspection
 , pam }:
 
 with lib;
@@ -28,7 +28,7 @@ in buildPythonApplication rec {
     })
   ];
 
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig gobject-introspection wrapGAppsHook ];
   buildInputs = [
     cython
 

--- a/pkgs/tools/admin/gtk-vnc/default.nix
+++ b/pkgs/tools/admin/gtk-vnc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gobjectIntrospection
+{ stdenv, fetchurl, gobject-introspection
 , gnutls, cairo, libtool, glib, pkgconfig
 , cyrus_sasl, intltool, libpulseaudio
 , libgcrypt, gtk3, vala, gnome3
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    python3 pkgconfig intltool libtool gobjectIntrospection vala
+    python3 pkgconfig intltool libtool gobject-introspection vala
   ];
   buildInputs = [
     gnutls cairo glib libgcrypt cyrus_sasl libpulseaudio gtk3

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, writeScript, glibcLocales, diffPlugins
-, pythonPackages, imagemagick, gobjectIntrospection, gst_all_1
+, pythonPackages, imagemagick, gobject-introspection, gst_all_1
 , fetchpatch
 
 # Attributes needed for tests of the external plugins
@@ -121,7 +121,7 @@ in pythonPackages.buildPythonApplication rec {
     pythonPackages.unidecode
     pythonPackages.gst-python
     pythonPackages.pygobject3
-    gobjectIntrospection
+    gobject-introspection
   ] ++ optional enableAcoustid      pythonPackages.pyacoustid
     ++ optional (enableFetchart
               || enableEmbyupdate

--- a/pkgs/tools/audio/playerctl/default.nix
+++ b/pkgs/tools/audio/playerctl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, meson, ninja, fetchFromGitHub, glib, pkgconfig, gobjectIntrospection }:
+{ stdenv, meson, ninja, fetchFromGitHub, glib, pkgconfig, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   name = "playerctl-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jnylj5d6i29c5y6yjxg1a88r2qfbac5pj95f2aljjkfh9428jbb";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
   buildInputs = [ glib ];
 
   # docs somehow crashes the install phase:

--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, intltool, pkgconfig, python3Packages, bluez, gtk3
 , obex_data_server, xdg_utils, libnotify, dnsmasq, dhcp
-, hicolor-icon-theme, librsvg, wrapGAppsHook, gobjectIntrospection
+, hicolor-icon-theme, librsvg, wrapGAppsHook, gobject-introspection
 , withPulseAudio ? true, libpulseaudio }:
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gobjectIntrospection intltool pkgconfig pythonPackages.cython
+    gobject-introspection intltool pkgconfig pythonPackages.cython
     pythonPackages.wrapPython wrapGAppsHook
   ];
 

--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   autoreconfHook,
   gtk-doc,
-  gobjectIntrospection,
+  gobject-introspection,
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "1dwcpmpqbgb9lkajnqv50mrsn97mxbxpq6b5aya7fgfkgdnrs9sw";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc gobject-introspection ];
   buildInputs = [ glib libxml2 fftw orc lcms
     imagemagick openexr libtiff libjpeg
     libgsf libexif python27 libpng expat ]

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, pkgconfig
-, anthy, ibus, glib, gobjectIntrospection, gtk3, python3
+, anthy, ibus, glib, gobject-introspection, gtk3, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-anthy-zipcode=${anthy}/share/anthy/zipcode.t" ];
 
   buildInputs = [
-    anthy glib gobjectIntrospection gtk3 ibus (python3.withPackages (ps: [ps.pygobject3]))
+    anthy glib gobject-introspection gtk3 ibus (python3.withPackages (ps: [ps.pygobject3]))
   ];
 
   nativeBuildInputs = [ intltool pkgconfig python3.pkgs.wrapPython ];

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , autoreconfHook, docbook2x, pkgconfig
-, gtk3, dconf, gobjectIntrospection
+, gtk3, dconf, gobject-introspection
 , ibus, python3 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    dconf gtk3 gobjectIntrospection ibus (python3.withPackages (pypkgs: with pypkgs; [ pygobject3 ]))
+    dconf gtk3 gobject-introspection ibus (python3.withPackages (pypkgs: with pypkgs; [ pygobject3 ]))
   ];
 
   nativeBuildInputs = [ autoreconfHook docbook2x pkgconfig python3.pkgs.wrapPython ];

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, python3, ibus, pkgconfig, gtk3, m17n_lib
-, wrapGAppsHook, gobjectIntrospection
+, wrapGAppsHook, gobject-introspection
 }:
 
 let
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./hunspell-dirs.patch ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook gobjectIntrospection ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook gobject-introspection ];
   buildInputs = [ python ibus gtk3 m17n_lib ];
 
   preFixup = ''

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchFromGitHub, autoreconfHook, gconf, intltool, makeWrapper, pkgconfig
-, vala, wrapGAppsHook, dbus, dconf ? null, glib, gdk_pixbuf, gobjectIntrospection, gtk2
+, vala, wrapGAppsHook, dbus, dconf ? null, glib, gdk_pixbuf, gobject-introspection, gtk2
 , gtk3, gtk-doc, isocodes, python3, json-glib, libnotify ? null, enablePythonLibrary ? true
 , enableUI ? true, withWayland ? false, libxkbcommon ? null, wayland ? null
 , buildPackages }:
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
     dbus
     dconf
     gdk_pixbuf
-    gobjectIntrospection
+    gobject-introspection
     gtk2
     gtk3
     isocodes

--- a/pkgs/tools/inputmethods/libkkc/default.nix
+++ b/pkgs/tools/inputmethods/libkkc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, vala, gobjectIntrospection, intltool, python2Packages, glib
+, vala, gobject-introspection, intltool, python2Packages, glib
 , pkgconfig
 , libgee, json-glib, marisa, libkkc-data
 }:
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    vala gobjectIntrospection
+    vala gobject-introspection
     python2Packages.python python2Packages.marisa
     intltool glib pkgconfig
   ];

--- a/pkgs/tools/misc/clipster/default.nix
+++ b/pkgs/tools/misc/clipster/default.nix
@@ -1,5 +1,5 @@
 {fetchFromGitHub , stdenv, python3, gtk3, libwnck3,
- gobjectIntrospection, wrapGAppsHook }:
+ gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation  rec {
   name = "clipster-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation  rec {
 
   pythonEnv = python3.withPackages(ps: with ps; [ pygobject3 ]);
 
-  buildInputs =  [ pythonEnv gtk3 libwnck3 gobjectIntrospection wrapGAppsHook ];
+  buildInputs =  [ pythonEnv gtk3 libwnck3 gobject-introspection wrapGAppsHook ];
 
   installPhase = ''
     sed -i 's/python/python3/g' clipster

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, bash-completion
 , glib, polkit, pkgconfig, gettext, gusb, lcms2, sqlite, systemd, dbus
-, gobjectIntrospection, argyllcms, meson, ninja, libxml2, vala_0_40
+, gobject-introspection, argyllcms, meson, ninja, libxml2, vala_0_40
 , libgudev, sane-backends, gnome3, makeWrapper }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     "-Denable-docs=false"
   ];
 
-  nativeBuildInputs = [ meson pkgconfig vala_0_40 ninja gettext libxml2 gobjectIntrospection makeWrapper ];
+  nativeBuildInputs = [ meson pkgconfig vala_0_40 ninja gettext libxml2 gobject-introspection makeWrapper ];
 
   buildInputs = [ glib polkit gusb lcms2 sqlite systemd dbus bash-completion argyllcms libgudev sane-backends ];
 

--- a/pkgs/tools/misc/hashit/default.nix
+++ b/pkgs/tools/misc/hashit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, cmake, vala_0_40, python3, gnome3, gtk3, granite, gobjectIntrospection, desktop-file-utils, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, cmake, vala_0_40, python3, gnome3, gtk3, granite, gobject-introspection, desktop-file-utils, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "hashit";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     desktop-file-utils
-    gobjectIntrospection
+    gobject-introspection
     meson
     ninja
     pkgconfig

--- a/pkgs/tools/misc/ldmtool/default.nix
+++ b/pkgs/tools/misc/ldmtool/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf, automake, gtk-doc, pkgconfig, libuuid,
-  libtool, readline, gobjectIntrospection, json-glib, lvm2, libxslt, docbook_xsl }:
+  libtool, readline, gobject-introspection, json-glib, lvm2, libxslt, docbook_xsl }:
 
 stdenv.mkDerivation rec {
    name = "ldmtool-${version}";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
    nativeBuildInputs = [ pkgconfig ];
    buildInputs = [ autoconf automake gtk-doc lvm2 libxslt.bin
-     libtool readline gobjectIntrospection json-glib libuuid
+     libtool readline gobject-introspection json-glib libuuid
    ];
 
    meta = with stdenv.lib; {

--- a/pkgs/tools/misc/ostree/default.nix
+++ b/pkgs/tools/misc/ostree/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, gtk-doc, gobjectIntrospection, gnome3
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, gtk-doc, gobject-introspection, gnome3
 , glib, systemd, xz, e2fsprogs, libsoup, gpgme, which, autoconf, automake, libtool, fuse, utillinuxMinimal, libselinux
 , libarchive, libcap, bzip2, yacc, libxslt, docbook_xsl, docbook_xml_dtd_42, python3
 }:
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
-    autoconf automake libtool pkgconfig gtk-doc gobjectIntrospection which yacc
+    autoconf automake libtool pkgconfig gtk-doc gobject-introspection which yacc
     libxslt docbook_xsl docbook_xml_dtd_42
   ];
 

--- a/pkgs/tools/misc/rpm-ostree/default.nix
+++ b/pkgs/tools/misc/rpm-ostree/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchpatch, fetchFromGitHub, ostree, rpm, which, autoconf, automake, libtool, pkgconfig,
-  gobjectIntrospection, gtk-doc, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, gperf, cmake,
+  gobject-introspection, gtk-doc, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, gperf, cmake,
   libcap, glib, systemd, json-glib, libarchive, libsolv, librepo, polkit,
   bubblewrap, pcre, check, python }:
 
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkgconfig which autoconf automake libtool cmake gperf
-    gobjectIntrospection gtk-doc libxml2 libxslt docbook_xsl docbook_xml_dtd_42
+    gobject-introspection gtk-doc libxml2 libxslt docbook_xsl docbook_xml_dtd_42
   ];
   buildInputs = [
     libcap ostree rpm glib systemd polkit bubblewrap

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, udev, intltool, pkgconfig, glib, xmlto, wrapGAppsHook
 , docbook_xml_dtd_412, docbook_xsl
 , libxml2, desktop-file-utils, libusb1, cups, gdk_pixbuf, pango, atk, libnotify
-, gobjectIntrospection, libsecret
+, gobject-introspection, libsecret
 , cups-filters
 , pythonPackages
 }:
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib udev libusb1 cups
     pythonPackages.python
-    libnotify gobjectIntrospection gdk_pixbuf pango atk
+    libnotify gobject-introspection gdk_pixbuf pango atk
     libsecret
   ];
 

--- a/pkgs/tools/networking/network-manager/applet.nix
+++ b/pkgs/tools/networking/network-manager/applet.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, meson, ninja, intltool, gtk-doc, pkgconfig, networkmanager, gnome3
 , libnotify, libsecret, polkit, isocodes, modemmanager, libxml2, docbook_xsl, docbook_xml_dtd_43
 , mobile-broadband-provider-info, glib-networking, gsettings-desktop-schemas
-, libgudev, jansson, wrapGAppsHook, gobjectIntrospection, python3
+, libgudev, jansson, wrapGAppsHook, gobject-introspection, python3
 , libappindicator-gtk3, withGnome ? false }:
 
 let
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     libappindicator-gtk3
   ] ++ stdenv.lib.optionals withGnome [ gnome3.gcr ]; # advanced certificate chooser
 
-  nativeBuildInputs = [ meson ninja intltool pkgconfig wrapGAppsHook gobjectIntrospection python3 gtk-doc docbook_xsl docbook_xml_dtd_43 libxml2 ];
+  nativeBuildInputs = [ meson ninja intltool pkgconfig wrapGAppsHook gobject-introspection python3 gtk-doc docbook_xsl docbook_xml_dtd_43 libxml2 ];
 
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch, substituteAll, intltool, pkgconfig, dbus-glib
 , gnome3, systemd, libuuid, polkit, gnutls, ppp, dhcp, iptables
 , libgcrypt, dnsmasq, bluez5, readline
-, gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
+, gobject-introspection, modemmanager, openresolv, libndp, newt, libsoup
 , ethtool, gnused, coreutils, file, inetutils, kmod, jansson, libxslt
 , python3Packages, docbook_xsl, openconnect, curl, autoreconfHook }:
 
@@ -84,7 +84,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     systemd libuuid polkit ppp libndp curl
-    bluez5 dnsmasq gobjectIntrospection modemmanager readline newt libsoup jansson
+    bluez5 dnsmasq gobject-introspection modemmanager readline newt libsoup jansson
   ];
 
   propagatedBuildInputs = [ dbus-glib gnutls libgcrypt python3Packages.pygobject3 ];

--- a/pkgs/tools/networking/network-manager/dmenu.nix
+++ b/pkgs/tools/networking/network-manager/dmenu.nix
@@ -1,5 +1,5 @@
 { stdenv, glib, fetchFromGitHub, networkmanager, python3Packages
-, gobjectIntrospection }:
+, gobject-introspection }:
 
 let inherit (python3Packages) python pygobject3;
 in stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1z6151z7c4jv5k2i50zr7ld4k3m07dgpmss9f3hsav95cv55dcnb";
   };
 
-  buildInputs = [ glib python pygobject3 gobjectIntrospection networkmanager python3Packages.wrapPython ];
+  buildInputs = [ glib python pygobject3 gobject-introspection networkmanager python3Packages.wrapPython ];
 
   dontBuild = true;
 

--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, lib
 , intltool, glib, pkgconfig, polkit, python, sqlite
-, gobjectIntrospection, vala_0_38, gtk-doc, autoreconfHook, autoconf-archive
+, gobject-introspection, vala_0_38, gtk-doc, autoreconfHook, autoconf-archive
 # TODO: set enableNixBackend to true, as soon as it builds
 , nix, enableNixBackend ? false, boost
 , enableCommandNotFound ? false
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zr4b3ax8lcd3wkgj1cybs2cqf38br2nvl91qkw9g2jmzlq6bvic";
   };
 
-  buildInputs = [ glib polkit python gobjectIntrospection vala_0_38 ]
+  buildInputs = [ glib polkit python gobject-introspection vala_0_38 ]
                   ++ lib.optional enableSystemd systemd
                   ++ lib.optional enableBashCompletion bash-completion;
   propagatedBuildInputs = [ sqlite nix boost ];

--- a/pkgs/tools/security/gencfsm/default.nix
+++ b/pkgs/tools/security/gencfsm/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoconf, automake, intltool, libtool, pkgconfig, encfs
-, glib , gnome3, gtk3, libgnome-keyring, vala, wrapGAppsHook, xorg, gobjectIntrospection
+, glib , gnome3, gtk3, libgnome-keyring, vala, wrapGAppsHook, xorg, gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ autoconf automake intltool libtool vala glib encfs
     gtk3 libgnome-keyring gnome3.libgee xorg.libSM xorg.libICE
-    wrapGAppsHook gobjectIntrospection  ];
+    wrapGAppsHook gobject-introspection  ];
 
   patches = [ ./makefile-mkdir.patch ];
 

--- a/pkgs/tools/security/onioncircuits/default.nix
+++ b/pkgs/tools/security/onioncircuits/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pythonPackages, intltool, gtk3, gobjectIntrospection, defaultIconTheme }:
+{ stdenv, fetchgit, pythonPackages, intltool, gtk3, gobject-introspection, defaultIconTheme }:
 
 pythonPackages.buildPythonApplication rec {
   name = "onioncircuits-${version}";
@@ -10,7 +10,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "13mqif9b9iajpkrl9ijspdnvy82kxhprxd5mw3njk68rcn4z2pcm";
   };
 
-  buildInputs = [ intltool gtk3 gobjectIntrospection ];
+  buildInputs = [ intltool gtk3 gobject-introspection ];
   propagatedBuildInputs =  with pythonPackages; [ stem distutils_extra pygobject3 ];
 
   postFixup = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -113,6 +113,7 @@ mapAliases ({
   gnome_themes_standard = gnome-themes-standard; # added 2018-02-25
   gnustep-make = gnustep.make; # added 2016-7-6
   go-pup = pup; # added 2017-12-19
+  gobjectIntrospection = gobject-introspection; # added 2018-12-02
   goimports = gotools; # added 2018-09-16
   googleAuthenticator = google-authenticator; # added 2016-10-16
   grantlee5 = libsForQt5.grantlee;  # added 2015-12-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9895,7 +9895,7 @@ with pkgs;
   gns3-gui = gns3Packages.guiStable;
   gns3-server = gns3Packages.serverStable;
 
-  gobjectIntrospection = callPackage ../development/libraries/gobject-introspection {
+  gobject-introspection = callPackage ../development/libraries/gobject-introspection {
     nixStoreDir = config.nix.storeDir or builtins.storeDir;
     inherit (darwin) cctools;
   };

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -7,7 +7,7 @@
 
 { fetchurl, stdenv, lua, callPackage, unzip, zziplib, pkgconfig
 , pcre, oniguruma, gnulib, tre, glibc, sqlite, openssl, expat
-, glib, gobjectIntrospection, libevent, zlib, autoreconfHook, gnum4
+, glib, gobject-introspection, libevent, zlib, autoreconfHook, gnum4
 , mysql, postgresql, cyrus_sasl
 , fetchFromGitHub, libmpack, which, fetchpatch, writeText
 }:
@@ -927,7 +927,7 @@ let
     };
 
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ glib gobjectIntrospection lua ];
+    buildInputs = [ glib gobject-introspection lua ];
 
     makeFlags = [ "LUA_VERSION=${lua.luaversion}" ];
 


### PR DESCRIPTION
###### Motivation for this change
camelCase package name was a huge inconsistency in GNOME package set. This has been on my mind for a long time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

