### PR TITLE
applications.audio.luppp: new package (at version 1.2.0)

### DIFF
--- a/pkgs/applications/audio/luppp/build-install.patch
+++ b/pkgs/applications/audio/luppp/build-install.patch
@@ -1,0 +1,16 @@
+commit 4ec09e6f6e00e40622a5207ed24dc657da9a9090
+Author: Pavol Rusnak <stick@gk2.sk>
+Date:   Tue Dec 4 12:06:22 2018 +0100
+
+    build: add install: true to executable in meson.build
+
+diff --git a/meson.build b/meson.build
+index 050e1b1..9224ed5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -39,4 +39,5 @@ endforeach
+ 
+ # compile the main project
+ executable('luppp', luppp_src + [version_hxx],
++    install: true,
+     dependencies: deps)

--- a/pkgs/applications/audio/luppp/default.nix
+++ b/pkgs/applications/audio/luppp/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, jack2
+, cairo
+, liblo
+, libsndfile
+, libsamplerate
+, ntk
+}:
+
+stdenv.mkDerivation rec {
+  name = "luppp-${version}";
+  version = "1.2.0";
+  patches = [ ./build-install.patch ];
+
+  src = fetchFromGitHub {
+    owner = "openAVproductions";
+    repo = "openAV-Luppp";
+    rev = "release-${version}";
+    sha256 = "194yq0lqc2psq9vyxmzif40ccawcvd9jndcn18mkz4f8h5w5rc1a";
+  };
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig
+  ];
+
+  buildInputs = [
+    jack2 cairo liblo libsndfile libsamplerate ntk
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://openavproductions.com/luppp/;
+    description = "A music creation tool, intended for live use";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17858,6 +17858,8 @@ in
     lua = lua5_1;
   };
 
+  luppp = callPackage ../applications/audio/luppp { };
+
   lv2bm = callPackage ../applications/audio/lv2bm { };
 
   lynx = callPackage ../applications/networking/browsers/lynx { };


### PR DESCRIPTION
###### Motivation for this change

This packages an interesting audio application called Luppp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

