### PR TITLE
geckodriver: unstable-2018-02-24 -> 0.22.0

### DIFF
--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -1,24 +1,26 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
+, stdenv
+, darwin
 }:
 
 with rustPlatform; 
 
 buildRustPackage rec {
-  version = "unstable-2018-02-24";
+  version = "0.22.0";
   name = "geckodriver-${version}";
 
   src = fetchFromGitHub {
     owner = "mozilla";
-    repo = "gecko-dev";
-    rev = "ecb86060b4c5a9808798b81a57e79e821bb47082";
-    sha256 = "1am84a60adw0bb12rlhdqbiwyywhza4qp5sf4f4fmssjl2qcr6nl";
+    repo = "geckodriver";
+    rev = "v${version}";
+    sha256 = "12m95lfqwdxs2m5kjh3yrpm9w2li5m8n3fw46a2nkxyfw6c94l4b";
   };
 
-  sourceRoot = "${src.name}/testing/geckodriver";
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
-  cargoSha256 = "0dvcvdb623jla29i93glx20nf8pbpfw6jj548ii6brzkcpafxxm8";
+  cargoSha256 = "1a8idl6falz0n9irh1p8hv5w2pmiknzsfnxl70k1psnznrpk2y8n";
 
   meta = with lib; {
     description = "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers";


### PR DESCRIPTION
closes NixOS/nixpkgs#50380

###### Motivation for this change

geckodriver unstable-2018-02-24 (which reports to be 0.19.1, but probably doesn't correspond to any actual geckodriver release) isn't compatible with the currently shipped Firefox version 63.0.

geckodriver ≥ 0.21 is needed to be compatible with Firefox > 62 according to [the documentation](https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Support.html#supported-platforms). The latest version seems to be geckodriver **0.23**.0, but the released source for that is missing the `Cargo.lock` file (see https://github.com/NixOS/nixpkgs/issues/50380#issuecomment-438894287, mozilla/geckodriver#1427, mozilla/geckodriver#1403), thus I've packaged **0.22**.0 for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - :warning: This failed due to a problem of `python37Packages.robotframework-selenium2library ` also present in `master` and `nixos-18.09` (reported as #51727)<details><summary>details</summary>

    `nix-shell -p nox --run "nox-review wip"` ran `nix-build -A python37Packages.selenium -A bepasty -A geckodriver -A python27Packages.bokeh -A python27Packages.selenium -A python37Packages.robotframework-selenium2library -A python27Packages.robotframework-selenium2library -A python37Packages.splinter -A python37Packages.bokeh -A searx -A python27Packages.splinter $PATH_TO_LOCAL_nixpkgs_CLONE`, which failed with
    ```
    [...]
    building
    Traceback (most recent call last):
      File "nix_run_setup", line 8, in <module>
        exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
      File "setup.py", line 7, in <module>
        from ez_setup import use_setuptools
      File "src/ez_setup.py", line 106
        except pkg_resources.VersionConflict, e:
                                            ^
    SyntaxError: invalid syntax
    builder for '/nix/store/jj08nah9ll8diwchdq0dkppfabykj8da-python3.7-robotframework-selenium2library-1.6.0.drv' failed with exit code 1
    error: build of '/nix/store/jj08nah9ll8diwchdq0dkppfabykj8da-python3.7-robotframework-selenium2library-1.6.0.drv', '/nix/store/pmpcvfn2qhaby7wbcqgk73y3k0wvlflp-python2.7-robotframework-selenium2library-1.6.0.drv', '/nix/store/w4y626wf9b7bx1m5zr03cmsr0533lk0j-python2.7-bokeh-1.0.0.drv', '/nix/store/yzg2ylkc8dsd2bc0vvf7mi4435c3ykh4-python3.7-bokeh-1.0.0.drv' failed
    ```

    </details>

    Because I noticed that `master` without my change (c37ae1dcf669b5b262350ddbb75a40be166e7e88) is affected too, I tried `nix-shell -p nox --run "nox-review --keep-going wip"` to see if the rest builds fine, but that failed with <details><summary>a `TypeError` in nox</summary>

    ```
    Building in /run/user/1000/nox-review-30j9pnse: python37Packages.selenium bepasty geckodriver python27Packages.bokeh python27Packages.selenium python37Packages.robotframework-selenium2library python27Packages.robotframework-selenium2library python37Packages.splinter python37Packages.bokeh searx python27Packages.splinter
    Traceback (most recent call last):
      File "/nix/store/x2symvh602bmn82vr6an3yzdhjp0rvmn-nox-0.0.6/bin/.nox-review-wrapped", line 12, in <module>
        sys.exit(cli())
      File "/nix/store/b50xpi3hclqjlbfbp4bcy4kj7a0ybnsr-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 722, in __call__
        return self.main(*args, **kwargs)
      File "/nix/store/b50xpi3hclqjlbfbp4bcy4kj7a0ybnsr-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 697, in main
        rv = self.invoke(ctx)
      File "/nix/store/b50xpi3hclqjlbfbp4bcy4kj7a0ybnsr-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/nix/store/b50xpi3hclqjlbfbp4bcy4kj7a0ybnsr-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 895, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/nix/store/b50xpi3hclqjlbfbp4bcy4kj7a0ybnsr-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 535, in invoke
        return callback(*args, **kwargs)
      File "/nix/store/b50xpi3hclqjlbfbp4bcy4kj7a0ybnsr-python3.6-click-6.7/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "/nix/store/x2symvh602bmn82vr6an3yzdhjp0rvmn-nox-0.0.6/lib/python3.6/site-packages/nox/review.py", line 71, in _
        f(*args, **kwargs)
      File "/nix/store/x2symvh602bmn82vr6an3yzdhjp0rvmn-nox-0.0.6/lib/python3.6/site-packages/nox/review.py", line 109, in wip
    build_in_path(ctx.obj['extra-args'], attrs, '.', dry_run=ctx.obj['dry_run'])
      File "/nix/store/x2symvh602bmn82vr6an3yzdhjp0rvmn-nox-0.0.6/lib/python3.6/site-packages/nox/review.py", line 38, in build_in_path
    click.echo('Invoking {}'.format(' '.join(command)))
    TypeError: sequence item 1: expected str instance, list found
    ```

    </details>
    This seems to be a known issue: madjar/nox#83
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

