### PR TITLE
ocamlPackages.elina: init at 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, perl, gmp, mpfr, ocaml, findlib, camlidl, apron }:
+
+stdenv.mkDerivation rec {
+  version = "1.1";
+  name = "ocaml${ocaml.version}-elina-${version}";
+  src = fetchurl {
+    url = "http://files.sri.inf.ethz.ch/elina-${version}.tar.gz";
+    sha256 = "1nymykskq1yx87y4xl6hl9i4q6kv0qaq25rniqgl1bfn883p1ysc";
+  };
+
+  buildInputs = [ perl ocaml findlib ];
+
+  propagatedBuildInputs = [ apron camlidl gmp mpfr ];
+
+  prefixKey = "--prefix ";
+  configureFlags = [
+    "--use-apron"
+    "--use-opam"
+    "--apron-prefix" "${apron}"
+  ]
+  ++ stdenv.lib.optional stdenv.isDarwin "--absolute-dylibs"
+  ;
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "ETH LIbrary for Numerical Analysis";
+    homepage = "http://elina.ethz.ch/";
+    license = stdenv.lib.licenses.lgpl3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -226,6 +226,8 @@ let
 
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
+    elina = callPackage ../development/ocaml-modules/elina { };
+
     eliom = callPackage ../development/ocaml-modules/eliom {
       js_of_ocaml-lwt = js_of_ocaml-lwt.override {
         ocaml_lwt = lwt3;


### PR DESCRIPTION
ELINA contains optimized implementations of popular numerical abstract domains
such as Polyhedra, Octagon and Zones for static analysis.

homepage: http://elina.ethz.ch/

###### Motivation for this change

https://discourse.nixos.org/t/install-ocaml-flambda-compiler/1618

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

