### PR TITLE
[18.09] python.pkgs.pygraphviz: add graphviz path

### DIFF
--- a/pkgs/development/python-modules/pygraphviz/default.nix
+++ b/pkgs/development/python-modules/pygraphviz/default.nix
@@ -13,8 +13,18 @@ buildPythonPackage rec {
   buildInputs = [ doctest-ignore-unicode mock nose ];
   propagatedBuildInputs = [ graphviz pkgconfig ];
 
-  # the tests are currently failing:
-  # check status of pygraphviz/pygraphviz#129
+  patches = [
+    # pygraphviz depends on graphviz being in PATH. This patch always prepends
+    # graphviz to PATH.
+    ./graphviz-path.patch
+  ];
+  postPatch = ''
+    substituteInPlace pygraphviz/agraph.py --subst-var-by graphvizPath '${graphviz}/bin'
+  '';
+
+  # The tests are currently failing because of a bug in graphviz 2.40.1.
+  # Upstream does not want to skip the relevant tests:
+  # https://github.com/pygraphviz/pygraphviz/pull/129
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pygraphviz/graphviz-path.patch
+++ b/pkgs/development/python-modules/pygraphviz/graphviz-path.patch
@@ -1,0 +1,13 @@
+diff --git a/pygraphviz/agraph.py b/pygraphviz/agraph.py
+index 8f72024..2d8358e 100644
+--- a/pygraphviz/agraph.py
++++ b/pygraphviz/agraph.py
+@@ -1557,7 +1557,7 @@ class AGraph(object):
+         import os
+         import glob
+ 
+-        paths = os.environ["PATH"]
++        paths = '@graphvizPath@:' + os.environ["PATH"]
+         if os.name == "nt":
+             exe = ".exe"
+         else:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7957,7 +7957,9 @@ in {
     };
   };
 
-  pygraphviz = callPackage ../development/python-modules/pygraphviz { };
+  pygraphviz = callPackage ../development/python-modules/pygraphviz {
+    graphviz = pkgs.graphviz; # not the python package
+  };
 
   pymc3 = callPackage ../development/python-modules/pymc3 { };
 


### PR DESCRIPTION
###### Motivation for this change

Backport of #51501, since it fixes a bug.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

