### PR TITLE
pythonPackages.pyjet: fix for python37

### DIFF
--- a/pkgs/development/python-modules/pyjet/default.nix
+++ b/pkgs/development/python-modules/pyjet/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, nose, numpy }:
+{ lib, buildPythonPackage, fetchPypi, cython, nose, numpy }:
 
 buildPythonPackage rec {
   pname = "pyjet";
@@ -8,6 +8,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1glcwv9ni8i40smfw6m456xjadlkackim5nk33xmas1fa96lpagg";
   };
+
+  # fix for python37
+  # https://github.com/scikit-hep/pyjet/issues/8
+  nativeBuildInputs = [ cython ];
+  preBuild = ''
+    for f in pyjet/src/*.{pyx,pxd}; do
+      cython --cplus "$f"
+    done
+  '';
 
   propagatedBuildInputs = [ numpy ];
   checkInputs = [ nose ];


### PR DESCRIPTION
###### Motivation for this change

python37 breaks old API, cython files need to be regenerated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upstream issue scikit-hep/pyjet#8