### PR TITLE
libffi: swap src URL from FTP to HTTPS

### DIFF
--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   name = "libffi-3.2.1";
 
   src = fetchurl {
-    url = "ftp://sourceware.org/pub/libffi/${name}.tar.gz";
+    url = "https://sourceware.org/pub/libffi/${name}.tar.gz";
     sha256 = "0dya49bnhianl0r65m65xndz6ls2jn1xngyn72gd28ls3n7bnvnh";
   };
 


### PR DESCRIPTION
HTTPS is never worse and often better than FTP, since it's faster, more secure,
and more likely to be accessible through firewalls.

This does not change the tarball sha, as confirmed by `nix-prefetch-url`.

