### PR TITLE
Csoundqt init 0.9.6-beta2 and python-qt init 3.2

### DIFF
--- a/pkgs/applications/audio/csound/csound-qt/default.nix
+++ b/pkgs/applications/audio/csound/csound-qt/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, csound, desktop-file-utils,
+  fetchFromGitHub, python, python-qt, qmake,
+  qtwebengine, rtmidi, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "csound-qt-${version}";
+  version = "0.9.6-beta2";
+
+  src = fetchFromGitHub {
+    owner = "CsoundQt";
+    repo = "CsoundQt";
+    rev = "${version}";
+    sha256 = "12jv7cvns3wj2npha0mvpn88kkkfsxsvhgzs2wrw04kbrvbhbffi";
+  };
+
+  patches = [ ./rtmidipath.patch ];
+
+  nativeBuildInputs = [ qmake qtwebengine ];
+
+  buildInputs = [ csound desktop-file-utils rtmidi unzip ];
+
+  qmakeFlags = [ "qcs.pro" "CONFIG+=rtmidi" "CONFIG+=pythonqt"
+                 "CSOUND_INCLUDE_DIR=${csound}/include/csound"
+                 "CSOUND_LIBRARY_DIR=${csound}/lib"
+                 "RTMIDI_DIR=${rtmidi.src}"
+                 "PYTHONQT_SRC_DIR=${python-qt}/lib"
+                 "PYTHONQT_LIB_DIR=${python-qt}/lib"
+                 "LIBS+=${python-qt}/lib/libPythonQt-Qt5-Python2.7.so"
+                 "LIBS+=${python-qt}/lib/libPythonQt_QtAll-Qt5-Python2.7.so"
+                 "INCLUDEPATH+=${python-qt}/include/PythonQt"
+                 "INCLUDEPATH+=${python}/include/python2.7"
+                 "INSTALL_DIR=$(out)"
+                 "SHARE_DIR=$(out)/share"
+                 ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r bin $out
+    make install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CsoundQt is a frontend for Csound with editor, integrated help, widgets and other features.";
+    homepage = https://csoundqt.github.io/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hlolli ];
+  };
+}

--- a/pkgs/applications/audio/csound/csound-qt/rtmidipath.patch
+++ b/pkgs/applications/audio/csound/csound-qt/rtmidipath.patch
@@ -1,0 +1,17 @@
+diff --git a/src/src.pri b/src/src.pri
+index e5e0c896..9a9fa513 100644
+--- a/src/src.pri
++++ b/src/src.pri
+@@ -155,9 +155,9 @@ pythonqt {
+         "src/pyqcsobject.cpp"
+ }
+ rtmidi {
+-    HEADERS += "src/../$${RTMIDI_DIR}/RtMidi.h"
+-    SOURCES += "src/../$${RTMIDI_DIR}/RtMidi.cpp"
+-    INCLUDEPATH += src/../$${RTMIDI_DIR}
++    HEADERS += "$${RTMIDI_DIR}/RtMidi.h"
++    SOURCES += "$${RTMIDI_DIR}/RtMidi.cpp"
++    INCLUDEPATH += $${RTMIDI_DIR}
+ }
+
+ perfThread_build {

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, python, qmake,
+  qtwebengine, qtxmlpatterns,
+  qttools, unzip }:
+
+stdenv.mkDerivation rec {
+  version = "3.2";
+  name = "python-qt-${version}";
+
+  src = fetchurl {
+    url="mirror://sourceforge/pythonqt/PythonQt${version}.zip";
+    sha256="13hzprk58m3yj39sj0xn6acg8796lll1256mpd81kw0z3yykyl8c";
+  };
+
+  hardeningDisable = [ "all" ];
+
+  nativeBuildInputs = [ qmake qtwebengine  qtxmlpatterns qttools ];
+
+  buildInputs = [ python unzip ];
+
+  qmakeFlags = [ "PythonQt.pro"
+                 "INCLUDEPATH+=${python}/include/python3.6"
+                 "PYTHON_PATH=${python}/bin"
+                 "PYTHON_LIB=${python}/lib"];
+
+  unpackCmd = "unzip $src";
+
+  installPhase = ''
+    mkdir -p $out/include/PythonQt
+    cp -r ./lib $out
+    cp -r ./src/* $out/include/PythonQt
+    cp extensions/PythonQt_QtAll/PythonQt_QtAll.h $out/include/PythonQt
+    cp extensions/PythonQt_QtAll/PythonQt_QtAll.cpp $out/include/PythonQt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PythonQt is a dynamic Python binding for the Qt framework. It offers an easy way to embed the Python scripting language into your C++ Qt applications.";
+    homepage = http://pythonqt.sourceforge.net/;
+    license = licenses.lgpl21;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ hlolli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11912,6 +11912,14 @@ with pkgs;
 
   pybind11 = callPackage ../development/libraries/pybind11 { };
 
+  python-qt = callPackage ../development/libraries/python-qt {
+    python = python27;
+    qmake = qt59.qmake;
+    qttools = qt59.qttools;
+    qtwebengine = qt59.qtwebengine;
+    qtxmlpatterns = qt59.qtxmlpatterns;
+  };
+
   re2 = callPackage ../development/libraries/re2 { };
 
   qbs = libsForQt5.callPackage ../development/tools/build-managers/qbs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16179,6 +16179,12 @@ with pkgs;
 
   csound = callPackage ../applications/audio/csound { };
 
+  csound-qt = callPackage ../applications/audio/csound/csound-qt {
+    python = python27;
+    qmake = qt59.qmake;
+    qtwebengine = qt59.qtwebengine;
+  };
+
   cinepaint = callPackage ../applications/graphics/cinepaint {
     fltk = fltk13;
     libpng = libpng12;


### PR DESCRIPTION
###### Motivation for this change

The standard front-end editor for Csound

###### Things done

I included python-qt, a library for embedding python interpreter into qt applications.


- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

