### PR TITLE
gnustep.base: Add explicit dependency on libbfd

### DIFF
--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -3,7 +3,7 @@
 , cups
 , fetchurl
 , gmp, gnutls
-, libffi
+, libffi, libbfd
 , libjpeg, libtiff, libpng, giflib, libungif
 , libxml2, libxslt, libiconv
 , libobjc, libgcrypt
@@ -24,7 +24,7 @@ gsmakeDerivation {
     aspell audiofile
     cups
     gmp gnutls
-    libffi
+    libffi libbfd
     libjpeg libtiff libpng giflib libungif
     libxml2 libxslt libiconv
     libobjc libgcrypt


### PR DESCRIPTION

###### Motivation for this change

Fixes #52283

Before beb063a, binutils included a libbfd install, which is now being removed in postFixup
https://github.com/NixOS/nixpkgs/commit/beb063a1031c08df77996d97e4f6f9a2da1d911a#diff-c59ce5deea2f4002004fffdb11c5ed57R131

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

