### PR TITLE
octoprint-plugins: remove redundant platforms

### DIFF
--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -2,6 +2,8 @@
 
 let
   buildPlugin = args: python2Packages.buildPythonPackage (args // {
+    pname = "OctoPrintPlugin-${args.pname}";
+    inherit (args) version;
     propagatedBuildInputs = (args.propagatedBuildInputs or []) ++ [ octoprint ];
     # none of the following have tests
     doCheck = false;
@@ -13,7 +15,7 @@ let
     m3d-fio = self.m33-fio; # added 2016-08-13
 
     m33-fio = buildPlugin rec {
-      name = "M33-Fio-${version}";
+      pname = "M33-Fio";
       version = "1.21";
 
       src = fetchFromGitHub {
@@ -36,15 +38,15 @@ let
       '';
 
       meta = with stdenv.lib; {
-        homepage = https://github.com/donovan6000/M33-Fio;
         description = "OctoPrint plugin for the Micro 3D printer";
+        homepage = https://github.com/donovan6000/M33-Fio;
         license = licenses.gpl3;
         maintainers = with maintainers; [ abbradar ];
       };
     };
 
     mqtt = buildPlugin rec {
-      name = "OctoPrint-MQTT-${version}";
+      pname = "MQTT";
       version = "0.8.0";
 
       src = fetchFromGitHub {
@@ -57,15 +59,15 @@ let
       propagatedBuildInputs = with python2Packages; [ paho-mqtt ];
 
       meta = with stdenv.lib; {
-        homepage = https://github.com/OctoPrint/OctoPrint-MQTT;
         description = "Publish printer status MQTT";
+        homepage = https://github.com/OctoPrint/OctoPrint-MQTT;
         license = licenses.agpl3;
         maintainers = with maintainers; [ peterhoeg ];
       };
     };
 
     titlestatus = buildPlugin rec {
-      name = "OctoPrint-TitleStatus-${version}";
+      pname = "TitleStatus";
       version = "0.0.4";
 
       src = fetchFromGitHub {
@@ -76,15 +78,15 @@ let
       };
 
       meta = with stdenv.lib; {
-        homepage = https://github.com/MoonshineSG/OctoPrint-TitleStatus;
         description = "Show printers status in window title";
+        homepage = https://github.com/MoonshineSG/OctoPrint-TitleStatus;
         license = licenses.agpl3;
         maintainers = with maintainers; [ abbradar ];
       };
     };
 
     stlviewer = buildPlugin rec {
-      name = "OctoPrint-STLViewer-${version}";
+      pname = "STLViewer";
       version = "0.4.1";
 
       src = fetchFromGitHub {
@@ -95,8 +97,8 @@ let
       };
 
       meta = with stdenv.lib; {
-        homepage = https://github.com/jneilliii/Octoprint-STLViewer;
         description = "A simple stl viewer tab for OctoPrint";
+        homepage = https://github.com/jneilliii/Octoprint-STLViewer;
         license = licenses.agpl3;
         maintainers = with maintainers; [ abbradar ];
       };

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -38,7 +38,6 @@ let
       meta = with stdenv.lib; {
         homepage = https://github.com/donovan6000/M33-Fio;
         description = "OctoPrint plugin for the Micro 3D printer";
-        platforms = platforms.all;
         license = licenses.gpl3;
         maintainers = with maintainers; [ abbradar ];
       };
@@ -60,7 +59,6 @@ let
       meta = with stdenv.lib; {
         homepage = https://github.com/OctoPrint/OctoPrint-MQTT;
         description = "Publish printer status MQTT";
-        platforms = platforms.all;
         license = licenses.agpl3;
         maintainers = with maintainers; [ peterhoeg ];
       };
@@ -80,7 +78,6 @@ let
       meta = with stdenv.lib; {
         homepage = https://github.com/MoonshineSG/OctoPrint-TitleStatus;
         description = "Show printers status in window title";
-        platforms = platforms.all;
         license = licenses.agpl3;
         maintainers = with maintainers; [ abbradar ];
       };
@@ -100,7 +97,6 @@ let
       meta = with stdenv.lib; {
         homepage = https://github.com/jneilliii/Octoprint-STLViewer;
         description = "A simple stl viewer tab for OctoPrint";
-        platforms = platforms.all;
         license = licenses.agpl3;
         maintainers = with maintainers; [ abbradar ];
       };


### PR DESCRIPTION
###### Motivation for this change

Further to #51610 as requested by @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

