### PR TITLE
displaylink: changed systemd start to not block

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
   '';
 
   patches = [ (substituteAll {
-    src = ./fix-script.patch;
+    src = ./udev-installer.patch;
     inherit systemd;
   })];
 

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, unzip, utillinux,
-  libusb1, evdi, systemd, makeWrapper, requireFile }:
+  libusb1, evdi, systemd, makeWrapper, requireFile, substituteAll }:
 
 let
   arch =
@@ -33,18 +33,23 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip makeWrapper ];
 
-  buildCommand = ''
+  unpackPhase = ''
     unzip $src
     chmod +x displaylink-driver-${version}.run
     ./displaylink-driver-${version}.run --target . --noexec
+  '';
 
+  patches = [ (substituteAll {
+    src = ./fix-script.patch;
+    inherit systemd;
+  })];
+
+  installPhase = ''
     sed -i "s,/opt/displaylink/udev.sh,$out/lib/udev/displaylink.sh,g" udev-installer.sh
     ( source udev-installer.sh
       mkdir -p $out/lib/udev/rules.d
       main systemd "$out/lib/udev/rules.d/99-displaylink.rules" "$out/lib/udev/displaylink.sh"
     )
-    sed -i '2iPATH=${systemd}/bin:$PATH' $out/lib/udev/displaylink.sh
-    sed -i 's,systemctl start,systemctl start --no-block,g' $out/lib/udev/displaylink.sh
 
     install -Dt $out/lib/displaylink *.spkg
     install -Dm755 ${bins}/DisplayLinkManager $out/bin/DisplayLinkManager
@@ -54,12 +59,11 @@ in stdenv.mkDerivation rec {
       $out/bin/DisplayLinkManager
     wrapProgram $out/bin/DisplayLinkManager \
       --run "cd $out/lib/displaylink"
-
-    fixupPhase
   '';
 
   dontStrip = true;
   dontPatchELF = true;
+
 
   meta = with stdenv.lib; {
     description = "DisplayLink DL-5xxx, DL-41xx and DL-3x00 Driver for Linux";

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -44,6 +44,7 @@ in stdenv.mkDerivation rec {
       main systemd "$out/lib/udev/rules.d/99-displaylink.rules" "$out/lib/udev/displaylink.sh"
     )
     sed -i '2iPATH=${systemd}/bin:$PATH' $out/lib/udev/displaylink.sh
+    sed -i 's,systemctl start,systemctl start --no-block,g' $out/lib/udev/displaylink.sh
 
     install -Dt $out/lib/displaylink *.spkg
     install -Dm755 ${bins}/DisplayLinkManager $out/bin/DisplayLinkManager

--- a/pkgs/os-specific/linux/displaylink/udev-installer.patch
+++ b/pkgs/os-specific/linux/displaylink/udev-installer.patch
@@ -5,7 +5,7 @@
  start_service()
  {
 -  systemctl start dlm
-+  @systemd@/bin/systemctl start dlm
++  @systemd@/bin/systemctl start --no-block dlm
  }
  
  stop_service()

--- a/pkgs/os-specific/linux/displaylink/udev-installer.patch
+++ b/pkgs/os-specific/linux/displaylink/udev-installer.patch
@@ -1,0 +1,18 @@
+--- a/udev-installer.sh	2018-12-09 12:05:53.772318942 +0100
++++ b/udev-installer.sh	2018-12-09 12:06:19.939947629 +0100
+@@ -21,12 +21,12 @@
+   cat <<'EOF'
+ start_service()
+ {
+-  systemctl start dlm
++  @systemd@/bin/systemctl start dlm
+ }
+ 
+ stop_service()
+ {
+-  systemctl stop dlm
++  @systemd@/bin/systemctl stop dlm
+ }
+ 
+ EOF
+


### PR DESCRIPTION
Previously during boot, displaylink would hang during boot for the 2 minutes timeout.
This fixes issue #51684 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

