### PR TITLE
jpeginfo: init at 1.6.1

### DIFF
--- a/pkgs/applications/graphics/jpeginfo/default.nix
+++ b/pkgs/applications/graphics/jpeginfo/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, libjpeg }:
+
+stdenv.mkDerivation rec {
+  name = "jpeginfo-${version}";
+  version = "1.6.1";
+
+  src = fetchurl {
+    url = "https://www.kokkonen.net/tjko/src/${name}.tar.gz";
+    sha256 = "0lvn3pnylyj56158d3ix9w1gas1s29klribw9bz1xym03p7k37k2";
+  };
+
+  buildInputs = [ libjpeg ];
+
+  meta = with stdenv.lib; {
+    description = "Prints information and tests integrity of JPEG/JFIF files";
+    homepage = "https://www.kokkonen.net/tjko/projects.html";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.bjornfor ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3558,6 +3558,8 @@ with pkgs;
 
   jp2a = callPackage ../applications/misc/jp2a { };
 
+  jpeginfo = callPackage ../applications/graphics/jpeginfo { };
+
   jpegoptim = callPackage ../applications/graphics/jpegoptim { };
 
   jpegrescan = callPackage ../applications/graphics/jpegrescan { };


### PR DESCRIPTION
###### Motivation for this change
jpeginfo prints information and tests integrity of JPEG/JFIF files.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

