### PR TITLE
Fixes three altcoins packages to use boost165

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -79,7 +79,7 @@ rec {
 
   stellar-core = callPackage ./stellar-core.nix { };
 
-  sumokoin = callPackage ./sumokoin.nix { };
+  sumokoin = callPackage ./sumokoin.nix { boost = boost165; };
 
   wownero = callPackage ./wownero.nix {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -65,7 +65,7 @@ rec {
   };
   litecoind = litecoin.override { withGui = false; };
 
-  masari = callPackage ./masari.nix { };
+  masari = callPackage ./masari.nix { boost = boost165; };
 
   memorycoin  = callPackage ./memorycoin.nix { boost = boost165; withGui = true; };
   memorycoind = callPackage ./memorycoin.nix { boost = boost165; withGui = false; };

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -45,7 +45,7 @@ rec {
   dcrd = callPackage ./dcrd.nix { };
   dcrwallet = callPackage ./dcrwallet.nix { };
 
-  dero = callPackage ./dero.nix { };
+  dero = callPackage ./dero.nix { boost = boost165; };
 
   dogecoin  = callPackage ./dogecoin.nix { boost = boost165; withGui = true; };
   dogecoind = callPackage ./dogecoin.nix { boost = boost165; withGui = false; };


### PR DESCRIPTION
###### Motivation for this change

Reduce the amount of ❌ in hydra.

(These were found and fixed while working my way through aarch64 failures cleanups)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

