### PR TITLE
sublime: add new download url

### DIFF
--- a/pkgs/applications/editors/sublime/2/default.nix
+++ b/pkgs/applications/editors/sublime/2/default.nix
@@ -9,13 +9,19 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         name = "sublimetext-2.0.2.tar.bz2";
-        url = http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.tar.bz2;
+        url = [
+          http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.tar.bz2
+          https://download.sublimetext.com/Sublime%20Text%202.0.2.tar.bz2
+        ];
         sha256 = "026g5mppk28lzzzn9ibykcqkrd5msfmg0sc0z8w8jd7v3h28wcq7";
       }
     else
       fetchurl {
         name = "sublimetext-2.0.2.tar.bz2";
-        url = http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2%20x64.tar.bz2;
+        url = [
+          http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%202.0.2.tar.bz2
+          https://download.sublimetext.com/Sublime%20Text%202.0.2%20x64.tar.bz2
+        ];
         sha256 = "115b71nbv9mv8cz6bkjwpbdf2ywnjc1zy2d3080f6ck4sqqfvfh1";
       };
   buildCommand = ''


### PR DESCRIPTION
The old one gave a 404. I left it there for if it ever comes back

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

