### PR TITLE
metals: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -743,6 +743,11 @@
     github = "cdepillabout";
     name = "Dennis Gosnell";
   };
+  ceedubs = {
+    email = "ceedubs@gmail.com";
+    github = "ceedubs";
+    name = "Cody Allen";
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/development/tools/metals/default.nix
+++ b/pkgs/development/tools/metals/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, fetchurl, coursier, jdk, jre, makeWrapper }:
+
+let
+  baseName = "metals";
+  version = "0.3.1";
+  deps = stdenv.mkDerivation {
+    name = "${baseName}-deps-${version}";
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      ${coursier}/bin/coursier fetch org.scalameta:metals_2.12:${version} \
+        -r "sonatype:releases" > deps
+      mkdir -p $out/share/java
+      cp -n $(< deps) $out/share/java/
+    '';
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash     = "09p0y9fh6awl3vrdxwa3jd33y7q0kk97sv45lxyh5a2ri5d85wnc";
+  };
+in
+stdenv.mkDerivation {
+  name = "${baseName}-${version}";
+  version = version;
+
+  buildInputs = [ jdk makeWrapper deps ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    makeWrapper ${jre}/bin/java $out/bin/metals \
+      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+      --add-flags "-cp $CLASSPATH scala.meta.metals.Main" \
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://scalameta.org/metals/;
+    license = licenses.asl20;
+    description = "Language server for Scala";
+    longDescription = ''
+      This executable includes a minimal number of flags by default, and when
+      using it, you will likely want to pass in additional flags such as:
+        -XX:+UseG1GC
+        -XX:+UseStringDeduplication
+        -Xss4m
+        -Xms1G
+        -Xmx4G
+        -Dmetals.client=vim-lsc
+    '';
+    maintainers = with maintainers; [ ceedubs ];
+  };
+}

--- a/pkgs/development/tools/metals/default.nix
+++ b/pkgs/development/tools/metals/default.nix
@@ -2,7 +2,7 @@
 
 let
   baseName = "metals";
-  version = "0.3.1";
+  version = "0.3.2";
   deps = stdenv.mkDerivation {
     name = "${baseName}-deps-${version}";
     buildCommand = ''
@@ -14,7 +14,7 @@ let
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash     = "09p0y9fh6awl3vrdxwa3jd33y7q0kk97sv45lxyh5a2ri5d85wnc";
+    outputHash     = "12hvnvrm63z2ibwzkr3c9fbx32dfkcfvp1pmmc3s6jqfjl5wnlgm";
   };
 in
 stdenv.mkDerivation {
@@ -47,6 +47,6 @@ stdenv.mkDerivation {
         -Xmx4G
         -Dmetals.client=vim-lsc
     '';
-    maintainers = with maintainers; [ ceedubs ];
+    maintainers = with maintainers; [ ceedubs coconnor ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8822,6 +8822,8 @@ in
 
   mage = callPackage ../development/tools/build-managers/mage { };
 
+  metals = callPackage ../development/tools/metals {};
+
   minify = callPackage ../development/web/minify { };
 
   minizinc = callPackage ../development/tools/minizinc { };


### PR DESCRIPTION
[Metals](https://scalameta.org/metals/) is a language server for the
Scala programming language.

###### Motivation for this change

Metals is a very useful piece of a Scala development environment, and being able to set up one's development environment through Nix is useful for reproducibility and the ability to perform rollbacks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

