### PR TITLE
qmltermwidget: add missing utmp lib on darwin

### DIFF
--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia }:
+{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp }:
 
 stdenv.mkDerivation rec {
   version = "0.1.0";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ca500mzcqglkj0i6km0z512y3a025dbm24605xyv18l6y0l2ny3";
   };
 
-  buildInputs = [ qtbase qtquick1 qtmultimedia ];
+  buildInputs = [ qtbase qtquick1 qtmultimedia ]
+                ++ stdenv.lib.optional stdenv.isDarwin utmp;
   nativeBuildInputs = [ qmake ];
 
   patchPhase = ''
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     description = "A QML port of qtermwidget";
     homepage = https://github.com/Swordfish90/qmltermwidget;
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = with stdenv.lib.maintainers; [ skeidel ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11852,7 +11852,9 @@ with pkgs;
 
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
-    qmltermwidget = callPackage ../development/libraries/qmltermwidget { };
+    qmltermwidget = callPackage ../development/libraries/qmltermwidget {
+      inherit (darwin.apple_sdk.libs) utmp;
+    };
     qmlbox2d = libsForQt59.callPackage ../development/libraries/qmlbox2d { };
 
     qscintilla = callPackage ../development/libraries/qscintilla {


### PR DESCRIPTION
###### Motivation for this change

qmltermwidget does not build on darwin. tested fix on 10.13.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

