### PR TITLE
terraform-docs: init at 0.5.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-docs/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-docs/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+buildGoPackage rec {
+  name = "${pname}-${version}";
+  pname = "terraform-docs";
+  version = "0.5.0";
+
+  goPackagePath = "github.com/segmentio/${pname}";
+
+  src = fetchFromGitHub {
+    owner  = "segmentio";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "12w2yr669hk5kxdb9rrzsn8hwvx8rzrc1rmn8hs9l8z1bkfhr4gg";
+  };
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-X main.version=${version}")
+  '';
+
+  meta = with lib; {
+    description = "A utility to generate documentation from Terraform modules in various output formats.";
+    homepage = "https://${goPackagePath}/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform-docs/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-docs/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
   '';
 
   meta = with lib; {
-    description = "A utility to generate documentation from Terraform modules in various output formats.";
+    description = "A utility to generate documentation from Terraform modules in various output formats";
     homepage = "https://${goPackagePath}/";
     license = licenses.mit;
     maintainers = with maintainers; [ zimbatm ];

--- a/pkgs/applications/networking/cluster/terraform-docs/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-docs/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
 
   meta = with lib; {
     description = "A utility to generate documentation from Terraform modules in various output formats";
-    homepage = "https://${goPackagePath}/";
+    homepage = "https://github.com/segmentio/terraform-docs/";
     license = licenses.mit;
     maintainers = with maintainers; [ zimbatm ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22655,6 +22655,8 @@ in
     callPackage ../applications/networking/cluster/terraform-providers {}
   );
 
+  terraform-docs = callPackage ../applications/networking/cluster/terraform-docs {};
+
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
 
   terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape {};


### PR DESCRIPTION
###### Motivation for this change

Package needed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

