### PR TITLE
atom, atom-beta: 1.32.1 -> 1.33.0, 1.33.0-beta1 -> 1.34.0-beta0, remove myself as maintainer

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -79,7 +79,7 @@ let
       description = "A hackable text editor for the 21st Century";
       homepage = https://atom.io/;
       license = licenses.mit;
-      maintainers = with maintainers; [ offline nequissimus synthetica ysndr ];
+      maintainers = with maintainers; [ offline nequissimus ysndr ];
       platforms = platforms.x86_64;
     };
   };

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -3,14 +3,14 @@
 let
   versions = {
     atom = {
-      version = "1.32.1";
-      sha256 = "1x22jbhvagqw9mvq0v7z4z09qp727vl0rkyvaxn98xnj9gvcfkq9";
+      version = "1.33.0";
+      sha256 = "0f6m6zwgz94m3q11ipyiliap3s5a3zlrg3ldjwkqnxjl6gwlxc2r";
     };
 
     atom-beta = {
-      version = "1.33.0";
-      beta = 1;
-      sha256 = "0sf98apmb57msgr5p1xly0mffzn2s808nsfsmbisk4qqmm9fv2m3";
+      version = "1.34.0";
+      beta = 0;
+      sha256 = "1xnrr4z55sj46hqr0il26sfs6s3knv60m340cw3rzzic271b3ifw";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

cc @offlinehacker @NeQuissimus @ysndr 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

