### PR TITLE
reptyr: 0.6.2 -> 0.7.0

### DIFF
--- a/pkgs/os-specific/linux/reptyr/default.nix
+++ b/pkgs/os-specific/linux/reptyr/default.nix
@@ -1,31 +1,32 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchFromGitHub, python2 }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.2";
+  version = "0.7.0";
   name = "reptyr-${version}";
+
   src = fetchFromGitHub {
     owner = "nelhage";
     repo = "reptyr";
     rev = "reptyr-${version}";
-    sha256 = "0yfy1p0mz05xg5gzp52vilfz0yl1sjjsvwn0z073mnr4wyam7fg8";
+    sha256 = "1hnijfz1ab34j2h2cxc3f43rmbclyihgn9x9wxa7jqqgb2xm71hj";
   };
 
-  # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
-  postPatch = ''
-    sed 1i'#include <sys/sysmacros.h>' -i platform/linux/linux.c
-  '';
+  makeFlags = [ "PREFIX=" "DESTDIR=$(out)" ];
 
-  # Needed with GCC 7
-  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
+  checkInputs = [ (python2.withPackages (p: [ p.pexpect ])) ];
+  doCheck = true;
 
-  makeFlags = ["PREFIX=$(out)"];
   meta = {
     platforms = [
       "i686-linux"
       "x86_64-linux"
       "i686-freebsd"
       "x86_64-freebsd"
-    ] ++ lib.platforms.arm;
+      "armv5tel-linux"
+      "armv6l-linux"
+      "armv7l-linux"
+      "aarch64-linux"
+    ];
     maintainers = with lib.maintainers; [raskin];
     license = lib.licenses.mit;
     description = "Reparent a running program to a new terminal";


### PR DESCRIPTION
###### Motivation for this change

Update reptyr to the latest version. This release adds support for `aarch64-linux`, and removes the need for the build system workarounds.

###### Things done

I added `aarch64-linux` to the supported platforms and also explicitly listed all the supported ARM platforms. I changed it to use `lib.platforms.arm` in #51259, but since then I decided that it would probably be better to explicitly list out the supported platforms, since reptyr would not work on `aarch64-freebsd` (hypothetically - we currently don't support that system), but it would be part of `lib.platforms.arm`.

I also enabled the tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

