### PR TITLE
intel-media-driver: init at 18.3.0

### DIFF
--- a/pkgs/development/libraries/intel-gmmlib/default.nix
+++ b/pkgs/development/libraries/intel-gmmlib/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  name = "intel-gmmlib-${version}";
+  version = "18.3.0";
+
+  src = fetchFromGitHub {
+    owner  = "intel";
+    repo   = "gmmlib";
+    rev    = name;
+    sha256 = "1x1p4xvi870vjka2ag6rmmw897hl7zhav1sgwhnrzrggsx9jrw80";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/intel/gmmlib;
+    license = licenses.mit;
+    description = "Intel Graphics Memory Management Library";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/libraries/intel-media-driver/default.nix
+++ b/pkgs/development/libraries/intel-media-driver/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub
+, cmake, pkgconfig
+, libva, libpciaccess, intel-gmmlib, libX11
+}:
+
+stdenv.mkDerivation rec {
+  name = "intel-media-driver-${version}";
+  version = "18.3.0";
+
+  src = fetchFromGitHub {
+    owner  = "intel";
+    repo   = "media-driver";
+    rev    = "intel-media-${version}";
+    sha256 = "15kcyg9ss2v1bbw6yvxqb833h1vs0h659n8ix0x5x03cfm1wsi57";
+  };
+
+  cmakeFlags = [ "-DINSTALL_DRIVER_SYSCONF=OFF" ];
+
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DLIBVA_DRIVERS_PATH=$out/lib/dri"
+  '';
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ libva libpciaccess intel-gmmlib libX11 ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/intel/media-driver;
+    license = with licenses; [ bsd3 mit ];
+    description = "Intel Media Driver for VAAPI — Broadwell+ iGPUs";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10255,6 +10255,8 @@ with pkgs;
 
   intel-gmmlib = callPackage ../development/libraries/intel-gmmlib { };
 
+  intel-media-driver = callPackage ../development/libraries/intel-media-driver { };
+
   intltool = callPackage ../development/tools/misc/intltool { };
 
   ios-cross-compile = callPackage ../development/compilers/ios-cross-compile/9.2.nix {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10253,6 +10253,8 @@ with pkgs;
 
   iniparser = callPackage ../development/libraries/iniparser { };
 
+  intel-gmmlib = callPackage ../development/libraries/intel-gmmlib { };
+
   intltool = callPackage ../development/tools/misc/intltool { };
 
   ios-cross-compile = callPackage ../development/compilers/ios-cross-compile/9.2.nix {};


### PR DESCRIPTION
###### Motivation for this change

This is the new VA-API driver for Intel chipsets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Tested with `vainfo` and `mpv`.
