### PR TITLE
epsxe: add libGLU_combined to buildInputs

### DIFF
--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, alsaLib, curl, gdk_pixbuf, glib, gtk3,
+{ stdenv, fetchurl, alsaLib, curl, gdk_pixbuf, glib, gtk3, libGLU_combined,
   libX11, openssl, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook }:
 
 with stdenv.lib;
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     glib
     gtk3
     libX11
+    libGLU_combined
     openssl
     ncurses5
     SDL


### PR DESCRIPTION
###### Motivation for this change

This fixes #51845.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

