### PR TITLE
vscode backports

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,9 +1,9 @@
 { stdenv, lib, fetchurl, unzip, atomEnv, makeDesktopItem,
-  gtk2, wrapGAppsHook, libXScrnSaver, libxkbfile, libsecret }:
+  gtk2, wrapGAppsHook, libXScrnSaver, libxkbfile, libsecret,
+  isInsiders ? false }:
 
 let
-  version = "1.29.1";
-  channel = "stable";
+  executableName = "code" + lib.optionalString isInsiders "-insiders";
 
   plat = {
     "i686-linux" = "linux-ia32";
@@ -31,19 +31,24 @@ let
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
+    version = "1.29.1";
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";
-      url = "https://vscode-update.azurewebsites.net/${version}/${plat}/${channel}";
+      url = "https://vscode-update.azurewebsites.net/${version}/${plat}/stable";
       inherit sha256;
     };
 
+    passthru = {
+      inherit executableName;
+    };
+
     desktopItem = makeDesktopItem {
-      name = "code";
-      exec = "code";
-      icon = "code";
+      name = executableName;
+      exec = executableName;
+      icon = "@out@/share/pixmaps/code.png";
       comment = "Code editor redefined and optimized for building and debugging modern web and cloud applications";
-      desktopName = "Visual Studio Code";
+      desktopName = "Visual Studio Code" + lib.optionalString isInsiders " Insiders";
       genericName = "Text Editor";
       categories = "GNOME;GTK;Utility;TextEditor;Development;";
     };
@@ -56,17 +61,18 @@ in
       if stdenv.hostPlatform.system == "x86_64-darwin" then ''
         mkdir -p $out/lib/vscode $out/bin
         cp -r ./* $out/lib/vscode
-        ln -s $out/lib/vscode/Contents/Resources/app/bin/code $out/bin
+        ln -s $out/lib/vscode/Contents/Resources/app/bin/${executableName} $out/bin
       '' else ''
         mkdir -p $out/lib/vscode $out/bin
         cp -r ./* $out/lib/vscode
 
-        substituteInPlace $out/lib/vscode/bin/code --replace '"$CLI" "$@"' '"$CLI" "--skip-getting-started" "$@"'
+        substituteInPlace $out/lib/vscode/bin/${executableName} --replace '"$CLI" "$@"' '"$CLI" "--skip-getting-started" "$@"'
 
-        ln -s $out/lib/vscode/bin/code $out/bin
+        ln -s $out/lib/vscode/bin/${executableName} $out/bin
 
         mkdir -p $out/share/applications
-        cp $desktopItem/share/applications/* $out/share/applications
+        substitute $desktopItem/share/applications/${executableName}.desktop $out/share/applications/${executableName}.desktop \
+          --subst-var out
 
         mkdir -p $out/share/pixmaps
         cp $out/lib/vscode/resources/app/resources/linux/code.png $out/share/pixmaps/code.png
@@ -76,7 +82,7 @@ in
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${rpath}" \
-        $out/lib/vscode/code
+        $out/lib/vscode/${executableName}
 
       patchelf \
         --set-rpath "${rpath}" \

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -12,9 +12,9 @@ let
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    "i686-linux" = "0r19i3gg6iz8j7plb89c0k8r3wlh9vxbv7mwbssy0yvhid2af3ww";
-    "x86_64-linux" = "1r66mjz4lgv3dk0rjb9p27ha9y7vj7xld9x9gqnjxqx9ify71r9i";
-    "x86_64-darwin" = "0akr8675hnppxwr8xy5lr6rlqz8zg1fj823vks5mx3ssmd3sg189";
+    "i686-linux" = "0bd2jdn67vnbhrsqy54bymz4di3fw3p18ni5j2wikqkl4d9h4jj1";
+    "x86_64-linux" = "1zbnyff0q15xkvkrs14rfgyn6xb9v0xivcnbl8yckl71s45vb2l1";
+    "x86_64-darwin" = "1qgzhpfzcwym1qyzx2v14336l106hzhs7ii84g356vxkm219x7kw";
   }.${stdenv.hostPlatform.system};
 
   archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";
@@ -31,7 +31,7 @@ let
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
-    version = "1.29.1";
+    version = "1.30.0";
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -2,7 +2,7 @@
   gtk2, wrapGAppsHook, libXScrnSaver, libxkbfile, libsecret }:
 
 let
-  version = "1.28.2";
+  version = "1.29.0";
   channel = "stable";
 
   plat = {
@@ -12,9 +12,9 @@ let
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    "i686-linux" = "13zgx80qzq1wvss3byh56rvp2bdxywc4xmhhljsqrxf17g86g2zr";
-    "x86_64-linux" = "1z50hkr9mcf76hlr1jb80nbvpxbpm2bh0l63yh9yqpalmz66xbfy";
-    "x86_64-darwin" = "0n7lavpylg1q89qa64z4z1v7pgmwb2kidc57cgpvjnhjg8idys33";
+    "i686-linux" = "12qanqd3bviw2lzf23pd79wapzn463ckivfrl2wbbi8dcyhp4sda";
+    "x86_64-linux" = "1v72i40hdsy8v7wrbsz6igj8r1q4sfzvrxri0ddxjb3y5mivzjwf";
+    "x86_64-darwin" = "0qxz6j468nvgv4d8fibsi13q5ymc8z2gdx5kqcf6wixzrk0clnv8";
   }.${stdenv.hostPlatform.system};
 
   archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -2,7 +2,7 @@
   gtk2, wrapGAppsHook, libXScrnSaver, libxkbfile, libsecret }:
 
 let
-  version = "1.29.0";
+  version = "1.29.1";
   channel = "stable";
 
   plat = {
@@ -12,9 +12,9 @@ let
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    "i686-linux" = "12qanqd3bviw2lzf23pd79wapzn463ckivfrl2wbbi8dcyhp4sda";
-    "x86_64-linux" = "1v72i40hdsy8v7wrbsz6igj8r1q4sfzvrxri0ddxjb3y5mivzjwf";
-    "x86_64-darwin" = "0qxz6j468nvgv4d8fibsi13q5ymc8z2gdx5kqcf6wixzrk0clnv8";
+    "i686-linux" = "0r19i3gg6iz8j7plb89c0k8r3wlh9vxbv7mwbssy0yvhid2af3ww";
+    "x86_64-linux" = "1r66mjz4lgv3dk0rjb9p27ha9y7vj7xld9x9gqnjxqx9ify71r9i";
+    "x86_64-darwin" = "0akr8675hnppxwr8xy5lr6rlqz8zg1fj823vks5mx3ssmd3sg189";
   }.${stdenv.hostPlatform.system};
 
   archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";

--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, runCommand, buildEnv, vscode, which, writeScript
+{ stdenv, lib, runCommand, buildEnv, vscode, makeWrapper
 , vscodeExtensions ? [] }:
 
 /*
@@ -43,6 +43,7 @@
 
 let
 
+  inherit (vscode) executableName;
   wrappedPkgVersion = lib.getVersion vscode;
   wrappedPkgName = lib.removeSuffix "-${wrappedPkgVersion}" vscode.name;
 
@@ -51,22 +52,12 @@ let
     paths = vscodeExtensions;
   };
 
-  wrappedExeName = "code";
-  exeName = wrappedExeName;
-
-  wrapperExeFile = writeScript "${exeName}" ''
-    #!${stdenv.shell}
-    exec ${vscode}/bin/${wrappedExeName} \
-      --extensions-dir "${combinedExtensionsDrv}/share/${wrappedPkgName}/extensions" \
-      "$@"
-  '';
-
 in
 
 # When no extensions are requested, we simply redirect to the original
 # non-wrapped vscode executable.
 runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}" {
-  buildInputs = [ vscode which ];
+  buildInputs = [ vscode makeWrapper ];
   dontPatchELF = true;
   dontStrip = true;
   meta = vscode.meta;
@@ -75,13 +66,9 @@ runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}" {
   mkdir -p "$out/share/applications"
   mkdir -p "$out/share/pixmaps"
 
-  ln -sT "${vscode}/share/applications/code.desktop" "$out/share/applications/code.desktop"
   ln -sT "${vscode}/share/pixmaps/code.png" "$out/share/pixmaps/code.png"
-  ${if [] == vscodeExtensions
-    then ''
-      ln -sT "${vscode}/bin/${wrappedExeName}" "$out/bin/${exeName}"
-    ''
-    else ''
-      ln -sT "${wrapperExeFile}" "$out/bin/${exeName}"
-    ''}
+  ln -sT "${vscode}/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
+  makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" \
+    --add-flags \
+      "--extensions-dir ${combinedExtensionsDrv}/share/${wrappedPkgName}/extensions"
 ''

--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -34,8 +34,9 @@ let
     name = "cpptools-language-component-binaries";
 
     src = fetchzip {
-      url = "https://download.visualstudio.microsoft.com/download/pr/e8bc2ccc-bb10-4d40-8e29-edcd78986e9a/2e86fa29aefdbde2ea2cd1a6fceadeaa/bin_linux.zip";
-      sha256 = "1hvrbp3c4733aryslgyh3l5azmqkw398j2wbgr3w788fphg4v6cc";
+      # Follow https://go.microsoft.com/fwlink/?linkid=2037608
+      url = "https://download.visualstudio.microsoft.com/download/pr/97ed3eeb-b31e-421c-92dc-4f3a98af301e/069a1e6ab1b4b017853a7e9e08067744/bin_linux.zip";
+      sha256 = "19flm4vcrg89x0b20bd0g45apabzfqgvcpjddnmyk312jc242gmb";
     };
 
     patchPhase = ''
@@ -67,8 +68,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "cpptools";
     publisher = "ms-vscode";
-    version = "0.19.0";
-    sha256 = "1x97mz859bzr4gxy6cnqgd8qmvnrjn9zdxh457slsxsk4wqcfmgj";
+    version = "0.20.1";
+    sha256 = "1gmnkrn26n57vx2nm5hhalkkl2irak38m2lklgja0bi10jb6y08l";
   };
 
   buildInputs = [

--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -67,8 +67,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "cpptools";
     publisher = "ms-vscode";
-    version = "0.17.6";
-    sha256 = "2625be8b922ffc199e1c776f784d39b6e004523212f7956c93ae40f9040ce6d5";
+    version = "0.19.0";
+    sha256 = "1x97mz859bzr4gxy6cnqgd8qmvnrjn9zdxh457slsxsk4wqcfmgj";
   };
 
   buildInputs = [

--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, vscode-utils, jq, mono46, clang-tools, writeScript
+{ stdenv, fetchzip, vscode-utils, jq, mono, clang-tools, writeScript
 , gdbUseFixed ? true, gdb # The gdb default setting will be fixed to specified. Use version from `PATH` otherwise.
 }:
 
@@ -59,7 +59,7 @@ let
           export PATH=''${PATH}''${PATH:+:}${gdb}/bin
         ''
         else ""}
-    ${mono46}/bin/mono $BIN_DIR/bin/OpenDebugAD7.exe $*
+    ${mono}/bin/mono $BIN_DIR/bin/OpenDebugAD7.exe $*
   '';
 in
 

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -26,4 +26,6 @@ rec {
   ms-vscode.cpptools = callPackage ./cpptools {};
 
   ms-python.python = callPackage ./python {};
+
+  WakaTime.vscode-wakatime = callPackage ./wakatime {};
 }

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -4,10 +4,10 @@ let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
 in
 #
-# Unless there is a good reason not to, we attemp to use the same name as the 
+# Unless there is a good reason not to, we attempt to use the same name as the
 # extension's unique identifier (the name the extension gets when installed
 # from vscode under `~/.vscode`) and found on the marketplace extension page.
-# So an extension's attribute name should be of the form: 
+# So an extension's attribute name should be of the form:
 # "${mktplcRef.publisher}.${mktplcRef.name}".
 #
 rec {
@@ -24,6 +24,6 @@ rec {
   };
 
   ms-vscode.cpptools = callPackage ./cpptools {};
-  
+
   ms-python.python = callPackage ./python {};
 }

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.8.0";
-    sha256 = "1x1wkqbc0d6h5w2m5qczv6gd5j6yrzhwp0c6wk49bhg2l0ibvyx6";
+    version = "2018.9.1";
+    sha256 = "050r1rb0xyfikfa6iq741s368xz600pqdk74w6cxszxpy8kl2hng";
   };
 
   postPatch = ''

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.10.1";
-    sha256 = "1j9nf09v31lmrjkxf7p1d78d064x6afzh0dvssmk3sjm2c5r432k";
+    version = "2018.11.0";
+    sha256 = "0z9ca14qzy6zw0cfir7hdnhin01c1wsr6lbb2xp6rpq06vh7nivl";
   };
 
   postPatch = ''

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.9.1";
-    sha256 = "050r1rb0xyfikfa6iq741s368xz600pqdk74w6cxszxpy8kl2hng";
+    version = "2018.10.1";
+    sha256 = "1j9nf09v31lmrjkxf7p1d78d064x6afzh0dvssmk3sjm2c5r432k";
   };
 
   postPatch = ''

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.7.0";
-    sha256 = "0ab6ce722b23274a8f70d156f55d02123dd3b686397b11d4eec0831ec69dbec5";
+    version = "2018.8.0";
+    sha256 = "1x1wkqbc0d6h5w2m5qczv6gd5j6yrzhwp0c6wk49bhg2l0ibvyx6";
   };
 
   postPatch = ''

--- a/pkgs/misc/vscode-extensions/vscode-utils.nix
+++ b/pkgs/misc/vscode-extensions/vscode-utils.nix
@@ -65,10 +65,10 @@ let
     "sha256"
   ];
 
-  mktplcExtRefToExtDrv = ext: 
-    buildVscodeMarketplaceExtension ((removeAttrs ext mktplcRefAttrList) // { 
-      mktplcRef = ext; 
-    }); 
+  mktplcExtRefToExtDrv = ext:
+    buildVscodeMarketplaceExtension ((removeAttrs ext mktplcRefAttrList) // {
+      mktplcRef = ext;
+    });
 
   extensionFromVscodeMarketplace = mktplcExtRefToExtDrv;
   extensionsFromVscodeMarketplace = mktplcExtRefList:
@@ -77,7 +77,7 @@ let
 in
 
 {
-  inherit fetchVsixFromVscodeMarketplace buildVscodeExtension 
+  inherit fetchVsixFromVscodeMarketplace buildVscodeExtension
           buildVscodeMarketplaceExtension extensionFromVscodeMarketplace
           extensionsFromVscodeMarketplace;
 }

--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -7,8 +7,8 @@ in
     mktplcRef = {
       name = "vscode-wakatime";
       publisher = "WakaTime";
-      version = "1.2.3";
-      sha256 = "1n7bxkwgpip11k6d7zc3ifp9zb6p7f27f4x4g584wisrnfnqj1bp";
+      version = "1.2.4";
+      sha256 = "0qghn4kakv0jrjcl65p1v5r6j7608269zyhh75b15p12mdvi21vb";
     };
 
     postPatch = ''

--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, wakatime, vscode-utils }:
+
+let
+  inherit (vscode-utils) buildVscodeMarketplaceExtension;
+in
+  buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-wakatime";
+      publisher = "WakaTime";
+      version = "1.2.3";
+      sha256 = "1n7bxkwgpip11k6d7zc3ifp9zb6p7f27f4x4g584wisrnfnqj1bp";
+    };
+
+    postPatch = ''
+      mkdir -p out/wakatime-master
+
+      cp -rt out/wakatime-master --no-preserve=all ${wakatime}/lib/python*/site-packages/wakatime
+    '';
+
+    meta = with stdenv.lib; {
+      description = ''
+        Visual Studio Code plugin for automatic time tracking and metrics generated
+        from your programming activity
+      '';
+      license = licenses.bsd3;
+      maintainers = with maintainers; [
+        eadwu
+      ];
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change
Was reviewing #52036 and I recalled that we should be backporting this stuff to stable.
I've also included all changes to the vscode-extensions.

Let me know if I missed anything.

cc @Mic92 (since you brought this to our attention a bit back)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

