### PR TITLE
thunar-archive-plugin: 0.3.1 -> 0.4

### DIFF
--- a/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
@@ -7,15 +7,15 @@
 
 stdenv.mkDerivation rec {
   p_name  = "thunar-archive-plugin";
-  ver_maj = "0.3";
-  ver_min = "1";
+  ver_maj = "0.4";
+  ver_min = "0";
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   src = fetchFromGitHub {
     owner = "xfce-mirror";
     repo = p_name;
-    rev = "72b23eefc348bee31e06a04f968e430bc7dfa51e";
-    sha256 = "0l8715x23qmk0jkywiza3qx0xxmafxi4grp7p82kkc5df5ccs8kx";
+    rev = "b63862f03a041c2467c18dc8828f3a63a2d00328";
+    sha256 = "1793zicm00fail4iknliwy2b668j239ndxhc9hy6jarvdyp08h38";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Things done

Updates `thunar-archive-plugin` to latest release.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

