### PR TITLE
pythonPackages.testfixtures: 6.2.0 -> 6.3.0

### DIFF
--- a/pkgs/development/python-modules/testfixtures/default.nix
+++ b/pkgs/development/python-modules/testfixtures/default.nix
@@ -1,23 +1,33 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, mock, manuel, pytest, sybil, zope_component }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
+, mock, pytest, sybil, zope_component }:
 
 buildPythonPackage rec {
   pname = "testfixtures";
-  version = "6.2.0";
+  version = "6.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7e4df89a8bf8b8905464160f08aff131a36f0b33654fe4f9e4387afe546eae25";
+    sha256 = "1x16xkw483nb1ngv74s7lgaj514pb1ldklal7kb7iwqbxcgnrh2k";
   };
 
-  checkInputs = [ mock manuel pytest sybil zope_component ];
+  checkInputs = [ pytest mock sybil zope_component ];
+
+  patches = [
+    # Fix tests for Python 3.7. Remove with the next release
+    (fetchpatch {
+      url = https://github.com/Simplistix/testfixtures/commit/6e8807543b804946aba58e2c9e92f5bdc3656a57.patch;
+      sha256 = "1584jz2qz04arx8z8f6d1l1vab7gi38k3akzm223rmp7j4m7yrii";
+    })
+  ];
 
   checkPhase = ''
     # django is too much hasle to setup at the moment
-    pytest --ignore=testfixtures/tests/test_django testfixtures/tests
+    pytest -W ignore::DeprecationWarning --ignore=testfixtures/tests/test_django testfixtures/tests
   '';
 
   meta = with stdenv.lib; {
-    homepage = "https://github.com/Simplistix/testfixtures";
+    homepage = https://github.com/Simplistix/testfixtures;
+    description = "A collection of helpers and mock objects for unit tests and doc tests";
+    license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
fixed build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

