### PR TITLE
pythonPackages.x256: init at 0.0.3

### DIFF
--- a/pkgs/development/python-modules/x256/default.nix
+++ b/pkgs/development/python-modules/x256/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi
+ }:
+
+buildPythonPackage rec {
+  pname = "x256";
+  version = "0.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00g02b9a6jsl377xb5fmxvkjff3lalw21n430a4zalqyv76dnmgq";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Return the nearest xterm 256 color code for rgb inputs.";
+    homepage = https://github.com/magarcia/python-x256;
+    license = licenses.mit;
+    maintainers = with maintainers; [ scriptkiddi ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17305,6 +17305,8 @@ EOF
 
   simpy = callPackage ../development/python-modules/simpy { };
 
+  x256 = callPackage ../development/python-modules/x256 { };
+
   z3 = (toPythonModule (pkgs.z3.override {
     inherit python;
   })).python;


### PR DESCRIPTION
###### Motivation for this change
I want to add the gif-for-cli python app and it needs this as dep

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

