### PR TITLE
displaylink: 4.1.9 -> 4.4.24

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
       comply with DisplayLink's EULA and download the binaries and
       sources from here:
 
-      http://www.displaylink.com/downloads/file?id=1087
+      http://www.displaylink.com/downloads/file?id=1261
 
       Once you have downloaded the file, please use the following
       commands and re-run the installation:

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -11,11 +11,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "displaylink-${version}";
-  version = "4.1.9";
+  version = "4.4.24";
 
   src = requireFile rec {
     name = "displaylink.zip";
-    sha256 = "d762145014df7fea8ca7af12206a077d73d8e7f2259c8dc2ce7e5fb1e69ef9a3";
+    sha256 = "0c02mg7vbijpfpk9imh0hmls1yiglc216zfllw5ar86r1slhd5y0";
     message = ''
       In order to install the DisplayLink drivers, you must first
       comply with DisplayLink's EULA and download the binaries and


### PR DESCRIPTION
###### Motivation for this change
Bumping the version to the latest displaylink version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

