### PR TITLE
mediawiki: 1.29.1 -> 1.31.1

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/mediawiki.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/mediawiki.nix
@@ -83,11 +83,11 @@ let
 
   # Unpack Mediawiki and put the config file in its root directory.
   mediawikiRoot = pkgs.stdenv.mkDerivation rec {
-    name= "mediawiki-1.29.1";
+    name= "mediawiki-1.31.1";
 
     src = pkgs.fetchurl {
-      url = "https://releases.wikimedia.org/mediawiki/1.29/${name}.tar.gz";
-      sha256 = "03mpazbxvb011s2nmlw5p6dc43yjgl5yrsilmj1imyykm57bwb3m";
+      url = "https://releases.wikimedia.org/mediawiki/1.31/${name}.tar.gz";
+      sha256 = "13x48clij21cmysjkpnx68vggchrdasqp7b290j87xlfgjhdhnnf";
     };
 
     skins = config.skins;
@@ -111,7 +111,7 @@ let
         sed -i \
         -e 's|/bin/bash|${pkgs.bash}/bin/bash|g' \
         -e 's|/usr/bin/timeout|${pkgs.coreutils}/bin/timeout|g' \
-          $out/includes/limit.sh \
+          $out/includes/shell/limit.sh \
           $out/includes/GlobalFunctions.php
       '';
   };


### PR DESCRIPTION
###### Motivation for this change
MediaWiki 1.29 is an obsolete release of MediaWiki. The final security and maintenance release was released on 20 September 2018"
MediaWiki 1.31 is the latest release of MediaWiki

Sources:

https://www.mediawiki.org/wiki/MediaWiki_1.29
https://www.mediawiki.org/wiki/MediaWiki_1.31

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

