### PR TITLE
msmtp: 1.6.8 -> 1.8.0

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -10,11 +10,11 @@ let
 in stdenv.mkDerivation rec {
   pname = "msmtp";
   name = "${pname}-${version}";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "https://marlam.de/msmtp/releases/${name}.tar.xz";
-    sha256 = "1k9wwlapkxk9ql3xq05y6vwn6ziqk9b1v8lyhj1866qd02zhqwxx";
+    sha256 = "1nm4vizrnrrnknc4mc8nr7grz9q76m1vraa0hsl5rfm34gnsg8ph";
   };
 
   patches = [

--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, autoreconfHook, pkgconfig
-, openssl, netcat-gnu, gnutls, gsasl, libidn2, Security
+, netcat-gnu, gnutls, gsasl, libidn2, Security
 , withKeyring ? true, libsecret ? null
 , systemd ? null }:
 
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
     ./paths.patch
   ];
 
-  buildInputs = [ openssl gnutls gsasl libidn2 ]
+  buildInputs = [ gnutls gsasl libidn2 ]
     ++ stdenv.lib.optional stdenv.isDarwin Security
     ++ stdenv.lib.optional withKeyring libsecret;
 

--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchpatch, fetchurl, autoreconfHook, pkgconfig
-, openssl, netcat-gnu, gnutls, gsasl, libidn, Security
+{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig
+, openssl, netcat-gnu, gnutls, gsasl, libidn2, Security
 , withKeyring ? true, libsecret ? null
 , systemd ? null }:
 
@@ -10,26 +10,18 @@ let
 in stdenv.mkDerivation rec {
   pname = "msmtp";
   name = "${pname}-${version}";
-  version = "1.6.8";
+  version = "1.8.0";
 
   src = fetchurl {
     url = "https://marlam.de/msmtp/releases/${name}.tar.xz";
-    sha256 = "1ysrnshvwhzwmvb2walw5i9jdzlvmckj7inr0xnvb26q0jirbzsm";
+    sha256 = "1k9wwlapkxk9ql3xq05y6vwn6ziqk9b1v8lyhj1866qd02zhqwxx";
   };
 
   patches = [
     ./paths.patch
-
-    # To support passwordeval commands that do not print a final
-    # newline.
-    (fetchpatch {
-      name = "passwordeval-without-nl.patch";
-      url = "https://gitlab.marlam.de/marlam/msmtp/commit/df22dccf9d1af06fcd09dfdd0d6a38e1372dd5e8.patch";
-      sha256 = "06gbhvzi46zqigmmsin2aard7b9v3ihx62hbz5ljmfbj9rfs1x5y";
-    })
   ];
 
-  buildInputs = [ openssl gnutls gsasl libidn ]
+  buildInputs = [ openssl gnutls gsasl libidn2 ]
     ++ stdenv.lib.optional stdenv.isDarwin Security
     ++ stdenv.lib.optional withKeyring libsecret;
 
@@ -61,7 +53,7 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Simple and easy to use SMTP client with excellent sendmail compatibility";
     homepage = https://marlam.de/msmtp/;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ garbas peterhoeg ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
https://marlam.de/msmtp/news/msmtp-1-8-0/

Uses libidn2 now instead of libidn.


###### Motivation for this change

Seems to work for me, configured via home-manager FWIW.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---