### PR TITLE
grobi: 0.3.0 -> 0.5.1

### DIFF
--- a/pkgs/tools/X11/grobi/default.nix
+++ b/pkgs/tools/X11/grobi/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, buildGoPackage }:
 
 buildGoPackage rec {
-  version = "0.3.0";
+  version = "0.5.1";
   name = "grobi-${version}";
 
   goPackagePath = "github.com/fd0/grobi";
 
   src = fetchFromGitHub {
-    rev = "78a0639ffad765933a5233a1c94d2626e24277b8";
+    rev = "5ddc167b9e4f84755a515828360abda15c54b7de";
     owner = "fd0";
     repo = "grobi";
-    sha256 = "16q7vnhb1p6ds561832sfdszvlafww67bjn3lc0d18v7lyak2l3i";
+    sha256 = "0iyxidq60pf6ki52f8fffplf10nl8w9jx1b7igg98csnc6iqxh89";
   };
 
    meta = with stdenv.lib; {


### PR DESCRIPTION
Update grobi to [0.5.1](https://github.com/fd0/grobi/releases/tag/v0.5.1)
- Tested on NixOS