### PR TITLE
llvm 7: Allow for specifying an arbitrary list of backends to build

### DIFF
--- a/pkgs/development/compilers/llvm/common.nix
+++ b/pkgs/development/compilers/llvm/common.nix
@@ -1,0 +1,18 @@
+{ lib }:
+
+rec {
+  llvmBackend = platform:
+    if platform.parsed.cpu.family == "x86" then
+      "X86"
+    else if platform.parsed.cpu.name == "aarch64" then
+      "AArch64"
+    else if platform.parsed.cpu.family == "arm" then
+      "ARM"
+    else if platform.parsed.cpu.family == "mips" then
+      "Mips"
+    else
+      throw "Unsupported system";
+
+  llvmBackendList = platforms:
+    lib.concatStringsSep ";" (map llvmBackend platforms);
+}


### PR DESCRIPTION
###### Motivation for this change

This `common.nix` is me hoping other things will also be factored out of the LLVM derivations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

