### PR TITLE
configure the evaluation of modules in a modular way

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -100,7 +100,7 @@ let
       cleanSource sourceByRegex sourceFilesBySuffices
       commitIdFromGitRepo cleanSourceWith pathHasContext
       canCleanSource;
-    inherit (modules) evalModules closeModules unifyModuleSyntax
+    inherit (modules) evalModules evalModules' closeModules unifyModuleSyntax
       applyIfFunction unpackSubmodule packSubmodule mergeModules
       mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions
       pushDownProperties dischargeProperties filterOverrides

--- a/lib/eval-modules.nix
+++ b/lib/eval-modules.nix
@@ -1,0 +1,59 @@
+callArgs:
+
+let
+  inherit (builtins.foldl' ({ modules, configurers }: m:
+    let
+      match = m: builtins.isAttrs m && m ? configureModules;
+      return = m: {
+        modules = modules ++ [ (removeAttrs m [ "configureModules" ]) ];
+        configurers = configurers ++ [ m.configureModules ];
+      };
+    in if match m then return m else
+    let m' = import m; in if !(builtins.isFunction m || builtins.isAttrs m) && match m'
+    then return (m' // { _file = toString m; key = toString m; })
+    else { modules = modules ++ [ m ]; inherit configurers; }
+  ) { modules = []; configurers = []; } callArgs.modules) modules configurers;
+
+  # Without updating the modules list, the `configureModules` attribute
+  # would not be removed from its module, and it is an invalid option or special attribute,
+  # so it would result in an error.
+  callArgs' = callArgs // { inherit modules; };
+
+  applyConfigureModules = x: if builtins.isFunction x
+    then x callArgs'
+    else callArgs' // x // builtins.listToAttrs (map
+      (name: { inherit name; value = callArgs'.${name} // x.${name}; })
+      (builtins.filter (name: x ? ${name}) [ "args" "specialArgs" ]));
+
+  configArgs = let len = builtins.length configurers; in if len == 1
+    then applyConfigureModules (builtins.head configurers)
+    else if len == 0 then callArgs'
+    else throw "Only one module (the entry point) is allowed to have a 'configureModules' attribute.";
+
+in
+(
+  { modules
+  , prefix ? []
+  , args ? {}
+  , specialArgs ? {}
+  , lib ? import ./.
+  , pkgs ? null
+  , check ? true
+  }:
+  let
+    evalModule = rec {
+      _file = toString ./eval-modules.nix;
+      key = _file;
+      config = lib.mkMerge [
+        { _module = { inherit args check; }; }
+        { _module.args.pkgs = lib.mkIf (pkgs != null) (lib.mkForce pkgs); }
+      ];
+    };
+
+  in lib.evalModules' {
+    inherit prefix;
+    modules = modules ++ [ evalModule ];
+    specialArgs = { modulesPath = toString ../nixos/modules; } // specialArgs // { inherit lib; };
+  }
+)
+(configArgs)

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -8,53 +8,46 @@
 # as subcomponents (e.g. the container feature, or nixops if network
 # expressions are ever made modular at the top level) can just use
 # types.submodule instead of using eval-config.nix
-{ # !!! system can be set modularly, would be nice to remove
-  system ? builtins.currentSystem
-, # !!! is this argument needed any more? The pkgs argument can
-  # be set modularly anyway.
-  pkgs ? null
-, # !!! what do we gain by making this configurable?
-  baseModules ? import ../modules/module-list.nix
-, # !!! See comment about args in lib/modules.nix
-  extraArgs ? {}
-, # !!! See comment about args in lib/modules.nix
-  specialArgs ? {}
-, modules
-, # !!! See comment about check in lib/modules.nix
-  check ? true
+# !!! All these arguments can be configured in a modular way
+# via the 'configureModules' attribute.
+{ modules
+, baseModules ? import ../modules/module-list.nix
 , prefix ? []
+, extraArgs ? {}
+, specialArgs ? {}
 , lib ? import ../../lib
+, system ? builtins.currentSystem
+, pkgs ? null
+, check ? true
 }:
 
-let extraArgs_ = extraArgs; pkgs_ = pkgs;
-    extraModules = let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
-                   in if e == "" then [] else [(import e)];
-in
-
 let
+  # These bindings will be shadowed by the rec attrset.
+  extraArgs_ = extraArgs; pkgs_ = pkgs;
+
+  # The option `nixpkgs.system` cannot be set inside `eval-modules.nix`,
+  # because it is dependent on being present in the supplied module list,
+  # which is not always the case for calls to `evalModules`, e.g. for submodules.
   pkgsModule = rec {
-    _file = ./eval-config.nix;
+    _file = toString ./eval-config.nix;
     key = _file;
     config = {
       # Explicit `nixpkgs.system` or `nixpkgs.localSystem` should override
-      # this.  Since the latter defaults to the former, the former should
+      # this. Since the latter defaults to the former, the former should
       # default to the argument. That way this new default could propagate all
       # they way through, but has the last priority behind everything else.
       nixpkgs.system = lib.mkDefault system;
-      _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
     };
   };
 
 in rec {
-
   # Merge the option definitions in all modules, forming the full
   # system configuration.
-  inherit (lib.evalModules {
-    inherit prefix check;
-    modules = modules ++ extraModules ++ baseModules ++ [ pkgsModule ];
+  inherit (import ../../lib/eval-modules.nix {
+    inherit prefix specialArgs lib check;
+    pkgs = pkgs_;
+    modules = modules ++ baseModules ++ [ pkgsModule ];
     args = extraArgs;
-    specialArgs =
-      { modulesPath = builtins.toString ../modules; } // specialArgs;
   }) config options;
 
   # These are the extra arguments passed to every module.  In


### PR DESCRIPTION
###### Motivation for this change
After realizing that all solutions I could come up with to replace the lib module argument in my NixOS configuration had some shortcoming or another (#51797), I realized that was I really just wanted to be able to do, was to supply arguments to `nixos/lib/eval-config.nix` based on my configuration (i.e. as part of my configuration). This would allow me to supply my configuration with a custom lib in a pure manner, i.e. no ad hoc extension mechanism through an impure environment variable, and would work with all existing code. Of course this purity cannot be enforced, you could always still call `getEnv` or similar, but this solution should not reduce purity to my knowledge. If it does, please do tell. This solution also addresses the non-modular arguments to `evalModules`, because except for the `modules` attribute to determine the `configureModules` attribute, everything else can be set through this `configureModules` attribute. And all the convenience attributes have been kept, but rewritten to their modular equivalent, so they could now be considered syntax sugar when using `configureModules`, but will still be allowed non-modular when supplied directly to `nixos/lib/eval-config.nix` for backwards compatibility. I thought it best to only allow the one module to have a `configureModules` attribute, which ought to be the entry point (e.g. `/etc/nixos/configuration.nix`), but unless it is safe to assume the first item in the list of modules is this entry point, I have no way to enforce this.

I have tested it with some complex configurations, but the code is not yet ready for a potential merge it its current state, so keep this in mind when giving feedback, but I thought it best to already make a PR so I could already get feedback, so that I know sooner rather than later whether it is a good idea to begin with and what I could do to refine it. Here is an example of it in use:

```nix
{
  configureModules = {
    lib = import ../../shared/lib;
  };

  imports = [
    ./main.nix
  ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

