### PR TITLE
swiftclient: init at 3.6.0

### DIFF
--- a/pkgs/tools/admin/swiftclient/default.nix
+++ b/pkgs/tools/admin/swiftclient/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonApplication, fetchPypi, requests, six, pbr }:
+
+buildPythonApplication rec {
+  pname = "python-swiftclient";
+  version = "3.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0sv6z72zdwzwdjng0djk3l2maryn9pz3khf69yq5ig2ycz8hh0qv";
+  };
+
+  propagatedBuildInputs = [ requests six pbr ];
+
+  # For the tests the following requirements are needed:
+  # https://github.com/openstack/python-swiftclient/blob/master/test-requirements.txt
+  #
+  # The ones missing in nixpkgs (currently) are:
+  # - hacking
+  # - keystoneauth
+  # - oslosphinx
+  # - stestr
+  # - reno
+  # - openstackdocstheme
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/openstack/python-swiftclient;
+    description = "Python bindings to the OpenStack Object Storage API";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ c0deaddict ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12586,6 +12586,8 @@ in
 
   svrcore = callPackage ../development/libraries/svrcore { };
 
+  swiftclient = python3.pkgs.callPackage ../tools/admin/swiftclient { };
+
   sword = callPackage ../development/libraries/sword { };
 
   biblesync = callPackage ../development/libraries/biblesync { };


### PR DESCRIPTION
###### Motivation for this change

[python-swiftclient](https://github.com/openstack/python-swiftclient) was missing from Nixpkgs and I needed it for work.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

