### PR TITLE
metamath: 0.167 -> 0.168

### DIFF
--- a/pkgs/development/interpreters/metamath/default.nix
+++ b/pkgs/development/interpreters/metamath/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "metamath-${version}";
-  version = "0.167";
+  version = "0.168";
 
   buildInputs = [ autoreconfHook ];
 
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Taneb";
     repo = "metamath";
-    rev = "579166a649c5d9ae0cdc641185e68219d2812f24";
-    sha256 = "0ly7qv3gajlaf283fsy9ak41r09sh49ygzj0s9yxyjfli6rgxdby";
+    rev = "542bfd5e53d8ce026ce5d29da9e7069ec807f5e0";
+    sha256 = "07ssgqh9ipiw1bf60snmjaxngln1an1h9q0vgszadc94wzw06zi4";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
It seems there's a new version pretty much the day after I get this package added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

