### PR TITLE
leela-zero: init at 0.16

### DIFF
--- a/pkgs/games/leela-zero/default.nix
+++ b/pkgs/games/leela-zero/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, fetchFromGitHub, cmake, boost, eigen
+, opencl-headers, ocl-icd, qtbase , zlib }:
+
+stdenv.mkDerivation rec {
+  name = "leela-zero-${version}";
+  version = "0.16";
+
+  src = fetchFromGitHub {
+    owner = "gcp";
+    repo = "leela-zero";
+    rev = "v${version}";
+    sha256 = "1px7wqvlv414gklzgrmppp8wzc2mkskinm1p75j4snbqr8qpbn5s";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ boost opencl-headers ocl-icd qtbase zlib ];
+
+  nativeBuildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Go engine modeled after AlphaGo Zero";
+    homepage    = https://github.com/gcp/leela-zero;
+    license     = licenses.gpl3;
+    maintainers = [ maintainers.averelld ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20523,6 +20523,8 @@ in
 
   kobodeluxe = callPackage ../games/kobodeluxe { };
 
+  leela-zero = libsForQt5.callPackage ../games/leela-zero { };
+
   lgogdownloader = callPackage ../games/lgogdownloader { };
 
   liberal-crime-squad = callPackage ../games/liberal-crime-squad { };


### PR DESCRIPTION
###### Motivation for this change
Best freely available Go-engine (requires separate GTP UI).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

