### PR TITLE
dmrconfig: 2018-11-07 -> 1.0

### DIFF
--- a/pkgs/applications/misc/dmrconfig/default.nix
+++ b/pkgs/applications/misc/dmrconfig/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "dmrconfig-${version}";
-  version = "2018-11-07";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "sergev";
     repo = "dmrconfig";
-    rev = "b58985d3c848b927e91699d97f96d9de014c3fc7";
-    sha256 = "083f21hz6vqjpndkn27nsjnhnc5a4bw0cr26ryfqcvz275rj4k18";
+    rev = version;
+    sha256 = "1bb3hahfdb5phxyzp1m5ibqwz3mcqplzaibb1aq7w273xcfrd9l9";
   };
 
   buildInputs = [
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    substituteInPlace Makefile --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig
+    substituteInPlace Makefile \
+      --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig \
+      --replace "\$(shell git describe --tags --abbrev=0)" ${version} \
+      --replace "\$(shell git rev-list HEAD --count)" 0
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Upstream have made a new release that builds, so switched to release versions instead of random commits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

