### PR TITLE
efivar: 36 -> 37

### DIFF
--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, efivar, popt }:
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, efivar, popt }:
 
 stdenv.mkDerivation rec {
   name = "efibootmgr-${version}";
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1niicijxg59rsmiw3rsjwy4bvi1n42dynvm01lnp9haixdzdpq03";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-extra-decl.patch";
+      url = "https://github.com/rhboot/efibootmgr/commit/99b578501643377e0b1994b2a068b790d189d5ad.patch";
+      sha256 = "1sbijvlpv4khkix3vix9mbhzffj8lp8zpnbxm9gnzjz8yssz9p5h";
+    })
+  ];
 
   makeFlags = [ "EFIDIR=nixos" ];
 

--- a/pkgs/tools/system/efivar/default.nix
+++ b/pkgs/tools/system/efivar/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "efivar-${version}";
-  version = "36";
+  version = "37";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "rhinstaller";
     repo = "efivar";
     rev = version;
-    sha256 = "0r39kx6sqgpk8rz19g1sil4dp7r82d5g1wlkbw1czwas95s50y7n";
+    sha256 = "1z2dw5x74wgvqgd8jvibfff0qhwkc53kxg54v12pzymyibagwf09";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/rhboot/efivar/releases/tag/37

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---