### PR TITLE
dsview: init at 0.99

### DIFF
--- a/pkgs/applications/science/electronics/dsview/default.nix
+++ b/pkgs/applications/science/electronics/dsview/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, autoreconfHook,
+glib, libzip, boost, fftw, qtbase,
+libusb, makeWrapper, libsigrok4dsl, libsigrokdecode4dsl
+}:
+
+stdenv.mkDerivation rec {
+  name = "dsview-${version}";
+
+  version = "0.99";
+
+  src = fetchFromGitHub {
+      owner = "DreamSourceLab";
+      repo = "DSView";
+      rev = version;
+      sha256 = "189i3baqgn8k3aypalayss0g489xi0an9hmvyggvxmgg1cvcwka2";
+  };
+
+  postUnpack = ''
+    export sourceRoot=$sourceRoot/DSView
+  '';
+
+  patches = [
+    # Fix absolute install paths
+    ./install.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
+
+  buildInputs = [
+   boost fftw qtbase libusb libzip libsigrokdecode4dsl libsigrok4dsl
+  ];
+
+  enableParallelBuilding = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/DSView --suffix QT_PLUGIN_PATH : \
+      ${qtbase.bin}/${qtbase.qtPluginPrefix}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A GUI program for supporting various instruments from DreamSourceLab, including logic analyzer, oscilloscope, etc";
+    homepage = http://www.dreamsourcelab.com/;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bachp ];
+  };
+}

--- a/pkgs/applications/science/electronics/dsview/install.patch
+++ b/pkgs/applications/science/electronics/dsview/install.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c1c33e1..208a184 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -403,8 +403,8 @@ install(DIRECTORY res DESTINATION share/${PROJECT_NAME})
+ install(FILES icons/logo.png DESTINATION share/${PROJECT_NAME} RENAME logo.png)
+ install(FILES ../NEWS DESTINATION share/${PROJECT_NAME} RENAME NEWS)
+ install(FILES ../ug.pdf DESTINATION share/${PROJECT_NAME} RENAME ug.pdf)
+-install(FILES DreamSourceLab.rules DESTINATION /etc/udev/rules.d/)
+-install(FILES DSView.desktop DESTINATION /usr/share/applications/)
++install(FILES DreamSourceLab.rules DESTINATION etc/udev/rules.d/)
++install(FILES DSView.desktop DESTINATION share/applications/)
+ 
+ #===============================================================================
+ #= Packaging (handled by CPack)

--- a/pkgs/applications/science/electronics/dsview/libsigrok4dsl.nix
+++ b/pkgs/applications/science/electronics/dsview/libsigrok4dsl.nix
@@ -1,0 +1,28 @@
+{ stdenv, pkgconfig, autoreconfHook,
+glib, libzip, libserialport, check, libusb, libftdi,
+systemd, alsaLib, dsview
+}:
+
+stdenv.mkDerivation rec {
+  inherit (dsview) version src;
+
+  name = "libsigrok4dsl-${version}";
+
+  postUnpack = ''
+    export sourceRoot=$sourceRoot/libsigrok4DSL
+  '';
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+
+  buildInputs = [
+    glib libzip libserialport libusb libftdi systemd check alsaLib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A fork of the sigrok library for usage with DSView";
+    homepage = http://www.dreamsourcelab.com/;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bachp ];
+  };
+}

--- a/pkgs/applications/science/electronics/dsview/libsigrokdecode4dsl.nix
+++ b/pkgs/applications/science/electronics/dsview/libsigrokdecode4dsl.nix
@@ -1,0 +1,27 @@
+{ stdenv, pkgconfig, autoreconfHook,
+glib, check, python3, dsview
+}:
+
+stdenv.mkDerivation rec {
+  inherit (dsview) version src;
+
+  name = "libsigrokdecode4dsl-${version}";
+
+  postUnpack = ''
+    export sourceRoot=$sourceRoot/libsigrokdecode4DSL
+  '';
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+
+  buildInputs = [
+    python3 glib check
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A fork of the sigrokdecode library for usage with DSView";
+    homepage = http://www.dreamsourcelab.com/;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bachp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2353,6 +2353,8 @@ in
 
   dropbear = callPackage ../tools/networking/dropbear { };
 
+  dsview = libsForQt5.callPackage ../applications/science/electronics/dsview { };
+
   dtach = callPackage ../tools/misc/dtach { };
 
   dtc = callPackage ../development/compilers/dtc { };
@@ -8519,6 +8521,10 @@ in
   };
 
   libsigrokdecode = callPackage ../development/tools/libsigrokdecode { };
+
+  # special forks used for dsview
+  libsigrok4dsl = callPackage ../applications/science/electronics/dsview/libsigrok4dsl.nix { };
+  libsigrokdecode4dsl = callPackage ../applications/science/electronics/dsview/libsigrokdecode4dsl.nix { };
 
   dcadec = callPackage ../development/tools/dcadec { };
 


### PR DESCRIPTION
###### Motivation for this change

GUI for the [dreamsourcelab](https://www.dreamsourcelab.com/) Logic Analyzer and Osciliscope.

The forks of libsigrok and libsigrokdecode are not comaptible with the upstream version (different dependencies) and thus have
separate derivation sinstead of just being an override.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

