### PR TITLE
libaom: create shared libraries, fix version reported in aom.pc

### DIFF
--- a/pkgs/development/libraries/libaom/default.nix
+++ b/pkgs/development/libraries/libaom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, yasm, perl, cmake, pkgconfig, python3Packages }:
+{ stdenv, fetchgit, yasm, perl, cmake, pkgconfig, python3Packages, writeText }:
 
 stdenv.mkDerivation rec {
   name = "libaom-${version}";
@@ -12,6 +12,32 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl yasm ];
   nativeBuildInputs = [ cmake pkgconfig python3Packages.python ];
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  # * libaom tries to detect what version it is
+  #   * I couldn't get it to grab this from git info,
+  #     (which needs at least leaveDotGit=true)
+  #   * it uses a perl script to parse from CHANGELOG,
+  #     but 1.0.0 doesn't contain an entry for itself :(
+  # * Upstream patch that adds the entry also nukes all of
+  #   the versions before a project change (open-sourcing?)
+  #   and as a result is 34K which is way too big just to fix this!
+  #   * A stable URL to fetch this from works, but...
+  # * Upon inspection the resulting CHANGELOG is shorter
+  #   than this comment, so while yes this is a bit gross
+  #   adding these 4 lines here does the job without
+  #   a huge patch in spirit of preferring upstream's fix
+  #   instead of `sed -i 's/v0\.1\.0/v1.0.0/g' aom.pc` or so.
+  postPatch = let actual_changelog = writeText "CHANGELOG" ''
+    2018-06-28 v1.0.0
+      AOMedia Codec Workgroup Approved version 1.0
+
+    2016-04-07 v0.1.0 "AOMedia Codec 1"
+      This release is the first Alliance for Open Media codec.
+  ''; in ''
+   cp ${actual_changelog} CHANGELOG
+  '';
 
   meta = with stdenv.lib; {
     description = "AV1 Bitstream and Decoding Library";


### PR DESCRIPTION
See added comment for explanation of version fix.


###### Motivation for this change

* Shared: match nixpkgs preference, happened to notice while
  investigating version problem
* Version: without this fix packages that require aom 1.0.0
  will incorrectly be told only 0.1.0 is available--
  I ran into this putting together ffmpeg upgrades.
  (will submit shortly)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---