### PR TITLE
libsass: 3.5.4 -> 3.5.5

### DIFF
--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -2,20 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "libsass-${version}";
-  version = "3.5.4";
+  version = "3.5.5";
 
   src = fetchurl {
     url = "https://github.com/sass/libsass/archive/${version}.tar.gz";
-    sha256 = "0w47hvzmbdpbjx8j83wn8dwcvglpab8abkszf9xfzrpqvb6wnqaz";
+    sha256 = "0w6v1xa00jvfyk4b29ir7dfkhiq72anz015gg580bi7x3n7saz28";
   };
-
-  patches = [
-    # CVE-2018-11693, is in master but no release yet
-    (fetchpatch {
-      url = "https://github.com/sass/libsass/commit/af0e12cdf09d43dbd1fc11e3f64b244277cc1a1e.patch";
-      sha256 = "1y8yvjvvz91lcr1kpq2pw8729xhdgp15mbldcw392pfzdlliwdyl";
-    })
-  ];
 
   preConfigure = ''
     export LIBSASS_VERSION=${version}


### PR DESCRIPTION
###### Motivation for this change
3.5.5 reverts the css import breaking behaviour from 3.5.3:
https://github.com/sass/libsass/releases

It also contains the included security patch, which could be therefore removed:
https://github.com/sass/libsass/commits/3.5.5

Not totally sure on backporting - this update breaks the current behaviour, but if you define the current behaviour as broken, for which there are reasons, it's more of an un-breaking than a breaking change.

Maintainers: @codyopel @offlinehacker

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

