### PR TITLE
lxrandr: init at 0.3.1

### DIFF
--- a/pkgs/desktops/lxde/core/lxrandr/default.nix
+++ b/pkgs/desktops/lxde/core/lxrandr/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pkgconfig, intltool, gtk2, libX11, xrandr, withGtk3 ? false, gtk3 }:
+
+stdenv.mkDerivation rec {
+  name = "lxrandr-0.3.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/lxde/${name}.tar.xz";
+    sha256 = "6d98338485a90d9e47f6d08184df77ca0d9715517f8a45a914e861750589184e";
+  };
+
+  configureFlags = stdenv.lib.optional withGtk3 "--enable-gtk3";
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ libX11 (if withGtk3 then gtk3 else gtk2) xrandr ];
+
+  meta = with stdenv.lib; {
+    description = "LXRandR is the standard screen manager of LXDE.";
+    homepage = https://lxde.org/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with maintainers; [ rawkode ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7723,6 +7723,8 @@ in
 
   lxtask = callPackage ../desktops/lxde/core/lxtask { };
 
+  lxrandr = callPackage ../desktops/lxde/core/lxrandr { };
+
   kona = callPackage ../development/interpreters/kona {};
 
   lolcode = callPackage ../development/interpreters/lolcode { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

