### PR TITLE
pythonPackages.graph-tool: fix build

### DIFF
--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -1,7 +1,9 @@
-{ stdenv, fetchurl, python, cairomm, sparsehash, pycairo, autoreconfHook,
-pkgconfig, boost, expat, scipy, cgal, gmp, mpfr,
-gobject-introspection, pygobject3, gtk3, matplotlib, ncurses,
-buildPythonPackage }:
+{ stdenv, fetchurl, python, cairomm, sparsehash, pycairo, autoreconfHook
+, pkgconfig, boost, expat, scipy, cgal, gmp, mpfr
+, gobject-introspection, pygobject3, gtk3, matplotlib, ncurses
+, buildPythonPackage
+, fetchpatch
+}:
 
 buildPythonPackage rec {
   pname = "graph-tool";
@@ -19,6 +21,15 @@ buildPythonPackage rec {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
     sha256 = "0w7pd2h8ayr88kjl82c8fdshnk6f3xslc77gy7ma09zkbvf76qnz";
   };
+
+  patches = [
+    # fix build with cgal 4.13 (https://git.skewed.de/count0/graph-tool/issues/509)
+    (fetchpatch {
+      name = "cgal-4.13.patch";
+      url = "https://git.skewed.de/count0/graph-tool/commit/aa39e4a6b42d43fac30c841d176c75aff92cc01a.patch";
+      sha256 = "1578inb4jqwq2fhhwscn5z95nzmaxvmvk30nzs5wirr26iznap4m";
+    })
+  ];
 
   configureFlags = [
     "--with-python-module-path=$(out)/${python.sitePackages}"


### PR DESCRIPTION
###### Motivation for this change

The new version of cgal introduced in #47826 requires a patch (that will
be included in the next graph-tool version).

Fixes #50446


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

