### PR TITLE
pythonPackages.cchardet: init at 2.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1894,6 +1894,10 @@
     github = "ironpinguin";
     name = "Michele Catalano";
   };
+  ivan = {
+    email = "ivan@ludios.org";
+    name = "Ivan Kozik";
+  };
   ivan-tkatchev = {
     email = "tkatchev@gmail.com";
     name = "Ivan Tkatchev";

--- a/pkgs/development/python-modules/cchardet/default.nix
+++ b/pkgs/development/python-modules/cchardet/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "cchardet";
+  version = "2.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h3wajwwgqpyb1q44lzr8djbcwr4y8cphph7kyscz90d83h4b5yc";
+  };
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    ${python.interpreter} setup.py nosetests
+  '';
+
+  meta = {
+    description = "High-speed universal character encoding detector";
+    homepage = https://github.com/PyYoshi/cChardet;
+    license = lib.licenses.mpl11;
+    maintainers = with lib.maintainers; [ ivan ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1176,6 +1176,8 @@ in {
 
   cccolutils = callPackage ../development/python-modules/cccolutils {};
 
+  cchardet = callPackage ../development/python-modules/cchardet { };
+
   CDDB = callPackage ../development/python-modules/cddb { };
 
   cntk = callPackage ../development/python-modules/cntk { };


### PR DESCRIPTION
###### Motivation for this change

This dependency will be used by an upcoming PR that adds [grab-site](https://github.com/ludios/grab-site).

[cChardet](https://github.com/PyYoshi/cChardet) is a faster version of [chardet](https://github.com/chardet/chardet).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

