### PR TITLE
powerline-fonts: 2017-05-25 -> 2018-11-11

### DIFF
--- a/pkgs/data/fonts/powerline-fonts/default.nix
+++ b/pkgs/data/fonts/powerline-fonts/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchzip}:
 
 fetchzip {
-  name = "powerline-fonts-2017-05-25";
+  name = "powerline-fonts-2018-11-11";
 
-  url = https://github.com/powerline/fonts/archive/fe396ef6f6b9b315f30af7d7229ff21f67a66e12.zip;
+  url = https://github.com/powerline/fonts/archive/e80e3eba9091dac0655a0a77472e10f53e754bb0.zip;
 
   postFetch = ''
     mkdir -p $out/share/fonts/opentype
@@ -22,7 +22,7 @@ fetchzip {
     unzip -j $downloadedFile '*/PSF/*.psf.gz' -d $out/share/fonts/psf
   '';
 
-  sha256 = "07yjbwri7nnnnynps86sz0dlivwqw7gfw045v63q969nab9dw388";
+  sha256 = "0irifak86gn7hawzgxcy53s22y215mxc2kjncv37h7q44jsqdqww";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/powerline/fonts;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

