### PR TITLE
solc: disable LLL installation

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -33,11 +33,10 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DBoost_USE_STATIC_LIBS=OFF"
     "-DBUILD_SHARED_LIBS=ON"
-    "-DINSTALL_LLLC=ON"
   ];
 
   doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
-  checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./liblll:./libevmasm:./libdevcore:./libyul:./liblangutil:$LD_LIBRARY_PATH " +
+  checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./libevmasm:./libdevcore:./libyul:./liblangutil:$LD_LIBRARY_PATH " +
                "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
 
   nativeBuildInputs = [ cmake ];
@@ -47,7 +46,6 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Compiler for Ethereum smart contract language Solidity";
-    longDescription = "This package also includes `lllc', the LLL compiler.";
     homepage = https://github.com/ethereum/solidity;
     license = licenses.gpl3;
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/development/compilers/solc/patches/shared-libs-install.patch
+++ b/pkgs/development/compilers/solc/patches/shared-libs-install.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 0c05208f..8893648e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -48,6 +48,25 @@ add_subdirectory(libevmasm)
+@@ -48,6 +48,22 @@ add_subdirectory(libevmasm)
  add_subdirectory(libsolidity)
  add_subdirectory(libsolc)
  
@@ -20,9 +20,6 @@ index 0c05208f..8893648e 100644
 +        FILES_MATCHING PATTERN "*.h")
 +install(DIRECTORY liblangutil/
 +        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/liblangutil
-+        FILES_MATCHING PATTERN "*.h")
-+install(DIRECTORY liblll/
-+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/liblll
 +        FILES_MATCHING PATTERN "*.h")
 +
  if (NOT EMSCRIPTEN)
@@ -46,15 +43,6 @@ index 86192c1b..e7f15e93 100644
  add_library(evmasm ${sources} ${headers})
  target_link_libraries(evmasm PUBLIC devcore)
 +install(TARGETS evmasm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-diff --git a/liblll/CMakeLists.txt b/liblll/CMakeLists.txt
-index 4cdc073a..b61f03c7 100644
---- a/liblll/CMakeLists.txt
-+++ b/liblll/CMakeLists.txt
-@@ -3,3 +3,4 @@ file(GLOB headers "*.h")
- 
- add_library(lll ${sources} ${headers})
- target_link_libraries(lll PUBLIC evmasm devcore)
-+install(TARGETS lll LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 diff --git a/libsolidity/CMakeLists.txt b/libsolidity/CMakeLists.txt
 index 0bdec4b4..e876177e 100644
 --- a/libsolidity/CMakeLists.txt


### PR DESCRIPTION
###### Motivation for this change

It has been [disabled by
default](https://github.com/ethereum/solidity/releases/tag/v0.5.1) in 0.5.1.

/cc @lionello 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

