### PR TITLE
unit: remove perl526, which is EOL

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -4,7 +4,6 @@
 , php71
 , php72
 , php73
-, perl526
 , perl
 , perldevel
 , ruby_2_3
@@ -32,7 +31,6 @@ stdenv.mkDerivation rec {
     php71
     php72
     php73
-    perl526
     perl
     perldevel
     ruby_2_3
@@ -52,7 +50,6 @@ stdenv.mkDerivation rec {
     ./configure php     --module=php71     --config=${php71.dev}/bin/php-config  --lib-path=${php71}/lib
     ./configure php     --module=php72     --config=${php72.dev}/bin/php-config  --lib-path=${php72}/lib
     ./configure php     --module=php73     --config=${php73.dev}/bin/php-config  --lib-path=${php73}/lib
-    ./configure perl    --module=perl526   --perl=${perl526}/bin/perl
     ./configure perl    --module=perl      --perl=${perl}/bin/perl
     ./configure perl    --module=perl529   --perl=${perldevel}/bin/perl
     ./configure ruby    --module=ruby23    --ruby=${ruby_2_3}/bin/ruby


### PR DESCRIPTION
related to https://github.com/NixOS/nixpkgs/pull/52062

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

