### PR TITLE
rig: init at 1.11

### DIFF
--- a/pkgs/tools/misc/rig/default.nix
+++ b/pkgs/tools/misc/rig/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl } :
+
+stdenv.mkDerivation rec {
+  version = "1.11";
+  name = "rig-${version}";
+
+  src = fetchurl {
+    url = "https://ayera.dl.sourceforge.net/project/rig/rig/${version}/rig-${version}.tar.gz";
+    sha256 = "1f3snysjqqlpk2kgvm5p2icrj4lsdymccmn3igkc2f60smqckgq0";
+  };
+
+  # Note: diff modified from Debian: Norbert Veber <nveber@debian.org>
+  # http://deb.debian.org/debian/pool/main/r/rig/rig_1.11-1.diff.gz
+  patches = [ ./rig_1.11-1.diff ];
+
+  meta = {
+    homepage = http://rig.sourceforge.net/; 
+    description = "Random identity generator";
+    longDescription = ''
+      RIG (Random Identity Generator) is a free replacement for a shareware
+      program out there called 'fake'. It generates random, yet real-looking,
+      personal data. It is useful if you need to feed a name to a Web site,
+      BBS, or real person, and are too lazy to think of one yourself. Also,
+      if the Web site/BBS/person you are giving the information to tries to
+      cross-check the city, state, zip, or area code, it will check out.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ tomberek ];
+    platforms = with stdenv.lib.platforms; all;
+  };
+}

--- a/pkgs/tools/misc/rig/rig_1.11-1.diff
+++ b/pkgs/tools/misc/rig/rig_1.11-1.diff
@@ -1,0 +1,39 @@
+--- rig-1.11.orig/Makefile
++++ rig-1.11/Makefile
+@@ -1,20 +1,21 @@
+-PREFIX=/usr/local
++PREFIX=${out}
+ BINDIR=${PREFIX}/bin
+ MANDIR=${PREFIX}/man
+ DATADIR=${PREFIX}/share/rig
++CXX=g++
+ 
+ all: rig rig.6
+ rig: rig.cc
+-	g++ -g rig.cc -o rig -Wall -DDATADIR="\"$(DATADIR)\""
++	${CXX} -O2 -g rig.cc -o rig -Wall -DDATADIR="\"$(DATADIR)\""
+ 
+ rig.6: rig.6.in
+ 	sed s@DATADIR@"$(DATADIR)"@g < rig.6.in > rig.6
+ 
+ install: rig rig.6
+-	install -g 0 -m 755 -o 0 -s rig $(BINDIR)
+-	install -g 0 -m 644 -o 0 rig.6 $(MANDIR)/man6/rig.6
+-	install -g 0 -m 755 -o 0 -d $(DATADIR)
+-	install -g 0 -m 644 -o 0 data/*.idx $(DATADIR)
++	install -m 755 -d $(DESTDIR)$(DATADIR)
++	install -m 755 -d $(DESTDIR)$(BINDIR)
++	install -m 755 rig $(DESTDIR)$(BINDIR)/rig
++	install -m 644 data/*.idx $(DESTDIR)$(DATADIR)
+ 
+ clean:
+ 	rm -rf *~ *.rej *.orig *.o rig rig.6
+--- rig-1.11.orig/rig.cc
++++ rig-1.11/rig.cc
+@@ -26,6 +26,7 @@
+ #include <time.h>
+ #include <errno.h>
+ #include <assert.h>
++#include <string.h>
+ 
+ using namespace std;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5004,6 +5004,8 @@ with pkgs;
 
   remarshal = callPackage ../development/tools/remarshal { };
 
+  rig = callPackage ../tools/misc/rig { };
+
   rocket = libsForQt5.callPackage ../tools/graphics/rocket { };
 
   rtaudio = callPackage ../development/libraries/audio/rtaudio { };


### PR DESCRIPTION
###### Motivation for this change
Simple package, available in other distros.

###### Things done
Took source files from homepage and patches from Debian (thanks Norbert Veber <nveber@debian.org>).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

