### PR TITLE
plata-theme: init at 0.4.9

### DIFF
--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -1,0 +1,80 @@
+{ stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, parallel
+, sassc, inkscape, libxml2, gnome2, gdk_pixbuf, librsvg, gtk-engine-murrine
+, cinnamonSupport ? true
+, gnomeFlashbackSupport ? true
+, gnomeShellSupport ? true
+, mateSupport ? true
+, openboxSupport ? true
+, xfceSupport ? true
+, gtkNextSupport ? false
+, plankSupport ? false
+, telegramSupport ? false
+, tweetdeckSupport ? false
+, selectionColor ? null # Primary color for 'selected-items' (Default: #3F51B5 = Indigo500)
+, accentColor ? null # Secondary color for notifications and OSDs (Default: #7986CB = Indigo300)
+, suggestionColor ? null # Secondary color for 'suggested' buttons (Default: #673AB7 = DPurple500)
+, destructionColor ? null # Tertiary color for 'destructive' buttons (Default: #F44336 = Red500)
+}:
+
+stdenv.mkDerivation rec {
+  name = "plata-theme-${version}";
+  version = "0.4.9";
+
+  src = fetchFromGitLab {
+    owner = "tista500";
+    repo = "plata-theme";
+    rev = version;
+    sha256 = "0kj04nj265rgkbbhzhz9f7q6z5yr1dxmcrnq1b5ldha3xqrq2pv9";
+  };
+
+  preferLocalBuild = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    parallel
+    sassc
+    inkscape
+    libxml2
+    gnome2.glib.dev
+  ];
+
+  buildInputs = [
+    gdk_pixbuf
+    librsvg
+  ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  postPatch = "patchShebangs .";
+
+  configureFlags =
+    let
+      inherit (stdenv.lib) enableFeature optional;
+      withOptional = value: feat: optional (value != null) "--with-${feat}=${value}";
+    in [
+      "--enable-parallel"
+      (enableFeature cinnamonSupport "cinnamon")
+      (enableFeature gnomeFlashbackSupport "flashback")
+      (enableFeature gnomeShellSupport "gnome")
+      (enableFeature mateSupport "mate")
+      (enableFeature openboxSupport "openbox")
+      (enableFeature xfceSupport "xfce")
+      (enableFeature gtkNextSupport "gtk_next")
+      (enableFeature plankSupport "plank")
+      (enableFeature telegramSupport "telegram")
+      (enableFeature tweetdeckSupport "tweetdeck")
+    ]
+    ++ (withOptional selectionColor "selection_color")
+    ++ (withOptional accentColor "accent_color")
+    ++ (withOptional suggestionColor "suggestion_color")
+    ++ (withOptional destructionColor "destruction_color");
+
+  meta = with stdenv.lib; {
+    description = "A Gtk+ theme based on Material Design Refresh";
+    homepage = https://gitlab.com/tista500/plata-theme;
+    license = with licenses; [ gpl2 cc-by-sa-40 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.tadfisher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15653,6 +15653,8 @@ in
 
   penna = callPackage ../data/fonts/penna { };
 
+  plata-theme = callPackage ../data/themes/plata {};
+
   poly = callPackage ../data/fonts/poly { };
 
   polytopes_db = callPackage ../data/misc/polytopes_db { };


### PR DESCRIPTION
###### Motivation for this change

Plata is a GTK+ theme based on Material Design Refresh. It was formerly known as Adapta 3.95.0, which I PR'd here: https://github.com/NixOS/nixpkgs/pull/47610

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

