### PR TITLE
[18.09] gnss-sdr: turn off unit tests explicitly

### DIFF
--- a/pkgs/applications/misc/gnss-sdr/default.nix
+++ b/pkgs/applications/misc/gnss-sdr/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DGFlags_ROOT_DIR=${google-gflags}/lib"
     "-DGLOG_INCLUDE_DIR=${glog}/include"
+    "-DENABLE_UNIT_TESTING=OFF"
 
     # gnss-sdr doesn't truly depend on BLAS or LAPACK, as long as
     # armadillo is built using both, so skip checking for them.


### PR DESCRIPTION
###### Motivation for this change
This unbreaks the build on 18.09. Already fixed on master. The commit that broke build was cherry-picked from master earlier (ff43959e75c24535b34e9dec0b381918b7854819)

###### Things done
(cherry picked from commit 0528001141170ef49ef37de41a40e7d2c7e0a49d)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

