### PR TITLE
freebind: init at 2017-12-27

### DIFF
--- a/pkgs/tools/networking/freebind/default.nix
+++ b/pkgs/tools/networking/freebind/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, libnetfilter_queue, libnfnetlink }:
+
+stdenv.mkDerivation rec {
+  name = "freebind-${version}";
+  version = "2017-12-27";
+
+  src = fetchFromGitHub {
+    owner = "blechschmidt";
+    repo = "freebind";
+    rev = "9a13d6f9c12aeea4f6d3513ba2461d34f841f278";
+    sha256 = "1iv2xiz9w8hbz684caw50fn4a9vc8ninfgaqafkh9sa8mzpfzcqr";
+  };
+
+  buildInputs = [ libnetfilter_queue libnfnetlink ];
+
+  postPatch = ''
+    substituteInPlace preloader.c --replace /usr/local/ $out/
+    substituteInPlace Makefile    --replace /usr/local/ $out/
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin $out/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "IPv4 and IPv6 address rate limiting evasion tool";
+    homepage = https://github.com/blechschmidt/freebind;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ volth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2756,6 +2756,8 @@ in
 
   freedroidrpg = callPackage ../games/freedroidrpg { };
 
+  freebind = callPackage ../tools/networking/freebind { };
+
   freeipmi = callPackage ../tools/system/freeipmi {};
 
   freetalk = callPackage ../applications/networking/instant-messengers/freetalk {


### PR DESCRIPTION
###### Motivation for this change

IPv4 and IPv6 address rate limiting evasion tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

