### PR TITLE
rtl8812au: 5.2.20_25672.20171213 -> 5.2.20.2_28373.20180619

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8812au-${kernel.version}-${version}";
-  version = "5.2.20_25672.20171213";
+  version = "5.2.20.2_28373.20180619";
 
   src = fetchFromGitHub {
     owner = "zebulon2";
     repo = "rtl8812au-driver-5.2.20";
-    rev = "aca1e0677bfe56c6c4914358df007c97486e7095";
-    sha256 = "19av8fkh3mvs2f57iibrg0cfyhjnnx4cbnfzv5aj7v5gb0j3dp0p";
+    rev = "2dad788f5d71d50df4f692b67a4428967ba3d42c";
+    sha256 = "17pn73j2xqya0g8f86hn1jyf9x9wp52md05yrg1md58ixsbh1kz3";
   };
 
   nativeBuildInputs = [ bc ];


### PR DESCRIPTION
###### Motivation for this change

Current version in nixpkgs doesn't support latest kernels >= 4.19. The updated version does.

Tested `linuxPackages.rtl8812au` and `linuxPackages_latest.rtl8812au`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

