### PR TITLE
Add cl-jpeg, cl-pdf & cl-typesetting, no extra external deps

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-jpeg.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-jpeg.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-jpeg'';
+  version = ''20170630-git'';
+
+  description = ''A self-contained baseline JPEG codec implementation'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-jpeg/2017-06-30/cl-jpeg-20170630-git.tgz'';
+    sha256 = ''1wwzn2valhh5ka7qkmab59pb1ijagcj296553fp8z03migl0sil0'';
+  };
+
+  packageName = "cl-jpeg";
+
+  asdFilesToKeep = ["cl-jpeg.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-jpeg DESCRIPTION
+    A self-contained baseline JPEG codec implementation SHA256
+    1wwzn2valhh5ka7qkmab59pb1ijagcj296553fp8z03migl0sil0 URL
+    http://beta.quicklisp.org/archive/cl-jpeg/2017-06-30/cl-jpeg-20170630-git.tgz
+    MD5 b6eb4ca5d893f428b5bbe46cd49f76ad NAME cl-jpeg FILENAME cl-jpeg DEPS NIL
+    DEPENDENCIES NIL VERSION 20170630-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-pdf.nix
@@ -1,0 +1,27 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-pdf'';
+  version = ''20170830-git'';
+
+  description = ''Common Lisp PDF Generation Library'';
+
+  deps = [ args."iterate" args."uiop" args."zpb-ttf" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-pdf/2017-08-30/cl-pdf-20170830-git.tgz'';
+    sha256 = ''1x4zk6l635f121p1anfd7d807iglyrlhsnmygydw5l49m3h6n08s'';
+  };
+
+  packageName = "cl-pdf";
+
+  asdFilesToKeep = ["cl-pdf.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-pdf DESCRIPTION Common Lisp PDF Generation Library SHA256
+    1x4zk6l635f121p1anfd7d807iglyrlhsnmygydw5l49m3h6n08s URL
+    http://beta.quicklisp.org/archive/cl-pdf/2017-08-30/cl-pdf-20170830-git.tgz
+    MD5 f865503aff50c0a4732a7a4597bdcc25 NAME cl-pdf FILENAME cl-pdf DEPS
+    ((NAME iterate FILENAME iterate) (NAME uiop FILENAME uiop)
+     (NAME zpb-ttf FILENAME zpb-ttf))
+    DEPENDENCIES (iterate uiop zpb-ttf) VERSION 20170830-git SIBLINGS
+    (cl-pdf-parser) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-typesetting.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/cl-typesetting.nix
@@ -1,0 +1,28 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''cl-typesetting'';
+  version = ''20170830-git'';
+
+  description = ''Common Lisp Typesetting system'';
+
+  deps = [ args."cl-pdf" args."iterate" args."zpb-ttf" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/cl-typesetting/2017-08-30/cl-typesetting-20170830-git.tgz'';
+    sha256 = ''1mkdr02qikzij3jiyrqy0dldzy8wsnvgcpznfha6x8p2xap586z3'';
+  };
+
+  packageName = "cl-typesetting";
+
+  asdFilesToKeep = ["cl-typesetting.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM cl-typesetting DESCRIPTION Common Lisp Typesetting system SHA256
+    1mkdr02qikzij3jiyrqy0dldzy8wsnvgcpznfha6x8p2xap586z3 URL
+    http://beta.quicklisp.org/archive/cl-typesetting/2017-08-30/cl-typesetting-20170830-git.tgz
+    MD5 e12b9f249c60c220c5dc4a0939eb3343 NAME cl-typesetting FILENAME
+    cl-typesetting DEPS
+    ((NAME cl-pdf FILENAME cl-pdf) (NAME iterate FILENAME iterate)
+     (NAME zpb-ttf FILENAME zpb-ttf))
+    DEPENDENCIES (cl-pdf iterate zpb-ttf) VERSION 20170830-git SIBLINGS
+    (xml-render cl-pdf-doc) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -28,12 +28,14 @@ cl-fuse
 cl-fuse-meta-fs
 cl-html-parse
 cl-html5-parser
+cl-jpeg
 cl-json
 cl-l10n
 cl-libuv
 cl-mysql
 closer-mop
 closure-html
+cl-pdf
 cl-ppcre
 cl-ppcre-template
 cl-ppcre-unicode
@@ -50,6 +52,7 @@ cl-syntax-annot
 cl-syntax-anonfun
 cl-syntax-markup
 cl-test-more
+cl-typesetting
 cl-unicode
 cl-unification
 cl-utilities

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -278,14 +278,6 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
-  "zpb-ttf" = buildLispPackage
-    ((f: x: (x // (f x)))
-       (qlOverrides."zpb-ttf" or (x: {}))
-       (import ./quicklisp-to-nix-output/zpb-ttf.nix {
-         inherit fetchurl;
-       }));
-
-
   "cl-store" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-store" or (x: {}))
@@ -357,6 +349,14 @@ let quicklisp-to-nix-packages = rec {
 
 
   "cl-ppcre-test" = quicklisp-to-nix-packages."cl-ppcre";
+
+
+  "zpb-ttf" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."zpb-ttf" or (x: {}))
+       (import ./quicklisp-to-nix-output/zpb-ttf.nix {
+         inherit fetchurl;
+       }));
 
 
   "puri" = buildLispPackage
@@ -1907,6 +1907,17 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-typesetting" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-typesetting" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-typesetting.nix {
+         inherit fetchurl;
+           "cl-pdf" = quicklisp-to-nix-packages."cl-pdf";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "zpb-ttf" = quicklisp-to-nix-packages."zpb-ttf";
+       }));
+
+
   "cl-test-more" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."cl-test-more" or (x: {}))
@@ -2103,6 +2114,17 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "cl-pdf" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-pdf" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-pdf.nix {
+         inherit fetchurl;
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "uiop" = quicklisp-to-nix-packages."uiop";
+           "zpb-ttf" = quicklisp-to-nix-packages."zpb-ttf";
+       }));
+
+
   "closure-html" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."closure-html" or (x: {}))
@@ -2187,6 +2209,14 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/cl-json.nix {
          inherit fetchurl;
            "fiveam" = quicklisp-to-nix-packages."fiveam";
+       }));
+
+
+  "cl-jpeg" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."cl-jpeg" or (x: {}))
+       (import ./quicklisp-to-nix-output/cl-jpeg.nix {
+         inherit fetchurl;
        }));
 
 


### PR DESCRIPTION
###### Motivation for this change

I have a Common Lisp app that needed cl-jpeg, cl-pdf and cl-typesetting.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions: Ubuntu 18.04 LTS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

