### PR TITLE
fix infinite recursion caused by the unnecessary inspection of options

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -7,9 +7,8 @@ rec {
                      || elem fs.mountPoint [ "/" "/nix" "/nix/store" "/var" "/var/log" "/var/lib" "/etc" ];
 
   # Check whenever `b` depends on `a` as a fileSystem
-  # FIXME: it's incorrect to simply use hasPrefix here: "/dev/a" is not a parent of "/dev/ab"
-  fsBefore = a: b: ((any (x: elem x [ "bind" "move" ]) b.options) && (a.mountPoint == b.device))
-                || (hasPrefix a.mountPoint b.mountPoint);
+  fsBefore = a: b: a.mountPoint == b.device
+                || hasPrefix "${a.mountPoint}${optionalString (!(hasSuffix "/" a.mountPoint)) "/"}" b.mountPoint;
 
   # Escape a path according to the systemd rules, e.g. /dev/xyzzy
   # becomes dev-xyzzy.  FIXME: slow.


### PR DESCRIPTION
###### Motivation for this change

When you have a NixOS configuration like the following:
```nix
{ config, ... }:

{
  boot.loader.grub.device = "nodev";
  fileSystems."/" = {
    device = "nodev";
    options = [ "uid=${toString config.users.users.root.uid}" ];
  };
  fileSystems."/foo" = {
    device = "nodev";
  };
}
```

And you test it like so:
```sh
NIXOS_CONFIG=debug-fs-user-recursion.nix nix-instantiate --eval \
  --expr '(import <nixpkgs/nixos> { }).config.services.rpcbind.enable'
```

You will get infinite recursion:
1. rpcbind.nix defines `users.extraUsers.rpc`
2. nfs.nix sets `services.rpcbind.enable` depending on `config.boot.supportedFilesystems`
3. filesystems.nix defines `boot.supportedFilesystems` based on `toposort fsBefore (attrValues config.fileSystems)`
4. utils.nix defines `fsBefore` and uses `config.fileSystems.<name>.options` to do so
5. this file defines `fileSystems."/".options` to refer to `config.users.users` (`extraUsers` is an alias for `users`)
6. causing infinite recursion

The original check had this:
```nix
((any (x: elem x [ "bind" "move" ]) b.options) && (a.mountPoint == b.device))
```
However any file system type that allows a device to be what is also valid in a mount point (i.e. normal directories), like "bind" and "move" do, are the only ones that will ever pass the `a.mountPoint == b.device` condition. Hence the precondition `any (x: elem x [ "bind" "move" ]) b.options` should be unnecessary. Removing the precondition solves the infinite recursion issue.

Then to address `# FIXME: it's incorrect to simply use hasPrefix here: "/dev/a" is not a parent of "/dev/ab"`, we could just ensure that the prefix check always end with a "/", such that hasPrefix only succeeds if its an actual parent, like so:
```nix
hasPrefix "${a.mountPoint}${optionalString (!(hasSuffix "/" a.mountPoint)) "/"}" b.mountPoint
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

