### PR TITLE
pythonPackages.markdown: 2.6.10 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/markdown/default.nix
+++ b/pkgs/development/python-modules/markdown/default.nix
@@ -7,16 +7,12 @@
 
 buildPythonPackage rec {
   pname = "Markdown";
-  version = "2.6.10";
+  version = "3.0.1";
 
   src = fetchPypi {
-    extension = "zip";
     inherit pname version;
-    sha256 = "cfa536d1ee8984007fcecc5a38a493ff05c174cb74cb2341dafd175e6bc30851";
+    sha256 = "0z6v8649sr434d5r5zmrhydka7v7f9yas4bwcgkcs0650jdhybnh";
   };
-
-  # error: invalid command 'test'
-#   doCheck = false;
 
   checkInputs = [ nose pyyaml ];
 


### PR DESCRIPTION
I haven't touched the Python parts of nixpkgs before, so I don't know if this is at all correct.
Particularly suspicious is the change in hash length!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

