### PR TITLE
vaapi-intel: added missing library libXfixes for x11

### DIFF
--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkgconfig, python2
-, intel-gpu-tools, libdrm, libva, libX11, libGL, wayland, libXext
+, intel-gpu-tools, libdrm, libva, libX11, libGL, wayland, libXext, libXfixes
 , enableHybridCodec ? false, vaapi-intel-hybrid
 }:
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook gnum4 pkgconfig python2 ];
 
-  buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext libGL wayland ]
+  buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext libXfixes libGL wayland ]
     ++ stdenv.lib.optional enableHybridCodec vaapi-intel-hybrid;
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Since vaapi-intel 2.0 libXfixes is also needed to get windowing system x11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

