### PR TITLE
zafiro-icons: 0.7.2 -> 0.7.3

### DIFF
--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -3,21 +3,21 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "zafiro-icons";
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "zayronxio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1rs3wazmvidlkig5q7x1n9nz7jhfq18wps3wsplax9zcdy0hv248";
+    sha256 = "02q3wcklmqdy4ycyly7477q98y3mkgnpr7c78jqxvy2yr486wwyx";
   };
 
   nativeBuildInputs = [ gtk3 ];
 
   installPhase = ''
-    mkdir -p $out/share/icons/Zafiro
-    cp -a * $out/share/icons/Zafiro
-    gtk-update-icon-cache "$out"/share/icons/Zafiro
+    mkdir -p $out/share/icons/Zafiro-icons
+    cp -a * $out/share/icons/Zafiro-icons
+    gtk-update-icon-cache "$out"/share/icons/Zafiro-icons
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

- Update to version [0.7.3](https://github.com/zayronxio/Zafiro-icons/releases/tag/v0.7.3)
- Fix the directory name

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).