### PR TITLE
fetchurl: fix and add extra KDE mirrors

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -70,15 +70,14 @@ rec {
     ftp://ftp.funet.fi/pub/mirrors/ftp.kernel.org/pub/
   ];
 
-  # Mirrors of ftp://ftp.kde.org/pub/kde/.
+  # Mirrors from https://download.kde.org/extra/download-mirrors.html
   kde = [
-    "http://download.kde.org/download.php?url="
+    "https://download.kde.org/download.php?url="
     https://ftp.gwdg.de/pub/linux/kde/
     https://mirrors.ocf.berkeley.edu/kde/
     http://mirrors.mit.edu/kde/
-    ftp://ftp.heanet.ie/mirrors/ftp.kde.org/
-    ftp://ftp.kde.org/pub/kde/
-    ftp://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/
+    https://mirrors.ustc.edu.cn/kde/
+    http://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/
   ];
 
   # Gentoo files.

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -73,7 +73,9 @@ rec {
   # Mirrors of ftp://ftp.kde.org/pub/kde/.
   kde = [
     "http://download.kde.org/download.php?url="
-    http://ftp.gwdg.de/pub/x11/kde/
+    https://ftp.gwdg.de/pub/linux/kde/
+    https://mirrors.ocf.berkeley.edu/kde/
+    http://mirrors.mit.edu/kde/
     ftp://ftp.heanet.ie/mirrors/ftp.kde.org/
     ftp://ftp.kde.org/pub/kde/
     ftp://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -78,6 +78,7 @@ rec {
     http://mirrors.mit.edu/kde/
     https://mirrors.ustc.edu.cn/kde/
     http://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/
+    ftp://ftp.kde.org/pub/kde/
   ];
 
   # Gentoo files.


### PR DESCRIPTION
- The gwdg.de mirror has moved the relative path of its KDE tarballs
- Add new mirrors from Berkeley and MIT, which are on the list of officially supported mirrors

https://download.kde.org/extra/download-mirrors.html

###### Motivation for this change
I had some issues downloading KDE source tarballs with the existing mirrors; at least 1 of them is broken, and fixed here.  The newly added ones work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

