### PR TITLE
bazel: 0.18.0 -> 0.20.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel-deps/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-deps/default.nix
@@ -21,6 +21,11 @@ buildBazelPackage rec {
 
   bazelTarget = "//src/scala/com/github/johnynek/bazel_deps:parseproject_deploy.jar";
 
+  bazelFlags = [
+    "--java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8"
+    "--host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8"
+  ];
+
   buildInputs = [ git makeWrapper ];
 
   fetchAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -14,7 +14,7 @@ let
   srcDeps = lib.singleton (
     fetchurl {
       url = "https://github.com/google/desugar_jdk_libs/archive/fd937f4180c1b557805219af4482f1a27eb0ff2b.zip";
-      sha256 = "04hs399340xfwcdajbbcpywnb2syp6z5ydwg966if3hqdb2zrf23";
+      sha256 = "43b8fcc56a180e178d498f375fbeb95e8b65b9bf6c2da91ae3ae0332521a1a12";
     }
   );
 
@@ -28,7 +28,7 @@ let
 in
 stdenv.mkDerivation rec {
 
-  version = "0.18.0";
+  version = "0.20.0";
 
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "0mbi4n4wp1x73l8qksg4vyh2sba52xh9hfl2m518gv41g0pnvs6h";
+    sha256 = "1g9hglly5199gcw929fzc5f0d0dwlharkh387h58p1fq9ylayi8r";
   };
 
   sourceRoot = ".";
@@ -131,10 +131,10 @@ stdenv.mkDerivation rec {
       echo "build --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\"" >> .bazelrc
       echo "build --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\"" >> .bazelrc
       echo "build --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\"" >> .bazelrc
-      sed -i -e "378 a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
-      sed -i -e "378 a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
-      sed -i -e "378 a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
-      sed -i -e "378 a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "421 a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "421 a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "421 a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "421 a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
 
       # --experimental_strict_action_env (which will soon become the
       # default, see bazelbuild/bazel#2574) hardcodes the default
@@ -186,6 +186,10 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     export TEST_TMPDIR=$(pwd)
     ./output/bazel test --test_output=errors \
+        --host_javabase=@bazel_tools//tools/jdk:absolute_javabase \
+        --define=ABSOLUTE_JAVABASE=$JAVA_HOME \
+        --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
+        --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
         examples/cpp:hello-success_test \
         examples/java-native/src/test/java/com/example/myproject:hello
   '';
@@ -212,6 +216,10 @@ stdenv.mkDerivation rec {
 
     hello_test () {
       $out/bin/bazel test --test_output=errors \
+        --host_javabase=@bazel_tools//tools/jdk:absolute_javabase \
+        --define=ABSOLUTE_JAVABASE=$JAVA_HOME \
+        --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
+        --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
         examples/cpp:hello-success_test \
         examples/java-native/src/test/java/com/example/myproject:hello
     }


### PR DESCRIPTION
###### Motivation for this change

Upgrading Bazel. Tested `bazel`, `bazel_jdk11`, `bazel-watcher`, `bazel-deps`, `pythonPackages.tensorflow`, `pythonPackages27.tensorflow`, `pythonPackages36.tensorflow`.
`bazel-watcher` requires https://github.com/NixOS/nixpkgs/pull/51723.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

