### PR TITLE
borgbackup: 1.1.7 -> 1.1.8

### DIFF
--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -130,6 +130,9 @@ in {
       # Make sure keepFile has the correct content
       $client->succeed("$borg extract '${localRepo}::${archiveName}'");
       $client->succeed('c=$(cat ${dataDir}/${keepFile}) && [[ "$c" == "${keepFileData}" ]]');
+      # Make sure the same is true when using `borg mount`
+      $client->succeed("mkdir -p /mnt/borg && $borg mount '${localRepo}::${archiveName}' /mnt/borg");
+      $client->succeed('c=$(cat /mnt/borg/${dataDir}/${keepFile}) && [[ "$c" == "${keepFileData}" ]]');
     };
 
     subtest "remote", sub {

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -2,21 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "borgbackup";
-  version = "1.1.7";
+  version = "1.1.8";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "f7b51a132e9edfbe1cacb4f478b28caf3622d79fffcb369bdae9f92d8c8a7fdc";
+    sha256 = "0b4370480ca0114cb0bb534286241af8a35c6ffb71404dfa409ed06099661b63";
   };
-
-  patches = [
-    # Workarounds for https://github.com/borgbackup/borg/issues/4093
-    # Can be deleted when 1.1.8 comes out
-    (fetchpatch {
-      url = "https://github.com/borgbackup/borg/commit/975cc33206e0e3644626fb7204c34d2157715b61.patch";
-      sha256 = "0b7apaixpa7bk0sy7g5ycm98cjpkg5gkwcgm7m37xj35lzxdlxhc";
-    })
-  ];
 
   nativeBuildInputs = with python3Packages; [
     # For building documentation:


### PR DESCRIPTION
###### Motivation for this change
https://borgbackup.readthedocs.io/en/stable/changes.html#version-1-1-8-2018-12-09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

