### PR TITLE
Add disable core optimizations

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -259,6 +259,9 @@ rec {
    */
   buildStrictly = pkg: buildFromSdist (failOnAllWarnings pkg);
 
+  /* Disable core optimizations, significantly speeds up build time */
+  disableCoreOpts = pkg: appendConfigureFlags pkg ["--ghc-options=-O0"];
+
   /* Turn on most of the compiler warnings and fail the build if any
      of them occur. */
   failOnAllWarnings = drv: appendConfigureFlag drv "--ghc-option=-Wall --ghc-option=-Werror";

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -260,7 +260,7 @@ rec {
   buildStrictly = pkg: buildFromSdist (failOnAllWarnings pkg);
 
   /* Disable core optimizations, significantly speeds up build time */
-  disableCoreOpts = pkg: appendConfigureFlags pkg ["--ghc-options=-O0"];
+  disableCoreOpts = pkg: appendConfigureFlag pkg "--disable-optimization";
 
   /* Turn on most of the compiler warnings and fail the build if any
      of them occur. */

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -260,7 +260,7 @@ rec {
   buildStrictly = pkg: buildFromSdist (failOnAllWarnings pkg);
 
   /* Disable core optimizations, significantly speeds up build time */
-  disableCoreOpts = pkg: appendConfigureFlag pkg "--disable-optimization";
+  disableOptimization = pkg: appendConfigureFlag pkg "--disable-optimization";
 
   /* Turn on most of the compiler warnings and fail the build if any
      of them occur. */


### PR DESCRIPTION
Adds a utility function for disabling GHC core optimizations.
Significantly increases build times.

###### Motivation for this change
This change is common enough it warrants its own function
This change will allow new Haskell / Nix users to speed up builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

