### PR TITLE
[wip] lib.makePerlPath -> perlPackages.makePerlPath

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,7 @@ let
     inherit (strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep makeSearchPath makeSearchPathOutput
-      makeLibraryPath makeBinPath makePerlPath makeFullPerlPath optionalString
+      makeLibraryPath makeBinPath optionalString
       hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -162,26 +162,6 @@ rec {
   */
   makeBinPath = makeSearchPathOutput "bin" "bin";
 
-
-  /* Construct a perl search path (such as $PERL5LIB)
-
-     Example:
-       pkgs = import <nixpkgs> { }
-       makePerlPath [ pkgs.perlPackages.libnet ]
-       => "/nix/store/n0m1fk9c960d8wlrs62sncnadygqqc6y-perl-Net-SMTP-1.25/lib/perl5/site_perl"
-  */
-  # FIXME(zimbatm): this should be moved in perl-specific code
-  makePerlPath = makeSearchPathOutput "lib" "lib/perl5/site_perl";
-
-  /* Construct a perl search path recursively including all dependencies (such as $PERL5LIB)
-
-     Example:
-       pkgs = import <nixpkgs> { }
-       makeFullPerlPath [ pkgs.perlPackages.CGI ]
-       => "/nix/store/fddivfrdc1xql02h9q500fpnqy12c74n-perl-CGI-4.38/lib/perl5/site_perl:/nix/store/8hsvdalmsxqkjg0c5ifigpf31vc4vsy2-perl-HTML-Parser-3.72/lib/perl5/site_perl:/nix/store/zhc7wh0xl8hz3y3f71nhlw1559iyvzld-perl-HTML-Tagset-3.20/lib/perl5/site_perl"
-  */
-  makeFullPerlPath = deps: makePerlPath (lib.misc.closePropagation deps);
-
   /* Depending on the boolean `cond', return either the given string
      or the empty string. Useful to concatenate against a bigger string.
 

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -34,14 +34,14 @@ in rec {
         cp ${./test-driver/test-driver.pl} $out/bin/nixos-test-driver
         chmod u+x $out/bin/nixos-test-driver
 
-        libDir=$out/lib/perl5/site_perl
+        libDir=$out/${perl.libPrefix}
         mkdir -p $libDir
         cp ${./test-driver/Machine.pm} $libDir/Machine.pm
         cp ${./test-driver/Logger.pm} $libDir/Logger.pm
 
         wrapProgram $out/bin/nixos-test-driver \
           --prefix PATH : "${lib.makeBinPath [ qemu_test vde2 netpbm coreutils ]}" \
-          --prefix PERL5LIB : "${with perlPackages; lib.makePerlPath [ TermReadLineGnu XMLWriter IOTty FileSlurp ]}:$out/lib/perl5/site_perl"
+          --prefix PERL5LIB : "${with perlPackages; makePerlPath [ TermReadLineGnu XMLWriter IOTty FileSlurp ]}:$out/${perl.libPrefix}"
       '';
   };
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -534,8 +534,8 @@ in {
         install -m 0755 -d /home
 
         ${pkgs.perl}/bin/perl -w \
-          -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl \
-          -I${pkgs.perlPackages.JSON}/lib/perl5/site_perl \
+          -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix} \
+          -I${pkgs.perlPackages.JSON}/${pkgs.perl.libPrefix} \
           ${./update-users-groups.pl} ${spec}
       '';
 

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -37,7 +37,7 @@ let
     name = "nixos-generate-config";
     src = ./nixos-generate-config.pl;
     path = [ pkgs.btrfs-progs ];
-    perl = "${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl";
+    perl = "${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix}";
     inherit (config.system.nixos) release;
   };
 

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -16,7 +16,7 @@ let
     isExecutable = true;
     inherit (pkgs) perl;
     inherit (cfg) dbPath;
-    perlFlags = concatStrings (map (path: "-I ${path}/lib/perl5/site_perl ")
+    perlFlags = concatStrings (map (path: "-I ${path}/${pkgs.perl.libPrefix} ")
       [ pkgs.perlPackages.DBI pkgs.perlPackages.DBDSQLite pkgs.perlPackages.StringShellQuote ]);
   };
 

--- a/nixos/modules/services/web-servers/lighttpd/collectd.nix
+++ b/nixos/modules/services/web-servers/lighttpd/collectd.nix
@@ -48,7 +48,7 @@ in
           "/collectd" => "${cfg.collectionCgi}"
         )
         setenv.add-environment = (
-          "PERL5LIB" => "${with pkgs; lib.makePerlPath [ perlPackages.CGI perlPackages.HTMLParser perlPackages.URI rrdtool ]}",
+          "PERL5LIB" => "${with pkgs.perlPackages; makePerlPath [ CGI HTMLParser URI pkgs.rrdtool ]}",
           "COLLECTION_CONF" => "${collectionConf}"
         )
       }

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -586,7 +586,7 @@ in
         in pkgs.writeScript "install-grub.sh" (''
         #!${pkgs.runtimeShell}
         set -e
-        export PERL5LIB=${makePerlPath (with pkgs.perlPackages; [ FileSlurp XMLLibXML XMLSAX XMLSAXBase ListCompare ])}
+        export PERL5LIB=${with pkgs.perlPackages; makePerlPath [ FileSlurp XMLLibXML XMLSAX XMLSAXBase ListCompare ]}
         ${optionalString cfg.enableCryptodisk "export GRUB_ENABLE_CRYPTODISK=y"}
       '' + flip concatMapStrings cfg.mirroredBoots (args: ''
         ${pkgs.perl}/bin/perl ${install-grub-pl} ${grubConfig args} $@

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -154,7 +154,7 @@ in
       ''
         # Set up the statically computed bits of /etc.
         echo "setting up /etc..."
-        ${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl ${./setup-etc.pl} ${etc}/etc
+        ${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix} ${./setup-etc.pl} ${etc}/etc
       '';
 
   };

--- a/nixos/modules/testing/service-runner.nix
+++ b/nixos/modules/testing/service-runner.nix
@@ -6,7 +6,7 @@ let
 
   makeScript = name: service: pkgs.writeScript "${name}-runner"
     ''
-      #! ${pkgs.perl}/bin/perl -w -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl
+      #! ${pkgs.perl}/bin/perl -w -I${pkgs.perlPackages.FileSlurp}/${pkgs.perl.libPrefix}
 
       use File::Slurp;
 

--- a/pkgs/applications/audio/abcde/default.nix
+++ b/pkgs/applications/audio/abcde/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, libcdio-paranoia, cddiscid, wget, which, vorbis-tools, id3v2, eyeD3
 , lame, flac, glyr
-, perl, MusicBrainz, MusicBrainzDiscID
+, perlPackages
 , makeWrapper }:
 
 let version = "2.9.2";
@@ -29,7 +29,7 @@ in
 
     nativeBuildInputs = [ makeWrapper ];
 
-    buildInputs = [ perl MusicBrainz MusicBrainzDiscID ];
+    buildInputs = with perlPackages; [ perl MusicBrainz MusicBrainzDiscID ];
 
     installFlags = [ "sysconfdir=$(out)/etc" ];
 

--- a/pkgs/applications/audio/crip/default.nix
+++ b/pkgs/applications/audio/crip/default.nix
@@ -2,7 +2,6 @@
 , fetchurl
 , makeWrapper
 
-, perl
 , perlPackages
 
 , cdparanoia
@@ -26,7 +25,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pk9152wll6fmkj1pki3fz3ijlf06jyk32v31yarwvdkwrk7s9xz";
   };
 
-  buildInputs = [ perl perlPackages.CDDB_get ];
+  buildInputs = [ perlPackages.perl perlPackages.CDDB_get ];
   nativeBuildInputs = [ makeWrapper ];
 
   toolDeps = makeBinPath [
@@ -53,7 +52,7 @@ stdenv.mkDerivation rec {
         --replace '$editor = "vim";' '$editor = "${nano}/bin/nano";'
 
       wrapProgram $out/bin/$script \
-        --set PERL5LIB "${makePerlPath [ perlPackages.CDDB_get ]}" \
+        --set PERL5LIB "${perlPackages.makePerlPath [ perlPackages.CDDB_get ]}" \
         --set PATH "${toolDeps}"
     done
   '';

--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ perlPackages.TestCommand perlPackages.TestHarness ];
   preCheck = ''
-    export PERL5LIB="${perlPackages.TestCommand}/lib/perl5/site_perl"
+    export PERL5LIB="${perlPackages.TestCommand}/${perl.libPrefix}"
   '';
 
   doCheck = true;

--- a/pkgs/applications/graphics/shutter/default.nix
+++ b/pkgs/applications/graphics/shutter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, perlPackages, makeWrapper, imagemagick, gdk_pixbuf, librsvg
+{ stdenv, fetchurl, perlPackages, makeWrapper, imagemagick, gdk_pixbuf, librsvg
 , hicolor-icon-theme, procps
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ perl procps gdk_pixbuf librsvg ] ++ perlModules;
+  buildInputs = [ perlPackages.perl procps gdk_pixbuf librsvg ] ++ perlModules;
 
   installPhase = ''
     mkdir -p "$out"
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     (cd "$out" && mv CHANGES README COPYING "$out/share/doc/shutter")
 
     wrapProgram $out/bin/shutter \
-      --set PERL5LIB "${stdenv.lib.makePerlPath perlModules}" \
+      --set PERL5LIB "${perlPackages.makePerlPath perlModules}" \
       --prefix PATH : "${imagemagick.out}/bin" \
       --suffix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, perl
-, MIMEtools, HTMLParser
-, cursesSupport ? true, CursesUI
-, uriFindSupport ? true, URIFind
+{ stdenv, lib, fetchFromGitHub, makeWrapper, perlPackages
+, cursesSupport ? true
+, uriFindSupport ? true
 }:
 
 let
   perlDeps =
-    [ MIMEtools HTMLParser ]
-    ++ lib.optional cursesSupport CursesUI
-    ++ lib.optional uriFindSupport URIFind;
+    [ perlPackages.MIMEtools perlPackages.HTMLParser ]
+    ++ lib.optional cursesSupport perlPackages.CursesUI
+    ++ lib.optional uriFindSupport perlPackages.URIFind;
 
 in stdenv.mkDerivation rec {
   name = "extract_url-${version}";
@@ -22,7 +21,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ perl ] ++ perlDeps;
+  buildInputs = [ perlPackages.perl ] ++ perlDeps;
 
   makeFlags = [ "prefix=$(out)" ];
   installFlags = [ "INSTALL=install" ];

--- a/pkgs/applications/misc/ikiwiki/default.nix
+++ b/pkgs/applications/misc/ikiwiki/default.nix
@@ -1,13 +1,9 @@
-{ stdenv, fetchurl, perl, gettext, makeWrapper, PerlMagick, YAML
-, TextMarkdown, URI, HTMLParser, HTMLScrubber, HTMLTemplate, TimeDate
-, CGISession, CGIFormBuilder, DBFile, LocaleGettext, RpcXML, XMLSimple
-, YAMLLibYAML, which, HTMLTree, AuthenPassphrase, NetOpenIDConsumer
-, LWPxParanoidAgent, CryptSSLeay
+{ stdenv, fetchurl, perlPackages, gettext, makeWrapper, PerlMagick, which
 , gitSupport ? false, git ? null
 , docutilsSupport ? false, python ? null, docutils ? null
 , monotoneSupport ? false, monotone ? null
 , bazaarSupport ? false, bazaar ? null
-, cvsSupport ? false, cvs ? null, cvsps ? null, Filechdir ? null
+, cvsSupport ? false, cvs ? null, cvsps ? null
 , subversionSupport ? false, subversion ? null
 , mercurialSupport ? false, mercurial ? null
 , extraUtils ? []
@@ -17,7 +13,7 @@ assert docutilsSupport -> (python != null && docutils != null);
 assert gitSupport -> (git != null);
 assert monotoneSupport -> (monotone != null);
 assert bazaarSupport -> (bazaar != null);
-assert cvsSupport -> (cvs != null && cvsps != null && Filechdir != null);
+assert cvsSupport -> (cvs != null && cvsps != null && perlPackages.Filechdir != null);
 assert subversionSupport -> (subversion != null);
 assert mercurialSupport -> (mercurial != null);
 
@@ -35,15 +31,16 @@ stdenv.mkDerivation {
     sha256 = "00d7yzv426fvqbhvzyafddv7fa6b4j2647b0wi371wd5yjj9j3sz";
   };
 
-  buildInputs = [ perl TextMarkdown URI HTMLParser HTMLScrubber HTMLTemplate
-    TimeDate gettext makeWrapper DBFile CGISession CGIFormBuilder LocaleGettext
-    RpcXML XMLSimple PerlMagick YAML YAMLLibYAML which HTMLTree AuthenPassphrase
-    NetOpenIDConsumer LWPxParanoidAgent CryptSSLeay ]
+  buildInputs = [ which ]
+    ++ (with perlPackages; [ perl TextMarkdown URI HTMLParser HTMLScrubber HTMLTemplate
+          TimeDate gettext makeWrapper DBFile CGISession CGIFormBuilder LocaleGettext
+          RpcXML XMLSimple PerlMagick YAML YAMLLibYAML HTMLTree AuthenPassphrase
+          NetOpenIDConsumer LWPxParanoidAgent CryptSSLeay ])
     ++ lib.optionals docutilsSupport [python docutils]
     ++ lib.optionals gitSupport [git]
     ++ lib.optionals monotoneSupport [monotone]
     ++ lib.optionals bazaarSupport [bazaar]
-    ++ lib.optionals cvsSupport [cvs cvsps Filechdir]
+    ++ lib.optionals cvsSupport [cvs cvsps perlPackages.Filechdir]
     ++ lib.optionals subversionSupport [subversion]
     ++ lib.optionals mercurialSupport [mercurial];
 

--- a/pkgs/applications/misc/qdirstat/default.nix
+++ b/pkgs/applications/misc/qdirstat/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, qmake
 , coreutils, xdg_utils, bash
-, perl, makeWrapper, perlPackages }:
+, makeWrapper, perlPackages }:
 
 let
   version = "1.4";
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake makeWrapper ];
 
-  buildInputs = [ perl ];
+  buildInputs = [ perlPackages.perl ];
 
   preBuild = ''
     substituteInPlace scripts/scripts.pro \
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/qdirstat-cache-writer \
-      --set PERL5LIB "${stdenv.lib.makePerlPath [ perlPackages.URI ]}"
+      --set PERL5LIB "${perlPackages.makePerlPath [ perlPackages.URI ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -51,8 +51,8 @@ stdenv.mkDerivation (rec {
     ''
     # make urxvt find its perl file lib/perl5/site_perl is added to PERL5LIB automatically
     + stdenv.lib.optionalString perlSupport ''
-      mkdir -p $out/lib/perl5
-      ln -s $out/{lib/urxvt,lib/perl5/site_perl}
+      mkdir -p $(dirname ${perl.libPrefix})
+      ln -s $out/lib/urxvt $out/${perl.libPrefix}
     '';
 
   postInstall = ''

--- a/pkgs/applications/misc/yarssr/default.nix
+++ b/pkgs/applications/misc/yarssr/default.nix
@@ -1,8 +1,4 @@
-{
-fetchFromGitHub, stdenv, lib,
-makeWrapper, pkgs,
-perl, perlPackages,
-gnome2 }:
+{ fetchFromGitHub, stdenv, lib, gettext, gtk2, makeWrapper, perlPackages, gnome2 }:
 
 let
   perlDeps = with perlPackages; [
@@ -24,7 +20,7 @@ let
   ];
   libs = [
     stdenv.cc.cc.lib
-    pkgs.gtk2
+    gtk2
   ];
 in
 stdenv.mkDerivation rec {
@@ -38,7 +34,7 @@ stdenv.mkDerivation rec {
     sha256 = "0x7hz8x8qyp3i1vb22zhcnvwxm3jhmmmlr22jqc5b09vpmbw1l45";
   };
 
-  nativeBuildInputs = [ perl pkgs.gettext makeWrapper ];
+  nativeBuildInputs = [ perlPackages.perl gettext makeWrapper ];
   buildInputs = perlDeps ++ [gnome2.libglade];
   propagatedBuildInputs = libs ++ perlDeps;
 
@@ -55,7 +51,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     wrapProgram $out/bin/yarssr \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath libs} \
-      --set PERL5LIB "${lib.makePerlPath perlDeps}"
+      --set PERL5LIB "${perlPackages.makePerlPath perlDeps}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, runCommand, writeScriptBin, buildEnv
-, pythonPackages, perl, perlPackages
+, pythonPackages, perlPackages
 }:
 
 weechat:
@@ -10,7 +10,7 @@ let
   }:
 
   let
-    perlInterpreter = perl;
+    perlInterpreter = perlPackages.perl;
     availablePlugins = let
         simplePlugin = name: {pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so";};
       in rec {
@@ -29,7 +29,7 @@ let
           withPackages = pkgsFun: (perl // {
             extraEnv = ''
               ${perl.extraEnv}
-              export PERL5LIB=${lib.makeFullPerlPath (pkgsFun perlPackages)}
+              export PERL5LIB=${perlPackages.makeFullPerlPath (pkgsFun perlPackages)}
             '';
           });
         };

--- a/pkgs/applications/networking/sieve-connect/default.nix
+++ b/pkgs/applications/networking/sieve-connect/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages }: stdenv.mkDerivation rec {
+{ stdenv, fetchFromGitHub, makeWrapper, perlPackages }:
+
+stdenv.mkDerivation rec {
   name = "sieve-connect-${version}";
   version = "0.89";
 
@@ -9,7 +11,7 @@
     sha256 = "0g7cv29wd5673inl4c87xb802k86bj6gcwh131xrbbg0a0g1c8fp";
   };
 
-  buildInputs = [ perl ];
+  buildInputs = [ perlPackages.perl ];
   nativeBuildInputs = [ makeWrapper ];
 
   preBuild = ''
@@ -20,7 +22,7 @@
     echo "$(date +%Y-%m-%d)" > datefile
   '';
 
-  buildFlags = [ "PERL5LIB=${stdenv.lib.makePerlPath [ perlPackages.FileSlurp ]}" "bin" "man" ];
+  buildFlags = [ "PERL5LIB=${perlPackages.makePerlPath [ perlPackages.FileSlurp ]}" "bin" "man" ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
@@ -28,9 +30,9 @@
     gzip -c sieve-connect.1 > $out/share/man/man1/sieve-connect.1.gz
 
     wrapProgram $out/bin/sieve-connect \
-      --prefix PERL5LIB : "${stdenv.lib.makePerlPath (with perlPackages; [
+      --prefix PERL5LIB : "${with perlPackages; makePerlPath [
         AuthenSASL Socket6 IOSocketInet6 IOSocketSSL NetSSLeay NetDNS PodUsage
-        TermReadKey TermReadLineGnu ])}"
+        TermReadKey TermReadLineGnu ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/tsung/default.nix
+++ b/pkgs/applications/networking/tsung/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, lib, makeWrapper,
   erlang,
   python2, python2Packages,
-  perl, perlPackages,
+  perlPackages,
   gnuplot }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     erlang
     gnuplot
-    perl
+    perlPackages.perl
     perlPackages.TemplateToolkit
     python2
     python2Packages.matplotlib
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     # Add Template Toolkit and gnuplot to tsung_stats.pl
     wrapProgram $out/bin/tsung_stats.pl \
         --prefix PATH : ${lib.makeBinPath [ gnuplot ]} \
-        --set PERL5LIB "${lib.makePerlPath [ perlPackages.TemplateToolkit ]}"
+        --set PERL5LIB "${perlPackages.makePerlPath [ perlPackages.TemplateToolkit ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/biology/N3/default.nix
+++ b/pkgs/applications/science/biology/N3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper,
-  perl, MNI-Perllib, GetoptTabular,
+  perlPackages,
   libminc, EBTKS }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libminc EBTKS ];
-  propagatedBuildInputs = [ perl MNI-Perllib GetoptTabular ];
+  propagatedBuildInputs = with perlPackages; [ perl MNI-Perllib GetoptTabular ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" "-DEBTKS_DIR=${EBTKS}/lib/" ];
 

--- a/pkgs/applications/science/biology/conglomerate/default.nix
+++ b/pkgs/applications/science/biology/conglomerate/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, cmake, coreutils, perl, bicpl, libminc, zlib, minc_tools,
-  makeWrapper, GetoptTabular, MNI-Perllib }:
+{ stdenv, fetchFromGitHub, cmake, coreutils, perlPackages, bicpl, libminc, zlib, minc_tools,
+  makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "conglomerate";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libminc zlib bicpl ];
-  propagatedBuildInputs = [ coreutils minc_tools perl GetoptTabular MNI-Perllib ];
+  propagatedBuildInputs = [ coreutils minc_tools ] ++ (with perlPackages; [ perl GetoptTabular MNI-Perllib ]);
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" "-DBICPL_DIR=${bicpl}/lib/" ];
 

--- a/pkgs/applications/science/biology/inormalize/default.nix
+++ b/pkgs/applications/science/biology/inormalize/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper,
-  perl, GetoptTabular, MNI-Perllib,
+  perlPackages,
   libminc, EBTKS }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libminc EBTKS ];
-  propagatedBuildInputs = [ perl GetoptTabular MNI-Perllib ];
+  propagatedBuildInputs = with perlPackages; [ perl GetoptTabular MNI-Perllib ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" "-DEBTKS_DIR=${EBTKS}/lib/" ];
 

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, flex, bison, perl, TextFormat, libminc, libjpeg, zlib }:
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, flex, bison, perlPackages, libminc, libjpeg, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "minc-tools";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake flex bison makeWrapper ];
   buildInputs = [ libminc libjpeg zlib ];
-  propagatedBuildInputs = [ perl TextFormat ];
+  propagatedBuildInputs = with perlPackages; [ perl TextFormat ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" ];
 

--- a/pkgs/applications/science/biology/minc-widgets/default.nix
+++ b/pkgs/applications/science/biology/minc-widgets/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper,
-  perl, GetoptTabular, MNI-Perllib,
+  perlPackages,
   libminc, octave, coreutils, minc_tools }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libminc ];
-  propagatedBuildInputs = [ perl GetoptTabular MNI-Perllib octave coreutils minc_tools ];
+  propagatedBuildInputs = (with perlPackages; [ perl GetoptTabular MNI-Perllib ]) ++ [ octave coreutils minc_tools ];
 
   postFixup = ''
     for p in $out/bin/*; do

--- a/pkgs/applications/science/biology/mni_autoreg/default.nix
+++ b/pkgs/applications/science/biology/mni_autoreg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, perl, GetoptTabular, MNI-Perllib, libminc }:
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, perlPackages, libminc }:
 
 stdenv.mkDerivation rec {
   pname = "mni_autoreg";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libminc ];
-  propagatedBuildInputs = [ perl GetoptTabular MNI-Perllib ];
+  propagatedBuildInputs = with perlPackages; [ perl GetoptTabular MNI-Perllib ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/" "-DBUILD_TESTING=FALSE" ];
   # testing broken: './minc_wrapper: Permission denied' from Testing/ellipse0.mnc

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, buildPackages
-, curl, openssl, zlib, expat, perl, python, gettext, cpio
+, curl, openssl, zlib, expat, perlPackages, python, gettext, cpio
 , gnugrep, gnused, gawk, coreutils # needed at runtime by git-filter-branch etc
 , openssh, pcre2
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
@@ -59,11 +59,11 @@ stdenv.mkDerivation {
         --subst-var-by gettext ${gettext}
   '';
 
-  nativeBuildInputs = [ gettext perl ]
+  nativeBuildInputs = [ gettext perlPackages.perl ]
     ++ stdenv.lib.optionals withManual [ asciidoc texinfo xmlto docbook2x
          docbook_xsl docbook_xml_dtd_45 libxslt ];
   buildInputs = [curl openssl zlib expat cpio makeWrapper libiconv]
-    ++ stdenv.lib.optionals perlSupport [ perl ]
+    ++ stdenv.lib.optionals perlSupport [ perlPackages.perl ]
     ++ stdenv.lib.optionals guiSupport [tcl tk]
     ++ stdenv.lib.optionals withpcre2 [ pcre2 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.Security ]
@@ -86,7 +86,7 @@ stdenv.mkDerivation {
     "prefix=\${out}"
     "SHELL_PATH=${stdenv.shell}"
   ]
-  ++ (if perlSupport then ["PERL_PATH=${perl}/bin/perl"] else ["NO_PERL=1"])
+  ++ (if perlSupport then ["PERL_PATH=${perlPackages.perl}/bin/perl"] else ["NO_PERL=1"])
   ++ (if pythonSupport then ["PYTHON_PATH=${python}/bin/python"] else ["NO_PYTHON=1"])
   ++ stdenv.lib.optionals stdenv.isSunOS ["INSTALL=install" "NO_INET_NTOP=" "NO_INET_PTON="]
   ++ (if stdenv.isDarwin then ["NO_APPLE_COMMON_CRYPTO=1"] else ["sysconfdir=/etc/"])
@@ -153,7 +153,7 @@ stdenv.mkDerivation {
             '${gnugrep}/bin/grep', '${gnused}/bin/sed', '${gawk}/bin/awk',
             '${coreutils}/bin/cut', '${coreutils}/bin/basename', '${coreutils}/bin/dirname',
             '${coreutils}/bin/wc', '${coreutils}/bin/tr'
-            ${stdenv.lib.optionalString perlSupport ", '${perl}/bin/perl'"}
+            ${stdenv.lib.optionalString perlSupport ", '${perlPackages.perl}/bin/perl'"}
           );
         }
         foreach $c (@a) {
@@ -174,47 +174,35 @@ stdenv.mkDerivation {
       mv $out/share/gitweb $gitweb/
 
       # wrap perl commands
-      gitperllib=$out/lib/perl5/site_perl
-      for i in ${builtins.toString perlLibs}; do
-        gitperllib=$gitperllib:$i/lib/perl5/site_perl
-      done
       wrapProgram $out/libexec/git-core/git-cvsimport \
-                  --set GITPERLLIB "$gitperllib"
+                  --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-add--interactive \
-                  --set GITPERLLIB "$gitperllib"
+                  --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-archimport \
-                  --set GITPERLLIB "$gitperllib"
+                  --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-instaweb \
-                  --set GITPERLLIB "$gitperllib"
+                  --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-cvsexportcommit \
-                  --set GITPERLLIB "$gitperllib"
+                  --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
     ''
 
-   + (if svnSupport then
-
-      ''# wrap git-svn
-        gitperllib=$out/lib/perl5/site_perl
-        for i in ${builtins.toString perlLibs} ${svn.out}; do
-          gitperllib=$gitperllib:$i/lib/perl5/site_perl
-        done
-        wrapProgram $out/libexec/git-core/git-svn     \
-                     --set GITPERLLIB "$gitperllib"   \
+   + (if svnSupport then ''
+        # wrap git-svn
+        wrapProgram $out/libexec/git-core/git-svn                                                                  \
+                     --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"  \
                      --prefix PATH : "${svn.out}/bin" ''
        else '' # replace git-svn by notification script
         notSupported $out/libexec/git-core/git-svn
-       '')
+     '')
 
-   + (if sendEmailSupport then
-      ''# wrap git-send-email
-        gitperllib=$out/lib/perl5/site_perl
-        for i in ${builtins.toString smtpPerlLibs}; do
-          gitperllib=$gitperllib:$i/lib/perl5/site_perl
-        done
+   + (if sendEmailSupport then ''
+        # wrap git-send-email
         wrapProgram $out/libexec/git-core/git-send-email \
-                     --set GITPERLLIB "$gitperllib" ''
-       else '' # replace git-send-email by notification script
+                     --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
+      '' else ''
+        # replace git-send-email by notification script
         notSupported $out/libexec/git-core/git-send-email
-       '')
+      '')
 
    + stdenv.lib.optionalString withManual ''# Install man pages and Info manual
        make -j $NIX_BUILD_CORES -l $NIX_BUILD_CORES PERL_PATH="${buildPackages.perl}/bin/perl" cmd-list.made install install-info \
@@ -236,9 +224,9 @@ stdenv.mkDerivation {
    + stdenv.lib.optionalString stdenv.isDarwin ''
     # enable git-credential-osxkeychain by default if darwin
     cat > $out/etc/gitconfig << EOF
-[credential]
-	helper = osxkeychain
-EOF
+    [credential]
+      helper = osxkeychain
+    EOF
   '';
 
 

--- a/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
           $out/gitweb.cgi
       # Give access to CGI.pm and friends (was removed from perl core in 5.22)
       for p in ${stdenv.lib.concatStringsSep " " gitwebPerlLibs}; do
-          sed -i -e "/use CGI /i use lib \"$p/lib/perl5/site_perl\";" \
+          sed -i -e "/use CGI /i use lib \"$p/${perl.libPrefix}\";" \
               "$out/gitweb.cgi"
       done
 

--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/${name}
     cp -rv contrib/ $out/share/${name}/contrib
-    mkdir -p $out/lib/perl5/site_perl/${perlVersion}
-    cp -v contrib/Monotone.pm $out/lib/perl5/site_perl/${perlVersion}
+    mkdir -p $out/${perl.libPrefix}/${perlVersion}
+    cp -v contrib/Monotone.pm $out/${perl.libPrefix}/${perlVersion}
   '';
 
   #doCheck = true; # some tests fail (and they take VERY long)

--- a/pkgs/applications/version-management/vcsh/default.nix
+++ b/pkgs/applications/version-management/vcsh/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchFromGitHub, which, git, ronn, perl, ShellCommand
-, TestMost, TestDifferences, TestDeep, TestException, TestWarn
-}:
+{ stdenv, fetchFromGitHub, which, git, ronn, perlPackages }:
 
 stdenv.mkDerivation rec {
   version = "1.20170915";       # date of commit we're pulling
@@ -13,10 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1wfzp8167lcq6akdpbi8fikjv0z3h1i5minh3423dljc04q0klm1";
   };
 
-  buildInputs = [
-    which git ronn perl ShellCommand TestMost TestDifferences TestDeep
-    TestException TestWarn
-  ];
+  buildInputs = [ which git ronn ]
+    ++ (with perlPackages; [ perl ShellCommand TestMost TestDifferences TestDeep TestException TestWarn ]);
 
   installPhase = "make install PREFIX=$out";
 

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -192,12 +192,12 @@ rec {
       name = "perl-environment";
       paths = libraries;
       pathsToLink = [
-        "/lib/perl5/site_perl"
+        "/${pkgs.perl.libPrefix}"
       ];
     };
   in
   makeScriptWriter {
-    interpreter = "${pkgs.perl}/bin/perl -I ${perl-env}/lib/perl5/site_perl";
+    interpreter = "${pkgs.perl}/bin/perl -I ${perl-env}/${pkgs.perl.libPrefix}";
   } name;
 
   # writePerlBin takes the same arguments as writePerl but outputs a directory (like writeScriptBin)

--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, autoreconfHook, makeWrapper
-, perl, libxml2, IOStringy }:
+, perlPackages, libxml2 }:
 
 stdenv.mkDerivation rec {
   name = "hivex-${version}";
@@ -14,9 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    autoreconfHook makeWrapper
-    perl libxml2 IOStringy
-  ];
+    autoreconfHook makeWrapper libxml2
+  ] ++ (with perlPackages; [ perl IOStringy ]);
 
   postInstall = ''
     for bin in $out/bin/*; do

--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, autoreconfHook, makeWrapper
-, ncurses, cpio, gperf, perl, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
+, ncurses, cpio, gperf, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex
-, gmp, readline, file, libintl_perl, GetoptLong, SysVirt, numactl, xen, libapparmor
+, gmp, readline, file, numactl, xen, libapparmor
 , getopt, perlPackages, ocamlPackages
 , appliance ? null
 , javaSupport ? false, jdk ? null }:
@@ -20,10 +20,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    makeWrapper autoreconfHook ncurses cpio gperf perl
+    makeWrapper autoreconfHook ncurses cpio gperf
     cdrkit flex bison qemu pcre augeas libxml2 acl libcap libcap_ng libconfig
-    systemd fuse yajl libvirt gmp readline file hivex libintl_perl GetoptLong
-    SysVirt numactl xen libapparmor getopt perlPackages.ModuleBuild
+    systemd fuse yajl libvirt gmp readline file hivex
+    numactl xen libapparmor getopt perlPackages.ModuleBuild
+  ] ++ (with perlPackages; [ perl libintl_perl GetoptLong SysVirt ])
   ] ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ocaml_libvirt ocaml_gettext ounit ])
     ++ stdenv.lib.optional javaSupport jdk;
 
@@ -52,7 +53,7 @@ stdenv.mkDerivation rec {
     for bin in $out/bin/*; do
       wrapProgram "$bin" \
         --prefix PATH     : "$out/bin:${hivex}/bin:${qemu}/bin" \
-        --prefix PERL5LIB : "$out/lib/perl5/site_perl"
+        --prefix PERL5LIB : "$out/${perl.libPrefix}"
     done
   '';
 

--- a/pkgs/development/perl-modules/DBD-SQLite/default.nix
+++ b/pkgs/development/perl-modules/DBD-SQLite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPerlPackage, DBI, sqlite }:
+{ stdenv, fetchurl, buildPerlPackage, perl, DBI, sqlite }:
 
 buildPerlPackage rec {
   name = "DBD-SQLite-1.58";
@@ -20,7 +20,7 @@ buildPerlPackage rec {
 
   postInstall = ''
     # Get rid of a pointless copy of the SQLite sources.
-    rm -rf $out/lib/perl5/site_perl/*/*/auto/share
+    rm -rf $out/${perl.libPrefix}/*/*/auto/share
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -2,7 +2,7 @@
 , llvm, clang-unwrapped
 , flex
 , zlib
-, perl, ExporterLite, FileWhich, GetoptTabular, RegexpCommon, TermReadKey
+, perlPackages
 , utillinux
 }:
 
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
     # Actual deps:
     llvm clang-unwrapped
     flex zlib
-    perl ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey
-  ];
+  ] ++ (with perlPackages; [ perl ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey ]);
 
   # On Linux, c-reduce's preferred way to reason about
   # the cpu architecture/topology is to use 'lscpu',

--- a/pkgs/development/tools/misc/csmith/default.nix
+++ b/pkgs/development/tools/misc/csmith/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, m4, makeWrapper, libbsd, perl, SysCPU }:
+{ stdenv, fetchurl, m4, makeWrapper, libbsd, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "csmith-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ m4 makeWrapper ];
-  buildInputs = [ perl SysCPU libbsd ];
+  buildInputs = [ libbsd ] ++ (with perlPackages; [ perl SysCPU ]);
 
   postInstall = ''
     substituteInPlace $out/bin/compiler_test.pl \

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, gettext, LocaleGettext }:
+{ stdenv, fetchurl, perlPackages, gettext }:
 
 stdenv.mkDerivation rec {
   name = "help2man-1.47.8";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1p5830h88cx0zn0snwaj0vpph81xicpsirfwlxmcgjrlmn0nm3sj";
   };
 
-  nativeBuildInputs = [ gettext LocaleGettext ];
-  buildInputs = [ perl LocaleGettext ];
+  nativeBuildInputs = [ gettext perlPackages.LocaleGettext ];
+  buildInputs = [ perlPackages.perl perlPackages.LocaleGettext ];
 
   doCheck = false;                                # target `check' is missing
 
@@ -18,11 +18,10 @@ stdenv.mkDerivation rec {
   # We don't use makeWrapper here because it uses substitutions our
   # bootstrap shell can't handle.
   postInstall = ''
-    gettext_perl="$(echo ${LocaleGettext}/lib/perl*/site_perl)"
     mv $out/bin/help2man $out/bin/.help2man-wrapped
     cat > $out/bin/help2man <<EOF
     #! $SHELL -e
-    export PERL5LIB=\''${PERL5LIB:+:}$gettext_perl
+    export PERL5LIB=\''${PERL5LIB:+:}${perlPackages.LocaleGettext}/${perlPackages.perl.libPrefix}
     ${stdenv.lib.optionalString stdenv.hostPlatform.isCygwin
         ''export PATH=\''${PATH:+:}${gettext}/bin''}
     exec -a \$0 $out/bin/.help2man-wrapped "\$@"

--- a/pkgs/development/tools/misc/icon-naming-utils/default.nix
+++ b/pkgs/development/tools/misc/icon-naming-utils/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl, XMLSimple, librsvg}:
+{stdenv, fetchurl, perlPackages, librsvg}:
 
 stdenv.mkDerivation rec {
   name = "icon-naming-utils-0.8.90";
@@ -8,13 +8,13 @@ stdenv.mkDerivation rec {
     sha256 = "071fj2jm5kydlz02ic5sylhmw6h2p3cgrm3gwdfabinqkqcv4jh4";
   };
 
-  buildInputs = [perl XMLSimple librsvg];
+  buildInputs = [ librsvg ] ++ (with perlPackages; [ perl XMLSimple ]);
 
   postInstall =
     ''
       # Add XML::Simple to the runtime search path.
       substituteInPlace $out/libexec/icon-name-mapping \
-          --replace '/bin/perl' '/bin/perl -I${XMLSimple}/lib/perl5/site_perl'
+          --replace '/bin/perl' '/bin/perl -I${perlPackages.XMLSimple}/${perlPackages.perl.libPrefix}'
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/sslmate/default.nix
+++ b/pkgs/development/tools/sslmate/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perlPackages, perl, makeWrapper, openssl }:
+{ stdenv, fetchurl, perlPackages, makeWrapper, openssl }:
 
 stdenv.mkDerivation rec {
   name = "sslmate-1.7.0";
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = "PREFIX=$(out)";
 
-  buildInputs = [ perl makeWrapper ];
+  buildInputs = [ perlPackages.perl makeWrapper ];
 
   postInstall = ''
     wrapProgram $out/bin/sslmate --prefix PERL5LIB : \
-      "${with perlPackages; stdenv.lib.makePerlPath [
+      "${with perlPackages; makePerlPath [
         URI
         JSONPP
         TermReadKey

--- a/pkgs/development/web/wml/default.nix
+++ b/pkgs/development/web/wml/default.nix
@@ -22,7 +22,7 @@ perlPackages.buildPerlPackage rec {
     sed -i '/p2_mp4h\/doc/d' Makefile.in
   '';
 
-  buildInputs = with perlPackages; 
+  buildInputs = with perlPackages;
     [ perl TermReadKey GD BitVector ncurses lynx makeWrapper ImageSize ];
 
   patches = [ ./redhat-with-thr.patch ./dynaloader.patch ./no_bitvector.patch ];
@@ -45,7 +45,7 @@ perlPackages.buildPerlPackage rec {
 
   preFixup = ''
     wrapProgram $out/bin/wml \
-      --set PERL5LIB ${with perlPackages; stdenv.lib.makePerlPath [
+      --set PERL5LIB ${with perlPackages; makePerlPath [
         BitVector TermReadKey ImageSize
       ]}
   '';

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, perl, fetchurl, Error, MailDKIM, MIMETools, NetServer }:
+{ stdenv, perlPackages, fetchurl }:
 
 let
   pkg = "dkimproxy";
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  buildInputs = [ perl ];
-  propagatedBuildInputs = [ Error MailDKIM MIMETools NetServer ];
+  buildInputs = [ perlPackages.perl ];
+  propagatedBuildInputs = with perlPackages; [ Error MailDKIM MIMETools NetServer ];
 
   meta = with stdenv.lib; {
     description = "SMTP-proxy that signs and/or verifies emails";

--- a/pkgs/servers/mail/dspam/default.nix
+++ b/pkgs/servers/mail/dspam/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, makeWrapper
 , gawk, gnused, gnugrep, coreutils, which
-, perl, libnet
+, perlPackages
 , withMySQL ? false, zlib, mysql57
 , withPgSQL ? false, postgresql
 , withSQLite ? false, sqlite
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1acklnxn1wvc7abn31l3qdj8q6k13s51k5gv86vka7q20jb5cxmf";
   };
 
-  buildInputs = [ perl ]
+  buildInputs = [ perlPackages.perl ]
                 ++ lib.optionals withMySQL [ zlib mysql57.connector-c ]
                 ++ lib.optional withPgSQL postgresql
                 ++ lib.optional withSQLite sqlite
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
     rm -rf $out/var
 
     wrapProgram $out/bin/dspam_notify \
-      --set PERL5LIB "${lib.makePerlPath [ libnet ]}"
+      --set PERL5LIB "${perlPackages.makePerlPath [ perlPackages.libnet ]}"
 
     # Install SQL scripts
     mkdir -p $out/share/dspam/sql

--- a/pkgs/servers/mail/postgrey/default.nix
+++ b/pkgs/servers/mail/postgrey/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, perl, perlPackages, lib, runCommand, postfix }:
+{ stdenv, fetchurl, perlPackages, lib, runCommand, postfix }:
 
 let
-    mk-perl-flags = inputs: lib.concatStringsSep " " (map (dep: "-I ${dep}/lib/perl5/site_perl") inputs);
+    mk-perl-flags = inputs: lib.concatStringsSep " " (map (dep: "-I ${dep}/${perlPackages.perl.libPrefix}") inputs);
     postgrey-flags = mk-perl-flags (with perlPackages; [
       NetServer BerkeleyDB DigestSHA1 NetAddrIP IOMultiplex
     ]);
@@ -26,9 +26,9 @@ in runCommand name {
     cd $out
     tar -xzf $src --strip-components=1
     mv postgrey policy-test bin
-    sed -i -e "s,#!/usr/bin/perl -T,#!${perl}/bin/perl -T ${postgrey-flags}," \
+    sed -i -e "s,#!/usr/bin/perl -T,#!${perlPackages.perl}/bin/perl -T ${postgrey-flags}," \
            -e "s#/etc/postfix#$out#" \
         bin/postgrey
-    sed -i -e "s,#!/usr/bin/perl,#!${perl}/bin/perl ${policy-test-flags}," \
+    sed -i -e "s,#!/usr/bin/perl,#!${perlPackages.perl}/bin/perl ${policy-test-flags}," \
         bin/policy-test
 ''

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchurl, perl, perlPackages, HTMLParser, NetDNS, NetAddrIP, DBFile
-, HTTPDate, MailDKIM, LWP, IOSocketSSL, makeWrapper, gnupg1
-}:
+{ stdenv, fetchurl, perlPackages, makeWrapper, gnupg1 }:
 
 perlPackages.buildPerlPackage rec {
   name = "SpamAssassin-3.4.1";
@@ -13,12 +11,12 @@ perlPackages.buildPerlPackage rec {
   # https://bz.apache.org/SpamAssassin/show_bug.cgi?id=7434
   patches = [ ./sa-update_add--siteconfigpath.patch ];
 
-  buildInputs = with perlPackages; [ makeWrapper HTMLParser NetDNS NetAddrIP DBFile HTTPDate MailDKIM
-    LWP IOSocketSSL DBI EncodeDetect IPCountry NetIdent Razor2ClientAgent MailSPF NetDNSResolverProgrammable ];
+  buildInputs = [ makeWrapper ] ++ (with perlPackages; [ HTMLParser NetDNS NetAddrIP DBFile HTTPDate MailDKIM
+    LWP IOSocketSSL DBI EncodeDetect IPCountry NetIdent Razor2ClientAgent MailSPF NetDNSResolverProgrammable ]);
 
   # Enabling 'taint' mode is desirable, but that flag disables support
   # for the PERL5LIB environment variable. Needs further investigation.
-  makeFlags = "PERL_BIN=${perl}/bin/perl PERL_TAINT=no";
+  makeFlags = "PERL_BIN=${perlPackages.perl}/bin/perl PERL_TAINT=no";
 
   makeMakerFlags = "CONFDIR=/homeless/shelter LOCALSTATEDIR=/var/lib/spamassassin";
 

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, which, coreutils, rrdtool, perl, perlPackages
+{ stdenv, fetchFromGitHub, makeWrapper, which, coreutils, rrdtool, perlPackages
 , python, ruby, jre, nettools, bc
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     coreutils
     rrdtool
     nettools
-    perl
+    perlPackages.perl
     perlPackages.ModuleBuild
     perlPackages.HTMLTemplate
     perlPackages.NetCIDR
@@ -60,8 +60,8 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   checkPhase = ''
-   export PERL5LIB="$PERL5LIB:${rrdtool}/lib/perl5/site_perl"
-   LC_ALL=C make -j1 test 
+   export PERL5LIB="$PERL5LIB:${rrdtool}/${perlPackages.perl.libPrefix}"
+   LC_ALL=C make -j1 test
   '';
 
   patches = [
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
   makeFlags = ''
     PREFIX=$(out)
     DESTDIR=$(out)
-    PERLLIB=$(out)/lib/perl5/site_perl
+    PERLLIB=$(out)/${perl.libPrefix}
     PERL=${perl}/bin/perl
     PYTHON=${python}/bin/python
     RUBY=${ruby}/bin/ruby
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
             *.jar) continue;;
         esac
         wrapProgram "$file" \
-          --set PERL5LIB "$out/lib/perl5/site_perl:${with perlPackages; stdenv.lib.makePerlPath [
+          --set PERL5LIB "$out/${perl.libPrefix}:${with perlPackages; makePerlPath [
                 LogLog4perl IOSocketInet6 Socket6 URI DBFile DateManip
                 HTMLTemplate FileCopyRecursive FCGI NetCIDR NetSNMP NetServer
                 ListMoreUtils TimeHiRes DBDPg LWP rrdtool

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -24,9 +24,8 @@ stdenv.mkDerivation rec {
 
   preConfigure =
     ''
-      perlversion=$(perl -e 'use Config; print $Config{version};')
       perlarchname=$(perl -e 'use Config; print $Config{archname};')
-      installFlags="INSTALLSITEARCH=$out/lib/perl5/site_perl/$perlversion/$perlarchname INSTALLSITEMAN3DIR=$out/share/man/man3"
+      installFlags="INSTALLSITEARCH=$out/${perl.libPrefix}/${perl.version}/$perlarchname INSTALLSITEMAN3DIR=$out/share/man/man3"
 
       # http://comments.gmane.org/gmane.network.net-snmp.user/32434
       substituteInPlace "man/Makefile.in" --replace 'grep -vE' '@EGREP@ -v'

--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchurl, autoreconfHook, makeWrapper
-, perl, DBDsybase, NetSNMP, coreutils, gnused, gnugrep }:
+, perlPackages, coreutils, gnused, gnugrep }:
 
 let
   glplugin = fetchFromGitHub {
@@ -12,7 +12,7 @@ let
   generic = { pname, version, sha256, description, buildInputs, ... }:
   let
     name' = "${stdenv.lib.replaceStrings [ "-" ] [ "_" ] "${pname}"}-${version}";
-  in perl.stdenv.mkDerivation {
+  in stdenv.mkDerivation {
     name = "${pname}-${version}";
 
     src = fetchurl {
@@ -20,7 +20,7 @@ let
       inherit sha256;
     };
 
-    buildInputs = [ perl ] ++ buildInputs;
+    buildInputs = [ perlPackages.perl ] ++ buildInputs;
 
     nativeBuildInputs = [ autoreconfHook makeWrapper ];
 
@@ -58,7 +58,7 @@ in {
     version     = "2.6.4.14";
     sha256      = "0w6gybrs7imx169l8740s0ax3adya867fw0abrampx59mnsj5pm1";
     description = "Check plugin for Microsoft SQL Server.";
-    buildInputs = [ DBDsybase ];
+    buildInputs = [ perlPackages.DBDsybase ];
   };
 
   check-nwc-health = generic {
@@ -66,7 +66,7 @@ in {
     version     = "7.0.1.3";
     sha256      = "0rgd6zgd7kplx3z72n8zbzwkh8vnd83361sk9ibh6ng78sds1sl5";
     description = "Check plugin for network equipment.";
-    buildInputs = [ NetSNMP ];
+    buildInputs = [ perlPackages.NetSNMP ];
   };
 
   check-ups-health = generic {
@@ -74,6 +74,6 @@ in {
     version     = "2.8.2.2";
     sha256      = "1gc2wjsymay2vk5ywc1jj9cvrbhs0fs851x8l4nc75df2g75v521";
     description = "Check plugin for UPSs.";
-    buildInputs = [ NetSNMP ];
+    buildInputs = [ perlPackages.NetSNMP ];
   };
 }

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, makeWrapper
-, perl, perlPackages, flac, faad2, sox, lame, monkeysAudio, wavpack }:
+, perlPackages, flac, faad2, sox, lame, monkeysAudio, wavpack }:
 
 perlPackages.buildPerlPackage rec {
   name = "slimserver-${version}";
@@ -12,7 +12,7 @@ perlPackages.buildPerlPackage rec {
 
   buildInputs = [
     makeWrapper
-    perl
+    perlPackages.perl
     perlPackages.AnyEvent
     perlPackages.AudioScan
     perlPackages.CarpClan
@@ -77,9 +77,9 @@ perlPackages.buildPerlPackage rec {
 
   buildPhase = ''
     mv lib tmp
-    mkdir -p lib/perl5/site_perl
-    mv CPAN_used/* lib/perl5/site_perl
-    cp -rf tmp/* lib/perl5/site_perl
+    mkdir -p ${perlPackages.perl.libPrefix}
+    mv CPAN_used/* ${perlPackages.perl.libPrefix}
+    cp -rf tmp/* ${perlPackages.perl.libPrefix}
   '';
 
   doCheck = false;

--- a/pkgs/tools/backup/store-backup/default.nix
+++ b/pkgs/tools/backup/store-backup/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
     for p in $out/bin/*
       do wrapProgram "$p" \
-      --prefix PERL5LIB ":" "${perlPackages.DBFile}/lib/perl5/site_perl" \
+      --prefix PERL5LIB ":" "${perlPackages.DBFile}/${perlPackages.perl.libPrefix}" \
       --prefix PATH ":" "${stdenv.lib.makeBinPath [ which bzip2 ]}"
     done
 

--- a/pkgs/tools/filesystems/file-rename/default.nix
+++ b/pkgs/tools/filesystems/file-rename/default.nix
@@ -12,7 +12,7 @@ perlPackages.buildPerlPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/rename \
-      --prefix PERL5LIB : $out/lib/perl5/site_perl
+      --prefix PERL5LIB : $out/${perlPackages.perl.libPrefix}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/fgallery/default.nix
+++ b/pkgs/tools/graphics/fgallery/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, unzip, makeWrapper, perl, ImageExifTool
-, CpanelJSONXS, coreutils, zip, imagemagick, pngcrush, lcms2
+{ stdenv, fetchurl, unzip, makeWrapper, perlPackages
+, coreutils, zip, imagemagick, pngcrush, lcms2
 , facedetect, fbida }:
 
 # TODO: add optional dependencies (snippet from fgallery source):
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "18wlvqbxcng8pawimbc8f2422s8fnk840hfr6946lzsxr0ijakvf";
   };
 
-  buildInputs = [ unzip makeWrapper perl ImageExifTool CpanelJSONXS ];
+  buildInputs = [ unzip makeWrapper ] ++ (with perlPackages; [ perl ImageExifTool CpanelJSONXS ]);
 
   installPhase = ''
     mkdir -p "$out/bin"

--- a/pkgs/tools/misc/arp-scan/default.nix
+++ b/pkgs/tools/misc/arp-scan/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     for name in get-{oui,iab}; do
-      wrapProgram "$out/bin/$name" --set PERL5LIB "${stdenv.lib.makePerlPath perlModules }"
+      wrapProgram "$out/bin/$name" --set PERL5LIB "${perlPackages.makePerlPath perlModules }"
     done;
   '';
 

--- a/pkgs/tools/misc/cloc/default.nix
+++ b/pkgs/tools/misc/cloc/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, perl
-, AlgorithmDiff, ParallelForkManager, RegexpCommon
-}:
+{ stdenv, fetchFromGitHub, makeWrapper, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "cloc-${version}";
@@ -17,9 +15,9 @@ stdenv.mkDerivation rec {
     sourceRoot=$(echo */Unix)
   '';
 
-  buildInputs = [
-    makeWrapper perl AlgorithmDiff ParallelForkManager RegexpCommon
-  ];
+  buildInputs = [ makeWrapper ] ++ (with perlPackages; [
+    perl AlgorithmDiff ParallelForkManager RegexpCommon
+  ]);
 
   makeFlags = [ "prefix=" "DESTDIR=$(out)" "INSTALL=install" ];
 

--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -1,5 +1,5 @@
-{stdenv, fetchurl, perl, CryptSSLeay, LWP, unzip, xz, dpkg, TimeDate, DBFile
-, FileDesktopEntry, libxslt, docbook_xsl, makeWrapper
+{stdenv, fetchurl, unzip, xz, dpkg,
+, libxslt, docbook_xsl, makeWrapper
 , python3Packages
 , perlPackages, curl, gnupg, diffutils
 , sendmailPath ? "/run/wrappers/bin/sendmail"
@@ -16,10 +16,8 @@ in stdenv.mkDerivation rec {
     sha256 = "0xy1nvqrnifx46g8ch69pk31by0va6hn10wpi1fkrsrgncanjjh1";
   };
 
-  buildInputs = [ perl CryptSSLeay LWP unzip xz dpkg TimeDate DBFile 
-    FileDesktopEntry libxslt python setuptools makeWrapper
-    perlPackages.ParseDebControl perlPackages.LWPProtocolHttps
-    curl gnupg diffutils ];
+  buildInputs = [ unzip xz dpkg libxslt python setuptools makeWrapper curl gnupg diffutils ] ++
+    (with perlPackages; [ perl CryptSSLeay LWP TimeDate DBFile FileDesktopEntry ParseDebControl LWPProtocolHttps ]);
 
   preConfigure = ''
     export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${dpkg}";

--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, libxml2, libxslt, docbook-xsl, docbook_xml_dtd_44, perl, IPCRun, TimeDate, TimeDuration, makeWrapper, darwin }:
+{ stdenv, fetchgit, libxml2, libxslt, docbook-xsl, docbook_xml_dtd_44, perlPackages, makeWrapper, darwin }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxml2 libxslt docbook-xsl docbook_xml_dtd_44 makeWrapper ]
     ++ optional stdenv.isDarwin darwin.cctools;
 
-  propagatedBuildInputs = [ perl IPCRun TimeDate TimeDuration ];
+  propagatedBuildInputs = with perlPackages; [ perl IPCRun TimeDate TimeDuration ];
 
   buildFlags = "CC=cc";
   installFlags = "PREFIX=$(out)";

--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # for munin and rrdtool support
-    mkdir -p $out/lib/perl5/site_perl/
-    mv $out/lib/perl/5* $out/lib/perl5/site_perl/
+    mkdir -p $out/${perl.libPrefix}
+    mv $out/lib/perl/5* $out/${perl.libPrefix}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/infiniband-diags/default.nix
+++ b/pkgs/tools/networking/infiniband-diags/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  configureFlags = [ "--with-perl-installdir=\${out}/lib/perl5/site_perl" "--sbindir=\${out}/bin" ];
+  configureFlags = [ "--with-perl-installdir=\${out}/${perl.libPrefix}" "--sbindir=\${out}/bin" ];
 
   postInstall = ''
     rmdir $out/var/run $out/var
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     for pls in $out/bin/{ibfindnodesusing.pl,ibidsverify.pl}; do
       echo "wrapping $pls"
-      wrapProgram $pls --prefix PERL5LIB : "$out/lib/perl5/site_perl"
+      wrapProgram $pls --prefix PERL5LIB : "$out/${perl.libPrefix}"
     done
   '';
 

--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig, IOTty
-, makeWrapper, perl, openssl, autoreconfHook, openssh, bash-completion
+{ lib, stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig,
+, makeWrapper, perlPackages, openssl, autoreconfHook, openssh, bash-completion
 , libutempter ? null, withUtempter ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ protobuf ncurses zlib IOTty makeWrapper perl openssl bash-completion ] ++ lib.optional withUtempter libutempter;
+  buildInputs = [ protobuf ncurses zlib makeWrapper openssl bash-completion ]
+    ++ (with perlPackages; [ perl IOTty ])
+    ++ lib.optional withUtempter libutempter;
 
   patches = [ ./ssh_path.patch ./utempter_path.patch ];
   postPatch = ''

--- a/pkgs/tools/networking/slimrat/default.nix
+++ b/pkgs/tools/networking/slimrat/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl, WWWMechanize, LWP, makeWrapper}:
+{stdenv, fetchurl, perlPackages, makeWrapper}:
 
 stdenv.mkDerivation {
   name = "slimrat-1.0";
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     sha256 = "139b71d45k4b1y47iq62a9732cnaqqbh8s4knkrgq2hx0jxpsk5a";
   };
 
-  buildInputs = [ perl WWWMechanize LWP makeWrapper ];
+  buildInputs = [ makeWrapper ] ++ (with perlPackages; [ perl WWWMechanize LWP ]);
 
   patchPhase = ''
     sed -e 's,#!.*,#!${perl}/bin/perl,' -i src/{slimrat,slimrat-gui}

--- a/pkgs/tools/networking/smokeping/default.nix
+++ b/pkgs/tools/networking/smokeping/default.nix
@@ -1,8 +1,4 @@
-{ stdenv, fetchurl, fping, rrdtool, FCGI, CGI
-, CGIFast, ConfigGrammar, DigestHMAC, NetTelnet
-, NetOpenSSH, NetSNMP, LWP, IOTty, perl, NetDNS
-, perlldap
-}:
+{ stdenv, fetchurl, fping, rrdtool, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "smokeping-${version}";
@@ -11,9 +7,10 @@ stdenv.mkDerivation rec {
     url = "https://oss.oetiker.ch/smokeping/pub/smokeping-${version}.tar.gz";
     sha256 = "1p9hpa2zs33p7hzrds80kwrm5255s0869v3s3qmsyx2sx63c7czj";
   };
-  propagatedBuildInputs = [
-    rrdtool FCGI CGI CGIFast ConfigGrammar DigestHMAC NetTelnet NetOpenSSH
-      NetSNMP LWP IOTty fping perl NetDNS perlldap ];
+  propagatedBuildInputs = [ rrdtool ] ++
+    (with perlPackages; [ perl FCGI CGI CGIFast ConfigGrammar DigestHMAC NetTelnet
+      NetOpenSSH NetSNMP LWP IOTty fping NetDNS perlldap ]);
+
   postInstall = ''
     mv $out/htdocs/smokeping.fcgi.dist $out/htdocs/smokeping.fcgi
   '';

--- a/pkgs/tools/networking/swaks/default.nix
+++ b/pkgs/tools/networking/swaks/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     mv swaks $out/bin/
 
     wrapProgram $out/bin/swaks --set PERL5LIB \
-      "${with perlPackages; stdenv.lib.makePerlPath [
+      "${with perlPackages; makePerlPath [
         NetSSLeay AuthenSASL NetDNS IOSocketInet6
       ]}"
   '';

--- a/pkgs/tools/networking/swec/default.nix
+++ b/pkgs/tools/networking/swec/default.nix
@@ -1,5 +1,4 @@
-{ fetchurl, stdenv, makeWrapper, perl, LWP, URI, HTMLParser
-, HTTPServerSimple, Parent }:
+{ fetchurl, stdenv, makeWrapper, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "swec-0.4";
@@ -9,13 +8,13 @@ stdenv.mkDerivation rec {
     sha256 = "1m3971z4z1wr0paggprfz0n8ng8vsnkc9m6s3bdplgyz7qjk6jwx";
   };
 
-  buildInputs = [ makeWrapper perl LWP URI HTMLParser ];
-  checkInputs = [ HTTPServerSimple Parent ];
+  buildInputs = [ makeWrapper perlPackages.perl perlPackages.LWP perlPackages.URI perlPackages.HTMLParser ];
+  checkInputs = [ perlPackages.HTTPServerSimple perlPackages.Parent ];
 
   configurePhase = ''
     for i in swec tests/{runTests,testServer}
     do
-      sed -i "$i" -e's|/usr/bin/perl|${perl}/bin/perl|g'
+      sed -i "$i" -e's|/usr/bin/perl|${perlPackages.perl}/bin/perl|g'
     done
   '';
 
@@ -29,9 +28,7 @@ stdenv.mkDerivation rec {
     sed -i "$out/bin/swec" -e"s|realpath(\$0)|'$out/share/${name}/swec'|g"
 
     wrapProgram "$out/bin/swec" \
-      --prefix PERL5LIB : \
-      ${stdenv.lib.concatStringsSep ":"
-          (map (x: "${x}/lib/perl5/site_perl") [ LWP URI HTMLParser ])}
+      --prefix PERL5LIB : ${with perlPackages; makePerlPath [ LWP URI HTMLParser ]}
   '';
 
   doCheck = true;

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, gettext, pkgconfig, perl
+{ stdenv, fetchurl, gettext, pkgconfig, perlPackages
 , libidn2, zlib, pcre, libuuid, libiconv, libintl
-, IOSocketSSL, LWP, python3, lzip
+, python3, lzip
 , libpsl ? null
 , openssl ? null }:
 
@@ -28,9 +28,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  nativeBuildInputs = [ gettext pkgconfig perl lzip libiconv libintl ];
+  nativeBuildInputs = [ gettext pkgconfig perlPackages.perl lzip libiconv libintl ];
   buildInputs = [ libidn2 zlib pcre libuuid ]
-    ++ stdenv.lib.optionals doCheck [ IOSocketSSL LWP python3 ]
+    ++ stdenv.lib.optionals doCheck [ perlPackages.IOSocketSSL perlPackages.LWP python3 ]
     ++ stdenv.lib.optional (openssl != null) openssl
     ++ stdenv.lib.optional (libpsl != null) libpsl
     ++ stdenv.lib.optional stdenv.isDarwin perl;

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, lib, fetchzip, pkgconfig, cmake, perl, curl, gtest, lzma, bzip2 , lz4
+{ stdenv, lib, fetchzip, pkgconfig, cmake, perlPackages, curl, gtest, lzma, bzip2, lz4
 , db, dpkg, libxslt, docbook_xsl, docbook_xml_dtd_45
 
 # used when WITH_DOC=ON
 , w3m
-, Po4a
 , doxygen
 
 # used when WITH_NLS=ON
@@ -27,15 +26,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [
-    cmake perl curl gtest lzma bzip2 lz4 db dpkg libxslt.bin
+    cmake perlPackages.perl curl gtest lzma bzip2 lz4 db dpkg libxslt.bin
   ] ++ lib.optionals withDocs [
-    doxygen Po4a w3m docbook_xml_dtd_45
+    doxygen perlPackages.Po4a w3m docbook_xml_dtd_45
   ] ++ lib.optionals withNLS [
     gettext
   ];
 
   preConfigure = ''
-    export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${Po4a}/lib/perl5";
+    export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${perlPackages.Po4a}/lib/perl5";
 
     cmakeFlagsArray+=(
       -DBERKELEY_DB_INCLUDE_DIRS=${db.dev}/include

--- a/pkgs/tools/security/kpcli/default.nix
+++ b/pkgs/tools/security/kpcli/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     chmod +x $out/share/kpcli.pl
 
     makeWrapper $out/share/kpcli.pl $out/bin/kpcli --set PERL5LIB \
-      "${with perlPackages; stdenv.lib.makePerlPath ([
+      "${with perlPackages; makePerlPath ([
          CaptureTiny Clipboard Clone CryptRijndael SortNaturally TermReadKey TermShellUI FileKeePass TermReadLineGnu XMLParser
       ] ++ stdenv.lib.optional stdenv.isDarwin MacPasteboard)}"
   '';

--- a/pkgs/tools/security/monkeysphere/default.nix
+++ b/pkgs/tools/security/monkeysphere/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   postFixup =
     let wrapperArgs = runtimeDeps:
           "--prefix PERL5LIB : "
-          + (with perlPackages; stdenv.lib.makePerlPath [
+          + (with perlPackages; makePerlPath [
               CryptOpenSSLRSA
               CryptOpenSSLBignum
             ])

--- a/pkgs/tools/security/pcsctools/default.nix
+++ b/pkgs/tools/security/pcsctools/default.nix
@@ -1,6 +1,5 @@
 { stdenv, lib, fetchurl, makeWrapper, pkgconfig, udev, dbus, pcsclite
-, wget, coreutils
-, perl, pcscperl, Glib, Gtk2, Pango, Cairo
+, wget, coreutils, perlPackages
 }:
 
 let deps = lib.makeBinPath [ wget coreutils ];
@@ -13,17 +12,17 @@ in stdenv.mkDerivation rec {
     sha256 = "050x3yqd5ywl385zai3k1zhbm2lz1f5ksalfpm9hd86s50f03ans";
   };
 
-  buildInputs = [ udev dbus perl pcsclite ];
+  buildInputs = [ udev dbus perlPackages.perl pcsclite ];
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
 
   postInstall = ''
     wrapProgram $out/bin/scriptor \
-      --set PERL5LIB "${lib.makePerlPath [ pcscperl ]}"
+      --set PERL5LIB "${perlPackages.makePerlPath [ pcscperl ]}"
     wrapProgram $out/bin/gscriptor \
-      --set PERL5LIB "${lib.makePerlPath [ pcscperl Glib Gtk2 Pango Cairo ]}"
+      --set PERL5LIB "${perlPackages.makePerlPath [ pcscperl Glib Gtk2 Pango Cairo ]}"
     wrapProgram $out/bin/ATR_analysis \
-      --set PERL5LIB "${lib.makePerlPath [ pcscperl ]}"
+      --set PERL5LIB "${perlPackages.makePerlPath [ pcscperl ]}"
     wrapProgram $out/bin/pcsc_scan \
       --set PATH "$out/bin:${deps}"
   '';

--- a/pkgs/tools/security/signing-party/default.nix
+++ b/pkgs/tools/security/signing-party/default.nix
@@ -122,14 +122,14 @@ in stdenv.mkDerivation rec {
     # scripts)
 
     wrapProgram $out/bin/caff --set PERL5LIB \
-      ${with perlPackages; stdenv.lib.makePerlPath ([
+      ${with perlPackages; makePerlPath ([
         TextTemplate MIMETools MailTools TimeDate NetIDNEncode ]
         ++ GnuPGInterfaceRuntimeDependencies)} \
       --prefix PATH ":" \
       "${stdenv.lib.makeBinPath [ nettools gnupg1 ]}"
 
     wrapProgram $out/bin/gpg-key2latex --set PERL5LIB \
-      ${stdenv.lib.makePerlPath GnuPGInterfaceRuntimeDependencies} \
+      ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
       "${stdenv.lib.makeBinPath [ gnupg1 libpaper ]}"
 
@@ -140,7 +140,7 @@ in stdenv.mkDerivation rec {
       "${stdenv.lib.makeBinPath [ gnupg1 qprint ]}"
 
     wrapProgram $out/bin/gpgdir --set PERL5LIB \
-      ${with perlPackages; stdenv.lib.makePerlPath ([
+      ${with perlPackages; makePerlPath ([
         TermReadKey ]
         ++ GnuPGInterfaceRuntimeDependencies)} \
       --prefix PATH ":" \
@@ -155,7 +155,7 @@ in stdenv.mkDerivation rec {
 #    wrapProgram $out/bin/gpgparticipants-prefill
 
     wrapProgram $out/bin/gpgsigs --set PERL5LIB \
-      ${stdenv.lib.makePerlPath GnuPGInterfaceRuntimeDependencies} \
+      ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
       "${stdenv.lib.makeBinPath [ gnupg1 ]}"
 
@@ -171,12 +171,12 @@ in stdenv.mkDerivation rec {
       "${stdenv.lib.makeBinPath [ gnupg1 ]}"
 
     wrapProgram $out/bin/pgp-clean --set PERL5LIB \
-      ${stdenv.lib.makePerlPath GnuPGInterfaceRuntimeDependencies} \
+      ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
       "${stdenv.lib.makeBinPath [ gnupg1 ]}"
 
     wrapProgram $out/bin/pgp-fixkey --set PERL5LIB \
-      ${stdenv.lib.makePerlPath GnuPGInterfaceRuntimeDependencies} \
+      ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
       "${stdenv.lib.makeBinPath [ gnupg1 ]}"
 
@@ -189,7 +189,7 @@ in stdenv.mkDerivation rec {
 #    wrapProgram $out/bin/sig2dot
 
     wrapProgram $out/bin/springgraph --set PERL5LIB \
-      ${with perlPackages; stdenv.lib.makePerlPath [ GD ]}
+      ${with perlPackages; makePerlPath [ GD ]}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/logcheck/default.nix
+++ b/pkgs/tools/system/logcheck/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lockfileProgs, perl, mimeConstruct }:
+{ stdenv, fetchurl, lockfileProgs, perlPackages }:
 
 stdenv.mkDerivation rec {
   name = "logcheck-${version}";
@@ -16,13 +16,13 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    substituteInPlace src/logtail --replace "/usr/bin/perl" "${perl}/bin/perl"
-    substituteInPlace src/logtail2 --replace "/usr/bin/perl" "${perl}/bin/perl"
+    substituteInPlace src/logtail --replace "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
+    substituteInPlace src/logtail2 --replace "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
 
     sed -i -e 's|! -f /usr/bin/lockfile|! -f ${lockfileProgs}/bin/lockfile|' \
            -e 's|^\([ \t]*\)lockfile-|\1${lockfileProgs}/bin/lockfile-|' \
            -e "s|/usr/sbin/logtail2|$out/sbin/logtail2|" \
-           -e 's|mime-construct|${mimeConstruct}/bin/mime-construct|' \
+           -e 's|mime-construct|${perlPackages.mimeConstruct}/bin/mime-construct|' \
            -e 's|\$(run-parts --list "\$dir")|"$dir"/*|' src/logcheck
   '';
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     "SBINDIR=sbin"
     "BINDIR=bin"
     "SHAREDIR=share/logtail/detectrotate"
- ];
+  ];
 
   meta = with stdenv.lib; {
     description = "Mails anomalies in the system logfiles to the administrator";
@@ -44,6 +44,5 @@ stdenv.mkDerivation rec {
     homepage = http://logcheck.alioth.debian.org/;
     license = licenses.gpl2;
     maintainers = [ maintainers.bluescreen303 ];
-    
   };
 }

--- a/pkgs/tools/text/mb2md/default.nix
+++ b/pkgs/tools/text/mb2md/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, perl, makeWrapper, perlPackages }:
+{ stdenv, lib, fetchurl, makeWrapper, perlPackages }:
 
 let
   perlDeps = with perlPackages; [ TimeDate ];
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ perl ];
+  buildInputs = [ perlPackages.perl ];
 
   unpackPhase = ''
     sourceRoot=.
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/mb2md \
-      --set PERL5LIB "${lib.makePerlPath perlDeps}"
+      --set PERL5LIB "${perlPackages.makePerlPath perlDeps}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/text/namazu/default.nix
+++ b/pkgs/tools/text/namazu/default.nix
@@ -11,14 +11,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ];
 
   # First install the `File::MMagic' Perl module.
-  # !!! this shouldn't refer to Perl 5.10.0!
   preConfigure = ''
-    ( cd File-MMagic &&				\
-      perl Makefile.PL				\
-        LIB="$out/lib/perl5/site_perl/5.10.0"	\
-        INSTALLSITEMAN3DIR="$out/man" &&	\
+    ( cd File-MMagic &&                              \
+      perl Makefile.PL                               \
+        LIB="$out/${perl.libPrefix}/${perl.version}" \
+        INSTALLSITEMAN3DIR="$out/man" &&             \
       make && make install )
-    export PERL5LIB="$out/lib/perl5/site_perl/5.10.0:$PERL5LIB"
+    export PERL5LIB="$out/${perl.libPrefix}/${perl.version}:$PERL5LIB"
   '';
 
   # FIXME: The `tests/namazu-6' test fails on GNU/Linux, presumably because

--- a/pkgs/tools/text/schema2ldif/default.nix
+++ b/pkgs/tools/text/schema2ldif/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, perl, perlPackages }: stdenv.mkDerivation rec {
+{ stdenv, fetchurl, makeWrapper, perlPackages }: stdenv.mkDerivation rec {
   name = "schema2ldif-${version}";
   version = "1.3";
 
@@ -7,7 +7,7 @@
     sha256 = "00cd9xx9g0mnnfn5lvay3vg166z84jla0ya1x34ljdc8bflxsr9a";
   };
 
-  buildInputs = [ perl ];
+  buildInputs = [ perlPackages.perl ];
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
@@ -18,7 +18,7 @@
     gzip -c man/ldap-schema-manager.1 > $out/share/man/man1/ldap-schema-manager.1.gz
 
     wrapProgram $out/bin/schema2ldif \
-       --prefix PERL5PATH : "${stdenv.lib.makePerlPath [ perlPackages.GetoptLong perlPackages.PodUsage ]}"
+       --prefix PERL5PATH : "${perlPackages.makePerlPath [ perlPackages.GetoptLong perlPackages.PodUsage ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/typesetting/docbook2odf/default.nix
+++ b/pkgs/tools/typesetting/docbook2odf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, makeWrapper, zip, libxslt, PerlMagick }:
+{ stdenv, fetchurl, perlPackages, makeWrapper, zip, libxslt }:
 
 stdenv.mkDerivation rec {
   name = "docbook2odf-0.244";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "10k44g0qqa37k30pfj8vz95j6zdzz0nmnqjq1lyahfs2h4glzgwb";
   };
 
-  buildInputs = [ perl makeWrapper ];
+  buildInputs = [ perlPackages.perl makeWrapper ];
 
   installPhase = ''
     mkdir -p "$out/bin/"
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram "$out/bin/docbook2odf" \
       --prefix PATH : "${stdenv.lib.makeBinPath [ zip libxslt ]}" \
-      --prefix PERL5PATH : "${stdenv.lib.makePerlPath [PerlMagick]}"
+      --prefix PERL5PATH : "${perlPackages.makePerlPath [ perlPackages.PerlMagick ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/typesetting/docbook2x/default.nix
+++ b/pkgs/tools/typesetting/docbook2x/default.nix
@@ -1,5 +1,4 @@
-{ fetchurl, stdenv, texinfo, perl
-, XMLSAX, XMLSAXBase, XMLParser, XMLNamespaceSupport
+{ fetchurl, stdenv, texinfo, perlPackages
 , groff, libxml2, libxslt, gnused, libiconv, opensp
 , docbook_xml_dtd_43
 , makeWrapper }:
@@ -16,8 +15,8 @@ stdenv.mkDerivation rec {
   # writes its output to stdout instead of creating a file.
   patches = [ ./db2x_texixml-to-stdout.patch ];
 
-  buildInputs = [ perl texinfo groff libxml2 libxslt makeWrapper
-                  XMLSAX XMLParser XMLNamespaceSupport opensp libiconv
+  buildInputs = [ texinfo groff libxml2 libxslt makeWrapper opensp libiconv
+                  perlPackages.perl perlPackages.XMLSAX perlPackages.XMLParser perlPackages.XMLNamespaceSupport
                 ];
 
   postConfigure = ''
@@ -36,10 +35,8 @@ stdenv.mkDerivation rec {
     do
       # XXX: We work around the fact that `wrapProgram' doesn't support
       # spaces below by inserting escaped backslashes.
-      wrapProgram $out/bin/$i --prefix PERL5LIB : \
-        "${XMLSAX}/lib/perl5/site_perl:${XMLSAXBase}/lib/perl5/site_perl:${XMLParser}/lib/perl5/site_perl" \
-        --prefix PERL5LIB : \
-        "${XMLNamespaceSupport}/lib/perl5/site_perl" \
+      wrapProgram $out/bin/$i \
+        --prefix PERL5LIB : ${with perlPackages; makeFullPerlPath [XMLSAX XMLParser XMLNamespaceSupport]}
         --prefix XML_CATALOG_FILES "\ " \
         "$out/share/docbook2X/dtd/catalog.xml\ $out/share/docbook2X/xslt/catalog.xml\ ${docbook_xml_dtd_43}/xml/dtd/docbook/catalog.xml"
     done

--- a/pkgs/tools/virtualization/nixos-container/default.nix
+++ b/pkgs/tools/virtualization/nixos-container/default.nix
@@ -1,11 +1,11 @@
-{ substituteAll, perl, perlPackages, shadow, utillinux }:
+{ substituteAll, perlPackages, shadow, utillinux }:
 
 substituteAll {
     name = "nixos-container";
     dir = "bin";
     isExecutable = true;
     src = ./nixos-container.pl;
-    perl = "${perl}/bin/perl -I${perlPackages.FileSlurp}/lib/perl5/site_perl";
+    perl = "${perlPackages.perl}/bin/perl -I${perlPackages.FileSlurp}/${perlPackages.perl.libPrefix}";
     su = "${shadow.su}/bin/su";
     inherit utillinux;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -669,7 +669,6 @@ in
   apg = callPackage ../tools/security/apg { };
 
   apt = callPackage ../tools/package-management/apt {
-    inherit (perlPackages) Po4a;
     # include/c++/6.4.0/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
     stdenv = overrideCC stdenv gcc5;
   };
@@ -2068,9 +2067,7 @@ in
 
   client-ip-echo = callPackage ../servers/misc/client-ip-echo { };
 
-  cloc = callPackage ../tools/misc/cloc {
-    inherit (perlPackages) perl AlgorithmDiff ParallelForkManager RegexpCommon;
-  };
+  cloc = callPackage ../tools/misc/cloc { };
 
   cloog = callPackage ../development/libraries/cloog {
     isl = isl_0_14;
@@ -2199,9 +2196,7 @@ in
 
   debianutils = callPackage ../tools/misc/debianutils { };
 
-  debian-devscripts = callPackage ../tools/misc/debian-devscripts {
-    inherit (perlPackages) CryptSSLeay LWP TimeDate DBFile FileDesktopEntry;
-  };
+  debian-devscripts = callPackage ../tools/misc/debian-devscripts { };
 
   debootstrap = callPackage ../tools/misc/debootstrap { };
 
@@ -2303,15 +2298,11 @@ in
 
   dmg2img = callPackage ../tools/misc/dmg2img { };
 
-  docbook2odf = callPackage ../tools/typesetting/docbook2odf {
-    inherit (perlPackages) PerlMagick;
-  };
+  docbook2odf = callPackage ../tools/typesetting/docbook2odf { };
 
   doas = callPackage ../tools/security/doas { };
 
-  docbook2x = callPackage ../tools/typesetting/docbook2x {
-    inherit (perlPackages) XMLSAX XMLSAXBase XMLParser XMLNamespaceSupport;
-  };
+  docbook2x = callPackage ../tools/typesetting/docbook2x { };
 
   docbook2mdoc = callPackage ../tools/misc/docbook2mdoc { };
 
@@ -2545,9 +2536,7 @@ in
 
   ext4magic = callPackage ../tools/filesystems/ext4magic { };
 
-  extract_url = callPackage ../applications/misc/extract_url {
-    inherit (perlPackages) MIMEtools HTMLParser CursesUI URIFind;
-  };
+  extract_url = callPackage ../applications/misc/extract_url { };
 
   extundelete = callPackage ../tools/filesystems/extundelete { };
 
@@ -2629,9 +2618,7 @@ in
 
   ferm = callPackage ../tools/networking/ferm { };
 
-  fgallery = callPackage ../tools/graphics/fgallery {
-    inherit (perlPackages) ImageExifTool CpanelJSONXS;
-  };
+  fgallery = callPackage ../tools/graphics/fgallery { };
 
   flannel = callPackage ../tools/networking/flannel { };
 
@@ -4013,9 +4000,7 @@ in
 
   localtime = callPackage ../tools/system/localtime { };
 
-  logcheck = callPackage ../tools/system/logcheck {
-    inherit (perlPackages) mimeConstruct;
-  };
+  logcheck = callPackage ../tools/system/logcheck { };
 
   logmein-hamachi = callPackage ../tools/networking/logmein-hamachi { };
 
@@ -4252,13 +4237,10 @@ in
   monit = callPackage ../tools/system/monit { };
 
   moreutils = callPackage ../tools/misc/moreutils {
-    inherit (perlPackages) IPCRun TimeDate TimeDuration;
     docbook-xsl = docbook_xsl;
   };
 
-  mosh = callPackage ../tools/networking/mosh {
-    inherit (perlPackages) IOTty;
-  };
+  mosh = callPackage ../tools/networking/mosh { };
 
   motuclient = callPackage ../applications/science/misc/motu-client { };
 
@@ -4764,9 +4746,7 @@ in
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
-  pcsctools = callPackage ../tools/security/pcsctools {
-    inherit (perlPackages) pcscperl Glib Gtk2 Pango Cairo;
-  };
+  pcsctools = callPackage ../tools/security/pcsctools { };
 
   pcsc-cyberjack = callPackage ../tools/security/pcsc-cyberjack { };
 
@@ -5443,9 +5423,7 @@ in
 
   sleepyhead = callPackage ../applications/misc/sleepyhead {};
 
-  slimrat = callPackage ../tools/networking/slimrat {
-    inherit (perlPackages) WWWMechanize LWP;
-  };
+  slimrat = callPackage ../tools/networking/slimrat { };
 
   slsnif = callPackage ../tools/misc/slsnif { };
 
@@ -5622,9 +5600,7 @@ in
 
   swagger-codegen = callPackage ../tools/networking/swagger-codegen { };
 
-  swec = callPackage ../tools/networking/swec {
-    inherit (perlPackages) LWP URI HTMLParser HTTPServerSimple Parent;
-  };
+  swec = callPackage ../tools/networking/swec { };
 
   swfdec = callPackage ../tools/graphics/swfdec {};
 
@@ -5965,10 +5941,7 @@ in
 
   vcftools = callPackage ../applications/science/biology/vcftools { };
 
-  vcsh = callPackage ../applications/version-management/vcsh {
-    inherit (perlPackages) ShellCommand TestMost TestDifferences TestDeep
-      TestException TestWarn;
-  };
+  vcsh = callPackage ../applications/version-management/vcsh { };
 
   vcstool = callPackage ../development/tools/vcstool { };
 
@@ -6274,7 +6247,6 @@ in
   weighttp = callPackage ../tools/networking/weighttp { };
 
   wget = callPackage ../tools/networking/wget {
-    inherit (perlPackages) IOSocketSSL LWP;
     libpsl = null;
   };
 
@@ -8411,16 +8383,12 @@ in
   };
 
   creduce = callPackage ../development/tools/misc/creduce {
-    inherit (perlPackages) perl
-      ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey;
     inherit (llvmPackages_6) llvm clang-unwrapped;
   };
 
   cscope = callPackage ../development/tools/misc/cscope { };
 
-  csmith = callPackage ../development/tools/misc/csmith {
-    inherit (perlPackages) perl SysCPU;
-  };
+  csmith = callPackage ../development/tools/misc/csmith { };
 
   csslint = callPackage ../development/web/csslint { };
 
@@ -8630,9 +8598,7 @@ in
 
   hcloud = callPackage ../development/tools/hcloud { };
 
-  help2man = callPackage ../development/tools/misc/help2man {
-    inherit (perlPackages) LocaleGettext;
-  };
+  help2man = callPackage ../development/tools/misc/help2man { };
 
   heroku = callPackage ../development/tools/heroku {
     nodejs = nodejs-10_x;
@@ -8650,9 +8616,7 @@ in
 
   icmake = callPackage ../development/tools/build-managers/icmake { };
 
-  iconnamingutils = callPackage ../development/tools/misc/icon-naming-utils {
-    inherit (perlPackages) XMLSimple;
-  };
+  iconnamingutils = callPackage ../development/tools/misc/icon-naming-utils { };
 
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
     llvmPackages = llvmPackages_6;
@@ -10185,9 +10149,7 @@ in
 
   hiredis = callPackage ../development/libraries/hiredis { };
 
-  hivex = callPackage ../development/libraries/hivex {
-    inherit (perlPackages) IOStringy;
-  };
+  hivex = callPackage ../development/libraries/hivex { };
 
   hound = callPackage ../development/tools/misc/hound { };
 
@@ -10812,7 +10774,6 @@ in
 
   libguestfs-appliance = callPackage ../development/libraries/libguestfs/appliance.nix {};
   libguestfs = callPackage ../development/libraries/libguestfs {
-    inherit (perlPackages) libintl_perl GetoptLong SysVirt;
     appliance = libguestfs-appliance;
   };
 
@@ -13343,16 +13304,12 @@ in
 
   diod = callPackage ../servers/diod { lua = lua5_1; };
 
-  dkimproxy = callPackage ../servers/mail/dkimproxy {
-    inherit (perlPackages) Error MailDKIM MIMETools NetServer;
-  };
+  dkimproxy = callPackage ../servers/mail/dkimproxy { };
 
   dovecot = callPackage ../servers/mail/dovecot { };
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };
 
-  dspam = callPackage ../servers/mail/dspam {
-    inherit (perlPackages) libnet;
-  };
+  dspam = callPackage ../servers/mail/dspam { };
 
   etcd = callPackage ../servers/etcd { };
 
@@ -13681,7 +13638,7 @@ in
 
   monitoring-plugins = callPackage ../servers/monitoring/plugins { };
 
-  inherit (callPackage ../servers/monitoring/plugins/labs_consol_de.nix { inherit (perlPackages) DBDsybase NetSNMP; })
+  inherit (callPackage ../servers/monitoring/plugins/labs_consol_de.nix { })
     check-mssql-health
     check-nwc-health
     check-ups-health;
@@ -13842,10 +13799,7 @@ in
 
   supervise = callPackage ../tools/system/supervise { };
 
-  spamassassin = callPackage ../servers/mail/spamassassin {
-    inherit (perlPackages) HTMLParser NetDNS NetAddrIP DBFile
-      HTTPDate MailDKIM LWP IOSocketSSL;
-  };
+  spamassassin = callPackage ../servers/mail/spamassassin { };
 
   deadpixi-sam-unstable = callPackage ../applications/editors/deadpixi-sam { };
   deadpixi-sam = deadpixi-sam-unstable;
@@ -15750,7 +15704,6 @@ in
   aacgain = callPackage ../applications/audio/aacgain { };
 
   abcde = callPackage ../applications/audio/abcde {
-    inherit (perlPackages) MusicBrainz MusicBrainzDiscID;
     inherit (pythonPackages) eyeD3;
   };
 
@@ -17455,10 +17408,6 @@ in
   ike = callPackage ../applications/networking/ike { };
 
   ikiwiki = callPackage ../applications/misc/ikiwiki {
-    inherit (perlPackages) TextMarkdown URI HTMLParser HTMLScrubber
-      HTMLTemplate TimeDate CGISession DBFile CGIFormBuilder LocaleGettext
-      RpcXML XMLSimple YAML YAMLLibYAML HTMLTree Filechdir
-      AuthenPassphrase NetOpenIDConsumer LWPxParanoidAgent CryptSSLeay;
     inherit (perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig;}; }) PerlMagick;
   };
 
@@ -21224,9 +21173,7 @@ in
 
   bcftools = callPackage ../applications/science/biology/bcftools { };
 
-  conglomerate = callPackage ../applications/science/biology/conglomerate {
-    inherit (perlPackages) GetoptTabular MNI-Perllib;
-  };
+  conglomerate = callPackage ../applications/science/biology/conglomerate { };
 
   dcm2niix = callPackage ../applications/science/biology/dcm2niix { };
 
@@ -21244,9 +21191,7 @@ in
 
   igv = callPackage ../applications/science/biology/igv { };
 
-  inormalize = callPackage ../applications/science/biology/inormalize {
-    inherit (perlPackages) GetoptTabular MNI-Perllib;
-  };
+  inormalize = callPackage ../applications/science/biology/inormalize { };
 
   iv = callPackage ../applications/science/biology/iv {
     neuron-version = neuron.version;
@@ -21258,9 +21203,7 @@ in
 
   muscle = callPackage ../applications/science/biology/muscle { };
 
-  n3 = callPackage ../applications/science/biology/N3 {
-    inherit (perlPackages) perl GetoptTabular MNI-Perllib;
-  };
+  n3 = callPackage ../applications/science/biology/N3 { };
 
   neuron = callPackage ../applications/science/biology/neuron {
     python = null;
@@ -21274,17 +21217,11 @@ in
 
   mrbayes = callPackage ../applications/science/biology/mrbayes { };
 
-  minc_tools = callPackage ../applications/science/biology/minc-tools {
-    inherit (perlPackages) TextFormat;
-  };
+  minc_tools = callPackage ../applications/science/biology/minc-tools { };
 
-  minc_widgets = callPackage ../applications/science/biology/minc-widgets {
-    inherit (perlPackages) GetoptTabular MNI-Perllib;
-  };
+  minc_widgets = callPackage ../applications/science/biology/minc-widgets { };
 
-  mni_autoreg = callPackage ../applications/science/biology/mni_autoreg {
-    inherit (perlPackages) GetoptTabular MNI-Perllib;
-  };
+  mni_autoreg = callPackage ../applications/science/biology/mni_autoreg { };
 
   minimap2 = callPackage ../applications/science/biology/minimap2 { };
 
@@ -22638,12 +22575,7 @@ in
     conf = config.slock.conf or null;
   };
 
-  smokeping = callPackage ../tools/networking/smokeping {
-    inherit fping rrdtool;
-    inherit (perlPackages)
-      FCGI CGI CGIFast ConfigGrammar DigestHMAC NetTelnet
-      NetOpenSSH NetSNMP LWP IOTty perl NetDNS perlldap;
-  };
+  smokeping = callPackage ../tools/networking/smokeping { };
 
   snapraid = callPackage ../tools/filesystems/snapraid { };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30,6 +30,24 @@ let
       checkPhase = "./Build test";
     });
 
+  /* Construct a perl search path (such as $PERL5LIB)
+
+     Example:
+       pkgs = import <nixpkgs> { }
+       makePerlPath [ pkgs.perlPackages.libnet ]
+       => "/nix/store/n0m1fk9c960d8wlrs62sncnadygqqc6y-perl-Net-SMTP-1.25/lib/perl5/site_perl"
+  */
+  makePerlPath = stdenv.lib.makeSearchPathOutput "lib" perl.libPrefix;
+
+  /* Construct a perl search path recursively including all dependencies (such as $PERL5LIB)
+
+     Example:
+       pkgs = import <nixpkgs> { }
+       makeFullPerlPath [ pkgs.perlPackages.CGI ]
+       => "/nix/store/fddivfrdc1xql02h9q500fpnqy12c74n-perl-CGI-4.38/lib/perl5/site_perl:/nix/store/8hsvdalmsxqkjg0c5ifigpf31vc4vsy2-perl-HTML-Parser-3.72/lib/perl5/site_perl:/nix/store/zhc7wh0xl8hz3y3f71nhlw1559iyvzld-perl-HTML-Tagset-3.20/lib/perl5/site_perl"
+  */
+  makeFullPerlPath = deps: makePerlPath (stdenv.lib.misc.closePropagation deps);
+
 
   ack = buildPerlPackage rec {
     name = "ack-2.24";
@@ -4026,8 +4044,8 @@ let
       sha256 = "5509e532cdd0e3d91eda550578deaac29e2f008a12b64576e8c261bb92e8c2c1";
     };
     postInstall = stdenv.lib.optionalString (perl ? crossVersion) ''
-      mkdir -p $out/lib/perl5/site_perl/cross_perl/${perl.version}/DBI
-      cat > $out/lib/perl5/site_perl/cross_perl/${perl.version}/DBI.pm <<EOF
+      mkdir -p $out/${perl.libPrefix}/cross_perl/${perl.version}/DBI
+      cat > $out/${perl.libPrefix}/cross_perl/${perl.version}/DBI.pm <<EOF
       package DBI;
       BEGIN {
       our \$VERSION = "$version";
@@ -4035,8 +4053,8 @@ let
       1;
       EOF
 
-      autodir=$(echo $out/lib/perl5/site_perl/${perl.version}/*/auto/DBI)
-      cat > $out/lib/perl5/site_perl/cross_perl/${perl.version}/DBI/DBD.pm <<EOF
+      autodir=$(echo $out/${perl.libPrefix}/${perl.version}/*/auto/DBI)
+      cat > $out/${perl.libPrefix}/cross_perl/${perl.version}/DBI/DBD.pm <<EOF
       package DBI::DBD;
       use Exporter ();
       use vars qw (@ISA @EXPORT);
@@ -9162,7 +9180,7 @@ let
     buildInputs = [ ModuleBuild NetDNSResolverProgrammable ];
     propagatedBuildInputs = [ Error NetAddrIP NetDNS URI ];
 
-    buildPhase = "perl Build.PL --install_base=$out --install_path=\"sbin=$out/bin\" --install_path=\"lib=$out/lib/perl5/site_perl\"; ./Build build ";
+    buildPhase = "perl Build.PL --install_base=$out --install_path=\"sbin=$out/bin\" --install_path=\"lib=$out/${perl.libPrefix}\"; ./Build build ";
 
     doCheck = false; # The main test performs network access
     meta = {
@@ -16142,7 +16160,7 @@ let
       install_name_tool -change "$oldPath" "$newPath" "$out/bin/biblex"
       install_name_tool -change "$oldPath" "$newPath" "$out/bin/bibparse"
       install_name_tool -change "$oldPath" "$newPath" "$out/bin/dumpnames"
-      install_name_tool -change "$oldPath" "$newPath" "$out/lib/perl5/site_perl/${perl.version}/darwin-2level/auto/Text/BibTeX/BibTeX.bundle"
+      install_name_tool -change "$oldPath" "$newPath" "$out/${perl.libPrefix}/${perl.version}/darwin-2level/auto/Text/BibTeX/BibTeX.bundle"
     '';
     meta = {
       description = "Interface to read and parse BibTeX files";


### PR DESCRIPTION
###### Motivation for this change

First, it has been in TODO comment

Second, to get rid of hardcoded "lib/perl5/site_perl", because ```perl.libPrefix``` == "lib/perl5/site_perl" only on POSIX platforms, it is not so on Windows

cc @zimbatm