### PR TITLE
buildRustCrate: fix extraRustcOpts so it is not discarded

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -75,6 +75,7 @@ let crate = crate_ // (lib.attrByPath [ crate_.crateName ] (attr: {}) crateOverr
     ];
     extraDerivationAttrs = lib.filterAttrs (n: v: ! lib.elem n processedAttrs) crate;
     buildInputs_ = buildInputs;
+    extraRustcOpts_ = extraRustcOpts;
 in
 stdenv.mkDerivation (rec {
 
@@ -141,7 +142,7 @@ stdenv.mkDerivation (rec {
               extraLinkFlags
               crateAuthors verbose colors target_os;
     };
-    extraRustcOpts = if crate ? extraRustcOpts then crate.extraRustcOpts else [];
+    extraRustcOpts = (if crate ? extraRustcOpts then crate.extraRustcOpts else []) ++ extraRustcOpts_;
     buildPhase = buildCrate {
       inherit crateName dependencies
               crateFeatures libName release libPath crateType


### PR DESCRIPTION
###### Motivation for this change

The overridable `extraRustcOpts` in `buildRustCrate` was actually discarded, so I piped it through to the right spot in the nix expression.

cc @P-E-Meunier @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

