### PR TITLE
pythonPackages.Yapsy: 1.11.223 -> 1.12.0 and enable tests

### DIFF
--- a/pkgs/development/python-modules/yapsy/default.nix
+++ b/pkgs/development/python-modules/yapsy/default.nix
@@ -5,14 +5,12 @@
 
 buildPythonPackage rec {
   pname = "Yapsy";
-  version = "1.11.223";
+  version = "1.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "19pjsnqizswnczhlav4lb7zlzs0n73ijrsgksy4374b14jkkkfs5";
+    sha256 = "0g1yd8nvhfdasckb929rijmj040x25ycns2b3l5wq53gm4lv537h";
   };
-
-  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = http://yapsy.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change

This newer version [supports Python 3.6+](https://github.com/tibonihoo/yapsy/blob/5cef30cd1da17e015dbed8aa83877be86e0552c2/package/CHANGELOG.txt#L2).

I have another PR coming later that depends on this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

