### PR TITLE
valgrind: run autoconf to pick up Makefile.am patch

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, gdb, llvm, cctools, xnu, bootstrap_cmds }:
+{ stdenv, fetchurl, perl, gdb, llvm, cctools, xnu, bootstrap_cmds, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "valgrind-3.14.0";
@@ -8,7 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "19ds42jwd89zrsjb94g7gizkkzipn8xik3xykrpcqxylxyzi2z03";
   };
 
+  # autoreconfHook is needed to pick up patching of Makefile.am
+  # Remove when the patch no longer applies.
   patches = [ ./coregrind-makefile-race.patch ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   outputs = [ "out" "dev" "man" "doc" ];
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/51107 added a patch to Makefile.am to fix
a race condition in the build. It was unfortunately never picked up as we were
using the generated makefile from the tarball.

cc #51444 and @srhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

