### PR TITLE
kind: master -> 0.0.1

### DIFF
--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -4,14 +4,13 @@ with stdenv.lib;
 
 buildGoPackage rec {
   name = "kind-${version}";
-  version = "2018-10-03-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "2ae73f8ef93609991b0e47a67825390ceec95b3f";
+  version = "0.0.1";
 
   src = fetchFromGitHub {
-    rev = rev;
+    rev = "${version}";
     owner = "kubernetes-sigs";
     repo = "kind";
-    sha256 = "0bg3y35sc1c73z4rfq11x1jz340786q91ywm165ri7vx280ffjgh";
+    sha256 = "1jldj864ip8hrk3zhkjifr4gzgc8kxmxxwvklxglymhv8cxc179f";
   };
 
   goPackagePath = "sigs.k8s.io/kind";
@@ -20,7 +19,8 @@ buildGoPackage rec {
   meta = {
     description = "Kubernetes IN Docker - local clusters for testing Kubernetes";
     homepage = https://github.com/kubernetes-sigs/kind;
-    maintainers = with maintainers; [ offline ];
+    maintainers = with maintainers; [ offline rawkode ];
     license = stdenv.lib.licenses.asl20;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Kind have tagged their first release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

