### PR TITLE
soapybladerf: 0.3.5 -> 0.4.0

### DIFF
--- a/pkgs/applications/misc/soapybladerf/default.nix
+++ b/pkgs/applications/misc/soapybladerf/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "0.3.5";
+  version = "0.4.0";
 
 in stdenv.mkDerivation {
   name = "soapybladerf-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "pothosware";
     repo = "SoapyBladeRF";
     rev = "soapy-bladerf-${version}";
-    sha256 = "1n7vy6y8k1smq3l729npxbhxbnrc79gz06dxkibsihz4k8sddkrg";
+    sha256 = "1gf1azfydw033nlg2bgs9cbsbp9npjdrgjwlsffn0d9x0qbgxjqp";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Resolves compatability issue with `libbladerf-2.0.2`

Changelog: https://github.com/pothosware/SoapyBladeRF/blob/master/Changelog.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

