### PR TITLE
libvncserver: add CVE-2018-7225 patch

### DIFF
--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl,
+{stdenv, fetchurl, fetchpatch,
  libtool, libjpeg, openssl, zlib, libgcrypt, autoreconfHook, pkgconfig, libpng,
  systemd
 }:
@@ -18,6 +18,13 @@ stdenv.mkDerivation {
   src = fetchurl {
     inherit (s) url sha256;
   };
+  patches = [
+    # CVE-2018-7225. Remove with the next release
+    (fetchpatch {
+      url = https://salsa.debian.org/debian/libvncserver/raw/master/debian/patches/CVE-2018-7225.patch;
+      sha256 = "1hj1lzxsrdmzzl061vg0ncdpvfmvvkrpk8q12mp70qvszcqa7ja3";
+    })
+  ];
   preConfigure = ''
     sed -e 's@/usr/include/linux@${stdenv.cc.libc}/include/linux@g' -i configure
   '';


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/52249

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

