### PR TITLE
Add bluez full package

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -25,9 +25,14 @@ in {
         type = types.package;
         default = pkgs.bluez;
         defaultText = "pkgs.bluez";
-        example = "pkgs.bluez.override { enableMidi = true; }";
+        example = "pkgs.bluezFull";
         description = ''
           Which BlueZ package to use.
+
+          <note><para>
+            Use the <literal>pkgs.bluezFull</literal> package to enable all
+            bluez plugins.
+          </para></note>
         '';
       };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14195,6 +14195,12 @@ in
 
   bluez = bluez5;
 
+  bluezFull = bluez.override {
+    enableWiimote = true;
+    enableMidi = true;
+    enableSixaxis = true;
+  };
+
   inherit (python3Packages) bedup;
 
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the top-level `bluezFull` package.  This `bluezFull` package enables all the plugins provided by the `bluez` package.

It would be nice to have this `bluezFull` package for people that want to just get a `bluez` with all the bells and whistles instead of having to enable them one-by-one and compile `bluez` themselves.

I think this will mainly be used by people who want to use the Wiimote and Playstation 3/4 controllers over bluetooth without having to enable the individual options on `bluez`.

I called this package `bluezFull` after the `gitFull` package, but I am open to suggestions as to what it should be called.  Another candidate might be `bluezWithPlugins`.

Pinging @veprbl (because of #51895).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

