### PR TITLE
python2Packages.rednose: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/rednose/default.nix
+++ b/pkgs/development/python-modules/rednose/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, nose, six, colorama, termstyle }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, nose, six, colorama, termstyle }:
 
 buildPythonPackage rec {
   pname = "rednose";
@@ -13,10 +13,14 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace "six==1.10.0" "six>=1.10.0"
   '';
 
+  # Do not test on Python 2 darwin because the tests suite gets stuck
+  # https://github.com/JBKahn/rednose/issues/23
+  doCheck = !(stdenv.isDarwin && isPy27);
+
   checkInputs = [ six ];
   propagatedBuildInputs = [ nose colorama termstyle ];
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "A python nose plugin adding color to console results";
     homepage = https://github.com/JBKahn/rednose;
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

