### PR TITLE
Metamath: init at 0.167

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4278,6 +4278,11 @@
     github = "talyz";
     name = "Kim Lindberger";
   };
+  taneb = {
+    email = "nvd1234@gmail.com";
+    github = "Taneb";
+    name = "Nathan van Doorn";
+  };
   tari = {
     email = "peter@taricorp.net";
     github = "tari";

--- a/pkgs/development/interpreters/metamath/default.nix
+++ b/pkgs/development/interpreters/metamath/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "metamath-${version}";
+  version = "0.167";
+
+  buildInputs = [ autoreconfHook ];
+
+  # This points to my own repository because there is no official repository
+  # for metamath; there's a download location but it gets updated in place with
+  # no permanent link. See discussion at
+  # https://groups.google.com/forum/#!topic/metamath/N4WEWQQVUfY
+  src = fetchFromGitHub {
+    owner = "Taneb";
+    repo = "metamath";
+    rev = "579166a649c5d9ae0cdc641185e68219d2812f24";
+    sha256 = "0ly7qv3gajlaf283fsy9ak41r09sh49ygzj0s9yxyjfli6rgxdby";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Interpreter for the metamath proof language";
+    longDescription = ''
+      The metamath program is an ASCII-based ANSI C program with a command-line
+      interface. It was used (along with mmj2) to build and verify the proofs
+      in the Metamath Proof Explorer, and it generated its web pages. The *.mm
+      ASCII databases (set.mm and others) are also included in this derivation.
+    '';
+    homepage = http://us.metamath.org;
+    downloadPage = "http://us.metamath.org/#downloads";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.taneb ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7779,6 +7779,8 @@ in
 
   mesos-dns = callPackage ../servers/mesos-dns { };
 
+  metamath = callPackage ../development/interpreters/metamath { };
+
   mujs = callPackage ../development/interpreters/mujs { };
 
   nix-exec = callPackage ../development/interpreters/nix-exec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

