### PR TITLE
libopusenc: init at 0.2.1

### DIFF
--- a/pkgs/development/libraries/libopusenc/default.nix
+++ b/pkgs/development/libraries/libopusenc/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, libopus }:
+
+let
+  version = "0.2.1";
+in
+stdenv.mkDerivation rec {
+  name = "libopusenc-${version}";
+
+  src = fetchurl {
+    url = "https://archive.mozilla.org/pub/opus/libopusenc-${version}.tar.gz";
+    sha256 = "1ffb0vhlymlsq70pxsjj0ksz77yfm2x0a1x8q50kxmnkm1hxp642";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  doCheck = true;
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libopus ];
+
+  meta = with stdenv.lib; {
+    description = "Library for encoding .opus audio files and live streams";
+    license = licenses.bsd3;
+    homepage = http://www.opus-codec.org/;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ pmiddend ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11123,6 +11123,8 @@ in
 
   libopus = callPackage ../development/libraries/libopus { };
 
+  libopusenc = callPackage ../development/libraries/libopusenc { };
+
   libosinfo = callPackage ../development/libraries/libosinfo {
     inherit (gnome3) libsoup;
   };


### PR DESCRIPTION
###### Motivation for this change

The package was missing and is needed by a newer version of `pyogg`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

