### PR TITLE
i2c-tools: 4.0 -> 4.1

### DIFF
--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -11,13 +11,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace eeprom/decode-edid --replace "/usr/sbin/parse-edid" "${read-edid}/bin/parse-edid"
     substituteInPlace stub/i2c-stub-from-dump --replace "/sbin/" ""
   '';
 
-  installPhase = ''
-    make install PREFIX=$out
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postInstall = ''
     rm -rf $out/include # Installs include/linux/i2c-dev.h that conflics with kernel headers
   '';
 

--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "i2c-tools-${version}";
-  version = "4.0";
+  version = "4.1";
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/utils/i2c-tools/${name}.tar.xz";
-    sha256 = "1mi8mykvl89y6liinc9jv1x8m2q093wrdc2hm86a47n524fcl06r";
+    sha256 = "1m97hpwqfaqjl9xvr4pvz2vdrsdvxbcn0nnx8pamnyc3s7pikcjp";
   };
 
   buildInputs = [ perl ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    make install prefix=$out
+    make install PREFIX=$out
     rm -rf $out/include # Installs include/linux/i2c-dev.h that conflics with kernel headers
   '';
 


### PR DESCRIPTION
###### Motivation for this change

https://marc.info/?l=linux-i2c&m=154383448901807&w=2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested that they /run/ but don't have hardware to do anything interesting :).