### PR TITLE
gamecube-tools: init at v1.0.2

### DIFF
--- a/pkgs/development/tools/gamecube-tools/default.nix
+++ b/pkgs/development/tools/gamecube-tools/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, which, autoconf, automake, fetchFromGitHub,
+  libtool, freeimage, mesa }:
+stdenv.mkDerivation rec {
+  version = "v1.0.2";
+  name = "gamecube-tools-${version}";
+
+  nativeBuildInputs = [ which autoconf automake libtool ];
+  buildInputs = [ freeimage mesa ];
+
+  src = fetchFromGitHub {
+    owner = "devkitPro";
+    repo  = "gamecube-tools";
+    rev = version;
+    sha256 = "0zvpkzqvl8iv4ndzhkjkmrzpampyzgb91spv0h2x2arl8zy4z7ca";
+  };
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "Tools for gamecube/wii projects";
+    homepage = "https://github.com/devkitPro/gamecube-tools/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tomsmeets ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -730,6 +730,8 @@ in
 
   genymotion = callPackage ../development/mobile/genymotion { };
 
+  gamecube-tools = callPackage ../development/tools/gamecube-tools { };
+
   gams = callPackage ../tools/misc/gams {
     licenseFile = config.gams.licenseFile or null;
     optgamsFile = config.gams.optgamsFile or null;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

