### PR TITLE
hunspell: unbreak mythes build, due transient dependencies

### DIFF
--- a/pkgs/development/libraries/mythes/default.nix
+++ b/pkgs/development/libraries/mythes/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, hunspell, pkgconfig, perl }:
+{ stdenv, fetchurl, hunspell, ncurses, pkgconfig, perl }:
 
 stdenv.mkDerivation rec {
   name = "mythes-1.2.4";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ hunspell ];
-  nativeBuildInputs = [ pkgconfig perl ];
+  nativeBuildInputs = [ ncurses pkgconfig perl ];
 
   meta = {
     homepage = http://hunspell.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

Linking of this was broken
`/nix/store/6s8dkfj3irwv52cap2hd9k7gaddklfs1-binutils-2.30/bin/ld: cannot find -ltinfo`

(and as mythes is transient dependency of libreoffice, LO was broken as well)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

