### PR TITLE
ghostscript: 9.25 -> 9.26

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -9,8 +9,8 @@ assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
 let
   version = "9.${ver_min}";
-  ver_min = "25";
-  sha512 = "18pcqzva7pq2a9mmqf9pq8x4winb6qmzni49vq2qx50k60rwyv1kdmixik3ym2bpj5p1j8g0vb47w7w2cf4lba5q583ylpd8rshn73s";
+  ver_min = "26";
+  sha512 = "0z2mvsh06qgnxl7p9isw7swg8jp8xcx3rnbqk727avw7ammvfh8785d2bn5i4fhz8y45ka3cpgp7b598m06yq5zawijhcnzkq187nrx";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";


### PR DESCRIPTION
backport of #51746 to 18.09

###### Motivation for this change
[CVE-2018-18284](https://nvd.nist.gov/vuln/detail/CVE-2018-18284)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

