### PR TITLE
 pythonPackages.fb-re2: init at 1.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1894,6 +1894,10 @@
     github = "ironpinguin";
     name = "Michele Catalano";
   };
+  ivan = {
+    email = "ivan@ludios.org";
+    name = "Ivan Kozik";
+  };
   ivan-tkatchev = {
     email = "tkatchev@gmail.com";
     name = "Ivan Tkatchev";

--- a/pkgs/development/python-modules/fb-re2/default.nix
+++ b/pkgs/development/python-modules/fb-re2/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, re2
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "fb-re2";
+  version = "1.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wd97qdcafcca90s6692g2dmzl5n6cdvm20vn7pmag3l9gvx395c";
+  };
+
+  buildInputs = [ re2 ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = {
+    description = "Python wrapper for Google's RE2";
+    homepage = https://github.com/facebook/pyre2;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ivan ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1663,6 +1663,8 @@ in {
     then callPackage ../development/python-modules/faulthandler {}
     else throw "faulthandler is built into ${python.executable}";
 
+  fb-re2 = callPackage ../development/python-modules/fb-re2 { };
+
   flit = callPackage ../development/python-modules/flit { };
 
   flowlogs_reader = callPackage ../development/python-modules/flowlogs_reader { };


### PR DESCRIPTION
###### Motivation for this change

This dependency will be used by an upcoming PR that adds [grab-site](https://github.com/ludios/grab-site).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

