### PR TITLE
python3Packages.cytoolz: fix build

### DIFF
--- a/pkgs/development/python-modules/cytoolz/default.nix
+++ b/pkgs/development/python-modules/cytoolz/default.nix
@@ -5,6 +5,7 @@
 , nose
 , toolz
 , python
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -15,6 +16,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "84cc06fa40aa310f2df79dd440fc5f84c3e20f01f9f7783fc9c38d0a11ba00e5";
   };
+
+  patches = [
+    # temporal fix for a test failure: https://github.com/pytoolz/cytoolz/issues/122
+    (fetchpatch {
+      name = "py37.patch";
+      url = https://salsa.debian.org/python-team/modules/python-cytoolz/raw/5ce4158deefc47475d1e76813f900e6c72ddcc6e/debian/patches/py37.patch;
+      sha256 = "1z29y7s5n751q3f74r3bz0f48yg6izvi68hc4pkwcalxmkq5r1n9";
+    })
+  ];
 
   # Extension types
   disabled = isPyPy;
@@ -28,7 +38,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    homepage = "https://github.com/pytoolz/cytoolz/";
+    homepage = https://github.com/pytoolz/cytoolz/;
     description = "Cython implementation of Toolz: High performance functional utilities";
     license = "licenses.bsd3";
     maintainers = with lib.maintainers; [ fridh ];


### PR DESCRIPTION
cytoolz has a [test failure with Python 3.7](https://github.com/pytoolz/cytoolz/issues/122). There is a [debian patch](https://salsa.debian.org/python-team/modules/python-cytoolz/blob/master/debian/patches/py37.patch) for it, which didn't make it into upstream yet.

###### Motivation for this change

`python3Packages.cytoolz` does not build on `master`.

###### Things done

Apply the patch from debian.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

