### PR TITLE
ipmicfg: 1.28.0 -> 1.29.0

### DIFF
--- a/pkgs/applications/misc/ipmicfg/default.nix
+++ b/pkgs/applications/misc/ipmicfg/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "ipmicfg-${version}";
-  version = "1.28.0";
-  buildVersion = "180302";
+  version = "1.29.0";
+  buildVersion = "181029";
 
   src = fetchzip {
     url = "ftp://ftp.supermicro.com/utility/IPMICFG/IPMICFG_${version}_build.${buildVersion}.zip";
-    sha256 = "0hw853cwaaxmxy1sa3m7l9gqalwpbbvp4ghk8inr7dzwxjljmr02";
+    sha256 = "18nljs4xg6hffahyd0d5zlg1jhbwl7zr9ym925bkzwcnrkgqs2v3";
     extraPostFetch = "chmod u+rwX,go-rwx+X $out/";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Package update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

