### PR TITLE
pythonPackages.parsimonious: 0.7.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/parsimonious/default.nix
+++ b/pkgs/development/python-modules/parsimonious/default.nix
@@ -1,22 +1,21 @@
 { stdenv
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , nose
 , six
 }:
 
 buildPythonPackage rec {
-  version = "0.7.0";
+  version = "0.8.1";
   pname = "parsimonious";
 
-  src = fetchFromGitHub {
-    repo = "parsimonious";
-    owner = "erikrose";
-    rev = version;
-    sha256 = "087npc8ccryrxabmqifcz56w4wd0hzmv0mc91wrbhc1sil196j0a";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b";
   };
 
-  propagatedBuildInputs = [ nose six ];
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ six ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/erikrose/parsimonious";


### PR DESCRIPTION
###### Motivation for this change

Using it for a parser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

