### PR TITLE
[WIP] imake: only use tradcpp on Darwin

### DIFF
--- a/pkgs/servers/x11/xorg/imake-setup-hook.sh
+++ b/pkgs/servers/x11/xorg/imake-setup-hook.sh
@@ -1,4 +1,6 @@
-export IMAKECPP="@tradcpp@/bin/tradcpp"
+if [ -n "@tradcpp@" ]; then
+    export IMAKECPP="@tradcpp@/bin/tradcpp"
+fi
 
 imakeConfigurePhase() {
     runHook preConfigure

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -68,7 +68,7 @@ self: super:
       then "${tradcpp}/bin/cpp"
       else "gcc"}"' ''
     ];
-    inherit tradcpp;
+    tradcpp = if stdenv.isDarwin then tradcpp else "";
   });
 
   mkfontdir = super.mkfontdir.overrideAttrs (attrs: {


### PR DESCRIPTION
###### Motivation for this change

Fixing `x11_ssh_askpass` on aarch64, see [hydra failure][].

For reasons I don't understand, when building with `tradcpp` as the `IMAKECPP`, the aarch64 build passes `LinuxMachineDefines` where it should pass `-D__aarch64__`.

This change was introduced in 613e262fc2f84d068da40ee6c45f0915c00e2193, cc @matthewbauer as the author.

[hydra failure]: https://hydra.nixos.org/build/85068911

Good:
```
building
build flags: SHELL=/nix/store/bsb6596kk4fp20hyl9yl55xwv1ax4b6s-bash-4.4-p23/bin/bash
gcc -O2 -fno-strict-aliasing      -I/nix/store/xisa9pqa1706nqiprscnp4qgvkqqysg8-xorg-cf-files-1.0.6/include    -Dlinux -D__aarch64__ -D_POSIX_C_SOURCE=199309L                          -D_POSIX_SOURCE -D_XOPEN_SOURCE                                 -D_BSD_SOURCE -D_SVID_SOURCE                                 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64                                                                   -DFUNCPROTO=15 -DNARROWPROTO       -c -o drawing.o drawing.c
...
```

Bad:
```
building
build flags: SHELL=/nix/store/bsb6596kk4fp20hyl9yl55xwv1ax4b6s-bash-4.4-p23/bin/bash
gcc -O      -I/nix/store/xisa9pqa1706nqiprscnp4qgvkqqysg8-xorg-cf-files-1.0.6/include    -Dlinux LinuxMachineDefines -D_POSIX_C_SOURCE=199309L                          -D_POSIX_SOURCE -D_XOPEN_SOURCE                                 -D_BSD_SOURCE -D_SVID_SOURCE                                 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64                                                                   -DFUNCPROTO=15 -DNARROWPROTO       -c -o drawing.o drawing.c
gcc: error: LinuxMachineDefines: No such file or directory
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

