### PR TITLE
flameshot: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, qtbase, qmake, qttools }:
+{ stdenv, fetchFromGitHub, qtbase, qmake, qttools, qtsvg }:
 
 stdenv.mkDerivation rec {
   name = "flameshot-${version}";
-  version = "0.5.1";
+  version = "0.6.0";
 
-  nativeBuildInputs = [ qmake qttools ];
+  nativeBuildInputs = [ qmake qttools qtsvg ];
   buildInputs = [ qtbase ];
 
   qmakeFlags = [
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "lupoDharkael";
     repo = "flameshot";
     rev = "v${version}";
-    sha256 = "13h77np93r796jf289v4r687cmnpqkyqs34dm9gif4akaig74ky0";
+    sha256 = "193szslh55v44jzxzx5g9kxhl8p8di7vbcnxlid4acfidhnvgazm";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
New version of flameshow is out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

