### PR TITLE
renderdoc: 1.1 -> 1.2

### DIFF
--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -7,19 +7,19 @@ let
   custom_swig = fetchFromGitHub {
     owner = "baldurk";
     repo = "swig";
-    rev = "renderdoc-modified-5";
-    sha256 = "0ihrxbx56p5wn589fbbsns93fp91sypqdzfxdy7l7v9sf69a41mw";
+    rev = "renderdoc-modified-6";
+    sha256 = "00ykqlzx1k9iwqjlc54kfch7cnzsj53hxn7ql70dj3rxqzrnadc0";
   };
 in
 stdenv.mkDerivation rec {
-  version = "1.1";
+  version = "1.2";
   name = "renderdoc-${version}";
 
   src = fetchFromGitHub {
     owner = "baldurk";
     repo = "renderdoc";
     rev = "v${version}";
-    sha256 = "0kb9m1dm0mnglqyh1srvl0f1bgjghxzbqarn0xfqw49wphqwhmcd";
+    sha256 = "0s1q5d58x18yz3nf94pv5i1qd2hc0a4gdj4qkpcn8s6ms2x05pz4";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Routine update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

