### PR TITLE
ghc: Allow the use to pass extraBuildMk to append to mk/build.mk

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -31,6 +31,9 @@
   # deterministic profiling symbol names, at the cost of a slightly
   # non-standard GHC API
   deterministicProfiling ? false
+
+, # Anything to add to build.mk.
+  extraBuildMk ? ""
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -63,7 +66,7 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  '';
+  '' + extraBuildMk;
 
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -33,6 +33,9 @@
   # deterministic profiling symbol names, at the cost of a slightly
   # non-standard GHC API
   deterministicProfiling ? false
+
+, # Anything to add to build.mk.
+  extraBuildMk ? ""
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -65,7 +68,7 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  '';
+  '' + extraBuildMk;
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -29,6 +29,9 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, # Anything to add to build.mk.
+  extraBuildMk ? ""
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -61,7 +64,7 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  '';
+  '' + extraBuildMk;
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]

--- a/pkgs/development/compilers/ghc/8.6.2.nix
+++ b/pkgs/development/compilers/ghc/8.6.2.nix
@@ -29,6 +29,9 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, # Anything to add to build.mk.
+  extraBuildMk ? ""
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -61,7 +64,7 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  '';
+  '' + extraBuildMk;
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]

--- a/pkgs/development/compilers/ghc/8.6.3.nix
+++ b/pkgs/development/compilers/ghc/8.6.3.nix
@@ -29,6 +29,9 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, # Anything to add to build.mk.
+  extraBuildMk ? ""
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -61,7 +64,7 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  '';
+  '' + extraBuildMk;
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -30,6 +30,9 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, # Anything to add to build.mk.
+  extraBuildMk ? ""
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -62,7 +65,7 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  '';
+  '' + extraBuildMk;
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]


### PR DESCRIPTION
There appears to be no sane way currently to add custom stuff to
mk/build.mk short of copying out the GHC expression and changing it
through there.

###### Things done

Does not cause rebuild.
