### PR TITLE
gitAndTools.git-test: init at 1.0.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -104,6 +104,8 @@ let
 
   git-sync = callPackage ./git-sync { };
 
+  git-test = callPackage ./git-test { };
+
   git2cl = callPackage ./git2cl { };
 
   gitFastExport = callPackage ./fast-export { };

--- a/pkgs/applications/version-management/git-and-tools/git-test/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-test/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, makeWrapper, git }:
+
+stdenv.mkDerivation rec {
+  name = "git-test-${version}";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "spotify";
+    repo = "git-test";
+    rev = "v${version}";
+    sha256 = "01h3f0andv1p7pwir3k6n01v92hgr5zbjadfwl144yjw9x37fm2f";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -m755 -Dt $out/bin git-test
+    install -m444 -Dt $out/share/man/man1 git-test.1
+
+    wrapProgram $out/bin/git-test \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ git ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Test your commits";
+    homepage = https://github.com/spotify/git-test;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

