### PR TITLE
pyflame: init at 1.6.7

### DIFF
--- a/pkgs/development/tools/profiling/pyflame/default.nix
+++ b/pkgs/development/tools/profiling/pyflame/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, coreutils, pkgconfig
+# pyflame needs one python version per ABI
+# are currently supported 
+# * 2.6 or 2.7 for 2.x ABI
+# * 3.4 or 3.5 for 3.{4,5} ABI
+# * 3.6        for 3.6+ ABI
+# if you want to disable support for some ABI, make the corresponding argument null
+, python2, python35, python36
+}:
+stdenv.mkDerivation rec {
+  pname = "pyflame";
+  version = "1.6.7"; 
+  src = fetchFromGitHub {
+    owner = "uber";
+    repo = "pyflame";
+    rev = "v${version}";
+    sha256 = "0hz1ryimh0w8zyxx4y8chcn54d6b02spflj5k9rcg26an2chkg2w";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ python36 python2 python35 ];
+
+  postPatch = ''
+    patchShebangs .
+    # some tests will fail in the sandbox
+    substituteInPlace tests/test_end_to_end.py \
+      --replace 'skipif(IS_DOCKER' 'skipif(True'
+  '';
+
+  doCheck = true;
+  # reproduces the logic of their test script, but without downloading pytest
+  # from the internet with pip
+  checkPhase = with stdenv.lib; concatMapStringsSep "\n" (python: ''
+    set -x
+    PYMAJORVERSION=${head (strings.stringToCharacters python.version)} \
+      PATH=${makeBinPath [ coreutils ]}\
+      PYTHONPATH= \
+      ${python.pkgs.pytest}/bin/pytest tests/
+    set +x
+  '') (filter (x: x!=null) buildInputs);
+
+  meta = with stdenv.lib; {
+    description = "A ptracing profiler for Python ";
+    longDescription = ''
+      Pyflame is a high performance profiling tool that generates flame graphs for
+      Python. Pyflame uses the Linux ptrace(2) system call to collect profiling
+      information. It can take snapshots of the Python call stack without
+      explicit instrumentation, meaning you can profile a program without
+      modifying its source code.
+    '';
+    homepage = https://github.com/uber/pyflame;
+    license = licenses.asl20;
+    maintainers = [ maintainers.symphorien ];
+    # arm: https://github.com/uber/pyflame/issues/136
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8850,6 +8850,8 @@ with pkgs;
 
   puppet-lint = callPackage ../development/tools/puppet/puppet-lint { };
 
+  pyflame = callPackage ../development/tools/profiling/pyflame { };
+
   pyrseas = callPackage ../development/tools/database/pyrseas { };
 
   qtcreator = libsForQt5.callPackage ../development/tools/qtcreator { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to try this tool yesterday. It is great :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

