### PR TITLE
xsecurelock: 1.1 -> 1.2

### DIFF
--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -4,16 +4,18 @@
 
 stdenv.mkDerivation rec {
   name = "xsecurelock-${version}";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "xsecurelock";
     rev = "v${version}";
-    sha256 = "0yqp5xhkl9jpjyrmrxbyp7azwxmqc3lxv5lxrjqjaapl3q3096g5";
+    sha256 = "1vaw2m3yyfazj1x7xdwppmm0ch075q399g5vzrmhhrkzdrs53r1x";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [
+    autoreconfHook pkgconfig
+  ];
   buildInputs = [
     libX11 libXcomposite libXft libXmu pam
     apacheHttpd imagemagick pamtester
@@ -23,6 +25,12 @@ stdenv.mkDerivation rec {
     "--with-pam-service-name=login"
     "--with-xscreensaver=${xscreensaver}/libexec/xscreensaver"
   ];
+
+  preConfigure = ''
+    cat > version.c <<'EOF'
+      const char *const git_version = "${version}";
+    EOF
+  '';
 
   preInstall = ''
     substituteInPlace helpers/saver_blank \


### PR DESCRIPTION
###### Motivation for this change

fixes upgrade so r-ryantm can do upgrades again.
Minimal testing beyond that.
cc @fpletz 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

