### PR TITLE
coqPackages: fix StructTact, Cheerios, InfSeqExt, Verdi

### DIFF
--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -1,32 +1,11 @@
 { stdenv, fetchFromGitHub, coq, StructTact }:
 
-let params =
+let param =
   {
-    "8.6" = {
       version = "20181102";
       rev = "04da309304bdd28a1f7dacca9fdf8696204a4ff2";
       sha256 = "1xfa78p70c90favds1mv1vj5sr9bv0ad3dsgg05v3v72006g2f1q";
-    };
-
-    "8.7" = {
-      version = "20181102";
-      rev = "04da309304bdd28a1f7dacca9fdf8696204a4ff2";
-      sha256 = "1xfa78p70c90favds1mv1vj5sr9bv0ad3dsgg05v3v72006g2f1q";
-    };
-
-    "8.8" = {
-      version = "20181102";
-      rev = "04da309304bdd28a1f7dacca9fdf8696204a4ff2";
-      sha256 = "1xfa78p70c90favds1mv1vj5sr9bv0ad3dsgg05v3v72006g2f1q";
-    };
-
-    "8.9" = {
-      version = "20181102";
-      rev = "04da309304bdd28a1f7dacca9fdf8696204a4ff2";
-      sha256 = "1xfa78p70c90favds1mv1vj5sr9bv0ad3dsgg05v3v72006g2f1q";
-    };
   };
-  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {
@@ -38,15 +17,16 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [
-    coq coq.ocaml coq.camlp5 coq.findlib StructTact
-  ];
+  buildInputs = [ coq ];
+
+  propagatedBuildInputs = [ StructTact ];
   enableParallelBuilding = true;
 
-  buildPhase = "make -j$NIX_BUILD_CORES";
+  preConfigure = "patchShebangs ./configure";
+
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.6";
  };
 }

--- a/pkgs/development/coq-modules/InfSeqExt/default.nix
+++ b/pkgs/development/coq-modules/InfSeqExt/default.nix
@@ -1,38 +1,11 @@
-{ stdenv, fetchFromGitHub, coq, mathcomp }:
+{ stdenv, fetchFromGitHub, coq }:
 
-let params =
+let param =
   {
-    "8.5" = {
       version = "20180918";
       rev = "243d6be45666da73a9da6c37d451327165275798";
       sha256 = "1nh2psb4pcppy1akk24ilb4p08m35cba357i4xyymmarmbwqpxmn";
-    };
-
-    "8.6" = {
-      version = "20180918";
-      rev = "243d6be45666da73a9da6c37d451327165275798";
-      sha256 = "1nh2psb4pcppy1akk24ilb4p08m35cba357i4xyymmarmbwqpxmn";
-    };
-
-    "8.7" = {
-      version = "20180918";
-      rev = "243d6be45666da73a9da6c37d451327165275798";
-      sha256 = "1nh2psb4pcppy1akk24ilb4p08m35cba357i4xyymmarmbwqpxmn";
-    };
-
-    "8.8" = {
-      version = "20180918";
-      rev = "243d6be45666da73a9da6c37d451327165275798";
-      sha256 = "1nh2psb4pcppy1akk24ilb4p08m35cba357i4xyymmarmbwqpxmn";
-    };
-
-    "8.9" = {
-      version = "20180918";
-      rev = "243d6be45666da73a9da6c37d451327165275798";
-      sha256 = "1nh2psb4pcppy1akk24ilb4p08m35cba357i4xyymmarmbwqpxmn";
-    };
   };
-  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {
@@ -44,15 +17,15 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [
-    coq coq.ocaml coq.camlp5 coq.findlib mathcomp
-  ];
+  buildInputs = [ coq ];
+
   enableParallelBuilding = true;
 
-  buildPhase = "make -j$NIX_BUILD_CORES";
+  preConfigure = "patchShebangs ./configure";
+
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.5";
  };
 }

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -1,38 +1,11 @@
 { stdenv, fetchFromGitHub, coq, mathcomp }:
 
-let params =
+let param =
   {
-    "8.5" = {
       version = "20181102";
       rev = "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
       sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
-    };
-
-    "8.6" = {
-      version = "20181102";
-      rev = "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
-      sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
-    };
-
-    "8.7" = {
-      version = "20181102";
-      rev = "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
-      sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
-    };
-
-    "8.8" = {
-      version = "20181102";
-      rev = "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
-      sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
-    };
-
-    "8.9" = {
-      version = "20181102";
-      rev = "82a85b7ec07e71fa6b30cfc05f6a7bfb09ef2510";
-      sha256 = "08zry20flgj7qq37xk32kzmg4fg6d4wi9m7pf9aph8fd3j2a0b5v";
-    };
   };
-  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {
@@ -44,15 +17,15 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [
-    coq coq.ocaml coq.camlp5 coq.findlib
-  ];
+  buildInputs = [ coq ];
+
   enableParallelBuilding = true;
 
-  buildPhase = "make -j$NIX_BUILD_CORES";
+  preConfigure = "patchShebangs ./configure";
+
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.5";
  };
 }

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -1,32 +1,11 @@
-{ stdenv, fetchFromGitHub, coq, mathcomp, StructTact, InfSeqExt, Cheerios }:
+{ stdenv, fetchFromGitHub, coq, Cheerios, InfSeqExt, ssreflect }:
 
-let params =
+let param =
   {
-    "8.6" = {
       version = "20181102";
       rev = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";
       sha256 = "1vw47c37k5vaa8vbr6ryqy8riagngwcrfmb3rai37yi9xhdqg55z";
-    };
-
-    "8.7" = {
-      version = "20181102";
-      rev = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";
-      sha256 = "1vw47c37k5vaa8vbr6ryqy8riagngwcrfmb3rai37yi9xhdqg55z";
-    };
-
-    "8.8" = {
-      version = "20181102";
-      rev = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";
-      sha256 = "1vw47c37k5vaa8vbr6ryqy8riagngwcrfmb3rai37yi9xhdqg55z";
-    };
-
-    "8.9" = {
-      version = "20181102";
-      rev = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";
-      sha256 = "1vw47c37k5vaa8vbr6ryqy8riagngwcrfmb3rai37yi9xhdqg55z";
-    };
   };
-  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {
@@ -38,15 +17,16 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
-  buildInputs = [
-    coq coq.ocaml coq.camlp5 coq.findlib mathcomp StructTact InfSeqExt Cheerios
-  ];
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ Cheerios InfSeqExt ssreflect ];
+
   enableParallelBuilding = true;
 
-  buildPhase = "make -j$NIX_BUILD_CORES";
+  preConfigure = "patchShebangs ./configure";
+
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.6";
  };
 }


### PR DESCRIPTION
###### Motivation for this change

These packages don’t build, e.g.:

> ./configure: /usr/bin/env: bad interpreter: No such file or directory

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc/ @jwiegley 