### PR TITLE
bitlbee-discord: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
@@ -3,13 +3,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "bitlbee-discord-${version}";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     rev = version;
     owner = "sm00th";
     repo = "bitlbee-discord";
-    sha256 = "1n3xw5mcmg7224r09gbm39bd6h2158dwl6jx21290636b4345f4c";
+    sha256 = "02pigk2vbz0jdz11f96sygdvp1j762yjn62h124fkcsc070g7a2f";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/sm00th/bitlbee-discord/releases/tag/0.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

