### PR TITLE
tootle: hicolor-icon-theme dep, clear cache

### DIFF
--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -2,7 +2,7 @@
 , meson, ninja, pkgconfig, python3
 , gnome3, vala, gobjectIntrospection, wrapGAppsHook
 , gtk3, granite
-, json-glib, glib, glib-networking
+, json-glib, glib, glib-networking, hicolor-icon-theme
 }:
 
 let
@@ -18,7 +18,10 @@ in stdenv.mkDerivation rec {
     sha256 = "1z3wyx316nns6gi7vlvcfmalhvxncmvcmmlgclbv6b6hwl5x2ysi";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig python3 vala gobjectIntrospection wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig
+    python3 vala gobjectIntrospection
+    wrapGAppsHook hicolor-icon-theme ];
   buildInputs = [
     gtk3 granite json-glib glib glib-networking
     gnome3.libgee gnome3.libsoup gnome3.gsettings-desktop-schemas


### PR DESCRIPTION
###### Motivation for this change

Otherwise this package conflicts with other packages sometimes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---