### PR TITLE
adoptopenjdk: autogenerate sources + add support for aarch64

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
+++ b/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i python3 -p python3 -p python3Packages.requests
+
+import json
+import re
+import requests
+import sys
+
+releases = ["openjdk11"]
+oses = ["mac", "linux"]
+types = ["jre", "jdk"]
+impls = ["hotspot", "openj9"]
+
+arch_to_nixos = {
+    "x64": "x86_64",
+    "aarch64": "aarch64",
+}
+
+def get_sha256(url):
+    resp = requests.get(url)
+    if resp.status_code != 200:
+        print("error: could not fetch checksum from url {}: code {}".format(url, resp.code), file=sys.stderr)
+        sys.exit(1)
+    return resp.text.strip().split(" ")[0]
+
+RE_RELEASE_NAME = re.compile(r'[^-]+-([0-9.]+)\+([0-9]+)') # example release name: jdk-11.0.1+13
+def generate_sources(release, assets):
+    out = {}
+    for asset in assets:
+        if asset["os"] not in oses: continue
+        if asset["binary_type"] not in types: continue
+        if asset["openjdk_impl"] not in impls: continue
+        if asset["heap_size"] != "normal": continue
+        if asset["architecture"] not in arch_to_nixos: continue
+
+        version, build = RE_RELEASE_NAME.match(asset["release_name"]).groups()
+
+        type_map = out.setdefault(asset["os"], {})
+        impl_map = type_map.setdefault(asset["binary_type"], {})
+        arch_map = impl_map.setdefault(asset["openjdk_impl"], {
+            "version": version,
+            "build": build,
+            "packageType": asset["binary_type"],
+            "vmType": asset["openjdk_impl"],
+        })
+
+        if arch_map["version"] != version or arch_map["build"] != build:
+            print("error: architectures have different latest versions ({}+{} vs {}+{})".format(
+                arch_map["version"], arch_map["build"], version, build
+            ), file=sys.stderr)
+            sys.exit(1)
+
+        arch_map[arch_to_nixos[asset["architecture"]]] = {
+            "url": asset["binary_link"],
+            "sha256": get_sha256(asset["checksum_link"]),
+        }
+
+    return out
+
+out = {}
+for release in releases:
+    resp = requests.get("https://api.adoptopenjdk.net/v2/latestAssets/releases/" + release)
+    if resp.status_code != 200:
+        print("error: could not fetch data for release {} (code {})".format(release, resp.code), file=sys.stderr)
+        sys.exit(1)
+    out[release] = generate_sources(release, resp.json())
+
+with open("sources.json", "w") as f:
+    json.dump(out, f, indent=2, sort_keys=True)

--- a/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
+++ b/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i python3 -p python3 -p python3Packages.requests
+#!nix-shell --pure -i python3 -p "python3.withPackages (ps: with ps; [ requests ])"
 
 import json
 import re

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -1,7 +1,4 @@
-{ name
-, url
-, sha256
-}:
+sourcePerArch:
 
 { swingSupport ? true # not used for now
 , stdenv
@@ -9,10 +6,12 @@
 }:
 
 let result = stdenv.mkDerivation rec {
-  inherit name;
+  name = if sourcePerArch.packageType == "jdk"
+    then "adoptopenjdk-${sourcePerArch.vmType}-bin-${sourcePerArch.version}"
+    else "adoptopenjdk-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin-${sourcePerArch.version}";
 
   src = fetchurl {
-    inherit url sha256;
+    inherit (sourcePerArch.${stdenv.hostPlatform.parsed.cpu.name}) url sha256;
   };
 
   # See: https://github.com/NixOS/patchelf/issues/10

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -1,7 +1,4 @@
-{ name
-, url
-, sha256
-}:
+sourcePerArch:
 
 { swingSupport ? true
 , stdenv
@@ -48,10 +45,12 @@ let
 in
 
 let result = stdenv.mkDerivation rec {
-  inherit name;
+  name = if sourcePerArch.packageType == "jdk"
+    then "adoptopenjdk-${sourcePerArch.vmType}-bin-${sourcePerArch.version}"
+    else "adoptopenjdk-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin-${sourcePerArch.version}";
 
   src = fetchurl {
-    inherit url sha256;
+    inherit (sourcePerArch.${stdenv.hostPlatform.parsed.cpu.name}) url sha256;
   };
 
   nativeBuildInputs = [ file ];
@@ -112,7 +111,7 @@ let result = stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     license = licenses.gpl2Classpath;
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";
-    platforms = [ "x86_64-linux" ]; # some inherit jre.meta.platforms
+    platforms = stdenv.lib.mapAttrsToList (arch: _: arch + "-linux") sourcePerArch; # some inherit jre.meta.platforms
     maintainers = with stdenv.lib.maintainers; [ taku0 ];
   };
 

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
@@ -1,43 +1,9 @@
 let
-  makePackage = { version, buildNumber, packageType, vmType, sha256 }: import ./jdk-darwin-base.nix {
-    name = if packageType == "jdk"
-      then
-        "adoptopenjdk-${vmType}-bin-${version}"
-      else
-        "adoptopenjdk-${packageType}-${vmType}-bin-${version}";
-
-    url = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}/OpenJDK11-${packageType}_x64_mac_${vmType}_${version}_${buildNumber}.tar.gz";
-
-    inherit sha256;
-  };
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = makePackage {
-    version = "11";
-    buildNumber = "28";
-    packageType = "jdk";
-    vmType = "hotspot";
-    sha256 = "ca0ec49548c626904061b491cae0a29b9b4b00fb34d8973dc217e10ab21fb0f3";
-  };
-  jre-hotspot = makePackage {
-    version = "11";
-    buildNumber = "28";
-    packageType = "jre";
-    vmType = "hotspot";
-    sha256 = "ef4dbfe5aed6ab2278fcc14db6cc73abbaab56e95f6ebb023790a7ebc6d7f30c";
-  };
-  jdk-openj9 = makePackage {
-    version = "11.0.1";
-    buildNumber = "13";
-    packageType = "jdk";
-    vmType = "openj9";
-    sha256 = "c5e9b588b4ac5b0bd5b4edd69d59265d1199bb98af7ca3270e119b264ffb6e3f";
-  };
-  jre-openj9 = makePackage {
-    version = "11.0.1";
-    buildNumber = "13";
-    packageType = "jre";
-    vmType = "openj9";
-    sha256 = "0901dc5946fdf967f92f7b719ddfffdcdde5bd3fef86a83d7a3f2f39ddbef1f8";
-  };
+  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk11.mac.jdk.hotspot;
+  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.hotspot;
+  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jdk.openj9;
+  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.openj9;
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-linux.nix
@@ -1,43 +1,9 @@
 let
-  makePackage = { version, buildNumber, packageType, vmType, sha256 }: import ./jdk-linux-base.nix {
-    name = if packageType == "jdk"
-      then
-        "adoptopenjdk-${vmType}-bin-${version}"
-      else
-        "adoptopenjdk-${packageType}-${vmType}-bin-${version}";
-
-    url = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${version}%2B${buildNumber}/OpenJDK11-${packageType}_x64_linux_${vmType}_${version}_${buildNumber}.tar.gz";
-
-    inherit sha256;
-  };
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
 in
 {
-  jdk-hotspot = makePackage {
-    version = "11";
-    buildNumber = "28";
-    packageType = "jdk";
-    vmType = "hotspot";
-    sha256 = "e1e18fc9ce2917473da3e0acb5a771bc651f600c0195a3cb40ef6f22f21660af";
-  };
-  jre-hotspot = makePackage {
-    version = "11";
-    buildNumber = "28";
-    packageType = "jre";
-    vmType = "hotspot";
-    sha256 = "346448142d46c6e51d0fadcaadbcde31251d7678922ec3eb010fcb1b6e17804c";
-  };
-  jdk-openj9 = makePackage {
-    version = "11.0.1";
-    buildNumber = "13";
-    packageType = "jdk";
-    vmType = "openj9";
-    sha256 = "765947ab9457a29d2aa9d11460a4849611343c1e0ea3b33b9c08409cd4672251";
-  };
-  jre-openj9 = makePackage {
-    version = "11.0.1";
-    buildNumber = "13";
-    packageType = "jre";
-    vmType = "openj9";
-    sha256 = "a016413fd8415429b42e543fed7a1bee5010b1dbaf71d29a26e1c699f334c6ff";
-  };
+  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk11.linux.jdk.hotspot;
+  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk11.linux.jre.hotspot;
+  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk11.linux.jdk.openj9;
+  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk11.linux.jre.openj9;
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -1,0 +1,94 @@
+{
+  "openjdk11": {
+    "linux": {
+      "jdk": {
+        "hotspot": {
+          "aarch64": {
+            "sha256": "b66121b9a0c2e7176373e670a499b9d55344bcb326f67140ad6d0dc24d13d3e2",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.1_13.tar.gz"
+          },
+          "build": "13",
+          "packageType": "jdk",
+          "version": "11.0.1",
+          "vmType": "hotspot",
+          "x86_64": {
+            "sha256": "22bd2f1a2e0cb6e4075967bfeda4a960b0325879305aa739a0ba2d6e5cd4c3e2",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
+          }
+        },
+        "openj9": {
+          "build": "13",
+          "packageType": "jdk",
+          "version": "11.0.1",
+          "vmType": "openj9",
+          "x86_64": {
+            "sha256": "ef9bf07cba79082285a9d426ea4eb3e8df57561ce2afe07cc5f299a8fa203279",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz"
+          }
+        }
+      },
+      "jre": {
+        "hotspot": {
+          "aarch64": {
+            "sha256": "6fd756bda392e3fddb48382460daae263c6fb5708683a691c8d30af2eb870bb8",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_aarch64_linux_hotspot_11_28.tar.gz"
+          },
+          "build": "28",
+          "packageType": "jre",
+          "version": "11",
+          "vmType": "hotspot",
+          "x86_64": {
+            "sha256": "346448142d46c6e51d0fadcaadbcde31251d7678922ec3eb010fcb1b6e17804c",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_hotspot_11_28.tar.gz"
+          }
+        },
+        "openj9": {
+          "build": "28",
+          "packageType": "jre",
+          "version": "11",
+          "vmType": "openj9",
+          "x86_64": {
+            "sha256": "83a7c95e6b2150a739bdd5e8a6fe0315904fd13d8867c95db67c0318304a2c42",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz"
+          }
+        }
+      }
+    },
+    "mac": {
+      "jdk": {
+        "hotspot": {
+          "build": "13",
+          "packageType": "jdk",
+          "version": "11.0.1",
+          "vmType": "hotspot",
+          "x86_64": {
+            "sha256": "e219e7e2d586ed09ae65f4ec390fca5d5f0c37a61b47677648610194daf1aaa7",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_hotspot_11.0.1_13.tar.gz"
+          }
+        },
+        "openj9": {
+          "build": "13",
+          "packageType": "jdk",
+          "version": "11.0.1",
+          "vmType": "openj9",
+          "x86_64": {
+            "sha256": "c9a816d6a3f8aac9dc5b3b41c5a9e4e5460af433a06e003ae25d5a06dea8375f",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_macosXL-jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz"
+          }
+        }
+      },
+      "jre": {
+        "hotspot": {
+          "build": "28",
+          "packageType": "jre",
+          "version": "11",
+          "vmType": "hotspot",
+          "x86_64": {
+            "sha256": "ef4dbfe5aed6ab2278fcc14db6cc73abbaab56e95f6ebb023790a7ebc6d7f30c",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_mac_hotspot_11_28.tar.gz"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
###### Motivation for this change

This automatically generates all the source hashes for the latest adoptopenjdk builds using the API, making updates easier. Another benefit is that it becomes easy to add support for other architectures, in this case I added support for aarch64-linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (only on linux, not darwin)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

