### PR TITLE
pythonPackages.effect: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -8,12 +8,12 @@
 , testtools
 }:
 buildPythonPackage rec {
-  version = "0.11.0";
+  version = "0.12.0";
   pname = "effect";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1q75w4magkqd8ggabhhzzxmxakpdnn0vdg7ygj89zdc9yl7561q6";
+    sha256 = "0s8zsncq4l0ar2b4dijf8yzrk13x2swr1w2nb30s1p5jd6r24czl";
   };
   checkInputs = [
     pytest
@@ -24,10 +24,8 @@ buildPythonPackage rec {
     attrs
   ];
   checkPhase = ''
-    pytest .
+    pytest
   '';
-  # Tests fails on python3.7 https://github.com/python-effect/effect/issues/78
-  doCheck = !isPy37;
   meta = with lib; {
     description = "Pure effects for Python";
     homepage = https://github.com/python-effect/effect;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

