### PR TITLE
aminal: 0.7.8 -> 0.7.12

### DIFF
--- a/pkgs/applications/misc/aminal/default.nix
+++ b/pkgs/applications/misc/aminal/default.nix
@@ -12,7 +12,7 @@
 
 buildGoPackage rec {
   name = "aminal-${version}";
-  version = "0.7.8";
+  version = "0.7.12";
 
   goPackagePath = "github.com/liamg/aminal";
 
@@ -36,7 +36,7 @@ buildGoPackage rec {
     owner = "liamg";
     repo = "aminal";
     rev = "v${version}";
-    sha256 = "02gamvvs56w4zwqdvalbsgb2gbh0398gl7qk36pgyqkcgj3bcwv8";
+    sha256 = "1ak5g2i4ggi00b4q7qigfwsrwb5rvswjjbr2hp9kyxd45nycb0g4";
   };
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/liamg/aminal/releases/tag/v0.7.12

(and intermediate releases :))


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---