### PR TITLE
[18.09] backport nix-{zsh,bash}-completions

### DIFF
--- a/pkgs/shells/bash/nix-bash-completions/default.nix
+++ b/pkgs/shells/bash/nix-bash-completions/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.6";
+  version = "0.6.7";
   name = "nix-bash-completions-${version}";
 
   src = fetchFromGitHub {
     owner = "hedning";
     repo = "nix-bash-completions";
     rev = "v${version}";
-    sha256 = "1lz9cgacyd4cphr7l90x4hn0ifhxwzz2d5829w1jcglasfacfpsw";
+    sha256 = "067j1gavpm9zv3vzw9gq0bi3bi0rjrijwprc1j016g44kvpq49qi";
   };
 
   # To enable lazy loading via. bash-completion we need a symlink to the script

--- a/pkgs/shells/zsh/nix-zsh-completions/default.nix
+++ b/pkgs/shells/zsh/nix-zsh-completions/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 let
-  version = "0.4.0";
+  version = "0.4.1";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
     rev = "${version}";
-    sha256 = "0m8b9xgbz2nvk1q7m0gqy83gbqa49n062gymhk9x93zhbdh8vwky";
+    sha256 = "1p2y1sg6jghixv2j3fwxnkyl3idj44gcm71bbn25mnqfhm0z25hr";
   };
 
   installPhase = ''

--- a/pkgs/shells/zsh/nix-zsh-completions/default.nix
+++ b/pkgs/shells/zsh/nix-zsh-completions/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 let
-  version = "0.4.1";
+  version = "0.4.2";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
     rev = "${version}";
-    sha256 = "1p2y1sg6jghixv2j3fwxnkyl3idj44gcm71bbn25mnqfhm0z25hr";
+    sha256 = "1pfyn8kd9fc9fyy77imzg6xj00nzddkjagwjs2594db8ynp6cfil";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes a bunch of small issues, and adds completion to `nixos-option` and full completion for `nix-prefetch-url`.