### PR TITLE
pythonPackages.flake8-future-import: fix build on Python 3.7

### DIFF
--- a/pkgs/development/python-modules/flake8-future-import/default.nix
+++ b/pkgs/development/python-modules/flake8-future-import/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonPackage, flake8, six }:
+{ lib, fetchFromGitHub, buildPythonPackage, fetchpatch, flake8, six }:
 
 buildPythonPackage rec {
   pname = "flake8-future-import";
@@ -11,6 +11,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "00fpxa6g8cabybnciwnpsbg60zhgydc966jgwyyggw1pcg0frdqr";
   };
+
+  patches = [
+    # Add Python 3.7 support. Remove with the next release
+    (fetchpatch {
+      url = https://github.com/xZise/flake8-future-import/commit/cace194a44d3b95c9c1ed96640bae49183acca04.patch;
+      sha256 = "17pkqnh035j5s5c53afs8bk49bq7lnmdwqp5k7izx7sw80z73p9r";
+    })
+  ];
 
   propagatedBuildInputs = [ flake8 six ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/51593

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

