### PR TITLE
libosmocore: 0.9.6 -> 0.12.1

### DIFF
--- a/pkgs/applications/misc/gnuradio/gsm.nix
+++ b/pkgs/applications/misc/gnuradio/gsm.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "Gnuradio block for gsm";
     homepage = https://github.com/ptrkrysik/gr-gsm;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/gnuradio/limesdr.nix
+++ b/pkgs/applications/misc/gnuradio/limesdr.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
     description = "Gnuradio source and sink blocks for LimeSDR";
     homepage = https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio;
     license = licenses.mit;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux;
     maintainers = [ maintainers.markuskowa ];
   };
 }

--- a/pkgs/applications/misc/libosmocore/default.nix
+++ b/pkgs/applications/misc/libosmocore/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "libosmocore";
     homepage = https://github.com/osmocom/libosmocore;
     license = licenses.gpl2Plus;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ mog ];
   };
 }

--- a/pkgs/applications/misc/libosmocore/default.nix
+++ b/pkgs/applications/misc/libosmocore/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, pcsclite, talloc, python2
+, pcsclite, talloc, python2, gnutls
 }:
 
 stdenv.mkDerivation rec {
   name = "libosmocore-${version}";
-  version = "0.9.6";
+  version = "0.12.1";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "libosmocore";
-    rev = "3cc757df1822114bf446dc2d5f6a95da92321a25";
-    sha256 = "0dk7065qcy2kjra0p8q2124p73jcyvvzz3cmhid1kx5scyxmr017";
+    rev = version;
+    sha256 = "140c9jii0qs00s50kji1znc2339s22x8sz259x4pj35rrjzyyjgp";
   };
 
   propagatedBuildInputs = [
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    pcsclite python2
+    pcsclite python2 gnutls
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16848,7 +16848,8 @@ in
 
   gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {
     inherit (python2Packages) python;
-    extraPackages = [ gnuradio-nacl gnuradio-osmosdr gnuradio-gsm gnuradio-ais gnuradio-rds gnuradio-limesdr ];
+    extraPackages = [ gnuradio-nacl gnuradio-osmosdr gnuradio-ais gnuradio-rds ]
+      ++ lib.optionals stdenv.isLinux [ gnuradio-gsm gnuradio-limesdr ];
   };
 
   gnuradio-nacl = callPackage ../applications/misc/gnuradio/nacl.nix { };


### PR DESCRIPTION
###### Motivation for this change
Update the rather old version. Should now be picked up by auto updater.

###### Things done
Add gnutls to buildInputs

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

