### PR TITLE
Revert "gcc-arm-embedded: remove"

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, ncurses5, python27 }:
+
+stdenv.mkDerivation rec {
+  name = "gcc-arm-embedded-${version}";
+  version = "6-2017-q2-update";
+  subdir = "6-2017q2";
+
+  platformString =
+    if stdenv.isLinux then "linux"
+    else if stdenv.isDarwin then "mac"
+    else throw "unsupported platform";
+
+  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-${platformString}.tar.bz2";
+
+  src =
+    if stdenv.isLinux then fetchurl { url=urlString; sha256="1hvwi02mx34al525sngnl0cm7dkmzxfkb1brq9kvbv28wcplp3p6"; }
+    else if stdenv.isDarwin then fetchurl { url=urlString; sha256="0019ylpq4inq7p5gydpmc9m8ni72fz2csrjlqmgx1698998q0c3x"; }
+    else throw "unsupported platform";
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf $f > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4/M7, Cortex-R4/R5/R7/R8)";
+    homepage = https://developer.arm.com/open-source/gnu-toolchain/gnu-rm;
+    license = with stdenv.lib.licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with stdenv.lib.maintainers; [ vinymeuh ];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchurl, ncurses5, python27 }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "gcc-arm-embedded-${version}";
+  version = "7-2018-q2-update";
+  subdir = "7-2018q2";
+
+  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
+
+  src = fetchurl { url=urlString; sha256="0sgysp3hfpgrkcbfiwkp0a7ymqs02khfbrjabm52b5z61sgi05xv"; };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf $f > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4/M7, Cortex-R4/R5/R7/R8)";
+    homepage = https://developer.arm.com/open-source/gnu-toolchain/gnu-rm;
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, bzip2, patchelf, glibc, gcc, fetchurl, version, releaseType, sha256, ncurses
+, dirName ? null, subdirName ? null }:
+with stdenv.lib;
+let
+  versionParts = splitString "-" version; # 4.7 2013q3 20130916
+  majorVersion = elemAt versionParts 0; # 4.7
+  yearQuarter = elemAt versionParts 1; # 2013q3
+  underscoreVersion = replaceChars ["."] ["_"] version; # 4_7-2013q3-20130916
+  yearQuarterParts = splitString "q" yearQuarter; # 2013 3
+  year = elemAt yearQuarterParts 0; # 2013
+  quarter = elemAt yearQuarterParts 1; # 3
+  dirName_ = if dirName != null then dirName else majorVersion;
+  subdirName_ = if subdirName != null then subdirName
+    else "${majorVersion}-${year}-q${quarter}-${releaseType}"; # 4.7-2013-q3-update
+in
+stdenv.mkDerivation {
+  name = "gcc-arm-embedded-${version}";
+
+  src = fetchurl {
+    url = "https://launchpad.net/gcc-arm-embedded/${dirName_}/${subdirName_}/+download/gcc-arm-none-eabi-${underscoreVersion}-linux.tar.bz2";
+    sha256 = sha256;
+  };
+
+  nativeBuildInputs = [ bzip2 patchelf ];
+
+  dontPatchELF = true;
+
+  phases = "unpackPhase patchPhase installPhase";
+
+  installPhase = ''
+    mkdir -pv $out
+    cp -r ./* $out
+
+    for f in $(find $out); do
+      if [ -f "$f" ] && patchelf "$f" 2> /dev/null; then
+        patchelf --set-interpreter ${getLib glibc}/lib/ld-linux.so.2 \
+                 --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" gcc ncurses ]} \
+                 "$f" || true
+      fi
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4, Cortex-R4/R5/R7)";
+    homepage = https://launchpad.net/gcc-arm-embedded;
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = [ maintainers.rasendubi ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6960,6 +6960,36 @@ in
 
   gcl_2_6_13_pre = callPackage ../development/compilers/gcl/2.6.13-pre.nix { };
 
+  gcc-arm-embedded-4_7 = pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
+    version = "4.7-2013q3-20130916";
+    releaseType = "update";
+    sha256 = "1bd9bi9q80xn2rpy0rn1vvj70rh15kb7dmah0qs4q2rv78fqj40d";
+    ncurses = pkgsi686Linux.ncurses5;
+  };
+  gcc-arm-embedded-4_8 = pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
+    version = "4.8-2014q1-20140314";
+    releaseType = "update";
+    sha256 = "ce92859550819d4a3d1a6e2672ea64882b30afa2c08cf67fa8e1d93788c2c577";
+    ncurses = pkgsi686Linux.ncurses5;
+  };
+  gcc-arm-embedded-4_9 = pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
+    version = "4.9-2015q1-20150306";
+    releaseType = "update";
+    sha256 = "c5e0025b065750bbd76b5357b4fc8606d88afbac9ff55b8a82927b4b96178154";
+    ncurses = pkgsi686Linux.ncurses5;
+  };
+  gcc-arm-embedded-5 = pkgs.pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
+    dirName = "5.0";
+    subdirName = "5-2016-q2-update";
+    version = "5.4-2016q2-20160622";
+    releaseType = "update";
+    sha256 = "1r0rqbnw7rf94f5bsa3gi8bick4xb7qnp1dkvdjfbvqjvysvc44r";
+    ncurses = pkgsi686Linux.ncurses5;
+  };
+  gcc-arm-embedded-6 = callPackage ../development/compilers/gcc-arm-embedded/6 {};
+  gcc-arm-embedded-7 = callPackage ../development/compilers/gcc-arm-embedded/7 {};
+  gcc-arm-embedded = gcc-arm-embedded-7;
+
   gforth = callPackage ../development/compilers/gforth {};
 
   gtk-server = callPackage ../development/interpreters/gtk-server {};


### PR DESCRIPTION
This (fully) reverts commit c327df544ae0875ce71b0a82ae7a650a8e34a268.

Fixes #51907.

some people still need gcc-arm-embedded to be available.

/cc @ejpcmac 
