### PR TITLE
home-assistant: use python37

### DIFF
--- a/pkgs/development/python-modules/ruamel_yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel_yaml/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , ruamel_base
-, typing
 , ruamel_ordereddict
 , isPy3k
 }:
@@ -19,7 +18,7 @@ buildPythonPackage rec {
   # Tests cannot load the module to test
   doCheck = false;
 
-  propagatedBuildInputs = [ ruamel_base typing ]
+  propagatedBuildInputs = [ ruamel_base ]
     ++ stdenv.lib.optional (!isPy3k) ruamel_ordereddict;
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, fetchpatch, python
+{ lib, fetchFromGitHub, fetchpatch, python3
 
 # Look up dependencies of specified components in component-packages.nix
 , extraComponents ? []
@@ -52,7 +52,7 @@ let
     (mkOverride "colorlog" "3.1.4"
       "418db638c9577f37f0fae4914074f395847a728158a011be2a193ac491b9779d")
 
-    # hass-frontend does not exist in python.pkgs
+    # hass-frontend does not exist in python3.pkgs
     (self: super: {
       hass-frontend = self.callPackage ./frontend.nix { };
     })
@@ -68,7 +68,7 @@ let
       });
     };
     
-  py = python.override {
+  py = python3.override {
     # Put packageOverrides at the start so they are applied after defaultOverrides
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([ packageOverrides ] ++ defaultOverrides);
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13498,9 +13498,7 @@ in
 
   hiawatha = callPackage ../servers/http/hiawatha {};
 
-  home-assistant = callPackage ../servers/home-assistant {
-    python = python36;
-  };
+  home-assistant = callPackage ../servers/home-assistant { };
 
   hydron = callPackage ../servers/hydron { };
 


### PR DESCRIPTION
Home Assistant builds with python37 now. However, hbmqtt does not until 494f969cd7e2cd28cbd09ab1af7b51126a462a1a lands in master. We should not merge until that happens.

###### Motivation for this change
Reduce the load on Hydra.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

