### PR TITLE
Allow skipping the use of the PYTHONNOUSERSITE variable

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -46,6 +46,9 @@
 # Skip wrapping of python programs altogether
 , dontWrapPythonPrograms ? false
 
+# Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
+, skipNoUserSite ? false
+
 # Remove bytecode from bin folder.
 # When a Python script has the extension `.py`, bytecode is generated
 # Typically, executables in bin have no extension, so no bytecode is generated.
@@ -93,6 +96,7 @@ let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attr
   installCheckInputs = checkInputs;
 
   postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
+    ${if skipNoUserSite then "export SKIPNOUSERSITE=1" else ""}
     wrapPythonPrograms
   '' + lib.optionalString removeBinBytecode ''
     if [ -d "$out/bin" ]; then

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -47,7 +47,7 @@
 , dontWrapPythonPrograms ? false
 
 # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
-, skipNoUserSite ? false
+, permitUserSite ? false
 
 # Remove bytecode from bin folder.
 # When a Python script has the extension `.py`, bytecode is generated
@@ -96,7 +96,6 @@ let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attr
   installCheckInputs = checkInputs;
 
   postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
-    ${if skipNoUserSite then "export SKIPNOUSERSITE=1" else ""}
     wrapPythonPrograms
   '' + lib.optionalString removeBinBytecode ''
     if [ -d "$out/bin" ]; then

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -75,7 +75,7 @@ wrapPythonProgramsIn() {
                                     --prefix PATH ':' "$program_PATH"
                                     )
 
-                    if [ -z "$SKIPNOUSERSITE" ]; then
+                    if [ -z "$permitUserSite" ]; then
                         wrap_args+=(--set PYTHONNOUSERSITE "true")
                     fi
 

--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -73,8 +73,11 @@ wrapPythonProgramsIn() {
                     # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
                     local -a wrap_args=("$f"
                                     --prefix PATH ':' "$program_PATH"
-                                    --set PYTHONNOUSERSITE "true"
                                     )
+
+                    if [ -z "$SKIPNOUSERSITE" ]; then
+                        wrap_args+=(--set PYTHONNOUSERSITE "true")
+                    fi
 
                     # Add any additional arguments provided by makeWrapperArgs
                     # argument to buildPythonPackage.

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -3,6 +3,7 @@
 , extraOutputsToInstall ? []
 , postBuild ? ""
 , ignoreCollisions ? false
+, permitUserSite ? false
 , requiredPythonModules
 # Wrap executables with the given argument.
 , makeWrapperArgs ? []
@@ -34,7 +35,7 @@ let
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out" --set PYTHONNOUSERSITE "true" ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out" ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
               fi
             fi
           done


### PR DESCRIPTION
###### Motivation for this change

By default, Nix-installed Python binaries use the `PYTHONNOUSERSITE` variable (see [here](https://docs.python.org/2/using/cmdline.html#envvar-PYTHONNOUSERSITE)) to prevent Python from looking for packages in the user's site-packages directory.

I wanted to be able to install a Python installation that is slightly impure, so that you can run `pip install --user some_package` and then use the resulting package. This is convenient when you want to set up an environment where the user either can't install new Python packages via Nix, or would prefer to use `pip` directly (for example, if a package version isn't available on Nix).

So, this PR introduces a flag `skipNoUserSite` that can be used to disable the `PYTHONNOUSERSITE` setting when needed. The change happens in two places:

1) `pkgs/development/interpreters/python/mk-python-derivation.nix` and `pkgs/development/interpreters/python/wrap.sh`: the change here allows you to disable `PYTHONNOUSERSITE` for individual Python **packages**, i.e. those built by `buildPythonPackage`.
2) `pkgs/development/interpreters/python/wrapper.nix`: the change here allows you to disable `PYTHONNOUSERSITE` for Python **environments**, i.e. those created by `python.withPackages`. It causes every wrapped binary inside the environment to be user site-packages aware.

This flag is purely opt-in, so hopefully it's okay to add a little impurity for this use case :)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

