### PR TITLE
jdk11_headless: fix the build on amd64

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -67,8 +67,8 @@ let
         # See https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg49006.html
         "--with-extra-cflags=-Wno-error=deprecated-declarations -Wno-error=format-contains-nul -Wno-error=unused-result"
     ''
-    + lib.optionalString (architecture == "amd64") "\"--with-jvm-features=zgc\""
-    + lib.optionalString minimal "\"--enable-headless-only\""
+    + lib.optionalString (architecture == "amd64") " \"--with-jvm-features=zgc\""
+    + lib.optionalString minimal " \"--enable-headless-only\""
     + ");"
     # https://bugzilla.redhat.com/show_bug.cgi?id=1306558
     # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716


### PR DESCRIPTION
This fixes #51859:

```
checking user specified JVM feature list...
configure: error: Cannot continue
configure: Unknown JVM features specified: "zgc--enable-headless-only"
configure: The available JVM features are: "aot cds cmsgc compiler1 compiler2 dtrace epsilongc g1gc graal jfr jni-check jvmci jvmti link-time-opt management minimal nmt parallelgc serialgc services static-build vm-structs zero zgc"
configure exiting with result code 1
builder for '/nix/store/1awwzd98crcgxad3srdkv8smhxgiz2qp-openjdk-11.0.1-b13.drv' failed with exit code 1
```

###### Motivation for this change

Fix build breakage introduced in https://github.com/NixOS/nixpkgs/commit/162914742327002d49bd1dde424d399842ff7b5f

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I verified that this unbreaks the configure step; it now does

```
<3>====================================================
<3>A new configuration has been successfully created in
<3>/build/jdk11u-jdk-11.0.1+13/build/linux-x86_64-normal-server-release
<3>using configure arguments '--prefix=/nix/store/hc9zyzfvzijra93b3n0a97q7wzazw0w0-openjdk-11.0.1-b13 --with-boot-jdk=/nix/store/i0himc6fzacdjkhasw5bmwkywdmpi89b-openjdk-bootstrap/lib/openjdk --with-update-version=11.0.1 --with-build-number=13 --with-milestone=fcs --enable-unlimited-crypto --disable-debug-symbols --with-zlib=system --with-giflib=system --with-stdc++lib=dynamic --with-extra-cflags='-Wno-error=deprecated-declarations -Wno-error=format-contains-nul -Wno-error=unused-result' --with-jvm-features=zgc --enable-headless-only'.
<3>
```