### PR TITLE
bluez: add support for the sixaxis controller

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, dbus, glib, alsaLib,
-  python3, readline, udev, libical,
-  systemd, enableWiimote ? false, enableMidi ? false }:
+  python3, readline, udev, libical, systemd,
+  enableWiimote ? false, enableMidi ? false, enableSixaxis ? false }:
 
 stdenv.mkDerivation rec {
   name = "bluez-5.50";
@@ -43,7 +43,8 @@ stdenv.mkDerivation rec {
     "--with-systemduserunitdir=$(out)/etc/systemd/user"
     "--with-udevdir=$(out)/lib/udev"
     ] ++ optional enableWiimote [ "--enable-wiimote" ]
-      ++ optional enableMidi    [ "--enable-midi" ]);
+      ++ optional enableMidi    [ "--enable-midi" ]
+      ++ optional enableSixaxis [ "--enable-sixaxis" ]);
 
   # Work around `make install' trying to create /var/lib/bluetooth.
   installFlags = "statedir=$(TMPDIR)/var/lib/bluetooth";


### PR DESCRIPTION
This should add support for the Playstation Dualshock 3 and DualShock 4
controllers.

###### Motivation for this change

Currently the `bluez` package does not enable the `sixaxis` plugin.  This `sixaxis` plugin is needed to support the Playstation Dualshock 3 and DualShock 4 controllers.

This can be easily compiled with the following command if you have this branch checked out:

```sh
nix-build -E 'with import ./. { }; bluez.override { enableSixaxis = true; }'
```

It looks like `bluez` doesn't have any maintainers, and a lot of people have touched the `bluez` derivation, so I'm not sure who to ping about reviewing this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

