### PR TITLE
nixos/tests/i3wm: fix terminal title (test is broken on master)

### DIFF
--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -33,7 +33,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       $machine->succeed("su - alice -c 'DISPLAY=:0.0 gnome-terminal &'");
       $machine->succeed("xauth merge ~alice/.Xauthority");
-      $machine->waitForWindow(qr/Terminal/);
+      $machine->waitForWindow(qr/alice.*machine/);
       $machine->succeed("timeout 900 bash -c 'while read msg; do if [[ \$msg =~ \"GNOME Shell started\" ]]; then break; fi; done < <(journalctl -f)'");
       $machine->sleep(10);
       $machine->screenshot("screen");

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -28,7 +28,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     $machine->waitForFile("/home/alice/.config/i3/config");
     $machine->sleep(2);
     $machine->sendKeys("alt-ret");
-    $machine->waitForWindow(qr/machine.*alice/);
+    $machine->waitForWindow(qr/alice.*machine/);
     $machine->sleep(2);
     $machine->screenshot("terminal");
   '';


### PR DESCRIPTION
###### Motivation for this change

#51678 changed terminal titles, breaking the i3wm test. For some reason the gnome3 test is okay even though it looks for the same window title.

cc @yegortimoshenko who did the bash title change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

