### PR TITLE
Applespi: Package and Nixos flag

### DIFF
--- a/nixos/modules/hardware/applespi.nix
+++ b/nixos/modules/hardware/applespi.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.hardware.applespi;
+
+  kernelPackages = config.boot.kernelPackages;
+
+in
+
+{
+
+  options.hardware.applespi.enable = mkEnableOption "applespi kernel module";
+
+  config = mkIf cfg.enable {
+
+    boot.kernelModules = [ "applespi" "spi_pxa2xx_platform" "spi_pxa2xx_pci" ];
+
+    boot.extraModulePackages = [ kernelPackages.applespi ];
+
+    # unload module during suspend/hibernate as it crashes the whole system
+    powerManagement.powerDownCommands = ''
+      ${pkgs.kmod}/bin/lsmod | ${pkgs.gnugrep}/bin/grep -q "^applespi" && ${pkgs.kmod}/bin/rmmod -f -v applespi
+    '';
+
+    # and load it back on resume
+    powerManagement.resumeCommands = ''
+      ${pkgs.kmod}/bin/modprobe -v applespi
+    '';
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -34,6 +34,7 @@
   ./config/vpnc.nix
   ./config/zram.nix
   ./hardware/all-firmware.nix
+  ./hardware/applespi.nix
   ./hardware/brightnessctl.nix
   ./hardware/ckb-next.nix
   ./hardware/cpu/amd-microcode.nix

--- a/pkgs/os-specific/linux/applespi/default.nix
+++ b/pkgs/os-specific/linux/applespi/default.nix
@@ -1,0 +1,41 @@
+{ fetchFromGitHub, stdenv,
+
+# Kernel dependencies
+kernel
+}:
+
+with stdenv.lib;
+
+assert kernel != null;
+
+stdenv.mkDerivation rec {
+  name = "applespi-master-${hash}-${kernel.version}";
+  hash = "aeb7ca96eaf7c82418eb967aba5d991a33006899";
+
+  src = fetchFromGitHub {
+    owner = "cb22";
+    repo = "macbook12-spi-driver";
+    rev = "${hash}";
+    sha256 = "04hcy8cfm2kdrqs1cyd9s37x4qh5az5vdy477y5lfw2f33rwid1l";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  enableParallelBuilding = true;
+ 
+  preConfigure = ''
+    export INSTALL_MOD_PATH="$out"
+  '';
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  meta = {
+    description = "WIP input driver for the SPI touchpad / keyboard found in the 12\" MacBook (MacBook8,1 + MacBook9,1)";
+
+    homepage = "https://github.com/cb22/macbook12-spi-driver";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14445,6 +14445,8 @@ with pkgs;
 
     amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { };
 
+    applespi = callPackage ../os-specific/linux/applespi {};
+
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc {


### PR DESCRIPTION
###### Motivation for this change
Applespi is required on newish macbooks for keyboard and trackpad to work. This adds a package for the driver and a flag to enable it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

