### PR TITLE
nixos/nvidia: fix inverted assertion

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -101,7 +101,7 @@ in
   config = mkIf enabled {
     assertions = [
       {
-        assertion = config.services.xserver.displayManager.gdm.wayland;
+        assertion = !config.services.xserver.displayManager.gdm.wayland;
         message = "NVIDIA drivers don't support wayland";
       }
       {


### PR DESCRIPTION
###### Motivation for this change

I can't turn off wayland, because my video drivers demand that wayland is enabled, because they don't support wayland.

This will cause all gdm+nvidia users to have to add the following to their config. Is there a way we can avoid this? Though as I understand it, gdm+nvidia is unable to start sessions (at least I saw this on 18.09), so there probably aren't any users.

```
services.xserver.displayManager.gdm.wayland = false;
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

