### PR TITLE
mythes: Remove spurious dependency on ncurses

### DIFF
--- a/pkgs/development/libraries/mythes/Move-example-from-noinst_PROGRAMS-to-check_PROGRAMS.patch
+++ b/pkgs/development/libraries/mythes/Move-example-from-noinst_PROGRAMS-to-check_PROGRAMS.patch
@@ -1,0 +1,26 @@
+From 1f5af8770809f15f0f4a5d2cc59af1198cde2fdc Mon Sep 17 00:00:00 2001
+From: Neil Mayhew <neil@neil.mayhew.name>
+Date: Mon, 3 Dec 2018 16:41:57 -0700
+Subject: [PATCH] Move example from noinst_PROGRAMS to check_PROGRAMS
+Content-Type: text/plain; charset=utf-8
+
+---
+ Makefile.am | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index c623df9..aba53b4 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,6 +1,7 @@
++AUTOMAKE_OPTIONS = foreign
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-noinst_PROGRAMS = example
++check_PROGRAMS = example
+ 
+ dist_bin_SCRIPTS = th_gen_idx.pl
+ 
+-- 
+2.19.1
+

--- a/pkgs/development/libraries/mythes/default.nix
+++ b/pkgs/development/libraries/mythes/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, hunspell, ncurses, pkgconfig, perl }:
+{ stdenv, fetchurl, autoreconfHook, hunspell, pkgconfig, perl }:
 
 stdenv.mkDerivation rec {
   name = "mythes-1.2.4";
@@ -8,8 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "0prh19wy1c74kmzkkavm9qslk99gz8h8wmjvwzjc6lf8v2az708y";
   };
 
-  buildInputs = [ hunspell ];
-  nativeBuildInputs = [ ncurses pkgconfig perl ];
+  buildInputs = [ autoreconfHook hunspell ];
+  nativeBuildInputs = [ pkgconfig perl ];
+
+  patches = [ ./Move-example-from-noinst_PROGRAMS-to-check_PROGRAMS.patch ];
 
   meta = {
     homepage = http://hunspell.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

A dependency on `ncurses` was added to fix a build failure, but `ncurses` is needed only for a test program which should be in `check_PROGRAMS` instead of `noinst_PROGRAMS`. This change adds a patch for this. I'll submit the patch upstream so it doesn't become a maintenance burden.

The bug is reported as #51297.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

