### PR TITLE
Backport "geckodriver: unstable-2018-02-24 -> 0.22.0" to 18.09

### DIFF
--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -1,24 +1,26 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
+, stdenv
+, darwin
 }:
 
 with rustPlatform; 
 
 buildRustPackage rec {
-  version = "unstable-2018-02-24";
+  version = "0.22.0";
   name = "geckodriver-${version}";
 
   src = fetchFromGitHub {
     owner = "mozilla";
-    repo = "gecko-dev";
-    rev = "ecb86060b4c5a9808798b81a57e79e821bb47082";
-    sha256 = "1am84a60adw0bb12rlhdqbiwyywhza4qp5sf4f4fmssjl2qcr6nl";
+    repo = "geckodriver";
+    rev = "v${version}";
+    sha256 = "12m95lfqwdxs2m5kjh3yrpm9w2li5m8n3fw46a2nkxyfw6c94l4b";
   };
 
-  sourceRoot = "${src.name}/testing/geckodriver";
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
-  cargoSha256 = "0dvcvdb623jla29i93glx20nf8pbpfw6jj548ii6brzkcpafxxm8";
+  cargoSha256 = "1a8idl6falz0n9irh1p8hv5w2pmiknzsfnxl70k1psnznrpk2y8n";
 
   meta = with lib; {
     description = "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/50380#issuecomment-439221549

cc @Mic92 @das-g

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

