### PR TITLE
hashcash: init at 1.22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2278,6 +2278,11 @@
     github = "kirelagin";
     name = "Kirill Elagin";
   };
+  kisonecat = {
+    email = "kisonecat@gmail.com";
+    github = "kisonecat";
+    name = "Jim Fowler";
+  };
   kkallio = {
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";

--- a/pkgs/tools/security/hashcash/default.nix
+++ b/pkgs/tools/security/hashcash/default.nix
@@ -1,23 +1,27 @@
 { stdenv, fetchurl, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "hashcash-${version}";
+  pname = "hashcash";
   version = "1.22";
-
+  
   buildInputs = [ openssl ];
 
   src = fetchurl {
-      url = "http://www.hashcash.org/source/hashcash-1.22.tgz";
-      sha256 = "15kqaimwb2y8wvzpn73021bvay9mz1gqqfc40gk4hj6f84nz34h1";
+    url = "http://www.hashcash.org/source/hashcash-${version}.tgz";
+    sha256 = "15kqaimwb2y8wvzpn73021bvay9mz1gqqfc40gk4hj6f84nz34h1";
   };
+  
+  makeFlags = [
+    "generic-openssl"
+    "LIBCRYPTO=-lcrypto"
+  ];
 
-  makeFlags = "generic-openssl LIBCRYPTO=-lcrypto";
-
-  installPhase = ''
-    install -D -m 0755 --target $out/bin hashcash sha1
-    install -D -m 0444 hashcash.1 $out/share/man/man1/hashcash.1
-  '';
-
+  installFlags = [
+    "INSTALL_PATH=${placeholder "out"}/bin"
+    "MAN_INSTALL_PATH=${placeholder "out"}/share/man/man1"
+    "DOC_INSTALL_PATH=${placeholder "out"}/share/doc/hashcash-$(version)"
+  ];
+  
   meta = with stdenv.lib; {
     description = "Proof-of-work algorithm used as spam and denial-of-service counter measure";
     homepage = http://hashcash.org;

--- a/pkgs/tools/security/hashcash/default.nix
+++ b/pkgs/tools/security/hashcash/default.nix
@@ -22,8 +22,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Hashcash is a proof-of-work algorithm, which has been used as a denial-of-service counter measure technique in a number of systems.";
+    description = "Proof-of-work algorithm used as spam and denial-of-service counter measure";
     homepage = http://hashcash.org;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ kisonecat ];
   };
 }

--- a/pkgs/tools/security/hashcash/default.nix
+++ b/pkgs/tools/security/hashcash/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "hashcash-${version}";
+  version = "1.22";
+
+  buildInputs = [ openssl ]; 
+
+  src = fetchurl {
+      url = "http://www.hashcash.org/source/hashcash-1.22.tgz";
+      sha256 = "15kqaimwb2y8wvzpn73021bvay9mz1gqqfc40gk4hj6f84nz34h1";
+  };
+ 
+  makeFlags = "generic-openssl LIBCRYPTO=-lcrypto";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1  
+    install -m 0755 hashcash $out/bin
+    install -m 0755 sha1 $out/bin
+    install -m 0444 hashcash.1 $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Hashcash is a proof-of-work algorithm, which has been used as a denial-of-service counter measure technique in a number of systems.";
+    homepage = http://hashcash.org;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/tools/security/hashcash/default.nix
+++ b/pkgs/tools/security/hashcash/default.nix
@@ -4,21 +4,18 @@ stdenv.mkDerivation rec {
   name = "hashcash-${version}";
   version = "1.22";
 
-  buildInputs = [ openssl ]; 
+  buildInputs = [ openssl ];
 
   src = fetchurl {
       url = "http://www.hashcash.org/source/hashcash-1.22.tgz";
       sha256 = "15kqaimwb2y8wvzpn73021bvay9mz1gqqfc40gk4hj6f84nz34h1";
   };
- 
+
   makeFlags = "generic-openssl LIBCRYPTO=-lcrypto";
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1  
-    install -m 0755 hashcash $out/bin
-    install -m 0755 sha1 $out/bin
-    install -m 0444 hashcash.1 $out/share/man/man1
+    install -D -m 0755 --target $out/bin hashcash sha1
+    install -D -m 0444 hashcash.1 $out/share/man/man1/hashcash.1
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3233,6 +3233,8 @@ in
 
   hardlink = callPackage ../tools/system/hardlink { };
 
+  hashcash = callPackage ../tools/security/hashcash { };
+
   hashcat = callPackage ../tools/security/hashcat { };
 
   hash_extender = callPackage ../tools/security/hash_extender { };


### PR DESCRIPTION
###### Motivation for this change

Hashcash is available in the AUR and missing in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

