### PR TITLE
Revert "linux: inside nix-shell, allow make menuconfig"

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,4 @@
 { buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
-, pkgconfig ? null, ncurses ? null
 , libelf
 , utillinux
 , writeTextFile
@@ -266,7 +265,6 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches
       ++ optional (stdenv.lib.versionAtLeast version "4.14") libelf
       ++ optional (stdenv.lib.versionAtLeast version "4.15") utillinux
       ++ optionals (stdenv.lib.versionAtLeast version "4.16") [ bison flex ]
-      ++ optionals stdenv.lib.inNixShell [ pkgconfig ncurses ]
       ;
 
   hardeningDisable = [ "bindnow" "format" "fortify" "stackprotector" "pic" "pie" ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#47909

Fix for https://github.com/NixOS/nixpkgs/issues/51681

