### PR TITLE
ps2client: init at 2018-10-18

### DIFF
--- a/pkgs/applications/networking/ps2client/default.nix
+++ b/pkgs/applications/networking/ps2client/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2018-10-18";
+  name = "ps2client-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ps2dev";
+    repo  = "ps2client";
+    rev = "92fcaf18aabf74daaed40bd50d428cce326a87c0";
+    sha256 = "1rlmns44pxm6dkh6d3cz9sw8v7pvi53r7r5r3kgwdzkhixjj0cdg";
+  };
+
+  patchPhase = ''
+   sed -i -e "s|-I/usr/include||g" -e "s|-I/usr/local/include||g" Makefile
+  '';
+  
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Desktop clients to interact with ps2link and ps2netfs";
+    homepage = https://github.com/ps2dev/ps2client;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18776,6 +18776,8 @@ in
 
   protonmail-bridge = libsForQt5.callPackage ../applications/networking/protonmail-bridge { };
 
+  ps2client = callPackage ../applications/networking/ps2client { };
+
   psi = callPackage ../applications/networking/instant-messengers/psi { };
 
   psi-plus = callPackage ../applications/networking/instant-messengers/psi-plus { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

