### PR TITLE
tradcpp: improved aarch64 support

### DIFF
--- a/pkgs/development/tools/tradcpp/aarch64.patch
+++ b/pkgs/development/tools/tradcpp/aarch64.patch
@@ -1,0 +1,12 @@
+diff a/config.h b/config.h
+--- a/config.h
++++ b/config.h
+@@ -124,6 +124,8 @@
+ #define CONFIG_CPU "__ppc64__"
+ #elif defined(__ARM__)
+ #define CONFIG_CPU "__ARM__"
++#elif defined(__aarch64__)
++#define CONFIG_CPU "__aarch64__"
+ #else
+ /* let it go */
+ #endif

--- a/pkgs/development/tools/tradcpp/default.nix
+++ b/pkgs/development/tools/tradcpp/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation {
   # tradcpp only comes with BSD-make Makefile; the patch adds configure support
   buildInputs = [ autoconf ];
   preConfigure = "autoconf";
-  patches = [ ./tradcpp-configure.patch ];
+  patches = [
+    ./tradcpp-configure.patch
+    ./aarch64.patch
+  ];
 
   meta = with stdenv.lib; {
     description = "A traditional (K&R-style) C macro preprocessor";


### PR DESCRIPTION
###### Motivation for this change

Fixes #51578

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-review pr 51585`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---