### PR TITLE
Networkmanager: rename service to match upstream

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -54,7 +54,7 @@
 
    <para>
     To manually configure the network on the graphical installer, first disable
-    network-manager with <command>systemctl stop network-manager</command>.
+    network-manager with <command>systemctl stop NetworkManager</command>.
    </para>
 
    <para>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -218,6 +218,13 @@
    </listitem>
    <listitem>
     <para>
+      The NetworkManager systemd unit was renamed back from network-manager.service to
+      NetworkManager.service for better compatibility with other applications expecting this name.
+      The same applies to ModemManager where modem-manager.service is now called ModemManager.service again.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Package <varname>rabbitmq_server</varname> is renamed to
      <varname>rabbitmq-server</varname>.
     </para>

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -466,7 +466,7 @@ in {
 
     systemd.packages = cfg.packages;
 
-    systemd.services."network-manager" = {
+    systemd.services."NetworkManager" = {
       wantedBy = [ "network.target" ];
       restartTriggers = [ configFile ];
 
@@ -478,9 +478,9 @@ in {
     };
 
     systemd.services.nm-setup-hostsdirs = mkIf dynamicHostsEnabled {
-      wantedBy = [ "network-manager.service" ];
-      before = [ "network-manager.service" ];
-      partOf = [ "network-manager.service" ];
+      wantedBy = [ "NetworkManager.service" ];
+      before = [ "NetworkManager.service" ];
+      partOf = [ "NetworkManager.service" ];
       script = concatStrings (mapAttrsToList (n: d: ''
         mkdir -p "/run/NetworkManager/hostsdirs/${n}"
         chown "${d.user}:${d.group}" "/run/NetworkManager/hostsdirs/${n}"

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -33,12 +33,9 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   postInstall = ''
-    # rename to modem-manager to be in style
-    mv $out/etc/systemd/system/ModemManager.service $out/etc/systemd/system/modem-manager.service
-
     # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
     # aliases ourselves.
-    ln -s $out/etc/systemd/system/modem-manager.service \
+    ln -s $out/etc/systemd/system/ModemManager.service \
       $out/etc/systemd/system/dbus-org.freedesktop.ModemManager1.service
   '';
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -88,13 +88,10 @@ in stdenv.mkDerivation rec {
     # FIXME: Workaround until NixOS' dbus+systemd supports at_console policy
     substituteInPlace $out/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf --replace 'at_console="true"' 'group="networkmanager"'
 
-    # rename to network-manager to be in style
-    mv $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/network-manager.service
-
     # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
     # aliases ourselves.
     ln -s $out/etc/systemd/system/NetworkManager-dispatcher.service $out/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
-    ln -s $out/etc/systemd/system/network-manager.service $out/etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
+    ln -s $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
   '';
 
   passthru = {

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -92,6 +92,11 @@ in stdenv.mkDerivation rec {
     # aliases ourselves.
     ln -s $out/etc/systemd/system/NetworkManager-dispatcher.service $out/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
     ln -s $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
+
+    # Add the legacy service name from before #51382 to prevent NetworkManager
+    # from not starting back up:
+    # TODO: remove this once 19.10 is released
+    ln -s $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/network-manager.service
   '';
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Compatibility with other distributions/software and expectation
of users coming from other systems should have higher priority over consistency.
In particular this fixes #51375, where the NetworkManager-wait-online.service
broke as a result of this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

