### PR TITLE
vnstat: 1.18 -> 2.1

### DIFF
--- a/pkgs/applications/networking/vnstat/default.nix
+++ b/pkgs/applications/networking/vnstat/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, gd, ncurses }:
+{ stdenv, fetchurl, gd, ncurses, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "vnstat-${version}";
-  version = "1.18";
+  version = "2.1";
 
   src = fetchurl {
-    sha256 = "1mc7qqvrnl0zyhgh8n7wx1g1cbwq74xpvbz8rfjmyi77p693a6fp";
+    sha256 = "0yk0x6bg9f36dsslhayyyi8fg04yvzjzqkjmlrcsrv6nnggchb6i";
     url = "https://humdi.net/vnstat/${name}.tar.gz";
   };
 
-  buildInputs = [ gd ncurses ];
+  buildInputs = [ gd ncurses sqlite ];
 
   postPatch = ''
     substituteInPlace src/cfg.c --replace /usr/local $out


### PR DESCRIPTION
###### Motivation for this change

No NixOS test for this, anyone use it and willing to test? :)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---