### PR TITLE
bazel: fix sandbox execution

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -119,7 +119,8 @@ stdenv.mkDerivation rec {
       find src/main/java/com/google/devtools -type f -print0 | while IFS="" read -r -d "" path; do
         substituteInPlace "$path" \
           --replace /bin/bash ${customBash}/bin/bash \
-          --replace /usr/bin/env ${coreutils}/bin/env
+          --replace /usr/bin/env ${coreutils}/bin/env \
+          --replace /bin/true ${coreutils}/bin/true
       done
       # Fixup scripts that generate scripts. Not fixed up by patchShebangs below.
       substituteInPlace scripts/bootstrap/compile.sh \


### PR DESCRIPTION
Bazel runs actions in a sandbox by default on Darwin and Linux.
However, the sandboxing was always and *silently* disabled previously,
because a Bazel feature test was always failing. The feature test
involved running `/bin/true` inside a sandbox. But on NixOS,
`/bin/true` does not exist...