### PR TITLE
[WIP] all-packages.nix: Use pkgs ("self") instead of res (next stage super)

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -828,7 +828,7 @@ in
 
   androidsdk = androidenv.androidsdk_8_0;
 
-  androidsdk_extras = res.androidenv.androidsdk_8_0_extras;
+  androidsdk_extras = pkgs.androidenv.androidsdk_8_0_extras;
 
   webos = recurseIntoAttrs {
     cmake-modules = callPackage ../development/mobile/webos/cmake-modules.nix { };
@@ -3544,7 +3544,7 @@ in
 
   jid = callPackage ../development/tools/jid { };
 
-  jing = res.jing-trang;
+  jing = pkgs.jing-trang;
   jing-trang = callPackage ../tools/text/xml/jing-trang { };
 
   jira-cli = callPackage ../development/tools/jira_cli { };
@@ -4841,23 +4841,23 @@ in
     libcap = if stdenv.isDarwin then null else libcap;
   };
 
-  pinentry_ncurses = res.pinentry.override {
+  pinentry_ncurses = pkgs.pinentry.override {
     gtk2 = null;
   };
 
-  pinentry_emacs = res.pinentry.override {
+  pinentry_emacs = pkgs.pinentry.override {
     enableEmacs = true;
   };
 
-  pinentry_gnome = res.pinentry.override {
+  pinentry_gnome = pkgs.pinentry.override {
     gcr = gnome3.gcr;
   };
 
-  pinentry_qt4 = res.pinentry.override {
+  pinentry_qt4 = pkgs.pinentry.override {
     qt = qt4;
   };
 
-  pinentry_qt5 = res.pinentry.override {
+  pinentry_qt5 = pkgs.pinentry.override {
     qt = qt5.qtbase;
   };
 
@@ -8591,11 +8591,11 @@ in
   gputils = callPackage ../development/tools/misc/gputils { };
 
   gradleGen = callPackage ../development/tools/build-managers/gradle { };
-  gradle = res.gradleGen.gradle_latest;
-  gradle_2_14 = res.gradleGen.gradle_2_14;
-  gradle_2_5 = res.gradleGen.gradle_2_5;
-  gradle_3_5 = res.gradleGen.gradle_3_5;
-  gradle_4_10 = res.gradleGen.gradle_4_10;
+  gradle = pkgs.gradleGen.gradle_latest;
+  gradle_2_14 = pkgs.gradleGen.gradle_2_14;
+  gradle_2_5 = pkgs.gradleGen.gradle_2_5;
+  gradle_3_5 = pkgs.gradleGen.gradle_3_5;
+  gradle_4_10 = pkgs.gradleGen.gradle_4_10;
 
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.
@@ -9069,7 +9069,7 @@ in
   valgrind = callPackage ../development/tools/analysis/valgrind {
     inherit (darwin) xnu bootstrap_cmds cctools;
   };
-  valgrind-light = res.valgrind.override { gdb = null; };
+  valgrind-light = pkgs.valgrind.override { gdb = null; };
 
   valkyrie = callPackage ../development/tools/analysis/valkyrie { };
 
@@ -9654,7 +9654,7 @@ in
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Cocoa AGL GLUT;
   };
-  fltk = res.fltk13;
+  fltk = pkgs.fltk13;
 
   flyway = callPackage ../development/tools/flyway { };
 
@@ -9667,7 +9667,7 @@ in
 
   freetts = callPackage ../development/libraries/freetts { };
 
-  frog = res.languageMachines.frog;
+  frog = pkgs.languageMachines.frog;
 
   fstrcmp = callPackage ../development/libraries/fstrcmp { };
 
@@ -9735,11 +9735,11 @@ in
   };
 
   gegl_0_3 = callPackage ../development/libraries/gegl/3.0.nix {
-    gtk = res.gtk2;
+    gtk = pkgs.gtk2;
   };
 
   gegl_0_4 = callPackage ../development/libraries/gegl/4.0.nix {
-    gtk = res.gtk2;
+    gtk = pkgs.gtk2;
   };
 
   geoclue2 = callPackage ../development/libraries/geoclue {};
@@ -10137,7 +10137,7 @@ in
   gumbo = callPackage ../development/libraries/gumbo { };
 
   gvfs = callPackage ../development/libraries/gvfs {
-    gnome = res.gnome3;
+    gnome = pkgs.gnome3;
   };
 
   gwenhywfar = callPackage ../development/libraries/aqbanking/gwenhywfar.nix { };
@@ -11366,7 +11366,7 @@ in
   libxml2 = callPackage ../development/libraries/libxml2 { };
 
   libxml2Python = pkgs.buildEnv { # slightly hacky
-    name = "libxml2+py-${res.libxml2.version}";
+    name = "libxml2+py-${pkgs.libxml2.version}";
     paths = with libxml2; [ dev bin py ];
     inherit (libxml2) passthru;
     # the hook to find catalogs is hidden by buildEnv
@@ -11806,9 +11806,9 @@ in
   };
 
   pcre = callPackage ../development/libraries/pcre { };
-  pcre16 = res.pcre.override { variant = "pcre16"; };
+  pcre16 = pkgs.pcre.override { variant = "pcre16"; };
   # pcre32 seems unused
-  pcre-cpp = res.pcre.override { variant = "cpp"; };
+  pcre-cpp = pkgs.pcre.override { variant = "cpp"; };
 
   pcre2 = callPackage ../development/libraries/pcre2 { };
 
@@ -12709,7 +12709,7 @@ in
     stdenv = overrideCC stdenv gcc6;
   });
 
-  v8_static = lowPrio (res.v8.override { static = true; });
+  v8_static = lowPrio (pkgs.v8.override { static = true; });
 
   vaapiIntel = callPackage ../development/libraries/vaapi-intel { };
 
@@ -15649,7 +15649,7 @@ in
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme {
-    gtk = res.gtk2;
+    gtk = pkgs.gtk2;
   };
 
   themes = name: callPackage (../data/misc/themes + ("/" + name + ".nix")) {};
@@ -15891,16 +15891,16 @@ in
   libbitcoin-explorer = callPackage ../tools/misc/libbitcoin/libbitcoin-explorer.nix { };
 
 
-  go-ethereum = res.altcoins.go-ethereum;
-  ethabi = res.altcoins.ethabi;
+  go-ethereum = pkgs.altcoins.go-ethereum;
+  ethabi = pkgs.altcoins.ethabi;
 
-  parity = res.altcoins.parity;
-  parity-beta = res.altcoins.parity-beta;
-  parity-ui = res.altcoins.parity-ui;
+  parity = pkgs.altcoins.parity;
+  parity-beta = pkgs.altcoins.parity-beta;
+  parity-ui = pkgs.altcoins.parity-ui;
 
-  stellar-core = res.altcoins.stellar-core;
+  stellar-core = pkgs.altcoins.stellar-core;
 
-  particl-core = res.altcoins.particl-core;
+  particl-core = pkgs.altcoins.particl-core;
 
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;
@@ -15995,7 +15995,7 @@ in
   };
   bitwig-studio2 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio2.nix {
     inherit (gnome3) zenity;
-    inherit (res) bitwig-studio1;
+    inherit (pkgs) bitwig-studio1;
   };
   bitwig-studio = bitwig-studio2;
 
@@ -16675,7 +16675,7 @@ in
   espeak-classic = callPackage ../applications/audio/espeak { };
 
   espeak-ng = callPackage ../applications/audio/espeak-ng { };
-  espeak = res.espeak-ng;
+  espeak = pkgs.espeak-ng;
 
   espeakedit = callPackage ../applications/audio/espeak/edit.nix { };
 
@@ -16968,7 +16968,7 @@ in
     inherit (pkgs.gnome3) defaultIconTheme;
   };
 
-  firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
+  firefox-beta-bin = pkgs.wrapFirefox firefox-beta-bin-unwrapped {
     browserName = "firefox";
     name = "firefox-beta-bin-" +
       (builtins.parseDrvName firefox-beta-bin-unwrapped.name).version;
@@ -16983,7 +16983,7 @@ in
     inherit (pkgs.gnome3) defaultIconTheme;
   };
 
-  firefox-devedition-bin = res.wrapFirefox firefox-devedition-bin-unwrapped {
+  firefox-devedition-bin = pkgs.wrapFirefox firefox-devedition-bin-unwrapped {
     browserName = "firefox";
     nameSuffix = "-devedition";
     name = "firefox-devedition-bin-" +
@@ -20877,7 +20877,7 @@ in
 
   ut2004Packages = callPackage ../games/ut2004 { };
 
-  ut2004demo = res.ut2004Packages.ut2004 [ res.ut2004Packages.ut2004-demo ];
+  ut2004demo = pkgs.ut2004Packages.ut2004 [ pkgs.ut2004Packages.ut2004-demo ];
 
   vapor = callPackage ../games/vapor { love = love_0_8; };
 
@@ -21014,8 +21014,8 @@ in
       # Included for backwards compatibility
       libsoup libwnck gtk-doc gnome-doc-utils;
 
-    gtk = res.gtk2;
-    gtkmm = res.gtkmm2;
+    gtk = pkgs.gtk2;
+    gtkmm = pkgs.gtkmm2;
   });
 
   gnome3 = recurseIntoAttrs (callPackage ../desktops/gnome-3 { });
@@ -22069,7 +22069,7 @@ in
 
   fakenes = callPackage ../misc/emulators/fakenes { };
 
-  faust = res.faust2;
+  faust = pkgs.faust2;
 
   faust1 = callPackage ../applications/audio/faust/faust1.nix { };
 
@@ -22291,7 +22291,7 @@ in
      parameter set to the right value for your deployment target.
   */
   nixos = configuration:
-    (import (res.path + "/nixos/lib/eval-config.nix") {
+    (import (pkgs.path + "/nixos/lib/eval-config.nix") {
       inherit (pkgs.stdenv.hostPlatform) system;
       modules = [(
                   { lib, ... }: {
@@ -22570,7 +22570,7 @@ in
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung/1.00.37.nix { };
   samsung-unified-linux-driver_4_00_39 = callPackage ../misc/cups/drivers/samsung/4.00.39 { };
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
-  samsung-unified-linux-driver = res.samsung-unified-linux-driver_4_01_17;
+  samsung-unified-linux-driver = pkgs.samsung-unified-linux-driver_4_01_17;
 
   sane-backends = callPackage ../applications/graphics/sane/backends {
     gt68xxFirmware = config.sane.gt68xxFirmware or null;


### PR DESCRIPTION
###### Motivation for this change

`res` is redundant. The goal of this PR is to run it on ofborg so [changes](https://gist.github.com/GrahamcOfBorg/2e3b568727ac6443314a5ffdc5209cdc) can be triaged.

@Ericson2314 have a look :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

