### PR TITLE
gawkextlib: init at unstable

### DIFF
--- a/pkgs/tools/text/gawk/gawk-with-extensions.nix
+++ b/pkgs/tools/text/gawk/gawk-with-extensions.nix
@@ -1,0 +1,12 @@
+{ runCommand, gawk, extensions ? [ ], makeWrapper }:
+
+runCommand "gawk-with-extensions" {
+  buildInputs = [ makeWrapper gawk ] ++ extensions;
+} ''
+  mkdir -p $out/bin
+  for i in ${gawk}/bin/*; do
+    name="$(basename "$i")"
+    makeWrapper $i $out/bin/$name \
+      --suffix AWKLIBPATH : "${gawk}/lib/gawk:''${AWKLIBPATH:-}"
+  done
+''

--- a/pkgs/tools/text/gawk/gawk-with-extensions.nix
+++ b/pkgs/tools/text/gawk/gawk-with-extensions.nix
@@ -1,4 +1,4 @@
-{ runCommand, gawk, extensions ? [ ], makeWrapper }:
+{ runCommand, gawk, extensions ? [], makeWrapper }:
 
 runCommand "gawk-with-extensions" {
   buildInputs = [ makeWrapper gawk ] ++ extensions;
@@ -7,6 +7,6 @@ runCommand "gawk-with-extensions" {
   for i in ${gawk}/bin/*; do
     name="$(basename "$i")"
     makeWrapper $i $out/bin/$name \
-      --suffix AWKLIBPATH : "${gawk}/lib/gawk:''${AWKLIBPATH:-}"
+      --prefix AWKLIBPATH : "${gawk}/lib/gawk:''${AWKLIBPATH:-}"
   done
 ''

--- a/pkgs/tools/text/gawk/gawk-with-extensions.nix
+++ b/pkgs/tools/text/gawk/gawk-with-extensions.nix
@@ -1,7 +1,11 @@
-{ runCommand, gawk, extensions ? [], makeWrapper }:
+{ runCommand, gawk, lib, extensions, makeWrapper }:
 
+let filtered_ext = with lib;
+   filterAttrs (n: v: n != "override" && n != "overrideDerivation" ) extensions;
+
+in
 runCommand "gawk-with-extensions" {
-  buildInputs = [ makeWrapper gawk ] ++ extensions;
+  buildInputs = [ makeWrapper gawk ] ++ (builtins.attrValues filtered_ext);
 } ''
   mkdir -p $out/bin
   for i in ${gawk}/bin/*; do

--- a/pkgs/tools/text/gawk/gawk-with-extensions.nix
+++ b/pkgs/tools/text/gawk/gawk-with-extensions.nix
@@ -1,4 +1,4 @@
-{ runCommand, gawk, lib, extensions, makeWrapper }:
+{ runCommand, gawk, extensions, makeWrapper }:
 
 runCommand "gawk-with-extensions" {
   buildInputs = [ makeWrapper gawk ] ++ extensions;

--- a/pkgs/tools/text/gawk/gawk-with-extensions.nix
+++ b/pkgs/tools/text/gawk/gawk-with-extensions.nix
@@ -1,11 +1,7 @@
 { runCommand, gawk, lib, extensions, makeWrapper }:
 
-let filtered_ext = with lib;
-   filterAttrs (n: v: n != "override" && n != "overrideDerivation" ) extensions;
-
-in
 runCommand "gawk-with-extensions" {
-  buildInputs = [ makeWrapper gawk ] ++ (builtins.attrValues filtered_ext);
+  buildInputs = [ makeWrapper gawk ] ++ extensions;
 } ''
   mkdir -p $out/bin
   for i in ${gawk}/bin/*; do

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -5,7 +5,7 @@ makeWrapper
 }:
 
 let
-  buildGawkextlibExtension = extension: extraDeps:
+  buildGawkextlibExtension = extension: extraBuildInputs:
     stdenv.mkDerivation rec {
       pname = "gawkextlib-${extension}";
       version = "unstable-2019-11-21";
@@ -19,7 +19,7 @@ let
       nativeBuildInputs =
         [ autoconf automake libtool autoreconfHook pkgconfig texinfo gettext ];
 
-      buildInputs = [ gawk ] ++ extraDeps;
+      buildInputs = [ gawk ] ++ extraBuildInputs;
       propagatedBuildInputs = [ gawkextlib ];
 
       configureFlags = [

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -41,6 +41,7 @@ let
       inherit gawk;
 
       doCheck = stdenv.isLinux;
+      checkInputs = [ more ];
 
       meta = with stdenv.lib; {
         homepage = "https://sourceforge.net/projects/gawkextlib/";
@@ -70,7 +71,7 @@ let
     aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
     csv         = buildGawkextlibExtension "csv"         [              ];
     errno       = buildGawkextlibExtension "errno"       [              ];
-    gd          = buildGawkextlibExtension "gd"          [ gd more      ];
+    gd          = buildGawkextlibExtension "gd"          [ gd           ];
     haru        = buildGawkextlibExtension "haru"        [ libharu      ];
     json        = buildGawkextlibExtension "json"        [ rapidjson    ];
     lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
@@ -81,7 +82,7 @@ let
     redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
     xml         = buildGawkextlibExtension "xml"         [ expat libiconv ];
     timex       = buildGawkextlibExtension "timex"       [              ];
-    select      = buildGawkextlibExtension "select"      [ more         ];
+    select      = buildGawkextlibExtension "select"      [              ];
   };
 in recurseIntoAttrs (libs // {
   inherit gawkextlib;

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -5,7 +5,7 @@ expat, tre, makeWrapper
 }:
 
 let
-  buildExtension = stdenv.lib.makeOverridable ({ name, gawkextlib, extraBuildInputs ? [] }:
+  buildExtension = stdenv.lib.makeOverridable ({ name, gawkextlib, extraBuildInputs ? [], doCheck ? true }:
     let is_extension = !isNull gawkextlib; in
     stdenv.mkDerivation rec {
       pname = "gawkextlib-${name}";
@@ -44,7 +44,7 @@ let
       setupHook = ./setup-hook.sh;
       inherit gawk;
 
-      doCheck = stdenv.isLinux;
+      inherit doCheck;
       checkInputs = [ more ];
 
       meta = with stdenv.lib; {
@@ -72,8 +72,17 @@ let
     gd          = buildExtension { inherit gawkextlib; name = "gd";          extraBuildInputs = [ gd           ]; };
     haru        = buildExtension { inherit gawkextlib; name = "haru";        extraBuildInputs = [ libharu      ]; };
     json        = buildExtension { inherit gawkextlib; name = "json";        extraBuildInputs = [ rapidjson    ]; };
-    lmdb        = buildExtension { inherit gawkextlib; name = "lmdb";        extraBuildInputs = [ lmdb         ]; };
-    mbs         = buildExtension { inherit gawkextlib; name = "mbs";         extraBuildInputs = [ glibcLocales ]; };
+    lmdb        = buildExtension { inherit gawkextlib; name = "lmdb";        extraBuildInputs = [ lmdb         ];
+      #  mdb_env_open(env, /dev/null)
+      #! No such device
+      #  mdb_env_open(env, /dev/null)
+      #! Operation not supported by device
+      doCheck = !stdenv.isDarwin;
+    };
+    mbs         = buildExtension { inherit gawkextlib; name = "mbs";         extraBuildInputs = [ glibcLocales ];
+      #! "spät": length: 5, mbs_length: 6, wcswidth: 4
+      doCheck = !stdenv.isDarwin;
+    };
     mpfr        = buildExtension { inherit gawkextlib; name = "mpfr";        extraBuildInputs = [ gmp mpfr     ]; };
     nl_langinfo = buildExtension { inherit gawkextlib; name = "nl_langinfo"; };
     pgsql       = buildExtension { inherit gawkextlib; name = "pgsql";       extraBuildInputs = [ postgresql   ]; };

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -18,7 +18,8 @@ let
       nativeBuildInputs =
         [ autoconf automake libtool autoreconfHook pkgconfig texinfo gettext ];
 
-      buildInputs = [ gawk gawkextlib ] ++ extraDeps;
+      buildInputs = [ gawk ] ++ extraDeps;
+      propagatedBuildInputs = [ gawkextlib ];
 
       configureFlags = [
         "--with-gawkextlib=${gawkextlib}/lib/"
@@ -57,10 +58,12 @@ let
     };
   gawkextlib = (buildGawkextlibExtension "lib" []).overrideAttrs (old: {
     configureFlags = [];
-    buildInputs = [ gawk ];
+    propagatedBuildInputs = [];
     postInstall = ''
       cp ../lib/gawkextlib.h $out/lib/.
     '';
+    setupHook = ./setup-hook-extlib.sh;
+    awklibpath = "${gawk}/lib/gawk";
   });
 in {
 
@@ -82,11 +85,5 @@ in {
   redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
   xml         = buildGawkextlibExtension "xml"         [ expat        ];
   timex       = buildGawkextlibExtension "timex"       [              ];
-
-  select = (buildGawkextlibExtension "select" [ more ]).overrideAttrs (old: {
-    # Needed for tests
-    preCheck = ''
-      AWKLIBPATH=${gawk}/lib/gawk
-    '';
-  });
+  select      = buildGawkextlibExtension "select"      [ more         ];
 }

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -1,95 +1,161 @@
-{ stdenv, recurseIntoAttrs, fetchgit, writeText, pkgconfig, autoreconfHook,
-autoconf, automake, libiconv, libtool, texinfo, gettext, gawk, rapidjson, gd,
-shapelib, libharu, lmdb, gmp, glibcLocales, mpfr, more, postgresql, hiredis,
-expat, tre, makeWrapper
-}:
+{ stdenv, recurseIntoAttrs, fetchgit, writeText, pkgconfig, autoreconfHook
+, autoconf, automake, libiconv, libtool, texinfo, gettext, gawk, rapidjson, gd
+, shapelib, libharu, lmdb, gmp, glibcLocales, mpfr, more, postgresql, hiredis
+, expat, tre, makeWrapper }:
 
 let
-  buildExtension = stdenv.lib.makeOverridable ({ name, gawkextlib, extraBuildInputs ? [], doCheck ? true }:
-    let is_extension = !isNull gawkextlib; in
-    stdenv.mkDerivation rec {
-      pname = "gawkextlib-${name}";
-      version = "unstable-2019-11-21";
+  buildExtension = stdenv.lib.makeOverridable
+    ({ name, gawkextlib, extraBuildInputs ? [ ], doCheck ? true }:
+      let is_extension = !isNull gawkextlib;
+      in stdenv.mkDerivation rec {
+        pname = "gawkextlib-${name}";
+        version = "unstable-2019-11-21";
 
-      src = fetchgit {
-        url = "git://git.code.sf.net/p/gawkextlib/code";
-        rev = "f70f10da2804e4fd0a0bac57736e9c1cf21e345d";
-        sha256 = "0r8fz89n3l4dfszs1980yqj0ah95430lj0y1lb7blfkwxa6c2xik";
-      };
+        src = fetchgit {
+          url = "git://git.code.sf.net/p/gawkextlib/code";
+          rev = "f70f10da2804e4fd0a0bac57736e9c1cf21e345d";
+          sha256 = "0r8fz89n3l4dfszs1980yqj0ah95430lj0y1lb7blfkwxa6c2xik";
+        };
 
-      nativeBuildInputs =
-        [ autoconf automake libtool autoreconfHook pkgconfig texinfo gettext ];
+        nativeBuildInputs = [
+          autoconf
+          automake
+          libtool
+          autoreconfHook
+          pkgconfig
+          texinfo
+          gettext
+        ];
 
-      buildInputs = [ gawk ] ++ extraBuildInputs;
-      propagatedBuildInputs = stdenv.lib.optional is_extension gawkextlib;
+        buildInputs = [ gawk ] ++ extraBuildInputs;
+        propagatedBuildInputs = stdenv.lib.optional is_extension gawkextlib;
 
-      configureFlags = stdenv.lib.optionals is_extension [
-        "--with-gawkextlib=${gawkextlib}/lib/"
-        "LDFLAGS=-L${gawkextlib}/lib"
-      ];
+        configureFlags = stdenv.lib.optionals is_extension [
+          "--with-gawkextlib=${gawkextlib}/lib/"
+          "LDFLAGS=-L${gawkextlib}/lib"
+        ];
 
-      postPatch = ''
-        cd ${name}
-      '';
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out/lib
-        cp ./.libs/* $out/lib
-      '' + (stdenv.lib.optionalString (!is_extension) ''
-        cp ../lib/gawkextlib.h $out/lib/.
-      '') + ''
-        runHook postInstall
-      '';
-
-      setupHook = ./setup-hook.sh;
-      inherit gawk;
-
-      inherit doCheck;
-      checkInputs = [ more ];
-
-      meta = with stdenv.lib; {
-        homepage = "https://sourceforge.net/projects/gawkextlib/";
-        description = "Dynamically loaded extension libraries for GNU AWK";
-        longDescription = ''
-          The gawkextlib project provides several extension libraries for
-          gawk (GNU AWK), as well as libgawkextlib containing some APIs that
-          are useful for building gawk extension libraries. These libraries
-          enable gawk to process XML data, interact with a PostgreSQL
-          database, use the GD graphics library, and perform unlimited
-          precision MPFR calculations.
+        postPatch = ''
+          cd ${name}
         '';
-        license = licenses.gpl3Plus;
-        platforms = platforms.unix;
-        maintainers = with maintainers; [ tomberek ];
-      };
-    });
-  gawkextlib = buildExtension { gawkextlib = null; name = "lib"; };
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/lib
+          cp ./.libs/* $out/lib
+        '' + (stdenv.lib.optionalString (!is_extension) ''
+          cp ../lib/gawkextlib.h $out/lib/.
+        '') + ''
+          runHook postInstall
+        '';
+
+        setupHook = ./setup-hook.sh;
+        inherit gawk;
+
+        inherit doCheck;
+        checkInputs = [ more ];
+
+        meta = with stdenv.lib; {
+          homepage = "https://sourceforge.net/projects/gawkextlib/";
+          description = "Dynamically loaded extension libraries for GNU AWK";
+          longDescription = ''
+            The gawkextlib project provides several extension libraries for
+            gawk (GNU AWK), as well as libgawkextlib containing some APIs that
+            are useful for building gawk extension libraries. These libraries
+            enable gawk to process XML data, interact with a PostgreSQL
+            database, use the GD graphics library, and perform unlimited
+            precision MPFR calculations.
+          '';
+          license = licenses.gpl3Plus;
+          platforms = platforms.unix;
+          maintainers = with maintainers; [ tomberek ];
+        };
+      });
+  gawkextlib = buildExtension {
+    gawkextlib = null;
+    name = "lib";
+  };
   libs = {
-    abort       = buildExtension { inherit gawkextlib; name = "abort"; };
-    aregex      = buildExtension { inherit gawkextlib; name = "aregex";      extraBuildInputs = [ tre          ]; };
-    csv         = buildExtension { inherit gawkextlib; name = "csv";  };
-    errno       = buildExtension { inherit gawkextlib; name = "errno"; };
-    gd          = buildExtension { inherit gawkextlib; name = "gd";          extraBuildInputs = [ gd           ]; };
-    haru        = buildExtension { inherit gawkextlib; name = "haru";        extraBuildInputs = [ libharu      ]; };
-    json        = buildExtension { inherit gawkextlib; name = "json";        extraBuildInputs = [ rapidjson    ]; };
-    lmdb        = buildExtension { inherit gawkextlib; name = "lmdb";        extraBuildInputs = [ lmdb         ];
+    abort = buildExtension {
+      inherit gawkextlib;
+      name = "abort";
+    };
+    aregex = buildExtension {
+      inherit gawkextlib;
+      name = "aregex";
+      extraBuildInputs = [ tre ];
+    };
+    csv = buildExtension {
+      inherit gawkextlib;
+      name = "csv";
+    };
+    errno = buildExtension {
+      inherit gawkextlib;
+      name = "errno";
+    };
+    gd = buildExtension {
+      inherit gawkextlib;
+      name = "gd";
+      extraBuildInputs = [ gd ];
+    };
+    haru = buildExtension {
+      inherit gawkextlib;
+      name = "haru";
+      extraBuildInputs = [ libharu ];
+    };
+    json = buildExtension {
+      inherit gawkextlib;
+      name = "json";
+      extraBuildInputs = [ rapidjson ];
+    };
+    lmdb = buildExtension {
+      inherit gawkextlib;
+      name = "lmdb";
+      extraBuildInputs = [ lmdb ];
       #  mdb_env_open(env, /dev/null)
       #! No such device
       #  mdb_env_open(env, /dev/null)
       #! Operation not supported by device
       doCheck = !stdenv.isDarwin;
     };
-    mbs         = buildExtension { inherit gawkextlib; name = "mbs";         extraBuildInputs = [ glibcLocales ];
+    mbs = buildExtension {
+      inherit gawkextlib;
+      name = "mbs";
+      extraBuildInputs = [ glibcLocales ];
       #! "spät": length: 5, mbs_length: 6, wcswidth: 4
       doCheck = !stdenv.isDarwin;
     };
-    mpfr        = buildExtension { inherit gawkextlib; name = "mpfr";        extraBuildInputs = [ gmp mpfr     ]; };
-    nl_langinfo = buildExtension { inherit gawkextlib; name = "nl_langinfo"; };
-    pgsql       = buildExtension { inherit gawkextlib; name = "pgsql";       extraBuildInputs = [ postgresql   ]; };
-    redis       = buildExtension { inherit gawkextlib; name = "redis";       extraBuildInputs = [ hiredis      ]; };
-    xml         = buildExtension { inherit gawkextlib; name = "xml";         extraBuildInputs = [ expat libiconv ]; };
-    timex       = buildExtension { inherit gawkextlib; name = "timex"; };
-    select      = buildExtension { inherit gawkextlib; name = "select"; };
+    mpfr = buildExtension {
+      inherit gawkextlib;
+      name = "mpfr";
+      extraBuildInputs = [ gmp mpfr ];
+    };
+    nl_langinfo = buildExtension {
+      inherit gawkextlib;
+      name = "nl_langinfo";
+    };
+    pgsql = buildExtension {
+      inherit gawkextlib;
+      name = "pgsql";
+      extraBuildInputs = [ postgresql ];
+    };
+    redis = buildExtension {
+      inherit gawkextlib;
+      name = "redis";
+      extraBuildInputs = [ hiredis ];
+    };
+    xml = buildExtension {
+      inherit gawkextlib;
+      name = "xml";
+      extraBuildInputs = [ expat libiconv ];
+    };
+    timex = buildExtension {
+      inherit gawkextlib;
+      name = "timex";
+    };
+    select = buildExtension {
+      inherit gawkextlib;
+      name = "select";
+    };
   };
 in recurseIntoAttrs (libs // {
   inherit gawkextlib;

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -6,12 +6,13 @@
 let
   buildGawkextlibExtension = extension: extraDeps:
     stdenv.mkDerivation rec {
-      name = "gawkextlib-${extension}-2019-11-21";
+      pname = "gawkextlib-${extension}";
+      version = "unstable-2019-11-21";
 
       src = fetchgit {
         url = "git://git.code.sf.net/p/gawkextlib/code";
         rev = "f70f10da2804e4fd0a0bac57736e9c1cf21e345d";
-        sha256 = "sha256-M3bBjOp8OrrOosEDScEgJUEFJPYApaC/do3QYRP6DmU=";
+        sha256 = "0r8fz89n3l4dfszs1980yqj0ah95430lj0y1lb7blfkwxa6c2xik";
       };
 
       nativeBuildInputs =
@@ -64,7 +65,7 @@ let
       };
     };
   gawkextlib = (buildGawkextlibExtension "lib" []).overrideAttrs (old: {
-    configureFlags = null;
+    configureFlags = [];
     buildInputs = [ gawk ];
     postInstall = ''
       cp ../lib/gawkextlib.h $out/lib/.

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -1,7 +1,7 @@
 { stdenv, recurseIntoAttrs, fetchgit, writeText, pkgconfig, autoreconfHook,
-autoconf, automake, libtool, texinfo, gettext, gawk, rapidjson, gd, shapelib,
-libharu, lmdb, gmp, glibcLocales, mpfr, more, postgresql, hiredis, expat, tre,
-makeWrapper
+autoconf, automake, libiconv, libtool, texinfo, gettext, gawk, rapidjson, gd,
+shapelib, libharu, lmdb, gmp, glibcLocales, mpfr, more, postgresql, hiredis,
+expat, tre, makeWrapper
 }:
 
 let
@@ -83,7 +83,7 @@ in recurseIntoAttrs {
   nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
   pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
   redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
-  xml         = buildGawkextlibExtension "xml"         [ expat        ];
+  xml         = buildGawkextlibExtension "xml"         [ expat libiconv ];
   timex       = buildGawkextlibExtension "timex"       [              ];
   select      = buildGawkextlibExtension "select"      [ more         ];
 }

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -129,18 +129,18 @@ let
       name = "redis";
       extraBuildInputs = [ hiredis ];
     };
-    xml = buildExtension {
+    select = buildExtension {
       inherit gawkextlib;
-      name = "xml";
-      extraBuildInputs = [ expat libiconv ];
+      name = "select";
     };
     timex = buildExtension {
       inherit gawkextlib;
       name = "timex";
     };
-    select = buildExtension {
+    xml = buildExtension {
       inherit gawkextlib;
-      name = "select";
+      name = "xml";
+      extraBuildInputs = [ expat libiconv ];
     };
   };
 in recurseIntoAttrs (libs // {

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -17,6 +17,10 @@ let
           sha256 = "0r8fz89n3l4dfszs1980yqj0ah95430lj0y1lb7blfkwxa6c2xik";
         };
 
+        postPatch = ''
+          cd ${name}
+        '';
+
         nativeBuildInputs = [
           autoconf
           automake
@@ -29,10 +33,6 @@ let
 
         buildInputs = [ gawk ] ++ extraBuildInputs;
         propagatedBuildInputs = stdenv.lib.optional is_extension gawkextlib;
-
-        postPatch = ''
-          cd ${name}
-        '';
 
         setupHook = if is_extension then ./setup-hook.sh else null;
         inherit gawk;

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -5,7 +5,7 @@ expat, tre, makeWrapper
 }:
 
 let
-  buildGawkextlibExtension = extension: extraBuildInputs:
+  buildExtension = extension: extraBuildInputs:
     stdenv.mkDerivation rec {
       pname = "gawkextlib-${extension}";
       version = "unstable-2019-11-21";
@@ -59,7 +59,7 @@ let
         maintainers = with maintainers; [ tomberek ];
       };
     };
-  gawkextlib = (buildGawkextlibExtension "lib" []).overrideAttrs (old: {
+  gawkextlib = (buildExtension "lib" []).overrideAttrs (old: {
     configureFlags = [];
     propagatedBuildInputs = [];
     postInstall = ''
@@ -67,22 +67,22 @@ let
     '';
   });
   libs = {
-    abort       = buildGawkextlibExtension "abort"       [              ];
-    aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
-    csv         = buildGawkextlibExtension "csv"         [              ];
-    errno       = buildGawkextlibExtension "errno"       [              ];
-    gd          = buildGawkextlibExtension "gd"          [ gd           ];
-    haru        = buildGawkextlibExtension "haru"        [ libharu      ];
-    json        = buildGawkextlibExtension "json"        [ rapidjson    ];
-    lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
-    mbs         = buildGawkextlibExtension "mbs"         [ glibcLocales ];
-    mpfr        = buildGawkextlibExtension "mpfr"        [ gmp mpfr     ];
-    nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
-    pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
-    redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
-    xml         = buildGawkextlibExtension "xml"         [ expat libiconv ];
-    timex       = buildGawkextlibExtension "timex"       [              ];
-    select      = buildGawkextlibExtension "select"      [              ];
+    abort       = buildExtension "abort"       [              ];
+    aregex      = buildExtension "aregex"      [ tre          ];
+    csv         = buildExtension "csv"         [              ];
+    errno       = buildExtension "errno"       [              ];
+    gd          = buildExtension "gd"          [ gd           ];
+    haru        = buildExtension "haru"        [ libharu      ];
+    json        = buildExtension "json"        [ rapidjson    ];
+    lmdb        = buildExtension "lmdb"        [ lmdb         ];
+    mbs         = buildExtension "mbs"         [ glibcLocales ];
+    mpfr        = buildExtension "mpfr"        [ gmp mpfr     ];
+    nl_langinfo = buildExtension "nl_langinfo" [              ];
+    pgsql       = buildExtension "pgsql"       [ postgresql   ];
+    redis       = buildExtension "redis"       [ hiredis      ];
+    xml         = buildExtension "xml"         [ expat libiconv ];
+    timex       = buildExtension "timex"       [              ];
+    select      = buildExtension "select"      [              ];
   };
 in recurseIntoAttrs (libs // {
   inherit gawkextlib;

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -144,6 +144,6 @@ let
     };
   };
 in recurseIntoAttrs (libs // {
-  inherit gawkextlib;
+  inherit gawkextlib buildExtension;
   full = builtins.attrValues libs;
 })

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -37,6 +37,7 @@ let
       '';
 
       setupHook = ./setup-hook.sh;
+      inherit gawk;
 
       doCheck = stdenv.isLinux;
 
@@ -62,8 +63,6 @@ let
     postInstall = ''
       cp ../lib/gawkextlib.h $out/lib/.
     '';
-    setupHook = ./setup-hook-extlib.sh;
-    awklibpath = "${gawk}/lib/gawk";
   });
 in {
 

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -30,11 +30,6 @@ let
         buildInputs = [ gawk ] ++ extraBuildInputs;
         propagatedBuildInputs = stdenv.lib.optional is_extension gawkextlib;
 
-        configureFlags = stdenv.lib.optionals is_extension [
-          "--with-gawkextlib=${gawkextlib}/lib/"
-          "LDFLAGS=-L${gawkextlib}/lib"
-        ];
-
         postPatch = ''
           cd ${name}
         '';

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -1,4 +1,4 @@
-{ stdenv, recurseIntoAttrs, fetchgit, writeText, pkgconfig, autoreconfHook, autoconf, automake
+{ stdenv, fetchgit, writeText, pkgconfig, autoreconfHook, autoconf, automake
 , libtool, texinfo, gettext, gawk, rapidjson, gd, shapelib, libharu, lmdb, gmp
 , glibcLocales, mpfr, more, postgresql, hiredis, expat, tre, makeWrapper
 }:
@@ -35,10 +35,6 @@ let
         runHook postInstall
       '';
 
-      # Needed for some tests
-      preCheck = ''
-        AWKLIBPATH=${gawk}/lib/gawk
-      '';
       setupHook = ./setup-hook.sh;
 
       doCheck = stdenv.isLinux;
@@ -66,32 +62,31 @@ let
       cp ../lib/gawkextlib.h $out/lib/.
     '';
   });
-in recurseIntoAttrs {
+in {
 
-  # callPackage injects extra items into the root attrSet
-  extensions = {
-    inherit gawkextlib;
+# callPackage injects extra items into the root attrSet
+  inherit gawkextlib;
 
-    abort       = buildGawkextlibExtension "abort"       [              ];
-    aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
-    csv         = buildGawkextlibExtension "csv"         [              ];
-    errno       = buildGawkextlibExtension "errno"       [              ];
-    gd          = buildGawkextlibExtension "gd"          [ gd more      ];
-    haru        = buildGawkextlibExtension "haru"        [ libharu      ];
-    json        = buildGawkextlibExtension "json"        [ rapidjson    ];
-    lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
-    mbs         = buildGawkextlibExtension "mbs"         [ glibcLocales ];
-    mpfr        = buildGawkextlibExtension "mpfr"        [ gmp mpfr     ];
-    nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
-    pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
-    select      = buildGawkextlibExtension "select"      [ more         ];
-    xml         = buildGawkextlibExtension "xml"         [ expat        ];
-    timex       = buildGawkextlibExtension "timex"       [              ];
+  abort       = buildGawkextlibExtension "abort"       [              ];
+  aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
+  csv         = buildGawkextlibExtension "csv"         [              ];
+  errno       = buildGawkextlibExtension "errno"       [              ];
+  gd          = buildGawkextlibExtension "gd"          [ gd more      ];
+  haru        = buildGawkextlibExtension "haru"        [ libharu      ];
+  json        = buildGawkextlibExtension "json"        [ rapidjson    ];
+  lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
+  mbs         = buildGawkextlibExtension "mbs"         [ glibcLocales ];
+  mpfr        = buildGawkextlibExtension "mpfr"        [ gmp mpfr     ];
+  nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
+  pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
+  redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
+  xml         = buildGawkextlibExtension "xml"         [ expat        ];
+  timex       = buildGawkextlibExtension "timex"       [              ];
 
-    redis = (buildGawkextlibExtension "redis" [ hiredis ]).overrideAttrs
-      (old: {
-        configureFlags = old.configureFlags
-          ++ [ "--with-hiredis=${hiredis}/lib/" ];
-      });
-  };
+  select = (buildGawkextlibExtension "select" [ more ]).overrideAttrs (old: {
+    # Needed for tests
+    preCheck = ''
+      AWKLIBPATH=${gawk}/lib/gawk
+    '';
+  });
 }

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -38,17 +38,8 @@ let
         postPatch = ''
           cd ${name}
         '';
-        installPhase = ''
-          runHook preInstall
-          mkdir -p $out/lib
-          cp ./.libs/* $out/lib
-        '' + (stdenv.lib.optionalString (!is_extension) ''
-          cp ../lib/gawkextlib.h $out/lib/.
-        '') + ''
-          runHook postInstall
-        '';
 
-        setupHook = ./setup-hook.sh;
+        setupHook = if is_extension then ./setup-hook.sh else null;
         inherit gawk;
 
         inherit doCheck;

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -1,0 +1,101 @@
+{ stdenv, fetchgit, writeText, pkgconfig, autoreconfHook, autoconf, automake
+, libtool, texinfo, gettext, gawk, rapidjson, gd, shapelib, libharu, lmdb, gmp
+, glibcLocales, mpfr, more, postgresql, hiredis, expat, tre, makeWrapper
+}:
+
+let
+  buildGawkextlibExtension = extension: extraDeps:
+    stdenv.mkDerivation rec {
+      name = "gawkextlib-${extension}-2019-11-21";
+
+      src = fetchgit {
+        url = "git://git.code.sf.net/p/gawkextlib/code";
+        rev = "f70f10da2804e4fd0a0bac57736e9c1cf21e345d";
+        sha256 = "sha256-M3bBjOp8OrrOosEDScEgJUEFJPYApaC/do3QYRP6DmU=";
+      };
+
+      nativeBuildInputs =
+        [ autoconf automake libtool autoreconfHook pkgconfig texinfo gettext ];
+
+      buildInputs = [
+        gawk
+        gawkextlib
+        #rapidjson gd shapelib libharu
+        #lmdb gmp mpfr postgresql hiredis expat tre
+      ] ++ extraDeps;
+      configureFlags = [
+        "--with-gawkextlib=${gawkextlib}/lib/"
+        "LDFLAGS=-L${gawkextlib}/lib"
+      ];
+
+      postPatch = ''
+        cd ${extension}
+      '';
+      installPhase = ''
+        mkdir -p $out/lib
+        cp ./.libs/* $out/lib
+        runHook postInstall
+      '';
+
+      # Needed for some tests
+      preCheck = ''
+        AWKLIBPATH=${gawk}/lib/gawk
+      '';
+      setupHook = writeText "setupHook.sh" ''
+        export AWKLIBPATH="''${AWKLIBPATH-}''${AWKLIBPATH:+:}"@out@/lib
+      '';
+
+      doCheck = stdenv.isLinux;
+
+      meta = with stdenv.lib; {
+        homepage = "https://sourceforge.net/projects/gawkextlib/";
+        description = "Dynamically loaded extension libraries for GNU AWK";
+        longDescription = ''
+          The gawkextlib project provides several extension libraries for
+          gawk (GNU AWK), as well as libgawkextlib containing some APIs that
+          are useful for building gawk extension libraries. These libraries
+          enable gawk to process XML data, interact with a PostgreSQL
+          database, use the GD graphics library, and perform unlimited
+          precision MPFR calculations.
+        '';
+        license = licenses.gpl3Plus;
+        platforms = platforms.unix;
+        maintainers = with maintainers; [ tomberek ];
+      };
+    };
+  gawkextlib = (buildGawkextlibExtension "lib" []).overrideAttrs (old: {
+    configureFlags = null;
+    buildInputs = [ gawk ];
+    postInstall = ''
+      cp ../lib/gawkextlib.h $out/lib/.
+    '';
+  });
+in {
+
+  # callPackage injects extra items into the root attrSet
+  full = {
+    inherit gawkextlib;
+
+    abort       = buildGawkextlibExtension "abort"       [              ];
+    aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
+    csv         = buildGawkextlibExtension "csv"         [              ];
+    errno       = buildGawkextlibExtension "errno"       [              ];
+    gd          = buildGawkextlibExtension "gd"          [ gd more      ];
+    haru        = buildGawkextlibExtension "haru"        [ libharu      ];
+    json        = buildGawkextlibExtension "json"        [ rapidjson    ];
+    lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
+    mbs         = buildGawkextlibExtension "mbs"         [ glibcLocales ];
+    mpfr        = buildGawkextlibExtension "mpfr"        [ gmp mpfr     ];
+    nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
+    pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
+    select      = buildGawkextlibExtension "select"      [ more         ];
+    xml         = buildGawkextlibExtension "xml"         [ expat        ];
+    timex       = buildGawkextlibExtension "timex"       [              ];
+
+    redis = (buildGawkextlibExtension "redis" [ hiredis ]).overrideAttrs
+      (old: {
+        configureFlags = old.configureFlags
+          ++ [ "--with-hiredis=${hiredis}/lib/" ];
+      });
+  };
+}

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -65,25 +65,25 @@ let
       cp ../lib/gawkextlib.h $out/lib/.
     '';
   });
-in recurseIntoAttrs {
-
-# callPackage injects extra items into the root attrSet
+  libs = {
+    abort       = buildGawkextlibExtension "abort"       [              ];
+    aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
+    csv         = buildGawkextlibExtension "csv"         [              ];
+    errno       = buildGawkextlibExtension "errno"       [              ];
+    gd          = buildGawkextlibExtension "gd"          [ gd more      ];
+    haru        = buildGawkextlibExtension "haru"        [ libharu      ];
+    json        = buildGawkextlibExtension "json"        [ rapidjson    ];
+    lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
+    mbs         = buildGawkextlibExtension "mbs"         [ glibcLocales ];
+    mpfr        = buildGawkextlibExtension "mpfr"        [ gmp mpfr     ];
+    nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
+    pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
+    redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
+    xml         = buildGawkextlibExtension "xml"         [ expat libiconv ];
+    timex       = buildGawkextlibExtension "timex"       [              ];
+    select      = buildGawkextlibExtension "select"      [ more         ];
+  };
+in recurseIntoAttrs (libs // {
   inherit gawkextlib;
-
-  abort       = buildGawkextlibExtension "abort"       [              ];
-  aregex      = buildGawkextlibExtension "aregex"      [ tre          ];
-  csv         = buildGawkextlibExtension "csv"         [              ];
-  errno       = buildGawkextlibExtension "errno"       [              ];
-  gd          = buildGawkextlibExtension "gd"          [ gd more      ];
-  haru        = buildGawkextlibExtension "haru"        [ libharu      ];
-  json        = buildGawkextlibExtension "json"        [ rapidjson    ];
-  lmdb        = buildGawkextlibExtension "lmdb"        [ lmdb         ];
-  mbs         = buildGawkextlibExtension "mbs"         [ glibcLocales ];
-  mpfr        = buildGawkextlibExtension "mpfr"        [ gmp mpfr     ];
-  nl_langinfo = buildGawkextlibExtension "nl_langinfo" [              ];
-  pgsql       = buildGawkextlibExtension "pgsql"       [ postgresql   ];
-  redis       = buildGawkextlibExtension "redis"       [ hiredis      ];
-  xml         = buildGawkextlibExtension "xml"         [ expat libiconv ];
-  timex       = buildGawkextlibExtension "timex"       [              ];
-  select      = buildGawkextlibExtension "select"      [ more         ];
-}
+  full = builtins.attrValues libs;
+})

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchgit, writeText, pkgconfig, autoreconfHook, autoconf, automake
-, libtool, texinfo, gettext, gawk, rapidjson, gd, shapelib, libharu, lmdb, gmp
-, glibcLocales, mpfr, more, postgresql, hiredis, expat, tre, makeWrapper
+{ stdenv, recurseIntoAttrs, fetchgit, writeText, pkgconfig, autoreconfHook,
+autoconf, automake, libtool, texinfo, gettext, gawk, rapidjson, gd, shapelib,
+libharu, lmdb, gmp, glibcLocales, mpfr, more, postgresql, hiredis, expat, tre,
+makeWrapper
 }:
 
 let
@@ -64,7 +65,7 @@ let
       cp ../lib/gawkextlib.h $out/lib/.
     '';
   });
-in {
+in recurseIntoAttrs {
 
 # callPackage injects extra items into the root attrSet
   inherit gawkextlib;

--- a/pkgs/tools/text/gawk/setup-hook-extlib.sh
+++ b/pkgs/tools/text/gawk/setup-hook-extlib.sh
@@ -1,1 +1,0 @@
-export AWKLIBPATH="${AWKLIBPATH-}${AWKLIBPATH:+:}"@awklibpath@:@out@/lib

--- a/pkgs/tools/text/gawk/setup-hook-extlib.sh
+++ b/pkgs/tools/text/gawk/setup-hook-extlib.sh
@@ -1,0 +1,1 @@
+export AWKLIBPATH="${AWKLIBPATH-}${AWKLIBPATH:+:}"@awklibpath@:@out@/lib

--- a/pkgs/tools/text/gawk/setup-hook.sh
+++ b/pkgs/tools/text/gawk/setup-hook.sh
@@ -1,1 +1,6 @@
-export AWKLIBPATH="${AWKLIBPATH-}${AWKLIBPATH:+:}"@out@/lib
+local oldOpts="-u"
+shopt -qo nounset || oldOpts="+u"
+set +u
+. @gawk@/etc/profile.d/gawk.sh
+gawklibpath_append @out@/lib
+set "$oldOpts"

--- a/pkgs/tools/text/gawk/setup-hook.sh
+++ b/pkgs/tools/text/gawk/setup-hook.sh
@@ -2,5 +2,5 @@ local oldOpts="-u"
 shopt -qo nounset || oldOpts="+u"
 set +u
 . @gawk@/etc/profile.d/gawk.sh
-gawklibpath_append @out@/lib
+gawklibpath_append @out@/lib/gawk
 set "$oldOpts"

--- a/pkgs/tools/text/gawk/setup-hook.sh
+++ b/pkgs/tools/text/gawk/setup-hook.sh
@@ -1,0 +1,1 @@
+export AWKLIBPATH="${AWKLIBPATH-}${AWKLIBPATH:+:}"@out@/lib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3394,10 +3394,11 @@ in
   };
 
   gawk-with-extensions = callPackage ../tools/text/gawk/gawk-with-extensions.nix {
-    inherit gawk;
-    extensions = builtins.attrValues gawkextlib-extensions.full;
+    extensions = let
+      gawkextlib = callPackage ../tools/text/gawk/gawkextlib.nix {};
+      in
+        builtins.attrValues gawkextlib.extensions;
   };
-  gawkextlib-extensions = callPackage ../tools/text/gawk/gawkextlib.nix {};
 
   gawkInteractive = appendToName "interactive"
     (gawk.override { interactive = true; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3394,11 +3394,9 @@ in
   };
 
   gawk-with-extensions = callPackage ../tools/text/gawk/gawk-with-extensions.nix {
-    extensions = let
-      gawkextlib = callPackage ../tools/text/gawk/gawkextlib.nix {};
-      in
-        builtins.attrValues gawkextlib.extensions;
+    extensions = gawkextlib;
   };
+  gawkextlib = callPackage ../tools/text/gawk/gawkextlib.nix {};
 
   gawkInteractive = appendToName "interactive"
     (gawk.override { interactive = true; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3393,6 +3393,12 @@ in
     inherit (darwin) locale;
   };
 
+  gawk-with-extensions = callPackage ../tools/text/gawk/gawk-with-extensions.nix {
+    inherit gawk;
+    extensions = builtins.attrValues gawkextlib-extensions.full;
+  };
+  gawkextlib-extensions = callPackage ../tools/text/gawk/gawkextlib.nix {};
+
   gawkInteractive = appendToName "interactive"
     (gawk.override { interactive = true; });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3394,7 +3394,7 @@ in
   };
 
   gawk-with-extensions = callPackage ../tools/text/gawk/gawk-with-extensions.nix {
-    extensions = gawkextlib;
+    extensions = gawkextlib.full;
   };
   gawkextlib = callPackage ../tools/text/gawk/gawkextlib.nix {};
 


### PR DESCRIPTION
###### Motivation for this change
Using AWK recently. Found some extensions that are useful for JSON, etc.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

