### PR TITLE
credstash: add standalone Python application

### DIFF
--- a/pkgs/development/python-modules/credstash/default.nix
+++ b/pkgs/development/python-modules/credstash/default.nix
@@ -9,6 +9,12 @@ buildPythonPackage rec {
     sha256 = "814560f99ae2409e2c6d906d878f9dadada5d1d0a950aafb6b2c0d535291bdfb";
   };
 
+  # The install phase puts an executable and a copy of the library it imports in
+  # bin/credstash and bin/credstash.py, despite the fact that the library is also
+  # installed to lib/python<version>/site-packages/credstash.py.
+  # If we apply wrapPythonPrograms to bin/credstash.py then the executable will try
+  # to import the credstash module from the resulting shell script. Removing this
+  # file ensures that Python imports the module from site-packages library.
   postInstall = "rm $out/bin/credstash.py";
 
   nativeBuildInputs = [ nose ];

--- a/pkgs/development/python-modules/credstash/default.nix
+++ b/pkgs/development/python-modules/credstash/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage rec {
     sha256 = "814560f99ae2409e2c6d906d878f9dadada5d1d0a950aafb6b2c0d535291bdfb";
   };
 
+  postInstall = "rm $out/bin/credstash.py";
+
   nativeBuildInputs = [ nose ];
 
   propagatedBuildInputs = [ cryptography boto3 pyyaml docutils ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8439,6 +8439,8 @@ in
     llvmPackages = llvmPackages_7;
   };
 
+  credstash = with python3Packages; toPythonApplication credstash;
+
   creduce = callPackage ../development/tools/misc/creduce {
     inherit (perlPackages) perl
       ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey;


### PR DESCRIPTION
###### Motivation for this change

I want to use the credstash command-line application, but credstash is currently only offered as a Python library.

In order for this to work, I needed to remove the copy of the library that's placed in `$out/bin` and marked executable during the install phase. Other than the patched shebang and executable bit, it's identical to the library that's installed to `$out/lib/python3.7/site-packages`.

Before postFixup has run `wrapPythonPrograms`, bin/ contains two Python files -- credstash and credstash.py -- where `bin/credstash` is the executable you'd expect a user to invoke from the command-line and `bin/credstash.py` contains the credstash module, which `bin/credstash` imports.

After `wrapPythonPrograms` has run, `bin/credstash` is a shell wrapper around the `bin/.credstash-wrapped` python entrypoint, and `bin/credstash.py` is shell wrapper around the `bin/.credstash.py-wrapped` python module. Invoking `bin/credstash` execs `bin/.credstash-wrapped`, which attempts to import the credstash module from `bin/credstash.py` (now a shell script), rather than either `bin/.credstash.py-wrapped` or `lib/python3.7/site-packages/credstash.py`.

This leads to an error:
```
$ credstash get mykey
Traceback (most recent call last):
  File "/nix/store/hk6yma716w6141lcdh509d6qyyi7zm0i-python3.7-credstash-1.15.0/bin/.credstash-wrapped", line 8, in <module>
    from credstash import main
  File "/nix/store/hk6yma716w6141lcdh509d6qyyi7zm0i-python3.7-credstash-1.15.0/bin/credstash.py", line 2
    export PATH='/nix/store/6lm4gi5iv8fbf1b1mm6g3gfnnv63f1gn-python3-3.7.1/bin:/nix/store/hk6yma716w6141lcdh509d6qyyi7zm0i-python3.7-credstash-1.15.0/bin:/nix/store/2n13gf1zdr39ir5dynxlkqndxgy36g08-python3.7-setuptools-40.4.3/bin:/nix/store/mhnqwpa4y1l81zi4cwx989i8h8z9g67l-python3.7-jmespath-0.9.0/bin:/nix/store/qc6q3a2nv4211wyh7q319v6zzd3ab6pc-python3.7-docutils-0.14/bin'${PATH:+':'}$PATH
              ^
SyntaxError: invalid syntax
```

I was able to resolve this by removing `bin/credstash.py` before the postFixup phase has a chance to wrap anything. Now the executable imports the library correctly:
```
(shell wrapper)
 bin/credstash
       │      (python executable)
       └─> bin/.credstash-wrapped
                  │                        (python library)
                  └─> lib/python3.7/site-packages/credstash.py
```

I tried using `dontWrapPythonPrograms` as an alternative solution, but that leads to a different error because runtime dependency lookups fail:
```
$ credstash get mykey
Traceback (most recent call last):
  File "/run/current-system/sw/bin/credstash", line 7, in <module>
    from credstash import main
  File "/nix/store/8rmldlvlv1z1xl7w02dy7f5qhkzdrg8z-python3.7-credstash-1.15.0/bin/credstash.py", line 26, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'
```

Fixes #47751

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
