### PR TITLE
openra-ura: init at 407

### DIFF
--- a/pkgs/games/openra-ura/Makefile.patch
+++ b/pkgs/games/openra-ura/Makefile.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index 076698b..33663b9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,11 +37,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+
+ check-sdk-scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -95,7 +92,6 @@ check-variables:
+ 	fi
+
+ engine: check-variables check-sdk-scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine

--- a/pkgs/games/openra-ura/default.nix
+++ b/pkgs/games/openra-ura/default.nix
@@ -1,0 +1,173 @@
+# Based on: pkgs/games/openra/default.nix
+# Based on: https://build.opensuse.org/package/show/home:fusion809/openra-ura
+{ stdenv, fetchFromGitHub, dos2unix, pkgconfig, makeWrapper
+, lua, mono, dotnetPackages, python
+, libGL, openal, SDL2
+, zenity ? null
+}:
+
+with stdenv.lib;
+
+let
+  pname = "openra-ura";
+  version = "410";
+  engine-version = "unplugged-cd82382";
+  path = makeBinPath ([ mono python ] ++ optional (zenity != null) zenity);
+  rpath = makeLibraryPath [ lua openal SDL2 ];
+
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "RAunplugged";
+      repo = "uRA";
+      rev = "b39e59a72ff1f1874acab0014e8a43280265b296";
+      sha256 = "0kdqaqki55kigapsff7n2kqwih3sf5gmp132gwqk996wgnqnayxj";
+      name = "uRA";
+    })
+    (fetchFromGitHub {
+      owner = "RAunplugged";
+      repo = "OpenRA" ;
+      rev = engine-version;
+      sha256 = "1p5hgxxvxlz8480vj0qkmnxjh7zj3hahk312m0zljxfdb40652w1";
+      name = "engine";
+
+      extraPostFetch = ''
+        sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
+        $out/thirdparty/fetch-thirdparty-deps.sh
+      '';
+    })
+  ];
+
+  sourceRoot = ".";
+
+  buildInputs = with dotnetPackages; [
+    FuzzyLogicLibrary
+    MaxMindDb
+    MaxMindGeoIP2
+    MonoNat
+    NewtonsoftJson
+    NUnit3
+    NUnitConsole
+    OpenNAT
+    RestSharp
+    SharpFont
+    SharpZipLib
+    SmartIrc4net
+    StyleCopMSBuild
+    StyleCopPlusMSBuild
+  ] ++ [
+    dos2unix
+    pkgconfig
+    makeWrapper
+    lua
+    mono
+    python
+    libGL
+    openal
+    SDL2
+  ];
+
+  postUnpack = ''
+    mv engine uRA
+    cd uRA
+  '';
+
+  patches = [ ./Makefile.patch ];
+
+  postPatch = ''
+    sed -i 's/^VERSION.*/VERSION = ${version}/g' Makefile
+
+    dos2unix *.md
+
+    sed -i \
+      -e 's/^VERSION.*/VERSION = ${engine-version}/g' \
+      -e '/fetch-geoip-db/d' \
+      -e '/GeoLite2-Country.mmdb.gz/d' \
+      engine/Makefile
+
+    sed -i 's|locations=.*|locations=${lua}/lib|' engine/thirdparty/configure-native-deps.sh
+  '';
+
+  configurePhase = ''
+    make version
+    ( cd engine; make version )
+  '';
+
+  makeFlags = "PREFIX=$(out)";
+
+  doCheck = true;
+  checkTarget = "check test";
+
+  installPhase = ''
+    mkdir -p $out/lib/openra-ura
+    substitute ${./launch-game.sh} $out/lib/openra-ura/launch-game.sh --subst-var out
+    chmod +x $out/lib/openra-ura/launch-game.sh
+
+    # Setting TERM=xterm fixes an issue with terminfo in mono: System.Exception: Magic number is wrong: 542
+    # https://github.com/mono/mono/issues/6752#issuecomment-365212655
+    wrapProgram $out/lib/openra-ura/launch-game.sh \
+      --prefix PATH : "${path}" \
+      --prefix LD_LIBRARY_PATH : "${rpath}" \
+      --set TERM xterm
+
+    mkdir -p $out/bin
+    makeWrapper $out/lib/openra-ura/launch-game.sh $out/bin/openra-ura \
+      --run "cd $out/lib/openra-ura"
+
+    cp -r engine/{${concatStringsSep "," [
+      "glsl"
+      "lua"
+      "AUTHORS"
+      "COPYING"
+      "Eluant.dll*"
+      "FuzzyLogicLibrary.dll"
+      "'global mix database.dat'"
+      "ICSharpCode.SharpZipLib.dll"
+      "MaxMind.Db.dll"
+      "OpenAL-CS.dll"
+      "OpenAL-CS.dll.config"
+      "Open.Nat.dll"
+      "OpenRA.Game.exe"
+      "OpenRA.Platforms.Default.dll"
+      "OpenRA.Server.exe"
+      "OpenRA.Utility.exe"
+      "rix0rrr.BeaconLib.dll"
+      "SDL2-CS.dll"
+      "SDL2-CS.dll.config"
+      "SharpFont.dll"
+      "SharpFont.dll.config"
+      "VERSION"
+    ]}} $out/lib/openra-ura
+
+    mkdir $out/lib/openra-ura/mods
+    cp -r engine/mods/{common,modcontent} $out/lib/openra-ura/mods
+    cp -r mods/ura $out/lib/openra-ura/mods
+
+    mkdir -p $out/share/applications
+    cp ${./openra-ura.desktop} $out/share/applications/openra-ura.desktop
+
+    mkdir -p $out/share/doc/packages/openra-ura
+    cp -r README.md $out/share/doc/packages/openra-ura/README.md
+
+    mkdir -p $out/share/pixmaps
+    cp -r mods/ura/icon.png $out/share/pixmaps/openra-ura.png
+
+    mkdir -p $out/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256}/apps
+    for size in 16 32 48 64 128 256; do
+      size=''${size}x''${size}
+      cp packaging/linux/mod_''${size}.png "$out/share/icons/hicolor/''${size}/apps/openra-ura.png"
+    done
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    description = "Re-imaginging of the original Command & Conquer Red Alert game";
+    homepage = http://redalertunplugged.com;
+    maintainers = with maintainers; [ msteen ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/openra-ura/launch-game.sh
+++ b/pkgs/games/openra-ura/launch-game.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+cd "@out@/lib/openra-ura"
+
+# Run the game
+mono --debug OpenRA.Game.exe Game.Mod=ura Engine.LaunchPath="@out@/bin/openra-ura" Engine.ModSearchPaths="@out@/lib/openra-ura/mods" "$@"
+
+# Show a crash dialog if something went wrong
+if [ $? != 0 ] && [ $? != 1 ]; then
+  error_message="OpenRA Red Alert Unplugged has encountered a fatal error.\nPlease refer to the crash logs for more information.\n\nLog files are located in ~/.openra/Logs\n"
+  if command -v zenity > /dev/null; then
+    zenity --no-wrap --error --title "OpenRA Red Alert Unplugged" --text "$error_message" 2>/dev/null
+  else
+    printf "${error_message}\n" >&2
+  fi
+  exit 1
+fi

--- a/pkgs/games/openra-ura/openra-ura.desktop
+++ b/pkgs/games/openra-ura/openra-ura.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=OpenRA - Red Alert Unplugged
+GenericName=Real Time Strategy Game
+GenericName[de]=Echtzeit-Strategiespiel
+Comment=Reimagining of the Red Alert game
+Icon=openra-ura
+Exec=openra-ura
+Terminal=false
+Categories=Game;StrategyGame;X-RTS;X-RealTimeStrategy;X-RealTimeStrategyGame;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20600,6 +20600,11 @@ in
 
   openra = callPackage ../games/openra { lua = lua5_1; };
 
+  openra-ura = callPackage ../games/openra-ura {
+    lua = lua5_1;
+    inherit (gnome3) zenity;
+  };
+
   openrw = callPackage ../games/openrw { };
 
   openspades = callPackage ../games/openspades { };


### PR DESCRIPTION
###### Motivation for this change
Red Alert - Unplugged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

