### PR TITLE
weechat: fix bad merge

### DIFF
--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -1,4 +1,5 @@
-{ pythonPackages, perl, runCommand, lib, writeScriptBin, stdenv
+{ stdenv, lib, runCommand, writeScriptBin, buildEnv
+, pythonPackages, perl, perlPackages
 }:
 
 weechat:
@@ -10,31 +11,37 @@ let
 
   let
     perlInterpreter = perl;
-    config = configure {
-      availablePlugins = let
-        simplePlugin = name: { pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so"; };
-        in rec {
-          python = {
-            pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
-            withPackages = pkgsFun: (python // {
-              extraEnv = ''
-                export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"
-              '';
-            });
-          };
-          perl = (simplePlugin "perl") // {
+    availablePlugins = let
+        simplePlugin = name: {pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so";};
+      in rec {
+        python = {
+          pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
+          withPackages = pkgsFun: (python // {
             extraEnv = ''
-              export PATH="${perlInterpreter}/bin:$PATH"
+              export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"
             '';
-          };
-          tcl = simplePlugin "tcl";
-          ruby = simplePlugin "ruby";
-          guile = simplePlugin "guile";
-          lua = simplePlugin "lua";
+          });
         };
-    };
+        perl = (simplePlugin "perl") // {
+          extraEnv = ''
+            export PATH="${perlInterpreter}/bin:$PATH"
+          '';
+          withPackages = pkgsFun: (perl // {
+            extraEnv = ''
+              ${perl.extraEnv}
+              export PERL5LIB=${lib.makeFullPerlPath (pkgsFun perlPackages)}
+            '';
+          });
+        };
+        tcl = simplePlugin "tcl";
+        ruby = simplePlugin "ruby";
+        guile = simplePlugin "guile";
+        lua = simplePlugin "lua";
+      };
 
-    inherit (config) plugins;
+    config = configure { inherit availablePlugins; };
+
+    plugins = config.plugins or (builtins.attrValues availablePlugins);
 
     pluginsDir = runCommand "weechat-plugins" {} ''
       mkdir -p $out/plugins
@@ -43,14 +50,30 @@ let
       done
     '';
 
-  in (writeScriptBin "weechat" ''
-    #!${stdenv.shell}
-    export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
-    ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}
-    exec ${weechat}/bin/weechat "$@"
-  '') // {
-    name = weechat.name;
-    unwrapped = weechat;
+    init = let
+      init = builtins.replaceStrings [ "\n" ] [ ";" ] (config.init or "");
+
+      mkScript = drv: lib.flip map drv.scripts (script: "/script load ${drv}/share/${script}");
+
+      scripts = builtins.concatStringsSep ";" (lib.foldl (scripts: drv: scripts ++ mkScript drv)
+        [ ] (config.scripts or []));
+    in "${scripts};${init}";
+
+    mkWeechat = bin: (writeScriptBin bin ''
+      #!${stdenv.shell}
+      export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
+      ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}
+      exec ${weechat}/bin/${bin} "$@" --run-command ${lib.escapeShellArg init}
+    '') // {
+      inherit (weechat) name meta;
+      unwrapped = weechat;
+    };
+  in buildEnv {
+    name = "weechat-bin-env-${weechat.version}";
+    paths = [
+      (mkWeechat "weechat")
+      (mkWeechat "weechat-headless")
+    ];
     meta = weechat.meta;
   };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/44102/commits/8887e1f697d9e13ad277ca7d7054bc42c2459548#r239097413

9504292b1e9948fb286b1b1cdbe83f66b367b64d accidentally reverted all the changes that had been made to the weechat wrapper since 8887e1f697d9e13ad277ca7d7054bc42c2459548.

I removed the wrapper, then wrote it again, but this time taking the code from the latest version of weechat before the bad merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Ma27 @lheckemann