### PR TITLE
gnumake: disable subsecond mtime on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/4.2/default.nix
@@ -27,7 +27,16 @@ stdenv.mkDerivation {
   nativeBuildInputs = stdenv.lib.optionals guileSupport [ pkgconfig ];
   buildInputs = stdenv.lib.optionals guileSupport [ guile ];
 
-  configureFlags = stdenv.lib.optional guileSupport "--with-guile";
+  configureFlags = stdenv.lib.optional guileSupport "--with-guile"
+
+    # Make uses this test to decide whether it should keep track of
+    # subseconds. Apple made this possible with APFS and macOS 10.13.
+    # However, we still support macOS 10.11 and 10.12. Binaries built
+    # in Nixpkgs will be unable to use futimens to set mtime less than
+    # a second. So, tell Make to ignore nanoseconds in mtime here by
+    # overriding the autoconf test for the struct.
+    # See https://github.com/NixOS/nixpkgs/issues/51221 for discussion.
+    ++ stdenv.lib.optional stdenv.isDarwin "ac_cv_struct_st_mtim_nsec=no";
 
   outputs = [ "out" "man" "info" ];
 


### PR DESCRIPTION
gnumake can support subsecond mtimes if it is available. But Darwin
doesn’t support setting subsecond mtimes until 10.13! So we can just
disable this check to avoid the issue where most of our built tools
use seconds but make uses nanoseconds. Might fix some parallel issues
along the way.

Fixes #51221

/cc @endgame @delroth @thoughtpolice 