### PR TITLE
perlPackages.Po4a: fix lib path

### DIFF
--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     makeFlagsArray=(
-      PERL5LIB="${perlPackages.Po4a}/lib/perl5/site_perl"
       DCFLAGS='-O -inline -release -version=StdLoggerDisableTrace'
     )
   '';

--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     makeFlagsArray=(
-      PERL5LIB="${perlPackages.Po4a}/lib/perl5"
+      PERL5LIB="${perlPackages.Po4a}/lib/perl5/site_perl"
       DCFLAGS='-O -inline -release -version=StdLoggerDisableTrace'
     )
   '';

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${Po4a}/lib/perl5/site_perl";
-
     cmakeFlagsArray+=(
       -DBERKELEY_DB_INCLUDE_DIRS=${db.dev}/include
       -DDOCBOOK_XSL="${docbook_xsl}"/share/xml/docbook-xsl

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${Po4a}/lib/perl5";
+    export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${Po4a}/lib/perl5/site_perl";
 
     cmakeFlagsArray+=(
       -DBERKELEY_DB_INCLUDE_DIRS=${db.dev}/include


### PR DESCRIPTION
###### Motivation for this change

Fix ```Po4a``` paths left after https://github.com/NixOS/nixpkgs/pull/48959

cc @alesguzik @jtojnar
