### PR TITLE
nixos/cockroachdb: supply defaultText for the package option

### DIFF
--- a/nixos/modules/services/databases/cockroachdb.nix
+++ b/nixos/modules/services/databases/cockroachdb.nix
@@ -149,6 +149,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.cockroachdb;
+        defaultText = "pkgs.cockroachdb";
         description = ''
           The CockroachDB derivation to use for running the service.
           


### PR DESCRIPTION
###### Motivation for this change

This was preventing evaluating the NixOS manual on platforms not supported by `cockroachdb` package itself:

```
Package ‘cockroach-2.1.1’ in /home/pbogdan/nixpkgs/pkgs/servers/sql/cockroachdb/default.nix:59 is not supported on ‘i686-unknown-linux-gnu’, refusing to evaluate.
```

Notably this currently prevents the tested Hydra job from evaluating as the manual is one of the constituents. 

https://hydra.nixos.org/jobset/nixos/trunk-combined#tabs-errors -> CTRL-F "in job ‘tested’:"

/cc @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

