### PR TITLE
kube-router: init at 0.2.3

### DIFF
--- a/pkgs/applications/networking/cluster/kube-router/default.nix
+++ b/pkgs/applications/networking/cluster/kube-router/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "kube-router-${version}";
+  version = "0.2.3";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/cloudnativelabs/kube-router";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "cloudnativelabs";
+    repo = "kube-router";
+    sha256 = "1dsr76dq6sycwgh75glrcb4scv52lrrd0aivskhc7mwq30plafcj";
+  };
+
+  buildFlagsArray = ''
+    -ldflags=
+    -X
+    ${goPackagePath}/pkg/cmd.version=${version}
+    -X
+    ${goPackagePath}/pkg/cmd.buildDate=Nix
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.kube-router.io/";
+    description = "All-in-one router, firewall and service proxy for Kubernetes";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ colemickens johanot ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3675,6 +3675,8 @@ in
 
   kdiff3 = libsForQt5.callPackage ../tools/text/kdiff3 { };
 
+  kube-router = callPackage ../applications/networking/cluster/kube-router { };
+
   kwalletcli = libsForQt5.callPackage ../tools/security/kwalletcli { };
 
   peruse = libsForQt5.callPackage ../tools/misc/peruse { };


### PR DESCRIPTION
###### Motivation for this change
Kube-router is a good alternative to flannel and weavenet as a self-contained kubernetes software defined network solution. It's written in Golang and utilizes iptables, ipvs and ip utilities directly.
Learn more at: https://github.com/cloudnativelabs/kube-router and https://www.kube-router.io/

As pre-agreed, I've added @colemickens as co-maintainer on this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
