### PR TITLE
[18.09] sqlite: 3.25.3 -> 3.26.0

### DIFF
--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  version = "3.25.3";
+  version = "3.26.0";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "08b4fs9mrah5gxl1865smlqs2ba6g7k7d6pfa084i6d78342p4n7";
+    sha256 = "0ysgi2jrl348amdfifsl3cx90d04bijm4pn4xnvivmi3m1dq4hp0";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-${version}";
-  version = "3.25.3";
+  version = "3.26.0";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2018/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "1pgkja0d13qp5p79ik9kh9lm5y79cwyxwwfc80cr8a1rw5xzksq0";
+    sha256 = "0pdzszb4sp73hl36siiv3p300jvfvbcdxi2rrmkwgs6inwznmajx";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

https://blade.tencent.com/magellan/index_en.html

The page suggests claims that sqlite <3.26.0 is vulnerable to "Remote code execution, leaking program memory or causing program crashes".

This PR backports the commit made by @dtzWill on master (PR #51352).

I am still a bit confused by the fact that google upgraded to 3.25.0 to fix the issue https://chromium.googlesource.com/chromium/src/+/c368e30ae55600a1c3c9cb1710a54f9c55de786e. If that is indeed sufficient we do not need merge this straight into the release branch but can let all the rebuilds take place on staging instead.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


I rebuild `python3Packages.sqlalchemy` successfully. It comes with a larger test suite that seems like a good "smoketest".


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

