### PR TITLE
ocamlPackages.csv-lwt: init at 2.2

### DIFF
--- a/pkgs/development/ocaml-modules/csv/lwt.nix
+++ b/pkgs/development/ocaml-modules/csv/lwt.nix
@@ -1,0 +1,14 @@
+{ lib, buildDunePackage, ocaml, csv, ocaml_lwt }:
+
+if !lib.versionAtLeast ocaml.version "4.02"
+then throw "csv-lwt is not available for OCaml ${ocaml.version}"
+else
+
+buildDunePackage {
+  pname = "csv-lwt";
+  inherit (csv) src version meta;
+
+  propagatedBuildInputs = [ csv ocaml_lwt ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.03";
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -200,6 +200,8 @@ let
       then callPackage ../development/ocaml-modules/csv { }
       else callPackage ../development/ocaml-modules/csv/1.5.nix { };
 
+    csv-lwt = callPackage ../development/ocaml-modules/csv/lwt.nix { };
+
     curses = callPackage ../development/ocaml-modules/curses { };
 
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

