### PR TITLE
openra: adding individual executables for each mod

### DIFF
--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -69,5 +69,11 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     makeWrapper $out/lib/openra/launch-game.sh $out/bin/openra --run "cd $out/lib/openra"
+    printf "#!/bin/sh\nexec $out/bin/openra Game.Mod=ra" > $out/bin/openra-ra
+    chmod +x $out/bin/openra-ra
+    printf "#!/bin/sh\nexec $out/bin/openra Game.Mod=cnc" > $out/bin/openra-cnc
+    chmod +x $out/bin/openra-cnc
+    printf "#!/bin/sh\nexec $out/bin/openra Game.Mod=d2k" > $out/bin/openra-d2k
+    chmod +x $out/bin/openra-d2k
   '';
 }


### PR DESCRIPTION
OpenRA desktop configuration files presently fail to launch the various mods, as the executable files (`openra-ra` for Red Alert, `openra-cnc` for Tiberian Dawn and `openra-d2k` for Dune 2K) they rely on are not present in this package.

###### Motivation for this change
As previously said the application launchers (i.e. desktop config files) fail to launch the various mods as the executable files they rely upon are not present in PATH (`openra-ra`, `openra-cnc` and `openra-d2k`). This PR creates these executables. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

