### PR TITLE
giac: 1.4.9 -> 1.5.0

### DIFF
--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, texlive, bison, flex, liblapack
-, gmp, mpfr, pari, ntl, gsl, blas, mpfi
+, gmp, mpfr, pari, ntl, gsl, blas, mpfi, ecm, glpk
 , readline, gettext, libpng, libao, gfortran, perl
 , enableGUI ? false, libGLU_combined ? null, xorg ? null, fltk ? null
 }:
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
 
   # perl is only needed for patchShebangs fixup.
   buildInputs = [
-    gmp mpfr pari ntl gsl blas mpfi
-    readline gettext libpng libao perl
+    gmp mpfr pari ntl gsl blas mpfi glpk
+    readline gettext libpng libao perl ecm
     # gfortran.cc default output contains static libraries compiled without -fPIC
     # we want libgfortran.so.3 instead
     (stdenv.lib.getLib gfortran.cc)
@@ -46,6 +46,13 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals enableGUI [
     libGLU_combined fltk xorg.libX11
   ];
+
+  /* fixes:
+  configure:16211: checking for main in -lntl
+  configure:16230: g++ -o conftest -g -O2   conftest.cpp -lntl  -llapack -lblas -lgfortran -ldl -lpng16 -lm -lmpfi -lmpfr -lgmp  >&5
+  /nix/store/y9c1v4x7y39j2rfbg17agjwqdzxpsn18-ntl-11.3.2/lib/libntl.so: undefined reference to `pthread_key_create'
+  */
+  NIX_CFLAGS_LINK="-lpthread";
 
   # xcas Phys and Turtle menus are broken with split outputs
   # and interactive use is likely to need docs
@@ -66,7 +73,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-gc" "--enable-png" "--enable-gsl" "--enable-lapack"
     "--enable-pari" "--enable-ntl" "--enable-gmpxx" # "--enable-cocoa"
-    "--enable-ao"
+    "--enable-ao" "--enable-ecm" "--enable-glpk"
   ] ++ stdenv.lib.optionals enableGUI [
     "--enable-gui" "--with-x"
   ];

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -9,11 +9,11 @@ assert enableGUI -> libGLU_combined != null && xorg != null && fltk != null;
 stdenv.mkDerivation rec {
   name = "${attr}-${version}";
   attr = if enableGUI then "giac-with-xcas" else "giac";
-  version = "1.4.9-59"; # TODO try to remove preCheck phase on upgrade
+  version = "1.5.0-21"; # TODO try to remove preCheck phase on upgrade
 
   src = fetchurl {
     url = "https://www-fourier.ujf-grenoble.fr/~parisse/debian/dists/stable/main/source/giac_${version}.tar.gz";
-    sha256 = "0dv5p5y6gkrsmz3xa7fw87rjyabwdwk09mqb09kb7gai9n9dgayk";
+    sha256 = "1b9khiv0mk2xzw1rblm2jy6qsf8y6f9k7qy15sxpb21d72hzzbl2";
   };
 
   patches = stdenv.lib.optionals (!enableGUI) [

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -47,7 +47,9 @@ stdenv.mkDerivation rec {
     libGLU_combined fltk xorg.libX11
   ];
 
-  outputs = [ "out" "doc" ];
+  # xcas Phys and Turtle menus are broken with split outputs
+  # and interactive use is likely to need docs
+  outputs = [ "out" ] ++ stdenv.lib.optional (!enableGUI) "doc";
 
   doCheck = true;
   preCheck = ''
@@ -80,9 +82,15 @@ stdenv.mkDerivation rec {
     # reference cycle
     rm "$out/share/giac/doc/el/"{casinter,tutoriel}/Makefile
 
-    mkdir -p "$doc/share/giac"
-    mv "$out/share/giac/doc" "$doc/share/giac"
-    mv "$out/share/giac/examples" "$doc/share/giac"
+    if [ -n "$doc" ]; then
+      mkdir -p "$doc/share/giac"
+      mv "$out/share/giac/doc" "$doc/share/giac"
+      mv "$out/share/giac/examples" "$doc/share/giac"
+    fi
+  '' + stdenv.lib.optionalString (!enableGUI) ''
+    for i in pixmaps application-registry applications icons; do
+      rm -r "$out/share/$i";
+    done;
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, texlive, bison, flex, liblapack
-, gmp, mpfr, pari, ntl, gsl, blas, mpfi, ecm, glpk
+, gmp, mpfr, pari, ntl, gsl, blas, mpfi, ecm, glpk, nauty
 , readline, gettext, libpng, libao, gfortran, perl
 , enableGUI ? false, libGLU_combined ? null, xorg ? null, fltk ? null
 }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   # perl is only needed for patchShebangs fixup.
   buildInputs = [
-    gmp mpfr pari ntl gsl blas mpfi glpk
+    gmp mpfr pari ntl gsl blas mpfi glpk nauty
     readline gettext libpng libao perl ecm
     # gfortran.cc default output contains static libraries compiled without -fPIC
     # we want libgfortran.so.3 instead

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -6,13 +6,20 @@ stdenv.mkDerivation rec {
     url = "http://pallini.di.uniroma1.it/nauty${version}.tar.gz";
     sha256 = "05z6mk7c31j70md83396cdjmvzzip1hqb88pfszzc6k4gy8h3m2y";
   };
+  outputs = [ "out" "dev" ];
   buildInputs = [];
   installPhase = ''
-    mkdir -p "$out"/{bin,share/doc/nauty}
+    mkdir -p "$out"/{bin,share/doc/nauty} "$dev"/{lib,include/nauty}
 
-    cp $(find . -type f -perm -111 \! -name '*.*' ) "$out/bin"
+    find . -type f -perm -111 \! -name '*.*' \! -name configure -exec cp '{}' "$out/bin" \;
     cp [Rr][Ee][Aa][Dd]* COPYRIGHT This* [Cc]hange* "$out/share/doc/nauty"
+
+    cp *.h $dev/include/nauty
+    for i in *.a; do
+      cp "$i" "$dev/lib/lib$i";
+    done
   '';
+  checkTarget = "checks";
   meta = {
     inherit version;
     description = ''Programs for computing automorphism groups of graphs and digraphs'';

--- a/pkgs/applications/science/math/sage/patches/giac-1.5.0.patch
+++ b/pkgs/applications/science/math/sage/patches/giac-1.5.0.patch
@@ -1,0 +1,14 @@
+--- a/src/sage/interfaces/giac.py	2018-12-08 22:11:56.285500644 +0100
++++ b/src/sage/interfaces/giac.py	2018-12-08 22:11:56.285500644 +0100
+@@ -617,10 +617,7 @@
+             '4\n3'
+             sage: s='g(x):={\nx+1;\nx+2;\n}'
+             sage: giac(s)
+-            (x)->{
+-            x+1;
+-            x+2;
+-            }
++            (x)->[x+1,x+2]
+             sage: giac.g(5)
+             7
+         """

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -79,6 +79,9 @@ stdenv.mkDerivation rec {
     # https://trac.sagemath.org/ticket/25260
     ./patches/numpy-1.15.1.patch
 
+    # https://trac.sagemath.org/ticket/26315
+    ./patches/giac-1.5.0.patch
+
     # needed for ntl update
     # https://trac.sagemath.org/ticket/25532
     (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change
update

this also fixes a bug where the xcas ui (notably menus) were broken because of split outputs. Apparently xcas uses its documentation to populate some ui elements.
I added a few optional dependencies.

###### Things done

* built sage with it. Patch sent upstream. cc @timokau 
* modiffied nauty to also install its libraries. cc @7c6f434c as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) only xcas
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

