### PR TITLE
cni/cni-plugins: Remove go references

### DIFF
--- a/pkgs/applications/networking/cluster/cni/default.nix
+++ b/pkgs/applications/networking/cluster/cni/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, go }:
+{ stdenv, fetchFromGitHub, go, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   name = "cni-${version}";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "00ajs2r5r2z3l0vqwxrcwhjfc9px12qbcv5vnvs2mdipvvls1y2y";
   };
 
-  buildInputs = [ go ];
+  buildInputs = [ removeReferencesTo go ];
+
+  GOCACHE = "off";
 
   buildPhase = ''
     patchShebangs build.sh
@@ -21,6 +23,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mv bin/cnitool $out/bin
+  '';
+
+  preFixup = ''
+    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/cluster/cni/plugins.nix
+++ b/pkgs/applications/networking/cluster/cni/plugins.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, go }:
+{ stdenv, lib, fetchFromGitHub, go, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   name = "cni-plugins-${version}";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "1sywllwnr6lc812sgkqjdd3y10r82shl88dlnwgnbgzs738q2vp2";
   };
 
-  buildInputs = [ go ];
+  buildInputs = [ removeReferencesTo go ];
+
+  GOCACHE = "off";
 
   buildPhase = ''
     patchShebangs build.sh
@@ -21,6 +23,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mv bin/* $out/bin
+  '';
+
+  preFixup = ''
+    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
This drastically reduces the closure size for the kubernetes service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

