### PR TITLE
noto-fonts: update 2017-10-24 -> 2018-11-30

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -2,11 +2,14 @@
 
 let
   mkNoto = { name, weights, sha256, }:
-    let version = "2017-10-24-phase3-second-cleanup"; in
+    let
+      version = "2018-11-30";
+      ref = "85e78f831469323c85847e23f95026c894159135";
+    in
     fetchzip {
       name = "${name}-${version}";
       inherit sha256;
-      url = "https://github.com/googlei18n/noto-fonts/archive/v${version}.zip";
+      url = "https://github.com/googlei18n/noto-fonts/archive/${ref}.zip";
       postFetch = ''
         unzip $downloadedFile
         mkdir -p $out/share/fonts/noto
@@ -47,12 +50,12 @@ rec {
   noto-fonts = mkNoto {
     name = "noto-fonts";
     weights = "{Regular,Bold,Light,Italic,BoldItalic,LightItalic}";
-    sha256 = "1dmarbsfank6xzzx31h5jdv6n99rzblqyb1iqjkpll6dl3627pnb";
+    sha256 = "0kvq5ldip2ra2njlxg9fxj46nfqzq5l3n359d3kwfbsld7hixm2d";
   };
   noto-fonts-extra = mkNoto {
     name = "noto-fonts-extra";
     weights = "{Black,Condensed,Extra,Medium,Semi,Thin}*";
-    sha256 = "1lih49bqmsmblczvbl7qb1bhn0bq8v5xkr991b3gjghpdkx584bc";
+    sha256 = "0l94aiy1b3qirg2mmbagbr0014vqk32za79pzck1acy2hgy716kq";
   };
   noto-fonts-cjk = let version = "1.004"; in fetchzip {
     name = "noto-fonts-cjk-${version}";


### PR DESCRIPTION
###### Motivation for this change

Update the Noto fonts, particularly to avoid an old ligature issue. Fixes: #51498.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

