### PR TITLE
luigi: include boto3

### DIFF
--- a/pkgs/applications/networking/cluster/luigi/default.nix
+++ b/pkgs/applications/networking/cluster/luigi/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
     sed -i 's/<2.2.0//' setup.py
   '';
 
-  propagatedBuildInputs = with python3Packages; [ tornado_4 python-daemon ];
+  propagatedBuildInputs = with python3Packages; [ tornado_4 python-daemon boto3 ];
 
   # Requires tox, hadoop, and google cloud
   doCheck = false;


### PR DESCRIPTION
A number of luigi modules use boto3 to access AWS and will not work
without it.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

