### PR TITLE
valgrind: fix build on darwin

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -31,12 +31,8 @@ stdenv.mkDerivation rec {
     in ''
       echo "Don't derive our xnu version using uname -r."
       substituteInPlace configure --replace "uname -r" "echo ${OSRELEASE}"
-    ''
-  );
 
-  postPatch = stdenv.lib.optionalString (stdenv.isDarwin)
-    # Apple's GCC doesn't recognize `-arch' (as of version 4.2.1, build 5666).
-    ''
+      # Apple's GCC doesn't recognize `-arch' (as of version 4.2.1, build 5666).
       echo "getting rid of the \`-arch' GCC option..."
       find -name Makefile\* -exec \
         sed -i {} -e's/DARWIN\(.*\)-arch [^ ]\+/DARWIN\1/g' \;
@@ -60,7 +56,10 @@ stdenv.mkDerivation rec {
       echo "substitute hardcoded /usr/bin/ld with ${cctools}/bin/ld"
       substituteInPlace coregrind/link_tool_exe_darwin.in \
         --replace /usr/bin/ld ${cctools}/bin/ld
-    '';
+    '');
+
+  # To prevent rebuild on linux when moving darwin's postPatch fixes to preConfigure
+  postPatch = "";
 
   configureFlags =
     stdenv.lib.optional (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "x86_64-darwin") "--enable-only64bit";


### PR DESCRIPTION
###### Motivation for this change

We fixed a race condition in #51505 and #51107. This required running
autoreconfHook to pick up the `coregrind-makefile-race.patch` patch.

Unfortunately this broke darwin's postPatch fixes as autoreconfHook would run
afterwards regenerating the fixed makefiles.

Moving the postPatch fixes to preConfigure should resolve the issue.

I left `postPatch = ""` in to avoid a rebuild on linux.

cc @srhb (if you could trigger an ofborg build on darwin that would be great waiting on trusted users merge atm).