### PR TITLE
nsjail: fix path to new{u|g}idmap

### DIFF
--- a/pkgs/tools/security/nsjail/default.nix
+++ b/pkgs/tools/security/nsjail/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, autoconf, bison, flex, libtool, pkgconfig, which
-, libnl, protobuf, protobufc }:
+, libnl, protobuf, protobufc, shadow
+}:
 
 stdenv.mkDerivation rec {
   name = "nsjail-${version}";
@@ -12,6 +13,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
     sha256          = "0cgycj0cz74plmz4asxryqprg6mkzpmnxzqbfsp1wwackinxq5fq";
   };
+
+  postPatch = ''
+    substituteInPlace user.cc \
+      --replace "/usr/bin/newgidmap" "${shadow}/bin/newgidmap" \
+      --replace "/usr/bin/newuidmap" "${shadow}/bin/newuidmap"
+  '';
 
   nativeBuildInputs = [ autoconf bison flex libtool pkgconfig which ];
   buildInputs = [ libnl protobuf protobufc ];


### PR DESCRIPTION
###### Motivation for this change

Closes #51496
/cc @andrewchambers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Test (failed -- it's still up to the user to define valid rules in `/etc/subuid` and `/etc/subgid` )

```ini
$ sudo ./result/bin/nsjail -Mo -U demo:24000:1 / -- /run/current-system/sw/bin/echo "ABC"
[2018-12-04T21:28:19+0100] Mode: STANDALONE_ONCE
[2018-12-04T21:28:19+0100] Jail parameters: hostname:'NSJAIL', chroot:'', process:'/', bind:[::]:0, max_conns_per_ip:0, time_limit:0, personality:0, daemonize:false, clone_newnet:true, clone_newuser:true, clone_newns:true, clone_newpid:true, clone_newipc:true, clonew_newuts:true, clone_newcgroup:true, keep_caps:false, disable_no_new_privs:false, max_cpus:0
[2018-12-04T21:28:19+0100] Mount point: '/' flags:MS_RDONLY type:'tmpfs' options:'' is_dir:true
[2018-12-04T21:28:19+0100] Mount point: '/proc' flags:MS_RDONLY type:'proc' options:'' is_dir:true
[2018-12-04T21:28:19+0100] Uid map: inside_uid:1000 outside_uid:24000 count:1 newuidmap:true
[2018-12-04T21:28:19+0100] Gid map: inside_gid:0 outside_gid:0 count:1 newgidmap:false
[2018-12-04T21:28:19+0100] [W][14124] void cmdline::logParams(nsjconf_t*)():262 Process will be GID/EGID=0 in the global user namespace, and will have group root-level access to files
newuidmap: uid range [1000-1001) -> [24000-24001) not allowed
[2018-12-04T21:28:19+0100] [E][14124] bool user::uidMapExternal(nsjconf_t*, pid_t)():200 '/nix/store/y8gbyldjb042kyy46dsf84z8f0b2flhq-shadow-4.6/bin/newuidmap' failed
[2018-12-04T21:28:19+0100] [E][14124] bool subproc::initParent(nsjconf_t*, pid_t, int)():383 Couldn't initialize user namespace for pid 14125
[2018-12-04T21:28:19+0100] [E][14124] int nsjail::standaloneMode(nsjconf_t*)():146 Couldn't launch the child process
[2018-12-04T21:28:19+0100] [F][1] bool subproc::runChild(nsjconf_t*, int, int, int)():431 Launching child process failed
```

But at least calls to `newuidmap` or `newgidmap` are working as expected