### PR TITLE
ikos: init at 2.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -505,6 +505,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     free = false;
   };
 
+  nasa13 = spdx {
+    spdxId = "NASA-1.3";
+    fullName = "NASA Open Source Agreement 1.3";
+    free = false;
+  };
+
   ncsa = spdx {
     spdxId = "NCSA";
     fullName  = "University of Illinois/NCSA Open Source License";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -401,6 +401,11 @@
     github = "aszlig";
     name = "aszlig";
   };
+  atnnn = {
+    email = "etienne@atnnn.com";
+    github = "atnnn";
+    name = "Etienne Laurin";
+  };
   auntie = {
     email = "auntieNeo@gmail.com";
     github = "auntie";

--- a/pkgs/development/tools/analysis/ikos/default.nix
+++ b/pkgs/development/tools/analysis/ikos/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, cmake, boost
+, gmp, llvm, clang, sqlite, python3
+, ocamlPackages, mpfr, ppl, doxygen, graphviz
+}:
+
+let
+  python = python3.withPackages (ps: with ps; [
+    pygments
+  ]);
+in
+
+stdenv.mkDerivation rec {
+  name = "ikos";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "NASA-SW-VnV";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "09nf47hpk5w5az4c0hcr5hhwvpz8zg1byyg185542cpzbq1xj8cb";
+  };
+
+  buildInputs = [ cmake boost gmp clang llvm sqlite python
+                  ocamlPackages.apron mpfr ppl doxygen graphviz ];
+
+  cmakeFlags = "-DAPRON_ROOT=${ocamlPackages.apron}";
+
+  postBuild = "make doc";
+
+  meta = with lib; {
+    homepage = https://github.com/NASA-SW-VnV/ikos;
+    description = "Static analyzer for C/C++ based on the theory of Abstract Interpretation";
+    license = licenses.nasa13;
+    maintainers = with maintainers; [ atnnn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8713,6 +8713,10 @@ in
     inherit (perlPackages) XMLSimple;
   };
 
+  ikos = callPackage ../development/tools/analysis/ikos {
+    inherit (llvmPackages_7) stdenv clang llvm;
+  };
+
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
     llvmPackages = llvmPackages_6;
   };


### PR DESCRIPTION
###### Motivation for this change

There is a new release of IKOS: https://github.com/NASA-SW-VnV/ikos/releases/tag/v2.1

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

