### PR TITLE
vboxExtpack: Fix the sha256 to be hex.

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -7,7 +7,11 @@ in
 fetchurl rec {
   name = "Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack";
   url = "https://download.virtualbox.org/virtualbox/${version}/${name}";
-  sha256 = "1vria59m7xr521hp2sakfihv8282xcfd5hl6dr1gbcjicmk514kp";
+  sha256 =
+    # Manually sha256sum the extensionPack file, must be hex!
+    # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
+    let value = "779250666551b2f5426e86c2d21ceb0209b46174536971611025f753535131ef";
+    in assert (builtins.stringLength value) == 64; value;
 
   meta = {
     description = "Oracle Extension pack for VirtualBox";


### PR DESCRIPTION
It does not work if the sha256 is not hex, it fails because VBoxExtPackHelperApp requires to be given a hex hash.
See https://github.com/NixOS/nixpkgs/issues/34846 where the same problem was fixed some time ago.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

