### PR TITLE
extlinux-conf: fix cross compilation

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
@@ -3,6 +3,6 @@
 pkgs.substituteAll {
   src = ./extlinux-conf-builder.sh;
   isExecutable = true;
-  path = [pkgs.coreutils pkgs.gnused pkgs.gnugrep];
-  inherit (pkgs) bash;
+  path = [pkgs.buildPackages.coreutils pkgs.buildPackages.gnused pkgs.buildPackages.gnugrep];
+  inherit (pkgs.buildPackages) bash;
 }


### PR DESCRIPTION
###### Motivation for this change

Fxs:
```
 9049 Device                                                                                                                                                                                   Boot  Start     End Sectors  Size Id Type
 9050 /nix/store/5aj337b2ww0ccijwipfygwkffhpl1ll0-nixos-sd-image-19.03.git.7a135ae-armv7l-linux.img-armv7l-unknown-linux-gnueabihf/sd-image/nixos-sd-image-19.03.git.7a135ae-armv7l-linux.img1 *     16384  262143  245760  120M  b W95 FAT32
 9051 /nix/store/5aj337b2ww0ccijwipfygwkffhpl1ll0-nixos-sd-image-19.03.git.7a135ae-armv7l-linux.img-armv7l-unknown-linux-gnueabihf/sd-image/nixos-sd-image-19.03.git.7a135ae-armv7l-linux.img2      262144 7146431 6884288  3.3G 83 Linux
 9052 
 9053 The partition table has been altered.
 9054 Syncing disks.
 9055 6859712+0 records in
 9056 6859712+0 records out
 9057 3512172544 bytes (3.5 GB, 3.3 GiB) copied, 98.8709 s, 35.5 MB/s
 9058 mkfs.fat 4.1 (2017-01-24)
 9059 /nix/store/mcnr9b07b2dc4wp1v3d5h0dncbiapx13-extlinux-conf-builder.sh-armv7l-unknown-linux-gnueabihf: line 38: /nix/store/bf2mqh9w16cszj6p0s7xb1fa19j49hj6-coreutils-8.30-armv7l-unknown-linux-gnueabihf/bin/mkdir: cannot execute binary\
       file: Exec format error
 9060 /nix/store/mcnr9b07b2dc4wp1v3d5h0dncbiapx13-extlinux-conf-builder.sh-armv7l-unknown-linux-gnueabihf: line 39: /nix/store/bf2mqh9w16cszj6p0s7xb1fa19j49hj6-coreutils-8.30-armv7l-unknown-linux-gnueabihf/bin/mkdir: cannot execute binary\
       file: Exec format error
 9061 /nix/store/mcnr9b07b2dc4wp1v3d5h0dncbiapx13-extlinux-conf-builder.sh-armv7l-unknown-linux-gnueabihf: line 107: ./boot/extlinux/extlinux.conf.tmp.296: No such file or directory
 9062 /nix/store/mcnr9b07b2dc4wp1v3d5h0dncbiapx13-extlinux-conf-builder.sh-armv7l-unknown-linux-gnueabihf: line 117: ./boot/extlinux/extlinux.conf.tmp.296: No such file or directory
 9063 /nix/store/mcnr9b07b2dc4wp1v3d5h0dncbiapx13-extlinux-conf-builder.sh-armv7l-unknown-linux-gnueabihf: line 132: /nix/store/bf2mqh9w16cszj6p0s7xb1fa19j49hj6-coreutils-8.30-armv7l-unknown-linux-gnueabihf/bin/mv: cannot execute binary f\
      ile: Exec format error
 9064 Copying bootcode.bin

```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

