### PR TITLE
bowtie2: fix missing dependencies

### DIFF
--- a/pkgs/applications/science/biology/bowtie2/default.nix
+++ b/pkgs/applications/science/biology/bowtie2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zlib, tbb }:
+{ stdenv, fetchFromGitHub, zlib, tbb, python, perl }:
 
 stdenv.mkDerivation rec {
   pname = "bowtie2";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1zl3cf327y2p7p03cavymbh7b00djc7lncfaqih33n96iy9q8ibp";
   };
 
-  buildInputs = [ zlib tbb ];
+  buildInputs = [ zlib tbb python perl ];
 
   installFlags = [ "prefix=$(out)" ];
 


### PR DESCRIPTION
###### Motivation for this change

Bowtie2 was missing required dependencies for execution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

