### PR TITLE
certbot, acme: 0.24.0 -> 0.30.2

### DIFF
--- a/pkgs/development/python-modules/acme/default.nix
+++ b/pkgs/development/python-modules/acme/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , certbot
 , nose
+, pytest
 , cryptography
 , pyasn1
 , pyopenssl
@@ -8,6 +9,7 @@
 , josepy
 , pytz
 , requests
+, requests-toolbelt
 , six
 , werkzeug
 , mock
@@ -20,11 +22,11 @@ buildPythonPackage rec {
   pname = "acme";
 
   propagatedBuildInputs = [
-    cryptography pyasn1 pyopenssl pyRFC3339 pytz requests six werkzeug mock
-    ndg-httpsclient josepy
+    cryptography pyasn1 pyopenssl pyRFC3339 pytz requests requests-toolbelt six
+    werkzeug mock ndg-httpsclient josepy
   ];
 
-  checkInputs = [ nose ];
+  checkInputs = [ nose pytest ];
 
   postUnpack = "sourceRoot=\${sourceRoot}/acme";
 

--- a/pkgs/development/python-modules/acme/default.nix
+++ b/pkgs/development/python-modules/acme/default.nix
@@ -1,6 +1,5 @@
 { buildPythonPackage
 , certbot
-, nose
 , pytest
 , cryptography
 , pyasn1
@@ -26,9 +25,9 @@ buildPythonPackage rec {
     werkzeug mock ndg-httpsclient josepy
   ];
 
-  checkInputs = [ nose pytest ];
+  checkInputs = [ pytest ];
 
-  postUnpack = "sourceRoot=\${sourceRoot}/acme";
+  sourceRoot = "source/${pname}";
 
   meta = certbot.meta // {
     description = "ACME protocol implementation in Python";

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -4,13 +4,13 @@
 
 pythonPackages.buildPythonApplication rec {
   name = "certbot-${version}";
-  version = "0.24.0";
+  version = "0.29.1";
 
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
     rev = "v${version}";
-    sha256 = "0gsq4si0bqwzd7ywf87y7bbprqg1m72qdj11h64qmwb5zl4vh444";
+    sha256 = "13gnqkvmh6mmlqsf18pw0wv6rp8fy0nbqhpw0sv3shkv7iqsmh2k";
   };
 
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -1,34 +1,32 @@
-{ stdenv, pythonPackages, fetchFromGitHub, dialog }:
+{ stdenv, python3Packages, fetchFromGitHub, dialog }:
 
-# Latest version of certbot supports python3 and python3 version of pythondialog
-
-pythonPackages.buildPythonApplication rec {
-  name = "certbot-${version}";
-  version = "0.29.1";
+python3Packages.buildPythonApplication rec {
+  pname = "certbot";
+  version = "0.30.2";
 
   src = fetchFromGitHub {
-    owner = "certbot";
-    repo = "certbot";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "13gnqkvmh6mmlqsf18pw0wv6rp8fy0nbqhpw0sv3shkv7iqsmh2k";
+    sha256 = "0lycmxc6y7mk18irv8qdasw6hsqiiw5p34950h2f5s3vjc09wnw3";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     ConfigArgParse
     acme
     configobj
     cryptography
+    josepy
     parsedatetime
     psutil
     pyRFC3339
     pyopenssl
-    python2-pythondialog
     pytz
     six
     zope_component
     zope_interface
   ];
-  buildInputs = [ dialog ] ++ (with pythonPackages; [ nose mock gnureadline ]);
+  buildInputs = [ dialog ] ++ (with python3Packages; [ mock gnureadline ]);
 
   patchPhase = ''
     substituteInPlace certbot/notify.py --replace "/usr/sbin/sendmail" "/run/wrappers/bin/sendmail"


### PR DESCRIPTION
(same source)


###### Motivation for this change

Have not reviewed changelogs or tested on a server.

Should at least make sure the 'acme' test passes :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---