### PR TITLE
xpra:  2.3.4 -> 2.4.2

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -14,11 +14,11 @@ let
   xf86videodummy = callPackage ./xf86videodummy { };
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "2.3.4";
+  version = "2.4.2";
 
   src = fetchurl {
     url = "https://xpra.org/src/${pname}-${version}.tar.xz";
-    sha256 = "0wa3kx54himy3i1b2801hlzfilh3cf4kjk40k1cjl0ds28m5hija";
+    sha256 = "01x4ri0arfq9cn01bh80h232lsj95jp6j1zw0z0q7a6mwrw4gr6i";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

XPRA is broken as of now (https://github.com/NixOS/nixpkgs/issues/41106 and https://github.com/NixOS/nixpkgs/issues/30822), here's hoping the bump fixes it.

There was another curious artifact in 2.3.4, by the way -- the features file had this:
```
$ ag LOCAL_SERVERS_SUPPORTED /nix/store/kfrnj33702mfa8y8629adh894ccn731z-xpra-2.3.4/lib/python3.6/site-packages/xpra/
/nix/store/kfrnj33702mfa8y8629adh894ccn731z-xpra-2.3.4/lib/python3.6/site-packages/xpra/platform/features.py
14:LOCAL_SERVERS_SUPPORTED = PYTHON2
```
..which resulted in `xpra` having no `start` subcommand.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

