### PR TITLE
wiiload: init at v0.5.1

### DIFF
--- a/pkgs/development/tools/wiiload/default.nix
+++ b/pkgs/development/tools/wiiload/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, zlib }:
+stdenv.mkDerivation rec {
+  version = "v0.5.1";
+  name = "wiiload-${version}";
+
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ zlib ];
+
+  src = fetchFromGitHub {
+    owner = "devkitPro";
+    repo  = "wiiload";
+    rev = version;
+    sha256 = "0dffy603zggkqv7g1a2jninmi64vy519gpgkdfhjnijhdm9gs5m3";
+  };
+
+  preConfigure = "./autogen.sh";
+
+  meta = with stdenv.lib; {
+    description = "Load homebrew apps over network/usbgecko to your Wii";
+    homepage = https://wiibrew.org/wiki/Wiiload;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tomsmeets ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -805,6 +805,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
+  wiiload = callPackage ../development/tools/wiiload { };
+
   xcodeenv = callPackage ../development/mobile/xcodeenv { };
 
   ssh-agents = callPackage ../tools/networking/ssh-agents { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

