### PR TITLE
polkadot: init at 0.2.17

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -94,5 +94,7 @@ rec {
   parity-beta = callPackage ./parity/beta.nix { };
   parity-ui = callPackage ./parity-ui { };
 
+  polkadot = callPackage ./polkadot { };
+
   particl-core = callPackage ./particl/particl-core.nix { miniupnpc = miniupnpc_2; };
 }

--- a/pkgs/applications/altcoins/polkadot/default.nix
+++ b/pkgs/applications/altcoins/polkadot/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkgconfig
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "polkadot-${version}";
+  version = "0.2.17";
+
+  src = fetchFromGitHub {
+    owner = "paritytech";
+    repo = "substrate";
+    rev = "19f4f4d4df3bb266086b4e488739f73d3d5e588c";
+    sha256 = "0v7g03rbml2afw0splmyjh9nqpjg0ldjw09hyc0jqd3qlhgxiiyj";
+  }; 
+
+  cargoSha256 = "0wwkaxqj2v5zach5xcqfzf6prc0gxy2v47janglp44xbxbx9xk08";
+
+  buildInputs = [ pkgconfig openssl openssl.dev ];
+
+  meta = with stdenv.lib; {
+    description = "Polkadot Node Implementation";
+    homepage = http://polkadot.network;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.akru ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15899,6 +15899,8 @@ in
   parity-beta = res.altcoins.parity-beta;
   parity-ui = res.altcoins.parity-ui;
 
+  polkadot = res.altcoins.polkadot;
+
   stellar-core = res.altcoins.stellar-core;
 
   particl-core = res.altcoins.particl-core;


### PR DESCRIPTION
###### Motivation for this change

Implementation of a https://polkadot.network node in Rust.
https://github.com/paritytech/polkadot

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

