### PR TITLE
acl: 2.2.52 -> 2.2.53

### DIFF
--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, gettext, attr }:
 
 stdenv.mkDerivation rec {
-  name = "acl-2.2.52";
+  name = "acl-2.2.53";
 
   src = fetchurl {
-    url = "mirror://savannah/acl/${name}.src.tar.gz";
-    sha256 = "08qd9s3wfhv0ajswsylnfwr5h0d7j9d4rgip855nrh400nxp940p";
+    url = "mirror://savannah/acl/${name}.tar.gz";
+    sha256 = "1ir6my3w74s6nfbgbqgzj6w570sn0qjf3524zx8xh67lqrjrigh6";
   };
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
 
     patchShebangs .
   '';
-
-  configureFlags = [ "MAKE=make" "MSGFMT=msgfmt" "MSGMERGE=msgmerge" "XGETTEXT=xgettext" "ZIP=gzip" "ECHO=echo" "SED=sed" "AWK=gawk" ];
-
-  installTargets = [ "install" "install-lib" "install-dev" ];
 
   meta = with stdenv.lib; {
     homepage = "https://savannah.nongnu.org/projects/acl";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

