### PR TITLE
pythonPackages.lmdb: enable tests

### DIFF
--- a/pkgs/development/python-modules/lmdb/default.nix
+++ b/pkgs/development/python-modules/lmdb/default.nix
@@ -1,7 +1,8 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, isPy3k
+, pytest
+, cffi
 }:
 
 buildPythonPackage rec {
@@ -13,8 +14,11 @@ buildPythonPackage rec {
     sha256 = "1zh38gvkqw1jm5105if6rr7ccbgyxr7k2rm5ygb9ab3bq82pyaww";
   };
 
-  # Some sort of mysterious failure with lmdb.tool
-  doCheck = !isPy3k;
+  checkInputs = [ pytest cffi ];
+  checkPhase = ''
+    export PYTHONPATH=.:$PYTHONPATH
+    py.test
+  '';
 
   meta = with stdenv.lib; {
     description = "Universal Python binding for the LMDB 'Lightning' Database";


### PR DESCRIPTION
###### Motivation for this change

I noticed that the pythonPackages.lmdb tests were unnecessarily disabled for Python 3. I confirmed that the tests for `python37Packages.lmdb` were failing with the error described, and that they no longer fail (on Linux, at least.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

