### PR TITLE
xpad: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/applications/misc/xpad/default.nix
+++ b/pkgs/applications/misc/xpad/default.nix
@@ -1,23 +1,19 @@
 { stdenv, fetchurl
 , autoreconfHook, pkgconfig, wrapGAppsHook
-, glib, intltool, gtk3, gtksourceview }:
+, glib, intltool, gtk3, gtksourceview, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "xpad-${version}";
-  version = "5.1.0";
+  version = "5.2.0";
 
   src = fetchurl {
     url = "https://launchpad.net/xpad/trunk/${version}/+download/xpad-${version}.tar.bz2";
-    sha256 = "0l0g5x8g6dwhf5ksnqqrjjsycy57kcvdslkmsr6bl3vrsjd7qml3";
+    sha256 = "1ab33vg3fz57lz19jjwa3vp3vnln4pnh60hwlkq59la53s8lyijk";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ glib intltool gtk3 gtksourceview ];
-
-  autoreconfPhase = ''
-    ./autogen.sh
-  '';
+  buildInputs = [ glib intltool gtk3 gtksourceview hicolor-icon-theme ];
 
   meta = with stdenv.lib; {
     description = "A sticky note application for jotting down things to remember";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---