### PR TITLE
systrayhelper: 0.0.3 -> 0.0.4

### DIFF
--- a/pkgs/tools/misc/systrayhelper/default.nix
+++ b/pkgs/tools/misc/systrayhelper/default.nix
@@ -2,16 +2,16 @@
 
 buildGoPackage rec {
   name = "systrayhelper-${version}";
-  version = "0.0.3";
-  rev = "0953942245566bf358ba937af840947100380e15";
+  version = "0.0.4";
+  rev = "ded1f2ed4d30f6ca2c89a13db0bd3046c6d6d0f9";
 
   goPackagePath = "github.com/ssbc/systrayhelper";
 
   src = fetchFromGitHub {
-    inherit rev;
+    rev = "v${version}";
     owner = "ssbc";
     repo = "systrayhelper";
-    sha256 = "12xmzcw94in4m1hl4hbfdsbvkkaqrljgb67b95m1qwkkjak3q9g6";
+    sha256 = "1iq643brha5q6w2v1hz5l3d1z0pqzqr43gpwih4cnx3m5br0wg2k";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/misc/systrayhelper/deps.nix
+++ b/pkgs/tools/misc/systrayhelper/deps.nix
@@ -59,8 +59,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/getlantern/systray";
-      rev =  "3fd1443dac5c8297999189fe28d5836b2b075b66";
-      sha256 = "1sb11n27zy8xmq0lvrpqikb53425jvwl5617cp201va6iwk1hgnh";
+      rev =  "e31397f8c6928d98a8a9a7e80087aebcf0090beb";
+      sha256 = "0ahb6qjd2c43nbbg0ssm76ilbzs9dq43a89f7fj6c029nympjmqn";
     };
   }
   {
@@ -86,8 +86,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/pkg/errors";
-      rev =  "c059e472caf75dbe73903f6521a20abac245b17f";
-      sha256 = "07xg8ym776j2w0k8445ii82lx8yz358cp1z96r739y13i1anqdzi";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
     };
   }
   {
@@ -95,8 +95,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "d0be0721c37eeb5299f245a996a483160fc36940";
-      sha256 = "081wyvfnlf842dqg03raxfz6lldlxpmyh1prix9lmrrm65arxb12";
+      rev =  "8e24a49d80f82323e1c4db1b5da3e0f31171a151";
+      sha256 = "0zsdnyb8dy98jw6f9yn6g5gdhaqwk39hqridr0mh4dhwvwvlj724";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

Patches a panic in it's message handling and updates it's dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

