### PR TITLE
stdenv: add armv7a-linux system

### DIFF
--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -43,6 +43,7 @@ in
     "x86_64-linux" = stagesLinux;
     "armv5tel-linux" = stagesLinux;
     "armv6l-linux" = stagesLinux;
+    "armv7a-linux" = stagesLinux;
     "armv7l-linux" = stagesLinux;
     "aarch64-linux" = stagesLinux;
     "mipsel-linux" = stagesLinux;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -13,6 +13,7 @@
       "x86_64-linux" = import ./bootstrap-files/x86_64.nix;
       "armv5tel-linux" = import ./bootstrap-files/armv5tel.nix;
       "armv6l-linux" = import ./bootstrap-files/armv6l.nix;
+      "armv7a-linux" = import ./bootstrap-files/armv7l.nix;
       "armv7l-linux" = import ./bootstrap-files/armv7l.nix;
       "aarch64-linux" = import ./bootstrap-files/aarch64.nix;
       "mipsel-linux" = import ./bootstrap-files/loongson2f.nix;


### PR DESCRIPTION
###### Motivation for this change
When building `nix` for ARM like this:
```
nix build nixpkgs.pkgsCross.armv7l-hf-multiplatform.nix
```
And installing it on a Cubieboard2, using https://github.com/NixOS/nixpkgs/pull/51626 .
One gets an `"armv7a-linux"` system, not an `"armv7l-linux"`.
```
% nix-instantiate --eval -E "(import <nixpkgs> {}).system"
"armv7a-linux"
```

I don't know the difference, nor the meaning of this "a" (maybe "android"?),
which maybe comes from `armv7l-hf-multiplatform.gcc.arch = "armv7-a"` in  `lib/systems/platforms.nix`.
This patch treats `"armv7a-linux"` like `"armv7l-linux"` in order to let nixpkgs find `libc` in nixpkgs:
```
% nix-instantiate --eval -E "(import <nixpkgs> {}).stdenv.cc.libc.name"
"glibc-2.27"
```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

