### PR TITLE
erlang: disable parallel building

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -59,7 +59,8 @@ in stdenv.mkDerivation ({
 
   debugInfo = enableDebugInfo;
 
-  enableParallelBuilding = true;
+  # On some machines, parallel build reliably crashes on `GEN    asn1ct_eval_ext.erl` step
+  enableParallelBuilding = false;
 
   # Clang 4 (rightfully) thinks signed comparisons of pointers with NULL are nonsense
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

All of the Erlang runtimes fail to build on my Hydra with parallel building enabled (implemented in #45484).  The same problem [was observed on an official Hydra machine](https://github.com/NixOS/nixpkgs/pull/47371#issuecomment-425014401) ([and again](https://github.com/NixOS/nixpkgs/pull/47369#issuecomment-424998726)), but ignored as a temporary issue.

This PR disables parallel building to avoid this build failure.

```
<3> ERLC   ../ebin/asn1ct_gen_ber_bin_v2.beam
<3> ERLC   ../ebin/asn1ct_rtt.beam
<3> ERLC   ../ebin/asn1ct_constructed_ber_bin_v2.beam
<3> GEN    asn1ct_eval_ext.erl
<3>{"init terminating in do_boot",{undef,[{asn1ct_func,start_link,[],[]},{prepare_templates,gen_asn1ct_eval,1,[{file,"prepare_templates.erl"},{line,58}]},{init,start_it,1,[]},{init,start_em,1,[]}]}}
<3>init terminating in do_boot ()
<3>
<3>Crash dump is being written to: erl_crash.dump...done
<3>make[2]: *** [Makefile:139: asn1ct_eval_ext.erl] Error 1
<3>make[2]: Leaving directory '/build/source/lib/asn1/src'
<3>make[1]: *** [/build/source/make/otp_subdir.mk:29: opt] Error 2
<3>make[1]: Leaving directory '/build/source/lib'
<3>make: *** [Makefile:550: secondary_bootstrap_build] Error 2
<3>builder for '/nix/store/5565imavv7imy514fycp2r1qi61qx2m6-erlang-18.3.4.8.drv' failed with exit code 2
```

```
<3> ERLC   ../ebin/asn1ct_gen_ber_bin_v2.beam
<3> ERLC   ../ebin/asn1ct_rtt.beam
<3> ERLC   ../ebin/asn1ct_constructed_ber_bin_v2.beam
<3> GEN    asn1ct_eval_ext.erl
<3>{"init terminating in do_boot",{undef,[{asn1ct_func,start_link,[],[]},{prepare_templates,gen_asn1ct_eval,1,[{file,"prepare_templates.erl"},{line,58}]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
<3>init terminating in do_boot ()
<3>
<3>Crash dump is being written to: erl_crash.dump...done
<3>make[2]: *** [Makefile:139: asn1ct_eval_ext.erl] Error 1
<3>make[2]: Leaving directory '/build/source/lib/asn1/src'
<3>make[1]: *** [/build/source/make/otp_subdir.mk:29: opt] Error 2
<3>make[1]: Leaving directory '/build/source/lib'
<3>make: *** [Makefile:550: secondary_bootstrap_build] Error 2
<3>builder for '/nix/store/sd9kp905syyfqb7gczrp3qpzxvhvl1pj-erlang-19.3.6.11.drv' failed with exit code 2
```

```
<3> ERLC   ../ebin/asn1ct_gen_ber_bin_v2.beam
<3> ERLC   ../ebin/asn1ct_rtt.beam
<3> ERLC   ../ebin/asn1ct_constructed_ber_bin_v2.beam
<3> GEN    asn1ct_eval_ext.erl
<3>{"init terminating in do_boot",{undef,[{asn1ct_func,start_link,[],[]},{prepare_templates,gen_asn1ct_eval,1,[{file,"prepare_templates.erl"},{line,58}]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
<3>init terminating in do_boot ({undef,[{asn1ct_func,start_link,[],[]},{prepare_templates,gen_asn1ct_eval,1,[{_},{_}]},{init,start_em,1,[]},{init,do_boot,3,[]}]})
<3>
<3>Crash dump is being written to: erl_crash.dump...done
<3>make[2]: *** [Makefile:138: asn1ct_eval_ext.erl] Error 1
<3>make[2]: Leaving directory '/build/source/lib/asn1/src'
<3>make[1]: *** [/build/source/make/otp_subdir.mk:29: opt] Error 2
<3>make[1]: Leaving directory '/build/source/lib'
<3>make: *** [Makefile:557: secondary_bootstrap_build] Error 2
<3>builder for '/nix/store/2dq6bp93q788bnz4gbbhhiyzrpgh38nz-erlang-20.3.8.9.drv' failed with exit code 2
```

```
<3> ERLC   ../ebin/asn1ct_gen_ber_bin_v2.beam
<3> ERLC   ../ebin/asn1ct_rtt.beam
<3> ERLC   ../ebin/asn1ct_constructed_ber_bin_v2.beam
<3> GEN    asn1ct_eval_ext.erl
<3>{"init terminating in do_boot",{undef,[{asn1ct_func,start_link,[],[]},{prepare_templates,gen_asn1ct_eval,1,[{file,"prepare_templates.erl"},{line,58}]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
<3>init terminating in do_boot ({undef,[{asn1ct_func,start_link,[],[]},{prepare_templates,gen_asn1ct_eval,1,[{_},{_}]},{init,start_em,1,[]},{init,do_boot,3,[]}]})
<3>
<3>Crash dump is being written to: erl_crash.dump...done
<3>make[2]: *** [Makefile:138: asn1ct_eval_ext.erl] Error 1
<3>make[2]: Leaving directory '/build/source/lib/asn1/src'
<3>make[1]: *** [/build/source/make/otp_subdir.mk:29: opt] Error 2
<3>make[1]: Leaving directory '/build/source/lib'
<3>make: *** [Makefile:575: secondary_bootstrap_build] Error 2
<3>builder for '/nix/store/f9h1xf6k0sjri4h0wkgx28b5z1xwxqkw-erlang-21.1.3.drv' failed with exit code 2
```

I don't know why these builds succeed elsewhere, but they fail reliably on my 8 core/16 thread Intel(R) Xeon(R) W-2145 CPU @ 3.70GHz with a NixOS (4.19.7 kernel, btrfs) in VMware on a Windows 10 1803 host.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

