### PR TITLE
Make pkgs.nixos and pkgs.nixosTest pure wrt NIXOS_EXTRA_MODULE_PATH

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -6,7 +6,8 @@
   # Nixpkgs, for qemu, lib and more
 , pkgs
 , # NixOS configuration to add to the VMs
-  extraConfigurations ? []
+  extraConfigurations ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
+                        in if e == "" then [] else [(import e)]
 }:
 
 with pkgs.lib;
@@ -37,9 +38,9 @@ rec {
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
-        ] ++ optional minimal ../modules/testing/minimal-kernel.nix
-          ++ extraConfigurations;
+        ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
       extraArgs = { inherit nodes; };
+      extraModules = extraConfigurations;
     };
 
 

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -24,11 +24,11 @@
   check ? true
 , prefix ? []
 , lib ? import ../../lib
+, extraModules ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
+                 in if e == "" then [] else [(import e)]
 }:
 
 let extraArgs_ = extraArgs; pkgs_ = pkgs;
-    extraModules = let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
-                   in if e == "" then [] else [(import e)];
 in
 
 let

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -24,6 +24,8 @@
   check ? true
 , prefix ? []
 , lib ? import ../../lib
+  # Extra modules to include. Defaults to NIXOS_EXTRA_MODULE_PATH.
+  # Otherwise equivalent to adding to modules.
 , extraModules ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
                  in if e == "" then [] else [(import e)]
 }:

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -4,8 +4,10 @@
 , minimal ? false
   # Ignored
 , config ? null
-  # Modules to add to each VM
-, extraConfigurations ? [] }:
+, # NixOS configuration to add to the VMs
+  extraConfigurations ? let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
+                        in if e == "" then [] else [(import e)]
+}:
 
 with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations; };
 with pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22362,6 +22362,10 @@ in
                   then configuration
                   else [configuration]
                 );
+
+      # The NIXOS_EXTRA_MODULE_PATH environment variable if Nixpkgs
+      # was invoked via impure.nix.
+      extraModules = config.nixosExtraModules or [];
     }).config.system.build;
 
 
@@ -22405,7 +22409,7 @@ in
             { lib, ... }: {
               config.nixpkgs.pkgs = lib.mkDefault pkgs;
             }
-          )];
+          )] ++ config.nixosExtraModules or [];
         });
     in
       test:


### PR DESCRIPTION
###### Motivation for this change

Includes #51850

This avoids the `NIXOS_EXTRA_MODULE_PATH` impurity in NixOS when
Nixpkgs is invoked 'purely' via `pkgs/top-level/default.nix`, but
passed the impurity along if invoked impurely via `/default.nix`
or `pkgs/top-level/impure.nix`.

`pkgs.nixosTests` remains impure by necessity until a possible future
optimization that will make it call `pkgs.nixosTest`, therefore
inheriting its behavior.

This duplicates the default in a number of places because these files are potentially public interfaces.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date (NIXOS_EXTRA_MODULE_PATH has minimal documentation in NixOS manual which remains correct)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

