### PR TITLE
mercurial: install zsh completions

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -49,8 +49,8 @@ in python2Packages.buildPythonApplication {
       cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin
       chmod u+x $out/share/cgi-bin/hgweb.cgi
 
-      # install bash completion
-      install -v -m644 -D contrib/bash_completion $out/share/bash-completion/completions/mercurial
+      # install bash/zsh completions
+      install -v -m644 -D contrib/bash_completion $out/share/bash-completion/completions/_hg
       install -v -m644 -D contrib/zsh_completion $out/share/zsh/site-functions/_hg
     '';
 

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -50,7 +50,8 @@ in python2Packages.buildPythonApplication {
       chmod u+x $out/share/cgi-bin/hgweb.cgi
 
       # install bash completion
-      install -D -v contrib/bash_completion $out/share/bash-completion/completions/mercurial
+      install -v -m644 -D contrib/bash_completion $out/share/bash-completion/completions/mercurial
+      install -v -m644 -D contrib/zsh_completion $out/share/zsh/site-functions/_hg
     '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

They're useful, you know :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---