### PR TITLE
nixos-artwork: make wallpapers available to KDE

### DIFF
--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -11,6 +11,15 @@ let
       installPhase = ''
         mkdir -p $out/share/artwork/gnome
         ln -s $src $out/share/artwork/gnome/${src.name}
+
+        # KDE
+        mkdir -p $out/share/wallpapers/${name}/contents/images
+        ln -s $src $out/share/wallpapers/${name}/contents/images/${src.name}
+        cat >>$out/share/wallpapers/${name}/metadata.desktop <<_EOF
+[Desktop Entry]
+Name=${name}
+X-KDE-PluginInfo-Name=${name}
+_EOF
       '';
 
       meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

We have some nice and clean wallpapers in https://github.com/NixOS/nixos-artwork - this PR makes them available to KDE when you right-click and choose "Configure Desktop".

If they aren't installed, they're not available either so the closure size impact is 0.

I haven't run the plasma tests yet but it works here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

