### PR TITLE
protonvpn-cli: init at 1.1.2

### DIFF
--- a/pkgs/applications/networking/protonvpn-cli/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, coreutils
+, openvpn, python, dialog, wget, update-resolv-conf }:
+
+let
+  expectedUpdateResolvPath = "/etc/openvpn/update-resolv-conf";
+  actualUpdateResolvePath = "${update-resolv-conf}/libexec/openvpn/update-resolv-conf";
+
+in stdenv.mkDerivation rec {
+  name = "protonvpn-cli";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "protonvpn-cli";
+    rev = "v${version}";
+    sha256 = "0xvflr8zf267n3dv63nkk4wjxhbckw56sqmyca3krf410vrd7zlv";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    substituteInPlace protonvpn-cli.sh \
+      --replace ${expectedUpdateResolvPath} ${actualUpdateResolvePath} \
+      --replace \$UID 0 \
+      --replace /etc/resolv.conf /dev/null \
+      --replace \
+        "  echo \"Connecting...\"" \
+        "  sed -ri 's@${expectedUpdateResolvPath}@${actualUpdateResolvePath}@g' \"\$openvpn_config\"; echo \"Connecting...\""
+    cp protonvpn-cli.sh "$out/bin/protonvpn-cli"
+    ln -s "$out/bin/protonvpn-cli" "$out/bin/pvpn"
+  '';
+
+  postInstallPhase = ''
+    wrapProgram $out/protonvpn-cli \
+      --prefix PATH : ${lib.makeBinPath [ coreutils openvpn python dialog wget update-resolv-conf ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "ProtonVPN Command-Line Tool";
+    homepage = https://github.com/ProtonVPN/protonvpn-cli;
+    maintainers = with maintainers; [ caugner ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18791,6 +18791,8 @@ in
 
   protonmail-bridge = libsForQt5.callPackage ../applications/networking/protonmail-bridge { };
 
+  protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
+
   psi = callPackage ../applications/networking/instant-messengers/psi { };
 
   psi-plus = callPackage ../applications/networking/instant-messengers/psi-plus { };


### PR DESCRIPTION
###### Motivation for this change

Makes the [protonvpn-cli](https://github.com/ProtonVPN/protonvpn-cli) available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

