### PR TITLE
python3Packages.spacy: 2.0.16 -> 2.0.18

### DIFF
--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -2,14 +2,12 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, html5lib
 , pytest
 , preshed
 , ftfy
 , numpy
 , murmurhash
 , plac
-, six
 , ujson
 , dill
 , requests
@@ -23,19 +21,17 @@
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "2.0.16";
+  version = "2.0.18";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ghgbv819ff4777904p1kzayq1dj34i7853anvg859sak59r7pj1";
+    sha256 = "0mybdms7c40jvk8ak180n65anjiyg4c8gkaqwkzicrd1mxq3ngqj";
   };
 
   prePatch = ''
     substituteInPlace setup.py \
       --replace "regex==" "regex>=" \
-      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6" \
-      --replace "thinc>=6.12.0,<6.13.0" "thinc>=6.12.0" \
-      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
+      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6"
   '';
 
   propagatedBuildInputs = [
@@ -45,8 +41,6 @@ buildPythonPackage rec {
    preshed
    thinc
    plac
-   six
-   html5lib
    ujson
    dill
    requests

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -19,18 +19,17 @@
 , plac
 , six
 , mock
-, termcolor
 , wrapt
 , dill
 }:
 
 buildPythonPackage rec {
   pname = "thinc";
-  version = "6.12.0";
+  version = "6.12.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0lfdf08v7rrj9b29z2vf8isaqa0zh16acw9im8chkqsh8bay4ykm";
+    sha256 = "1kkp8b3xcs3yn3ia5sxrh086c9xv27s2khdxd17abdypxxa99ich";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
@@ -45,20 +44,18 @@ buildPythonPackage rec {
    preshed
    numpy
    murmurhash
-   pytest
-   hypothesis
    tqdm
    cytoolz
    plac
    six
-   mock
-   termcolor
    wrapt
    dill
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
 
   checkInputs = [
+    hypothesis
+    mock
     pytest
   ];
 
@@ -66,7 +63,7 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "pathlib==1.0.1" "pathlib>=1.0.0,<2.0.0" \
       --replace "plac>=0.9.6,<1.0.0" "plac>=0.9.6" \
-      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.31.0"
+      --replace "msgpack-numpy<0.4.4" "msgpack-numpy"
   '';
 
   # Cannot find cython modules.


### PR DESCRIPTION
###### Motivation for this change

Update spaCy to 2.0.18. Also, it seems that we cannot build spaCy on Python 2 anymore, since one of its transitive dependencies (ftfy) does not work with Python 2 anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

