### PR TITLE
gnomeExtensions.topicons-plus: 21 -> 22

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/topicons-plus/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-topicons-plus-${version}";
-  version = "21";
+  version = "22";
 
   src = fetchFromGitHub {
     owner = "phocean";
     repo = "TopIcons-plus";
     rev = "v${version}";
-    sha256 = "15p61krd7lcmgr1d4s2ydfjy3pyq79pq5100xzy6dln1538901m3";
+    sha256 = "196s1gdir52gbc444pzrb5l7gn5xr5vqk5ajqaiqryqlmp3i8vil";
   };
 
   buildInputs = [ glib ];


### PR DESCRIPTION
###### Motivation for this change
This extension seemed to break with gnome 3.30, but according to the website it should work with this newer version.

I have only tested the build though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jtojnar 