### PR TITLE
installer: Adds AArch64 UEFI installer support. (Work towards SBBR and EBBR support)

### DIFF
--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -47,7 +47,8 @@ if test -n "$bootable"; then
 
     isoBootFlags="-eltorito-boot ${bootImage}
                   -eltorito-catalog .boot.cat
-                  -no-emul-boot -boot-load-size 4 -boot-info-table"
+                  -no-emul-boot -boot-load-size 4 -boot-info-table
+                  --sort-weight 1 /isolinux" # Make sure isolinux is near the beginning of the ISO
 fi
 
 if test -n "$usbBootable"; then
@@ -112,7 +113,7 @@ xorriso="xorriso
  -r
  -path-list pathlist
  --sort-weight 0 /
- --sort-weight 1 /isolinux" # Make sure isolinux is near the beginning of the ISO
+"
 
 $xorriso -output $out/iso/$isoName
 

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -50,7 +50,7 @@ let
     finalCfg = {
       name = "NixOS ${config.system.nixos.label}${config.isoImage.appendToMenuLabel}";
       params = "init=${config.system.build.toplevel}/init ${additional} ${toString config.boot.kernelParams}";
-      image = "/boot/bzImage";
+      image = "/boot/${config.system.boot.loader.kernelFile}";
       initrd = "/boot/initrd";
     };
   in
@@ -163,7 +163,7 @@ let
       cp -v ${pkgs.refind}/share/refind/refind_x64.efi $out/EFI/boot/
       ''
     else
-      "# No refind for ia32"
+      "# No refind for ${targetArch}"
   ;
 
   grubMenuCfg = ''
@@ -222,18 +222,34 @@ let
   efiDir = pkgs.runCommand "efi-directory" {} ''
     mkdir -p $out/EFI/boot/
 
+    # ALWAYS required modules.
     MODULES="fat iso9660 part_gpt part_msdos \
              normal boot linux configfile loopback chain halt \
-             efifwsetup efi_gop efi_uga \
+             efifwsetup efi_gop \
              ls search search_label search_fs_uuid search_fs_file \
              gfxmenu gfxterm gfxterm_background gfxterm_menu test all_video loadenv \
              exfat ext2 ntfs btrfs hfsplus udf \
              videoinfo png \
              echo serial \
             "
+
+    echo "Building GRUB with modules:"
+    for mod in $MODULES; do
+      echo " - $mod"
+    done
+
+    # Modules that may or may not be available per-platform.
+    echo "Adding additional modules:"
+    for mod in efi_uga; do
+      if [ -f ${pkgs.grub2_efi}/lib/grub/${pkgs.grub2_efi.grubTarget}/$mod.mod ]; then
+        echo " - $mod"
+        MODULES+=" $mod"
+      fi
+    done
+
     # Make our own efi program, we can't rely on "grub-install" since it seems to
     # probe for devices, even with --skip-fs-probe.
-    ${pkgs.grub2_efi}/bin/grub-mkimage -o $out/EFI/boot/${if targetArch == "x64" then "bootx64" else "bootia32"}.efi -p /EFI/boot -O ${if targetArch == "x64" then "x86_64" else "i386"}-efi \
+    ${pkgs.grub2_efi}/bin/grub-mkimage -o $out/EFI/boot/boot${targetArch}.efi -p /EFI/boot -O ${pkgs.grub2_efi.grubTarget} \
       $MODULES
     cp ${pkgs.grub2_efi}/share/grub/unicode.pf2 $out/EFI/boot/
 
@@ -344,12 +360,19 @@ let
       ${pkgs.dosfstools}/sbin/fsck.vfat -vn "$out"
     ''; # */
 
-  targetArch = if pkgs.stdenv.isi686 then
-    "ia32"
-  else if pkgs.stdenv.isx86_64 then
-    "x64"
-  else
-    throw "Unsupported architecture";
+  # Name used by UEFI for architectures.
+  targetArch =
+    if pkgs.stdenv.isi686 then
+      "ia32"
+    else if pkgs.stdenv.isx86_64 then
+      "x64"
+    else if pkgs.stdenv.isAarch64 then
+      "aa64"
+    else
+      throw "Unsupported architecture";
+
+  # Syslinux (and isolinux) only supports x86-based architectures.
+  canx86BiosBoot = pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64;
 
 in
 
@@ -483,9 +506,9 @@ in
     # here and it causes a cyclic dependency.
     boot.loader.grub.enable = false;
 
-    # !!! Hack - attributes expected by other modules.
-    system.boot.loader.kernelFile = "bzImage";
-    environment.systemPackages = [ pkgs.grub2 pkgs.grub2_efi pkgs.syslinux ];
+    environment.systemPackages = [ pkgs.grub2 pkgs.grub2_efi ]
+      ++ optional canx86BiosBoot pkgs.syslinux
+    ;
 
     # In stage 1 of the boot, mount the CD as the root FS by label so
     # that we don't need to know its device.  We pass the label of the
@@ -556,13 +579,7 @@ in
     # Individual files to be included on the CD, outside of the Nix
     # store on the CD.
     isoImage.contents =
-      [ { source = pkgs.substituteAll  {
-            name = "isolinux.cfg";
-            src = pkgs.writeText "isolinux.cfg-in" isolinuxCfg;
-            bootRoot = "/boot";
-          };
-          target = "/isolinux/isolinux.cfg";
-        }
+      [
         { source = config.boot.kernelPackages.kernel + "/" + config.system.boot.loader.kernelFile;
           target = "/boot/" + config.system.boot.loader.kernelFile;
         }
@@ -571,9 +588,6 @@ in
         }
         { source = config.system.build.squashfsStore;
           target = "/nix-store.squashfs";
-        }
-        { source = "${pkgs.syslinux}/share/syslinux";
-          target = "/isolinux";
         }
         { source = config.isoImage.efiSplashImage;
           target = "/EFI/boot/efi-background.png";
@@ -584,6 +598,17 @@ in
         { source = pkgs.writeText "version" config.system.nixos.label;
           target = "/version.txt";
         }
+      ] ++ optionals canx86BiosBoot [
+        { source = pkgs.substituteAll  {
+            name = "isolinux.cfg";
+            src = pkgs.writeText "isolinux.cfg-in" isolinuxCfg;
+            bootRoot = "/boot";
+          };
+          target = "/isolinux/isolinux.cfg";
+        }
+        { source = "${pkgs.syslinux}/share/syslinux";
+          target = "/isolinux";
+        }
       ] ++ optionals config.isoImage.makeEfiBootable [
         { source = efiImg;
           target = "/boot/efi.img";
@@ -591,7 +616,7 @@ in
         { source = "${efiDir}/EFI";
           target = "/EFI";
         }
-      ] ++ optionals config.boot.loader.grub.memtest86.enable [
+      ] ++ optionals (config.boot.loader.grub.memtest86.enable && canx86BiosBoot) [
         { source = "${pkgs.memtest86plus}/memtest.bin";
           target = "/boot/memtest.bin";
         }
@@ -606,9 +631,10 @@ in
     # Create the ISO image.
     system.build.isoImage = pkgs.callPackage ../../../lib/make-iso9660-image.nix ({
       inherit (config.isoImage) isoName compressImage volumeID contents;
-      bootable = true;
+      bootable = canx86BiosBoot;
       bootImage = "/isolinux/isolinux.bin";
-    } // optionalAttrs config.isoImage.makeUsbBootable {
+      syslinux = if canx86BiosBoot then pkgs.syslinux else null;
+    } // optionalAttrs (config.isoImage.makeUsbBootable && canx86BiosBoot) {
       usbBootable = true;
       isohybridMbrImage = "${pkgs.syslinux}/share/syslinux/isohdpfx.bin";
     } // optionalAttrs config.isoImage.makeEfiBootable {


### PR DESCRIPTION
###### Motivation for this change

Eventually make NixOS work with [SBBR](http://infocenter.arm.com/help/topic/com.arm.doc.den0044c/index.html) and [EBBR](https://github.com/ARM-software/ebbr) compliant platforms.

A good first step for distros is to provide a UEFI-bootable image for ARM.

This PR makes the build process for the installer image work for AArch64.

###### Testing on real-world hardware

You will need an AArch64 machine which can UEFI boot. This is not as onerous as one could think. Mainline u-boot has the ability to boot UEFI-based images (this is an exercise left to the reader).

One of the most popuplar SBC, the Raspberry Pi, in its third major revision, the **Raspberry Pi 3B**, can boot Tiano Core, which is a reference UEFI implementation, using `@`andreiw's [64-bit Tiano Core UEFI for the Raspberry Pi 3](https://github.com/andreiw/RaspberryPiPkg). This is one of the way I have verified the work.

First, pick an SD card you wan to use as your UEFI firmware, it can be really small, it only needs to fit the Tiano Core build. Format one FAT32 partition on it, name it as you want, I chose `$TIANOCORE$` to make sure I don't accidentally use it. Copy the contents of one of the pre-built Tiano Core builds (found under `Binary/prebuilt/*/RELEASE`) to the root of the FAT32 partition. Eject your SD card and put it in the Raspberry Pi. Ensure it boots to Tiano Core (it should show up a gigantic raspberry with a countdown timer, it will eventually boot the UEFI shell).

Then, burn the AArch64 iso as you would the normal x86_64 iso, (a simple `dd`). Plug that USB drive to the Raspberry Pi, boot it, it should automatically continue to GRUB. For the graphical console to work on the Raspberry Pi, you will need to add `cma=32M` to the command line (press `e`  to edit an entry, `CTRL+X` to boot it.) This PR does not touch the kernel parameters as they are a board-specific quirk.

> **NOTE**: it's possible that the graphical console may fail late in stage-2, before being given control of the system. This is related to the mainline kernel's vc4 modesetting driver not liking it when the Raspberry Pi's own firmware writes to the buffer (probably wrongly oversimplified explanation). If you get some weirdness there (mainly, being shown older boot messages), it's *not* this PR's fault. Things to try: (1) have a powerful enough, and properly rated power supply (2) add `avoid_warnings=1` to the Raspberry Pi's config.txt. It is possible, most times, to recover by switching back and forth between VTs, so CTRL+ALT+F2 followed by CTRL+ALT+F1 may recover it. 

###### Related testing

A bad rough draft of this implementation was [tested](https://logs.nix.samueldr.com/nixos-aarch64/2018-11-21#1739705) by @nbp on a [SoftIron Overdrive 1000](https://softiron.com/development-tools/overdrive-1000/). I would like it if @nbp could test this cleaned-up build. (It should be 99% equivalent.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- 🆖 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dezgeg (arm and aarch64 knowledgeable)