### PR TITLE
hivemind: init at 1.0.4

### DIFF
--- a/pkgs/applications/misc/hivemind/default.nix
+++ b/pkgs/applications/misc/hivemind/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "hivemind-${version}";
+  version = "1.0.4";
+  goPackagePath = "github.com/DarthSim/hivemind";
+
+  src = fetchFromGitHub {
+    owner = "DarthSim";
+    repo = "hivemind";
+    rev = "v${version}";
+    sha256 = "1z2izvyf0j3gi0cas5v22kkmkls03sg67182k8v3p6kwhzn0jw67";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/DarthSim/;
+    description = "Process manager for Procfile-based applications";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.sveitser ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3312,6 +3312,8 @@ in
 
   hiera-eyaml = callPackage ../tools/system/hiera-eyaml { };
 
+  hivemind = callPackage ../applications/misc/hivemind { };
+
   hfsprogs = callPackage ../tools/filesystems/hfsprogs { };
 
   highlight = callPackage ../tools/text/highlight ({


### PR DESCRIPTION
###### Motivation for this change
A "simpler" version of `overmind` without the `tmux` dependency. 

FYI. When searching the the issues I noticed that there was another, unrelated package called `hivemind` that has since been removed.

https://github.com/canndrew/nixpkgs/blob/42d7fa2c7160d513c9e043b9f6e1ba6b58b4deaa/pkgs/applications/altcoins/hivemind.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

