### PR TITLE
[18.09] rust-cbindgen: 0.6.2 -> 0.6.7

### DIFF
--- a/pkgs/development/tools/rust/cbindgen/0_6_7.nix
+++ b/pkgs/development/tools/rust/cbindgen/0_6_7.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "rust-cbindgen-${version}";
+  version = "0.6.7";
+
+  src = fetchFromGitHub {
+    owner = "eqrion";
+    repo = "cbindgen";
+    rev = "v${version}";
+    sha256 = "0sgkgvkqrc6l46fvk6d9hsy0xrjpl2ix47f3cv5bi74dv8i4y2b4";
+  };
+
+  cargoSha256 = "137dqj1sp02dh0dz9psf8i8q57gmz3rfgmwk073k7x5zzkgvj21c";
+
+  meta = with stdenv.lib; {
+    description = "A project for generating C bindings from Rust code";
+    homepage = https://github.com/eqrion/cbindgen;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7246,6 +7246,7 @@ with pkgs;
   rustracerd = callPackage ../development/tools/rust/racerd { };
   rust-bindgen = callPackage ../development/tools/rust/bindgen { };
   rust-cbindgen = callPackage ../development/tools/rust/cbindgen { };
+  rust-cbindgen_0_6_7 = callPackage ../development/tools/rust/cbindgen/0_6_7.nix { };
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
This update is required for the upcoming firefox release. We can defer merging until the firefox bump has arrived since it provides little value and causes useless rebuilds.

I did successfully rebuild the stable firefox and the latest ffx beta release with this bump.