### PR TITLE
gosec: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/gosec/default.nix
+++ b/pkgs/development/tools/gosec/default.nix
@@ -5,7 +5,7 @@
 
 buildGoPackage rec {
   name = "gosec-${version}";
-  version = "1.1.0";
+  version = "1.2.0";
 
   goPackagePath = "github.com/securego/gosec";
   excludedPackages = ''cmd/tlsconfig'';
@@ -14,7 +14,7 @@ buildGoPackage rec {
     owner = "securego";
     repo = "gosec";
     rev = "${version}";
-    sha256 = "0vjn3g6w4y4ayx0g766jp31vb78cipl90fcg0mccjr0a539qrpy6";
+    sha256 = "1420yl4cjp4v4xv0l0wbahgl6bjhz77lx5va9hqa6abddmqvx1hg";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest releases of `gosec`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

