### PR TITLE
soapyremote: 0.4.3 -> 0.5.0

### DIFF
--- a/pkgs/applications/misc/soapyremote/default.nix
+++ b/pkgs/applications/misc/soapyremote/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, soapysdr }:
+{ stdenv, fetchFromGitHub, cmake, soapysdr, avahi }:
 
 let
-  version = "0.4.3";
+  version = "0.5.0";
 
 in stdenv.mkDerivation {
   name = "soapyremote-${version}";
@@ -9,12 +9,12 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "pothosware";
     repo = "SoapyRemote";
-    rev = "d07f43863b1ef79252f8029cfb5947220f21311d";
-    sha256 = "0i101dfqq0aawybv0qyjgsnhk39dc4q6z6ys2gsvwjhpf3d48aw0";
+    rev = "soapy-remote-${version}";
+    sha256 = "1lyjhf934zap61ky7rbk46bp8s8sjk8sgdyszhryfyf571jv9b2i";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ soapysdr ];
+  buildInputs = [ soapysdr avahi ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 


### PR DESCRIPTION
###### Motivation for this change
Manual update. Future should be updated by the auto updater. 

Changelog: https://github.com/pothosware/SoapyRemote/blob/master/Changelog.txt

###### Things done
* add avahi for DNS-SD
* test with RTL-SDR

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

