### PR TITLE
nixos/kubernetes: don't enable all alpha feature gates for the kubernetes tests

### DIFF
--- a/nixos/tests/kubernetes/kubernetes-common.nix
+++ b/nixos/tests/kubernetes/kubernetes-common.nix
@@ -3,7 +3,6 @@ with pkgs.lib;
 let
   base = {
     inherit roles;
-    featureGates = ["AllAlpha"];
     flannel.enable = true;
     addons.dashboard.enable = true;
 


### PR DESCRIPTION
###### Motivation for this change

Kubernetes alpha features are considered unstable and are less documented, and they might change or be removed at any time. Thus, it causes confusion and sometimes false negatives on the kubernetes test case results to have all alpha features enabled for the test cases only. The module defaults to having alpha features disabled.

In particular and currently, the `AllAlpha=true` flag causes the tests to break with the v1.13.0 upgrade proposed in https://github.com/NixOS/nixpkgs/pull/51896, even though all regular features of kubernetes work as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
