### PR TITLE
aarch64: ZHF for aarch64 (1/??)

### DIFF
--- a/nixos/modules/services/databases/aerospike.nix
+++ b/nixos/modules/services/databases/aerospike.nix
@@ -43,6 +43,7 @@ in
 
       package = mkOption {
         default = pkgs.aerospike;
+        defaultText = "pkgs.aerospike";
         type = types.package;
         description = "Which Aerospike derivation to use";
       };

--- a/pkgs/applications/audio/ams-lv2/default.nix
+++ b/pkgs/applications/audio/ams-lv2/default.nix
@@ -21,5 +21,7 @@ stdenv.mkDerivation  rec {
     license = licenses.gpl3;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;
+    # Build uses `-msse` and `-mfpmath=sse`
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/audio/artyFX/default.nix
+++ b/pkgs/applications/audio/artyFX/default.nix
@@ -20,5 +20,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;
+    # Build uses `-msse` and `-mfpmath=sse`
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/science/logic/aspino/default.nix
+++ b/pkgs/applications/science/logic/aspino/default.nix
@@ -44,5 +44,7 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.asl20;
     homepage = http://alviano.net/software/maxino/;
+    # See pkgs/applications/science/logic/glucose/default.nix
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/science/logic/avy/default.nix
+++ b/pkgs/applications/science/logic/avy/default.nix
@@ -46,5 +46,8 @@ stdenv.mkDerivation rec {
     license     = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ thoughtpolice ];
     platforms   = stdenv.lib.platforms.linux;
+    # See pkgs/applications/science/logic/glucose/default.nix
+    # (The error is different due to glucose-fenv.patch, but the same)
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/science/logic/glucose/default.nix
+++ b/pkgs/applications/science/logic/glucose/default.nix
@@ -23,5 +23,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ gebner ];
+    # Build uses _FPU_EXTENDED macro
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -83,6 +83,7 @@ stdenv.mkDerivation rec {
     homepage    = https://cisco.github.io/ChezScheme/;
     license     = stdenv.lib.licenses.asl20;
     platforms   = stdenv.lib.platforms.unix;
+    badPlatforms = [ "aarch64-linux" ];
     maintainers = with stdenv.lib.maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/interpreters/angelscript/2.22.nix
+++ b/pkgs/development/interpreters/angelscript/2.22.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.zlib ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
     downloadPage = "http://www.angelcode.com/angelscript/downloads.html";
     homepage="http://www.angelcode.com/angelscript/";
   };

--- a/pkgs/development/libraries/aften/default.nix
+++ b/pkgs/development/libraries/aften/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
 		description = "An audio encoder which generates compressed audio streams based on ATSC A/52 specification";
 		homepage = "http://aften.sourceforge.net/";
 		license = stdenv.lib.licenses.lgpl2;
-		platforms = stdenv.lib.platforms.unix;
+		platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
 	};
 }

--- a/pkgs/development/libraries/beignet/default.nix
+++ b/pkgs/development/libraries/beignet/default.nix
@@ -107,5 +107,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ artuuge zimbatm ];
     platforms = platforms.linux;
+    # Requires libdrm_intel
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -111,7 +111,8 @@ stdenv.mkDerivation {
     description = "Collection of C++ libraries";
     license = stdenv.lib.licenses.boost;
 
-    platforms = (if versionOlder version "1.59" then remove "aarch64-linux" else id) (platforms.unix ++ platforms.windows);
+    platforms = (platforms.unix ++ platforms.windows);
+    badPlatforms = stdenv.lib.optional (versionOlder version "1.59") "aarch64-linux";
     maintainers = with maintainers; [ peti wkennington ];
   };
 

--- a/pkgs/development/libraries/bootil/default.nix
+++ b/pkgs/development/libraries/bootil/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.free;
     maintainers = [ stdenv.lib.maintainers.abigailbuccaneer ];
     platforms = stdenv.lib.platforms.all;
+    # Build uses `-msse` and `-mfpmath=sse`
+    badPlatforms = [ "aarch64-linux" ];
   };
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/gsl/gsl-1_16.nix
+++ b/pkgs/development/libraries/gsl/gsl-1_16.nix
@@ -36,5 +36,7 @@ stdenv.mkDerivation rec {
       extensive test suite.
     '';
     platforms = stdenv.lib.platforms.unix;
+    # Failing "eigen" tests on aarch64.
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkgconfig }:
+{stdenv, fetchurl, fetchpatch, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "openbabel-${version}";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "https://github.com/openbabel/openbabel/archive/openbabel-${stdenv.lib.replaceStrings ["."] ["-"] version}.tar.gz";
     sha256 = "0xm7y859ivq2cp0q08mwshfxm0jq31xkyr4x8s0j6l7khf57yk2r";
   };
+
+  patches = [
+    # ARM / AArch64 fixes.
+    (fetchpatch {
+      url = https://github.com/openbabel/openbabel/commit/ee11c98a655296550710db1207b294f00e168216.patch;
+      sha256 = "0wjqjrkr4pfirzzicdvlyr591vppydk572ix28jd2sagnfnf566g";
+    })
+  ];
 
   # TODO : perl & python bindings;
   # TODO : wxGTK: I have no time to compile

--- a/pkgs/misc/emulators/blastem/default.nix
+++ b/pkgs/misc/emulators/blastem/default.nix
@@ -44,5 +44,7 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ puffnfresh ];
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.linux;
+    # Makefile:140: *** aarch64 is not a supported architecture.  Stop.
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/servers/nosql/aerospike/default.nix
+++ b/pkgs/servers/nosql/aerospike/default.nix
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
     description = "Flash-optimized, in-memory, NoSQL database";
     homepage = http://aerospike.com/;
     license = licenses.agpl3;
-    #platforms = [ "x86_64-linux" ];  # breaks eval of nixos manual for aarch64
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kalbasit ];
   };
 }

--- a/pkgs/tools/networking/bud/default.nix
+++ b/pkgs/tools/networking/bud/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     description = "A TLS terminating proxy";
     license     = licenses.mit;
     platforms   = platforms.linux;
+    # Does not build on aarch64-linux.
+    badPlatforms = [ "aarch64-linux" ];
     maintainers = with maintainers; [ cstrahan ];
   };
 }

--- a/pkgs/tools/package-management/cde/default.nix
+++ b/pkgs/tools/package-management/cde/default.nix
@@ -33,5 +33,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = [ maintainers.rlupton20 ];
     platforms = platforms.linux;
+    # error: architecture aarch64 is not supported by strace
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/tools/security/b2sum/default.nix
+++ b/pkgs/tools/security/b2sum/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://blake2.net";
     license = with licenses; [ asl20 cc0 openssl ];
     maintainers = with maintainers; [ kirelagin ];
-    platforms = platforms.all;
+    # "This code requires at least SSE2."
+    platforms = with platforms; [ "x86_64-linux" "i686-linux" ] ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Reduce the amount of failures for aarch64. This is done mainly through disabling builds for packages **which cannot** build on aarch64. I have skipped over some packages which could realistically be built, with effort. Most of those disabled here use x86_64 features pretty explicitly.

There is either a comment preceding the `badPlatforms` property with details, or a detailed explanation in the commit message.

* * *

###### Some additional notes:

**aerospike** has been disabled again on aarch64-linux, this time it's been removed as a default for aarch64 in the module, making it not fail uselessly in Hydra. ~~I'm thinking the entire module could also be conditional on valid platforms for the package, but it would stop end-users from using it with a fork for fixing it :/.~~ (With `defaultText` it's not as much an issue. No hairy conditional.) cc @kalbasit 

**boost** 1.55 was previously flagged as not building on aarch64-linux for versions preceding 1.59, but the semantics of *platforms* changed, re-adding the failing build.

**openbabel** is given a patch from upstream to fix its build. This additional patch will be removed once they release another version including the change.

Anything else is trivial.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

