### PR TITLE
Fix NetworkManager-wait-online.service

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -103,6 +103,9 @@ in stdenv.mkDerivation rec {
     # FIXME: Workaround until NixOS' dbus+systemd supports at_console policy
     substituteInPlace $out/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf --replace 'at_console="true"' 'group="networkmanager"'
 
+    # Fix NetworkManager-wait-online link to NetworkManager.service
+    substituteInPlace $out/etc/systemd/system/NetworkManager-wait-online.service --replace 'NetworkManager.service' 'network-manager.service'
+
     # rename to network-manager to be in style
     mv $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/network-manager.service
 


### PR DESCRIPTION
###### Motivation for this change

`NetworkManager-wait-online.service` is broken due to `NetworkManager.service` being renamed `network-manager.service` (See #51375)

###### Things done

Just patched the service to replace `NetworkManager.service` by `network-manager.service`

@Mic92 Should be good this time!

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

