### PR TITLE
systems/parse.nix: support eabihf

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -110,6 +110,10 @@ rec {
     config = "arm-none-eabi";
     libc = "newlib";
   };
+  armhf-embedded = {
+    config = "arm-none-eabihf";
+    libc = "newlib";
+  };
 
   aarch64-embedded = {
     config = "aarch64-none-elf";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -209,8 +209,15 @@ rec {
   abis = setTypes types.openAbi {
     cygnus       = {};
     msvc         = {};
-    eabi         = {};
-    elf         = {};
+
+    # Note: eabi is specific to ARM and PowerPC.
+    # On PowerPC, this corresponds to PPCEABI.
+    # On ARM, this corresponds to ARMEABI.
+    eabi         = { float = "soft"; };
+    eabihf       = { float = "hard"; };
+
+    # Other architectures should use ELF in embedded situations.
+    elf          = {};
 
     androideabi  = {};
     android      = {
@@ -272,10 +279,8 @@ rec {
     "2" = # We only do 2-part hacks for things Nix already supports
       if elemAt l 1 == "cygwin"
         then { cpu = elemAt l 0;                      kernel = "windows";  abi = "cygnus";   }
-      else if (elemAt l 1 == "eabi")
-        then { cpu = elemAt l 0; vendor = "none"; kernel = "none"; abi = elemAt l 1; }
-      else if (elemAt l 1 == "elf")
-        then { cpu = elemAt l 0; vendor = "none"; kernel = "none"; abi = elemAt l 1; }
+      else if (elemAt l 1) == "elf"
+      then { cpu = elemAt l 0; vendor = "unknown";    kernel = "none";     abi = elemAt l 1; }
       else   { cpu = elemAt l 0;                      kernel = elemAt l 1;                   };
     "3" = # Awkwards hacks, beware!
       if elemAt l 1 == "apple"
@@ -286,10 +291,8 @@ rec {
         then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "windows";  abi = "gnu"; }
       else if hasPrefix "netbsd" (elemAt l 2)
         then { cpu = elemAt l 0; vendor = elemAt l 1;    kernel = elemAt l 2;                }
-      else if (elemAt l 2 == "eabi")
-        then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "none"; abi = elemAt l 2; }
-      else if (elemAt l 2 == "elf")
-        then { cpu = elemAt l 0; vendor = elemAt l 1; kernel = "none"; abi = elemAt l 2; }
+      else if (elem (elemAt l 2) ["eabi" "eabihf" "elf"])
+        then { cpu = elemAt l 0; vendor = "unknown"; kernel = elemAt l 1; abi = elemAt l 2; }
       else throw "Target specification with 3 components is ambiguous";
     "4" =    { cpu = elemAt l 0; vendor = elemAt l 1; kernel = elemAt l 2; abi = elemAt l 3; };
   }.${toString (length l)}

--- a/pkgs/development/misc/qmk_firmware/default.nix
+++ b/pkgs/development/misc/qmk_firmware/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , avrgcc, avrbinutils
-, gcc-arm-embedded, binutils-arm-embedded
+, gcc-arm-embedded, gcc-armhf-embedded
 , teensy-loader-cli, dfu-programmer, dfu-util }:
 
 let version = "0.6.144";
@@ -14,12 +14,23 @@ in stdenv.mkDerivation {
     sha256 = "0m71f9w32ksqjkrwhqwhr74q5v3pr38bihjyb9ks0k5id0inhrjn";
     fetchSubmodules = true;
   };
+  postPatch = ''
+    substituteInPlace tmk_core/arm_atsam.mk \
+      --replace arm-none-eabi arm-none-eabihf
+    rm keyboards/handwired/frenchdev/rules.mk keyboards/dk60/rules.mk
+  '';
   buildFlags = "all:default";
+  doCheck = true;
+  checkTarget = "test:all";
+  installPhase = ''
+    mkdir $out
+  '';
   NIX_CFLAGS_COMPILE = "-Wno-error";
   nativeBuildInputs = [
     avrgcc
     avrbinutils
     gcc-arm-embedded
+    gcc-armhf-embedded
     teensy-loader-cli
     dfu-programmer
     dfu-util

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23027,7 +23027,7 @@ with pkgs;
     avrgcc = pkgsCross.avr.buildPackages.gcc;
     avrbinutils = pkgsCross.avr.buildPackages.binutils;
     gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
-    binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
+    gcc-armhf-embedded = pkgsCross.armhf-embedded.buildPackages.gcc;
   };
 
   newlib = callPackage ../development/misc/newlib { };


### PR DESCRIPTION
eabihf is an abi that can be used with ARM architectures that support
the “hard float”. It should probably only be used with ARM32 when you
are absolutely sure your binaries will run on ARM systems with a FPU.

Also, add an example "armhf-embedded" to match the preexisting
arm-embedded system. qmk_firmware needs hard float in a few places, so
add them here to get that to work.

Fixes #51184
