### PR TITLE
pyflame: also install flame-chart-json

### DIFF
--- a/pkgs/development/tools/profiling/pyflame/default.nix
+++ b/pkgs/development/tools/profiling/pyflame/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchFromGitHub, autoreconfHook, coreutils, pkgconfig
 # pyflame needs one python version per ABI
-# are currently supported 
+# are currently supported
 # * 2.6 or 2.7 for 2.x ABI
 # * 3.4 or 3.5 for 3.{4,5} ABI
 # * 3.6        for 3.6+ ABI
 # if you want to disable support for some ABI, make the corresponding argument null
-, python2, python35, python36
+, python2, python35, python36, python3
 }:
 stdenv.mkDerivation rec {
   pname = "pyflame";
-  version = "1.6.7"; 
+  version = "1.6.7";
   src = fetchFromGitHub {
     owner = "uber";
     repo = "pyflame";
@@ -25,6 +25,14 @@ stdenv.mkDerivation rec {
     # some tests will fail in the sandbox
     substituteInPlace tests/test_end_to_end.py \
       --replace 'skipif(IS_DOCKER' 'skipif(True'
+
+    # don't use patchShebangs here to be explicit about the python version
+    substituteInPlace utils/flame-chart-json \
+      --replace '#!usr/bin/env python' '#!${python3.interpreter}'
+  '';
+
+  postInstall = ''
+    install	-D utils/flame-chart-json $out/bin/flame-chart-json
   '';
 
   doCheck = true;


### PR DESCRIPTION
This is useful to use chrome's flamechart viewer.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

cc @symphorien

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

