### PR TITLE
passExtensions.pass-genphrase: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3940,6 +3940,11 @@
     github = "seppeljordan";
     name = "Sebastian Jordan";
   };
+  seqizz = {
+    email = "seqizz@gmail.com";
+    github = "seqizz";
+    name = "Gurkan Gur";
+  };
   sfrijters = {
     email = "sfrijters@gmail.com";
     github = "sfrijters";

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -12,4 +12,5 @@ with pkgs;
   pass-otp = callPackage ./otp.nix {};
   pass-tomb = callPackage ./tomb.nix {};
   pass-update = callPackage ./update.nix {};
+  pass-genphrase = callPackage ./genphrase.nix {};
 }

--- a/pkgs/tools/security/pass/extensions/genphrase.nix
+++ b/pkgs/tools/security/pass/extensions/genphrase.nix
@@ -1,0 +1,32 @@
+{ stdenv, pass, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "pass-genphrase-${version}";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "congma";
+    repo = "pass-genphrase";
+    rev = "${version}";
+    sha256 = "0vcg3b79n1r949qfn8ns85bq2mfsmbf4jw2dlzif8425n8ppfsgd";
+  };
+
+  dontBuild = true;
+
+  installTargets = "globalinstall";
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    substituteInPlace $out/lib/password-store/extensions/genphrase.bash \
+      --replace '$EXTENSIONS' "$out/lib/password-store/extensions/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pass extension that generates memorable passwords";
+    homepage = https://github.com/congma/pass-genphrase;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ seqizz ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Genphrase extension generates memorable passwords (like [this xkcd example](https://xkcd.com/936/))

Please check it though, this is my first contribution and I am sure you can find a lot of errors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

