### PR TITLE
opusTools: 0.1.10 -> 0.2

### DIFF
--- a/pkgs/applications/audio/opus-tools/default.nix
+++ b/pkgs/applications/audio/opus-tools/default.nix
@@ -1,14 +1,14 @@
-{stdenv, fetchurl, libogg, libao, pkgconfig, libopus, flac}:
+{stdenv, fetchurl, libogg, libao, pkgconfig, flac, opusfile, libopusenc}:
 
 stdenv.mkDerivation rec {
-  name = "opus-tools-0.1.10";
+  name = "opus-tools-0.2";
   src = fetchurl {
     url = "http://downloads.xiph.org/releases/opus/${name}.tar.gz";
-    sha256 = "135jfb9ny3xvd27idsxj7j5ns90lslbyrq70cq3bfwcls4r7add2";
+    sha256 = "11pzl27s4vcz4m18ch72nivbhww2zmzn56wspb7rll1y1nq6rrdl";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libogg libao libopus flac ];
+  buildInputs = [ libogg libao flac opusfile libopusenc ];
 
   meta = {
     description = "Tools to work with opus encoded audio streams";


### PR DESCRIPTION
###### Motivation for this change

Now that `libopusenc` is in nixpkgs, we can upgrade opus-tools, too!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

