### PR TITLE
rtl-sdr: remove linker-fix.patch, unbreak on darwin

### DIFF
--- a/pkgs/applications/misc/rtl-sdr/default.nix
+++ b/pkgs/applications/misc/rtl-sdr/default.nix
@@ -26,13 +26,7 @@ stdenv.mkDerivation rec {
     grep -q "Requires:" "$pcfile" && { echo "Upstream has added 'Requires:' in $(basename "$pcfile"); update nix expression."; exit 1; }
     echo "Requires: libusb-1.0" >> "$pcfile"
   '';
-  patches = lib.optionals stdenv.isDarwin [
-    (fetchpatch {
-      name = "linker-fix.patch";
-      url = "https://github.com/lukeadams/rtl-sdr/commit/7a66dcf268305b5aa507d1756799942c74549b72.patch";
-      sha256 = "0cn9fyf4ay4i3shvxj1ivgyxjvfm401irk560jdjl594nzadrcsl";
-    })
-  ];
+
   meta = with stdenv.lib; {
     description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
     homepage = http://sdr.osmocom.org/trac/wiki/rtl-sdr;


### PR DESCRIPTION
###### Motivation for this change
The linker patch for darwin does not succeed on rtl-sdr-0.6.0. This enables building of rtl-sdr on darwin again.

CC @lukeadams 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

