### PR TITLE
shiboken: add support for Python 3.7

### DIFF
--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, cmake, buildPythonPackage, libxml2, libxslt, pysideApiextractor, pysideGeneratorrunner, python, sphinx, qt4, isPy3k, isPy35, isPy36 }:
+{ lib, fetchurl, cmake, buildPythonPackage, libxml2, libxslt, pysideApiextractor, pysideGeneratorrunner, python, sphinx, qt4, isPy3k, isPy35, isPy36, isPy37 }:
 
 # This derivation provides a Python module and should therefore be called via `python-packages.nix`.
 # Python 3.5 is not supported: https://github.com/PySide/Shiboken/issues/77
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   # gcc6 patch was also sent upstream: https://github.com/pyside/Shiboken/pull/86
-  patches = [ ./gcc6.patch ] ++ (lib.optional (isPy35 || isPy36) ./shiboken_py35.patch);
+  patches = [ ./gcc6.patch ] ++ (lib.optional (isPy35 || isPy36 || isPy37) ./shiboken_py35.patch);
 
   cmakeFlags = if isPy3k then "-DUSE_PYTHON3=TRUE" else null;
 

--- a/pkgs/development/python-modules/pyside/shiboken_py35.patch
+++ b/pkgs/development/python-modules/pyside/shiboken_py35.patch
@@ -6,7 +6,7 @@ diff --git a/cmake/Modules/FindPython3Libs.cmake b/cmake/Modules/FindPython3Libs
  # CMAKE_FIND_FRAMEWORKS(Python)
  
 -FOREACH(_CURRENT_VERSION 3.4 3.3 3.2 3.1 3.0)
-+FOREACH(_CURRENT_VERSION 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
++FOREACH(_CURRENT_VERSION 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
    IF(_CURRENT_VERSION GREATER 3.1)
        SET(_32FLAGS "m" "u" "mu" "dm" "du" "dmu" "")
    ELSE()


### PR DESCRIPTION
###### Motivation for this change

@flokli requested in #51634 to have a look on shiboken. I was still using Python 3.6 and it was working, so I had a look and noticed that shiboken was patched for Python 3.5 and 3.6. This PR extends the same patch use for 3.7, as well.

I have not run nix-review (I must start doing so), but I have built and run successfully the `spyder` application that @flokli mentioned on the previous PR. (P.S.: spyder could get updated to a newer version, but hopefully someone else can take it from here.)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

