### PR TITLE
Fluidsynth 1

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -14,6 +14,9 @@
 
 stdenv.mkDerivation rec {
   name = "csound-${version}";
+  # When updating, please check if https://github.com/csound/csound/issues/1078
+  # has been fixed in the new version so we can use the normal fluidsynth
+  # version and remove fluidsynth 1.x from nixpkgs again.
   version = "6.12.0";
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -1,17 +1,32 @@
 { stdenv, lib, fetchFromGitHub, pkgconfig, cmake
 , alsaLib, glib, libjack2, libsndfile, libpulseaudio
 , AudioUnit, CoreAudio, CoreMIDI, CoreServices
+, version ? "2"
 }:
 
+let
+  versionMap = {
+    "1" = {
+      fluidsynthVersion = "1.1.11";
+      sha256 = "0n75jq3xgq46hfmjkaaxz3gic77shs4fzajq40c8gk043i84xbdh";
+    };
+    "2" = {
+      fluidsynthVersion = "2.0.1";
+      sha256 = "1mqyym5qkh8xd1rqj3yhfxbw5dxjcrljb6nkfqzvcarlv4h6rjn7";
+    };
+  };
+in
+
+with versionMap.${version};
+
 stdenv.mkDerivation  rec {
-  name = "fluidsynth-${version}";
-  version = "2.0.1";
+  name = "fluidsynth-${fluidsynthVersion}";
 
   src = fetchFromGitHub {
     owner = "FluidSynth";
     repo = "fluidsynth";
-    rev = "v${version}";
-    sha256 = "1mqyym5qkh8xd1rqj3yhfxbw5dxjcrljb6nkfqzvcarlv4h6rjn7";
+    rev = "v${fluidsynthVersion}";
+    inherit sha256;
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];

--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -21,6 +21,7 @@ with versionMap.${version};
 
 stdenv.mkDerivation  rec {
   name = "fluidsynth-${fluidsynthVersion}";
+  version = fluidsynthVersion;
 
   src = fetchFromGitHub {
     owner = "FluidSynth";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16267,7 +16267,9 @@ in
 
   csa = callPackage ../applications/audio/csa { };
 
-  csound = callPackage ../applications/audio/csound { };
+  csound = callPackage ../applications/audio/csound {
+    fluidsynth = fluidsynth_1;
+  };
 
   cinepaint = callPackage ../applications/graphics/cinepaint {
     fltk = fltk13;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16836,6 +16836,7 @@ in
   fluidsynth = callPackage ../applications/audio/fluidsynth {
      inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio CoreMIDI CoreServices;
   };
+  fluidsynth_1 = fluidsynth.override { version = "1"; };
 
   fmit = libsForQt5.callPackage ../applications/audio/fmit { };
 


### PR DESCRIPTION
###### Motivation for this change

csound needs fluidsynth 1, see https://github.com/csound/csound/issues/1078

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

