### PR TITLE
pkgsStatic for 18.09

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -4,6 +4,7 @@
 , mouseSupport ? false
 , unicode ? true
 , enableStatic ? stdenv.hostPlatform.useAndroidPrebuilt
+, enableShared ? !enableStatic
 , withCxx ? !stdenv.hostPlatform.useAndroidPrebuilt
 
 , gpm
@@ -28,7 +29,7 @@ stdenv.mkDerivation rec {
   setOutputFlags = false; # some aren't supported
 
   configureFlags = [
-    "--with-shared"
+    (lib.withFeature enableShared "shared")
     "--without-debug"
     "--enable-pc-files"
     "--enable-symlinks"

--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
@@ -15,7 +15,7 @@ appleDerivation {
     (lib.enableFeature enableShared "shared")
   ];
 
-  postInstall = lib.optionalString (!enableStatic) ''
+  postInstall = lib.optionalString enableShared ''
     mv $out/lib/libiconv.dylib $out/lib/libiconv-nocharset.dylib
     ${stdenv.cc.bintools.targetPrefix}install_name_tool -id $out/lib/libiconv-nocharset.dylib $out/lib/libiconv-nocharset.dylib
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -32,13 +32,15 @@ rec {
   # Return a modified stdenv that tries to build statically linked
   # binaries.
   makeStaticBinaries = stdenv: stdenv //
-    { mkDerivation = args: stdenv.mkDerivation (args // {
-        NIX_CFLAGS_LINK = "-static";
+    { mkDerivation = args:
+      if stdenv.hostPlatform.isDarwin
+      then throw "Cannot build fully static binaries on Darwin/macOS"
+      else stdenv.mkDerivation (args // {
+        NIX_CFLAGS_LINK = toString (args.NIX_CFLAGS_LINK or "") + "-static";
         configureFlags = (args.configureFlags or []) ++ [
             "--disable-shared" # brrr...
           ];
       });
-      isStatic = true;
     };
 
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -1,11 +1,14 @@
 { lib
-, localSystem, crossSystem, config, overlays
+, localSystem, crossSystem, config, overlays, crossOverlays ? []
 }:
 
 let
   bootStages = import ../. {
     inherit lib localSystem overlays;
-    crossSystem = null;
+
+    crossSystem = localSystem;
+    crossOverlays = [];
+
     # Ignore custom stdenvs when cross compiling for compatability
     config = builtins.removeAttrs config [ "replaceStdenv" ];
   };
@@ -33,7 +36,8 @@ in lib.init bootStages ++ [
 
   # Run Packages
   (buildPackages: {
-    inherit config overlays;
+    inherit config;
+    overlays = overlays ++ crossOverlays;
     selfBuild = false;
     stdenv = buildPackages.stdenv.override (old: rec {
       buildPlatform = localSystem;
@@ -48,7 +52,7 @@ in lib.init bootStages ++ [
 
       cc = if crossSystem.useiOSPrebuilt or false
              then buildPackages.darwin.iosSdkPkgs.clang
-           else if crossSystem.useAndroidPrebuilt
+           else if crossSystem.useAndroidPrebuilt or false
              then buildPackages.androidenv."androidndkPkgs_${crossSystem.ndkVer}".gcc
            else buildPackages.gcc;
 
@@ -56,6 +60,7 @@ in lib.init bootStages ++ [
         ++ lib.optionals
              (hostPlatform.isLinux && !buildPlatform.isLinux)
              [ buildPackages.patchelf buildPackages.paxctl ]
+        ++ lib.optional hostPlatform.isDarwin buildPackages.clang
         ++ lib.optional
              (let f = p: !p.isx86 || p.libc == "musl"; in f hostPlatform && !(f buildPlatform))
              buildPackages.updateAutotoolsGnuConfigScriptsHook

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -2,7 +2,7 @@
 , localSystem, crossSystem, config, overlays
 }:
 
-assert crossSystem == null;
+assert crossSystem == localSystem;
 
 let
   bootStages = import ../. {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1,5 +1,5 @@
 { lib
-, localSystem, crossSystem, config, overlays
+, localSystem, crossSystem, config, overlays, crossOverlays ? []
 
 # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
 , bootstrapFiles ? let
@@ -16,7 +16,7 @@
   }
 }:
 
-assert crossSystem == null;
+assert crossSystem == localSystem;
 
 let
   inherit (localSystem) system platform;

--- a/pkgs/stdenv/darwin/portable-libsystem.sh
+++ b/pkgs/stdenv/darwin/portable-libsystem.sh
@@ -1,0 +1,10 @@
+# Make /nix/store/...-libSystem “portable” for static built binaries.
+# This just rewrites everything in $1/bin to use the
+# /usr/lib/libSystem.B.dylib that is provided on every macOS system.
+
+fixupOutputHooks+=('fixLibsystemRefs $prefix')
+
+fixLibsystemRefs() {
+  find "$1/bin" \
+    -exec install_name_tool -change @libsystem@ /usr/lib/libSystem.B.dylib {} \;
+}

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -7,7 +7,7 @@
 { # Args just for stdenvs' usage
   lib
   # Args to pass on to the pkgset builder, too
-, localSystem, crossSystem, config, overlays
+, localSystem, crossSystem, config, overlays, crossOverlays ? []
 } @ args:
 
 let
@@ -36,7 +36,7 @@ let
 
   # Select the appropriate stages for the platform `system'.
 in
-  if crossSystem != null then stagesCross
+  if crossSystem != localSystem || crossOverlays != [] then stagesCross
   else if config ? replaceStdenv then stagesCustom
   else { # switch
     "i686-linux" = stagesLinux;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -2,7 +2,7 @@
 , localSystem, crossSystem, config, overlays
 }:
 
-assert crossSystem == null;
+assert crossSystem == localSystem;
 let inherit (localSystem) system; in
 
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -4,7 +4,7 @@
 # compiler and linker that do not search in default locations,
 # ensuring purity of components produced by it.
 { lib
-, localSystem, crossSystem, config, overlays
+, localSystem, crossSystem, config, overlays, crossOverlays ? []
 
 , bootstrapFiles ?
   let table = {
@@ -32,7 +32,7 @@
   in files
 }:
 
-assert crossSystem == null;
+assert crossSystem == localSystem;
 
 let
   inherit (localSystem) system platform;

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -2,7 +2,7 @@
 , localSystem, crossSystem, config, overlays
 }:
 
-assert crossSystem == null;
+assert crossSystem == localSystem;
 
 let
   inherit (localSystem) system;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -1,10 +1,10 @@
 { lib
-, crossSystem, config, overlays
+, crossSystem, localSystem, config, overlays
 , bootStages
 , ...
 }:
 
-assert crossSystem == null;
+assert crossSystem == localSystem;
 
 bootStages ++ [
   (prevStage: {

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -22,15 +22,17 @@
   # `*Platform`s.
   localSystem
 
-, # The system packages will ultimately be run on. Null if the two should be the
-  # same.
-  crossSystem ? null
+, # The system packages will ultimately be run on.
+  crossSystem ? localSystem
 
 , # Allow a configuration attribute set to be passed in as an argument.
   config ? {}
 
 , # List of overlays layers used to extend Nixpkgs.
   overlays ? []
+
+, # List of overlays to apply to target packages only.
+  crossOverlays ? []
 
 , # A function booting the final package set for a specific standard
   # environment. See below for the arguments given to that function, the type of
@@ -61,7 +63,8 @@ in let
     builtins.intersectAttrs { platform = null; } config
     // args.localSystem);
 
-  crossSystem = lib.mapNullable lib.systems.elaborate crossSystem0;
+  crossSystem = if crossSystem0 == null then localSystem
+                else lib.systems.elaborate crossSystem0;
 
   # A few packages make a new package set to draw their dependencies from.
   # (Currently to get a cross tool chain, or forced-i686 package.) Rather than
@@ -91,7 +94,7 @@ in let
   boot = import ../stdenv/booter.nix { inherit lib allPackages; };
 
   stages = stdenvStages {
-    inherit lib localSystem crossSystem config overlays;
+    inherit lib localSystem crossSystem config overlays crossOverlays;
   };
 
   pkgs = boot stages;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -160,6 +160,23 @@ let
         };
       };
     };
+
+    # Fully static packages.
+    # Currently uses Musl on Linux (couldn’t get static glibc to work).
+    pkgsStatic = nixpkgsFun ({
+      crossOverlays = [ (import ./static.nix) ];
+    } // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      crossSystem = {
+        parsed = stdenv.hostPlatform.parsed // {
+          abi = {
+            "gnu" = lib.systems.parse.abis.musl;
+            "gnueabi" = lib.systems.parse.abis.musleabi;
+            "gnueabihf" = lib.systems.parse.abis.musleabihf;
+          }.${stdenv.hostPlatform.parsed.abi.name}
+            or lib.systems.parse.abis.musl;
+        };
+      };
+    });
   };
 
   # The complete chain of package set builders, applied from top to bottom.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -163,7 +163,7 @@ let
 
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
-    pkgsStatic = nixpkgsFun ({
+    pkgsStatic = lib.warn "This a provisional API backported from master for convenience." (nixpkgsFun ({
       crossOverlays = [ (import ./static.nix) ];
     } // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       crossSystem = {
@@ -176,7 +176,7 @@ let
             or lib.systems.parse.abis.musl;
         };
       };
-    });
+    }));
   };
 
   # The complete chain of package set builders, applied from top to bottom.

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -1,0 +1,150 @@
+# Overlay that builds static packages.
+
+# Not all packages will build but support is done on a
+# best effort basic.
+#
+# Note on Darwin/macOS: Apple does not provide a static libc
+# so any attempts at static binaries are going to be very
+# unsupported.
+#
+# Basic things like pkgsStatic.hello should work out of the box. More
+# complicated things will need to be fixed with overrides.
+
+self: super: let
+  inherit (super.stdenvAdapters) makeStaticBinaries
+                                 overrideInStdenv
+                                 makeStaticLibraries;
+  inherit (super.lib) foldl optional flip id optionalAttrs composeExtensions;
+  inherit (super) makeSetupHook;
+
+  # Best effort static binaries. Will still be linked to libSystem,
+  # but more portable than Nix store binaries.
+  makeStaticDarwin = stdenv: stdenv // {
+    mkDerivation = args: stdenv.mkDerivation (args // {
+      NIX_CFLAGS_LINK = toString (args.NIX_CFLAGS_LINK or "")
+                      + " -static-libgcc";
+      nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ (makeSetupHook {
+        substitutions = {
+          libsystem = "${stdenv.cc.libc}/lib/libSystem.B.dylib";
+        };
+      } ../stdenv/darwin/portable-libsystem.sh) ];
+    });
+  };
+
+  staticAdapters = [ makeStaticLibraries ]
+
+    # Apple does not provide a static version of libSystem or crt0.o
+    # So we can’t build static binaries without extensive hacks.
+    ++ optional (!super.stdenv.hostPlatform.isDarwin) makeStaticBinaries
+
+    ++ optional super.stdenv.hostPlatform.isDarwin makeStaticDarwin
+
+    # Glibc doesn’t come with static runtimes by default.
+    # ++ optional (super.stdenv.hostPlatform.libc == "glibc") ((flip overrideInStdenv) [ self.stdenv.glibc.static ])
+  ;
+
+  # Force everything to link statically.
+  haskellStaticAdapter = self: super: {
+    mkDerivation = attrs: super.mkDerivation (attrs // {
+      enableSharedLibraries = false;
+      enableSharedExecutables = false;
+      enableStaticLibraries = true;
+    });
+  };
+
+in {
+  stdenv = foldl (flip id) super.stdenv staticAdapters;
+
+  haskell = super.haskell // {
+    packageOverrides = composeExtensions
+      (super.haskell.packageOverrides or (_: _: {}))
+      haskellStaticAdapter;
+  };
+
+  ncurses = super.ncurses.override {
+    enableStatic = true;
+  };
+  libxml2 = super.libxml2.override {
+    enableShared = false;
+    enableStatic = true;
+  };
+  zlib = super.zlib.override {
+    static = true;
+    shared = false;
+
+    # Don’t use new stdenv zlib because
+    # it doesn’t like the --disable-shared flag
+    stdenv = super.stdenv;
+  };
+  xz = super.xz.override {
+    enableStatic = true;
+  };
+  busybox = super.busybox.override {
+    enableStatic = true;
+  };
+  v8 = super.v8.override {
+    static = true;
+  };
+  libiberty = super.libiberty.override {
+    staticBuild = true;
+  };
+  ipmitool = super.ipmitool.override {
+    static = true;
+  };
+  neon = super.neon.override {
+    static = true;
+    shared = false;
+  };
+  libjpeg = super.libjpeg.override {
+    static = true;
+  };
+  gifsicle = super.gifsicle.override {
+    static = true;
+  };
+  bzip2 = super.bzip2.override {
+    linkStatic = true;
+  };
+  optipng = super.optipng.override {
+    static = true;
+  };
+  openssl = super.openssl.override {
+    static = true;
+
+    # Don’t use new stdenv for openssl because it doesn’t like the
+    # --disable-shared flag
+    stdenv = super.stdenv;
+  };
+  boost = super.boost.override {
+    enableStatic = true;
+    enableShared = false;
+  };
+  gmp = super.gmp.override {
+    withStatic = true;
+  };
+  cdo = super.cdo.override {
+    enable_all_static = true;
+  };
+  gsm = super.gsm.override {
+    staticSupport = true;
+  };
+  parted = super.parted.override {
+    enableStatic = true;
+  };
+  libiconvReal = super.libiconvReal.override {
+    enableShared = false;
+    enableStatic = true;
+  };
+  perl = super.perl.override {
+    # Don’t use new stdenv zlib because
+    # it doesn’t like the --disable-shared flag
+    stdenv = super.stdenv;
+  };
+
+  darwin = super.darwin // {
+    libiconv = super.darwin.libiconv.override {
+      enableShared = false;
+      enableStatic = true;
+    };
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

A backport of #48803 for those wanting to use this but unable to switch from stable to master. A note is adding saying the interface is provisional. Presumably in 19.03 this will arrive on staging "the normal way" and the dust will have settled again.

Rebased on a recentish common ancestor of `master` and `relase-18.09`. This way any further fixes can be made on top of this (minus the top commit) and then easily merged into both `master` and `release-19.09`. This is a lot easier than cherry-pick; with cherry-pick alone it wouldn't make sense to pre-release new interfaces on stable.

N.B. I skipped b966d3c5835fdbaa153a9eacd08cdbf789ee1b40 because that is a breaking interface change not appropriate for stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @vaibhavsagar 
