### PR TITLE
dsniff: init at 2.4b1

### DIFF
--- a/pkgs/tools/networking/dsniff/default.nix
+++ b/pkgs/tools/networking/dsniff/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, fetchFromGitLab, autoreconfHook, libpcap, db, glib, libnet, libnids, symlinkJoin, openssl_1_1 }:
+let
+  /*
+  dsniff's build system unconditionnaly wants static libraries and does not
+  support multi output derivations. We do some overriding to give it
+  satisfaction.
+  */
+  staticdb = symlinkJoin {
+    inherit (db) name;
+    paths = with db.overrideAttrs(old: { dontDisableStatic = true; }); [ out dev ];
+    postBuild = ''
+      rm $out/lib/*.so*
+    '';
+  };
+  pcap = symlinkJoin {
+    inherit (libpcap) name;
+    paths = [ libpcap ];
+    postBuild = ''
+      cp -rs $out/include/pcap $out/include/net
+      # prevent references to libpcap
+      rm $out/lib/*.so*
+    '';
+  };
+  net = symlinkJoin {
+    inherit (libnet) name;
+    paths = [ (libnet.overrideAttrs(old: { dontDisableStatic = true; })) ];
+    postBuild = ''
+      # prevent dynamic linking, now that we have a static library
+      rm $out/lib/*.so*
+    '';
+  };
+  nids = libnids.overrideAttrs(old: {
+    dontDisableStatic = true;
+  });
+  ssl = symlinkJoin {
+    inherit (openssl_1_1) name;
+    paths = with openssl_1_1.override { static = true; }; [ out dev ];
+  };
+in stdenv.mkDerivation {
+  pname = "dsniff";
+  version = "2.4b1";
+  # upstream is so old that nearly every distribution packages the beta version.
+  # Also, upstream only serves the latest version, so we use debian's sources.
+  # this way we can benefit the numerous debian patches to be able to build
+  # dsniff with recent libraries.
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "pkg-security-team";
+    repo = "dsniff";
+    rev = "debian%2F2.4b1%2Bdebian-29"; # %2B = urlquote("+"), %2F = urlquote("/")
+    sha256 = "10zz9krf65jsqvlcr72ycp5cd27xwr18jkc38zqp2i4j6x0caj2g";
+    name = "dsniff.tar.gz";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ glib pcap ];
+  NIX_CFLAGS_LINK = "-lglib-2.0";
+  postPatch = ''
+    for patch in debian/patches/*.patch; do
+      patch < $patch
+    done;
+  '';
+  configureFlags = [
+    "--with-db=${staticdb}"
+    "--with-libpcap=${pcap}"
+    "--with-libnet=${net}"
+    "--with-libnids=${nids}"
+    "--with-openssl=${ssl}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "collection of tools for network auditing and penetration testing";
+    longDescription = ''
+      dsniff, filesnarf, mailsnarf, msgsnarf, urlsnarf, and webspy passively monitor a network for interesting data (passwords, e-mail, files, etc.). arpspoof, dnsspoof, and macof facilitate the interception of network traffic normally unavailable to an attacker (e.g, due to layer-2 switching). sshmitm and webmitm implement active monkey-in-the-middle attacks against redirected SSH and HTTPS sessions by exploiting weak bindings in ad-hoc PKI.
+    '';
+    homepage = https://www.monkey.org/~dugsong/dsniff/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.symphorien ];
+    # bsd and solaris should work as well
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/libnids/default.nix
+++ b/pkgs/tools/networking/libnids/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchzip, libpcap, glib, pkgconfig, libnet }:
+stdenv.mkDerivation {
+  pname = "libnids";
+  version = "1.24";
+  src = fetchzip {
+    url = "mirror://sourceforge/libnids/libnids-1.24.tar.gz";
+    sha256 = "1cblklfdfxcmy0an6xyyzx4l877xdawhjd28daqfsvrh81mb07k1";
+  };
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libpcap glib libnet ];
+
+  /*
+  Quoting the documentation of glib: g_thread_init has been deprecated since
+  version 2.32 and should not be used in newly-written code.  This function is
+  no longer necessary. The GLib threading system is automatically initialized
+  at the start of your program.
+
+  this is necessary for dsniff to compile; otherwise g_thread_init is a missing
+  symbol when linking (?!?)
+  */
+  NIX_CFLAGS_COMPILE="-Dg_thread_init= ";
+
+  meta = with stdenv.lib; {
+    description = "An E-component of Network Intrusion Detection System which emulates the IP stack of Linux 2.0.x";
+    homepage = http://libnids.sourceforge.net/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.symphorien ];
+    # probably also bsd and solaris
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22975,6 +22975,8 @@ with pkgs;
     inherit (darwin) libresolv;
   };
 
+  dsniff = callPackage ../tools/networking/dsniff {};
+
   wal-g = callPackage ../tools/backup/wal-g {};
 
   tlwg = callPackage ../data/fonts/tlwg { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3959,6 +3959,8 @@ with pkgs;
 
   libpointmatcher = callPackage ../development/libraries/libpointmatcher { };
 
+  libnids = callPackage ../tools/networking/libnids { };
+
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };
 
   libmpack = callPackage ../development/libraries/libmpack { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to use tcpkill

###### Things done
upstream does not provide a stable url. So I used debian as source. This enables me to use their 36 patches to have dsniff build with recent version of libraries like openssl. Debian only provides the beta version, like most distros according to repology. This is probably because dsniff is not much maintained. If you think we should not add dsniff to nixpkgs for this reason, I'd understand. I do this PR mainly because I spent time on it, so I'd like to share :)

Their build system demands static libraries and header files under the same prefix. So I have to override all libraries and merge their outputs. In the end, there is still a reference to openssl for `/nix/store/a23xvnnl29scqqjvcqya6vgs0vnz1shi-openssl-1.1.1/etc/ssl/ct_log_list.cnf` so dsniff will depend on openssl dev output... This is very sad.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~ only tcpkill
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

