### PR TITLE
polar-bookshelf: 1.0.13 -> 1.1.0

### DIFF
--- a/pkgs/applications/misc/polar-bookshelf/default.nix
+++ b/pkgs/applications/misc/polar-bookshelf/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   name = "polar-bookshelf-${version}";
-  version = "1.0.13";
+  version = "1.1.0";
 
   # fetching a .deb because there's no easy way to package this Electron app
   src = fetchurl {
     url = "https://github.com/burtonator/polar-bookshelf/releases/download/v${version}/polar-bookshelf-${version}-amd64.deb";
-    sha256 = "0dh7pw8ncm8kr9anb6jqw7rr4lxgmq8a40c9zlrhzyswdpvnp1g7";
+    sha256 = "13h6c9sqbc7c5p1rc1wm7wza249sh0j04aq67n6gnqg5p22a7pmw";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
```
# 1.0.14

- Upgrade to latest semver and firebase-tools 

- Fixed bug where the lightbox was kept enabled after we deleted an annotation

- We can now capture a new class of documents that use a vertical height on 
  their CSS selectors. 

- We can now capture XML documents which used XSL stylesheets.

- Major refactor of the disk datastore for the pending cloud sync functionality
  we're working on.

# 1.1.0

Polar 1.1 is fresh out the door and a lot of amazing features and bug fixes are enabled in this release.

The biggest feature by far is our support for the 'Save to Polar' chrome extension that allows you to send the URL of your active tab to Polar for content capture.

This makes it a lot easier to work with Polar as you can just click a button in Chrome and have it sent to Polar.

We plan on adding support for Safari, and Firefox in the future but we're taking things one step at a time.

Other features in 1.1 include:
- Disabling amp for now until we have a better solution on how to show the user that an AMP page is displayed and how to disable / enable it. Otherwise its confusing and often the amp page is WORSE not better.
- Fixed bugs with the browser size not changing during capture browser changing and also fixed some issues with it not properly accepting the browser change in some situations.
- Fixed bug in HTML zoom where the page would be truncated improperly.
- Blocked amp ads during the capture but they aren't blocked during the preview at the moment.
- "Fixed" nasty anti-aliasing bug in electron by blocking amp ads. They were annoying anyway but for some reason they were breaking chrome rendering - probably due to some web component nonsense.
- Implemented a new strategy with the vertical height algorithm in the capture system to revert it back to auto instead of a fixed max-height. Works a lot better now.
- Date/times no longer include ' ago' to be a bit more concise.
- Added small FAQ entry to enable Anki sync.
- Fixed a bug where we could select text and not properly work with elements.
- Renderer analytics didn't understand that a callback without an error wasn't a failure.
- Upgraded a number of important react packages: react react-dom react-moment react-select @types/react-table @types/react-select @types/react @types/prop-types @types/node-fetch
- removed inversify package (were not using it)
- latest fontawesome
- latest node-fetch
- fixed issue with electron-builder where it was forcing us to upgrade to the latest version for each release.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

