### PR TITLE
remind: 3.1.15 -> 3.1.16, new home, cleanup

### DIFF
--- a/pkgs/tools/misc/remind/default.nix
+++ b/pkgs/tools/misc/remind/default.nix
@@ -6,30 +6,31 @@ assert tkremind -> tk != null;
 assert tkremind -> tcllib != null;
 assert tkremind -> makeWrapper != null;
 
-stdenv.mkDerivation rec {
-  name = "remind-3.1.15";
-  src = fetchurl {
-    url = https://www.roaringpenguin.com/files/download/remind-03.01.15.tar.gz;
-    sha256 = "1hcfcxz5fjzl7606prlb7dgls5kr8z3wb51h48s6qm8ang0b9nla";
-  };
-
-  tclLibraries = if tkremind then [ tcllib tk ] else [];
+let
+  inherit (stdenv.lib) optional optionals optionalString;
+  tclLibraries = stdenv.lib.optionals tkremind [ tcllib tk ];
   tclLibPaths = stdenv.lib.concatStringsSep " "
     (map (p: "${p}/lib/${p.libPrefix}") tclLibraries);
+in stdenv.mkDerivation {
+  name = "remind-3.1.16";
+  src = fetchurl {
+    url = https://dianne.skoll.ca/projects/remind/download/remind-03.01.16.tar.gz;
+    sha256 = "14yavwqmimba8rdpwx3wlav9sfb0v5rcd1iyzqrs08wx07a9pdzf";
+  };
 
-  buildInputs = if tkremind then [ makeWrapper ] else [];
+  nativeBuildInputs = optional tkremind makeWrapper;
   propagatedBuildInputs = tclLibraries;
 
-  postPatch = if tkremind then ''
+  postPatch = optionalString tkremind ''
     substituteInPlace scripts/tkremind --replace "exec wish" "exec ${tk}/bin/wish"
-  '' else "";
+  '';
 
-  postInstall = if tkremind then ''
+  postInstall = optionalString tkremind ''
     wrapProgram $out/bin/tkremind --set TCLLIBPATH "${tclLibPaths}"
-  '' else "";
+  '';
 
   meta = {
-    homepage = http://www.roaringpenguin.com/products/remind;
+    homepage = https://dianne.skoll.ca/projects/remind/;
     description = "Sophisticated calendar and alarm program for the console";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [raskin kovirobi];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---