### PR TITLE
tecoc: add BSD and Darwin/OSX support

### DIFF
--- a/pkgs/applications/editors/tecoc/default.nix
+++ b/pkgs/applications/editors/tecoc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit
+{ stdenv, fetchFromGitHub
 , ncurses }:
 
 stdenv.mkDerivation rec {
@@ -6,20 +6,27 @@ stdenv.mkDerivation rec {
   name = "tecoc-git-${version}";
   version = "20150606";
 
-  src = fetchgit {
-    url = "https://github.com/blakemcbride/TECOC.git";
+  src = fetchFromGitHub {
+    owner = "blakemcbride";
+    repo = "TECOC";
     rev = "d7dffdeb1dfb812e579d6d3b518545b23e1b50cb";
     sha256 = "11zfa73dlx71c0hmjz5n3wqcvk6082rpb4sss877nfiayisc0njj";
   };
 
   buildInputs = [ ncurses ];
 
-  configurePhase = ''
-    cp src/makefile.linux src/Makefile    
-  '';
-  buildPhase = ''
-    make CC=${stdenv.cc}/bin/cc -C src/
-  '';
+  makefile = if stdenv.hostPlatform.isDarwin
+  	     then "makefile.osx"
+	     else if stdenv.hostPlatform.isFreeBSD
+  	     then "makefile.bsd"
+  	     else if stdenv.hostPlatform.isOpenBSD
+  	     then "makefile.bsd"
+  	     else if stdenv.hostPlatform.isWindows
+  	     then "makefile.win"
+	     else "makefile.linux"; # I think Linux is a safe default...
+
+  makeFlags = [ "CC=${stdenv.cc}/bin/cc" "-C src/" ];
+
   installPhase = ''
     mkdir -p $out/bin $out/share/doc/${name} $out/lib/teco/macros
     cp src/tecoc $out/bin
@@ -31,26 +38,26 @@ stdenv.mkDerivation rec {
      ln -s tecoc teco
      ln -s tecoc Inspect )
   '';
-	
+
   meta = with stdenv.lib; {
     description = "A clone of the good old TECO editor";
     longDescription = ''
-      For those who don't know: TECO is the acronym of Tape Editor and
-      COrrector (because it was a paper tape edition tool in its debut 
-      days). Now the acronym follows after Text Editor and Corrector, 
-      or Text Editor Character-Oriented.
-      
-      TECO is a character-oriented text editor, originally developed
-      bu Dan Murphy at MIT circa 1962. It is also a Turing-complete
-      imperative interpreted programming language for text
-      manipulation, done via user-loaded sets of macros. In fact, Emacs
-      was born as a set of Editor MACroS for TECO.
+      For those who don't know: TECO is the acronym of Tape Editor and COrrector
+      (because it was a paper tape edition tool in its debut days). Now the
+      acronym follows after Text Editor and Corrector, or Text Editor
+      Character-Oriented.
+
+      TECO is a character-oriented text editor, originally developed by Dan
+      Murphy at MIT circa 1962. It is also a Turing-complete imperative
+      interpreted programming language for text manipulation, done via
+      user-loaded sets of macros. In fact, the venerable Emacs was born as a set
+      of Editor MACroS for TECO.
 
       TECOC is a portable C implementation of TECO-11.
  '';
     homepage = https://github.com/blakemcbride/TECOC;
+    license = {  url = https://github.com/blakemcbride/TECOC/tree/master/doc/readme-1st.txt; };
     maintainers = [ maintainers.AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }
-# TODO: test in other platforms - especially Darwin


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

