### PR TITLE
wego: 20160407-81d72ff -> 20170403-415efdf

### DIFF
--- a/pkgs/applications/misc/wego/default.nix
+++ b/pkgs/applications/misc/wego/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "wego-${version}";
-  version = "20160407-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "81d72ffd761f032fbd73dba4f94bd94c8c2d53d5";
+  version = "20170403-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "415efdfab5d5ee68300bf261a0c6f630c6c2584c";
   
   goPackagePath = "github.com/schachmat/wego";
 
   src = fetchgit {
     inherit rev;
     url = "https://github.com/schachmat/wego";
-    sha256 = "14p3hvv82bsxqnbnzz8hjv75i39kzg154a132n6cdxx3vgw76gck";
+    sha256 = "0w8sypwg0s2mvhk9cdibqr8bz5ipiiacs60a39sdswrpc4z486hg";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/misc/wego/deps.nix
+++ b/pkgs/applications/misc/wego/deps.nix
@@ -1,11 +1,20 @@
 [
   {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.4";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
     goPackagePath = "github.com/mattn/go-runewidth";
     fetch = {
       type = "git";
       url = "https://github.com/mattn/go-runewidth";
-      rev = "d6bea18f789704b5f83375793155289da36a3c7f";
-      sha256 = "1hnigpn7rjbwd1ircxkyx9hvi0xmxr32b2jdy2jzw6b3jmcnz1fs";
+      rev = "v0.0.4";
+      sha256 = "00b3ssm7wiqln3k54z2wcnxr3k3c7m1ybyhb9h8ixzbzspld0qzs";
     };
   }
   {
@@ -13,8 +22,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/mattn/go-colorable";
-      rev = "3dac7b4f76f6e17fb39b768b89e3783d16e237fe";
-      sha256 = "08680mba8hh2rghymqbzd4m40r9k765w5kbzvrif9ngd6h85qnw6";
+      rev = "v0.0.9";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
     };
   }
   {
@@ -22,8 +31,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/schachmat/ingo";
-      rev = "fab41e4e62cbef5d92998746ec25f7e195100f38";
-      sha256 = "04yfnch7pdabjjqfl2qxjmsaknvp4m1rbjlv8qrpmnqwjkxzx0hb";
+      rev = "a4bdc0729a3fda62cc4069b6e490fc657fd54e33";
+      sha256 = "1gw0kddy7jh3467imsqni86cf9yq7k6vpfc0ywkbwj0zsjsdgd49";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

The previous snapshot of `wego` stopped working due to third party API changes.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS _(on 18.09)_
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) _(on 18.09)_
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

