### PR TITLE
cowsay: fix cross

### DIFF
--- a/pkgs/tools/misc/cowsay/default.nix
+++ b/pkgs/tools/misc/cowsay/default.nix
@@ -11,8 +11,18 @@ stdenv.mkDerivation rec{
 
   buildInputs = [ perl ];
 
+  postBuild = ''
+    substituteInPlace cowsay --replace "%BANGPERL%" "!${perl}/bin/perl" \
+      --replace "%PREFIX%" "$out"
+  '';
+
   installPhase = ''
-    bash ./install.sh $out
+    mkdir -p $out/{bin,man/man1,share/cows}
+    install -m755 cowsay $out/bin/cowsay
+    ln -s cowsay $out/bin/cowthink
+    install -m644 cowsay.1 $out/man/man1/cowsay.1
+    ln -s cowsay.1 $out/man/man1/cowthink.1
+    install -m644 cows/* -t $out/share/cows/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
The install.sh script looks for all perls in $PATH, tries to execute
these to test whether that perl is "good", if it is, takes it and
puts it into the shebang.

This obviously can't work for cross. As installation seems to be pretty
trivial, do it in a custom install phase.

###### Motivation for this change
I wanted to cross-compile `cowsay`, who wouldn't want to do that?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

