### PR TITLE
openssl_1_1: Add "doc" output to contain HTML documentation

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -7,7 +7,7 @@
 with stdenv.lib;
 
 let
-  common = args@{ version, sha256, patches ? [] }: stdenv.mkDerivation rec {
+  common = args@{ version, sha256, patches ? [], withDocs ? false }: stdenv.mkDerivation rec {
     name = "openssl-${version}";
 
     src = fetchurl {
@@ -33,7 +33,7 @@ let
                   '!defined(__ANDROID__) && !defined(__OpenBSD__) && 0'
     '';
 
-    outputs = [ "bin" "dev" "out" "man" ];
+    outputs = [ "bin" "dev" "out" "man" ] ++ optional withDocs "doc";
     setOutputFlags = false;
     separateDebugInfo = stdenv.hostPlatform.isLinux;
 
@@ -135,6 +135,7 @@ in {
     version = "1.1.1a";
     sha256 = "0hcz7znzznbibpy3iyyhvlqrq44y88plxwdj32wjzgbwic7i687w";
     patches = [ ./1.1/nix-ssl-cert-file.patch ];
+    withDocs = true;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
This prevents cluttering up openssl_1_1.out with many megabytes of
documentation.

Fixes #51659

`nix path-info -S` on all outputs (removes ~4MiB):
```
/nix/store/b0grh9y7jha1bqylys19nhlhgla5c0li-openssl-1.1.1a      	   33366856
/nix/store/ayag935jq2v3f815l71axzixgki36q9s-openssl-1.1.1a-bin  	   99291400
/nix/store/wxzrd0k1y040hkgjcya4s3w59skdd46q-openssl-1.1.1a-debug	  178042592
/nix/store/7r9cmd94zybr6c4d2wyv1j2mkv15mkqc-openssl-1.1.1a-dev  	  100675240
/nix/store/f2v9hm0n6a7yqsim2z84515vsrbk36g0-openssl-1.1.1a-man  	    2991344

/nix/store/hmdb0z6428q3x816c4zcgxkfbl9qmgl0-openssl-1.1.1a      	   29183200
/nix/store/scln0ian29fiph1f31cagzg1j67r8dgm-openssl-1.1.1a-bin  	   95107744
/nix/store/5gkvli9rj2ki07m5bywyksmqdhgc52m8-openssl-1.1.1a-debug	  178042592
/nix/store/z8j2k6anpa7hhw14wx9kvc0if2bzd8wr-openssl-1.1.1a-dev  	   96491584
/nix/store/wjw5mfwzcsfrpkhixc9ghcjsh3rcfz41-openssl-1.1.1a-man  	    2991344
/nix/store/qxsdprn78ci05m386xk320zbblf4kf5v-openssl-1.1.1a-doc  	    4183752
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @joachifm 