### PR TITLE
pythonPackages.curtsies: fix build

### DIFF
--- a/pkgs/development/python-modules/curtsies/default.nix
+++ b/pkgs/development/python-modules/curtsies/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, blessings, mock, nose, pyte, wcwidth, typing }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, pythonOlder, blessings, mock, nose, pyte, wcwidth, typing }:
 
 buildPythonPackage rec {
   pname = "curtsies";
@@ -8,7 +8,16 @@ buildPythonPackage rec {
     sha256 = "89c802ec051d01dec6fc983e9856a3706e4ea8265d2940b1f6d504a9e26ed3a9";
   };
 
-  propagatedBuildInputs = [ blessings wcwidth typing ];
+  patches = [
+    # Fix dependency on typing. Remove with the next release
+    (fetchpatch {
+      url = https://github.com/bpython/curtsies/commit/217b4f83e954837f8adc4c549c1f2f9f2bb272a7.patch;
+      sha256 = "1d3zwx9c7i0drb4nvydalm9mr83jrvdm75ffgisri89h337hiffs";
+    })
+  ];
+
+  propagatedBuildInputs = [ blessings wcwidth ]
+    ++ stdenv.lib.optionals (pythonOlder "3.5") [ typing ];
 
   checkInputs = [ mock pyte nose ];
 
@@ -18,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Curses-like terminal wrapper, with colored strings!";
-    homepage = https://pypi.python.org/pypi/curtsies;
+    homepage = https://github.com/bpython/curtsies;
     license = licenses.mit;
     maintainers = with maintainers; [ flokli ];
   };


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/51543

cc: @mmlb 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

