### PR TITLE
(JavaFXSceneBuilder): Init at version 2

### DIFF
--- a/pkgs/applications/editors/javafx-scene-builder/default.nix
+++ b/pkgs/applications/editors/javafx-scene-builder/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, autoPatchelfHook, lib, makeWrapper, requireFile,
+ffmpeg_0_10,
+glib,
+pango,
+cairo,
+freetype,
+fontconfig,
+atk,
+gdk_pixbuf,
+gtk2,
+libxslt,
+libxml2,
+libXtst,
+libXxf86vm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "JavaSceneBuilder";
+  version = "2_0";
+  name = "${pname}-${version}";
+
+  src = requireFile {
+    name = "javafx_scenebuilder-${version}-linux-x64.tar.gz";
+      sha256 = "0b66wxrg9n6i0ysvl4n07kj1d5zqk32vywxrvdn3spykn8pxixj4";
+    message = ''
+      SceneBuilder cannot be downloaded without license acception.
+      1. Download a copy from https://www.oracle.com/technetwork/java/javase/downloads/javafxscenebuilder-1x-archive-2199384.html
+      2. In a shell, execute:
+         nix-prefetch-url file:///path/to/Xcode_7.2.dmg
+     '';
+  };
+
+  buildInputs = [
+    ffmpeg_0_10
+    glib
+    pango
+    cairo
+    freetype
+    fontconfig
+    atk
+    gdk_pixbuf
+    gtk2
+    libxslt
+    libxml2
+    libXtst
+    libXxf86vm autoPatchelfHook];
+
+  unpackPhase = ''
+    tar -xzf ${src}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv ./JavaFXSceneBuilder2.0/* $out
+    ln -s $out/JavaFXSceneBuilder2.0 $out/bin
+    autoPatchelf $out
+    ls -lar $out
+  '';
+
+
+
+  meta = with lib; {
+    description = "A Visual Layout Tool for JavaFX Applications";
+    homepage = https://www.oracle.com/technetwork/java/javase/downloads/javafxscenebuilder-info-2157684.html;
+    license = licenses.unfree;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ysndr ];
+  };
+}

--- a/pkgs/applications/editors/javafx-scene-builder/default.nix
+++ b/pkgs/applications/editors/javafx-scene-builder/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       SceneBuilder cannot be downloaded without license acception.
       1. Download a copy from https://www.oracle.com/technetwork/java/javase/downloads/javafxscenebuilder-1x-archive-2199384.html
       2. In a shell, execute:
-         nix-prefetch-url file:///path/to/Xcode_7.2.dmg
+         nix-prefetch-url file:///path/to/javafx_scenebuilder-2_0-linux-x64.tar.gz
      '';
   };
 

--- a/pkgs/applications/editors/javafx-scene-builder/default.nix
+++ b/pkgs/applications/editors/javafx-scene-builder/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     name = "javafx_scenebuilder-${version}-linux-x64.tar.gz";
       sha256 = "0b66wxrg9n6i0ysvl4n07kj1d5zqk32vywxrvdn3spykn8pxixj4";
     message = ''
-      SceneBuilder cannot be downloaded without license acception.
+      SceneBuilder cannot be downloaded without accepting a license.
       1. Download a copy from https://www.oracle.com/technetwork/java/javase/downloads/javafxscenebuilder-1x-archive-2199384.html
       2. In a shell, execute:
          nix-prefetch-url file:///path/to/javafx_scenebuilder-2_0-linux-x64.tar.gz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3528,6 +3528,8 @@ in
 
   jade = callPackage ../tools/text/sgml/jade { };
 
+  javafx-scene-builder = callPackage ../applications/editors/javafx-scene-builder { };
+
   jazzy = callPackage ../development/tools/jazzy { };
 
   jd = callPackage ../development/tools/jd { };


### PR DESCRIPTION
###### Motivation for this change
Add JavaFXSceneBuilder to be used standalone or inside intellij or other IDEs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

