### PR TITLE
tree-wide: nixos: /var/run -> /run

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -226,9 +226,7 @@ in
 
     environment.shells =
       [ "/run/current-system/sw/bin/bash"
-        "/var/run/current-system/sw/bin/bash"
         "/run/current-system/sw/bin/sh"
-        "/var/run/current-system/sw/bin/sh"
         "${pkgs.bashInteractive}/bin/bash"
         "${pkgs.bashInteractive}/bin/sh"
       ];

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -232,7 +232,6 @@ in
 
     environment.shells = [
       "/run/current-system/sw/bin/fish"
-      "/var/run/current-system/sw/bin/fish"
       "${pkgs.fish}/bin/fish"
     ];
 

--- a/nixos/modules/programs/xonsh.nix
+++ b/nixos/modules/programs/xonsh.nix
@@ -50,7 +50,6 @@ in
 
     environment.shells =
       [ "/run/current-system/sw/bin/xonsh"
-        "/var/run/current-system/sw/bin/xonsh"
         "${pkgs.xonsh}/bin/xonsh"
       ];
 

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -203,7 +203,6 @@ in
 
     environment.shells =
       [ "/run/current-system/sw/bin/zsh"
-        "/var/run/current-system/sw/bin/zsh"
         "${pkgs.zsh}/bin/zsh"
       ];
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -208,7 +208,7 @@ with lib;
         inetPort = [ "services" "postgrey" "inetPort" ];
       in
         if value inetAddr == null
-        then { path = "/var/run/postgrey.sock"; }
+        then { path = "/run/postgrey.sock"; }
         else { addr = value inetAddr; port = value inetPort; }
     ))
 

--- a/nixos/modules/services/backup/bacula.nix
+++ b/nixos/modules/services/backup/bacula.nix
@@ -15,7 +15,7 @@ let
         Name = "${fd_cfg.name}";
         FDPort = ${toString fd_cfg.port};
         WorkingDirectory = "${libDir}";
-        Pid Directory = "/var/run";
+        Pid Directory = "/run";
         ${fd_cfg.extraClientConfig}
       }
      
@@ -41,7 +41,7 @@ let
         Name = "${sd_cfg.name}";
         SDPort = ${toString sd_cfg.port};
         WorkingDirectory = "${libDir}";
-        Pid Directory = "/var/run";
+        Pid Directory = "/run";
         ${sd_cfg.extraStorageConfig}
       }
  
@@ -77,7 +77,7 @@ let
       Password = "${dir_cfg.password}";
       DirPort = ${toString dir_cfg.port};
       Working Directory = "${libDir}";
-      Pid Directory = "/var/run/";
+      Pid Directory = "/run/";
       QueryFile = "${pkgs.bacula}/etc/query.sql";
       ${dir_cfg.extraDirectorConfig}
     }

--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -85,7 +85,7 @@ in {
 
       uriFile = mkOption {
         type = types.path;
-        default = "/var/run/couchdb/couchdb.uri";
+        default = "/run/couchdb/couchdb.uri";
         description = ''
           This file contains the full URI that can be used to access this
           instance of CouchDB. It is used to help discover the port CouchDB is

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -65,7 +65,7 @@ in
       };
 
       pidFile = mkOption {
-        default = "/var/run/mongodb.pid";
+        default = "/run/mongodb.pid";
         description = "Location of MongoDB pid file";
       };
 

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -134,8 +134,8 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       preStart = ''
-        mkdir -p /var/run/slapd
-        chown -R "${cfg.user}:${cfg.group}" /var/run/slapd
+        mkdir -p /run/slapd
+        chown -R "${cfg.user}:${cfg.group}" /run/slapd
         ${optionalString (cfg.declarativeContents != null) ''
           rm -Rf "${cfg.dataDir}"
         ''}

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -95,7 +95,7 @@ in
         type = with types; nullOr path;
         default = null;
         description = "The path to the socket to bind to.";
-        example = "/var/run/redis.sock";
+        example = "/run/redis.sock";
       };
 
       logLevel = mkOption {

--- a/nixos/modules/services/databases/rethinkdb.nix
+++ b/nixos/modules/services/databases/rethinkdb.nix
@@ -41,7 +41,7 @@ in
       };
 
       pidpath = mkOption {
-        default = "/var/run/rethinkdb";
+        default = "/run/rethinkdb";
         description = "Location where each instance's pid file is located.";
       };
 

--- a/nixos/modules/services/mail/pfix-srsd.nix
+++ b/nixos/modules/services/mail/pfix-srsd.nix
@@ -48,8 +48,8 @@ with lib;
       requiredBy = [ "postfix.service" ];
       serviceConfig = {
         Type = "forking";
-        PIDFile = "/var/run/pfix-srsd.pid";
-        ExecStart = "${pkgs.pfixtools}/bin/pfix-srsd -p /var/run/pfix-srsd.pid -I ${config.services.pfix-srsd.domain} ${config.services.pfix-srsd.secretsFile}";
+        PIDFile = "/run/pfix-srsd.pid";
+        ExecStart = "${pkgs.pfixtools}/bin/pfix-srsd -p /run/pfix-srsd.pid -I ${config.services.pfix-srsd.domain} ${config.services.pfix-srsd.secretsFile}";
       };
     };
   };

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -29,7 +29,7 @@ with lib; let
     options = {
       path = mkOption {
         type = path;
-        default = "/var/run/postgrey.sock";
+        default = "/run/postgrey.sock";
         description = "Path of the unix socket";
       };
 
@@ -53,7 +53,7 @@ in {
       socket = mkOption {
         type = socket;
         default = {
-          path = "/var/run/postgrey.sock";
+          path = "/run/postgrey.sock";
           mode = "0777";
         };
         example = {

--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -174,7 +174,7 @@ in
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.spamassassin}/bin/spamd ${optionalString cfg.debug "-D"} --username=spamd --groupname=spamd --siteconfigpath=${spamdEnv} --virtual-config-dir=/var/lib/spamassassin/user-%u --allow-tell --pidfile=/var/run/spamd.pid";
+        ExecStart = "${pkgs.spamassassin}/bin/spamd ${optionalString cfg.debug "-D"} --username=spamd --groupname=spamd --siteconfigpath=${spamdEnv} --virtual-config-dir=/var/lib/spamassassin/user-%u --allow-tell --pidfile=/run/spamd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };
 

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -30,7 +30,7 @@ ${optionalString (cfg.bind_host != null) ''
 bind_host: "${cfg.bind_host}"
 ''}
 server_name: "${cfg.server_name}"
-pid_file: "/var/run/matrix-synapse.pid"
+pid_file: "/run/matrix-synapse.pid"
 web_client: ${boolToString cfg.web_client}
 ${optionalString (cfg.public_baseurl != null) ''
 public_baseurl: "${cfg.public_baseurl}"

--- a/nixos/modules/services/misc/mbpfan.nix
+++ b/nixos/modules/services/misc/mbpfan.nix
@@ -101,7 +101,7 @@ in {
         Type = "simple";
         ExecStart = "${cfg.package}/bin/mbpfan -f${verbose}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        PIDFile = "/var/run/mbpfan.pid";
+        PIDFile = "/run/mbpfan.pid";
         Restart = "always";
       };
     };

--- a/nixos/modules/services/misc/spice-vdagentd.nix
+++ b/nixos/modules/services/misc/spice-vdagentd.nix
@@ -19,7 +19,7 @@ in
       description = "spice-vdagent daemon";
       wantedBy = [ "graphical.target" ];
       preStart = ''
-        mkdir -p "/var/run/spice-vdagentd/"
+        mkdir -p "/run/spice-vdagentd/"
       '';
       serviceConfig = {
         Type = "forking";

--- a/nixos/modules/services/misc/svnserve.nix
+++ b/nixos/modules/services/misc/svnserve.nix
@@ -38,7 +38,7 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = "mkdir -p ${cfg.svnBaseDir}";
-      script = "${pkgs.subversion.out}/bin/svnserve -r ${cfg.svnBaseDir} -d --foreground --pid-file=/var/run/svnserve.pid";
+      script = "${pkgs.subversion.out}/bin/svnserve -r ${cfg.svnBaseDir} -d --foreground --pid-file=/run/svnserve.pid";
     };
   };
 }

--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -24,7 +24,7 @@ let
       status_file=${nagiosState}/status.dat
       object_cache_file=${nagiosState}/objects.cache
       temp_file=${nagiosState}/nagios.tmp
-      lock_file=/var/run/nagios.lock # Not used I think.
+      lock_file=/run/nagios.lock # Not used I think.
       state_retention_file=${nagiosState}/retention.dat
       query_socket=${nagiosState}/nagios.qh
       check_result_path=${nagiosState}

--- a/nixos/modules/services/monitoring/zabbix-agent.nix
+++ b/nixos/modules/services/monitoring/zabbix-agent.nix
@@ -9,7 +9,7 @@ let
 
   zabbix = cfg.package;
 
-  stateDir = "/var/run/zabbix";
+  stateDir = "/run/zabbix";
 
   logDir = "/var/log/zabbix";
 

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -7,7 +7,7 @@ let
 
   cfg = config.services.zabbixServer;
 
-  stateDir = "/var/run/zabbix";
+  stateDir = "/run/zabbix";
 
   logDir = "/var/log/zabbix";
 

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -45,7 +45,7 @@ let
       astdatadir => /var/lib/asterisk
       astagidir => /var/lib/asterisk/agi-bin
       astspooldir => /var/spool/asterisk
-      astrundir => /var/run/asterisk
+      astrundir => /run/asterisk
       astlogdir => /var/log/asterisk
       astsbindir => ${cfg.package}/sbin
     '';
@@ -257,7 +257,7 @@ in
         ExecReload = ''${cfg.package}/bin/asterisk -x "core reload"
           '';
         Type = "forking";
-        PIDFile = "/var/run/asterisk/asterisk.pid";
+        PIDFile = "/run/asterisk/asterisk.pid";
       };
     };
   };

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -214,7 +214,7 @@ in
 
     systemd.sockets.avahi-daemon =
       { description = "Avahi mDNS/DNS-SD Stack Activation Socket";
-        listenStreams = [ "/var/run/avahi-daemon/socket" ];
+        listenStreams = [ "/run/avahi-daemon/socket" ];
         wantedBy = [ "sockets.target" ];
       };
 
@@ -229,7 +229,7 @@ in
 
         path = [ pkgs.coreutils pkgs.avahi ];
 
-        preStart = "mkdir -p /var/run/avahi-daemon";
+        preStart = "mkdir -p /run/avahi-daemon";
 
         script =
           ''

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -25,8 +25,8 @@ let
         blackhole { badnetworks; };
         forward first;
         forwarders { ${concatMapStrings (entry: " ${entry}; ") cfg.forwarders} };
-        directory "/var/run/named";
-        pid-file "/var/run/named/named.pid";
+        directory "/run/named";
+        pid-file "/run/named/named.pid";
         ${cfg.extraOptions}
       };
 
@@ -187,8 +187,8 @@ in
           ${pkgs.bind.out}/sbin/rndc-confgen -r /dev/urandom -c /etc/bind/rndc.key -u ${bindUser} -a -A hmac-sha256 2>/dev/null
         fi
 
-        ${pkgs.coreutils}/bin/mkdir -p /var/run/named
-        chown ${bindUser} /var/run/named
+        ${pkgs.coreutils}/bin/mkdir -p /run/named
+        chown ${bindUser} /run/named
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -25,7 +25,7 @@ let
     logger_stdout=-1
     logger_stdout_level=2
 
-    ctrl_interface=/var/run/hostapd
+    ctrl_interface=/run/hostapd
     ctrl_interface_group=${cfg.group}
 
     ${if cfg.wpa then ''

--- a/nixos/modules/services/networking/htpdate.nix
+++ b/nixos/modules/services/networking/htpdate.nix
@@ -62,7 +62,7 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "forking";
-        PIDFile = "/var/run/htpdate.pid";
+        PIDFile = "/run/htpdate.pid";
         ExecStart = concatStringsSep " " [
           "${htpdate}/bin/htpdate"
           "-D -u nobody"

--- a/nixos/modules/services/networking/ircd-hybrid/ircd.conf
+++ b/nixos/modules/services/networking/ircd-hybrid/ircd.conf
@@ -987,7 +987,7 @@ general {
 	 * egdpool_path: path to EGD pool. Not necessary for OpenSSL >= 0.9.7
 	 * which automatically finds the path.
 	 */
-#	egdpool_path = "/var/run/egd-pool";
+#	egdpool_path = "/run/egd-pool";
 
 
 	/*

--- a/nixos/modules/services/networking/lldpd.nix
+++ b/nixos/modules/services/networking/lldpd.nix
@@ -23,7 +23,7 @@ in
     users.users._lldpd = {
       description = "lldpd user";
       group = "_lldpd";
-      home = "/var/run/lldpd";
+      home = "/run/lldpd";
       isSystemUser = true;
     };
     users.groups._lldpd = {};

--- a/nixos/modules/services/networking/miniupnpd.nix
+++ b/nixos/modules/services/networking/miniupnpd.nix
@@ -71,7 +71,7 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = "${pkgs.miniupnpd}/bin/miniupnpd -f ${configFile}";
-        PIDFile = "/var/run/miniupnpd.pid";
+        PIDFile = "/run/miniupnpd.pid";
         Type = "forking";
       };
     };

--- a/nixos/modules/services/networking/ocserv.nix
+++ b/nixos/modules/services/networking/ocserv.nix
@@ -31,7 +31,7 @@ in
         udp-port = 443
         run-as-user = nobody
         run-as-group = nogroup
-        socket-file = /var/run/ocserv-socket
+        socket-file = /run/ocserv-socket
         server-cert = certs/server-cert.pem
         server-key = certs/server-key.pem
         keepalive = 32400
@@ -50,7 +50,7 @@ in
         rekey-time = 172800
         rekey-method = ssl
         use-occtl = true
-        pid-file = /var/run/ocserv.pid
+        pid-file = /run/ocserv.pid
         device = vpns
         predictable-ips = true
         default-domain = example.com
@@ -90,8 +90,8 @@ in
 
       serviceConfig = {
         PrivateTmp = true;
-        PIDFile = "/var/run/ocserv.pid";
-        ExecStart = "${pkgs.ocserv}/bin/ocserv --foreground --pid-file /var/run/ocesrv.pid --config /etc/ocserv/ocserv.conf";
+        PIDFile = "/run/ocserv.pid";
+        ExecStart = "${pkgs.ocserv}/bin/ocserv --foreground --pid-file /run/ocesrv.pid --config /etc/ocserv/ocserv.conf";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };
     };

--- a/nixos/modules/services/networking/racoon.nix
+++ b/nixos/modules/services/networking/racoon.nix
@@ -32,12 +32,12 @@ in {
           else cfg.configPath
         }";
         ExecReload = "${pkgs.ipsecTools}/bin/racoonctl reload-config";
-        PIDFile = "/var/run/racoon.pid";
+        PIDFile = "/run/racoon.pid";
         Type = "forking";
         Restart = "always";
       };
       preStart = ''
-        rm /var/run/racoon.pid || true
+        rm /run/racoon.pid || true
         mkdir -p /var/racoon
       '';
     };

--- a/nixos/modules/services/networking/supplicant.nix
+++ b/nixos/modules/services/networking/supplicant.nix
@@ -132,7 +132,7 @@ in
           extraCmdArgs = mkOption {
             type = types.str;
             default = "";
-            example = "-e/var/run/wpa_supplicant/entropy.bin";
+            example = "-e/run/wpa_supplicant/entropy.bin";
             description =
               "Command line arguments to add when executing <literal>wpa_supplicant</literal>.";
           };
@@ -164,7 +164,7 @@ in
   
             socketDir = mkOption {
               type = types.str;
-              default = "/var/run/wpa_supplicant";
+              default = "/run/wpa_supplicant";
               description = "Directory of sockets for controlling wpa_supplicant.";
             };
   

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -6,7 +6,7 @@ let
   cfg = config.networking.wireless;
   configFile = if cfg.networks != {} then pkgs.writeText "wpa_supplicant.conf" ''
     ${optionalString cfg.userControlled.enable ''
-      ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=${cfg.userControlled.group}
+      ctrl_interface=DIR=/run/wpa_supplicant GROUP=${cfg.userControlled.group}
       update_config=1''}
     ${cfg.extraConfig}
     ${concatStringsSep "\n" (mapAttrsToList (ssid: config: with config; let

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -17,7 +17,7 @@ let
     chmod +x $out/startwm.sh
 
     substituteInPlace $out/xrdp.ini \
-      --replace "#rsakeys_ini=" "rsakeys_ini=/var/run/xrdp/rsakeys.ini" \
+      --replace "#rsakeys_ini=" "rsakeys_ini=/run/xrdp/rsakeys.ini" \
       --replace "certificate=" "certificate=${cfg.sslCert}" \
       --replace "key_file=" "key_file=${cfg.sslKey}" \
       --replace LogFile=xrdp.log LogFile=/dev/null \
@@ -132,9 +132,9 @@ in
             chown root:xrdp ${cfg.sslKey} ${cfg.sslCert}
             chmod 440 ${cfg.sslKey} ${cfg.sslCert}
           fi
-          if [ ! -s /var/run/xrdp/rsakeys.ini ]; then
-            mkdir -p /var/run/xrdp
-            ${cfg.package}/bin/xrdp-keygen xrdp /var/run/xrdp/rsakeys.ini
+          if [ ! -s /run/xrdp/rsakeys.ini ]; then
+            mkdir -p /run/xrdp
+            ${cfg.package}/bin/xrdp-keygen xrdp /run/xrdp/rsakeys.ini
           fi
         '';
         serviceConfig = {

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -74,7 +74,7 @@ let
     ${concatMapStrings (addr: ''
       Listen ${addr}
     '') cfg.listenAddresses}
-    Listen /var/run/cups/cups.sock
+    Listen /run/cups/cups.sock
 
     SetEnv PATH /var/lib/cups/path/lib/cups/filter:/var/lib/cups/path/bin
 

--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -100,8 +100,8 @@ in
             in
             pkgs.writeText "fcron.conf" ''
               fcrontabs   =       /var/spool/fcron
-              pidfile     =       /var/run/fcron.pid
-              fifofile    =       /var/run/fcron.fifo
+              pidfile     =       /run/fcron.pid
+              fifofile    =       /run/fcron.fifo
               fcronallow  =       /etc/fcron.allow
               fcrondeny   =       /etc/fcron.deny
               shell       =       /bin/sh

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -45,7 +45,7 @@ in {
       wantedBy    = [ "multi-user.target" ];
       requires    = [ "network-link-dummy0.service" "network-addresses-dummy0.service" ]; 
       preStart = ''
-        /run/current-system/sw/bin/rm -fv /var/run/hologram.sock
+        /run/current-system/sw/bin/rm -fv /run/hologram.sock
       '';
       serviceConfig = {
         ExecStart = "${pkgs.hologram.bin}/bin/hologram-agent -debug -conf ${cfgFile} -port ${cfg.httpPort}";

--- a/nixos/modules/services/web-apps/codimd.nix
+++ b/nixos/modules/services/web-apps/codimd.nix
@@ -67,7 +67,7 @@ in
       path = mkOption {
         type = types.nullOr types.str;
         default = null;
-        example = "/var/run/codimd.sock";
+        example = "/run/codimd.sock";
         description = ''
           Specify where a UNIX domain socket should be placed.
         '';

--- a/nixos/modules/services/web-apps/restya-board.nix
+++ b/nixos/modules/services/web-apps/restya-board.nix
@@ -13,7 +13,7 @@ let
   runDir = "/run/restya-board";
 
   poolName = "restya-board";
-  phpfpmSocketName = "/var/run/phpfpm/${poolName}.sock";
+  phpfpmSocketName = "/run/phpfpm/${poolName}.sock";
 
 in
 

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -4,7 +4,7 @@ let
   cfg = config.services.selfoss;
 
   poolName = "selfoss_pool";
-  phpfpmSocketName = "/var/run/phpfpm/${poolName}.sock";
+  phpfpmSocketName = "/run/phpfpm/${poolName}.sock";
 
   dataDir = "/var/lib/selfoss";
 

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -15,7 +15,7 @@ let
     else cfg.database.port;
 
   poolName = "tt-rss";
-  phpfpmSocketName = "/var/run/phpfpm/${poolName}.sock";
+  phpfpmSocketName = "/run/phpfpm/${poolName}.sock";
 
   tt-rss-config = pkgs.writeText "config.php" ''
     <?php

--- a/nixos/modules/services/web-servers/mighttpd2.nix
+++ b/nixos/modules/services/web-servers/mighttpd2.nix
@@ -22,7 +22,7 @@ in {
         User: root
         # If available, "nobody" is much more secure for Group:.
         Group: root
-        Pid_File: /var/run/mighty.pid
+        Pid_File: /run/mighty.pid
         Logging: Yes # Yes or No
         Log_File: /var/log/mighty # The directory must be writable by User:
         Log_File_Size: 16777216 # bytes

--- a/nixos/modules/services/x11/desktop-managers/kodi.nix
+++ b/nixos/modules/services/x11/desktop-managers/kodi.nix
@@ -20,7 +20,7 @@ in
     services.xserver.desktopManager.session = [{
       name = "kodi";
       start = ''
-        ${pkgs.kodi}/bin/kodi --lircdev /var/run/lirc/lircd --standalone &
+        ${pkgs.kodi}/bin/kodi --lircdev /run/lirc/lircd --standalone &
         waitPID=$!
       '';
     }];

--- a/nixos/modules/services/x11/display-managers/xpra.nix
+++ b/nixos/modules/services/x11/display-managers/xpra.nix
@@ -221,7 +221,7 @@ in
 
     services.xserver.displayManager.job.execCmd = ''
       ${optionalString (cfg.pulseaudio)
-        "export PULSE_COOKIE=/var/run/pulse/.config/pulse/cookie"}
+        "export PULSE_COOKIE=/run/pulse/.config/pulse/cookie"}
       exec ${pkgs.xpra}/bin/xpra start \
         --daemon=off \
         --log-dir=/var/log \
@@ -233,7 +233,7 @@ in
         --mdns=no \
         --pulseaudio=no \
         ${optionalString (cfg.pulseaudio) "--sound-source=pulse"} \
-        --socket-dirs=/var/run/xpra \
+        --socket-dirs=/run/xpra \
         --xvfb="xpra_Xdummy ${concatStringsSep " " dmcfg.xserverArgs}" \
         ${optionalString (cfg.bindTcp != null) "--bind-tcp=${cfg.bindTcp}"} \
         --auth=${cfg.auth} \

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -31,7 +31,7 @@ in
     listenOptions =
       mkOption {
         type = types.listOf types.str;
-        default = ["/var/run/docker.sock"];
+        default = ["/run/docker.sock"];
         description =
           ''
             A list of unix and tcp docker should listen to. The format follows

--- a/nixos/modules/virtualisation/openvswitch.nix
+++ b/nixos/modules/virtualisation/openvswitch.nix
@@ -49,7 +49,7 @@ in {
   config = mkIf cfg.enable (let
 
     # Where the communication sockets live
-    runDir = "/var/run/openvswitch";
+    runDir = "/run/openvswitch";
 
     # The path to the an initialized version of the database
     db = pkgs.stdenv.mkDerivation {
@@ -99,13 +99,13 @@ in {
             --certificate=db:Open_vSwitch,SSL,certificate \
             --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert \
             --unixctl=ovsdb.ctl.sock \
-            --pidfile=/var/run/openvswitch/ovsdb.pid \
+            --pidfile=/run/openvswitch/ovsdb.pid \
             --detach \
             /var/db/openvswitch/conf.db
           '';
         Restart = "always";
         RestartSec = 3;
-        PIDFile = "/var/run/openvswitch/ovsdb.pid";
+        PIDFile = "/run/openvswitch/ovsdb.pid";
         # Use service type 'forking' to correctly determine when ovsdb-server is ready.
         Type = "forking";
       };
@@ -123,10 +123,10 @@ in {
       serviceConfig = {
         ExecStart = ''
           ${cfg.package}/bin/ovs-vswitchd \
-          --pidfile=/var/run/openvswitch/ovs-vswitchd.pid \
+          --pidfile=/run/openvswitch/ovs-vswitchd.pid \
           --detach
         '';
-        PIDFile = "/var/run/openvswitch/ovs-vswitchd.pid";
+        PIDFile = "/run/openvswitch/ovs-vswitchd.pid";
         # Use service type 'forking' to correctly determine when vswitchd is ready.
         Type = "forking";
       };
@@ -152,11 +152,11 @@ in {
         ExecStart = ''
           ${cfg.package}/bin/ovs-monitor-ipsec \
             --root-prefix ${runDir}/ipsec \
-            --pidfile /var/run/openvswitch/ovs-monitor-ipsec.pid \
+            --pidfile /run/openvswitch/ovs-monitor-ipsec.pid \
             --monitor --detach \
-            unix:/var/run/openvswitch/db.sock
+            unix:/run/openvswitch/db.sock
         '';
-        PIDFile = "/var/run/openvswitch/ovs-monitor-ipsec.pid";
+        PIDFile = "/run/openvswitch/ovs-monitor-ipsec.pid";
         # Use service type 'forking' to correctly determine when ovs-monitor-ipsec is ready.
         Type = "forking";
       };
@@ -167,7 +167,7 @@ in {
         ln -fs ${pkgs.ipsecTools}/bin/setkey ${runDir}/ipsec/usr/sbin/setkey
         ln -fs ${pkgs.writeScript "racoon-restart" ''
         #!${pkgs.runtimeShell}
-        /var/run/current-system/sw/bin/systemctl $1 racoon
+        /run/current-system/sw/bin/systemctl $1 racoon
         ''} ${runDir}/ipsec/etc/init.d/racoon
       '';
     };

--- a/nixos/tests/nghttpx.nix
+++ b/nixos/tests/nghttpx.nix
@@ -1,5 +1,5 @@
 let
-  nginxRoot = "/var/run/nginx";
+  nginxRoot = "/run/nginx";
 in
   import ./make-test.nix ({...}: {
     name  = "nghttpx";

--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -11,7 +11,7 @@ with lib;
   machine = {
     services.osquery.enable = true;
     services.osquery.loggerPath = "/var/log/osquery/logs";
-    services.osquery.pidfile = "/var/run/osqueryd.pid";
+    services.osquery.pidfile = "/run/osqueryd.pid";
   };
 
   testScript = ''
@@ -23,6 +23,6 @@ with lib;
       "echo 'SELECT value FROM osquery_flags WHERE name = \"logger_path\";' | osqueryi | grep /var/log/osquery/logs"
     );
 
-    $machine->succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"pidfile\";' | osqueryi | grep /var/run/osqueryd.pid");
+    $machine->succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"pidfile\";' | osqueryi | grep /run/osqueryd.pid");
   '';
 })

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -42,7 +42,7 @@ import ./make-test.nix ({pkgs, ... }: {
       # check local encrypted connections work without error
       $client->succeed("lpstat -E -r") =~ /scheduler is running/ or die;
       # Test that UNIX socket is used for connections.
-      $client->succeed("lpstat -H") =~ "/var/run/cups/cups.sock" or die;
+      $client->succeed("lpstat -H") =~ "/run/cups/cups.sock" or die;
       # Test that HTTP server is available too.
       $client->succeed("curl --fail http://localhost:631/");
       $client->succeed("curl --fail http://server:631/");


### PR DESCRIPTION
###### Motivation for this change

Fixes #51800 
Continuation of #47856 

`/var/run` is deprecated in `tmpfiles.d` and `/run` should be used. Currently this produces a warning every time `nixos-rebuild switch` runs for each service that uses `tmpfiles.d` with an entry for `/var/run`.

This PR changes `/var/run` instances into `/run` across nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

