### PR TITLE
bundlerEnv: improve handling of groups

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -94,6 +94,15 @@ rec {
   attrValues = builtins.attrValues or (attrs: attrVals (attrNames attrs) attrs);
 
 
+  /* Given a set of attribute names, return the set of the corresponding
+     attributes from the given set.
+
+     Example:
+       getAttrs [ "a" "b" ] { a = 1; b = 2; c = 3; }
+       => { a = 1; b = 2; }
+  */
+  getAttrs = names: attrs: genAttrs names (name: attrs.${name});
+
   /* Collect each attribute named `attr' from a list of attribute
      sets.  Sets that don't contain the named attribute are ignored.
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -61,10 +61,10 @@ let
       boolToString mergeAttrs flip mapNullable inNixShell min max
       importJSON warn info nixpkgsVersion version mod compare
       splitByAndCompare functionArgs setFunctionArgs isFunction;
-    inherit (fixedPoints) fix fix' extends composeExtensions
+    inherit (fixedPoints) fix fix' converge extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;
     inherit (attrsets) attrByPath hasAttrByPath setAttrByPath
-      getAttrFromPath attrVals attrValues catAttrs filterAttrs
+      getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList mapAttrsRecursive mapAttrsRecursiveCond
       genAttrs isDerivation toDerivation optionalAttrs

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -24,6 +24,16 @@ rec {
   # for a concrete example.
   fix' = f: let x = f x // { __unfix__ = f; }; in x;
 
+  # Return the fixpoint that `f` converges to when called recursively, starting
+  # with the input `x`.
+  #
+  #     nix-repl> converge (x: x / 2) 16
+  #     0
+  converge = f: x:
+    if (f x) == x
+    then x
+    else converge f (f x);
+
   # Modify the contents of an explicitly recursive attribute set in a way that
   # honors `self`-references. This is accomplished with a function
   #

--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -17,7 +17,7 @@
 , postBuild ? null
 , document ? []
 , meta ? {}
-, groups ? ["default"]
+, groups ? null
 , ignoreCollisions ? false
 , buildInputs ? []
 , ...

--- a/pkgs/development/ruby-modules/bundled-common/functions.nix
+++ b/pkgs/development/ruby-modules/bundled-common/functions.nix
@@ -52,7 +52,7 @@ in rec {
 
   groupMatches = groups: attrs:
     groups == null || !(attrs ? "groups") ||
-      (intersectLists groups attrs.groups) != [];
+      (intersectLists (groups ++ [ "default" ]) attrs.groups) != [];
 
   applyGemConfigs = attrs:
     (if gemConfig ? "${attrs.gemName}"

--- a/pkgs/development/ruby-modules/bundled-common/functions.nix
+++ b/pkgs/development/ruby-modules/bundled-common/functions.nix
@@ -1,7 +1,8 @@
 { lib, gemConfig, ... }:
 
 let
-  inherit (lib) attrValues concatMap converge filterAttrs getAttrs;
+  inherit (lib) attrValues concatMap converge filterAttrs getAttrs
+                intersectLists;
 
 in rec {
   bundlerFiles = {
@@ -49,10 +50,9 @@ in rec {
     ) attrs.platforms
   );
 
-  groupMatches = groups: attrs: (
-  !(attrs ? "groups") ||
-    builtins.any (gemGroup: builtins.any (group: group == gemGroup) groups) attrs.groups
-  );
+  groupMatches = groups: attrs:
+    groups == null || !(attrs ? "groups") ||
+      (intersectLists groups attrs.groups) != [];
 
   applyGemConfigs = attrs:
     (if gemConfig ? "${attrs.gemName}"


### PR DESCRIPTION
###### Motivation for this change

The most recent version of Bundix introduces group attribute generation. This has revealed some deficiencies with how groups are handled by bundlerEnv. These would be addressed by making the following changes:

- Suppose I have a Gemfile like this:

  ```ruby
  source "https://rubygems.org"
  gem "actioncable"
  gem "websocket-driver", group: :test
  ```

  The gemset.nix generated by Bundix 2.4.1 will set ActionCable's groups to `[ "default" ]`, and websocket-driver's to `[ "test" ]`. This means that the generated `bundlerEnv` wouldn't include websocket-driver unless the test group was included, even though it's required by the default group.

  This is arguably a bug in Bundix (https://github.com/manveru/bundix/issues/39) (websocket-driver's groups should probably be `[ "default" "test" ]` or just `[ "default" ]`), but there's no reason `bundlerEnv` should omit dependencies even given such an input -- it won't necessarily come from Bundix, and it would be good for `bundlerEnv` to do the right thing.

  To fix this, `filterGemset` is now a recursive function, that adds dependencies of gems in the group to the filtered gemset until it stabilises on the gems that match the required groups, and all of their recursive dependencies.

- All groups are now included by default. This wasn't really an issue until the latest minor release of Bundix (2.4), because prior to then Bundix didn't emit group attributes, and so this functionality of `bundlerEnv` wasn't really used. However, it is now apparent that a better default for `bundlerEnv` would be to include all gem groups by default, not just the default group. This matches the behavior of Bundler, and makes more sense, because the default group alone isn't necessarily useful for anything -- consider a Rails app with production, development, and test groups. It has the additional benefit of being backwards compatible with how this would have worked before the Bundix update.

- Default gems are always included. `default` isn't really a group, it's more the absence of one. With Bundler, this means that a gem should be installed unconditionally, regardless of which groups are specified. It doesn't really make sense to allow these gems to be omitted from a `bundlerEnv`.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---