### PR TITLE
gitlab: 11.5.1 -> 11.5.4

### DIFF
--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -8,7 +8,7 @@ import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
 
   nodes = {
     gitlab = { ... }: {
-      virtualisation.memorySize = 2047;
+      virtualisation.memorySize = if pkgs.stdenv.is64bit then 4096 else 2047;
       systemd.services.gitlab.serviceConfig.Restart = mkForce "no";
       systemd.services.gitlab-workhorse.serviceConfig.Restart = mkForce "no";
       systemd.services.gitaly.serviceConfig.Restart = mkForce "no";

--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,12 +1,12 @@
 {
   "ce": {
-    "version": "11.5.1",
-    "repo_hash": "0drfan4yncvpcbmmb0lcr1zgk2bav2bzza70mwv3a65habhsy0x5",
-    "deb_hash": "04v5xqimj985718csjzfx7rmnmbfbrm2bp05i4s3x7byrzkl8w9d",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.5.1-ce.0_amd64.deb/download.deb",
+    "version": "11.5.4",
+    "repo_hash": "1mk7zj79cz9g8y6b5p4cznv90h94mwgy14w9vdvmqbgbnx9bayc8",
+    "deb_hash": "18i3w1k8l5hj3732w3adw3cma78l9hx77wlrgvssg9gz609kqvx6",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.5.4-ce.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ce",
-    "rev": "v11.5.1",
+    "rev": "v11.5.4",
     "passthru": {
       "GITALY_SERVER_VERSION": "0.129.0",
       "GITLAB_PAGES_VERSION": "1.3.1",

--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -15,13 +15,13 @@
     }
   },
   "ee": {
-    "version": "11.5.1",
-    "repo_hash": "150f7lnci88d821qxxla0dhwly3w59s3yzgvakzfc6p6iy07m9jp",
-    "deb_hash": "0gg3p4r6xscilw6igjk6l9mcxj3d7npnzg872r5y44p0q8faafhg",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.5.1-ee.0_amd64.deb/download.deb",
+    "version": "11.5.4",
+    "repo_hash": "1rpj34wblhk6yirix16grrlhg4dfna3mjvhn8bz82m94dkhx06lc",
+    "deb_hash": "05lizhf45xv4j0y0yafrpcrqmav1xmncxxgsm97s2mlhdwn5rfnd",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.5.4-ee.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ee",
-    "rev": "v11.5.1-ee",
+    "rev": "v11.5.4-ee",
     "passthru": {
       "GITALY_SERVER_VERSION": "0.129.0",
       "GITLAB_PAGES_VERSION": "1.3.1",

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile.lock
@@ -596,7 +596,7 @@ GEM
       get_process_mem (~> 0.2)
       puma (>= 2.7, < 4)
     pyu-ruby-sasl (0.0.3.3)
-    rack (1.6.11)
+    rack (1.6.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (4.4.1)

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/gemset.nix
@@ -2250,10 +2250,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
+      sha256 = "0in0amn0kwvzmi8h5zg6ijrx5wpsf8h96zrfmnk1kwh2ql4sxs2q";
       type = "gem";
     };
-    version = "1.6.11";
+    version = "1.6.10";
   };
   rack-accept = {
     dependencies = ["rack"];

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile.lock
@@ -625,7 +625,7 @@ GEM
       get_process_mem (~> 0.2)
       puma (>= 2.7, < 4)
     pyu-ruby-sasl (0.0.3.3)
-    rack (1.6.11)
+    rack (1.6.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (4.4.1)

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/gemset.nix
@@ -2371,10 +2371,10 @@
   rack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
+      sha256 = "0in0amn0kwvzmi8h5zg6ijrx5wpsf8h96zrfmnk1kwh2ql4sxs2q";
       type = "gem";
     };
-    version = "1.6.11";
+    version = "1.6.10";
   };
   rack-accept = {
     dependencies = ["rack"];


### PR DESCRIPTION
###### Motivation for this change
This bumps gitlab-(ce,ee) from 11.5.1 to 11.5.4, fixing [CVE-2018-19856](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19856) and [CVE-2018-20144](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20144)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

