### PR TITLE
rustc: 1.30.1 -> 1.31.0

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.30.0";
+  version = "1.30.1";
 
   # fetch hashes by running `print-hashes.sh 1.30.0`
   hashes = {
-    i686-unknown-linux-gnu = "4ceb0e3011d96504587abb7edfdea9c1b4b7cb2c4488cc4a25adc2f3b6a88b21";
-    x86_64-unknown-linux-gnu = "f620e3125cc505c842150bd873c0603432b6cee984cdae8b226cf92c8aa1a80f";
-    armv7-unknown-linux-gnueabihf = "63991f6769ca8db693562c34ac25473e9d4f9f214d6ee98917891be469d69cfd";
-    aarch64-unknown-linux-gnu = "9690c7c50eba5a8461184ee4138b4c284bad31ccc4aa1f2ddeec58b253e6363e";
-    i686-apple-darwin = "b8e5ac31f0a192a58b0e98ff88c47035a2882598946352fa5a86c28ede079230";
-    x86_64-apple-darwin = "07008d90932712282bc599f1e9a226e97879c758dc1f935e6e2675e45694cc1b";
+    i686-unknown-linux-gnu = "c61655977fb16decf0ceb76043b9ae2190927aa9cc24f013d444384dcab99bbf";
+    x86_64-unknown-linux-gnu = "a01a493ed8946fc1c15f63e74fc53299b26ebf705938b4d04a388a746dfdbf9e";
+    armv7-unknown-linux-gnueabihf = "9b3b6df02a2a92757e4993a7357fdd02e07b60101a748b4618e6ae1b90bc1b6b";
+    aarch64-unknown-linux-gnu = "6d87d81561285abd6c1987e07b60b2d723936f037c4b46eedcc12e8566fd3874";
+    i686-apple-darwin = "a7c14b18e96406d9f43d69d0f984b2fa6f92cc7b7b37e2bb7b70b6f44b02b083";
+    x86_64-apple-darwin = "3ba1704a7defe3d9a6f0c1f68792c084da83bcba85e936d597bac0c019914b94";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -7,11 +7,11 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
-  version = "1.30.1";
-  cargoVersion = "1.30.0";
+  version = "1.31.0";
+  cargoVersion = "1.31.0";
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "0aavdc1lqv0cjzbqwl5n59yd0bqdlhn0zas61ljf38yrvc18k8rn";
+    sha256 = "01pg2619bwjnhjbphryrbkwaz0lw8cfffm4xlz35znzipb04vmcs";
   };
 in rec {
   rustc = callPackage ./rustc.nix {


### PR DESCRIPTION
###### Motivation for this change

- [x] aarch64-linux
- [x] x86_64-linux
- [x] x86_64-darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

