### PR TITLE
parity: 2.2.4 -> 2.2.5

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.2.4";
-  sha256      = "12qcfmc56vnay25nlflgwhm3iwlr7hd286wzzanlsalizaj5s5ja";
-  cargoSha256 = "11cwzqd459ld0apl2wnarfc4nb6j9j0dh26y3smvr0zsxvaz1r53";
+  version     = "2.2.5";
+  sha256      = "0q9vgwc0jlja73r4na7yil624iagq1607ac47wh8a7xgfjmjjai1";
+  cargoSha256 = "0ibdmyh1jvfq51vhwn4riyhilqwhf71hjd4vyj525smn95p75b14";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.1.9";
-  sha256      = "1xxpv2cxfcjwxfxkn2732y1wxh9rpiwmlb2ij09cg5nph669hy0v";
-  cargoSha256 = "1v44l90bacw8d3ilnmrc49dxdpyckh7iamylkpa1pc0rrpiv5vy4";
+  version     = "2.1.10";
+  sha256      = "1l4yl8i24q8v4hzljzai37f587x8m3cz3byzifhvq3bjky7p8h80";
+  cargoSha256 = "04pni9cmz8nhlqznwafz9d81006808kh24aqnb8rjdcr84d11zis";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/paritytech/parity-ethereum/releases/tag/v2.2.5
* https://github.com/paritytech/parity-ethereum/releases/tag/v2.1.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

