### PR TITLE
sublime3-dev: 3176 → 3183

### DIFF
--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -1,14 +1,14 @@
 {buildVersion, x32sha256, x64sha256}:
 
-{ fetchurl, stdenv, glib, xorg, cairo, gtk2, pango, makeWrapper, openssl, bzip2,
+{ fetchurl, stdenv, glib, xorg, cairo, gtk2, gtk3, pango, makeWrapper, wrapGAppsHook, openssl, bzip2,
   pkexecPath ? "/run/wrappers/bin/pkexec", libredirect,
   gksuSupport ? false, gksu, unzip, zip, bash}:
 
 assert gksuSupport -> gksu != null;
 
 let
-
-  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk2 cairo pango];
+  legacy = stdenv.lib.versionOlder buildVersion "3181";
+  libPath = stdenv.lib.makeLibraryPath [ glib xorg.libX11 (if legacy then gtk2 else gtk3) cairo pango ];
   redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
     ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
 in let
@@ -36,11 +36,14 @@ in let
 
     dontStrip = true;
     dontPatchELF = true;
-    buildInputs = [ makeWrapper zip unzip ];
+    buildInputs = stdenv.lib.optionals (!legacy) [ glib gtk3 ]; # for GSETTINGS_SCHEMAS_PATH
+    nativeBuildInputs = [ makeWrapper zip unzip ] ++ stdenv.lib.optional (!legacy) wrapGAppsHook;
 
     # make exec.py in Default.sublime-package use own bash with
     # an LD_PRELOAD instead of "/bin/bash"
     patchPhase = ''
+      runHook prePatch
+
       mkdir Default.sublime-package-fix
       ( cd Default.sublime-package-fix
         unzip -q ../Packages/Default.sublime-package
@@ -50,9 +53,13 @@ in let
         zip -q ../Packages/Default.sublime-package **/*
       )
       rm -r Default.sublime-package-fix
+
+      runHook postPatch
     '';
 
     buildPhase = ''
+      runHook preBuild
+
       for i in sublime_text plugin_host crash_reporter; do
         patchelf \
           --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
@@ -62,9 +69,13 @@ in let
 
       # Rewrite pkexec|gksudo argument. Note that we can't delete bytes in binary.
       sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' sublime_text
+
+      runHook postBuild
     '';
 
     installPhase = ''
+      runHook preInstall
+
       # Correct sublime_text.desktop to exec `sublime' instead of /opt/sublime_text
       sed -e "s,/opt/sublime_text/sublime_text,$out/sublime_text," -i sublime_text.desktop
 
@@ -74,12 +85,20 @@ in let
       # We can't just call /usr/bin/env bash because a relocation error occurs
       # when trying to run a build from within Sublime Text
       ln -s ${bash}/bin/bash $out/sublime_bash
+
+      runHook postInstall
+    '';
+
+    dontWrapGApps = true; # non-standard location, need to wrap the executables manually
+
+    postFixup = ''
       wrapProgram $out/sublime_bash \
         --set LD_PRELOAD "${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1"
 
       wrapProgram $out/sublime_text \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
-        --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects}
+        --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects} \
+        ${stdenv.lib.optionalString (!legacy) ''"''${gappsWrapperArgs[@]}"''}
 
       # Without this, plugin_host crashes, even though it has the rpath
       wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${openssl.out}/lib/libssl.so:${bzip2.out}/lib/libbz2.so

--- a/pkgs/applications/editors/sublime/3/packages.nix
+++ b/pkgs/applications/editors/sublime/3/packages.nix
@@ -5,9 +5,9 @@ let
 in
   rec {
     sublime3-dev = common {
-      buildVersion = "3176";
-      x32sha256 = "08asz13888d4ddsz81cfk7k3319dabzz1kgbnshw0756pvyrvr23";
-      x64sha256 = "0cppkh5jx2g8f6jyy1bs81fpb90l0kn5m7y3skackpjdxhd7rwbl";
+      buildVersion = "3183";
+      x32sha256 = "0rgah7iq9y3afbawcb723d2b7m56lz0ji5l8klxvkp59c9rphqxh";
+      x64sha256 = "1n3zarkhs22p2vi32fswb0fvcn9fzivmziw6zcvjy02c0rmxmdkz";
     } {};
 
     sublime3 = common {


### PR DESCRIPTION
###### Motivation for this change
Sublime finally switched to GTK 3!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @wmertens @demin-dmitriy @zimbatm