### PR TITLE
ant-theme: init at 1.2.0

### DIFF
--- a/pkgs/data/themes/ant-theme/default.nix
+++ b/pkgs/data/themes/ant-theme/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "ant-theme";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/EliverLara/Ant/releases/download/v${version}/Ant.tar";
+    sha256 = "15751pnb94g2wi6y932l3d7ksaz18402zbzp3l7ryy0lqwjnqvkj";
+  };
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes/Ant
+    cp -a * $out/share/themes/Ant
+    rm -r $out/share/themes/Ant/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
+    runHook postInstall
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1fzy7bq5v9fzjpfxplvk0nwjgamcva83462gkz01lhr1mipb92h1";
+
+  meta = with stdenv.lib; {
+    description = "A flat and light theme with a modern look";
+    homepage = https://github.com/EliverLara/Ant;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [
+      maintainers.pbogdan
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15219,6 +15219,8 @@ in
 
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
+  ant-theme = callPackage ../data/themes/ant-theme { };
+
   arc-icon-theme = callPackage ../data/icons/arc-icon-theme { };
 
   arkpandora_ttf = callPackage ../data/fonts/arkpandora { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

