### PR TITLE
 pythonPackages.manhole: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1894,6 +1894,10 @@
     github = "ironpinguin";
     name = "Michele Catalano";
   };
+  ivan = {
+    email = "ivan@ludios.org";
+    name = "Ivan Kozik";
+  };
   ivan-tkatchev = {
     email = "tkatchev@gmail.com";
     name = "Ivan Tkatchev";

--- a/pkgs/development/python-modules/manhole/default.nix
+++ b/pkgs/development/python-modules/manhole/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, requests
+, process-tests
+}:
+
+buildPythonPackage rec {
+  pname = "manhole";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11ivy8qiv87jl2lc1ldhv9dc4jwf3hz7wysdfiagdcd9kkd48v8m";
+  };
+
+  # test_help expects architecture-dependent Linux signal numbers.
+  #
+  # {test_locals,test_socket_path} fail to remove /tmp/manhole-socket
+  # on the x86_64-darwin builder.
+  doCheck = stdenv.isLinux;
+
+  checkInputs = [ pytest requests process-tests ];
+  checkPhase = ''
+    # Based on its tox.ini
+    export PYTHONUNBUFFERED=yes
+    export PYTHONPATH=.:tests:$PYTHONPATH
+
+    # The tests use manhole-cli
+    export PATH="$PATH:$out/bin"
+
+    # test_uwsgi fails with:
+    # http.client.RemoteDisconnected: Remote end closed connection without response
+    py.test -vv -k "not test_uwsgi"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ionelmc/python-manhole;
+    description = "Debugging manhole for Python applications";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ivan ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -422,6 +422,8 @@ in {
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
+  manhole = callPackage ../development/python-modules/manhole { };
+
   markerlib = callPackage ../development/python-modules/markerlib { };
 
   matchpy = callPackage ../development/python-modules/matchpy { };


### PR DESCRIPTION
###### Motivation for this change

[manhole](https://github.com/ionelmc/python-manhole) is generally useful for connecting to and debugging long-running Python programs.

This dependency will be used by an upcoming PR that adds [grab-site](https://github.com/ludios/grab-site).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested `pythonPackages.manhole` and `python37Packages.manhole` on NixOS.