### PR TITLE
stdenv: Add a fake date utility together with setup

### DIFF
--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -13,6 +13,18 @@ echo "defaultBuildInputs=\"$defaultBuildInputs\"" >> $out/setup
 echo "$preHook" >> $out/setup
 cat "$setup" >> $out/setup
 
+# Setup fake date
+mkdir $out/bin
+real_date=$(type -Pa date | sed 1d)
+if test -n "$real_date"; then
+    cat >$out/bin/date <<EOF
+#!$shell
+exec $real_date -d0 "\$@"
+EOF
+    chmod +x $out/bin/date
+    initialPath="$out $initialPath"
+fi
+
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
 mkdir $out/nix-support


### PR DESCRIPTION
This is 1 out of the remaining 3 points (fake date in stdenv, numbering names in stdenv, fake time in stdenv) needed to be resolved for #2281.

Based on https://github.com/NixOS/nixpkgs/pull/2281/commits/c232efa244cb0ca38bba6392a7d5a88b609f9b92.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

