### PR TITLE
meson: 0.48.2 → 0.49.0

### DIFF
--- a/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
+++ b/pkgs/development/tools/build-managers/meson/allow-dirs-outside-of-prefix.patch
@@ -1,6 +1,6 @@
 --- a/mesonbuild/coredata.py
 +++ b/mesonbuild/coredata.py
-@@ -298,18 +298,13 @@
+@@ -375,18 +375,13 @@
          '''
          if option.endswith('dir') and os.path.isabs(value) and \
             option not in builtin_dir_noprefix_options:

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,12 +1,12 @@
 { lib, python3Packages, stdenv, writeTextDir, substituteAll, targetPackages }:
 
 python3Packages.buildPythonApplication rec {
-  version = "0.48.2";
+  version = "0.49.0";
   pname = "meson";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1shfbr0mf8gmwpw5ivrmwp8282qw9mfhxmccd7fsgidp4x3nslby";
+    sha256 = "0895igla1qav8k250z2qv03a0fg491wzzkfpbk50wwq848vmbkd0";
   };
 
   postFixup = ''

--- a/pkgs/development/tools/build-managers/meson/fix-rpath.patch
+++ b/pkgs/development/tools/build-managers/meson/fix-rpath.patch
@@ -1,27 +1,18 @@
 --- a/mesonbuild/compilers/compilers.py
 +++ b/mesonbuild/compilers/compilers.py
-@@ -1112,6 +1112,8 @@
-         for p in rpath_paths:
-             if p == from_dir:
-                 relative = '' # relpath errors out in this case
-+            elif os.path.isabs(p):
-+                relative = p # These can be outside of build dir.
-             else:
-                 relative = os.path.relpath(os.path.join(build_dir, p), os.path.join(build_dir, from_dir))
-             rel_rpaths.append(relative)
-@@ -1121,8 +1123,10 @@
-             if paths != '':
-                 paths += ':'
-             paths += build_rpath
--        if len(paths) < len(install_rpath):
--            padding = 'X' * (len(install_rpath) - len(paths))
-+        store_paths = ':'.join(filter(lambda path: path.startswith('@storeDir@'), paths.split(':')))
-+        extra_space_needed = len(install_rpath + (':' if install_rpath and store_paths else '') + store_paths) - len(paths)
-+        if extra_space_needed > 0:
-+            padding = 'X' * extra_space_needed
-             if not paths:
-                 paths = padding
-             else:
+@@ -1202,8 +1202,10 @@
+             # In order to avoid relinking for RPATH removal, the binary needs to contain just
+             # enough space in the ELF header to hold the final installation RPATH.
+             paths = ':'.join(all_paths)
+-            if len(paths) < len(install_rpath):
+-                padding = 'X' * (len(install_rpath) - len(paths))
++            store_paths = ':'.join(filter(lambda path: path.startswith('@storeDir@'), all_paths))
++            extra_space_needed = len(install_rpath + (':' if install_rpath and store_paths else '') + store_paths) - len(paths)
++            if extra_space_needed > 0:
++                padding = 'X' * extra_space_needed
+                 if not paths:
+                     paths = padding
+                 else:
 --- a/mesonbuild/scripts/depfixer.py
 +++ b/mesonbuild/scripts/depfixer.py
 @@ -303,6 +303,14 @@

--- a/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
+++ b/pkgs/development/tools/build-managers/meson/gir-fallback-path.patch
@@ -1,6 +1,6 @@
 --- a/mesonbuild/modules/gnome.py
 +++ b/mesonbuild/modules/gnome.py
-@@ -780,6 +780,13 @@
+@@ -805,6 +805,13 @@
          scan_command += self._scan_langs(state, [lc[0] for lc in langs_compilers])
          scan_command += list(external_ldflags)
  


### PR DESCRIPTION
###### Motivation for this change
http://mesonbuild.com/Release-notes-for-0-49-0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

