### PR TITLE
ocamlPackages.atdgen: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -1,0 +1,26 @@
+{ buildDunePackage, atd, biniou, yojson }:
+
+let runtime =
+  buildDunePackage {
+    pname = "atdgen-runtime";
+    inherit (atd) version src;
+
+    propagatedBuildInputs = [ biniou yojson ];
+
+    meta = { inherit (atd.meta) license; };
+  }
+; in
+
+buildDunePackage {
+  pname = "atdgen";
+  inherit (atd) version src;
+
+  buildInputs = [ atd ];
+
+  propagatedBuildInputs = [ runtime ];
+
+  meta = {
+    description = "Generates efficient JSON serializers, deserializers and validators";
+    inherit (atd.meta) license;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -54,6 +54,8 @@ let
 
     atd = callPackage ../development/ocaml-modules/atd { };
 
+    atdgen = callPackage ../development/ocaml-modules/atdgen { };
+
     base64 = callPackage ../development/ocaml-modules/base64 { };
 
     bap = callPackage ../development/ocaml-modules/bap {


### PR DESCRIPTION
Atdgen is a command-line program that takes as input type definitions in the
ATD syntax and produces OCaml code suitable for data serialization and
deserialization.

Homepage: https://github.com/mjambon/atd

###### Motivation for this change

https://discourse.nixos.org/t/install-ocaml-flambda-compiler/1618

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

