### PR TITLE
font-lock-plus: fix recipe

### DIFF
--- a/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
+++ b/pkgs/applications/editors/emacs-modes/font-lock-plus/default.nix
@@ -1,7 +1,7 @@
-{ fetchurl, lib, melpaBuild }:
+{ fetchurl, lib, melpaBuild, writeText }:
 
 melpaBuild {
-  pname = "font-lock-plus";
+  pname = "font-lock+";
   version = "20180101.25";
 
   src = fetchurl {
@@ -10,11 +10,7 @@ melpaBuild {
     name = "font-lock+.el";
   };
 
-  recipe = fetchurl {
-    url = "https://raw.githubusercontent.com/milkypostman/melpa/a5d15f875b0080b12ce45cf696c581f6bbf061ba/recipes/font-lock+";
-    sha256 = "1wn99cb53ykds87lg9mrlfpalrmjj177nwskrnp9wglyqs65lk4g";
-    name = "font-lock-plus";
-  };
+  recipe = writeText "recipe" "(font-lock+ :fetcher github :repo \"\")";
 
   meta = {
     homepage = "https://melpa.org/#/font-lock+";


### PR DESCRIPTION
Used the wiki fetcher which doesn't seem to exist.

Replaced with a fake repo. Doesnt seem to be used.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

