### PR TITLE
[WIP] mpd: 0.20.23 -> 0.21.3

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -18,7 +18,9 @@ let
     ''}
     state_file          "${cfg.dataDir}/state"
     sticker_file        "${cfg.dataDir}/sticker.sql"
+    ${lib.optionalString (lib.versionOlder pkgs.mpd.version "0.21.0") ''
     log_file            "syslog"
+    ''}
     user                "${cfg.user}"
     group               "${cfg.group}"
 
@@ -144,6 +146,7 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.mpd ];
 
     systemd.sockets.mpd = mkIf cfg.startWhenNeeded {
       description = "Music Player Daemon Socket";

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -4,15 +4,11 @@
 , systemd
 
 # database plugins
-, upnpSupport ? false, libupnp ? null
 , clientSupport ? true, mpd_clientlib
 
 # storage plugins
-, udisksSupport ? false, udisks2 ? null
-, webdavSupport ? false
 
 # input plugins
-, cdioParanoiaSupport ? false, libcdio ? null, libcdio-paranoia ? null
 , curlSupport ? true, curl
 , mmsSupport ? true, glib, libmms
 , nfsSupport ? true, libnfs
@@ -20,20 +16,15 @@
 
 # commercial services
 , soundcloudSupport ? true
-, qobuzSupport ? false, libgcrypt ? null
-, tidalSupport ? false
 
 # archive plugins
 , bzip2Support ? true, bzip2
-, iso9660Support ? false
 , zipSupport ? true, zziplib
 
 # tag plugins
 , id3tagSupport ? true, libid3tag
-, chromaprintSupport ? false, chromaprint ? null
 
 # decoder plugins
-# , adplugSupport ? false
 , audiofileSupport ? true, audiofile
 , aacSupport ? true, faad2
 , ffmpegSupport ? true, ffmpeg
@@ -42,94 +33,40 @@
 , gmeSupport ? true, game-music-emu
 , madSupport ? true, libmad
 , mikmodSupport ? true, libmikmod
-, modplugSupport ? false, libmodplug ? null
-, mpcdecSupport ? false, libmpcdec ? null
 , mpg123Support ? true, mpg123
 , opusSupport ? true, libopus, libogg
-, sidplaySupport ? false, libsidplayfp ? null
-, sndfileSupport ? false, libsndfile ? null
 , vorbisSupport ? true, libvorbis
-, wavpackSupport ? false, wavpack ? null
-, wildmidiSupport ? false, wildmidi ? null
 
 # encoder plugins
 , vorbisencSupport ? true
 , lameSupport ? true, lame
-, twolameSupport ? false, twolame ? null
-# , shineSupport ? false
 
 # filter plugins
 , samplerateSupport ? true, libsamplerate
-, soxrSupport ? false, soxr ? null
 
 # output plugins
 , alsaSupport ? true, alsaLib
 , aoSupport ? true, libao
 , jackSupport ? true, libjack2
-, openalSupport ? false, openal ? null
 , ossSupport ? true
 , pulseaudioSupport ? true, libpulseaudio
 , shoutSupport ? true, libshout
-# , sndioSupport ? false
-, solarisOutputSupport ? false
 
 # misc libraries
 , dbusSupport ? true, dbus
-, expatSupport ? false, expat
 , icuSupport ? true, icu
 , iconvSupport ? true
-, libwrapSupport ? false, tcp_wrappers ? null
 , pcreSupport ? true, pcre
 , sqliteSupport ? true, sqlite
 , yajlSupport ? true, yajl
-, zlibSupport ? false, zlib ? null
 
 # this should be zeroconf support
 , avahiSupport ? true, avahi
 }:
 
-assert upnpSupport -> libupnp != null;
-assert upnpSupport -> curlSupport == true;
-assert upnpSupport -> expatSupport == true;
-
-assert udisksSupport -> udisks2 != null;
-assert udisksSupport -> dbusSupport == true;
-
-assert cdioParanoiaSupport -> libcdio != null && libcdio-paranoia != null;
-
-assert iso9660Support -> libcdio != null;
-
-assert chromaprintSupport -> chromaprint != null;
-
-assert modplugSupport -> libmodplug != null;
-
-assert mpcdecSupport -> libmpcdec != null;
-
-assert sidplaySupport -> libsidplayfp  != null;
-
-assert sndfileSupport -> libsndfile != null;
-
-assert wavpackSupport -> wavpack != null;
-
-assert wildmidiSupport -> wildmidi != null;
-
-assert twolameSupport -> twolame != null;
-
-assert soxrSupport -> soxr != null;
-
-assert openalSupport -> openal != null;
-
-assert webdavSupport -> curlSupport == true;
-assert webdavSupport -> expatSupport == true;
-
-assert libwrapSupport -> tcp_wrappers != null;
-
-assert zlibSupport -> zlib != null;
 
 assert soundcloudSupport -> curlSupport == true;
 assert soundcloudSupport -> yajlSupport == true;
-
-assert qobuzSupport -> libgcrypt != null;
 
 assert vorbisencSupport -> vorbisSupport == true;
 
@@ -164,25 +101,19 @@ in stdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.CoreAudioKit
   ]
     # database plugins
-    ++ optional upnpSupport libupnp
     ++ optional clientSupport mpd_clientlib
     # storage plugins
-    ++ optional udisksSupport udisks2
     # input plugins
-    ++ optionals cdioParanoiaSupport [ libcdio libcdio-paranoia ]
     ++ optional curlSupport curl
     ++ optionals mmsSupport [ glib libmms ]
     ++ optional (!stdenv.isDarwin && nfsSupport) libnfs
     ++ optional (!stdenv.isDarwin && smbSupport) samba
     # commercial services
-    ++ optional qobuzSupport libgcrypt
     # archive plugins
     ++ optional bzip2Support bzip2
-    ++ optional iso9660Support libcdio
     ++ optional zipSupport zziplib
     # tag plugins
     ++ optional id3tagSupport libid3tag
-    ++ optional chromaprintSupport chromaprint
     # decoder plugins
     ++ optional audiofileSupport audiofile
     ++ optional aacSupport faad2
@@ -194,37 +125,25 @@ in stdenv.mkDerivation rec {
     # is probably a solution, but I'm disabling it for now
     ++ optional (!stdenv.isDarwin && madSupport) libmad
     ++ optional mikmodSupport libmikmod
-    ++ optional modplugSupport libmodplug
-    ++ optional mpcdecSupport libmpcdec
     ++ optional mpg123Support mpg123
     ++ optionals opusSupport [ libopus libogg ]
-    ++ optional sidplaySupport libsidplayfp
-    ++ optional sndfileSupport libsndfile
     ++ optional vorbisSupport libvorbis
-    ++ optional wavpackSupport wavpack
-    ++ optional wildmidiSupport wildmidi
     # encoder plugins
     ++ optional lameSupport lame
-    ++ optional twolameSupport twolame
     # filter plugins
     ++ optional samplerateSupport libsamplerate
-    ++ optional soxrSupport soxr
     # output plugins
     ++ optional (stdenv.isLinux && alsaSupport) alsaLib
     ++ optional aoSupport libao
     ++ optional (!stdenv.isDarwin && jackSupport) libjack2
-    ++ optional openalSupport openal
     ++ optional (!stdenv.isDarwin && pulseaudioSupport) libpulseaudio
     ++ optional shoutSupport libshout
     # misc libraries
     ++ optional dbusSupport dbus
-    ++ optional expatSupport expat
     ++ optional icuSupport icu
-    ++ optional libwrapSupport tcp_wrappers
     ++ optional pcreSupport pcre
     ++ optional sqliteSupport sqlite
     ++ optional yajlSupport yajl
-    ++ optional zlibSupport zlib
 
     ++ optional avahiSupport avahi
   ;
@@ -247,30 +166,21 @@ in stdenv.mkDerivation rec {
     "-Dsystemd_user_unit_dir=${placeholder "out"}/etc/systemd/user"
   ] ++ [
     # database plugins
-    (feature upnpSupport "upnp")
     (feature clientSupport "libmpdclient")
     # storage plugins
-    (feature udisksSupport "udisks")
-    (feature webdavSupport "webdav")
     # input plugins
-    (feature cdioParanoiaSupport "cdio_paranoia")
     (feature curlSupport "curl")
     (feature mmsSupport "mms")
     (feature (!stdenv.isDarwin && nfsSupport) "nfs")
     (feature (!stdenv.isDarwin && smbSupport) "smbclient")
     # commercial services
     (feature soundcloudSupport "soundcloud")
-    (feature qobuzSupport "qobuz")
-    (feature tidalSupport "tidal")
     # archive plugins
     (feature bzip2Support "bzip2")
-    (feature iso9660Support "iso9660")
     (feature zipSupport "zzip")
     # tag plugins
     (feature id3tagSupport "id3tag")
-    (feature chromaprintSupport "chromaprint")
     # decoder plugins
-    # (feature adplugSupport "adplug")
     (feature audiofileSupport "audiofile")
     (feature aacSupport "faad")
     (feature ffmpegSupport "ffmpeg")
@@ -279,42 +189,28 @@ in stdenv.mkDerivation rec {
     (feature gmeSupport "gme")
     (feature (!stdenv.isDarwin && madSupport) "mad")
     (feature mikmodSupport "mikmod")
-    (feature modplugSupport "modplug")
-    (feature mpcdecSupport "mpcdec")
     (feature mpg123Support "mpg123")
     (feature opusSupport "opus")
-    (feature sidplaySupport "sidplay")
-    (feature sndfileSupport "sndfile")
     (feature vorbisSupport "vorbis")
-    (feature wavpackSupport "wavpack")
-    (feature wildmidiSupport "wildmidi")
     # encoder plugins
     (feature vorbisencSupport "vorbisenc")
     (feature lameSupport "lame")
-    (feature twolameSupport "twolame")
     # filter plugins
     (feature samplerateSupport "libsamplerate")
-    (feature soxrSupport "soxr")
     # output plugins
     (feature (stdenv.isLinux && alsaSupport) "alsa")
     (feature aoSupport "ao")
     (feature (!stdenv.isDarwin && jackSupport) "jack")
-    (feature openalSupport "openal")
     (feature ossSupport "oss")
     (feature (!stdenv.isDarwin && pulseaudioSupport) "pulse")
     (feature shoutSupport "shout")
-    # (feature sndioSupport "sndio")
-    (feature solarisOutputSupport "solaris_output")
     # misc libraries
     (feature dbusSupport "dbus")
-    (feature expatSupport "expat")
     (feature icuSupport "icu")
     (feature iconvSupport "iconv")
-    (feature libwrapSupport "libwrap")
     (feature pcreSupport "pcre")
     (feature sqliteSupport "sqlite")
     (feature yajlSupport "yajl")
-    (feature zlibSupport "zlib")
     (optionalString avahiSupport "-Dzeroconf=avahi")
   ];
 


### PR DESCRIPTION
https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/v0.21.3/NEWS

###### Motivation for this change

Update to the latest release.

(Among other changes) upstream switched the build system to meson, and as neither the flag names nor semantics of enabling / disabling flags match the autoconf build this makes the diff rather large.

Also since I had to go through meson build options anyway to map the current features to their new flag names I added a bunch of new flags. Probably doesn't make sense to keep all of them but figured might show what's available in the new build system. Feature-wise this build should match the current derivation and shouldn't enable / disable any new features.

I also may have inadvertently broken support for platforms other that x86_64-linux as I'm unable to test outside that platform.

Finally, this isn't tested heavily. My own personal setup is extremely simple and I'm not even sure how to check many of the features (that are enabled by default).

Anyway, had these changes sitting around for a while so figured might open a PR in case it's helpful at all and helps with the update. Should at least take care of the tediousness of mapping things to the new build system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

