### PR TITLE
rendersvg: init at 0.7.0

### DIFF
--- a/pkgs/applications/graphics/rendersvg/default.nix
+++ b/pkgs/applications/graphics/rendersvg/default.nix
@@ -1,0 +1,49 @@
+{ stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pango,
+  gdk_pixbuf,
+  pkgconfig,
+  qtbase
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "rendersvg-${version}";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "RazrFalcon";
+    repo = "resvg";
+    rev = "v${version}";
+    sha256 = "1aajrs6alcm8l9b89w9gva6ljyhda803lmdasaw8s8ga76apb729";
+  };
+
+  cargoSha256 = "056cdpd79r6j2vh3h6k8kzlnyvhaqfsfc2igmq2riab2zjfrz1dz";
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    pango
+    gdk_pixbuf
+    qtbase
+  ];
+
+  buildPhase = ''
+    cd tools/rendersvg/
+    cargo build --release --features="qt-backend cairo-backend raqote-backend"
+  '';
+
+  installPhase = ''
+    install -D ../../target/release/rendersvg $out/bin/rendersvg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A SVG rendering application based on resvg";
+    homepage = https://github.com/RazrFalcon/resvg/tree/master/tools/rendersvg;
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ flosse ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5719,6 +5719,8 @@ in
 
   renderdoc = libsForQt5.callPackage ../applications/graphics/renderdoc { };
 
+  rendersvg = libsForQt5.callPackage ../applications/graphics/rendersvg { };
+
   replace = callPackage ../tools/text/replace { };
 
   reckon = callPackage ../tools/text/reckon { };


### PR DESCRIPTION
###### Motivation for this change
`rendersvg` enables me to render SVG-Files without Inkscape :)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

