### PR TITLE
unit: init at v1.6

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -13,6 +13,7 @@ let
   { version
   , sha256
   , extraPatches ? []
+  , withSystemd ? config.php.systemd or stdenv.isLinux
   , imapSupport ? config.php.imap or (!stdenv.isDarwin)
   , ldapSupport ? config.php.ldap or true
   , mhashSupport ? config.php.mhash or true
@@ -68,7 +69,7 @@ let
 
       nativeBuildInputs = [ pkgconfig autoconf ];
       buildInputs = [ flex bison pcre ]
-        ++ optional stdenv.isLinux systemd
+        ++ optional withSystemd systemd
         ++ optionals imapSupport [ uwimap openssl pam ]
         ++ optionals curlSupport [ curl openssl ]
         ++ optionals ldapSupport [ openldap openssl ]
@@ -105,7 +106,7 @@ let
         "--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"
       ]
       ++ optional stdenv.isDarwin "--with-iconv=${libiconv}"
-      ++ optional stdenv.isLinux  "--with-fpm-systemd"
+      ++ optional withSystemd "--with-fpm-systemd"
       ++ optionals imapSupport [
         "--with-imap=${uwimap}"
         "--with-imap-ssl"

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, fetchurl
+, which
+, python
+, php71
+, php72
+, perl526
+, perl
+, perldevel
+, ruby_2_3
+, ruby_2_4
+, ruby
+, withSSL ? true, openssl ? null
+, withIPv6 ? true
+, withDebug ? false
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "1.6";
+  name = "unit-${version}";
+
+  src = fetchurl {
+    url = "https://unit.nginx.org/download/${name}.tar.gz";
+    sha256 = "0lws5xpzkcmv0gc7vi8pgnymin02dq4gw0zb41jfzq0vbljxxl14";
+  };
+
+  buildInputs = [
+    which
+    python
+    php71
+    php72
+    perl526
+    perl
+    perldevel
+    ruby_2_3
+    ruby_2_4
+    ruby
+  ] ++ optional withSSL openssl;
+
+  configureFlags = [
+    "--control=unix:/run/control.unit.sock"
+    "--pid=/run/unit.pid"
+  ] ++ optional withSSL     [ "--openssl" ]
+    ++ optional (!withIPv6) [ "--no-ipv6" ]
+    ++ optional withDebug   [ "--debug" ];
+
+  postConfigure = ''
+    ./configure python  --module=python    --config=${python}/bin/python-config  --lib-path=${python}/lib
+    ./configure php     --module=php71     --config=${php71.dev}/bin/php-config  --lib-path=${php71}/lib
+    ./configure php     --module=php72     --config=${php72.dev}/bin/php-config  --lib-path=${php72}/lib
+    ./configure perl    --module=perl526   --perl=${perl526}/bin/perl
+    ./configure perl    --module=perl      --perl=${perl}/bin/perl
+    ./configure perl    --module=perl529   --perl=${perldevel}/bin/perl
+    ./configure ruby    --module=ruby23    --ruby=${ruby_2_3}/bin/ruby
+    ./configure ruby    --module=ruby24    --ruby=${ruby_2_4}/bin/ruby
+    ./configure ruby    --module=ruby      --ruby=${ruby}/bin/ruby
+  '';
+
+  meta = {
+    description = "Dynamic web and application server, designed to run applications in multiple languages.";
+    homepage    = https://unit.nginx.org/;
+    license     = licenses.asl20;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7859,12 +7859,14 @@ in
   php71-unit = php71.override {
     config.php.embed = true;
     config.php.apxs2 = false;
+    config.php.systemd = false;
     config.php.fpm = false;
   };
 
   php72-unit = php72.override {
     config.php.embed = true;
     config.php.apxs2 = false;
+    config.php.systemd = false;
     config.php.fpm = false;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7829,6 +7829,15 @@ in
     php = php72;
   });
 
+  phpPackages-unit = php72Packages-unit;
+
+  php71Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php71-unit;
+  });
+   php72Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php72-unit;
+  });
+
   inherit (callPackages ../development/interpreters/php { })
     php71
     php72;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7829,7 +7829,6 @@ in
     php = php72;
   });
 
-
   inherit (callPackages ../development/interpreters/php { })
     php71
     php72;
@@ -7844,6 +7843,20 @@ in
   php72-embed = php72.override {
     config.php.embed = true;
     config.php.apxs2 = false;
+  };
+
+  php-unit = php72-unit;
+
+  php71-unit = php71.override {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+    config.php.fpm = false;
+  };
+
+  php72-unit = php72.override {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+    config.php.fpm = false;
   };
 
   picoc = callPackage ../development/interpreters/picoc {};
@@ -13513,6 +13526,11 @@ in
   nats-streaming-server = callPackage ../servers/nats-streaming-server { };
 
   neard = callPackage ../servers/neard { };
+
+  unit = callPackage ../servers/http/unit {
+    php71 = php71-unit;
+    php72 = php72-unit;
+  };
 
   nginx = nginxStable;
 


### PR DESCRIPTION
###### Motivation for this change
Add dynamic web and application server - nginx unit v1.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

