### PR TITLE
octoprint: 1.3.8 -> 1.3.9

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -1,91 +1,62 @@
-{ stdenv, fetchFromGitHub, python2 }:
+{ stdenv, lib, fetchFromGitHub, python2 }:
 
 let
-
-  pythonPackages = python2.pkgs.override {
-    overrides = self: super: with self; {
-      backports_ssl_match_hostname = super.backports_ssl_match_hostname.overridePythonAttrs (oldAttrs: rec {
-        version = "3.4.0.2";
+  mkOverride = attrname: version: sha256:
+    self: super: {
+      ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
+        inherit version;
         src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "07410e7fb09aab7bdaf5e618de66c3dac84e2e3d628352814dc4c37de321d6ae";
-        };
-      });
-
-      flask = super.flask.overridePythonAttrs (oldAttrs: rec {
-        version = "0.12.4";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "2ea22336f6d388b4b242bc3abf8a01244a8aa3e236e7407469ef78c16ba355dd";
-        };
-      });
-
-      tornado = buildPythonPackage rec {
-        pname = "tornado";
-        version = "4.0.2";
-
-        propagatedBuildInputs = [ backports_ssl_match_hostname certifi ];
-
-        src = fetchPypi {
-          inherit pname version;
-          sha256 = "1yhvn8i05lp3b1953majg48i8pqsyj45h34aiv59hrfvxcj5234h";
-        };
-      };
-
-      flask_login = buildPythonPackage rec {
-        pname = "Flask-Login";
-        version = "0.2.2";
-
-        src = fetchPypi {
-          inherit pname version;
-          sha256 = "09ygn0r3i3jz065a5psng6bhlsqm78msnly4z6x39bs48r5ww17p";
-        };
-
-        propagatedBuildInputs = [ flask ];
-        checkInputs = [ nose ];
-
-        # No tests included
-        doCheck = false;
-      };
-
-      jinja2 = buildPythonPackage rec {
-        pname = "Jinja2";
-        version = "2.8.1";
-
-        src = fetchPypi {
-          inherit pname version;
-          sha256 = "14aqmhkc9rw5w0v311jhixdm6ym8vsm29dhyxyrjfqxljwx1yd1m";
-        };
-
-        propagatedBuildInputs = [ markupsafe ];
-
-        # No tests included
-        doCheck = false;
-      };
-
-      pylru = super.pylru.overridePythonAttrs (oldAttrs: rec {
-        version = "1.0.9";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "71376192671f0ad1690b2a7427d39a29b1df994c8469a9b46b03ed7e28c0172c";
+          inherit version sha256;
         };
       });
     };
+
+  py = python2.override {
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
+      (mkOverride "flask"       "0.10.1" "0wrkavjdjndknhp8ya8j850jq7a1cli4g5a93mg8nh1xz2gq50sc")
+      (mkOverride "flask_login" "0.2.11" "1rg3rsjs1gwi2pw6vr9jmhaqm9b3vc9c4hfcsvp4y8agbh7g3mc3")
+      (mkOverride "jinja2"      "2.8.1"  "14aqmhkc9rw5w0v311jhixdm6ym8vsm29dhyxyrjfqxljwx1yd1m")
+      (mkOverride "pylru"       "1.0.9"  "0b0pq0l7xv83dfsajsc49jcxzc99kb9jfx1a1dlx22hzcy962dvi")
+      (mkOverride "sarge"       "0.1.4"  "08s8896973bz1gg0pkr592w6g4p6v47bkfvws5i91p9xf8b35yar")
+      (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
+    ]);
   };
 
-in pythonPackages.buildPythonApplication rec {
+  ignoreVersionConstraints = [
+    "Click"
+    "Flask-Assets"
+    "Flask-Babel"
+    "Flask-Principal"
+    "PyYAML"
+    "emoji"
+    "flask"
+    "future"
+    "futures"
+    "pkginfo"
+    "psutil"
+    "pyserial"
+    "python-dateutil"
+    "requests"
+    "rsa"
+    "scandir"
+    "semantic_version"
+    "websocket-client"
+    "werkzeug"
+    "wrapt"
+  ];
+
+in py.pkgs.buildPythonApplication rec {
   pname = "OctoPrint";
-  version = "1.3.8";
+  version = "1.3.9";
 
   src = fetchFromGitHub {
-    owner = "foosel";
-    repo = "OctoPrint";
-    rev = version;
-    sha256 = "00zd5yrlihwfd3ly0mxibr77ffa8r8vkm6jhml2ml43dqb99caa3";
+    owner  = "foosel";
+    repo   = "OctoPrint";
+    rev    = version;
+    sha256 = "1yqbsfmkx4wiykjrh66a05lhn15qhpc9ay67l37kv8bhdqf2xkj4";
   };
 
-  # We need old Tornado
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with py.pkgs; [
     awesome-slugify flask_assets rsa requests pkginfo watchdog
     semantic-version flask_principal werkzeug flaskbabel tornado
     psutil pyserial flask_login netaddr markdown sockjs-tornado
@@ -94,31 +65,13 @@ in pythonPackages.buildPythonApplication rec {
     frozendict
   ];
 
-  checkInputs = with pythonPackages; [ nose mock ddt ];
+  checkInputs = with py.pkgs; [ nose mock ddt ];
 
-  # Jailbreak dependencies.
   postPatch = ''
-    sed -i \
-      -e 's,pkginfo>=[^"]*,pkginfo,g' \
-      -e 's,Flask-Principal>=[^"]*,Flask-Principal,g' \
-      -e 's,websocket-client>=[^"]*,websocket-client,g' \
-      -e 's,Click>=[^"]*,Click,g' \
-      -e 's,rsa>=[^"]*,rsa,g' \
-      -e 's,flask>=[^"]*,flask,g' \
-      -e 's,Flask-Babel>=[^"]*,Flask-Babel,g' \
-      -e 's,Flask-Assets>=[^"]*,Flask-Assets,g' \
-      -e 's,PyYAML>=[^"]*,PyYAML,g' \
-      -e 's,scandir>=[^"]*,scandir,g' \
-      -e 's,werkzeug>=[^"]*,werkzeug,g' \
-      -e 's,psutil==[^"]*,psutil,g' \
-      -e 's,requests>=[^"]*,requests,g' \
-      -e 's,future>=[^"]*,future,g' \
-      -e 's,pyserial>=[^"]*,pyserial,g' \
-      -e 's,semantic_version>=[^"]*,semantic_version,g' \
-      -e 's,wrapt>=[^"]*,wrapt,g' \
-      -e 's,python-dateutil>=[^"]*,python-dateutil,g' \
-      -e 's,emoji>=[^"]*,emoji,g' \
-      -e 's,futures>=[^"]*,futures,g' \
+    sed -r -i \
+      ${lib.concatStringsSep "\n" (map (e:
+        ''-e 's@${e}[<>=]+.*@${e}",@g' \''
+      ) ignoreVersionConstraints)}
       setup.py
   '';
 

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchFromGitHub, octoprint, pythonPackages }:
+{ stdenv, fetchFromGitHub, octoprint, python2Packages }:
 
 let
-  buildPlugin = args: pythonPackages.buildPythonApplication (args // {
-    buildInputs = (args.buildInputs or []) ++ [ octoprint ];
+  buildPlugin = args: python2Packages.buildPythonPackage (args // {
+    propagatedBuildInputs = (args.propagatedBuildInputs or []) ++ [ octoprint ];
+    # none of the following have tests
+    doCheck = false;
   });
 
   self = {
@@ -39,6 +41,28 @@ let
         platforms = platforms.all;
         license = licenses.gpl3;
         maintainers = with maintainers; [ abbradar ];
+      };
+    };
+
+    mqtt = buildPlugin rec {
+      name = "OctoPrint-MQTT-${version}";
+      version = "0.8.0";
+
+      src = fetchFromGitHub {
+        owner = "OctoPrint";
+        repo = "OctoPrint-MQTT";
+        rev = version;
+        sha256 = "1318pgwy39gkdqgll3q5lwm7avslgdwyiwb5v8m23cgyh5w8cjq7";
+      };
+
+      propagatedBuildInputs = with python2Packages; [ paho-mqtt ];
+
+      meta = with stdenv.lib; {
+        homepage = https://github.com/OctoPrint/OctoPrint-MQTT;
+        description = "Publish printer status MQTT";
+        platforms = platforms.all;
+        license = licenses.agpl3;
+        maintainers = with maintainers; [ peterhoeg ];
       };
     };
 

--- a/pkgs/development/python-modules/flask-login/default.nix
+++ b/pkgs/development/python-modules/flask-login/default.nix
@@ -1,15 +1,13 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pythonAtLeast
+{ stdenv, buildPythonPackage, fetchPypi, pythonAtLeast
 , flask, blinker, nose, mock, semantic-version }:
 
 buildPythonPackage rec {
   pname = "Flask-Login";
   version = "0.4.1";
 
-  src = fetchFromGitHub {
-    owner = "maxcountryman";
-    repo = "flask-login";
-    rev = version;
-    sha256 = "1rj0qwyxapxnp84fi4lhmvh3d91fdiwz7hibw77x3d5i72knqaa9";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1v2j8zd558xfmgn3rfbw0xz4vizjcnk8kqw52q4f4d9ygfnc25f8";
   };
 
   checkInputs = [ nose mock semantic-version ];


### PR DESCRIPTION
###### Motivation for this change

Apart from upgrading octoprint, perform a number of cleanups concerning dependencies and constraints.

Cc: @abbradar 

Also add octoprint-mqtt.

I haven't actually tried all this out yet (tests pass though) as our printer *just* arrived y'day.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

