### PR TITLE
 python3Packages.secretstorage: 2.3.1 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/jeepney/default.nix
+++ b/pkgs/development/python-modules/jeepney/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pytest
+, testpath
+, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "jeepney";
+  version = "0.4";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0w1w1rawl9k4lx91w16d19kbmf1349mhy8ph8x3w0qp1blm432b0";
+  };
+
+  propagatedBuildInputs = [
+    tornado
+  ];
+
+  checkInputs = [
+    pytest
+    testpath
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = https://gitlab.com/takluyver/jeepney;
+    description = "Pure Python DBus interface";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -1,23 +1,28 @@
-{ stdenv, fetchFromGitHub, buildPythonPackage
-, dbus-python, cryptography }:
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, cryptography, jeepney, pygobject3 }:
 
 buildPythonPackage rec {
   pname = "secretstorage";
-  version = "2.3.1";
+  version = "3.1.0";
 
-  src = fetchFromGitHub {
-    owner = "mitya57";
-    repo = "secretstorage";
-    rev = version;
-    sha256 = "1sjd2jjbxgkkxyrfwx89x0hsnn39w2cr2qkxbg1iz52znr4sqism";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    pname = "SecretStorage";
+    inherit version;
+    sha256 = "12vxzradibfmznssh7x2zd7qym2hl7wn34fn2yn58pnx6sykrai9";
   };
 
-  propagatedBuildInputs = [ dbus-python cryptography ];
+  propagatedBuildInputs = [
+    cryptography
+    jeepney
+    pygobject3
+  ];
 
-  doCheck = false; # requires dbus session
+  # Needs a D-Bus Sesison
+  doCheck = false;
 
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/mitya57/secretstorage";
+  meta = with lib; {
+    homepage = https://github.com/mitya57/secretstorage;
     description = "Python bindings to FreeDesktop.org Secret Service API";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ teto ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2706,6 +2706,8 @@ in {
 
   jellyfish = callPackage ../development/python-modules/jellyfish { };
 
+  jeepney = callPackage ../development/python-modules/jeepney { };
+
   j2cli = callPackage ../development/python-modules/j2cli { };
 
   jinja2 = callPackage ../development/python-modules/jinja2 { };


### PR DESCRIPTION
#### Changelog: https://github.com/mitya57/secretstorage/blob/master/changelog

Pertinent changes:

- ported from dbus-python to jeepney
  Thusly Python 3.5 or newer is required.
- We can use pypi
- Add pygobject3

###### Motivation for this change
This comment from @Mic92 https://github.com/NixOS/nixpkgs/pull/51269#issuecomment-445198589

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

