### PR TITLE
postgresql: Build with icu support

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -1,9 +1,14 @@
-{ lib, stdenv, glibc, fetchurl, zlib, readline, libossp_uuid, openssl, libxml2, makeWrapper, tzdata, systemd }:
+{ lib, stdenv, glibc, fetchurl, zlib, readline, libossp_uuid, openssl, libxml2, makeWrapper, tzdata, systemd, icu, pkgconfig }:
 
 let
 
   common = { version, sha256, psqlSchema }:
-   let atLeast = lib.versionAtLeast version; in stdenv.mkDerivation (rec {
+  let
+    atLeast = lib.versionAtLeast version;
+
+    # Build with ICU by default on versions that support it
+    icuEnabled = atLeast "10";
+  in stdenv.mkDerivation (rec {
     name = "postgresql-${version}";
     inherit version;
 
@@ -17,8 +22,11 @@ let
 
     buildInputs =
       [ zlib readline openssl libxml2 makeWrapper ]
+      ++ lib.optionals icuEnabled [ icu ]
       ++ lib.optionals (atLeast "9.6" && !stdenv.isDarwin) [ systemd ]
       ++ lib.optionals (!stdenv.isDarwin) [ libossp_uuid ];
+
+    nativeBuildInputs = lib.optionals icuEnabled [ pkgconfig ];
 
     enableParallelBuilding = !stdenv.isDarwin;
 
@@ -37,7 +45,7 @@ let
       "--with-system-tzdata=${tzdata}/share/zoneinfo"
       (lib.optionalString (atLeast "9.6" && !stdenv.isDarwin) "--with-systemd")
       (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
-    ];
+    ] ++ lib.optionals icuEnabled [ "--with-icu" ];
 
     patches =
       [ (if atLeast "9.4" then ./disable-resolve_symlinks-94.patch else ./disable-resolve_symlinks.patch)


### PR DESCRIPTION
###### Motivation for this change
Compile PostgreSQL with ICU collation support
https://wiki.postgresql.org/wiki/New_in_postgres_10#ICU_Collation_Support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

