### PR TITLE
Gif for cli

### DIFF
--- a/pkgs/development/python-modules/x256/default.nix
+++ b/pkgs/development/python-modules/x256/default.nix
@@ -10,11 +10,13 @@ buildPythonPackage rec {
     sha256 = "00g02b9a6jsl377xb5fmxvkjff3lalw21n430a4zalqyv76dnmgq";
   };
 
+  doCheck = false;
+
   meta = with stdenv.lib; {
-    description = "Return the nearest xterm 256 color code for rgb inputs.";
+    description = "Find the nearest xterm 256 color index for an RGB";
     homepage = https://github.com/magarcia/python-x256;
     license = licenses.mit;
-    maintainers = with maintainers; [ scriptkiddi ];
+    maintainers = with maintainers; [ Scriptkiddi ];
   };
 }
 

--- a/pkgs/development/python-modules/x256/default.nix
+++ b/pkgs/development/python-modules/x256/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "x256";
+  version = "0.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00g02b9a6jsl377xb5fmxvkjff3lalw21n430a4zalqyv76dnmgq";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Return the nearest xterm 256 color code for rgb inputs.";
+    homepage = https://github.com/magarcia/python-x256;
+    license = licenses.mit;
+    maintainers = with maintainers; [ scriptkiddi ];
+  };
+}
+

--- a/pkgs/tools/misc/gif-for-cli/default.nix
+++ b/pkgs/tools/misc/gif-for-cli/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, python3Packages, ffmpeg, zlib, libjpeg }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gif-for-cli";
+  version = "unstable-2018-08-14";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "gif-for-cli";
+    rev = "9696f25fea2e38499b7c248a3151030c3c68bb00";
+    sha256 = "1rj8wjfsabn27k1ds7a5fdqgf2r28zpz4lvhbzssjfj1yf0mfh7s";
+  };
+
+  checkInputs = [ python3Packages.coverage ];
+  buildInputs = [ ffmpeg zlib libjpeg ];
+  propagatedBuildInputs = with python3Packages; [ pillow requests x256 ];
+
+  meta = with stdenv.lib; {
+    description = "Render gifs as ASCII art in your cli";
+    longDescription = "Takes in a GIF, short video, or a query to the Tenor GIF API and converts it to animated ASCII art.";
+    homepage = https://github.com/google/gif-for-cli;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1434,6 +1434,8 @@ in
 
   gh-ost = callPackage ../tools/misc/gh-ost { };
 
+  gif-for-cli = callPackage ../tools/misc/gif-for-cli { };
+
   gist = callPackage ../tools/text/gist { };
 
   gixy = callPackage ../tools/admin/gixy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5066,6 +5066,8 @@ in {
 
   simpy = callPackage ../development/python-modules/simpy { };
 
+  x256 = callPackage ../development/python-modules/x256 { };
+
   yattag = callPackage ../development/python-modules/yattag { };
 
   z3 = (toPythonModule (pkgs.z3.override {


### PR DESCRIPTION
###### Motivation for this change
Wanted to use it for my dotfiles


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

