### PR TITLE
arduino-mk: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1495,6 +1495,11 @@
     github = "expipiplus1";
     name = "Joe Hermaszewski";
   };
+  eyjhb = {
+    email = "eyjhbb@gmail.com";
+    github = "eyJhb";
+    name = "eyJhb";
+  };
   f--t = {
     email = "git@f-t.me";
     github = "f--t";

--- a/pkgs/development/arduino/arduino-mk/default.nix
+++ b/pkgs/development/arduino/arduino-mk/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "1.6.0";
+  name = "arduino-mk-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "sudar";
+    repo   = "Arduino-Makefile";
+    rev    = "${version}";
+    sha256 = "0flpl97d2231gp51n3y4qvf3y1l8xzafi1sgpwc305vwc2h4dl2x";
+  };
+
+  phases = ["installPhase"];
+  installPhase = "ln -s $src $out";
+
+  meta = {
+    description = "Makefile for Arduino sketches";
+    homepage = https://github.com/sudar/Arduino-Makefile;
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.eyjhb ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -507,6 +507,8 @@ in
     withGui = false;
   };
 
+  arduino-mk = callPackage ../development/arduino/arduino-mk {};
+
   apitrace = libsForQt5.callPackage ../applications/graphics/apitrace {};
 
   arguments = callPackage ../development/libraries/arguments { };


### PR DESCRIPTION
###### Motivation for this change
Standard package in ubuntu etc. so this makes it easy to include it in the default configuration.nix, without having to do additional configuration in $HOME.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

