### PR TITLE
nordic-polar: init at 1.3.0

### DIFF
--- a/pkgs/data/themes/nordic-polar/default.nix
+++ b/pkgs/data/themes/nordic-polar/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "nordic-polar-${version}";
+  version = "1.3.0";
+
+  srcs = [
+    (fetchurl {
+      url = "https://github.com/EliverLara/Nordic-Polar/releases/download/v${version}/Nordic-Polar.tar.xz";
+      sha256 = "1c5zgymkwd89fr680c49siwbkhfbay56iq9vlyqkj1dp0xnc528s";
+    })
+    (fetchurl {
+      url = "https://github.com/EliverLara/Nordic-Polar/releases/download/v${version}/Nordic-Polar-standard-buttons.tar.xz";
+      sha256 = "0nxzcgqzc42qvnhafranz6rwanqb4wzf9ychm5m4yrlp3ngw38p4";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -a Nordic-Polar* $out/share/themes
+    rm $out/share/themes/*/{LICENSE,README.md}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gtk theme created using the awesome Nord color pallete";
+    homepage = https://github.com/EliverLara/Nordic-Polar;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15478,6 +15478,8 @@ in
 
   nafees = callPackage ../data/fonts/nafees { };
 
+  nordic-polar = callPackage ../data/themes/nordic-polar { };
+
   inherit (callPackages ../data/fonts/noto-fonts {})
     noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-extra;
 


### PR DESCRIPTION
###### Motivation for this change

Add [nordic-polar](https://github.com/EliverLara/Nordic-Polar), a Gtk3.20+ theme created using the awesome [Nord](https://github.com/arcticicestudio/nord) color palette.

![nordic](https://user-images.githubusercontent.com/1217934/49415706-41eb7c00-f756-11e8-9160-d491b38b9c13.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).