### PR TITLE
heaptrack: wrap GUI for QT plugins

### DIFF
--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -1,6 +1,6 @@
 {
   stdenv, fetchFromGitHub, cmake, extra-cmake-modules,
-  zlib, boost, libunwind, elfutils, sparsehash,
+  zlib, boost, libunwind, elfutils, sparsehash, makeWrapper,
   qtbase, kio, kitemmodels, threadweaver, kconfigwidgets, kcoreaddons, kdiagram
 }:
 
@@ -17,9 +17,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [
-    zlib boost libunwind elfutils sparsehash
+    zlib boost libunwind elfutils sparsehash makeWrapper
     qtbase kio kitemmodels threadweaver kconfigwidgets kcoreaddons kdiagram
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/heaptrack_gui --set QT_PLUGIN_PATH ${qtbase}/${qtbase.qtPluginPrefix}
+  '';
 
   meta = with stdenv.lib; {
     description = "Heap memory profiler for Linux";


### PR DESCRIPTION
The `heaptrack_gui` program requires QT plugins. This works if it's included in
a full install, since QT will search the users' `$PATH` for plugins; however it
immediately crashes if run in a pure environment.

This wraps the program to find the given `qtbase` plugins directory without
requiring an impure installation.

Related: https://github.com/NixOS/nixpkgs/issues/9680

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

