### PR TITLE
vault: 0.11.2 -> 0.11.5

### DIFF
--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -1,23 +1,14 @@
 { stdenv, fetchFromGitHub, go, gox, removeReferencesTo }:
 
-let
-  # Deprecated since vault 0.8.2: use `vault -autocomplete-install` instead
-  # to install auto-complete for bash, zsh and fish
-  vaultBashCompletions = fetchFromGitHub {
-    owner = "iljaweis";
-    repo = "vault-bash-completion";
-    rev = "e2f59b64be1fa5430fa05c91b6274284de4ea77c";
-    sha256 = "10m75rp3hy71wlmnd88grmpjhqy0pwb9m8wm19l0f463xla54frd";
-  };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "vault-${version}";
-  version = "0.11.2";
+  version = "0.11.5";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "0lckpfp1yw6rfq2cardsp2qjiajg706qjk98cycrlsa5nr2csafa";
+    sha256 = "1skf9l3a4gwag9gp2vwmniajk8rb05g93s15q5xfwqb6sg6zplfw";
   };
 
   nativeBuildInputs = [ go gox removeReferencesTo ];
@@ -39,7 +30,7 @@ in stdenv.mkDerivation rec {
     cp pkg/*/* $out/bin/
     find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
 
-    cp ${vaultBashCompletions}/vault-bash-completion.sh $out/share/bash-completion/completions/vault
+    echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update bash completion method as described in
https://www.vaultproject.io/docs/commands/#autocompletion

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

