### PR TITLE
monero: change desktop item name to Monero

### DIFF
--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     name = "monero-wallet-gui";
     exec = "monero-wallet-gui";
     icon = "monero";
-    desktopName = "Monero Wallet";
+    desktopName = "Monero";
     genericName = "Wallet";
     categories  = "Application;Network;Utility;";
   };


### PR DESCRIPTION
###### Motivation for this change

Rationale is to make it match application window title: https://github.com/monero-project/monero-gui/blob/0f05127262cf662ab549deae426c9deebf77967e/main.qml#L48

cc @rnhmjoj 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

