### PR TITLE
kdeconnect: init module

### DIFF
--- a/nixos/modules/programs/kdeconnect.nix
+++ b/nixos/modules/programs/kdeconnect.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.eliasp ];
+
+  options = {
+    programs.kdeconnect = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Enable KDE Connect and configure the firewall for it.";
+      };
+    };
+  };
+
+  config = mkIf config.programs.kdeconnect.enable {
+    environment.systemPackages = [ pkgs.kdeconnect ];
+    networking.firewall.allowedTCPPortRanges = [ { from = 1714; to = 1764; } ];
+    networking.firewall.allowedUDPPortRanges = [ { from = 1714; to = 1764; } ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

I struggled to get KDE Connect working on NixOS until I found out I manually need to open a few ports by adding this to my `configuration.nix`:

```
networking.firewall.allowedTCPPortRanges = [ { from = 1714; to = 1764; } ];
networking.firewall.allowedUDPPortRanges = [ { from = 1714; to = 1764; } ];
```

I wanted to make this a little more discoverable/accessible by providing a global option to enable KDE Connect.

###### Things done

- Tested it by:
  - including `nixos/modules/programs/kdeconnect.nix` in my `configuration.nix`
  - disabling my previous lines to make KDE Connect work (see above)
  - setting `programs.kdeconnect.enable = true;`
  - rebuilding my environment
  - testing KDE Connect's functionality (e.g. test-pinging my smartphone from my desktop and vice versa).

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

