### PR TITLE
nixos/containers: Add assertion for container name length

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -457,6 +457,16 @@ in
                       { boot.isContainer = true;
                         networking.hostName = mkDefault name;
                         networking.useDHCP = false;
+                        assertions = [
+                          {
+                            assertion =  config.privateNetwork -> stringLength name < 12;
+                            message = ''
+                              Container name `${name}` is too long: When `privateNetwork` is enabled, container names can
+                              not be longer than 11 characters, because the container's interface name is derived from it.
+                              This might be fixed in the future. See https://github.com/NixOS/nixpkgs/issues/38509
+                            '';
+                          }
+                        ];
                       };
                     in [ extraConfig ] ++ (map (x: x.value) defs);
                   prefix = [ "containers" name ];


### PR DESCRIPTION

Fixes #38509

###### Motivation for this change

When privateNetwork is enabled, currently the container's interface name
is derived from the container name. However, there's a hard limit
on the size of interface names. To avoid conflicts and other issues,
we set a limit on the container name when privateNetwork is enabled.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

