### PR TITLE
nixos: kubernetes: use /run instead of /var/run

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -1014,10 +1014,10 @@ in {
             --leader-elect=${boolToString cfg.controllerManager.leaderElect} \
             ${if (cfg.controllerManager.serviceAccountKeyFile!=null)
               then "--service-account-private-key-file=${cfg.controllerManager.serviceAccountKeyFile}"
-              else "--service-account-private-key-file=/var/run/kubernetes/apiserver.key"} \
+              else "--service-account-private-key-file=/run/kubernetes/apiserver.key"} \
             ${if (cfg.controllerManager.rootCaFile!=null)
               then "--root-ca-file=${cfg.controllerManager.rootCaFile}"
-              else "--root-ca-file=/var/run/kubernetes/apiserver.crt"} \
+              else "--root-ca-file=/run/kubernetes/apiserver.crt"} \
             ${if (cfg.clusterCidr!=null)
               then "--cluster-cidr=${cfg.clusterCidr} --allocate-node-cidrs=true"
               else "--allocate-node-cidrs=false"} \
@@ -1132,7 +1132,7 @@ in {
 
       systemd.tmpfiles.rules = [
         "d /opt/cni/bin 0755 root root -"
-        "d /var/run/kubernetes 0755 kubernetes kubernetes -"
+        "d /run/kubernetes 0755 kubernetes kubernetes -"
         "d /var/lib/kubernetes 0755 kubernetes kubernetes -"
       ];
 


### PR DESCRIPTION
###### Motivation for this change

Currently `tmpfiles` is giving a warning upon `nixos-rebuild switch` like the following:

```
setting up tmpfiles
[/etc/tmpfiles.d/nixos.conf:6] Line references path below legacy directory /var/run/, updating /var/run/kubernetes → /run/kubernetes; please update the tmpfiles.d/ drop-in file accordingly.
```

`/etc/tmpfiles.d/nixos.conf:6`:

```
d /var/run/kubernetes 0755 kubernetes kubernetes -
```

This PR changes the directory from `/var/run/kubernetes` to `/run/kubernetes`.

Related #51800 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
