### PR TITLE
fontconfig: fix cross make-fonts-cache & make-fonts-config

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -1,8 +1,8 @@
-{ runCommand, lib, fontconfig, fontDirectories }:
+{ runCommand, lib, fontconfig, fontDirectories, buildPackages }:
 
 runCommand "fc-cache"
   rec {
-    buildInputs = [ fontconfig.bin ];
+    nativeBuildInputs = [ buildPackages.fontconfig.bin ];
     preferLocalBuild = true;
     passAsFile = [ "fontDirs" ];
     fontDirs = ''

--- a/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-conf.nix
@@ -2,7 +2,7 @@
 
 runCommand "fonts.conf"
   {
-    buildInputs = [ libxslt fontconfig ];
+    nativeBuildInputs = [ libxslt fontconfig ];
     # Add a default font for non-nixos systems, <1MB and in nixos defaults.
     fontDirectories = fontDirectories ++ [ dejavu_fonts.minimal ];
   }


### PR DESCRIPTION
###### Motivation for this change

Fxs binary dependencies during cross compilation.
Fixes: #51563

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

