### PR TITLE
pkgsi686Linux.nixosTests.gitlab: fix 32 bit tests

### DIFF
--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -8,7 +8,7 @@ import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
 
   nodes = {
     gitlab = { ... }: {
-      virtualisation.memorySize = 4096;
+      virtualisation.memorySize = 2047;
       systemd.services.gitlab.serviceConfig.Restart = mkForce "no";
       systemd.services.gitlab-workhorse.serviceConfig.Restart = mkForce "no";
       systemd.services.gitaly.serviceConfig.Restart = mkForce "no";


### PR DESCRIPTION
GitLab 11.5.1 dropped the dependency to posix_spawn, which is broken on
32bit. (See https://gitlab.com/gitlab-org/gitlab-ce/issues/53525)

The only part missing is decreasing virtualisation.memorySize to
something that a 32 bit qemu still executes.

The maximum seems to be 2047, and tests passed with that value for me.

###### Motivation for this change
getting [32 bit gitlab vm tests](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.gitlab.i686-linux) to run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @globin, can you backport this as alongside #51526?
