### PR TITLE
gmp: don't use uname to detect system features

### DIFF
--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -29,16 +29,13 @@ let self = stdenv.mkDerivation rec {
     #
     # no darwin because gmp uses ASM that clang doesn't like
     (stdenv.lib.enableFeature (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "fat")
+    # The config.guess in GMP tries to runtime-detect various
+    # ARM optimization flags via /proc/cpuinfo (and is also
+    # broken on multicore CPUs). Avoid this impurity.
+    "--build=${stdenv.buildPlatform.config}"
   ] ++ optional (cxx && stdenv.isDarwin) "CPPFLAGS=-fexceptions"
     ++ optional (stdenv.isDarwin && stdenv.is64bit) "ABI=64"
     ;
-
-  # The config.guess in GMP tries to runtime-detect various
-  # ARM optimization flags via /proc/cpuinfo (and is also
-  # broken on multicore CPUs). Avoid this impurity.
-  preConfigure = optionalString stdenv.isAarch32 ''
-      configureFlagsArray+=("--build=$(./configfsf.guess)")
-    '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -30,17 +30,14 @@ let self = stdenv.mkDerivation rec {
     #
     # no darwin because gmp uses ASM that clang doesn't like
     (stdenv.lib.enableFeature (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "fat")
+    # The config.guess in GMP tries to runtime-detect various
+    # ARM optimization flags via /proc/cpuinfo (and is also
+    # broken on multicore CPUs). Avoid this impurity.
+    "--build=${stdenv.buildPlatform.config}"
   ] ++ optional (cxx && stdenv.isDarwin) "CPPFLAGS=-fexceptions"
     ++ optional (stdenv.isDarwin && stdenv.is64bit) "ABI=64"
     ++ optional (with stdenv.hostPlatform; useAndroidPrebuilt || useiOSPrebuilt) "--disable-assembly"
     ;
-
-  # The config.guess in GMP tries to runtime-detect various
-  # ARM optimization flags via /proc/cpuinfo (and is also
-  # broken on multicore CPUs). Avoid this impurity.
-  preConfigure = optionalString stdenv.isAarch32 ''
-      configureFlagsArray+=("--build=$(./configfsf.guess)")
-    '';
 
   doCheck = true; # not cross;
 


### PR DESCRIPTION
###### Motivation for this change

On 32-bit ARM, gmp is explicitly configured with an alternative way to autodetect the build platform to work around a bug in the default system detection. This has the side effect of making it impossible to build correctly for armv6l on an armv7l machine.

###### Things done

This PR replaces the `configfsf.guess` script with `stdenv.buildPlatform.config`. This makes the build more pure and also makes the derivation a little cleaner because we can use `configureFlags` instead of the `preConfigure` script.

I split the change into two commits, the first which avoids a mass rebuild on architectures other than 32-bit ARM, and second which cleans up the derivation with a mass rebuild (removing the `preConfigure` attribute).

I would like to get the first commit into master, and the second into staging, but I'm not sure what the procedure is for that.

cc @peti @vrthra 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

