### PR TITLE
lmdb: ship static library, too

### DIFF
--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     moveToOutput bin "$bin"
-    moveToOutput "lib/*.a" REMOVE # until someone needs it
   ''
     # add lmdb.pc (dynamic only)
     + ''


### PR DESCRIPTION
This is useful if you're using `pkgs.pkgsMusl` to build static libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

