### PR TITLE
python3Packages.flit: 1.0 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -20,22 +20,23 @@
 
 buildPythonPackage rec {
   pname = "flit";
-  version = "1.0";
+  version = "1.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "95b8577b2232da39ee14ae237575b7a85afeeabc1e87f4a19485fac34f85aa89";
+    sha256 = "6aefa6ff89a993af7a7af40d3df3d0387d6663df99797981ec41b1431ec6d1e1";
   };
 
   disabled = !isPy3k;
-  propagatedBuildInputs = [ docutils requests requests_download pytoml ] ++ lib.optional (pythonOlder "3.6") zipfile36;
+  propagatedBuildInputs = [ docutils requests requests_download pytoml ]
+    ++ lib.optional (pythonOlder "3.6") zipfile36;
 
   checkInputs = [ pytest testpath responses ];
 
   # Disable test that needs some ini file.
   # Disable test that wants hg
   checkPhase = ''
-    py.test -k "not test_invalid_classifier and not test_build_sdist"
+    HOME=$(mktemp -d) pytest -k "not test_invalid_classifier and not test_build_sdist"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

flit adds `requires-extra` to newer versions for extra packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

