### PR TITLE
ocamlPackages.ppx_deriving_yojson: 3.1 -> 3.3

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -1,29 +1,30 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg, cppo
-, ppx_deriving, yojson, ounit
+{ lib, buildDunePackage, fetchFromGitHub, ppxfind, ounit
+, ppx_deriving, yojson
 }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ppx_deriving_yojson-${version}";
-  version = "3.1";
+buildDunePackage rec {
+  pname = "ppx_deriving_yojson";
+  version = "3.3";
+
+  minimumOCamlVersion = "4.04";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = "ppx_deriving_yojson";
     rev = "v${version}";
-    sha256 = "1pwfnq7z60nchba4gnf58918ll11w3gj5i88qhz1p2jm45hxqgnw";
+    sha256 = "1gbfziw03r9azqlsmyn6izrgrf1xc30s88jgdany1kblpgq41rsz";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cppo ounit ];
+  buildInputs = [ ppxfind ounit ];
 
   propagatedBuildInputs = [ ppx_deriving yojson ];
 
-  inherit (topkg) installPhase;
+  doCheck = true;
 
   meta = {
-    description = "A Yojson codec generator for OCaml >= 4.02.";
+    description = "A Yojson codec generator for OCaml >= 4.04";
     inherit (src.meta) homepage;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ppxfind/default.nix
+++ b/pkgs/development/ocaml-modules/ppxfind/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, fetchurl, ocaml-migrate-parsetree }:
+
+buildDunePackage rec {
+	pname = "ppxfind";
+	version = "1.2";
+	src = fetchurl {
+		url = "https://github.com/diml/ppxfind/releases/download/${version}/ppxfind-${version}.tbz";
+		sha256 = "1687jbgii5w5dvvid3ri2cx006ysv0rrspn8dz8x7ma8615whz2h";
+	};
+
+	minimumOCamlVersion = "4.03";
+
+	buildInputs = [ ocaml-migrate-parsetree ];
+
+	meta = {
+		homepage = "https://github.com/diml/ppxfind";
+		description = "ocamlfind ppx tool";
+		license = lib.licenses.bsd3;
+		maintainers = [ lib.maintainers.vbgl ];
+	};
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -578,6 +578,8 @@ let
     piqi = callPackage ../development/ocaml-modules/piqi { };
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
+
     ppxlib = callPackage ../development/ocaml-modules/ppxlib { };
 
     psmt2-frontend = callPackage ../development/ocaml-modules/psmt2-frontend { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

