### PR TITLE
ber_metaocaml: cleanup, tweaks

### DIFF
--- a/pkgs/development/compilers/ocaml/ber-metaocaml.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml.nix
@@ -1,17 +1,24 @@
-{ stdenv, fetchurl, ncurses, libX11, xproto, buildEnv }:
+{ stdenv, fetchurl
+, ncurses
+, libX11, xproto, buildEnv
+}:
 
 let
    useX11 = stdenv.isi686 || stdenv.isx86_64;
+   x11deps = [ libX11 xproto ];
    inherit (stdenv.lib) optionals;
+
+   baseOcamlBranch  = "4.07";
+   baseOcamlVersion = "${baseOcamlBranch}.1";
+   metaocamlPatch   = "107";
 in
 
 stdenv.mkDerivation rec {
-
   name = "ber-metaocaml-${version}";
-  version = "107";
+  version = metaocamlPatch;
 
   src = fetchurl {
-    url = "https://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz";
+    url = "https://caml.inria.fr/pub/distrib/ocaml-${baseOcamlBranch}/ocaml-${baseOcamlVersion}.tar.gz";
     sha256 = "1x4sln131mcspisr22qc304590rvg720rbl7g2i4xiymgvhkpm1a";
   };
 
@@ -20,21 +27,19 @@ stdenv.mkDerivation rec {
     sha256 = "0xy6n0yj1f53pk612zfmn49pn04bd75qa40xgmr0w0lzx6dqsfmm";
   };
 
-  # Needed to avoid a SIGBUS on the final executable on mips
-  NIX_CFLAGS_COMPILE = if stdenv.isMips then "-fPIC" else "";
-
-  x11env = buildEnv { name = "x11env"; paths = [libX11 xproto];};
-  x11lib = x11env + "/lib";
-  x11inc = x11env + "/include";
+  x11env = buildEnv { name = "x11env"; paths = x11deps; };
+  x11lib = "${x11env}/lib";
+  x11inc = "${x11env}/include";
 
   prefixKey = "-prefix ";
-  configureFlags = optionals useX11 [ "-x11lib" x11lib
-                                      "-x11include" x11inc ];
+  configureFlags = optionals useX11
+    [ "-x11lib" x11lib
+      "-x11include" x11inc
+      "-flambda"
+    ];
 
   dontStrip = true;
-  buildInputs = [ncurses] ++ optionals useX11 [ libX11 xproto ];
-  installFlags = "-i";
-  installTargets = "install"; # + optionalString useNativeCompilers " installopt";
+  buildInputs = [ ncurses ] ++ optionals useX11 x11deps;
 
   postConfigure = ''
     tar -xvzf $metaocaml
@@ -42,6 +47,7 @@ stdenv.mkDerivation rec {
     make patch
     cd ..
   '';
+
   buildPhase = ''
     make world
     make -i install
@@ -53,13 +59,13 @@ stdenv.mkDerivation rec {
     ln -sv $out/lib/ocaml/caml $out/include/caml
     cd ${name}
     make all
+  '';
+
+  installPhase = ''
     make install
     make install.opt
-    cd ..
- '';
-  installPhase = "";
-  postBuild = ''
   '';
+
   checkPhase = ''
     cd ${name}
     make test
@@ -68,16 +74,23 @@ stdenv.mkDerivation rec {
     cd ..
   '';
 
+  passthru = {
+    nativeCompilers = true;
+  };
+
   meta = with stdenv.lib; {
-    homepage = "http://okmij.org/ftp/ML/index.html#ber-metaocaml";
-    license = with licenses; [
-      qpl /* compiler */
-      lgpl2 /* library */
-    ];
-    description = "Conservative extension of OCaml";
+    description     = "Multi-Stage Programming extension for OCaml";
+    homepage        = http://okmij.org/ftp/ML/MetaOCaml.html;
+    license         = with licenses; [ /* compiler */ qpl /* library */ lgpl2 ];
+    maintainers     = with maintainers; [ thoughtpolice ];
+
+    branch          = baseOcamlBranch;
+    platforms       = with platforms; linux ++ darwin;
+    broken          = stdenv.isAarch64 || stdenv.isMips;
+
     longDescription = ''
-      A conservative extension of OCaml with the primitive type of code values,
-      and three basic multi-stage expression forms: Brackets, Escape, and Run
+      A simple extension of OCaml with the primitive type of code values, and
+      three basic multi-stage expression forms: Brackets, Escape, and Run.
     '';
   };
 }


### PR DESCRIPTION
###### Motivation

This puts MetaOCaml on more equal footing with the normal OCaml
packages, which have a few passthru's and expect to have more 'meta'
information available (such as 'platforms').

With these changes, you can use the ber_metaocaml package along with
ocaml-ng.mkOcamlPackages in order to create a full package set with
Native MetaOCaml support, though this currently isn't implemented (you
have to do this yourself).

There are also other light cleanups, for example this also removes the
old MIPS support and restricts the platforms to x86 Linux/Darwin, for
now. Other platforms can be added on a case-by-case basis.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

