### PR TITLE
Don't fail on haskell configure warning

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -86,7 +86,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "0f0pp0d5q4122cjh4j7iasnjh234fmkvlwgb3f49087cg8rr2czh";
+      sha256 = "0iav8l9k7q4n7cs04mqss7z9vxjqz6p4avg30r5wmxxgxfnm626s";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1200,4 +1200,7 @@ self: super: {
   # https://github.com/mgajda/json-autotype/issues/25
   json-autotype = dontCheck super.json-autotype;
 
+  # https://github.com/kazu-yamamoto/iproute/issues/43
+  appar = self.appar_0_1_7;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -682,7 +682,8 @@ self: super: {
   # Fix an aarch64 issue with cryptonite-0.25:
   # https://github.com/haskell-crypto/cryptonite/issues/234
   # This has been committed upstream, but there is, as of yet, no new release.
-  cryptonite = appendPatch super.cryptonite (pkgs.fetchpatch {
+  # Also, disable the test suite to avoid https://github.com/haskell-crypto/cryptonite/issues/260.
+  cryptonite = appendPatch (dontCheck super.cryptonite) (pkgs.fetchpatch {
     url = https://github.com/haskell-crypto/cryptonite/commit/4622e5fc8ece82f4cf31358e31cd02cf020e558e.patch;
     sha256 = "1m2d47ni4jbrpvxry50imj91qahr3r7zkqm157clrzlmw6gzpgnq";
   });

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -46,7 +46,7 @@ self: super: {
 
   # LTS-12.x versions do not compile.
   base-orphans = self.base-orphans_0_8;
-  brick = self.brick_0_42_1;
+  brick = self.brick_0_44_1;
   cassava-megaparsec = doJailbreak super.cassava-megaparsec;
   config-ini = doJailbreak super.config-ini;   # https://github.com/aisamanra/config-ini/issues/18
   contravariant = self.contravariant_1_5;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -45,7 +45,7 @@ default-package-overrides:
   - base-compat-batteries ==0.10.1
   # Newer versions don't work in LTS-12.x
   - cassava-megaparsec < 2
-  # LTS Haskell 12.21
+  # LTS Haskell 12.22
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
@@ -184,7 +184,7 @@ default-package-overrides:
   - ansi-wl-pprint ==0.6.8.2
   - ANum ==0.2.0.2
   - api-field-json-th ==0.1.0.2
-  - appar ==0.1.4
+  - appar ==0.1.5
   - apply-refact ==0.5.0.0
   - apportionment ==0.0.0.3
   - approximate ==0.3.1
@@ -230,7 +230,7 @@ default-package-overrides:
   - base16-bytestring ==0.1.1.6
   - base32string ==0.9.1
   - base58string ==0.10.0
-  - base64-bytestring ==1.0.0.1
+  - base64-bytestring ==1.0.0.2
   - base64-bytestring-type ==1
   - base64-string ==0.2
   - base-compat ==0.10.5
@@ -361,7 +361,7 @@ default-package-overrides:
   - cereal-time ==0.1.0.0
   - cereal-vector ==0.2.0.1
   - cfenv ==0.1.0.0
-  - chan ==0.0.4
+  - chan ==0.0.4.1
   - ChannelT ==0.0.0.7
   - charset ==0.3.7.1
   - charsetdetect-ae ==1.1.0.4
@@ -565,7 +565,7 @@ default-package-overrides:
   - Decimal ==0.5.1
   - declarative ==0.5.2
   - deepseq-generics ==0.2.0.0
-  - dejafu ==1.11.0.3
+  - dejafu ==1.11.0.4
   - dependent-map ==0.2.4.0
   - dependent-sum ==0.4
   - dependent-sum-template ==0.0.0.6
@@ -732,11 +732,11 @@ default-package-overrides:
   - fileplow ==0.1.0.0
   - filter-logger ==0.6.0.0
   - filtrable ==0.1.1.0
-  - Fin ==0.2.6.0
   - fin ==0.0.1
+  - Fin ==0.2.6.0
   - FindBin ==0.0.5
   - find-clumpiness ==0.2.3.1
-  - fingertree ==0.1.4.1
+  - fingertree ==0.1.4.2
   - finite-typelits ==0.1.4.2
   - first-class-patterns ==0.3.2.4
   - fixed ==0.2.1.1
@@ -754,7 +754,7 @@ default-package-overrides:
   - fmlist ==0.9.2
   - fn ==0.3.0.2
   - focus ==0.1.5.2
-  - focuslist ==0.1.0.0
+  - focuslist ==0.1.0.1
   - foldable1 ==0.1.0.0
   - fold-debounce ==0.2.0.8
   - fold-debounce-conduit ==0.2.0.3
@@ -960,7 +960,7 @@ default-package-overrides:
   - hebrew-time ==0.1.1
   - hedgehog ==0.6.1
   - hedgehog-corpus ==0.1.0
-  - hedis ==0.10.8
+  - hedis ==0.10.10
   - here ==1.2.13
   - heredoc ==0.2.0.0
   - heterocephalus ==1.0.5.2
@@ -1016,8 +1016,8 @@ default-package-overrides:
   - hsdns ==1.7.1
   - hsebaysdk ==0.4.0.0
   - hsemail ==2
-  - HSet ==0.0.1
   - hset ==2.2.0
+  - HSet ==0.0.1
   - hsexif ==0.6.1.6
   - hs-functors ==0.1.3.0
   - hs-GeoIP ==0.3
@@ -1083,7 +1083,7 @@ default-package-overrides:
   - hvect ==0.4.0.0
   - hvega ==0.1.0.3
   - hw-balancedparens ==0.2.0.2
-  - hw-bits ==0.7.0.4
+  - hw-bits ==0.7.0.5
   - hw-conduit ==0.2.0.5
   - hw-diagnostics ==0.0.0.5
   - hweblib ==0.6.3
@@ -1130,7 +1130,7 @@ default-package-overrides:
   - Imlib ==0.1.2
   - immortal ==0.3
   - include-file ==0.1.0.3
-  - incremental-parser ==0.3.2
+  - incremental-parser ==0.3.2.1
   - indentation-core ==0.0.0.2
   - indentation-parsec ==0.0.0.2
   - indents ==0.5.0.0
@@ -1316,7 +1316,7 @@ default-package-overrides:
   - markdown-unlit ==0.5.0
   - markov-chain ==0.0.3.4
   - marvin-interpolate ==1.1.2
-  - massiv ==0.2.4.0
+  - massiv ==0.2.5.0
   - massiv-io ==0.1.4.0
   - mathexpr ==0.3.0.0
   - math-functions ==0.2.1.0
@@ -1772,7 +1772,7 @@ default-package-overrides:
   - rhine ==0.4.0.1
   - riak ==1.1.2.5
   - riak-protobuf ==0.23.0.0
-  - rio ==0.1.5.0
+  - rio ==0.1.6.0
   - rio-orphans ==0.1.1.0
   - rng-utils ==0.3.0
   - roles ==0.2.0.0
@@ -1802,8 +1802,8 @@ default-package-overrides:
   - say ==0.1.0.1
   - sbp ==2.3.17
   - sbv ==7.12
-  - SCalendar ==1.1.0
   - scalendar ==1.2.0
+  - SCalendar ==1.1.0
   - scalpel ==0.5.1
   - scalpel-core ==0.5.1
   - scanner ==0.2
@@ -1899,8 +1899,8 @@ default-package-overrides:
   - siphash ==1.0.3
   - size-based ==0.1.2.0
   - skein ==1.0.9.4
-  - skylighting ==0.7.4
-  - skylighting-core ==0.7.4
+  - skylighting ==0.7.5
+  - skylighting-core ==0.7.5
   - slack-web ==0.2.0.9
   - slave-thread ==1.0.2
   - smallcheck ==1.1.5
@@ -2026,7 +2026,7 @@ default-package-overrides:
   - tardis ==0.4.1.0
   - tasty ==1.1.0.4
   - tasty-ant-xml ==1.1.4
-  - tasty-dejafu ==1.2.0.7
+  - tasty-dejafu ==1.2.0.8
   - tasty-discover ==4.2.1
   - tasty-expected-failure ==0.11.1.1
   - tasty-golden ==2.3.2
@@ -2220,7 +2220,7 @@ default-package-overrides:
   - valor ==0.1.0.0
   - vault ==0.3.1.2
   - vec ==0.1
-  - vector ==0.12.0.1
+  - vector ==0.12.0.2
   - vector-algorithms ==0.7.0.4
   - vector-binary-instances ==0.2.5.1
   - vector-buffer ==0.4.1
@@ -2236,7 +2236,7 @@ default-package-overrides:
   - verbosity ==0.2.3.0
   - versions ==3.4.0.1
   - ViennaRNAParser ==1.3.3
-  - viewprof ==0.0.0.24
+  - viewprof ==0.0.0.25
   - vinyl ==0.8.1.1
   - vivid ==0.3.0.2
   - vivid-osc ==0.3.0.0
@@ -2357,7 +2357,7 @@ default-package-overrides:
   - yesod-auth-fb ==1.9.1
   - yesod-auth-hashdb ==1.7.1
   - yesod-bin ==1.6.0.3
-  - yesod-core ==1.6.8.1
+  - yesod-core ==1.6.9
   - yesod-csp ==0.2.4.0
   - yesod-eventsource ==1.6.0
   - yesod-fb ==0.5.0

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -41,8 +41,6 @@ core-packages:
   - ghcjs-base-0
 
 default-package-overrides:
-  # Newer versions require contravariant-1.5.*, which many builds refuse at the moment.
-  - base-compat-batteries ==0.10.1
   # Newer versions don't work in LTS-12.x
   - cassava-megaparsec < 2
   # LTS Haskell 12.22

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2401,6 +2401,7 @@ extra-packages:
   - binary > 0.7 && < 0.8               # keep a 7.x major release around for older compilers
   - binary > 0.8 && < 0.9               # keep a 8.x major release around for older compilers
   - blank-canvas < 0.6.3                # more recent versions depend on base-compat-batteries == 0.10.* but we're on base-compat-0.9.*
+  - brick <0.44                         # https://github.com/simonmichael/hledger/issues/935
   - Cabal == 1.18.*                     # required for cabal-install et al on old GHC versions
   - Cabal == 1.20.*                     # required for cabal-install et al on old GHC versions
   - Cabal == 1.24.*                     # required for jailbreak-cabal etc.
@@ -2440,12 +2441,13 @@ extra-packages:
   - mtl-prelude < 2                     # required for to build postgrest on mtl 2.1.x platforms
   - network == 2.6.3.1                  # newer versions don't compile with GHC 7.4.x and below
   - parallel == 3.2.0.3                 # newer versions don't work with GHC 6.12.3
+  - patience ^>= 0.1                    # required by chell-0.4.x
   - persistent >=2.5 && <2.8            # pre-lts-11.x versions neeed by git-annex 6.20180227
   - persistent-sqlite < 2.7             # pre-lts-11.x versions neeed by git-annex 6.20180227
   - primitive == 0.5.1.*                # required to build alex with GHC 6.12.3
   - proto-lens == 0.2.*                 # required for tensorflow-proto-0.1.x on GHC 8.2.x
-  - proto-lens-protoc == 0.2.*          # required for tensorflow-proto-0.1.x on GHC 8.2.x
   - proto-lens-protobuf-types == 0.2.*  # required for tensorflow-proto-0.1.x on GHC 8.2.x
+  - proto-lens-protoc == 0.2.*          # required for tensorflow-proto-0.1.x on GHC 8.2.x
   - QuickCheck < 2                      # required by test-framework-quickcheck and its users
   - resourcet ==1.1.*                   # pre-lts-11.x versions neeed by git-annex 6.20180227
   - seqid < 0.2                         # newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x
@@ -2461,7 +2463,6 @@ extra-packages:
   - yesod-persistent < 1.5              # pre-lts-11.x versions neeed by git-annex 6.20180227
   - yesod-static ^>= 1.5                # pre-lts-11.x versions neeed by git-annex 6.20180227
   - yesod-test ^>= 1.5                  # pre-lts-11.x versions neeed by git-annex 6.20180227
-  - patience ^>= 0.1                    # required by chell-0.4.x
 
 package-maintainers:
   peti:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2402,9 +2402,6 @@ extra-packages:
   - binary > 0.8 && < 0.9               # keep a 8.x major release around for older compilers
   - blank-canvas < 0.6.3                # more recent versions depend on base-compat-batteries == 0.10.* but we're on base-compat-0.9.*
   - brick <0.44                         # https://github.com/simonmichael/hledger/issues/935
-  - Cabal == 1.18.*                     # required for cabal-install et al on old GHC versions
-  - Cabal == 1.20.*                     # required for cabal-install et al on old GHC versions
-  - Cabal == 1.24.*                     # required for jailbreak-cabal etc.
   - Cabal == 2.2.*                      # required for jailbreak-cabal etc.
   - colour < 2.3.4                      # newer versions don't support GHC 7.10.x
   - conduit >=1.1 && <1.3               # pre-lts-11.x versions neeed by git-annex 6.20180227

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -6,7 +6,7 @@ let
   isCross = stdenv.buildPlatform != stdenv.hostPlatform;
   inherit (buildPackages)
     fetchurl removeReferencesTo
-    pkgconfig coreutils gnugrep gnused glibcLocales;
+    pkgconfig coreutils gnused glibcLocales;
 in
 
 { pname

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -336,10 +336,6 @@ stdenv.mkDerivation ({
 
     echo configureFlags: $configureFlags
     ${setupCommand} configure $configureFlags 2>&1 | ${coreutils}/bin/tee "$NIX_BUILD_TOP/cabal-configure.log"
-    if ${gnugrep}/bin/egrep -q -z 'Warning:.*depends on multiple versions' "$NIX_BUILD_TOP/cabal-configure.log"; then
-      echo >&2 "*** abort because of serious configure-time warning from Cabal"
-      exit 1
-    fi
 
     export GHC_PACKAGE_PATH="$packageConfDir:"
 


### PR DESCRIPTION
###### Motivation for this change

The current Haskell builder fails when it encounters the a warning
from Setup about "indirectly depending on multiple versions of the
same pacakge". There is a call to grep which exits if the
warning string is in the output of Setup.

While indirectly depending on different versions of the
same package *can* be a problem, it can also be the desired
behavior. I ran into this limitation when I was intentionally building
a project that indirect dependencies on megaparsec 6 and megaparsec 7
in a way that did not interfere—having different indirect dependency not
only worked but was also the only way I could get the project to
build.

The cases where this *does* cause problems will be caught at
compile time further into the build process with a reasonably readable
error message, so it should be fine to let the warning remain a
warning rather than exiting the build when we encounter it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

