### PR TITLE
github-changelog-generator: init at v1.14.3

### DIFF
--- a/pkgs/development/tools/github-changelog-generator/Gemfile
+++ b/pkgs/development/tools/github-changelog-generator/Gemfile
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby RUBY_VERSION
+
+gemspec
+
+group :development, :test do
+  gem "bundler"
+  gem "overcommit", ">= 0.31"
+  gem "rake"
+  gem "rubocop", ">= 0.50"
+  gem "yard-junk"
+end
+
+group :development do
+  gem "bump"
+end
+
+group :test do
+  gem "codeclimate-test-reporter", "~> 1.0"
+  gem "coveralls", "~>0.8", require: false
+  gem "json"
+  gem "multi_json"
+  gem "rspec", "< 4"
+  gem "simplecov", "~>0.10", require: false
+  gem "vcr"
+  gem "webmock"
+end

--- a/pkgs/development/tools/github-changelog-generator/Gemfile.lock
+++ b/pkgs/development/tools/github-changelog-generator/Gemfile.lock
@@ -1,0 +1,144 @@
+PATH
+  remote: .
+  specs:
+    github_changelog_generator (1.15.0.pre.rc)
+      activesupport
+      faraday-http-cache
+      multi_json
+      octokit (~> 4.6)
+      rainbow (>= 2.2.1)
+      rake (>= 10.0)
+      retriable (~> 3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    backports (3.11.4)
+    bump (0.7.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    codeclimate-test-reporter (1.0.7)
+      simplecov
+    concurrent-ruby (1.1.3)
+    coveralls (0.8.22)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    docile (1.3.1)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (2.0.0)
+      faraday (~> 0.8)
+    ffi (1.9.25)
+    hashdiff (0.3.7)
+    i18n (1.2.0)
+      concurrent-ruby (~> 1.0)
+    iniparse (1.4.4)
+    jaro_winkler (1.5.1)
+    json (2.1.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    overcommit (0.46.0)
+      childprocess (~> 0.6, >= 0.6.3)
+      iniparse (~> 1.4)
+    parallel (1.12.1)
+    parser (2.5.3.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    public_suffix (3.0.3)
+    rainbow (3.0.0)
+    rake (12.3.2)
+    retriable (3.1.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubocop (0.61.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
+    safe_yaml (1.0.4)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    term-ansicolor (1.7.0)
+      tins (~> 1.0)
+    thor (0.19.4)
+    thread_safe (0.3.6)
+    tins (1.20.2)
+    tty-color (0.4.3)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.4.0)
+    vcr (4.0.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+    yard (0.9.16)
+    yard-junk (0.0.7)
+      backports
+      rainbow
+      tty-color
+      yard
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bump
+  bundler
+  codeclimate-test-reporter (~> 1.0)
+  coveralls (~> 0.8)
+  github_changelog_generator!
+  json
+  multi_json
+  overcommit (>= 0.31)
+  rake
+  rspec (< 4)
+  rubocop (>= 0.50)
+  simplecov (~> 0.10)
+  vcr
+  webmock
+  yard-junk
+
+RUBY VERSION
+   ruby 2.5.3p105
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/development/tools/github-changelog-generator/default.nix
+++ b/pkgs/development/tools/github-changelog-generator/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, bundlerEnv, ruby, fetchFromGitHub,  makeWrapper}:
+let
+  env = bundlerEnv {
+    inherit ruby;
+    name = "github-changelog-generator-env";
+    gemdir = ./.;
+  };
+in stdenv.mkDerivation rec {
+  name = "github-changelog-generator-${version}";
+  version = "v1.14.3";
+
+  src = fetchFromGitHub {
+    owner = "github-changelog-generator";
+    repo = "github-changelog-generator";
+    rev = version; # Always use a commit id here!
+    sha256 = "0bmv5z8cjj9mhmmjy54nhfwkszhxx4zbi8x1h0yx219fxihi00pd";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib}
+    cp -R lib/* $out/lib/
+    cp -R bin/* $out/bin/
+    chmod +x bin/*
+    makeWrapper $out/bin/git-generate-changelog $out/bin/git-generate-changelog-wrapped --prefix PATH : ${lib.makeBinPath [ ruby ]}
+    makeWrapper $out/bin/github_changelog_generator $out/bin/github_changelog_generator-wrapped --prefix PATH : ${lib.makeBinPath [ ruby ]}
+  '';
+
+  meta = with lib; {
+    description = "Fully automated changelog generation - This gem generates a changelog file based on tags, issues and merged pull requests";
+    homepage    = https://github.com/github-changelog-generator/github-changelog-generator;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ scriptkiddi ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/github-changelog-generator/gemset.nix
+++ b/pkgs/development/tools/github-changelog-generator/gemset.nix
@@ -1,0 +1,460 @@
+{
+  activesupport = {
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1iya7vxqwxysr74s7b4z1x19gmnx5advimzip3cbmsd5bd43wfgz";
+      type = "gem";
+    };
+    version = "5.2.2";
+  };
+  addressable = {
+    dependencies = ["public_suffix"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0viqszpkggqi8hq87pqp0xykhvz60g99nwmkwsb0v45kc2liwxvk";
+      type = "gem";
+    };
+    version = "2.5.2";
+  };
+  ast = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "184ssy3w93nkajlz2c70ifm79jp3j737294kbc5fjw69v1w0n9x7";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  backports = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hshjxww2h7s0dk57njrygq4zpp0nlqrjfya7zwm27iq3rhc3y8g";
+      type = "gem";
+    };
+    version = "3.11.4";
+  };
+  bump = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xinbr9rzh6cj75x24niwgqcnbhdxc68a8bc41lk8xv6fd906fym";
+      type = "gem";
+    };
+    version = "0.7.0";
+  };
+  childprocess = {
+    dependencies = ["ffi"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0a61922kmvcxyj5l70fycapr87gz1dzzlkfpq85rfqk5vdh3d28p";
+      type = "gem";
+    };
+    version = "0.9.0";
+  };
+  codeclimate-test-reporter = {
+    dependencies = ["simplecov"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cgi6xcd739k5c4r1nmi8dx11hfb041w3jyvb1y39g1gbwd2vca9";
+      type = "gem";
+    };
+    version = "1.0.7";
+  };
+  concurrent-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18q9skp5pfq4jwbxzmw8q2rn4cpw6mf4561i2hsjcl1nxdag2jvb";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  coveralls = {
+    dependencies = ["json" "simplecov" "term-ansicolor" "thor" "tins"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "022kc16np6w4mv17hq3m9hhw9l8hjl78ld3fzqqx6337vwvwvwcg";
+      type = "gem";
+    };
+    version = "0.8.22";
+  };
+  crack = {
+    dependencies = ["safe_yaml"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0abb0fvgw00akyik1zxnq7yv391va148151qxdghnzngv66bl62k";
+      type = "gem";
+    };
+    version = "0.4.3";
+  };
+  diff-lcs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18w22bjz424gzafv6nzv98h0aqkwz3d9xhm7cbr1wfbyas8zayza";
+      type = "gem";
+    };
+    version = "1.3";
+  };
+  docile = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04d2izkna3ahfn6fwq4xrcafa715d3bbqczxm16fq40fqy87xn17";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  faraday = {
+    dependencies = ["multipart-post"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0s72m05jvzc1pd6cw1i289chas399q0a14xrwg4rvkdwy7bgzrh0";
+      type = "gem";
+    };
+    version = "0.15.4";
+  };
+  faraday-http-cache = {
+    dependencies = ["faraday"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08j86fgcwl7z792qyijdsq680arzpfiydqd24ja405z2rbm7r2i0";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  ffi = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jpm2dis1j7zvvy3lg7axz9jml316zrn7s0j59vyq3qr127z0m7q";
+      type = "gem";
+    };
+    version = "1.9.25";
+  };
+  github_changelog_generator = {
+    dependencies = ["activesupport" "faraday-http-cache" "multi_json" "octokit" "rainbow" "rake" "retriable"];
+  };
+  hashdiff = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yj5l2rw8i8jc725hbcpc4wks0qlaaimr3dpaqamfjkjkxl0hjp9";
+      type = "gem";
+    };
+    version = "0.3.7";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "079sqshk08mqs3d6yzvshmqf4s175lpi2pp71f1p10l09sgmrixr";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  iniparse = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xbik6838gfh5yq9ahh1m7dzszxlk0g7x5lvhb8amk60mafkrgws";
+      type = "gem";
+    };
+    version = "1.4.4";
+  };
+  jaro_winkler = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rr797nqz081bfk30m2apj5h24bg5d1jr1c8p3xwx4hbwsrbclah";
+      type = "gem";
+    };
+    version = "1.5.1";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  minitest = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0icglrhghgwdlnzzp4jf76b0mbc71s80njn5afyfjn4wqji8mqbq";
+      type = "gem";
+    };
+    version = "5.11.3";
+  };
+  multi_json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rl0qy4inf1mp8mybfk56dfga0mvx97zwpmq5xmiwl5r770171nv";
+      type = "gem";
+    };
+    version = "1.13.1";
+  };
+  multipart-post = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09k0b3cybqilk1gwrwwain95rdypixb2q9w65gd44gfzsd84xi1x";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  octokit = {
+    dependencies = ["sawyer"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yh0yzzqg575ix3y2l2261b9ag82gv2v4f1wczdhcmfbxcz755x6";
+      type = "gem";
+    };
+    version = "4.13.0";
+  };
+  overcommit = {
+    dependencies = ["childprocess" "iniparse"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jfgpprjkq7hkyk7z0wc8difnnzmvmkin0b3bgsmnh6vvpyrz0mn";
+      type = "gem";
+    };
+    version = "0.46.0";
+  };
+  parallel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01hj8v1qnyl5ndrs33g8ld8ibk0rbcqdpkpznr04gkbxd11pqn67";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  parser = {
+    dependencies = ["ast"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zjk0w1kjj3xk8ymy1430aa4gg0k8ckphfj88br6il4pm83f0n1f";
+      type = "gem";
+    };
+    version = "2.5.3.0";
+  };
+  powerpack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1r51d67wd467rpdfl6x43y84vwm8f5ql9l9m85ak1s2sp3nc5hyv";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  public_suffix = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
+      type = "gem";
+    };
+    version = "3.0.3";
+  };
+  rainbow = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bb2fpjspydr6x0s8pn1pqkzmxszvkfapv0p4627mywl7ky4zkhk";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  rake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sy5a7nh6xjdc9yhcw31jji7ssrf9v5806hn95gbrzr998a2ydjn";
+      type = "gem";
+    };
+    version = "12.3.2";
+  };
+  retriable = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1q48hqws2dy1vws9schc0kmina40gy7sn5qsndpsfqdslh65snha";
+      type = "gem";
+    };
+    version = "3.1.2";
+  };
+  rspec = {
+    dependencies = ["rspec-core" "rspec-expectations" "rspec-mocks"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15ppasvb9qrscwlyjz67ppw1lnxiqnkzx5vkx1bd8x5n3dhikxc3";
+      type = "gem";
+    };
+    version = "3.8.0";
+  };
+  rspec-core = {
+    dependencies = ["rspec-support"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1p1s5bnbqp3sxk67y0fh0x884jjym527r0vgmhbm81w7aq6b7l4p";
+      type = "gem";
+    };
+    version = "3.8.0";
+  };
+  rspec-expectations = {
+    dependencies = ["diff-lcs" "rspec-support"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18l21hy1zdc2pgc2yb17k3n2al1khpfr0z6pijlm852iz6vj0dkm";
+      type = "gem";
+    };
+    version = "3.8.2";
+  };
+  rspec-mocks = {
+    dependencies = ["diff-lcs" "rspec-support"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06y508cjqycb4yfhxmb3nxn0v9xqf17qbd46l1dh4xhncinr4fyp";
+      type = "gem";
+    };
+    version = "3.8.0";
+  };
+  rspec-support = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0p3m7drixrlhvj2zpc38b11x145bvm311x6f33jjcxmvcm0wq609";
+      type = "gem";
+    };
+    version = "3.8.0";
+  };
+  rubocop = {
+    dependencies = ["jaro_winkler" "parallel" "parser" "powerpack" "rainbow" "ruby-progressbar" "unicode-display_width"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1njsjg60cff085n17qvf2slwhzbxk2lrrfmrvdklhnpfcwak0l46";
+      type = "gem";
+    };
+    version = "0.61.1";
+  };
+  ruby-progressbar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cv2ym3rl09svw8940ny67bav7b2db4ms39i4raaqzkf59jmhglk";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+  safe_yaml = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hly915584hyi9q9vgd968x2nsi5yag9jyf5kq60lwzi5scr7094";
+      type = "gem";
+    };
+    version = "1.0.4";
+  };
+  sawyer = {
+    dependencies = ["addressable" "faraday"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sv1463r7bqzvx4drqdmd36m7rrv6sf1v3c6vswpnq3k6vdw2dvd";
+      type = "gem";
+    };
+    version = "0.8.1";
+  };
+  simplecov = {
+    dependencies = ["docile" "json" "simplecov-html"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sfyfgf7zrp2n42v7rswkqgk3bbwk1bnsphm24y7laxv3f8z0947";
+      type = "gem";
+    };
+    version = "0.16.1";
+  };
+  simplecov-html = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lihraa4rgxk8wbfl77fy9sf0ypk31iivly8vl3w04srd7i0clzn";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+  term-ansicolor = {
+    dependencies = ["tins"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "079hbagd9mk0839rkajsdrbzkn992gj8ah2n45qd64v25ml27i6d";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  thor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01n5dv9kql60m6a00zc0r66jvaxx98qhdny3klyj0p3w34pad2ns";
+      type = "gem";
+    };
+    version = "0.19.4";
+  };
+  thread_safe = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nmhcgq6cgz44srylra07bmaw99f5271l0dpsvl5f75m44l0gmwy";
+      type = "gem";
+    };
+    version = "0.3.6";
+  };
+  tins = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pqj45n216zrz7yckdbdknlmhh187iqzx8fp76y2h0jrgqjfkxmj";
+      type = "gem";
+    };
+    version = "1.20.2";
+  };
+  tty-color = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zz5xa6xbrj69h334d8nx7z732fz80s1a0b02b53mim95p80s7bk";
+      type = "gem";
+    };
+    version = "0.4.3";
+  };
+  tzinfo = {
+    dependencies = ["thread_safe"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fjx9j327xpkkdlxwmkl3a8wqj7i4l4jwlrv3z13mg95z9wl253z";
+      type = "gem";
+    };
+    version = "1.2.5";
+  };
+  unicode-display_width = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0040bsdpcmvp8w31lqi2s9s4p4h031zv52401qidmh25cgyh4a57";
+      type = "gem";
+    };
+    version = "1.4.0";
+  };
+  vcr = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qh7lkj9b0shph84dw1wsrlaprl0jn1i4339fpsfy99402290zrr";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  webmock = {
+    dependencies = ["addressable" "crack" "hashdiff"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03994dxs4xayvkxqp01dd1ivhg4xxx7z35f7cxw7y2mwj3xn24ib";
+      type = "gem";
+    };
+    version = "3.4.2";
+  };
+  yard = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0lmmr1839qgbb3zxfa7jf5mzy17yjl1yirwlgzdhws4452gqhn67";
+      type = "gem";
+    };
+    version = "0.9.16";
+  };
+  yard-junk = {
+    dependencies = ["backports" "rainbow" "tty-color" "yard"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06ira0bgilsjz89whn6cgf54xwzv875aprd0anx6j8igw4rgxz97";
+      type = "gem";
+    };
+    version = "0.0.7";
+  };
+}

--- a/pkgs/development/tools/github-changelog-generator/shell.nix
+++ b/pkgs/development/tools/github-changelog-generator/shell.nix
@@ -1,0 +1,16 @@
+# Env to update Gemfile.lock / gemset.nix
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+  name = "env";
+  buildInputs = [
+    ruby.devEnv
+    git
+    sqlite
+    libpcap
+    postgresql
+    libxml2
+    libxslt
+    pkgconfig
+    bundix
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -644,6 +644,8 @@ with pkgs;
 
   git-fire = callPackage ../tools/misc/git-fire { };
 
+  github-changelog-generator = callPackage ../development/tools/github-changelog-generator { };
+
   gitless = callPackage ../applications/version-management/gitless { };
 
   grc = callPackage ../tools/misc/grc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

