### PR TITLE
pharo: Simple fix for Iceberg

### DIFF
--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -92,9 +92,7 @@ stdenv.mkDerivation rec {
     LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/pharo "\$@"
     EOF
     chmod +x "$out/bin/${cmd}"
-    ln -s ${libgit2}/lib/libgit2.so.0.26.6 "$out/"
-    ln -s ${libgit2}/lib/libgit2.so.26 "$out/"
-    ln -s ${libgit2}/lib/libgit2.so "$out/"
+    ln -s ${libgit2}/lib/libgit2.so* "$out/"
   '';
 
   enableParallelBuilding = true;
@@ -107,7 +105,7 @@ stdenv.mkDerivation rec {
   #
   # (stack protection is disabled above for gcc 4.8 compatibility.)
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ bash unzip glibc openssl gcc48 libgit2 libGLU_combined freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid ];
+  buildInputs = [ bash unzip glibc openssl gcc48 libGLU_combined freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid ];
 
   meta = with stdenv.lib; {
     description = "Clean and innovative Smalltalk-inspired environment";

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -92,9 +92,9 @@ stdenv.mkDerivation rec {
     LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/pharo "\$@"
     EOF
     chmod +x "$out/bin/${cmd}"
-    cp ${libgit2}/lib/libgit2.so.0.26.6 "$out/"
-    cp ${libgit2}/lib/libgit2.so.26 "$out/"
-    cp ${libgit2}/lib/libgit2.so "$out/"
+    ln -s ${libgit2}/lib/libgit2.so.0.26.6 "$out/"
+    ln -s ${libgit2}/lib/libgit2.so.26 "$out/"
+    ln -s ${libgit2}/lib/libgit2.so "$out/"
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -1,4 +1,19 @@
-{ stdenv, fetchurl, bash, unzip, glibc, openssl, libgit2, libGLU_combined, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, ... }:
+{ stdenv
+, fetchurl
+, bash
+, unzip
+, glibc
+, openssl
+, libgit2
+, libGLU_combined
+, freetype
+, xorg
+, alsaLib
+, cairo
+, libuuid
+, autoreconfHook
+, gcc48
+, ... }:
 
 { name, src, version, source-date, source-url, ... }:
 
@@ -65,7 +80,19 @@ stdenv.mkDerivation rec {
 
   # (No special build phase.)
 
-  installPhase = ''
+  installPhase = let
+    libs = [
+      cairo
+      libgit2
+      libGLU_combined
+      freetype
+      openssl
+      libuuid
+      alsaLib
+      xorg.libICE
+      xorg.libSM
+    ];
+  in ''
     # Install in working directory and then copy
     make install-squeak install-plugins prefix=$(pwd)/products
 
@@ -83,7 +110,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
 
     # Note: include ELF rpath in LD_LIBRARY_PATH for finding libc.
-    libs=$out:$(patchelf --print-rpath "$out/pharo"):${cairo}/lib:${libgit2}/lib:${libGLU_combined}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
+    libs=$out:$(patchelf --print-rpath "$out/pharo"):${stdenv.lib.makeLibraryPath libs}
 
     # Create the script
     cat > "$out/bin/${cmd}" <<EOF
@@ -105,7 +132,22 @@ stdenv.mkDerivation rec {
   #
   # (stack protection is disabled above for gcc 4.8 compatibility.)
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ bash unzip glibc openssl gcc48 libGLU_combined freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid ];
+  buildInputs = [
+    bash
+    unzip
+    glibc
+    openssl
+    gcc48
+    libGLU_combined
+    freetype
+    xorg.libX11
+    xorg.libICE
+    xorg.libSM
+    alsaLib
+    cairo
+    pharo-share
+    libuuid
+  ];
 
   meta = with stdenv.lib; {
     description = "Clean and innovative Smalltalk-inspired environment";

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bash, unzip, glibc, openssl, libGLU_combined, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, ... }:
+{ stdenv, fetchurl, bash, unzip, glibc, openssl, libgit2, libGLU_combined, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, ... }:
 
 { name, src, version, source-date, source-url, ... }:
 
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
 
     # Note: include ELF rpath in LD_LIBRARY_PATH for finding libc.
-    libs=$out:$(patchelf --print-rpath "$out/pharo"):${cairo}/lib:${libGLU_combined}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
+    libs=$out:$(patchelf --print-rpath "$out/pharo"):${cairo}/lib:${libgit2}/lib:${libGLU_combined}/lib:${freetype}/lib:${openssl}/lib:${libuuid}/lib:${alsaLib}/lib:${xorg.libICE}/lib:${xorg.libSM}/lib
 
     # Create the script
     cat > "$out/bin/${cmd}" <<EOF
@@ -92,6 +92,9 @@ stdenv.mkDerivation rec {
     LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$libs" exec $out/pharo "\$@"
     EOF
     chmod +x "$out/bin/${cmd}"
+    cp ${libgit2}/lib/libgit2.so.0.26.6 "$out/"
+    cp ${libgit2}/lib/libgit2.so.26 "$out/"
+    cp ${libgit2}/lib/libgit2.so "$out/"
   '';
 
   enableParallelBuilding = true;
@@ -104,7 +107,7 @@ stdenv.mkDerivation rec {
   #
   # (stack protection is disabled above for gcc 4.8 compatibility.)
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ bash unzip glibc openssl gcc48 libGLU_combined freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid ];
+  buildInputs = [ bash unzip glibc openssl gcc48 libgit2 libGLU_combined freetype xorg.libX11 xorg.libICE xorg.libSM alsaLib cairo pharo-share libuuid ];
 
   meta = with stdenv.lib; {
     description = "Clean and innovative Smalltalk-inspired environment";

--- a/pkgs/development/pharo/vm/vms.nix
+++ b/pkgs/development/pharo/vm/vms.nix
@@ -1,4 +1,4 @@
-{ cmake, stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, libGLU_combined, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, fetchFromGitHub, makeWrapper} @args:
+{ cmake, stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, libgit2, libGLU_combined, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, fetchFromGitHub, makeWrapper} @args:
 
 let
   pharo-vm-build = import ./build-vm.nix args;

--- a/pkgs/development/pharo/vm/vms.nix
+++ b/pkgs/development/pharo/vm/vms.nix
@@ -1,4 +1,23 @@
-{ cmake, stdenv, fetchurl, bash, unzip, glibc, openssl, gcc, libgit2, libGLU_combined, freetype, xorg, alsaLib, cairo, libuuid, autoreconfHook, gcc48, fetchFromGitHub, makeWrapper} @args:
+{ cmake
+, stdenv
+, fetchurl
+, bash
+, unzip
+, glibc
+, openssl
+, gcc
+, libgit2
+, libGLU_combined
+, freetype
+, xorg
+, alsaLib
+, cairo
+, libuuid
+, autoreconfHook
+, gcc48
+, fetchFromGitHub
+, makeWrapper
+} @args:
 
 let
   pharo-vm-build = import ./build-vm.nix args;


### PR DESCRIPTION
###### Motivation for this change

Pharo now includes a tool called Iceberg, capable of managing source code repositories from within the Pharo image. For git repositories, it relies upon `libgit2`.
For it to work in NixOS, we need to patch the Pharo elf to provide the path of `libgit2.so` dependency, and also add it to the same folder as the Pharo VM. This is needed because Iceberg assumes it'll be using the `libgit2` bundled by Pharo, which is expected to be in the same folder as the VM itself. Even if `libgit2` dependency is resolved at runtime, Iceberg performs that check and would fail if the file is not where Iceberg expects it to be.

This PR is just adding `libgit2` dependency and copying the `libgit2.so` file to the destination folder.

#52465

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

