### PR TITLE
vagrant: build and install vagrant-libvirt plugin

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -23,7 +23,7 @@
 , cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
 , msgpack, qt59, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobject-introspection, gdk_pixbuf, zeromq, graphicsmagick, libcxx, file
-, libselinux ? null, libsepol ? null
+, libselinux ? null, libsepol ? null, libvirt
 }@args:
 
 let
@@ -319,6 +319,14 @@ in
   rmagick = attrs: {
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ imagemagick which ];
+  };
+
+  ruby-libvirt = attrs: {
+    buildInputs = [ libvirt pkgconfig ];
+    buildFlags = [
+      "--with-libvirt-include=${libvirt}/include"
+      "--with-libvirt-lib=${libvirt}/lib"
+    ];
   };
 
   ruby-lxc = attrs: {

--- a/pkgs/development/tools/vagrant/0004-Support-system-installed-plugins.patch
+++ b/pkgs/development/tools/vagrant/0004-Support-system-installed-plugins.patch
@@ -1,0 +1,97 @@
+From: Antonio Terceiro <terceiro@debian.org>
+Date: Wed, 27 May 2015 09:36:17 -0300
+Subject: Support system-installed plugins
+Source: https://salsa.debian.org/ruby-team/vagrant/blob/cb672c6dc0c63f6552c5ec4d6d7d22929d353503/debian/patches/0004-Support-system-installed-plugins.patch
+
+Plugins must be installed as regular Ruby libraries, and they must
+contain /usr/share/vagrant-plugins/plugins.d/$PLUGINNAME.json with the
+following content:
+
+{
+  "${PLUGINNAME}": {
+    "ruby_version":"$(ruby -e 'puts RUBY_VERSION')",
+    "vagrant_version":"$(cat /usr/share/vagrant/version.txt)",
+    "gem_version":"",
+    "require":"",
+    "sources":[]
+  }
+}
+---
+ lib/vagrant/plugin/manager.rb    |  4 ++--
+ lib/vagrant/plugin/state_file.rb | 22 +++++++++++++++++++++-
+ 2 files changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/lib/vagrant/plugin/manager.rb b/lib/vagrant/plugin/manager.rb
+index 567347d..d9d76a0 100644
+--- a/lib/vagrant/plugin/manager.rb
++++ b/lib/vagrant/plugin/manager.rb
+@@ -18,7 +18,7 @@ module Vagrant
+ 
+       # Returns the path to the [StateFile] for system plugins.
+       def self.system_plugins_file
+-        dir = Vagrant.installer_embedded_dir
++        dir = '@system_plugin_dir@'
+         return nil if !dir
+         Pathname.new(dir).join("plugins.json")
+       end
+@@ -38,7 +38,7 @@ module Vagrant
+ 
+         system_path  = self.class.system_plugins_file
+         @system_file = nil
+-        @system_file = StateFile.new(system_path) if system_path && system_path.file?
++        @system_file = StateFile.new(system_path, true) if system_path && system_path.file?
+ 
+         @local_file = nil
+         @globalized = @localized = false
+diff --git a/lib/vagrant/plugin/state_file.rb b/lib/vagrant/plugin/state_file.rb
+index c6872d4..935d431 100644
+--- a/lib/vagrant/plugin/state_file.rb
++++ b/lib/vagrant/plugin/state_file.rb
+@@ -11,8 +11,9 @@ module Vagrant
+       # @return [Pathname] path to file
+       attr_reader :path
+ 
+-      def initialize(path)
++      def initialize(path, system = false)
+         @path = path
++        @system = system
+ 
+         @data = {}
+         if @path.exist?
+@@ -28,6 +29,21 @@ module Vagrant
+ 
+         @data["version"] ||= "1"
+         @data["installed"] ||= {}
++        load_extra_plugins
++      end
++
++      def load_extra_plugins
++        extra_plugins = Dir.glob(@path.dirname.join('plugins.d', '*.json'))
++        extra_plugins.each do |filename|
++          json = File.read(filename)
++          begin
++            plugin_data = JSON.parse(json)
++            @data["installed"].merge!(plugin_data)
++          rescue JSON::ParserError => e
++            raise Vagrant::Errors::PluginStateFileParseError,
++              path: filename, message: e.message
++          end
++        end
+       end
+ 
+       # Add a plugin that is installed to the state file.
+@@ -107,6 +123,14 @@ module Vagrant
+           f.close
+           FileUtils.mv(f.path, @path)
+         end
++      rescue Errno::EACCES
++        # Ignore permission denied against system-installed plugins; regular
++        # users are not supposed to write there.
++        raise unless @system
++      rescue Errno::EROFS
++        # Ignore read-only filesystem against system-installed plugins; regular
++        # users are not supposed to write there.
++        raise unless @system
+       end
+ 
+       protected

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive, writeText, withLibvirt ? true, libvirt, pkgconfig }:
+{ lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive, writeText, withLibvirt ? true}:
 
 let
   # NOTE: bumping the version and updating the hash is insufficient;
@@ -35,8 +35,6 @@ in buildRubyGem rec {
   dontBuild = false;
   src = fetchurl { inherit url sha256; };
 
-  buildInputs = lib.optional withLibvirt [ libvirt pkgconfig ];
-
   patches = [
     ./unofficial-installation-nowarn.patch
     ./use-system-bundler-version.patch
@@ -53,12 +51,7 @@ in buildRubyGem rec {
   postInstall = ''
     wrapProgram "$out/bin/vagrant" \
       --set GEM_PATH "${deps}/lib/ruby/gems/${ruby.version.libDir}" \
-      --prefix PATH ':' "${lib.getBin libarchive}/bin" \
-      ${lib.optionalString withLibvirt ''
-        --prefix PATH ':' "${pkgconfig}/bin" \
-        --prefix PKG_CONFIG_PATH ':' \
-          "${lib.makeSearchPath "lib/pkgconfig" [ libvirt ]}"
-      ''}
+      --prefix PATH ':' "${lib.getBin libarchive}/bin"
 
     mkdir -p "$out/vagrant-plugins/plugins.d"
     echo '{}' > "$out/vagrant-plugins/plugins.json"

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -62,6 +62,11 @@ in buildRubyGem rec {
 
     mkdir -p "$out/vagrant-plugins/plugins.d"
     echo '{}' > "$out/vagrant-plugins/plugins.json"
+  '' +
+  lib.optionalString withLibvirt ''
+    substitute ${./vagrant-libvirt.json.in} $out/vagrant-plugins/plugins.d/vagrant-libvirt.json \
+      --subst-var-by ruby_version ${ruby.version} \
+      --subst-var-by vagrant_version ${version}
   '';
 
   installCheckPhase = ''

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -40,7 +40,13 @@ in buildRubyGem rec {
   patches = [
     ./unofficial-installation-nowarn.patch
     ./use-system-bundler-version.patch
+    ./0004-Support-system-installed-plugins.patch
   ];
+
+  postPatch = ''
+    substituteInPlace lib/vagrant/plugin/manager.rb --subst-var-by \
+      system_plugin_dir "$out/vagrant-plugins"
+  '';
 
   # PATH additions:
   #   - libarchive: Make `bsdtar` available for extracting downloaded boxes
@@ -53,6 +59,9 @@ in buildRubyGem rec {
         --prefix PKG_CONFIG_PATH ':' \
           "${lib.makeSearchPath "lib/pkgconfig" [ libvirt ]}"
       ''}
+
+    mkdir -p "$out/vagrant-plugins/plugins.d"
+    echo '{}' > "$out/vagrant-plugins/plugins.json"
   '';
 
   installCheckPhase = ''

--- a/pkgs/development/tools/vagrant/gemset_libvirt.nix
+++ b/pkgs/development/tools/vagrant/gemset_libvirt.nix
@@ -1,19 +1,118 @@
 {
-  mini_portile2 = {
+  excon = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0gzfmcywp1da8nzfqsql2zqi648mfnx6qwkig3cv36n9m0yy676y";
+      sha256 = "15l9w0938c19nxmrp09n75qpmm64k12xj69h47yvxzcxcpbgnkb2";
+      type = "gem";
+    };
+    version = "0.62.0";
+  };
+  fog-core = {
+    dependencies = ["builder" "excon" "formatador"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ac25s2wv7m6av7h7vjzd2bg3srhnn5yrz3lq1xpimhnfmp82sw6";
+      type = "gem";
+    };
+    version = "1.43.0";
+  };
+  fog-json = {
+    dependencies = ["fog-core" "multi_json"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zj8llzc119zafbmfa4ai3z5s7c4vp9akfs0f9l2piyvcarmlkyx";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  fog-libvirt = {
+    dependencies = ["fog-core" "fog-json" "fog-xml" "json" "ruby-libvirt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gk16gsjd51x71wla7h5jqr6x5ywpwz5l8jdv76f9mr6fp1j2bkf";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+  fog-xml = {
+    dependencies = ["fog-core" "nokogiri"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "043lwdw2wsi6d55ifk0w3izi5l1d1h0alwyr3fixic7b94kc812n";
+      type = "gem";
+    };
+    version = "0.1.3";
+  };
+  formatador = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gc26phrwlmlqrmz4bagq1wd5b7g64avpx0ghxr9xdxcvmlii0l0";
+      type = "gem";
+    };
+    version = "0.2.5";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13d32jjadpjj6d2wdhkfpsmy68zjx90p49bgf8f7nkpz86r1fr11";
       type = "gem";
     };
     version = "2.3.0";
   };
   nokogiri = {
     dependencies = ["mini_portile2"];
-      source = {
-        remotes = ["https://rubygems.org"];
-        sha256 = "0byyxrazkfm29ypcx5q4syrv126nvjnf7z6bqi01sqkv4llsi4qz";
-        type = "gem";
-      };
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0byyxrazkfm29ypcx5q4syrv126nvjnf7z6bqi01sqkv4llsi4qz";
+      type = "gem";
+    };
     version = "1.8.5";
+  };
+  ruby-libvirt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d754d6pgdqyq52pl9hp0x38q1vn3vf9nz4nm5gqdj5i4fw7pba6";
+      type = "gem";
+    };
+    version = "0.7.1";
+  };
+  vagrant-libvirt = {
+    dependencies = ["fog-core" "fog-libvirt" "nokogiri"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wm5yvml3sxdzpnlp4q6yhy695syy8byd1g7cxll4pmj1kwlknym";
+      type = "gem";
+    };
+    version = "0.0.45";
   };
 }

--- a/pkgs/development/tools/vagrant/vagrant-libvirt.json.in
+++ b/pkgs/development/tools/vagrant/vagrant-libvirt.json.in
@@ -1,0 +1,9 @@
+{
+  "vagrant-libvirt": {
+    "ruby_version":"@ruby_version@",
+    "vagrant_version":"@vagrant_version@",
+    "gem_version":"",
+    "require":"",
+    "sources":[]
+  }
+}


### PR DESCRIPTION
###### Motivation for this change

I was having trouble installing vagrant-libvirt with `vagrant plugin install vagrant-libvirt`, and I think it's cleaner to just let Nix manage everything.

#26202

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

