### PR TITLE
soapyrtlsdr: init at 0.2.5

### DIFF
--- a/pkgs/applications/misc/soapyrtlsdr/default.nix
+++ b/pkgs/applications/misc/soapyrtlsdr/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, rtl-sdr, soapysdr
+} :
+
+let
+  version = "0.2.5";
+
+in stdenv.mkDerivation {
+  name = "soapyrtlsdr-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyRTLSDR";
+    rev = "soapy-rtlsdr-${version}";
+    sha256 = "1wyghfqq3vcbjn5w06h5ik62m6555inrlkyrsnk2r78865xilkv3";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ rtl-sdr soapysdr ];
+
+  cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pothosware/SoapyRTLSDR;
+    description = "SoapySDR plugin for RTL-SDR devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ragge ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12388,9 +12388,12 @@ in
       soapybladerf
       soapyhackrf
       soapyremote
+      soapyrtlsdr
       soapyuhd
     ];
   };
+
+  soapyrtlsdr = callPackage ../applications/misc/soapyrtlsdr { };
 
   soapyuhd = callPackage ../applications/misc/soapyuhd { };
 


### PR DESCRIPTION
###### Motivation for this change

Add the Soapy RTL-SDR module which provides support for RTL-SDR dongles within the SoapySDR API and software that supports SoapySDR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

