### PR TITLE
firejail: disable parallel building

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -43,7 +43,9 @@ stdenv.mkDerivation {
     sed -E -e 's@^include (.*)(/firejail/.*.local)$@include /etc\2@g' -i $out/etc/firejail/*.profile
   '';
 
-  enableParallelBuilding = true;
+  # At high parallelism, the build sometimes fails with:
+  # bash: src/fsec-optimize/fsec-optimize: No such file or directory
+  enableParallelBuilding = false;
 
   meta = {
     inherit (s) version;


### PR DESCRIPTION
###### Motivation for this change

firejail was frequently failing to build on my Hydra machine at -j16, and the error looked like a typical parallel build problem:

```
<3>make[1]: Entering directory '/build/firejail-0.9.56/src/fcopy'
<3>gcc -ggdb  -O2 -DVERSION='"0.9.56"'   -DPREFIX='"/nix/store/0dm1agiwiggn8pmnqkknil7mkh25il0k-firejail-0.9.56"'  -DSYSCONFDIR='"/nix/store/0dm1agiwiggn8pmnqkknil7mkh25il0k-firejail-0.9.56/etc/firejail"' -DLIBDIR='"/nix/store/0dm1agiwiggn8pmnqkknil7mkh25il0k-firejail-0.9.56/lib"' -DHAVE_X11 -DHAVE_PRIVATE_HOME  -DHAVE_OVERLAYFS -DHAVE_SECCOMP -DHAVE_GLOBALCFG -DHAVE_SECCOMP_H -DHAVE_CHROOT -DHAVE_NETWORK -DHAVE_USERNS -DHAVE_FILE_TRANSFER -DHAVE_WHITELIST -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security -mindirect-branch=thunk   -c main.c -o main.o
<3>gcc  -pie -Wl,-z,relro -Wl,-z,now -lpthread -o fcopy main.o
<3>make[1]: Leaving directory '/build/firejail-0.9.56/src/fcopy'
<3>make -C src/fldd
<3>make[1]: Entering directory '/build/firejail-0.9.56/src/fldd'
<3>gcc -ggdb  -O2 -DVERSION='"0.9.56"'   -DPREFIX='"/nix/store/0dm1agiwiggn8pmnqkknil7mkh25il0k-firejail-0.9.56"'  -DSYSCONFDIR='"/nix/store/0dm1agiwiggn8pmnqkknil7mkh25il0k-firejail-0.9.56/etc/firejail"' -DLIBDIR='"/nix/store/0dm1agiwiggn8pmnqkknil7mkh25il0k-firejail-0.9.56/lib"' -DHAVE_X11 -DHAVE_PRIVATE_HOME  -DHAVE_OVERLAYFS -DHAVE_SECCOMP -DHAVE_GLOBALCFG -DHAVE_SECCOMP_H -DHAVE_CHROOT -DHAVE_NETWORK -DHAVE_USERNS -DHAVE_FILE_TRANSFER -DHAVE_WHITELIST -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security -mindirect-branch=thunk   -c main.c -o main.o
<3>gcc  -pie -Wl,-z,relro -Wl,-z,now -lpthread -o fldd main.o ../lib/ldd_utils.o
<3>make[1]: Leaving directory '/build/firejail-0.9.56/src/fldd'
<3>make -C src/libpostexecseccomp
<3>make[1]: Entering directory '/build/firejail-0.9.56/src/libpostexecseccomp'
<3>gcc -ggdb  -O2 -DVERSION='"0.9.56"' -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC -Wformat -Wformat-security  -c libpostexecseccomp.c -o libpostexecseccomp.o
<3>gcc -pie -Wl,-z,relro -Wl,-z,now -shared -fPIC -z relro -o libpostexecseccomp.so libpostexecseccomp.o -ldl
<3>make[1]: Leaving directory '/build/firejail-0.9.56/src/libpostexecseccomp'
<3>src/fseccomp/fseccomp default seccomp
<3>src/fsec-optimize/fsec-optimize seccomp
<3>/nix/store/6abyjgibafsbhlc7v7lab50mb3dj81jg-bash-4.4-p23/bin/bash: src/fsec-optimize/fsec-optimize: No such file or directory
<3>make: *** [Makefile:43: filters] Error 127
<3>builder for '/nix/store/30srqmpqrjyr11nhx4jbpr84m9pnmyv5-firejail-0.9.56.drv' failed with exit code 2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

