### PR TITLE
Make __DATE__/__TIME__ deterministic when NIX_ENFORCE_PURITY=1

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -137,6 +137,15 @@ source @out@/nix-support/add-hardening.sh
 extraAfter=($NIX_@infixSalt@_CFLAGS_COMPILE)
 extraBefore=(${hardeningCFlags[@]+"${hardeningCFlags[@]}"})
 
+# When enforcing purity, pretend gcc can't find the current date and
+# time
+if [[ "${NIX_ENFORCE_PURITY:-}" = 1 ]]; then
+    extraAfter=(-D__DATE__=\"???-??-????\"
+        -D__TIME__=\"??:??:??\"
+        -Wno-builtin-macro-redefined
+	"${extraAfter[@]}")
+fi
+
 if [ "$dontLink" != 1 ]; then
 
     # Add the flags that should only be passed to the compiler when


### PR DESCRIPTION
Extracted from https://github.com/NixOS/nixpkgs/pull/2281/commits/3dba999c62011e64222e593f835f63ebd3f0f47e.

See #2281. This is the gcc stuff in the list made by @Ekleog in https://github.com/NixOS/nixpkgs/pull/2281#issuecomment-424810028, excluding the PGO commit.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

