### PR TITLE
duplicacy: init at 2.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1467,6 +1467,11 @@
     github = "fdns";
     name = "Felipe Espinoza";
   };
+  ffinkdevs = {
+    email = "fink@h0st.space";
+    github = "ffinkdevs";
+    name = "Fabian Fink";
+  };
   fgaz = {
     email = "francygazz@gmail.com";
     github = "fgaz";

--- a/pkgs/tools/backup/duplicacy/default.nix
+++ b/pkgs/tools/backup/duplicacy/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "duplicacy-${version}";
+  pname = "duplicacy";
   version = "2.1.2";
 
   goPackagePath = "github.com/gilbertchen/duplicacy/";
@@ -19,8 +19,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin
-    cp duplicacy_main $bin/bin/duplicacy
+    install -D duplicacy_main $bin/bin/duplicacy
   '';
 
   meta = with lib; {

--- a/pkgs/tools/backup/duplicacy/default.nix
+++ b/pkgs/tools/backup/duplicacy/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "duplicacy-${version}";
+  version = "2.1.2";
+
+  goPackagePath = "github.com/gilbertchen/duplicacy/";
+
+  src = fetchFromGitHub {
+    owner = "gilbertchen";
+    repo = "duplicacy";
+    rev = "v${version}";
+    sha256 = "0v3rk4da4b6dhqq8zsr4z27wd8p7crxapkn265kwpsaa99xszzbv";
+  };
+  goDeps = ./deps.nix;
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    go build duplicacy/duplicacy_main.go
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin
+    cp duplicacy_main $bin/bin/duplicacy
+  '';
+
+  meta = with lib; {
+    homepage = https://duplicacy.com;
+    description = "A new generation cloud backup tool ";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.unfree;
+    maintainers = with maintainers; [ ffinkdevs ];
+  };
+}

--- a/pkgs/tools/backup/duplicacy/deps.nix
+++ b/pkgs/tools/backup/duplicacy/deps.nix
@@ -1,0 +1,336 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "2d3a6656c17a60b0815b7e06ab0be04eacb6e613";
+      sha256 = "0fi3qj9fvc4bxbrwa1m5sxsb8yhvawiwigaddvmmizjykxbq5csq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/azure-sdk-for-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/azure-sdk-for-go";
+      rev =  "b7fadebe0e7f5c5720986080a01495bd8d27be37";
+      sha256 = "11zcmd17206byxhgz2a75qascilydlzjbz73l2mrqng3yyr20yk1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/go-autorest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-autorest";
+      rev =  "0ae36a9e544696de46fdadb7b0d5fb38af48c063";
+      sha256 = "0f2qcv24l9bx3jys2m9ycyy77vqlx7dbfa3frxlk19wnrwiv3p6g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/aryann/difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aryann/difflib";
+      rev =  "e206f873d14a916d3d26c40ab667bca123f365a3";
+      sha256 = "00zb9sx6l6b2zq614x45zlyshl20zjhwfj8r5krw4f9y0mx3n2dm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev =  "a32b1dcd091264b5dee7b386149b6cc3823395c9";
+      sha256 = "1yicb7l6m4hs3mi724hz74wn8305qvx6g73mjqafaaqvh6dyn86m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bkaradzic/go-lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bkaradzic/go-lz4";
+      rev =  "74ddf82598bc4745b965729e9c6a463bedd33049";
+      sha256 = "1vdid8v0c2v2qhrg9rzn3l7ya1h34jirrxfnir7gv7w6s4ivdvc1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "dbeaa9332f19a944acb5736b4456cfcc02140e29";
+      sha256 = "0zk6l6kzsjdijfn7c4h0aywdjx5j2hjwi67vy1k6wr46hc8ks2hs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/azure-sdk-for-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/azure-sdk-for-go";
+      rev =  "bbf89bd4d716c184f158d1e1428c2dbef4a18307";
+      sha256 = "14563izc2y05k8s20fmhanvjydbcq8k5adp4cgw91d9bs52qivx7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/cli";
+      rev =  "1de0a1836ce9c3ae1bf737a0869c4f04f28a7f98";
+      sha256 = "00vbyjsn009cqg24sxcizq10rgicnmrv0f8jg3fa1fw6yp5gqdl5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/go-dropbox";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/go-dropbox";
+      rev =  "90711b603312b1f973f3a5da3793ac4f1e5c2f2a";
+      sha256 = "0y2ydl3mjbkfbqyygrwq7vqig9hjh7cxvzsn2gxc1851haqp4h19";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/go-ole";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/go-ole";
+      rev =  "0e87ea779d9deb219633b828a023b32e1244dd57";
+      sha256 = "1d937b4i9mrwfgs1s17qhbd78dcd97wwm8zsajkarky8d55rz1bw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/go.dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/go.dbus";
+      rev =  "9e442e6378618c083fd3b85b703ffd202721fb17";
+      sha256 = "0q8ld38gnr4adzw5287lw5f5l14yp8slxsz1za5ryrkprh04bhkv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/goamz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/goamz";
+      rev =  "eada9f4e8cc2a45db775dee08a2c37597ce4760a";
+      sha256 = "0v6i4jdly06wixmm58ygxh284hnlbfxczvcwxvywiyy9bp5qyaid";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/gopass";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/gopass";
+      rev =  "bf9dde6d0d2c004a008c27aaee91170c786f6db8";
+      sha256 = "1jxzyfnqi0h1fzlsvlkn10bncic803bfhslyijcxk55mgh297g45";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/keyring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/keyring";
+      rev =  "8855f5632086e51468cd7ce91056f8da69687ef6";
+      sha256 = "1ja623dqnhkr1cvynrcai10s8kn2aiq53cvd8yxr47bb8i2a2q1m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gilbertchen/xattr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gilbertchen/xattr";
+      rev =  "68e7a6806b0137a396d7d05601d7403ae1abac58";
+      sha256 = "120lq8vasc5yh0ajczsdpi8cfzgi4ymrnphgqdfcar3b9rsvx80b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev =  "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a";
+      sha256 = "0mhgxw5q6b0pryhikx3k4wby7g32rwjjljzihi47lwn34kw5y1qn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "1e59b77b52bf8e4b449a57e6f79f21226d571845";
+      sha256 = "19bkh81wnp6njg3931wky6hsnnl2d1ig20vfjxpv450sd3k6yys8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/googleapis/gax-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gax-go";
+      rev =  "317e0006254c44a0ac427cc52a0e083ff0b9622f";
+      sha256 = "0h92x579vbrv2fka8q2ddy1kq6a63qbqa8zc09ygl6skzn9gw1dh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev =  "0b12d6b5";
+      sha256 = "1vv6hph8j6xgv7gwl9vvhlsaaqsm22sxxqmgmldi4v11783pc1ld";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kr/fs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/fs";
+      rev =  "2788f0dbd16903de03cb8186e5c7d97b69ad387b";
+      sha256 = "1c0fipl4rsh0v5liq1ska1dl83v3llab4k6lm8mvrx9c4dyp71ly";
+    };
+  }
+  {
+    goPackagePath  = "github.com/marstr/guid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/marstr/guid";
+      rev =  "8bd9a64bf37eb297b492a4101fb28e80ac0b290f";
+      sha256 = "081qrar6wwpmb2pq3swv4byh73r9riyhl2dwv0902d8jg3kwricm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/minio/blake2b-simd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/blake2b-simd";
+      rev =  "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4";
+      sha256 = "0b6jbnj62c0gmmfd4zdmh8xbg01p80f13yygir9xprqkzk6fikmd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ncw/swift";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ncw/swift";
+      rev =  "ae9f0ea1605b9aa6434ed5c731ca35d83ba67c55";
+      sha256 = "0a0iwynhgxsl3czabl7ajnxpyw6x0dzbiqz6il8aw7kn10ld1rvl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/sftp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/sftp";
+      rev =  "98203f5a8333288eb3163b7c667d4260fe1333e9";
+      sha256 = "09wxyrhwwh20rzpzb06vsj8k2bmw52cjlx7j4115zhky27528sx9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/satori/go.uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/satori/go.uuid";
+      rev =  "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3";
+      sha256 = "1j4s5pfg2ldm35y8ls8jah4dya2grfnx2drb4jcbjsyrp4cm5yfb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/vaughan0/go-ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vaughan0/go-ini";
+      rev =  "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1";
+      sha256 = "1l1isi3czis009d9k5awsj4xdxgbxn4n9yqjc1ac7f724x6jacfa";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94";
+      sha256 = "1mhmr6ljzl3iafsz4qy8vval7rmr828wh59dlqqqjqx6sqmcs1dv";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "9dfe39835686865bff950a07b394c12a98ddc811";
+      sha256 = "0z8mnl4mi88syafrgqys2ak2gg3yrbna25hpz88y3anl8x4jhg1a";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "f95fa95eaa936d9d87489b15d1d18b97c1ba9c28";
+      sha256 = "0p9kis69wvhv8a2qbcjxvn9ggpdh81cbfjpq5pjga7n8k6d065fh";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "82aafbf43bf885069dc71b7e7c2f9d7a614d47da";
+      sha256 = "1jvngpvy0q40f7krkgmwf5bbjzhv449297awcr0y78kzn0cyawi2";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "88f656faf3f37f690df1a32515b479415e1a6769";
+      sha256 = "0zakmgg6dlwnkhignwjajn0dckzqq18zxvnmmg0fq6455x7fs673";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/google-api-go-client";
+      rev =  "17b5f22a248d6d3913171c1a557552ace0d9c806";
+      sha256 = "0gs78qsxfg89kpiiray1x9jiv6bh328jmjkwd3ghnygf3l98kc8c";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "150dc57a1b433e64154302bdc40b6bb8aefa313a";
+      sha256 = "0w3knznv39k8bm85ri62f83czcrxknql7dv6p9hk1a5jx3xljgxq";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev =  "891aceb7c239e72692819142dfca057bdcbfcb96";
+      sha256 = "1axim84fqzsp6iialk6zl4fsbfpx658vssc6ccakn4yy1xc9h854";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev =  "5a9f7b402fe85096d2e1d0383435ee1876e863d0";
+      sha256 = "1hlirgvmzb929jpb1dvh930646ih5ffg3b6pmlilqr7ffdkl5z3j";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2367,6 +2367,8 @@ in
 
   duo-unix = callPackage ../tools/security/duo-unix { };
 
+  duplicacy = callPackage ../tools/backup/duplicacy { };
+  
   duplicati = callPackage ../tools/backup/duplicati { };
 
   duplicity = callPackage ../tools/backup/duplicity {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

