### PR TITLE
ghc: Add `enableDwarf` flag, off by default.

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -3,6 +3,7 @@
 # build-tools
 , bootPkgs
 , autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3, m4, sphinx
+, elfutils # for DWARF support
 
 , libiconv ? null, ncurses
 
@@ -15,6 +16,9 @@
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? !(stdenv.lib.any (stdenv.lib.meta.platformMatch stdenv.hostPlatform) gmp.meta.platforms), gmp
+
+, # Allows this GHC to produce binaries that have DWARF debug symbols.
+  enableDwarf ? false # disabled by default due to https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-447602333
 
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
@@ -32,6 +36,9 @@
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+# TODO Use stdenv.???Platform.parsed.kernel.execFormat == stdenv.lib.systems.parse.execFormats.elf
+# instead, see https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-450521802
+assert enableDwarf -> !stdenv.isDarwin; # elfutils libdw supports only ELF
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -56,6 +63,9 @@ let
     HADDOCK_DOCS = NO
     BUILD_SPHINX_HTML = NO
     BUILD_SPHINX_PDF = NO
+  '' + stdenv.lib.optionalString enableDwarf ''
+    GhcLibHcOpts += -g3
+    GhcRtsHcOpts += -g3
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
@@ -66,6 +76,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional enableDwarf elfutils # elfutils provides libdw
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget =
@@ -94,7 +105,11 @@ stdenv.mkDerivation (rec {
     url = "http://tarballs.nixos.org/sha256/${sha256}";
     name = "D5123.diff";
     sha256 = "0nhqwdamf2y4gbwqxcgjxs0kqx23w9gv5kj0zv6450dq19rji82n";
-  })];
+  })]
+    # Combination backport of
+    #   https://git.haskell.org/ghc.git/commitdiff_plain/cb882fc993b4972f7f212b291229ef9e9ade0af9
+    #   https://git.haskell.org/ghc.git/commitdiff_plain/126aa794743b807b7447545697b96dd165ec3e16
+    ++ stdenv.lib.optional enableDwarf ./ghc-Require-libdw-for-enable-dwarf-unwind-fixed-comma.patch;
 
   postPatch = "patchShebangs .";
 
@@ -153,6 +168,8 @@ stdenv.mkDerivation (rec {
     "--with-gmp-includes=${targetPackages.gmp.dev}/include" "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optional enableDwarf [
+    "--enable-dwarf-unwind"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
   ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [

--- a/pkgs/development/compilers/ghc/8.6.2.nix
+++ b/pkgs/development/compilers/ghc/8.6.2.nix
@@ -3,6 +3,7 @@
 # build-tools
 , bootPkgs
 , autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3, m4, sphinx
+, elfutils # for DWARF support
 
 , libiconv ? null, ncurses
 
@@ -15,6 +16,9 @@
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? !(stdenv.lib.any (stdenv.lib.meta.platformMatch stdenv.hostPlatform) gmp.meta.platforms), gmp
+
+, # Allows this GHC to produce binaries that have DWARF debug symbols.
+  enableDwarf ? false # disabled by default due to https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-447602333
 
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
@@ -32,6 +36,9 @@
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+# TODO Use stdenv.???Platform.parsed.kernel.execFormat == stdenv.lib.systems.parse.execFormats.elf
+# instead, see https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-450521802
+assert enableDwarf -> !stdenv.isDarwin; # elfutils libdw supports only ELF
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -56,6 +63,9 @@ let
     HADDOCK_DOCS = NO
     BUILD_SPHINX_HTML = NO
     BUILD_SPHINX_PDF = NO
+  '' + stdenv.lib.optionalString enableDwarf ''
+    GhcLibHcOpts += -g3
+    GhcRtsHcOpts += -g3
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
@@ -66,6 +76,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional enableDwarf elfutils # elfutils provides libdw
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget =
@@ -94,7 +105,11 @@ stdenv.mkDerivation (rec {
     url = "http://tarballs.nixos.org/sha256/${sha256}";
     name = "D5123.diff";
     sha256 = "0nhqwdamf2y4gbwqxcgjxs0kqx23w9gv5kj0zv6450dq19rji82n";
-  })];
+  })]
+    # Combination backport of
+    #   https://git.haskell.org/ghc.git/commitdiff_plain/cb882fc993b4972f7f212b291229ef9e9ade0af9
+    #   https://git.haskell.org/ghc.git/commitdiff_plain/126aa794743b807b7447545697b96dd165ec3e16
+    ++ stdenv.lib.optional enableDwarf ./ghc-Require-libdw-for-enable-dwarf-unwind-fixed-comma.patch;
 
   postPatch = "patchShebangs .";
 
@@ -153,6 +168,8 @@ stdenv.mkDerivation (rec {
     "--with-gmp-includes=${targetPackages.gmp.dev}/include" "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optional enableDwarf [
+    "--enable-dwarf-unwind"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
   ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [

--- a/pkgs/development/compilers/ghc/8.6.3.nix
+++ b/pkgs/development/compilers/ghc/8.6.3.nix
@@ -3,6 +3,7 @@
 # build-tools
 , bootPkgs
 , autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3, m4, sphinx
+, elfutils # for DWARF support
 
 , libiconv ? null, ncurses
 
@@ -15,6 +16,9 @@
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? !(stdenv.lib.any (stdenv.lib.meta.platformMatch stdenv.hostPlatform) gmp.meta.platforms), gmp
+
+, # Allows this GHC to produce binaries that have DWARF debug symbols.
+  enableDwarf ? false # disabled by default due to https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-447602333
 
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
@@ -32,6 +36,9 @@
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+# TODO Use stdenv.???Platform.parsed.kernel.execFormat == stdenv.lib.systems.parse.execFormats.elf
+# instead, see https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-450521802
+assert enableDwarf -> !stdenv.isDarwin; # elfutils libdw supports only ELF
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -56,6 +63,9 @@ let
     HADDOCK_DOCS = NO
     BUILD_SPHINX_HTML = NO
     BUILD_SPHINX_PDF = NO
+  '' + stdenv.lib.optionalString enableDwarf ''
+    GhcLibHcOpts += -g3
+    GhcRtsHcOpts += -g3
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
@@ -66,6 +76,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional enableDwarf elfutils # elfutils provides libdw
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget =
@@ -94,7 +105,11 @@ stdenv.mkDerivation (rec {
     url = "http://tarballs.nixos.org/sha256/${sha256}";
     name = "D5123.diff";
     sha256 = "0nhqwdamf2y4gbwqxcgjxs0kqx23w9gv5kj0zv6450dq19rji82n";
-  })];
+  })]
+    # Combination backport of
+    #   https://git.haskell.org/ghc.git/commitdiff_plain/cb882fc993b4972f7f212b291229ef9e9ade0af9
+    #   https://git.haskell.org/ghc.git/commitdiff_plain/126aa794743b807b7447545697b96dd165ec3e16
+    ++ stdenv.lib.optional enableDwarf ./ghc-Require-libdw-for-enable-dwarf-unwind-fixed-comma.patch;
 
   postPatch = "patchShebangs .";
 
@@ -153,6 +168,8 @@ stdenv.mkDerivation (rec {
     "--with-gmp-includes=${targetPackages.gmp.dev}/include" "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optional enableDwarf [
+    "--enable-dwarf-unwind"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
   ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [

--- a/pkgs/development/compilers/ghc/ghc-Require-libdw-for-enable-dwarf-unwind-fixed-comma.patch
+++ b/pkgs/development/compilers/ghc/ghc-Require-libdw-for-enable-dwarf-unwind-fixed-comma.patch
@@ -1,0 +1,41 @@
+From: Alec Theriault <alec.theriault@gmail.com>
+Date: Sat, 8 Dec 2018 04:18:15 +0000 (-0500)
+Subject: Require 'libdw' for '--enable-dwarf-unwind'
+X-Git-Url: https://git.haskell.org/ghc.git/commitdiff_plain/cb882fc993b4972f7f212b291229ef9e9ade0af9
+
+Require 'libdw' for '--enable-dwarf-unwind'
+
+This causes './configure --enable-dwarf-unwind' to exit with a helpful
+error message when 'libdw' cannot be found (compared to the previous
+behaviour of silently pretending the user hadn't requested DWARF support
+at all).
+
+Test Plan: ./configure --enable-dwarf-unwind # on systems with/without
+libdw
+
+Reviewers: bgamari, nh2
+
+Reviewed By: nh2
+
+Subscribers: nh2, rwbarton, erikd, carter
+
+GHC Trac Issues: #15968
+
+Differential Revision: https://phabricator.haskell.org/D5424
+---
+
+diff --git a/configure.ac b/configure.ac
+index 88eddca..2cf98a7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1248,7 +1248,9 @@ USE_LIBDW=0
+ AC_ARG_ENABLE(dwarf-unwind,
+     [AC_HELP_STRING([--enable-dwarf-unwind],
+         [Enable DWARF unwinding support in the runtime system via elfutils' libdw [default=no]])],
+-    [AC_CHECK_LIB(dw, dwfl_attach_state, [UseLibdw=YES], [UseLibdw=NO])],
++    [AC_CHECK_LIB(dw, dwfl_attach_state,
++      [UseLibdw=YES],
++      [AC_MSG_ERROR([Cannot find system libdw (required by --enable-dwarf-unwind)])])],
+     [UseLibdw=NO]
+ )
+ AC_SUBST(UseLibdw)

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -3,6 +3,7 @@
 # build-tools
 , bootPkgs
 , autoconf, automake, coreutils, fetchgit, perl, python3, m4, sphinx
+, elfutils # for DWARF support
 
 , libiconv ? null, ncurses
 
@@ -15,6 +16,9 @@
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
   enableIntegerSimple ? !(stdenv.lib.any (stdenv.lib.meta.platformMatch stdenv.hostPlatform) gmp.meta.platforms), gmp
+
+, # Allows this GHC to produce binaries that have DWARF debug symbols.
+  enableDwarf ? false # disabled by default due to https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-447602333
 
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform
@@ -33,6 +37,9 @@
 }:
 
 assert !enableIntegerSimple -> gmp != null;
+# TODO Use stdenv.???Platform.parsed.kernel.execFormat == stdenv.lib.systems.parse.execFormats.elf
+# instead, see https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-450521802
+assert enableDwarf -> !stdenv.isDarwin; # elfutils libdw supports only ELF
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -57,6 +64,9 @@ let
     HADDOCK_DOCS = NO
     BUILD_SPHINX_HTML = NO
     BUILD_SPHINX_PDF = NO
+  '' + stdenv.lib.optionalString enableDwarf ''
+    GhcLibHcOpts += -g3
+    GhcRtsHcOpts += -g3
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
@@ -67,6 +77,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
+    ++ stdenv.lib.optional enableDwarf elfutils # elfutils provides libdw
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget =
@@ -135,6 +146,8 @@ stdenv.mkDerivation (rec {
     "--with-gmp-includes=${gmp.dev}/include" "--with-gmp-libraries=${gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
     "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+  ] ++ stdenv.lib.optional enableDwarf [
+    "--enable-dwarf-unwind"
   ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
     "--enable-bootstrap-with-devel-snapshot"
   ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -203,10 +203,14 @@ rec {
    * This includes dontStrip.
    */
   enableDWARFDebugging = drv:
-   # -g: enables debugging symbols
+   # --enable-debug-info: enables debugging symbols
    # --disable-*-stripping: tell GHC not to strip resulting binaries
    # dontStrip: see above
-   appendConfigureFlag (dontStrip drv) "--ghc-options=-g --disable-executable-stripping --disable-library-stripping";
+   appendConfigureFlags (dontStrip drv) [
+     "--enable-debug-info=3"
+     "--disable-library-stripping"
+     "--disable-executable-stripping"
+   ];
 
   /* Create a source distribution tarball like those found on hackage,
      instead of building the package.

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -13,6 +13,10 @@ let
     "integer-simple"
   ];
 
+  integerSimpleGhcNames = pkgs.lib.filter
+    (name: ! builtins.elem name integerSimpleExcludes)
+    (pkgs.lib.attrNames compiler);
+
   haskellLib = import ../development/haskell-modules/lib.nix {
     inherit (pkgs) lib;
     inherit pkgs;
@@ -94,12 +98,8 @@ in {
     };
 
     # The integer-simple attribute set contains all the GHC compilers
-    # build with integer-simple instead of integer-gmp.
-    integer-simple = let
-      integerSimpleGhcNames = pkgs.lib.filter
-        (name: ! builtins.elem name integerSimpleExcludes)
-        (pkgs.lib.attrNames compiler);
-    in pkgs.recurseIntoAttrs (pkgs.lib.genAttrs
+    # built with integer-simple instead of integer-gmp.
+    integer-simple = pkgs.recurseIntoAttrs (pkgs.lib.genAttrs
       integerSimpleGhcNames
       (name: compiler."${name}".override { enableIntegerSimple = true; }));
   };
@@ -174,11 +174,7 @@ in {
 
     # The integer-simple attribute set contains package sets for all the GHC compilers
     # using integer-simple instead of integer-gmp.
-    integer-simple = let
-      integerSimpleGhcNames = pkgs.lib.filter
-        (name: ! builtins.elem name integerSimpleExcludes)
-        (pkgs.lib.attrNames packages);
-    in pkgs.lib.genAttrs integerSimpleGhcNames (name: packages."${name}".override {
+    integer-simple = pkgs.lib.genAttrs integerSimpleGhcNames (name: packages."${name}".override {
       ghc = bh.compiler.integer-simple."${name}";
       buildHaskellPackages = bh.packages.integer-simple."${name}";
       overrides = _self : _super : {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -3,19 +3,27 @@
 }:
 
 let
+  # These are attributes in compiler for which we can build special
+  # ghc variants like integer-simple, DWARF etc.
+  # The entries in here must only have 1 level (they cannot be package
+  # sets like e.g. `integer-simple`).
+  normalGhcCompilers = [
+    "ghc822"
+    "ghc844"
+    "ghc861"
+    "ghc862"
+    "ghc863"
+    "ghcHEAD"
+  ];
+
   # These are attributes in compiler and packages that don't support integer-simple.
   integerSimpleExcludes = [
-    "ghc822Binary"
     "ghc844"
-    "ghcjs"
-    "ghcjs82"
-    "ghcjs84"
-    "integer-simple"
   ];
 
   integerSimpleGhcNames = pkgs.lib.filter
     (name: ! builtins.elem name integerSimpleExcludes)
-    (pkgs.lib.attrNames compiler);
+    normalGhcCompilers;
 
   haskellLib = import ../development/haskell-modules/lib.nix {
     inherit (pkgs) lib;
@@ -78,6 +86,8 @@ in {
       buildLlvmPackages = buildPackages.llvmPackages_6;
       llvmPackages = pkgs.llvmPackages_6;
     };
+    # When adding a new compiler here, don't forget to update
+    # normalGhcCompilers.
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs = packages.ghc822Binary;
       inherit (buildPackages.python3Packages) sphinx;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -213,7 +213,13 @@ in {
       ghc = bh.compiler.integer-simple."${name}";
       buildHaskellPackages = bh.packages.integer-simple."${name}";
       overrides = _self : _super : {
+        # Usually, integer-simple is a normal package that you can build.
+        # In this package set, it is a ghc-bundled library, so we
+        # set it to `null` (ghc-bundled libraries are always `null`
+        # in `haskellPackages` package sets).
         integer-simple = null;
+        # Get rid of `integer-gmp` as a safety measure to notice
+        # when anything hard-depends on it.
         integer-gmp = null;
       };
     });


### PR DESCRIPTION
This allows our GHCs to build programs with DWARF debug information when `-g` is passed, see https://ghc.haskell.org/trac/ghc/wiki/DWARF.

~On by default on non-Darwin only because `elfutils` (which GHC uses for this) works only for ELF executables.~ Off by default until [GHC ticket #15960 - Using -g causes differences in generated core](https://ghc.haskell.org/trac/ghc/ticket/15960) is fixed.

PR is against `staging` so that the impact can be properly evaluated.

###### Motivation for this change

This can make debugging of many Haskell bugs and performance issues significantly easier.

Common use cases are:

* load the core dumps in gdb and see from what Haskell segfaulting C code is called
* set breakpoints and use valgrind to debug malloc issues
* you can also use `perf` and `kcachegrind` to debug performance issues but results here are mixed

~This change is expected to increase the size of GHC and Haskell libraries, as debugging symbols are added to the object files.

The size of the eventual Haskell binaries that are not explicitly built with `ghc -g` should remain unaffected when the standard statish linking is used (that links Haskell libraries statically, and system libraries dynamically, which is nixpkgs' default).

Closure size should rise minimally to the addition of `elfutils` that provides `libdw`.

I believe that the slightly increased download size for developers will be tremendously offset by the benefits of being able to trouble-shoot crashes and performance issues without having to recompile the entire ecosystem.
(This is from my own perspective of using Haskell for work every day for many years, but I'm relatively sure that others feel the same.)

CC @bgamari @angerman @Gabriel439 @vaibhavsagar @basvandijk @roelvandijk 

###### Things done

Much of the below isn't ticked yet because building takes a while and I added it for all GHC versions.

I have tested the change on 8.2.2 on top of `release-18.03` so far, where I managed to produce dwarf symbols.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

## TODO list

* [ ] Leave some time to collect info on who's onboard with this change
* [x] Fix [forgotten `GhcLibHcOpts = -g3` and `GhcRtsHcOpts = -g3` entries](https://github.com/bgamari/ghc-utils/blob/9f5a7dc633e567f193027685174736c83ed2520a/rel-eng/bin-release.sh#L182-L188) (same as, from https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-447597748)
  * [x] Fix [build error](https://github.com/NixOS/nixpkgs/pull/52255#issuecomment-447610795)
* [x] Figure out how to make it built by Hydra even though it's off by default for now
  * @basvandijk showed me how to do it, adding an attribute set [here](https://github.com/NixOS/nixpkgs/blob/47a4d99c4feae07ca5c9cbaa4888e4081c20cdbb/pkgs/top-level/haskell-packages.nix#L123) which will automatically be built on Hydra by [`release.nix`](https://github.com/NixOS/nixpkgs/blob/47a4d99c4feae07ca5c9cbaa4888e4081c20cdbb/pkgs/top-level/release.nix#L180) (see e.g. how the `integer-simple` one is built [here](https://hydra.nixos.org/job/nixpkgs/trunk/haskell.compiler.integer-simple.ghc822.x86_64-linux)/[here](https://hydra.nixos.org/build/85586694))
* [ ] Do some testing if everything works as expected