### PR TITLE
nixos/pmount: add pmount programs module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -43,6 +43,11 @@
      <literal>./programs/nm-applet.nix</literal>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <literal>./programs/pmount.nix</literal>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -110,6 +110,7 @@
   ./programs/npm.nix
   ./programs/oblogout.nix
   ./programs/plotinus.nix
+  ./programs/pmount.nix
   ./programs/qt5ct.nix
   ./programs/screen.nix
   ./programs/sedutil.nix

--- a/nixos/modules/programs/pmount.nix
+++ b/nixos/modules/programs/pmount.nix
@@ -1,0 +1,16 @@
+{ config, lib, pkgs, ... }:
+
+{
+  options.programs.pmount.enable = lib.mkEnableOption "pmount with setuid wrapper";
+
+  config = lib.mkIf config.programs.pmount.enable {
+
+    security.wrappers = {
+      pmount.source = "${pkgs.pmount.out}/bin/pmount";
+      pumount.source = "${pkgs.pmount.out}/bin/pumount";
+    };
+
+    system.activationScripts.pmount = "mkdir -p /media";
+
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add pmount module with setuid wrapper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

