### PR TITLE
androidndk: Adds missing patch for 18b

### DIFF
--- a/pkgs/development/mobile/androidenv/make_standalone_toolchain.py_18b.patch
+++ b/pkgs/development/mobile/androidenv/make_standalone_toolchain.py_18b.patch
@@ -1,0 +1,98 @@
+diff --git a/build/tools/make_standalone_toolchain.py b/build/tools/make_standalone_toolchain.py
+index b8172b28..95daa6a6 100755
+--- a/build/tools/make_standalone_toolchain.py
++++ b/build/tools/make_standalone_toolchain.py
+@@ -353,7 +353,9 @@ def create_toolchain(install_path, arch, api, gcc_path, clang_path,
+                      platforms_path, host_tag):
+     """Create a standalone toolchain."""
+     copy_directory_contents(gcc_path, install_path)
++    os.system('chmod -R +w "{}"'.format(install_path))
+     copy_directory_contents(clang_path, install_path)
++    os.system('chmod -R +w "{}"'.format(install_path))
+     triple = get_triple(arch)
+     make_clang_scripts(
+         install_path, triple, api, host_tag.startswith('windows'))
+@@ -365,9 +367,11 @@ def create_toolchain(install_path, arch, api, gcc_path, clang_path,
+     install_headers = os.path.join(install_sysroot, 'usr/include')
+     os.makedirs(os.path.dirname(install_headers))
+     shutil.copytree(headers, install_headers)
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     arch_headers = os.path.join(sysroot, 'usr/include', triple)
+     copy_directory_contents(arch_headers, os.path.join(install_headers))
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     for lib_suffix in ('', '64'):
+         lib_path = os.path.join(platforms_path, 'usr/lib{}'.format(lib_suffix))
+@@ -375,20 +379,24 @@ def create_toolchain(install_path, arch, api, gcc_path, clang_path,
+             install_sysroot, 'usr/lib{}'.format(lib_suffix))
+         if os.path.exists(lib_path):
+             shutil.copytree(lib_path, lib_install)
++            os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     static_lib_path = os.path.join(sysroot, 'usr/lib', triple)
+     static_lib_install = os.path.join(install_sysroot, 'usr/lib')
+     if arch == 'x86_64':
+         static_lib_install += '64'
+     copy_directory_contents(static_lib_path, static_lib_install)
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     prebuilt_path = os.path.join(NDK_DIR, 'prebuilt', host_tag)
+     copy_directory_contents(prebuilt_path, install_path)
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     gdbserver_path = os.path.join(
+         NDK_DIR, 'prebuilt', 'android-' + arch, 'gdbserver')
+     gdbserver_install = os.path.join(install_path, 'share', 'gdbserver')
+     shutil.copytree(gdbserver_path, gdbserver_install)
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     toolchain_lib_dir = os.path.join(gcc_path, 'lib/gcc', triple)
+     dirs = os.listdir(toolchain_lib_dir)
+@@ -401,6 +409,7 @@ def create_toolchain(install_path, arch, api, gcc_path, clang_path,
+     libcxxabi_dir = os.path.join(NDK_DIR, 'sources/cxx-stl/llvm-libc++abi')
+     support_dir = os.path.join(NDK_DIR, 'sources/android/support')
+     copy_directory_contents(os.path.join(libcxx_dir, 'include'), cxx_headers)
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     if api < 21:
+         # For any libc header that is in libandroid_support, we actually have
+@@ -412,11 +421,13 @@ def create_toolchain(install_path, arch, api, gcc_path, clang_path,
+         copy_directory_contents(
+             os.path.join(support_dir, 'include'),
+             os.path.join(install_path, 'sysroot/usr/local/include'))
++        os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     # I have no idea why we need this, but the old one does it too.
+     copy_directory_contents(
+         os.path.join(libcxxabi_dir, 'include'),
+         os.path.join(install_path, 'include/llvm-libc++abi/include'))
++    os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     headers = [
+         'cxxabi.h',
+@@ -426,20 +437,24 @@ def create_toolchain(install_path, arch, api, gcc_path, clang_path,
+         shutil.copy2(
+             os.path.join(libcxxabi_dir, 'include', header),
+             os.path.join(cxx_headers, header))
++        os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     for abi in get_abis(arch):
+         src_libdir = get_src_libdir(libcxx_dir, abi)
+         dest_libdir = get_dest_libdir(install_path, triple, abi)
+         copy_libcxx_libs(src_libdir, dest_libdir, abi, api)
++        os.system('chmod -R +w "{}"'.format(install_path))
+         if arch == 'arm':
+             thumb_libdir = os.path.join(dest_libdir, 'thumb')
+             copy_libcxx_libs(src_libdir, thumb_libdir, abi, api)
++            os.system('chmod -R +w "{}"'.format(install_path))
+ 
+     # Not needed for every STL, but the old one does this. Keep it for the sake
+     # of diff. Done at the end so copytree works.
+     cxx_target_headers = os.path.join(cxx_headers, triple)
+     if not os.path.exists(cxx_target_headers):
+         os.makedirs(cxx_target_headers)
++        os.system('chmod -R +w "{}"'.format(install_path))
+ 
+ 
+ def parse_args():


### PR DESCRIPTION
###### Motivation for this change

Adds patch that was missed to add in: https://github.com/NixOS/nixpkgs/pull/50837

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

