### PR TITLE
pythonPackages.robotframework-selenium2library: 1.6.0 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy37, pyperclip }:
+
+buildPythonPackage rec {
+  version = "0.2.4";
+  pname = "approvaltests";
+
+  # no tests included in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "approvals";
+    repo = "ApprovalTests.Python";
+    rev = version;
+    sha256 = "05lj5i13zpkgw1wdc1v81wj4zqj8bpzqiwycdnwlg08azcy7k7j1";
+  };
+
+  propagatedBuildInputs = [ pyperclip ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pyperclip==1.5.27" "pyperclip>=1.5.27"
+  '';
+
+  # Tests fail on Python 3.7
+  # https://github.com/approvals/ApprovalTests.Python/issues/36
+  doCheck = !isPy37;
+
+  # Disable Linux failing test, because tries to use darwin/windows specific reporters
+  preCheck = stdenv.lib.optionalString stdenv.isLinux ''
+    substituteInPlace tests/test_genericdiffreporter.py \
+      --replace "test_find_working_reporter" "_find_working_reporter"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Assertion/verification library to aid testing";
+    homepage = https://github.com/approvals/ApprovalTests.Python;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/development/python-modules/mockito/default.nix
+++ b/pkgs/development/python-modules/mockito/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, funcsigs, pytest, numpy }:
+
+buildPythonPackage rec {
+  version = "1.1.1";
+  pname = "mockito";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "142f5e8865a422ad2d67b9c67a382e3296e8f1633dbccd0e322180fba7d5303d";
+  };
+
+  # Failing tests due 2to3
+  doCheck = !isPy3k;
+
+  propagatedBuildInputs = stdenv.lib.optionals (!isPy3k) [ funcsigs ];
+  checkInputs = [ pytest numpy ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Spying framework";
+    homepage = https://github.com/kaste/mockito-python;
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/development/python-modules/robotframework-selenium2library/default.nix
+++ b/pkgs/development/python-modules/robotframework-selenium2library/default.nix
@@ -1,30 +1,24 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, robotframework
-, selenium
-, docutils
-, decorator
-}:
+{ stdenv, buildPythonPackage, fetchPypi, robotframework-seleniumlibrary }:
 
 buildPythonPackage rec {
-  version = "1.6.0";
+  version = "3.0.0";
   pname = "robotframework-selenium2library";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1asdwrpb4s7q08bx641yrh3yicgba14n3hxmsqs58mqf86ignwly";
+    sha256 = "2a8e942b0788b16ded253039008b34d2b46199283461b294f0f41a579c70fda7";
   };
 
-  # error: invalid command 'test'
-  #doCheck = false;
+  # Neither the PyPI tarball nor the repository has tests
+  doCheck = false;
 
-  propagatedBuildInputs = [ robotframework selenium docutils decorator ];
+  propagatedBuildInputs = [ robotframework-seleniumlibrary ];
 
   meta = with stdenv.lib; {
     description = "Web testing library for Robot Framework";
-    homepage = http://robotframework.org/;
+    homepage = https://github.com/robotframework/Selenium2Library;
     license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
   };
 
 }

--- a/pkgs/development/python-modules/robotframework-seleniumlibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-seleniumlibrary/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, robotframework, selenium, mockito, robotstatuschecker, approvaltests }:
+
+buildPythonPackage rec {
+  version = "3.2.0";
+  pname = "robotframework-seleniumlibrary";
+
+  # no tests included in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "robotframework";
+    repo = "SeleniumLibrary";
+    rev = "v${version}";
+    sha256 = "106dl0qgf52wqk1xn4ghj7n2fjhaq0fh2wlnqn29aczbv5q581y3";
+  };
+
+  propagatedBuildInputs = [ robotframework selenium ];
+  checkInputs = [ mockito robotstatuschecker approvaltests ];
+
+  # Only execute Unit Tests. Acceptance Tests require headlesschrome, currently
+  # not available in nixpkgs
+  checkPhase = ''
+    ${python.interpreter} utest/run.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Web testing library for Robot Framework";
+    homepage = https://github.com/robotframework/SeleniumLibrary;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/development/python-modules/robotstatuschecker/default.nix
+++ b/pkgs/development/python-modules/robotstatuschecker/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, robotframework }:
+
+buildPythonPackage rec {
+  version = "1.3";
+  pname = "robotstatuschecker";
+
+  # no tests included in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "robotframework";
+    repo = "statuschecker";
+    rev = version;
+    sha256 = "0rppwwpp4djn5c43x7icwslnxbzcfnnn3c6awpg1k97j69d2nmln";
+  };
+
+  propagatedBuildInputs = [ robotframework ];
+
+  checkPhase = ''
+    ${python.interpreter} test/run.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool for checking that Robot Framework test cases have expected statuses and log messages";
+    homepage = https://github.com/robotframework/statuschecker;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3810,6 +3810,8 @@ in {
 
   robotframework-tools = callPackage ../development/python-modules/robotframework-tools { };
 
+  robotstatuschecker = callPackage ../development/python-modules/robotstatuschecker { };
+
   robotsuite = callPackage ../development/python-modules/robotsuite { };
 
   serpent = callPackage ../development/python-modules/serpent { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -835,6 +835,8 @@ in {
 
   appnope = callPackage ../development/python-modules/appnope { };
 
+  approvaltests = callPackage ../development/python-modules/approvaltests { };
+
   apsw = callPackage ../development/python-modules/apsw {};
 
   astor = callPackage ../development/python-modules/astor {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3810,6 +3810,8 @@ in {
 
   robotframework-ride = callPackage ../development/python-modules/robotframework-ride { };
 
+  robotframework-seleniumlibrary = callPackage ../development/python-modules/robotframework-seleniumlibrary { };
+
   robotframework-selenium2library = callPackage ../development/python-modules/robotframework-selenium2library { };
 
   robotframework-tools = callPackage ../development/python-modules/robotframework-tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2969,6 +2969,8 @@ in {
 
   mock-open = callPackage ../development/python-modules/mock-open { };
 
+  mockito = callPackage ../development/python-modules/mockito { };
+
   modestmaps = callPackage ../development/python-modules/modestmaps { };
 
   # Needed here because moinmoin is loaded as a Python library.


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/51727
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

