### PR TITLE
python: add geographiclib and update geopy

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2859,6 +2859,11 @@
     github = "mmahut";
     name = "Marek Mahut";
   };
+  mmesch = {
+    email = "qzwbgq@gmail.com";
+    github = "MMesch";
+    name = "MMesch";
+  };
   mmlb = {
     email = "me.mmlb@mmlb.me";
     github = "mmlb";

--- a/pkgs/development/python-modules/geographiclib/default.nix
+++ b/pkgs/development/python-modules/geographiclib/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "geographiclib";
+  version = "1.49";
+  disabled = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "635da648fce80a57b81b28875d103dacf7deb12a3f5f7387ba7d39c51e096533";
+  };
+
+  doCheck = false;  # too much
+
+  meta = with stdenv.lib; {
+    homepage = "https://geographiclib.sourceforge.io";
+    description = "Algorithms for geodesics (Karney, 2013) for solving the direct and inverse problems for an ellipsoid of revolution";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mmesch ];
+  };
+
+}

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -11,7 +11,7 @@
 buildPythonPackage rec {
   pname = "geopy";
   version = "1.18.0";
-  disabled = !isPy27;
+  disabled = false;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , isPy27
+, geographiclib
 , mock
 , tox
 , pylint
@@ -9,17 +10,17 @@
 
 buildPythonPackage rec {
   pname = "geopy";
-  version = "1.11.0";
+  version = "1.18.0";
   disabled = !isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04j1lxcsfyv03h0n0q7p2ig7a4n13x4x20fzxn8bkazpx6lyal22";
+    sha256 = "e448b41932985d71329d6caba5d95be53207c49b74e88acd651fb7b9c6896750";
   };
 
   doCheck = false;  # too much
 
-  buildInputs = [ mock tox pylint ];
+  buildInputs = [ geographiclib mock tox pylint ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/geopy/geopy";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3784,6 +3784,8 @@ in {
 
   geopy = callPackage ../development/python-modules/geopy { };
 
+  geographiclib = callPackage ../development/python-modules/geographiclib { };
+
   django-haystack = callPackage ../development/python-modules/django-haystack { };
 
   django-multiselectfield = callPackage ../development/python-modules/django-multiselectfield { };


### PR DESCRIPTION
###### Motivation for this change

my first nixpkgs PR. Let me know if something should be different.

(1) added geographiclib from pip.
(2) updated geopy from 1.11 -> 1.18
(3) enabled python3 support for geopy

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

