### PR TITLE
ocamlPackages.lablgtk3: init at 3.0.beta1

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pkgconfig, ocaml, findlib, gtk3, gtkspell3, gtksourceview }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "lablgtk3 is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "3.0.beta1";
+  name = "ocaml${ocaml.version}-lablgtk3-${version}";
+  src = fetchurl {
+    url = https://forge.ocamlcore.org/frs/download.php/1769/lablgtk-3.0.beta1.tar.gz;
+    sha256 = "08izn2kwxdz1i74m11lqkl9n50bs7sy6pl8mcq6br77znarvqb91";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ ocaml findlib gtk3 gtkspell3 gtksourceview ];
+
+  buildFlags = "world";
+
+  meta = {
+    description = "OCaml interface to gtk+-3";
+    homepage = "http://lablgtk.forge.ocamlcore.org/";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -359,6 +359,8 @@ let
 
     lablgl = callPackage ../development/ocaml-modules/lablgl { };
 
+    lablgtk3 = callPackage ../development/ocaml-modules/lablgtk3 { };
+
     lablgtk_2_14 = callPackage ../development/ocaml-modules/lablgtk/2.14.0.nix {
       inherit (pkgs.gnome2) libgnomecanvas libglade gtksourceview;
     };


### PR DESCRIPTION
###### Motivation for this change

https://inbox.ocaml.org/caml-list/966B3CBE-29BB-4336-BDBF-0012723E7099@math.nagoya-u.ac.jp/T/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

