### PR TITLE
vault: 0.11.5 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/govers/default.nix
+++ b/pkgs/development/tools/govers/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "govers-${version}";
-  version = "20150109-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "3b5f175f65d601d06f48d78fcbdb0add633565b9";
+  version = "20160623-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "77fd787551fc5e7ae30696e009e334d52d2d3a43";
 
   goPackagePath = "github.com/rogpeppe/govers";
 
   src = fetchgit {
     inherit rev;
     url = "https://github.com/rogpeppe/govers";
-    sha256 = "0din5a7nff6hpc4wg0yad2nwbgy4q1qaazxl8ni49lkkr4hyp8pc";
+    sha256 = "12w83vyi8mgn48fwdm2js693qcydimxapg8rk0yf01w0ab03r5wn";
   };
 
   dontRenameImports = true;

--- a/pkgs/development/tools/gox/default.nix
+++ b/pkgs/development/tools/gox/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "gox-${version}";
-  version = "0.4.0";
+  version = "20181025";
 
   goPackagePath = "github.com/mitchellh/gox";
 
   src = fetchFromGitHub {
     owner = "mitchellh";
     repo = "gox";
-    rev = "v${version}";
-    sha256 = "1q4fdkw904mrmh1q5z8pfd3r0gcn5dm776kldqawddy93iiwnp8r";
+    rev = "9cc487598128d0963ff9dcc51176e722788ec645";
+    sha256 = "18indkdwq2m1wy95d71lgbf46jxxrfc5km1fys5laapz993h77v6";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "vault-${version}";
-  version = "0.11.5";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "1skf9l3a4gwag9gp2vwmniajk8rb05g93s15q5xfwqb6sg6zplfw";
+    sha256 = "0wqqf9mif6icfl888w2izvml7vqs4hkd5hrq4dhzcyig5w1bp0if";
   };
 
   nativeBuildInputs = [ go gox removeReferencesTo ];


### PR DESCRIPTION
###### Motivation for this change

HackerNews-driven package upgrade

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

