### PR TITLE
cyrus_sasl: remove old patch

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -24,11 +24,6 @@ stdenv.mkDerivation rec {
   patches = [
     ./missing-size_t.patch # https://bugzilla.redhat.com/show_bug.cgi?id=906519
     ./cyrus-sasl-ac-try-run-fix.patch
-    (fetchpatch {
-      name = "CVE-2013-4122.patch";
-      url = "mirror://sourceforge/miscellaneouspa/files/glibc217/cyrus-sasl-2.1.26-glibc217-crypt.diff";
-      sha256 = "05l7dh1w9d5fvzg0pjwzqh0fy4ah8y5cv6v67s4ssbq8xwd4pkf2";
-    })
   ] ++ lib.optional stdenv.isFreeBSD (
       fetchurl {
         url = "http://www.linuxfromscratch.org/patches/blfs/svn/cyrus-sasl-2.1.26-fixes-3.patch";


### PR DESCRIPTION
###### Motivation for this change

it was removed with "cyrus_sasl: 2.1.26 -> 2.1.27" https://github.com/NixOS/nixpkgs/commit/b13af1e87b26a3ee7d81c4b237710a93e1f243e8

but reappeared in broken "Merge staging-next into staging" https://github.com/NixOS/nixpkgs/commit/9b81c7e455c278a45db0f6c21d7e16bb0ff9bf37
