### PR TITLE
nextcloud-client: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   name = "nextcloud-client-${version}";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchgit {
     url = "git://github.com/nextcloud/desktop.git";
     rev = "refs/tags/v${version}";
-    sha256 = "1wz5bz4nmni0qxzcvgmpg9ywrfixzvdd7ixgqmdm4d8g6dm8pk9k";
+    sha256 = "0r6jj3vbmwh7ipv83c8w1b25pbfq3mzrjgcijdw2gwfxwx9pfq7d";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Changelog:
```
Fixup the port in server notification URLs
GUI: let Clang-Tidy modernize nullptr & override usage
Improve the slide show
Libsync: let Clang-Tidy modernize nullptr & override usage 1
SettingsDialog: fix a little glitch in the account tool button size
SettingsDialog: tweak color aware icons
More verbose error and proper app name on configuration read error 1
Fix cmake build using WITH_PROVIDERS=OFF 1
Debian/Ubuntu target repository update 4
Change man page names and contents for nextcloud 1
Share dialog alignment
Fixed typo
Change link to docs for NC 15 1
Do not fetch activities if they are not enabled
Do not read system exclude list if user exclude is present
Fix the activity loop 5
Write the actual folder to the log
Fix appname for Nautilus integration script
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

