### PR TITLE
ghc: don’t add libiconv automatically

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2527,6 +2527,23 @@ addEnvHooks "$hostOffset" myBashFunction
     </varlistentry>
     <varlistentry>
      <term>
+      libiconv, libintl
+     </term>
+     <listitem>
+       <para>
+	 A few libraries automatically add to
+	 <literal>NIX_LDFLAGS</literal> their library, making their
+	 symbols automatically available to the linker. This includes
+	 libiconv and libintl (gettext). This is done to provide
+	 compatibility between GNU Linux, where libiconv and libintl
+	 are bundled in, and other systems where that might not be the
+	 case. Sometimes, this behavior is not desired. To disable
+	 this behavior, set <literal>dontAddExtraLibs</literal>.
+       </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
       cmake
      </term>
      <listitem>

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -206,6 +206,9 @@ stdenv.mkDerivation (rec {
     "--disable-large-address-space"
   ];
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -186,6 +186,9 @@ stdenv.mkDerivation (rec {
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -167,6 +167,9 @@ stdenv.mkDerivation (rec {
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour

--- a/pkgs/development/compilers/ghc/8.6.2.nix
+++ b/pkgs/development/compilers/ghc/8.6.2.nix
@@ -167,6 +167,9 @@ stdenv.mkDerivation (rec {
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -149,6 +149,9 @@ stdenv.mkDerivation (rec {
   # Make sure we never relax`$PATH` and hooks support for compatability.
   strictDeps = true;
 
+  # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
+  dontAddExtraLibs = true;
+
   nativeBuildInputs = [
     perl autoconf automake m4 python3
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -10,7 +10,7 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-if [ ! -z "@gettextNeedsLdflags@" ]; then
+if [ -n "@gettextNeedsLdflags@" -a -z "$dontAddExtraLibs" ]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
     export NIX_${role_pre}LDFLAGS+=" -lintl"

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -2,5 +2,7 @@
 # it doesn't hurt to have it in Glibc either though
 
 # See pkgs/build-support/setup-hooks/role.bash
-getHostRole
-export NIX_${role_pre}LDFLAGS+=" -liconv"
+if [ -z "$dontAddExtraLibs" ]; then
+    getHostRole
+    export NIX_${role_pre}LDFLAGS+=" -liconv"
+fi


### PR DESCRIPTION
ghc needs it to fail to correctly detect it for later. GHC uses autoconf to detect whether "-liconv" is needed. The test tries a test program that needs libiconv to work. If the test fails, libiconv is added to all LDFLAGS that GHC compiles. We want this to happen so that GHC works outside of Nix's cc-wrapper! So, this PR adds ```dontAddExtraLibs``` that tells cc-wrapper to not add extra libraries. I've added a short description in the docs explaining the situation as well.

Fixes #46814.