### PR TITLE
grafana: 5.3.4 -> 5.4.0

### DIFF
--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -169,8 +169,9 @@ in {
           Sets the maximum amount of time (in seconds) a connection may be reused.
           For MySQL this setting should be shorter than the `wait_timeout' variable.
         '';
-        default = 14400;
-        type = types.int;
+        default = "unlimited";
+        example = 14400;
+        type = types.either types.int (types.enum [ "unlimited" ]);
       };
     };
 

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchurl, fetchFromGitHub, phantomjs2 }:
 
 buildGoPackage rec {
-  version = "5.3.4";
+  version = "5.4.0";
   name = "grafana-${version}";
   goPackagePath = "github.com/grafana/grafana";
 
@@ -9,12 +9,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "1fhzdkd1hr7l9cy7c9r03pgaxklfgj09q21ljrahqr006gcn1wgn";
+    sha256 = "090p8j0ddgpc6pz7ax2nz5d196xfhdmgxirszcpkgx2rkidndxlv";
   };
 
   srcStatic = fetchurl {
     url = "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "06andnnnsh68lmra9gc85rsmyx88cwlq2kwzks1d5axpy2mq5arv";
+    sha256 = "06ysq5njlnb9d5x4jchxlk6zmy2ahb9njnj6n3fblpjzdbkjlcgp";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
[Latest release](https://github.com/grafana/grafana/releases/tag/v5.4.0) which includes various bugfixes, some new features and also a "breaking change" regarding database connection limits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Successfully ran tests for 86_64-linux and aarch64-linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I updated the default for `database.connMaxLifetime` in the module.

(Note that go still failes to compile grafana on hosts with too many available cores.)