### PR TITLE
ola: use python36

### DIFF
--- a/pkgs/applications/misc/ola/default.nix
+++ b/pkgs/applications/misc/ola/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, bison, flex, pkgconfig
 , libuuid, cppunit, protobuf3_1, zlib, avahi, libmicrohttpd
-, perl, python3, python3Packages
+, perl, python36 # Replace by python3 after the next update
 }:
 
 stdenv.mkDerivation rec {
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook bison flex pkgconfig perl ];
-  buildInputs = [ libuuid cppunit protobuf3_1 zlib avahi libmicrohttpd python3 ];
+  buildInputs = [ libuuid cppunit protobuf3_1 zlib avahi libmicrohttpd python36 ];
   propagatedBuildInputs = [
-    (python3Packages.protobuf.override { protobuf = protobuf3_1; })
-    python3Packages.numpy
+    (python36.pkgs.protobuf.override { protobuf = protobuf3_1; })
+    python36.pkgs.numpy
   ];
 
   configureFlags = [ "--enable-python-libs" ];


### PR DESCRIPTION
###### Motivation for this change
python37.pkgs.protobuf does not build with protobuf3_1
Fixes https://github.com/NixOS/nixpkgs/issues/52090.
A similar thing has been done in #51809.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

