### PR TITLE
fltrator : init at 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2640,6 +2640,11 @@
     email = "markus@wotringer.de";
     name = "Markus Wotringer";
   };
+  marius851000 = {
+    email = "mariusdavid@laposte.net";
+    name = "Marius David";
+    github = "marius851000";
+  };
   marsam = {
     email = "marsam@users.noreply.github.com";
     github = "marsam";

--- a/pkgs/games/fltrator/default.nix
+++ b/pkgs/games/fltrator/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, unzip, fltk, which, libjpeg }:
+
+stdenv.mkDerivation rec {
+  name = "fltrator-${version}";
+  version = "2.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/fltrator/fltrator-${version}-code.zip";
+    sha256 = "125aqq1sfrm0c9cm6gyylwdmc8xrb0rjf563xvw7q28sdbl6ayp7";
+  };
+
+  buildInputs = [ fltk libjpeg ];
+  nativeBuildInputs = [ unzip which ];
+
+  postPatch = ''
+    substituteInPlace src/fltrator.cxx\
+      --replace 'home += "fltrator/"' "home = \"$out/fltrator/\""
+    substituteInPlace src/fltrator-landscape.cxx\
+      --replace 'home += "fltrator/"' "home = \"$out/fltrator/\""
+    substituteInPlace rsc/fltrator.desktop \
+      --replace 'Exec=fltrator' "Exec=$out/bin/fltrator"
+  '';
+
+  dontAddPrefix = true;
+
+  makeFlags = [ "HOME=$(out)" "RSC_PATH=$(out)/fltrator"];
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp rsc/fltrator.desktop $out/share/applications
+    mkdir -p $out/share/icons/hicolor/128x128/apps/
+    cp rsc/fltrator-128.png $out/share/icons/hicolor/128x128/apps/fltrator2.png
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple retro style arcade side-scroller game.";
+    longDescription = '' FLTrator is a simple retro style arcade side-scroller game in which you steer a spaceship through a landscape with hostile rockets and other obstacles.
+    It has ten different levels and a level editor to create new levels or modify the existing.''; # from https://libregamewiki.org/FLTrator
+    homepage = http://fltrator.sourceforge.net/;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.marius851000 ];
+    license = licenses.gpl3;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20489,6 +20489,8 @@ in
 
   exult = callPackage ../games/exult { };
 
+  fltrator = callPackage ../games/fltrator { };
+
   factorio = callPackage ../games/factorio { releaseType = "alpha"; };
 
   factorio-experimental = factorio.override { releaseType = "alpha"; experimental = true; };


### PR DESCRIPTION
###### Motivation for this change
I wanted to learn how to make a nix package. I've picked a random ( apparently simple ) open source game from libregamewiki, and make a package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` - no package depend on it
- [x] Tested execution of all binary files (usually in `./result/bin/`)

- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

