### PR TITLE
[WIP] pythonPackages.pymdown-extensions: init at 6.0

### DIFF
--- a/pkgs/development/python-modules/pymdown-extensions/default.nix
+++ b/pkgs/development/python-modules/pymdown-extensions/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pyyaml
+, pygments
+, markdown
+}:
+
+buildPythonPackage rec {
+  pname = "pymdown-extensions";
+  version = "6.0";
+
+  src = fetchPypi {
+    extension = "tar.gz";
+    inherit pname version;
+    sha256 = "1pclfrfvzbazpsikarnvzdbcx2a71wr2zp12rqd2jfx0nlvczw3c";
+  };
+
+  propagatedBuildInputs = [ markdown ];
+
+  checkInputs = [ pytest pyyaml pygments ];
+
+  meta = {
+    description = "Extension pack for Python Markdown";
+    homepage = https://github.com/facelessuser/pymdown-extensions/;
+    # TODO: exceptions?
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5026,6 +5026,8 @@ in {
 
   aiohue = callPackage ../development/python-modules/aiohue { };
 
+  pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
+
   PyMVGLive = callPackage ../development/python-modules/pymvglive { };
 
   coinmarketcap = callPackage ../development/python-modules/coinmarketcap { };


### PR DESCRIPTION
Depends on #52058 (should it have been one PR, or is this okay?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

