### PR TITLE
hackrf: 2017.02.1 -> 2018.01.1

### DIFF
--- a/pkgs/applications/misc/hackrf/default.nix
+++ b/pkgs/applications/misc/hackrf/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, cmake, pkgconfig, libusb, fftwSinglePrec }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libusb, fftwSinglePrec }:
 
 stdenv.mkDerivation rec {
   name = "hackrf-${version}";
-  version = "2017.02.1";
+  version = "2018.01.1";
 
-  src = fetchgit {
-    url = "git://github.com/mossmann/hackrf";
-    rev = "refs/tags/v${version}";
-    sha256 = "16hd61icvzaciv7s9jpgm9c8q6m4mwvj97gxrb20sc65p5gjb7hv";
+  src = fetchFromGitHub {
+    owner = "mossmann";
+    repo = "hackrf";
+    rev = "v${version}";
+    sha256 = "0idh983xh6gndk9kdgx5nzz76x3mxb42b02c5xvdqahadsfx3b9w";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Minor version bump.
https://github.com/mossmann/hackrf/releases

###### Things done
Use fetchFromGitHub instead of fetchgit

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

