### PR TITLE
mpop: 1.2.6 -> 1.4.1

### DIFF
--- a/pkgs/applications/networking/mpop/default.nix
+++ b/pkgs/applications/networking/mpop/default.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.4.0";
+  version = "1.4.1";
   name = "mpop-${version}";
 
   src = fetchurl {
     url = "https://marlam.de/mpop/releases/${name}.tar.xz";
-    sha256 = "14xsvpm5bc1wycisq882gqrnamnyi1q4rlk6anlw8ihzvwgm4h2j";
+    sha256 = "1b9mj6yfa8vg5flxw1xb8xalifjg87dghbg523i6fbr7679zl9iy";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/networking/mpop/default.nix
+++ b/pkgs/applications/networking/mpop/default.nix
@@ -12,11 +12,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl gnutls gsasl libidn ]
+  buildInputs = [ gnutls gsasl libidn ]
     ++ optional stdenv.isDarwin Security;
 
-  configureFlags = [ "--with-tls=openssl" ] ++
-    optional stdenv.isDarwin [ "--with-macosx-keyring" ];
+  configureFlags = optional stdenv.isDarwin [ "--with-macosx-keyring" ];
 
   meta = {
       description = "POP3 mail retrieval agent";

--- a/pkgs/applications/networking/mpop/default.nix
+++ b/pkgs/applications/networking/mpop/default.nix
@@ -3,24 +3,24 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.2.6";
+  version = "1.4.0";
   name = "mpop-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/mpop/${name}.tar.xz";
-    sha256 = "0p1ix63jh64dibrlccch8q7gxl9nn18wd2qpyr5z1h4gs2fpmv4z";
+    url = "https://marlam.de/mpop/releases/${name}.tar.xz";
+    sha256 = "14xsvpm5bc1wycisq882gqrnamnyi1q4rlk6anlw8ihzvwgm4h2j";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl gnutls gsasl libidn ]
     ++ optional stdenv.isDarwin Security;
 
-  configureFlags =
+  configureFlags = [ "--with-tls=openssl" ] ++
     optional stdenv.isDarwin [ "--with-macosx-keyring" ];
 
   meta = {
       description = "POP3 mail retrieval agent";
-      homepage = http://mpop.sourceforge.net/;
+      homepage = https://marlam.de/mpop;
       license = licenses.gpl3Plus;
       platforms = platforms.unix;
     };


### PR DESCRIPTION
Update homepage and license.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---