### PR TITLE
lvm2: 2.02.177 -> 2.03.01

### DIFF
--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, systemd, udev, utillinux, libuuid
-, thin-provisioning-tools, enable_dmeventd ? false }:
+{ stdenv, fetchgit, fetchpatch, pkgconfig, systemd, udev, utillinux, libuuid
+, thin-provisioning-tools, libaio
+, enable_dmeventd ? false }:
 
 let
-  version = "2.02.177";
+  version = "2.03.01";
 in
 
 stdenv.mkDerivation {
   name = "lvm2-${version}";
 
-  src = fetchurl {
-    url = "ftp://sources.redhat.com/pub/lvm2/releases/LVM2.${version}.tgz";
-    sha256 = "1wl0isn0yz5wvglwylnlqkppafwmvhliq5bd92vjqp5ir4za49a0";
+  src = fetchgit {
+    url = "git://sourceware.org/git/lvm2.git";
+    rev = "v${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "0jlaswf1srdxiqpgpp97j950ddjds8z0kr4pbwmal2za2blrgvbl";
   };
 
   configureFlags = [
@@ -27,7 +29,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ udev libuuid thin-provisioning-tools ];
+  buildInputs = [ udev libuuid thin-provisioning-tools libaio ];
 
   preConfigure =
     ''

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, flex, bison, python
+{ stdenv, fetchurl, fetchpatch, flex, bison, python
 , gettext, ncurses, libusb, freetype, qemu, lvm2, unifont, pkgconfig
 , fuse # only needed for grub-mount
 , zfs ? null
@@ -82,7 +82,16 @@ stdenv.mkDerivation rec {
       unset CPP # setting CPP intereferes with dependency calculation
     '';
 
-  patches = [ ./fix-bash-completion.patch ];
+  patches = [
+    ./fix-bash-completion.patch
+    # This patch makes grub compatible with the XFS sparse inode
+    # feature introduced by xfsprogs-4.16.
+    # to be removed in grub-2.03
+    (fetchpatch {
+      url = https://git.savannah.gnu.org/cgit/grub.git/patch/?id=cda0a857dd7a27cd5d621747464bfe71e8727fff;
+      sha256 = "0k9qrkdxwdqk6sz05q9smqwjr6pvgc9adx1mlf0807g4im91xnm0";
+    })
+  ];
 
   configureFlags = [ "--enable-grub-mount" ] # dep of os-prober
     ++ optional zfsSupport "--enable-libzfs"


### PR DESCRIPTION
###### Motivation for this change
Version bump. Switched the source to the git repository. Should now be fit for the auto updater.

CC @7c6f434c 

###### Things done
* switch to sources to git
* add `libaio` to `buildInputs`
* Fix grub (fallout from xfsprogs-4.19 update).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

