### PR TITLE
Revert "dropbox: add mesa, libxshmfence and libpthreadstubs"

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -36,7 +36,7 @@ buildFHSUserEnv {
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
     libXxf86vm libxcb xkeyboardconfig
     curl dbus firefox-bin fontconfig freetype gcc glib gnutar libxml2 libxslt
-    procps zlib mesa libxshmfence libpthreadstubs
+    procps zlib
   ];
 
   extraInstallCommands = ''


### PR DESCRIPTION
Breaks eval

This reverts commit 1d83bd047bb68edec27b8dccb254c97c3ff2f9db.

###### Motivation for this change

