### PR TITLE
retroarch: Remove --menu from wrapper

### DIFF
--- a/pkgs/misc/emulators/retroarch/wrapper.nix
+++ b/pkgs/misc/emulators/retroarch/wrapper.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
     makeWrapper ${retroarch}/bin/retroarch $out/bin/retroarch \
       --suffix-each LD_LIBRARY_PATH ':' "$cores" \
-      --add-flags "-L $out/lib/ --menu" \
+      --add-flags "-L $out/lib/" \
   '';
 
   cores = map (x: x + x.libretroCore) cores;


### PR DESCRIPTION
###### Motivation for this change
Retroarch already opens a menu without needing --menu to be passed to it, and explicitly passing it means you cannot later override it. This means in nixos, passing -L to retroarch to specify a specific core is broken. Removing --menu makes the default behavior the same but fixes -L.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

