### PR TITLE
scrcpy: 1.3 -> 1.5

### DIFF
--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "1.3";
+  version = "1.5";
   prebuilt_server = fetchurl {
-    url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}.jar";
-    sha256 = "1ha04wfmghblwr9ajfl96cswacfgrk0b7klq2ixfvw1kgwhmm6hg";
+    url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}-fixversion/scrcpy-server-v${version}.jar";
+    sha256 = "1pi47khfrs9pygs32l9rj8l927z0sdm8bhkrzzkk6ki9c1psnynr";
   };
 in
 stdenv.mkDerivation rec {
@@ -21,9 +21,22 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Genymobile";
     repo = "scrcpy";
-    rev = "v${version}";
-    sha256 = "02szi8w3w0lacyz42hlayxififi863qpm63yg9qir3jcl2vs7vdk";
+    rev = "v${version}-fixversion";
+    sha256 = "0magmc44pahw1f4jhzkhjlfc31mk3qq43hzn9513idcl4kh4sb8i";
   };
+
+  # postPatch:
+  #   screen.c: When run without a hardware accelerator, this allows the command to continue working rather than failing unexpectedly.
+  #   This can happen when running on non-NixOS because then scrcpy seems to have a hard time using the host OpenGL-supporting hardware.
+  #   It would be better to fix the OpenGL problem, but that seems much more intrusive.
+  #
+  #   command.c: When copying over the prebuilt binary to mobile, it also copies the permissions of the nix store, and thus it cannot delete normally.
+  postPatch = ''
+    substituteInPlace app/src/screen.c \
+      --replace "SDL_RENDERER_ACCELERATED" "SDL_RENDERER_ACCELERATED || SDL_RENDERER_SOFTWARE"
+    substituteInPlace app/src/command.c \
+      --replace 'const char *const adb_cmd[] = {"shell", "rm", path};' 'const char *const adb_cmd[] = {"shell", "rm", "-f", path};'
+  '';
 
   nativeBuildInputs = [ makeWrapper meson ninja pkgconfig ];
 
@@ -34,6 +47,7 @@ stdenv.mkDerivation rec {
     echo -n > server/meson.build
   '';
 
+  mesonFlags = ["-Doverride_server_path=${prebuilt_server}"];
   postInstall = ''
     mkdir -p "$out/share/scrcpy"
     ln -s "${prebuilt_server}" "$out/share/scrcpy/scrcpy-server.jar"


### PR DESCRIPTION
###### Motivation for this change
Update to newest version

###### Things done
Updated version.
Added configurations to allow hardware and software rendering.
Added configuration to remove unneeded errors.
Added configuration to use prebuilt server directly.
Tested on Ubuntu, NixOS.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

