### PR TITLE
treewide: cross-fixes (memcached, opendkim, gdb, tcl, xorg*)

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -98,7 +98,7 @@ rec {
       in
         if final.parsed.kernel.name == pkgs.stdenv.hostPlatform.parsed.kernel.name &&
            (final.parsed.cpu.name == pkgs.stdenv.hostPlatform.parsed.cpu.name ||
-            (final.platform.isi686 && pkgs.stdenv.hostPlatform.isx86_64))
+            (final.isi686 && pkgs.stdenv.hostPlatform.isx86_64))
         then pkgs.runtimeShell
         else if final.isWindows
         then "${wine}/bin/${wine-name}"

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -15,14 +15,17 @@ stdenv.mkDerivation rec {
   setOutputFlags = false;
 
   preConfigure = ''
-    # Note: using $out instead of $man to prevent a runtime dependency on $man.
-    configureFlagsArray+=(--mandir=$out/share/man --enable-man-symlinks)
-
-    # Don't install tzdata because NixOS already has a more up-to-date copy.
-    configureFlagsArray+=(--with-tzdata=no)
-
     cd unix
   '';
+
+  configureFlags = [
+    # Note: using $out instead of $man to prevent a runtime dependency on $man.
+    "--mandir=${placeholder "out"}/share/man"
+    "--enable-man-symlinks"
+    # Don't install tzdata because NixOS already has a more up-to-date copy.
+    "--with-tzdata=no"
+    "tcl_cv_strtod_unbroken=ok"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -19,13 +19,14 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
+    "--enable-threads"
     # Note: using $out instead of $man to prevent a runtime dependency on $man.
     "--mandir=${placeholder "out"}/share/man"
     "--enable-man-symlinks"
     # Don't install tzdata because NixOS already has a more up-to-date copy.
     "--with-tzdata=no"
     "tcl_cv_strtod_unbroken=ok"
-  ];
+  ] ++ stdenv.lib.optional stdenv.is64bit "--enable-64bit";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libmilter/default.nix
+++ b/pkgs/development/libraries/libmilter/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib
     cd libmilter
     cat > a.m4 <<EOF
+      define(\`confCC', \`$CC')
+      define(\`confAR', \`$AR')
       define(\`confEBINDIR', \`$out/libexec')
       define(\`confINCLUDEDIR', \`$out/include')
       define(\`confLIBDIR', \`$out/lib')
@@ -29,9 +31,9 @@ stdenv.mkDerivation rec {
     sh Build -f ./a.m4
   '';
 
-  patches = [ ./install.patch ./sharedlib.patch];
+  patches = [ ./install.patch ./sharedlib.patch ];
 
-  buildInputs = [ m4 ];
+  nativeBuildInputs = [ m4 ];
 
   meta = with stdenv.lib; {
     description = "Sendmail Milter mail filtering API library";

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, intltool, autoreconfHook
 , file, expat, libdrm, xorg, wayland, wayland-protocols, openssl
 , llvmPackages, libffi, libomxil-bellagio, libva-minimal
-, libelf, libvdpau, valgrind-light, python2
+, libelf, libvdpau, valgrind-light, python2, python2Packages
 , libglvnd
 , enableRadv ? true
 , galliumDrivers ? null
@@ -134,11 +134,14 @@ let self = stdenv.mkDerivation {
     "--disable-opencl"
   ];
 
-  nativeBuildInputs = [ autoreconfHook intltool pkgconfig file ];
+  nativeBuildInputs = [
+    autoreconfHook intltool pkgconfig file
+    python2 python2Packages.Mako
+  ];
 
-  propagatedBuildInputs = with xorg;
-    [ libXdamage libXxf86vm ]
-    ++ optional stdenv.isLinux libdrm
+  propagatedBuildInputs = with xorg; [
+    libXdamage libXxf86vm
+  ] ++ optional stdenv.isLinux libdrm
     ++ optionals stdenv.isDarwin [ OpenGL Xplugin ];
 
   buildInputs = with xorg; [
@@ -147,7 +150,6 @@ let self = stdenv.mkDerivation {
     libX11 libXext libxcb libXt libXfixes libxshmfence libXrandr
     libffi libvdpau libelf libXvMC
     libpthreadstubs openssl /*or another sha1 provider*/
-    python2 python2.pkgs.Mako
   ] ++ lib.optionals (elem "wayland" eglPlatforms) [ wayland wayland-protocols ]
     ++ lib.optionals stdenv.isLinux [ valgrind-light libomxil-bellagio libva-minimal ];
 

--- a/pkgs/development/libraries/opendkim/default.nix
+++ b/pkgs/development/libraries/opendkim/default.nix
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "06v8bqhh604sz9rh5bvw278issrwjgc4h1wx2pz9a84lpxbvm823";
   };
 
-  configureFlags= [ "--with-milter=${libmilter}" ];
+  configureFlags= [
+    "--with-milter=${libmilter}"
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, python, pkgconfig, readline, libxslt
-, docbook_xsl, docbook_xml_dtd_42
+{ stdenv, fetchurl, python2, pkgconfig, readline, libxslt
+, docbook_xsl, docbook_xml_dtd_42, buildPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -10,28 +10,32 @@ stdenv.mkDerivation rec {
     sha256 = "1ibcz466xwk1x6xvzlgzd5va4lyrjzm3rnjak29kkwk7cmhw4gva";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig python2 ];
   buildInputs = [
-    python readline libxslt docbook_xsl docbook_xml_dtd_42
+    readline libxslt docbook_xsl docbook_xml_dtd_42
   ];
 
   preConfigure = ''
-    sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,g' buildtools/bin/waf
+    patchShebangs buildtools/bin/waf
   '';
 
   configureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--cross-compile"
+    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
+  configurePlatforms = [ ];
 
   meta = with stdenv.lib; {
     description = "The trivial database";
-    longDescription =
-      '' TDB is a Trivial Database. In concept, it is very much like GDBM,
-         and BSD's DB except that it allows multiple simultaneous writers and
-         uses locking internally to keep writers from trampling on each
-         other.  TDB is also extremely small.
-      '';
+    longDescription = ''
+      TDB is a Trivial Database. In concept, it is very much like GDBM,
+      and BSD's DB except that it allows multiple simultaneous writers
+      and uses locking internally to keep writers from trampling on each
+      other. TDB is also extremely small.
+    '';
     homepage = https://tdb.samba.org/;
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ wkennington ];

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -11,15 +11,15 @@ stdenv.mkDerivation rec {
   # autoreconfHook is needed to pick up patching of Makefile.am
   # Remove when the patch no longer applies.
   patches = [ ./coregrind-makefile-race.patch ];
-  nativeBuildInputs = [ autoreconfHook ];
+  # Perl is needed for `cg_annotate'.
+  nativeBuildInputs = [ autoreconfHook perl ];
 
   outputs = [ "out" "dev" "man" "doc" ];
 
   hardeningDisable = [ "stackprotector" ];
 
-  # Perl is needed for `cg_annotate'.
   # GDB is needed to provide a sane default for `--db-command'.
-  buildInputs = [ perl gdb ]  ++ stdenv.lib.optionals (stdenv.isDarwin) [ bootstrap_cmds xnu ];
+  buildInputs = [ gdb ]  ++ stdenv.lib.optionals (stdenv.isDarwin) [ bootstrap_cmds xnu ];
 
   enableParallelBuilding = true;
   separateDebugInfo = stdenv.isLinux;

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 
 # Build time
-, fetchurl, fetchpatch, pkgconfig, perl, texinfo, setupDebugInfoDirs
+, fetchurl, fetchpatch, pkgconfig, perl, texinfo, setupDebugInfoDirs, buildPackages
 
 # Run time
 , ncurses, readline, gmp, mpfr, expat, zlib, dejagnu
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional doCheck dejagnu;
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "0aav15f0lh8k4i62aza2bdv4s8vv65j38pz2zc4v45snd3arfby0";
   };
 
+  configureFlags = [
+     "ac_cv_c_endian=${if stdenv.hostPlatform.isBigEndian then "big" else "little"}"
+  ];
+
   buildInputs = [cyrus_sasl libevent];
 
   hardeningEnable = [ "pie" ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -251,6 +251,8 @@ self: super:
 
   libXvMC = super.libXvMC.overrideAttrs (attrs: {
     outputs = [ "out" "dev" "doc" ];
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
     buildInputs = attrs.buildInputs ++ [self.renderproto];
   });
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -214,6 +214,8 @@ self: super:
 
   libXinerama = super.libXinerama.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
   });
 
   libXmu = super.libXmu.overrideAttrs (attrs: {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -145,7 +145,8 @@ self: super:
     configureFlags = attrs.configureFlags or []
       ++ malloc0ReturnsNullCrossFlag;
     propagatedBuildInputs = [ self.libSM ];
-    CPP = stdenv.lib.optionalString stdenv.isDarwin "clang -E -";
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    CPP = if stdenv.isDarwin then "clang -E -" else "${stdenv.cc.targetPrefix}cc -E -";
     outputs = [ "out" "dev" "devdoc" ];
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12588,9 +12588,7 @@ in
     python = python2;
   };
 
-  tdb = callPackage ../development/libraries/tdb {
-    python = python2;
-  };
+  tdb = callPackage ../development/libraries/tdb {};
 
   tecla = callPackage ../development/libraries/tecla { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

