### PR TITLE
gnome3.nautilus: fix thumbnail generation

### DIFF
--- a/pkgs/desktops/gnome-3/core/nautilus/bubblewrap-paths.patch
+++ b/pkgs/desktops/gnome-3/core/nautilus/bubblewrap-paths.patch
@@ -1,0 +1,19 @@
+---   a/src/gnome-desktop/gnome-desktop-thumbnail-script.c
++++   a/src/gnome-desktop/gnome-desktop-thumbnail-script.c
+@@ -514,14 +514,10 @@ add_bwrap (GPtrArray   *array,
+   g_return_val_if_fail (script->s_infile != NULL, FALSE);
+ 
+   add_args (array,
+-	    "bwrap",
+-	    "--ro-bind", "/usr", "/usr",
+-	    "--ro-bind", "/lib", "/lib",
+-	    "--ro-bind", "/lib64", "/lib64",
++      "@bubblewrap_bin@",
++      "--ro-bind", "@storeDir@", "@storeDir@",
+ 	    "--proc", "/proc",
+ 	    "--dev", "/dev",
+-	    "--symlink", "usr/bin", "/bin",
+-	    "--symlink", "usr/sbin", "/sbin",
+ 	    "--chdir", "/",
+ 	    "--setenv", "GIO_USE_VFS", "local",
+ 	    "--unshare-all",

--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, libxml2, desktop-file-utils, python3, wrapGAppsHook
-, gtk, gnome3, gnome-autoar, glib-networking, shared-mime-info, libnotify, libexif, libseccomp
-, exempi, librsvg, tracker, tracker-miners, gnome-desktop, gexiv2, libselinux, gdk_pixbuf }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, libxml2
+, desktop-file-utils, python3, wrapGAppsHook , gtk, gnome3, gnome-autoar
+, glib-networking, shared-mime-info, libnotify, libexif, libseccomp , exempi
+, librsvg, tracker, tracker-miners, gexiv2, libselinux, gdk_pixbuf
+, substituteAll, bubblewrap
+}:
 
 let
   pname = "nautilus";
@@ -13,11 +16,14 @@ in stdenv.mkDerivation rec {
     sha256 = "144r4py9b8w9ycsg6fggjg05kwvymh003qsb3h6apgpch5y3zgnv";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig libxml2 gettext python3 wrapGAppsHook desktop-file-utils ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig libxml2 gettext python3 wrapGAppsHook
+    desktop-file-utils
+  ];
 
   buildInputs = [
     glib-networking shared-mime-info libexif gtk exempi libnotify libselinux
-    tracker tracker-miners gnome-desktop gexiv2 libseccomp
+    tracker tracker-miners gexiv2 libseccomp bubblewrap
     gnome3.adwaita-icon-theme gnome3.gsettings-desktop-schemas
   ];
 
@@ -36,7 +42,16 @@ in stdenv.mkDerivation rec {
     patchShebangs build-aux/meson/postinstall.py
   '';
 
-  patches = [ ./extension_dir.patch ];
+  patches = [
+    ./extension_dir.patch
+    # 3.30 now generates it's own thummbnails,
+    # and no longer depends on `gnome-desktop`
+    (substituteAll {
+      src = ./bubblewrap-paths.patch;
+      bubblewrap_bin = "${bubblewrap}/bin/bwrap";
+      inherit (builtins) storeDir;
+    })
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
###### Motivation for this change

3.30 copied over the thumbnail code frome gnome-desktop:
https://gitlab.gnome.org/GNOME/nautilus/commit/673c81cf9f1d68b71041220e6e44624dee44dbfc

Simply patch nautilus too.

ref https://github.com/NixOS/nixpkgs/issues/50494

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

