### PR TITLE
luigi: enable local modules discovery

### DIFF
--- a/pkgs/applications/networking/cluster/luigi/default.nix
+++ b/pkgs/applications/networking/cluster/luigi/default.nix
@@ -19,6 +19,9 @@ python3Packages.buildPythonApplication rec {
   # Requires tox, hadoop, and google cloud
   doCheck = false;
 
+  # This enables accessing modules stored in cwd
+  makeWrapperArgs = ["--prefix PYTHONPATH . :"];
+
   meta = with lib; {
     homepage = https://github.com/spotify/luigi;
     description = "Python package that helps you build complex pipelines of batch jobs";


### PR DESCRIPTION
Currently, local module discovery is broken with luigi installed from
this derivation.

In the documentation, you can see the following command line syntax
used:

```
luigi --module module_name ...
```

However, currently this will result in an error:

```
ModuleNotFoundError: No module named 'module_name'
```

However, if the call is prepended with this:

```
PYTHONPATH=.:$PYTHONPATH
```

then it will work as expected.

This patch makes this the default behaviour.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

