### PR TITLE
Provide real dsymutil to darwin stdenv

### DIFF
--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, binutils-unwrapped, cctools
-}:
+{ stdenv, binutils-unwrapped, cctools, llvm }:
 
 # Make sure both underlying packages claim to have prepended their binaries
 # with the same targetPrefix.
@@ -8,12 +7,12 @@ assert binutils-unwrapped.targetPrefix == cctools.targetPrefix;
 let
   inherit (binutils-unwrapped) targetPrefix;
   cmds = [
-    "ar" "ranlib" "as" "dsymutil" "install_name_tool"
+    "ar" "ranlib" "as" "install_name_tool"
     "ld" "strip" "otool" "lipo" "nm" "strings" "size"
   ];
 in
 
-# TODO loop over targetPrefixed binaries too
+# TODO: loop over targetPrefixed binaries too
 stdenv.mkDerivation {
   name = "${targetPrefix}cctools-binutils-darwin";
   outputs = [ "out" "info" "man" ];
@@ -25,9 +24,8 @@ stdenv.mkDerivation {
     # We specifically need:
     # - ld: binutils doesn't provide it on darwin
     # - as: as above
-    # - ar: the binutils one prodices .a files that the cctools ld doesn't like
+    # - ar: the binutils one produces .a files that the cctools ld doesn't like
     # - ranlib: for compatibility with ar
-    # - dsymutil: soon going away once it goes into LLVM (this one is fake anyway)
     # - otool: we use it for some of our name mangling
     # - install_name_tool: we use it to rewrite stuff in our bootstrap tools
     # - strip: the binutils one seems to break mach-o files
@@ -36,6 +34,8 @@ stdenv.mkDerivation {
     for i in ${stdenv.lib.concatStringsSep " " (builtins.map (e: targetPrefix + e) cmds)}; do
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
+
+    ln -s ${llvm}/bin/llvm-dsymutil $out/bin/dsymutil
 
     ln -s ${binutils-unwrapped.out}/share $out/share
 

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -92,13 +92,6 @@ let
       popd
     '';
 
-    postInstall = ''
-      cat >$out/bin/dsymutil << EOF
-      #!${stdenv.shell}
-      EOF
-      chmod +x $out/bin/dsymutil
-    '';
-
     passthru = {
       inherit targetPrefix;
     };

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -15,6 +15,7 @@ in
   binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
     inherit (darwin) cctools;
     inherit (pkgs) binutils-unwrapped;
+    inherit (pkgs.llvmPackages_5) llvm;
   };
 
   binutils = pkgs.wrapBintoolsWith {


### PR DESCRIPTION
We were previously using a dummy wrapper for dsymutil. This meant that
debug symbols were not getting generated when dsymutil was otherwise
available. This should fix that issue & provide a real dsymutil from
llvm.

Fixes #52148.
