### PR TITLE
ut2004demo: fix download URL

### DIFF
--- a/pkgs/games/ut2004/demo.nix
+++ b/pkgs/games/ut2004/demo.nix
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   version = "3334";
 
   src = fetchurl {
-    url = "http://treefort.icculus.org/ut2004/UT2004-LNX-Demo${version}.run.gz";
+    url = "http://vlaai.snt.utwente.nl/pub/games/UT2004/demo/UT2004-LNX-Demo${version}.run.gz";
     sha256 = "0d5f84qz8l1rg16yzx2k4ikr46n9iwj68na1bqi87wrww7ck6jh7";
   };
 


### PR DESCRIPTION
###### Motivation for this change

http://treefort.icculus.org/ut2004/UT2004-LNX-Demo3334.run.gz is gone.

The file is on web.archive.org, but Wayback doesn't manage to serve a complete copy. I found it elsewhere with the same hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

My local build log:

```
# NIXPKGS_ALLOW_UNFREE=1 nix-env -f ~/code/system/nixpkgs -iA ut2004demo
installing 'ut2004'
these derivations will be built:
  /nix/store/p9gpsc0qsfx6iflf02yvsdc094siwjp1-UT2004-LNX-Demo3334.run.gz.drv
  /nix/store/qigs9adp6kyldf861nckrfccvir29gqq-ut2004-demo-3334.drv
  /nix/store/6csvxv0nwm7wiglxlcxnr7aj2crg36x3-ut2004-game.drv
  /nix/store/kydikfhmxy1p6z7jh8s905a88235ki06-ut2004.drv
building '/nix/store/p9gpsc0qsfx6iflf02yvsdc094siwjp1-UT2004-LNX-Demo3334.run.gz.drv'...

trying http://vlaai.snt.utwente.nl/pub/games/UT2004/demo/UT2004-LNX-Demo3334.run.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  275M  100  275M    0     0  1510k      0  0:03:06  0:03:06 --:--:-- 1868k
building '/nix/store/qigs9adp6kyldf861nckrfccvir29gqq-ut2004-demo-3334.drv'...
Verifying archive integrity... All good.
Uncompressing Unreal Tournament 2004 for GNU/Linux Demo 3334.....
building '/nix/store/6csvxv0nwm7wiglxlcxnr7aj2crg36x3-ut2004-game.drv'...
created 230 symlinks in user environment
building '/nix/store/kydikfhmxy1p6z7jh8s905a88235ki06-ut2004.drv'...
building '/nix/store/9jyyr4drlsrxk22m56a5m7clns8dd4px-user-environment.drv'...
created 2849 symlinks in user environment
```

The splash screen works for me, but the game exits during startup:

```
# ut2004
AL lib: (EE) UpdateDeviceParams: Failed to set 44100hz, got 48000hz instead
Couldn't set video mode: Couldn't find matching GLX visual


History:

Exiting due to error
```

I think it might still work on someone else's machine?
