### PR TITLE
dino: 2018-11-27 -> 2018-11-29

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -14,13 +14,13 @@
  }:
 
 stdenv.mkDerivation rec {
-  name = "dino-unstable-2018-11-27";
+  name = "dino-unstable-2018-11-29";
 
   src = fetchFromGitHub {
     owner = "dino";
     repo = "dino";
-    rev = "141db9e40a3a81cfa3ad3587dc47f69c541d0fde";
-    sha256 = "006r1x7drlz39jjxlfdnxgrnambw9amhl9jcgf6p1dx71h1x8221";
+    rev = "680d28360c781ff29e810821801cfaba0493c526";
+    sha256 = "1w08xc842p2nggdxf0dwqw8izhwsrqah10w3s0v1i7dp33yhycln";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

I've been testing dino on release-18.09 for several days now, but at a
newer commit than packaged in nixpkgs-master.
Thus this updates dino again, to be backported to release-18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

