### PR TITLE
libpng: 1.6.35 -> 1.6.36, license v2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -451,6 +451,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "libpng License";
   };
 
+  libpng2 = {
+    fullName = "libpng License v2"; # 1.6.36+
+    inherit (libpng) url;
+  };
+
   libtiff = spdx {
     spdxId = "libtiff";
     fullName = "libtiff License";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -453,7 +453,7 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
 
   libpng2 = {
     fullName = "libpng License v2"; # 1.6.36+
-    inherit (libpng) url;
+    url = "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt";
   };
 
   libtiff = spdx {

--- a/pkgs/development/libraries/libpng/default.nix
+++ b/pkgs/development/libraries/libpng/default.nix
@@ -3,20 +3,20 @@
 assert zlib != null;
 
 let
-  patchVersion = "1.6.35";
+  patchVersion = "1.6.36";
   patch_src = fetchurl {
     url = "mirror://sourceforge/libpng-apng/libpng-${patchVersion}-apng.patch.gz";
-    sha256 = "011fq5wgyz07pfrqs9albixbiksx3agx5nkcf3535gbvhlwv5khq";
+    sha256 = "03ywdwaq1k3pfslvbs2b33z3pdmazz6yp8g56mzafacvfgd367wc";
   };
   whenPatched = stdenv.lib.optionalString apngSupport;
 
 in stdenv.mkDerivation rec {
   name = "libpng" + whenPatched "-apng" + "-${version}";
-  version = "1.6.35";
+  version = "1.6.36";
 
   src = fetchurl {
     url = "mirror://sourceforge/libpng/libpng-${version}.tar.xz";
-    sha256 = "1mxwjf5cdzk7g0y51gl9w3f0j5ypcls05i89kgnifjaqr742x493";
+    sha256 = "06d35a3xz2a0kph82r56hqm1fn8fbwrqs07xzmr93dx63x695szc";
   };
   postPatch = whenPatched "gunzip < ${patch_src} | patch -Np1";
 
@@ -25,14 +25,14 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ zlib ];
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = true;
 
   passthru = { inherit zlib; };
 
   meta = with stdenv.lib; {
     description = "The official reference implementation for the PNG file format" + whenPatched " with animation patch";
     homepage = http://www.libpng.org/pub/png/libpng.html;
-    license = licenses.libpng;
+    license = licenses.libpng2;
     platforms = platforms.all;
     maintainers = [ maintainers.vcunat maintainers.fuuzetsu ];
   };


### PR DESCRIPTION
###### Motivation for this change

https://sourceforge.net/p/png-mng/mailman/message/36483059/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---