### PR TITLE
vulkan-validation-layers: 1.1.82.0 -> 1.1.85.0

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -2,22 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "glslang-git-${version}";
-  version = "2018-07-27";
+  version = "2018-09-26";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "e99a26810f65314183163c07664a40e05647c15f";
-    sha256 = "1w11z518xfbnf34xgzg1mp3xicpw2qmpcvaixlzw79s9ifqg5lqs";
+    rev = "91ac4290bcf2cb930b4fb0981f09c00c0b6797e1";
+    sha256 = "0q477pm0n495acnss16ddlf82a6i5l2dfmvc7r8yi0bgmgpzi4av";
   };
-
-  patches = [
-    # spirv-tools bump for vulkan sdk 1.1.82.1; remove on update
-    (fetchpatch {
-      url = "https://github.com/lenny-lunarg/glslang/commit/c7f4e818ac55f545289f87f8c37571b2eadcde86.patch";
-      sha256 = "197293alxjdpm3x1vd6pksdb1d9za42vlyn8yn2w786av0l7vf1k";
-    })
-  ];
 
   buildInputs = [ cmake bison jq ] ++ spirv-tools.buildInputs;
   enableParallelBuilding = true;

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -7,14 +7,14 @@ spirv_sources = {
   tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "1a283f41ed09e31cd720744f904af3d823ceddbf";
-    sha256 = "1z65wglg081pri9rmiyydvppgd67qr269ppphy4yhg2wg81gg72c";
+    rev = "9bfe0eb25e3dfdf4f3fd86ab6c0cda009c9bd661";
+    sha256 = "1spfii4zib1lmz40vnz1d1cr6is7q2n7rvar1vfzi33gwrn8rqhi";
   };
   headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "ff684ffc6a35d2a58f0f63108877d0064ea33feb";
-    sha256 = "0ypjx61ksr6vda2iy3kxhyjia5qxf0x4qa4jij0giw9x5rsnga6g";
+    rev = "d5b2e1255f706ce1f88812217e9a554f299848af";
+    sha256 = "18530mpa030ckjhn78z9vbfd35l5jgh3mg22ra6k8gw8zx4wjhsl";
   };
 };
 
@@ -22,7 +22,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "spirv-tools-${version}";
-  version = "2018-07-04";
+  version = "2018-09-20";
 
   src = spirv_sources.tools;
   patchPhase = ''ln -sv ${spirv_sources.headers} external/spirv-headers'';

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchFromGitHub, cmake, python3, vulkan-headers, vulkan-loader,
-  glslang, pkgconfig, xlibsWrapper, libxcb, libXrandr, wayland }:
+{ stdenv, fetchFromGitHub, cmake, writeText, python3
+, vulkan-headers, vulkan-loader, glslang
+, pkgconfig, xlibsWrapper, libxcb, libXrandr, wayland }:
 
 stdenv.mkDerivation rec {
   name = "vulkan-validation-layers-${version}";
-  version = "1.1.82.0";
+  version = "1.1.85.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
     rev = "sdk-${version}";
-    sha256 = "0vq2hbha2i5wsi6w6kmxbv01a5f0d55w2grl73nya9i06764fdg6";
+    sha256 = "1y5ny587h62139fxnz760hsyv1dmw29m1a9vq096sn8qafh3jzbz";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -17,6 +18,17 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [ "-DGLSLANG_INSTALL_DIR=${glslang}" ];
+
+  # Help vulkan-loader find the validation layers
+  setupHook = writeText "setup-hook" ''
+    export XDG_DATA_DIRS=@out@/share:$XDG_DATA_DIRS
+  '';
+
+  # Include absolute paths to layer libraries in their associated
+  # layer definition json files.
+  patchPhase = ''
+    sed "s|\([[:space:]]*set(INSTALL_DEFINES \''${INSTALL_DEFINES} -DRELATIVE_LAYER_BINARY=\"\)\(\$<TARGET_FILE_NAME:\''${TARGET_NAME}>\")\)|\1$out/lib/\2|" -i layers/CMakeLists.txt
+  '';
 
   meta = with stdenv.lib; {
     description = "LunarG Vulkan loader";


### PR DESCRIPTION
This requires knock-on upgrades for glslang and spirv-tools.

I have also made the validation layers easier to use:
- library files identified by layer definitions now use absolute paths
- a VK_LAYER_PATH environment variable is set

Previously, one would have to modify LD_LIBRARY_PATH or install the
derivation in a known location for vulkan-loader to find relevant
files. These changes make using validation layers in a nix-shell work automatically.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

