### PR TITLE
bitwarden-cli: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4718,6 +4718,11 @@
     github = "woffs";
     name = "Frank Doepper";
   };
+  wolfereign = {
+    email = "nvonwolff@gmail.com";
+    github = "Wolfereign";
+    name = "Wolfereign";
+  };
   womfoo = {
     email = "kranium@gikos.net";
     github = "womfoo";

--- a/pkgs/tools/security/bitwarden-cli/default.nix
+++ b/pkgs/tools/security/bitwarden-cli/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, nodejs }:
+
+stdenv.mkDerivation rec {
+  name = "bitwarden-cli-${version}";
+  version = "v1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "bitwarden";
+    repo = "cli";
+    rev = "${version}";
+    fetchSubmodules = true; 
+    sha256 = "1csdbv692l69lickzzl8246gvl0gi58hc91aja3xmb1kcxiphc7c";
+  };
+
+  buildInputs = [ nodejs ];
+  buildCommand = ''
+    unpackPhase  
+    cd "$sourceRoot"
+    export HOME="."
+
+    npm install
+    npm run dist:lin
+
+    mkdir -p "$out/bin"
+    cp "./dist/linux/bw" "$out/bin/bw"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bitwarden Command-line Interface";
+    longDescription = ''
+      The Bitwarden CLI is a powerful, full-featured command-line interface (CLI) tool to access and manage a Bitwarden vault. The CLI is written with TypeScript and Node.js and can be run on Windows, macOS, and Linux distributions.
+    '';
+    homepage = "https://bitwarden.com/";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.wolfereign ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/security/bitwarden-cli/default.nix
+++ b/pkgs/tools/security/bitwarden-cli/default.nix
@@ -2,19 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "bitwarden-cli-${version}";
-  version = "v1.6.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "cli";
-    rev = "${version}";
+    rev = "v${version}";
     fetchSubmodules = true; 
     sha256 = "1csdbv692l69lickzzl8246gvl0gi58hc91aja3xmb1kcxiphc7c";
   };
 
   buildInputs = [ nodejs ];
   buildCommand = ''
-    unpackPhase  
+    unpackPhase
     cd "$sourceRoot"
     export HOME="."
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -665,6 +665,8 @@ with pkgs;
 
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
+  bitwarden-cli = callPackage ../tools/security/bitwarden-cli { };
+
   bmap-tools = callPackage ../tools/misc/bmap-tools { };
 
   bonnie = callPackage ../tools/filesystems/bonnie { };


### PR DESCRIPTION
###### Motivation for this change
Make the bitwarden cli client available to nix/nixos. https://github.com/NixOS/nixpkgs/issues/51212

###### Things done
- added "pkgs/tools/security/bitwarden-cli/default.nix"
- updated all-packages.nix to include bitwarden-cli
- added myself to the maintainer list as "wolfereign"

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

