### PR TITLE
allow extending lib with an overlay

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -23,7 +23,7 @@
 , # !!! See comment about check in lib/modules.nix
   check ? true
 , prefix ? []
-, lib ? import ../../lib
+, lib ? import (let res = builtins.tryEval <nixos-lib>; in if res.success then res.value else ../../lib)
 }:
 
 let extraArgs_ = extraArgs; pkgs_ = pkgs;
@@ -54,7 +54,7 @@ in rec {
     modules = modules ++ extraModules ++ baseModules ++ [ pkgsModule ];
     args = extraArgs;
     specialArgs =
-      { modulesPath = builtins.toString ../modules; } // specialArgs;
+      { modulesPath = builtins.toString ../modules; } // specialArgs // { inherit lib; };
   }) config options;
 
   # These are the extra arguments passed to every module.  In


### PR DESCRIPTION
###### Motivation for this change
I want to be able to extend lib, not just the lib argument being passed to NixOS modules, but I also want to be able to use the extended lib in e.g. my Nix scripts. I made a comment about this in the existing proposal to extend lib (#51109), but I felt this was not being sufficiently addressed, so I made this counter proposal. I will outline the problems I see with the existing proposal and my own initial plan, and how this proposal addresses them.

The problems with the existing proposal (#51109):
1. For all calls to `./lib/eval-config.nix` to behave consistently, they would need to be passed the same lib, but right now they are only being passed to the calls to `./lib/eval-config.nix` being made in `nixos/default.nix`, but just to give an example, `./lib/eval-config.nix` is also being called in `nixos/lib/build-vms.nix`. So placing the logic to determine the custom lib in `nixos/default.nix` seems like the wrong place to me.
2. It adds an extra argument to the `nixos/default.nix` function. At first this might look like it could be considered a feature, because it would allow you to easily overwrite the lib being passed to modules as an argument, but it would suffer from the same issues as described in (1). This is actually also being warned about in a comment above the `evalModules` function defined in `lib/modules.nix`. The feature of being able to just change the lib being passed to modules as an argument could be implemented without triggering this issue, e.g. by setting `{ _module.args.lib = customLib; }` and changing `lib/modules.nix` from inheriting lib to `lib = _module.args.lib or lib`, but I consider this is a separate feature request / issue than being able to extend lib in general.
3. It is better not to try and reverse engineer looking up paths in `NIX_PATH`, so rather than your `looks-like-nixos-lib`, it is probably better to use something based on `tryEval`, like how `<nixpkgs-overlays>` is being looked up in `pkgs/top-level/impure.nix`.
4. Even if the goal was to only change the lib being used when defining your configuration, then the proposed approach would still only affect lib being passed as module argument and does not consider other references to lib commonly used when defining a configuration, like `pkgs.lib`. They would still refer to the default lib.
5. There are multiple locations throughout Nixpkgs where lib is being imported directly via some relative path like `../lib`, so these would still refer to default lib. It could be argued that this is fine, because they were implemented with the default lib in mind, unlike the NixOS configuration if we are allowed to modify lib, but it misses the point. I want to be able to modify lib, like Nixpkgs overrides/overlays allow me to modify `pkgs` without having to modify a Nixpkgs checkout directly, since the modifications could include tweaks or bug fixes that I might want to have applied everywhere lib is being used.
6. Taking the above into account, I do not like naming the `NIX_PATH` prefix `nixos-lib`, because it implies the lib only being used for NixOS.

My own initial plan to extend lib was to just duplicate what we have to overlay `pkgs`. In my prototype I used `<nixpkgs-lib-overlays>` and `~/.config/nixpkgs/lib/overlays{,.nix}`. It worked, but it too has problems aside those already mentioned above:

7. The scale of `pkgs` is much larger than that of `lib`. The need for multiple overlays is clear in the case of `pkgs`, since even if you were to forget user defined overlays, it is already needed (or at least useful) in `pkgs/top-level/stage.nix`. In case of extending lib, the most common solution right now is to just do something like `with import ./custom-lib.nix;`, where `./custom-lib.nix` tends to just hold a few definitions, not something you need complex layering for.
8. In this context nixpkgs implicitly refers to the the Nix packages, not the nixpkgs repository, so the naming and paths feel wrong. I am not sure what the better naming/paths would have been, but since I will not be proposing this solution, it is irrelevant.

Other problems as already noted in the existing proposal by @4z3:

9. Although it would be nice if we could specify a custom lib via the `NIX_PATH` prefix `<nixpkgs/lib>`, i.e. using the path itself as prefix, you can than no longer extend the default lib (without tricks) by referring to `<nixpkgs/lib>`, this would now refer to the custom lib and so result in infinite recursion.

This proposal for an extendable lib solves the above mentioned problems as follows:

- Not requiring changes to the call site of `./lib/eval-config.nix`, this solves (1).
- There are no additional arguments added anywhere, except for `lib/modules.nix`, which needs a reference to the final lib (i.e. the extended one) in order to pass it along as an argument, but that is a safe argument to add and completely internal, so (2) does not apply.
- I have copied over the `try` function defined in `pkgs/top-level/impure.nix` and added it to the default lib. I wish I could remove the duplication and use lib.try in `pkgs/top-level/impure.nix`, but that would require having to import (inefficient to reuse just one definition) or pass along lib as an argument (I am not sure what the impact of that is, considering potential problems as described in (2)). By defining and using `try` (the interface I would have liked to see for the `tryEval` builtin), we avoid (3).
- By using an overlay, we solve the issue of having to reference to the default lib via `<nixpkgs/lib>` when defining our custom lib, solving (9). And the overlay will be applied in `nixpkgs/lib/default.nix` itself, so everything will automatically refer to the extended lib, with the exception of the default lib itself, which will still be defined in terms of itself (i.e. the way overlays work), which solves (4) and (5).
- To make clear that lib will be extended via an overlay rather than replacing it for a custom lib as a whole (as proposed in the existing proposal), I thought it best to name the `NIX_PATH` prefix `lib-overlay`. No, `nixos` prefix (solves (6)), because that would imply too much coupling with NixOS, which is not the case, nor a `nixpkgs` prefix, because like mentioned in (8) `nixpkgs` in `NIX_PATH` and the NixOS `nixpkgs` options refer to Nix packages rather than `nixpkgs` the repo. If you talk about lib in the context of NixOS or some Nix script, it always refers to `<nixpkgs/lib>`, so I propose no prefix.
- For my configurations I actually do want the heavy machinery of having multiple overlays for my lib, hence my initial idea, but I can realize that by implementing my lib overlay such that it in turn is defined by multiple overlays, solving (7).

That should cover all the above mentioned problems.

I just saw the following comment by Eelco at the existing proposal:

> Not really in favor of adding another ad-hoc override mechanism. Also, in the future, the Nix search path is likely to be deprecated in favor of flakes, where the Nixpkgs library may well be factored out into a separate flake, which would allow it to be overriden easily.

So I am not sure how long this pull request will remain relevant, but in the meantime I will be using this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

