### PR TITLE
cyrus_sasl: merge PR #51651 into master 

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -24,12 +24,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./missing-size_t.patch # https://bugzilla.redhat.com/show_bug.cgi?id=906519
     ./cyrus-sasl-ac-try-run-fix.patch
-  ] ++ lib.optional stdenv.isFreeBSD (
-      fetchurl {
-        url = "http://www.linuxfromscratch.org/patches/blfs/svn/cyrus-sasl-2.1.26-fixes-3.patch";
-        sha256 = "1vh4pc2rxxm6yvykx0b7kg09jbcwcxwv5rs6yq2ag3y8p6a9x86w";
-      }
-    );
+  ];
 
   configureFlags = [
     "--with-openssl=${openssl.dev}"

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -36,12 +36,6 @@ stdenv.mkDerivation rec {
 
   installFlags = lib.optional stdenv.isDarwin [ "framedir=$(out)/Library/Frameworks/SASL2.framework" ];
 
-  postInstall = ''
-    for f in $out/lib/*.la $out/lib/sasl2/*.la; do
-      substituteInPlace $f --replace "${openssl.dev}/lib" "${openssl.out}/lib"
-    done
-  '';
-
   meta = {
     homepage = https://www.cyrusimap.org/sasl;
     description = "Library for adding authentication support to connection-based protocols";

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, openssl, openldap, kerberos, db, gettext
 , pam, fixDarwinDylibNames, autoreconfHook, fetchpatch, enableLdap ? false
-, buildPackages }:
+, buildPackages, pruneLibtoolFiles }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ autoreconfHook fixDarwinDylibNames ];
+  nativeBuildInputs = [ autoreconfHook fixDarwinDylibNames pruneLibtoolFiles ];
   buildInputs =
     [ openssl db gettext kerberos ]
     ++ lib.optional enableLdap openldap


### PR DESCRIPTION
###### Motivation for this change

Without this qemu is broken in master, it probably shouldn't be.

The original PR made its way into the `staging-next` branch but not before that branch was merged into master.

It is a mass-rebuild on master but without this fix no NixOS tests can be run which doesn't seem ideal.

Not sure what else could be done short of waiting for another `staging-next` merge which seems to have already accumulated some other changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

