### PR TITLE
go: 1.11.2 -> 1.11.4, 1.10.3 -> 1.10.7 [CVE-2018-16873, CVE-2018-16874, CVE-2018-16875]

### DIFF
--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -22,13 +22,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.10.3";
+  version = "1.10.7";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "0i89298dgnmpmam3ifkm0ax266vvbq1yz7wfw8wwrcma0szrbrnb";
+    sha256 = "1alc7dagijdg4p4hhvlznlgcxsl8gz94v7p9wk3kn303y782dl41";
   };
 
   GOCACHE = "off";

--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -28,13 +28,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.11.2";
+  version = "1.11.4";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "go";
     rev = "go${version}";
-    sha256 = "0pk7pxfm3ij2ksdrg49jz501fr1d103zr4mjjwv821if9g279jc9";
+    sha256 = "036nc17hffy0gcfs9j64qzwpjry65znbm4klf2h0xn81dp8d6mxk";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
###### Motivation for this change

https://groups.google.com/forum/#!msg/golang-announce/Kw31K8G7Fi0/z2olKn-QCAAJ "We have just released Go 1.11.3 and Go 1.10.6 to address three recently reported security issues."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

