### PR TITLE
lz4: Fix pkgsStatic build

### DIFF
--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, valgrind }:
+{ stdenv, fetchFromGitHub, valgrind
+, enableStatic ? false, enableShared ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "lz4-${version}";
@@ -17,12 +19,23 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  makeFlags = [ "PREFIX=$(out)" "INCLUDEDIR=$(dev)/include" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "INCLUDEDIR=$(dev)/include"
+    # TODO do this instead
+    #"BUILD_STATIC=${if enableStatic then "yes" else "no"}"
+    #"BUILD_SHARED=${if enableShared then "yes" else "no"}"
+  ]
+    # TODO delete and do above
+    ++ stdenv.lib.optional (enableStatic) "BUILD_STATIC=yes"
+    ++ stdenv.lib.optional (!enableShared) "BUILD_SHARED=no"
+    ;
 
   doCheck = false; # tests take a very long time
   checkTarget = "test";
 
-  postInstall = "rm $out/lib/*.a";
+  # TODO remove
+  postInstall = stdenv.lib.optionalString (!enableStatic) "rm $out/lib/*.a";
 
   meta = with stdenv.lib; {
     description = "Extremely fast compression algorithm";

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -139,6 +139,10 @@ in {
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
   };
+  lz4 = super.lz4.override {
+    enableShared = false;
+    enableStatic = true;
+  };
 
   darwin = super.darwin // {
     libiconv = super.darwin.libiconv.override {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

