### PR TITLE
Add mock to the list of whisper's test inputs.

### DIFF
--- a/pkgs/development/python-modules/whisper/default.nix
+++ b/pkgs/development/python-modules/whisper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, six }:
+{ stdenv, buildPythonPackage, fetchPypi, mock, six }:
 
 buildPythonPackage rec {
   pname = "whisper";
@@ -10,6 +10,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six ];
+  checkInputs           = [ mock ];
 
   meta = with stdenv.lib; {
     homepage = http://graphite.wikidot.com/;


### PR DESCRIPTION
This was required as the versiof whisper was upgraded from
1.1.3 to 1.1.4 and mock was added as a test dependency in
that release:
https://github.com/graphite-project/whisper/commit/703dd9d3a60a0f79383c03a541ee66bd50966a01#diff-62849af500c571aa4532da7be8833e73R14

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/51484

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

