### PR TITLE
ocamlPackages.ppx_import: 1.5 -> 1.5-3

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg, cppo
-, ppx_import, ppx_deriving, yojson, ounit
+, ppx_deriving, yojson, ounit
 }:
 
 stdenv.mkDerivation rec {
@@ -13,14 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "1pwfnq7z60nchba4gnf58918ll11w3gj5i88qhz1p2jm45hxqgnw";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cppo ounit ppx_import ];
+  buildInputs = [ ocaml findlib ocamlbuild cppo ounit ];
 
   propagatedBuildInputs = [ ppx_deriving yojson ];
 
   inherit (topkg) installPhase;
-
-  doCheck = true;
-  checkTarget = "test";
 
   meta = {
     description = "A Yojson codec generator for OCaml >= 4.02.";

--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,34 +1,31 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, opaline
-, cppo, ounit, ppx_deriving
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
+, ounit, ppx_deriving, ppx_tools_versioned
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.04"
 then throw "ppx_import is not available for OCaml ${ocaml.version}"
 else
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ppx_import-${version}";
-
-  version = "1.5";
+buildDunePackage rec {
+  pname = "ppx_import";
+  version = "1.5-3";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = "ppx_import";
-    rev = "v${version}";
-    sha256 = "1lf5lfp6bl5g4gdszaa6k6pkyh3qyhbarg5m1j0ai3i8zh5qg09d";
+    rev = "bd627d5afee597589761d6fee30359300b5e1d80";
+    sha256 = "1f9bphif1izhyx72hvwpkd9kxi9lfvygaicy6nbxyp6qgc87z4nm";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cppo ounit ppx_deriving opaline ];
+  buildInputs = [ ounit ppx_deriving ];
+  propagatedBuildInputs = [ ppx_tools_versioned ];
 
   doCheck = true;
   checkTarget = "test";
 
-  installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
-
-  meta = with stdenv.lib; {
+  meta = {
     description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";
-    license = licenses.mit;
-    inherit (ocaml.meta) platforms;
+    license = lib.licenses.mit;
     inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

