### PR TITLE
vivid: init at 0.4.0

### DIFF
--- a/pkgs/tools/misc/vivid/default.nix
+++ b/pkgs/tools/misc/vivid/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "${pname}-${version}";
+  pname = "vivid";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13x0295v5blvv8dxhimbdjh81l7xl0vm6zni3qjd85psfn61371q";
+  };
+
+  postPatch = ''
+    substituteInPlace src/main.rs --replace /usr/share $out/share
+  '';
+
+  cargoSha256 = "156wapa2ds7ij1jhrpa8mm6dicwq934qxl56sqw3bgz6pfa8fldz";
+
+  postInstall = ''
+    mkdir -p $out/share/${pname}
+    cp -rv config/* themes $out/share/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A generator for LS_COLORS with support for multiple color themes";
+    homepage = https://github.com/sharkdp/vivid;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = [ maintainers.dtzWill ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22890,6 +22890,8 @@ in
 
   virglrenderer = callPackage ../development/libraries/virglrenderer { };
 
+  vivid = callPackage ../tools/misc/vivid { };
+
   vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
   wavegain = callPackage ../applications/audio/wavegain { };


### PR DESCRIPTION
###### Motivation for this change

Interesting, limited in themes it ships with
but configurable and hopefully more to come.

Found poking at 'exa' :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---