### PR TITLE
Emacs site-start: Use correct feature name

### DIFF
--- a/pkgs/applications/editors/emacs/site-start.el
+++ b/pkgs/applications/editors/emacs/site-start.el
@@ -30,7 +30,7 @@ least specific (the system profile)"
                  woman-manpath)))
 
 ;;; Make tramp work for remote NixOS machines
-(eval-after-load 'tramp
+(eval-after-load 'tramp-sh
   ;; TODO: We should also add the other `NIX_PROFILES' to this path.
   ;; However, these are user-specific, so we would need to discover
   ;; them dynamically after connecting via `tramp'


### PR DESCRIPTION
###### Motivation for this change
Tramp upstream recently dropped the autoload cookie from
tramp-remote-path. This makes Emacs error when trying to load tramp.
Using the correct feature name fixes this.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

