### PR TITLE
pyqt5: make qtwebkit optional, disable by default

### DIFF
--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -25,7 +25,7 @@
     DESTDIR=$(out)
   '';
 
-  propagatedBuildInputs = with python3Packages; [ pyqt5 ];
+  propagatedBuildInputs = with python3Packages; [ pyqt5_with_qtwebkit ];
 
   postInstall = ''
     # replace with our own wrappers. They need to be changed manually since it wouldn't work otherwise

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 
   prePatch = ''
-    sed -i "/pyqt_sip_dir/ s:=.*:= '${python2Packages.pyqt5}/share/sip/PyQt5':"  \
+    sed -i "/pyqt_sip_dir/ s:=.*:= '${python2Packages.pyqt5_with_qtwebkit}/share/sip/PyQt5':"  \
       setup/build_environment.py
 
     # Remove unneeded files and libs
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     fontconfig podofo qtbase chmlib icu sqlite libusb1 libmtp xdg_utils wrapGAppsHook
   ] ++ (with python2Packages; [
     apsw cssselect cssutils dateutil dnspython html5-parser lxml mechanize netifaces pillow
-    python pyqt5 sip
+    python pyqt5_with_qtwebkit sip
     regex msgpack
     # the following are distributed with calibre, but we use upstream instead
     odfpy

--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication rec {
     pbkdf2
     pyaes
     pycrypto
-    pyqt5
+    pyqt5_with_qtwebkit # TODO: qtwebkit not needed?
     pysocks
     qrcode
     requests

--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication rec {
     pbkdf2
     pyaes
     pycrypto
-    pyqt5_with_qtwebkit # TODO: qtwebkit not needed?
+    pyqt5
     pysocks
     qrcode
     requests

--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -4,7 +4,6 @@
 , libxslt, gst_all_1 ? null
 , withPdfReader        ? true
 , withMediaPlayback    ? true
-, withWebEngineDefault ? true
 }:
 
 assert withMediaPlayback -> gst_all_1 != null;
@@ -39,7 +38,7 @@ in python3Packages.buildPythonApplication rec {
   ] ++ lib.optionals withMediaPlayback (with gst_all_1; [
     gst-plugins-base gst-plugins-good
     gst-plugins-bad gst-plugins-ugly gst-libav
-  ]) ++ lib.optional (!withWebEngineDefault) python3Packages.qtwebkit-plugins;
+  ]);
 
   nativeBuildInputs = [
     makeWrapper wrapGAppsHook asciidoc
@@ -88,10 +87,6 @@ in python3Packages.buildPythonApplication rec {
     for i in $scripts; do
       patchPythonScript "$i"
     done
-  '';
-
-  postFixup = lib.optionalString (! withWebEngineDefault) ''
-    wrapProgram $out/bin/qutebrowser --add-flags "--backend webkit"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
     sed -i 's|@out@|'"''${out}"'|g' blink/resources.py
   '';
 
-  propagatedBuildInputs = with pythonPackages; [ pyqt5 cjson sipsimple twisted google_api_python_client ];
+  propagatedBuildInputs = with pythonPackages; [ pyqt5_with_qtwebkit cjson sipsimple twisted google_api_python_client ];
 
   buildInputs = [ pythonPackages.cython zlib libvncserver libvpx ];
 

--- a/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
+++ b/pkgs/applications/networking/instant-messengers/scudcloud/default.nix
@@ -9,7 +9,7 @@ in python3Packages.buildPythonPackage {
     sha256 = "e0d1cb72115d0fda17db92d28be51558ad8fe250972683fac3086dbe8d350d22";
   };
 
-  propagatedBuildInputs = with python3Packages; [ pyqt5 dbus-python jsmin ];
+  propagatedBuildInputs = with python3Packages; [ pyqt5_with_qtwebkit dbus-python jsmin ];
 
   meta = with stdenv.lib; {
     description = "Non-official desktop client for Slack";

--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, gettext, git }:
 
 let
-  inherit (pythonPackages) buildPythonApplication pyqt5 sip pyinotify;
+  inherit (pythonPackages) buildPythonApplication pyqt5_with_qtwebkit sip pyinotify;
 in buildPythonApplication rec {
   name = "git-cola-${version}";
   version = "3.2";
@@ -14,7 +14,7 @@ in buildPythonApplication rec {
   };
 
   buildInputs = [ git gettext ];
-  propagatedBuildInputs = [ pyqt5 sip pyinotify ];
+  propagatedBuildInputs = [ pyqt5_with_qtwebkit sip pyinotify ];
 
   doCheck = false;
 

--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, pythonPackages, gettext, git }:
 
 let
-  inherit (pythonPackages) buildPythonApplication pyqt5_with_qtwebkit sip pyinotify;
+  inherit (pythonPackages) buildPythonApplication pyqt5 sip pyinotify;
+
 in buildPythonApplication rec {
   name = "git-cola-${version}";
   version = "3.2";
@@ -14,7 +15,7 @@ in buildPythonApplication rec {
   };
 
   buildInputs = [ git gettext ];
-  propagatedBuildInputs = [ pyqt5_with_qtwebkit sip pyinotify ];
+  propagatedBuildInputs = [ pyqt5 sip pyinotify ];
 
   doCheck = false;
 

--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication rec {
 
   buildInputs = [ gtk3 ];
 
-  propagatedBuildInputs = with python3Packages; [ libopenshot pyqt5 requests sip httplib2 pyzmq ];
+  propagatedBuildInputs = with python3Packages; [ libopenshot pyqt5_with_qtwebkit requests sip httplib2 pyzmq ];
 
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -1,7 +1,8 @@
 { lib, fetchurl, fetchpatch, pythonPackages, pkgconfig
-, qmake, lndir, qtbase, qtsvg, qtwebkit, qtwebengine, dbus
-, withWebSockets ? false, qtwebsockets
+, qmake, lndir, qtbase, qtsvg, qtwebengine, dbus
 , withConnectivity ? false, qtconnectivity
+, withWebKit ? false, qtwebkit
+, withWebSockets ? false, qtwebsockets
 }:
 
 let
@@ -36,9 +37,11 @@ in buildPythonPackage {
 
   buildInputs = [ dbus sip ];
 
-  propagatedBuildInputs = [
-    qtbase qtsvg qtwebkit qtwebengine
-  ] ++ lib.optional (!isPy3k) enum34 ++ lib.optional withWebSockets qtwebsockets ++ lib.optional withConnectivity qtconnectivity;
+  propagatedBuildInputs = [ qtbase qtsvg qtwebengine ]
+    ++ lib.optional (!isPy3k) enum34
+    ++ lib.optional withConnectivity qtconnectivity
+    ++ lib.optional withWebKit qtwebkit
+    ++ lib.optional withWebSockets qtwebsockets;
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -6,25 +6,15 @@
 }:
 
 let
-  pname = "PyQt";
-  version = "5.11.3";
 
   inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34;
 
   sip = pythonPackages.sip.override { sip-module = "PyQt5.sip"; };
 
-in buildPythonPackage {
-  pname = pname;
-  version = version;
+in buildPythonPackage rec {
+  pname = "PyQt";
+  version = "5.11.3";
   format = "other";
-
-  meta = with lib; {
-    description = "Python bindings for Qt5";
-    homepage    = http://www.riverbankcomputing.co.uk;
-    license     = licenses.gpl3;
-    platforms   = platforms.mesaPlatforms;
-    maintainers = with maintainers; [ sander ];
-  };
 
   src = fetchurl {
     url = "mirror://sourceforge/pyqt/PyQt5/PyQt-${version}/PyQt5_gpl-${version}.tar.gz";
@@ -73,4 +63,12 @@ in buildPythonPackage {
   '';
 
   enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Python bindings for Qt5";
+    homepage    = http://www.riverbankcomputing.co.uk;
+    license     = licenses.gpl3;
+    platforms   = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ sander ];
+  };
 }

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -49,10 +49,6 @@ in buildPythonPackage {
 
     export PYTHONPATH=$PYTHONPATH:$out/${python.sitePackages}
 
-    substituteInPlace configure.py \
-      --replace 'install_dir=pydbusmoddir' "install_dir='$out/${python.sitePackages}/dbus/mainloop'" \
-      --replace "ModuleMetadata(qmake_QT=['webkitwidgets'])" "ModuleMetadata(qmake_QT=['webkitwidgets', 'printsupport'])"
-
     ${python.executable} configure.py  -w \
       --confirm-license \
       --dbus=${dbus.dev}/include/dbus-1.0 \

--- a/pkgs/development/python-modules/qtconsole/default.nix
+++ b/pkgs/development/python-modules/qtconsole/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     description = "Jupyter Qt console";
     homepage = http://jupyter.org/;
     license = lib.licenses.bsd3;
-    platforms = lib.platforms.linux; # fails on Darwin
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs = with python3Packages; [
-    lilypond pygame python-ly
+    lilypond pygame python-ly sip
     pyqt5_with_qtwebkit (poppler-qt5.override { pyqt5 = pyqt5_with_qtwebkit; })
   ];
 

--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -11,7 +11,10 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1yn18pwsjxpxz5j3yfysmaif8k0vqahj5c7ays9cxsylpg9hl7jd";
   };
 
-  propagatedBuildInputs = with python3Packages; [ lilypond pygame python-ly poppler-qt5 ];
+  propagatedBuildInputs = with python3Packages; [
+    lilypond pygame python-ly
+    pyqt5_with_qtwebkit (poppler-qt5.override { pyqt5 = pyqt5_with_qtwebkit; })
+  ];
 
   # no tests in shipped with upstream
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -614,6 +614,12 @@ in {
   pyqt5 = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt/5.x.nix {
     pythonPackages = self;
   };
+
+  /*
+    `pyqt5_with_qtwebkit` should not be used by python libraries in
+    pkgs/development/python-modules/*. Putting this attribute in
+    `propagatedBuildInputs` may cause collisions.
+  */
   pyqt5_with_qtwebkit = self.pyqt5.override { withWebKit = true; };
 
   pysc2 = callPackage ../development/python-modules/pysc2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -614,6 +614,7 @@ in {
   pyqt5 = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt/5.x.nix {
     pythonPackages = self;
   };
+  pyqt5_with_qtwebkit = self.pyqt5.override { withWebKit = true; };
 
   pysc2 = callPackage ../development/python-modules/pysc2 { };
 


### PR DESCRIPTION
###### Motivation for this change

qtwebkit appears to be unsupported in Qt 5.11. We are using some old port
https://github.com/NixOS/nixpkgs/blob/475d653afdbd8fe3e00ccfd22a30014b0df7aeaa/pkgs/development/libraries/qt-5/5.11/default.nix#L39-L48
and it is broken on darwin. We are likely will be looking to be phasing out QtWebKit in the future as it will break and have more and more security problems. It is nice to have packages that still rely on it to be marked out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-review pr 51846`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- Test if QtWebKit is needed (`grep -r QtWebKit ...` and try to run the binary)
   - [x] anki
   - [x] blink - broken runtime, but grep shows that it does import QtWebKit and QtWebKitWidgets
     - [x] fix
     - [ ] test (Segfaults on master)
   - [x] cadence - works, but could potentially try to import QtWebKitWidgets
     - [x] fix
     - [x] test
   - [x] calibre - imports QtWebKitWidgets
     - [x] fix
     - [x] test
   - [x] cura
   - [x] ~electron-cash - was broken on Hydra due to cytoolz, setup-release.py says it needs PyQt5.QtWebKit~ *doesn't need QtWebKit*
   - [x] electrum - crashes, grep QtWebKit on sources gives nothing
   - [x] electrum-ltc
   - [x] flent
   - [x] frescobaldi - imports QtWebKitWidgets
     - [x] fix
     - [x] test
   - [x] git-cola - ~imports QtWebKitWidgets~ *imports QtWebKitWidgets, but only if QtWebEngine is not available*
   - [x] gns3-gui
   - [x] hplip
   - [x] hplipWithPlugin
   - [x] ihaskell - depends on jupyter
   - [x] kmymoney
   - [x] krop
   - [x] leo-editor - if QtWebKit is not available seems to gracefully switch to QtWebEngine
   - [x] manuskript
   - [x] multibootusb
   - [x] nagstamon
   - [x] openshot-qt - imports QtWebKitWidgets
     - [x] fix
     - [x] test
   - [x] picard
   - [x] plover.dev
   - [x] python27Packages.jupyter
   - [x] python27Packages.ovito
   - [x] python27Packages.poppler-qt5
   - [x] python27Packages.qtconsole
   - [x] python27Packages.weboob
   - [x] python37Packages.jupyter
   - [x] python37Packages.ovito
   - [x] python37Packages.poppler-qt5
   - [x] python37Packages.qtconsole
   - [x] python37Packages.uranium
   - [x] scudcloud - needs QtWebKitWidgets
     - [x] fix
     - [x] test
   - [x] qarte
   - [x] qutebrowser
   - [x] spyder
   - [x] tribler
   - [x] urh
 - Investigate failed builds
   - [x] gitAndTools.git-annex-metadata-gui - broken on Hydra due to git-annex-adapter, grep QtWebKit on sources gives nothing
   - [x] mnemosyne - broken on Hydra due to objgraph, judging by sources it uses QtWebEngine, grep QtWebKit on sources gives nothing
   - [x] rapid-photo-downloader - broken on Hydra due to rawkit, grep QtWebKit on sources gives nothing

---