### PR TITLE
cool-retro-term: fix on darwin

### DIFF
--- a/pkgs/applications/misc/cool-retro-term/default.nix
+++ b/pkgs/applications/misc/cool-retro-term/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmltermwidget,
-qtquickcontrols, qtgraphicaleffects, qmake }:
+{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmltermwidget
+, qtquickcontrols, qtgraphicaleffects, qmake }:
 
 stdenv.mkDerivation rec {
   version = "1.0.1";
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       eye-candy, customizable, and reasonably lightweight.
     '';
     homepage = https://github.com/Swordfish90/cool-retro-term;
-    license = with stdenv.lib.licenses; [ gpl2 gpl3 ];
+    license = stdenv.lib.licenses.gpl3Plus;
     platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = with stdenv.lib.maintainers; [ skeidel ];
   };

--- a/pkgs/applications/misc/cool-retro-term/default.nix
+++ b/pkgs/applications/misc/cool-retro-term/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     mv $out/usr/share $out/share
     mv $out/usr/bin $out/bin
     rmdir $out/usr
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s $out/bin/cool-retro-term.app/Contents/MacOS/cool-retro-term $out/bin/cool-retro-term
   '';
 
   enableParallelBuilding = true;
@@ -38,7 +40,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/Swordfish90/cool-retro-term;
     license = with stdenv.lib.licenses; [ gpl2 gpl3 ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = with stdenv.lib.maintainers; [ skeidel ];
   };
 }

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     repo = "qmltermwidget";
     owner = "Swordfish90";
-    rev = "v${version}";
-    sha256 = "0ca500mzcqglkj0i6km0z512y3a025dbm24605xyv18l6y0l2ny3";
+    rev = "48274c75660e28d44af7c195e79accdf1bd44963";
+    sha256 = "028nb1xp84jmakif5mmzx52q3rsjwckw27jdpahyaqw7j7i5znq6";
   };
 
   buildInputs = [ qtbase qtquick1 qtmultimedia ]

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp }:
 
 stdenv.mkDerivation rec {
-  version = "0.1.0";
-  name = "qmltermwidget-${version}";
+  version = "2018-11-24";
+  name = "qmltermwidget-unstable-${version}";
 
   src = fetchFromGitHub {
     repo = "qmltermwidget";


### PR DESCRIPTION
###### Motivation for this change

cool-retro-term had two problems on darwin:
 - binary not placed in `$PATH` due to macOS packaging
 - https://github.com/Swordfish90/cool-retro-term/issues/366

add a symlink to the macOS binary on darwin and update qmltermwidget makes it work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

