### PR TITLE
docs: Remove nix-repl references

### DIFF
--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -49,12 +49,12 @@ texlive.combine {
    </listitem>
    <listitem>
     <para>
-     You can list packages e.g. by <command>nix-repl</command>.
-<programlisting>
-$ nix-repl
-nix-repl> :l &lt;nixpkgs>
-nix-repl> texlive.collection-&lt;TAB>
-      </programlisting>
+     You can list packages e.g. by <command>nix repl</command>.
+<programlisting><![CDATA[
+$ nix repl
+nix-repl> :l <nixpkgs>
+nix-repl> texlive.collection-<TAB>
+]]></programlisting>
     </para>
    </listitem>
    <listitem>

--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -113,12 +113,10 @@ $ nixos-option <xref linkend="opt-boot.kernelModules"/>
 [ "tun" "ipv6" "loop" <replaceable>...</replaceable> ]
 </screen>
   Interactive exploration of the configuration is possible using
-  <command
-xlink:href="https://github.com/edolstra/nix-repl">nix-repl</command>,
-  a read-eval-print loop for Nix expressions. It’s not installed by default;
-  run <literal>nix-env -i nix-repl</literal> to get it. A typical use:
+  <command>nix repl</command>, a read-eval-print loop for Nix expressions.
+  A typical use:
 <screen>
-$ nix-repl '&lt;nixpkgs/nixos>'
+$ nix repl '&lt;nixpkgs/nixos>'
 
 nix-repl> config.<xref linkend="opt-networking.hostName"/>
 "mandark"


### PR DESCRIPTION
###### Motivation for this change

nix-repl has been deprecated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

