### PR TITLE
dpt-rp1-py: init at 2018-10-16

### DIFF
--- a/pkgs/tools/misc/dpt-rp1-py/default.nix
+++ b/pkgs/tools/misc/dpt-rp1-py/default.nix
@@ -1,0 +1,28 @@
+{ lib, python3Packages, fetchFromGitHub }:
+python3Packages.buildPythonApplication rec {
+  pname = "dpt-rp1-py";
+  version = "2018-10-16";
+
+  src = fetchFromGitHub {
+    owner = "janten";
+    repo = pname;
+    rev = "4551b4432f8470de5f2ad9171105f731a6259395";
+    sha256 = "176y5j31aci1vpi8v6r5ki55432fbdsazh9bsyzr90im9zimkffl";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    httpsig
+    requests
+    pbkdf2
+    urllib3
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/janten/dpt-rp1-py;
+    description = "Python script to manage Sony DPT-RP1 without Digital Paper App";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mt-caret ];
+  };
+}

--- a/pkgs/tools/misc/dpt-rp1-py/default.nix
+++ b/pkgs/tools/misc/dpt-rp1-py/default.nix
@@ -1,7 +1,7 @@
 { lib, python3Packages, fetchFromGitHub }:
 python3Packages.buildPythonApplication rec {
   pname = "dpt-rp1-py";
-  version = "2018-10-16";
+  version = "unstable-2018-10-16";
 
   src = fetchFromGitHub {
     owner = "janten";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -697,6 +697,8 @@ with pkgs;
 
   dkimpy = with pythonPackages; toPythonApplication dkimpy;
 
+  dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   sedutil = callPackage ../tools/security/sedutil { };


### PR DESCRIPTION
###### Motivation for this change

Adds dpt-rp1-py, a command-line client for the SONY DPT-RP1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

