### PR TITLE
libcxxabi: also install libc++abi.a

### DIFF
--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -44,6 +44,11 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
+  postInstall = ''
+    mv $out/lib/libc++.a $out/lib/libc++_static.a
+    cp ${./libc++.a} $out/lib/libc++.a
+  '';
+
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/4/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/4/libc++/libc++.a
@@ -1,0 +1,1 @@
+INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/4/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/4/libc++abi.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     ''
     else ''
       install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.a $out/lib
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       install -m 644 ../include/cxxabi.h $out/include
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -38,6 +38,11 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
+  postInstall = ''
+    mv $out/lib/libc++.a $out/lib/libc++_static.a
+    cp ${./libc++.a} $out/lib/libc++.a
+  '';
+
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/5/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/5/libc++/libc++.a
@@ -1,0 +1,1 @@
+INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/5/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/5/libc++abi.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
     ''
     else ''
       install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.a $out/lib
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       install -m 644 ../include/cxxabi.h $out/include
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -38,6 +38,11 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
+  postInstall = ''
+    mv $out/lib/libc++.a $out/lib/libc++_static.a
+    cp ${./libc++.a} $out/lib/libc++.a
+  '';
+
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/6/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/6/libc++/libc++.a
@@ -1,0 +1,1 @@
+INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/6/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/6/libc++abi.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
     ''
     else ''
       install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.a $out/lib
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       install -m 644 ../include/cxxabi.h $out/include
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so

--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
+  postInstall = ''
+    mv $out/lib/libc++.a $out/lib/libc++_static.a
+    cp ${./libc++.a} $out/lib/libc++.a
+  '';
+
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/7/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/7/libc++/libc++.a
@@ -1,0 +1,1 @@
+INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/7/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/7/libc++abi.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
     ''
     else ''
       install -d -m 755 $out/include $out/lib
+      install -m 644 lib/libc++abi.a $out/lib
       install -m 644 lib/libc++abi.so.1.0 $out/lib
       install -m 644 ../include/cxxabi.h $out/include
       ln -s libc++abi.so.1.0 $out/lib/libc++abi.so


### PR DESCRIPTION
###### Motivation for this change
Allows building static binaries with `libcxxStdenv`.  The file is only 536K in size, so it seems a waste to throw it away after building it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

