### PR TITLE
weechatScripts.weechat-autosort: init at unstable-2018-01-11

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -12,4 +12,6 @@
   wee-slack = callPackage ./wee-slack {
     inherit pythonPackages;
   };
+
+  weechat-autosort = callPackage ./weechat-autosort { };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "weechat-autosort-${version}";
+  version = "unstable-2018-01-11";
+
+  src = fetchFromGitHub {
+    owner = "de-vri-es";
+    repo = "weechat-autosort";
+    rev = "35ccd6335afd78ae8a6e050ed971d54c8524e37e";
+    sha256 = "1rgws960xys65cd1m529csalcgny87h7fkiwjv1yj9rpqp088z26";
+  };
+
+  passthru.scripts = [ "autosort.py" ];
+  installPhase = ''
+    mkdir -p $out/share
+    cp autosort.py $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Autosort is a weechat script to automatically or manually keep your buffers sorted";
+    homepage = https://github.com/de-vri-es/weechat-autosort;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
 
   passthru.scripts = [ "autosort.py" ];
   installPhase = ''
-    mkdir -p $out/share
-    cp autosort.py $out/share
+    install -D autosort.py $out/share/autosort.py
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Helpful weechat script to automatically keep buffers sorted.

Can be activated like this:

``` nix
weechat.override {
  configure = { ... }: {
    scripts = [
      weechatScripts.weechat-autosort
    ];
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

