### PR TITLE
buildkit: init at v0.4.0

### DIFF
--- a/pkgs/development/tools/buildkit/default.nix
+++ b/pkgs/development/tools/buildkit/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  pname = "buildkit";
+  version = "0.4.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/moby/buildkit";
+  subPackages = [ "cmd/buildctl" ] ++ stdenv.lib.optionals stdenv.isLinux [ "cmd/buildkitd" ];
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "moby";
+    repo = "buildkit";
+    sha256 = "0gkwcjqbcskn63y79jwa26hxkps452z4bgz8lrryaskzbdpvhh3d";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit";
+    homepage = https://github.com/moby/buildkit;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ vdemeester ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1071,6 +1071,8 @@ in
 
   buildah = callPackage ../development/tools/buildah { };
 
+  buildkit = callPackage ../development/tools/buildkit { };
+
   bukubrow = callPackage ../tools/networking/bukubrow { };
 
   burpsuite = callPackage ../tools/networking/burpsuite {};


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

> BuildKit is a toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner.

`buildkit` is also used inside the `docker` daemon since 18.06 (experimental) and 18.09 (stable).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

