### PR TITLE
vscode: fix rpath for native modules

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -9,11 +9,13 @@ let
   longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
   shortName = "Code" + lib.optionalString isInsiders " - Insiders";
 
+  inherit (stdenv.hostPlatform) system;
+
   plat = {
     "i686-linux" = "linux-ia32";
     "x86_64-linux" = "linux-x64";
     "x86_64-darwin" = "darwin";
-  }.${stdenv.hostPlatform.system};
+  }.${system};
 
   sha256 = {
     "i686-linux" = "1g73fay6fxlqhalkqq5m6rjbp68k9npk0rrxrkhdj8mw0cz74dpm";
@@ -21,7 +23,7 @@ let
     "x86_64-darwin" = "07r52scs1sgafzxqal39r8vf9p9qqvwwx8f6z09gqcf6clr6k48q";
   }.${stdenv.hostPlatform.system};
 
-  archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";
+  archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
@@ -82,8 +84,11 @@ in
 
     nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;
 
+    dontBuild = true;
+    dontConfigure = true;
+
     installPhase =
-      if stdenv.hostPlatform.system == "x86_64-darwin" then ''
+      if system == "x86_64-darwin" then ''
         mkdir -p $out/lib/vscode $out/bin
         cp -r ./* $out/lib/vscode
         ln -s $out/lib/vscode/Contents/Resources/app/bin/${executableName} $out/bin
@@ -105,11 +110,8 @@ in
         cp $out/lib/vscode/resources/app/resources/linux/code.png $out/share/pixmaps/code.png
       '';
 
-    postFixup = lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux") ''
-      wrapProgram $out/lib/vscode/${executableName} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd fontconfig ]}
-
-      ln -s ${lib.makeLibraryPath [libsecret]}/libsecret-1.so.0 $out/lib/vscode/libsecret-1.so.0
+    preFixup = lib.optionalString (system == "i686-linux" || system == "x86_64-linux") ''
+      gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd fontconfig ]})
     '';
 
     meta = with stdenv.lib; {

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, lib, fetchurl, unzip, atomEnv, makeDesktopItem,
-  gtk2, wrapGAppsHook, libXScrnSaver, libxkbfile, libsecret,
-  isInsiders ? false }:
+{ stdenv, lib, fetchurl, makeDesktopItem
+, unzip, libsecret, libXScrnSaver, wrapGAppsHook
+, gtk2, atomEnv, at-spi2-atk, autoPatchelfHook
+, systemd, fontconfig
+, isInsiders ? false }:
 
 let
   executableName = "code" + lib.optionalString isInsiders "-insiders";
@@ -20,16 +22,6 @@ let
   }.${stdenv.hostPlatform.system};
 
   archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";
-
-  rpath = lib.concatStringsSep ":" [
-    atomEnv.libPath
-    "${lib.makeLibraryPath [gtk2]}"
-    "${lib.makeLibraryPath [libsecret]}/libsecret-1.so.0"
-    "${lib.makeLibraryPath [libXScrnSaver]}/libXss.so.1"
-    "${lib.makeLibraryPath [libxkbfile]}/libxkbfile.so.1"
-    "$out/lib/vscode"
-  ];
-
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
@@ -83,9 +75,12 @@ in
       '';
     };
 
-    buildInputs = if stdenv.hostPlatform.system == "x86_64-darwin"
-      then [ unzip libXScrnSaver libsecret ]
-      else [ wrapGAppsHook libXScrnSaver libxkbfile libsecret ];
+    buildInputs = (if stdenv.isDarwin
+      then [ unzip ]
+      else [ gtk2 at-spi2-atk wrapGAppsHook ] ++ atomEnv.packages)
+        ++ [ libsecret libXScrnSaver ];
+
+    nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;
 
     installPhase =
       if stdenv.hostPlatform.system == "x86_64-darwin" then ''
@@ -111,19 +106,8 @@ in
       '';
 
     postFixup = lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux") ''
-      patchelf \
-        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${rpath}" \
-        $out/lib/vscode/${executableName}
-
-      patchelf \
-        --set-rpath "${rpath}" \
-        $out/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
-
-      patchelf \
-        --set-rpath "${rpath}" \
-        "$out/lib/vscode/resources/app/node_modules.asar.unpacked/native-keymap/build/Release/\
-      keymapping.node"
+      wrapProgram $out/lib/vscode/${executableName} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd fontconfig ]}
 
       ln -s ${lib.makeLibraryPath [libsecret]}/libsecret-1.so.0 $out/lib/vscode/libsecret-1.so.0
     '';


### PR DESCRIPTION
###### Motivation for this change
Affects at least VSCode Insiders 1544768411 and 1545113902.
Current VSCode stable 1.30.1 doesn't need this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

