### PR TITLE
nixos/oh-my-zsh: fix wrong manual information

### DIFF
--- a/nixos/modules/programs/zsh/oh-my-zsh.xml
+++ b/nixos/modules/programs/zsh/oh-my-zsh.xml
@@ -19,7 +19,7 @@
    configuration format of <literal>oh-my-zsh</literal>.
 <programlisting>
 {
-  programs.ohMyZsh = {
+  programs.zsh.ohMyZsh = {
     enable = true;
     plugins = [ "git" "python" "man" ];
     theme = "agnoster";
@@ -51,7 +51,7 @@
    The module can do this as well:
 <programlisting>
 {
-  programs.ohMyZsh.custom = "~/path/to/custom/scripts";
+  programs.zsh.ohMyZsh.custom = "~/path/to/custom/scripts";
 }
 </programlisting>
   </para>
@@ -73,7 +73,7 @@
 <programlisting>
 { pkgs, ... }:
 {
-  programs.ohMyZsh.customPkgs = with pkgs; [
+  programs.zsh.ohMyZsh.customPkgs = with pkgs; [
     pkgs.nix-zsh-completions
     # and even more...
   ];
@@ -87,7 +87,7 @@
 
   <para>
    <emphasis>Please keep in mind that this is not compatible with
-   <literal>programs.ohMyZsh.custom</literal> as it requires an immutable store
+   <literal>programs.zsh.ohMyZsh.custom</literal> as it requires an immutable store
    path while <literal>custom</literal> shall remain mutable! An evaluation
    failure will be thrown if both <literal>custom</literal> and
    <literal>customPkgs</literal> are set.</emphasis>


### PR DESCRIPTION
###### Motivation for this change
The manual still refers to 'programs.ohMyZsh' although it should be 'programs.zsh.ohMyZsh' [\[1\]](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/zsh) [\[2\]](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/zsh/oh-my-zsh.nix#L33).
We change this, because we want to provide correct information to users reading the manual. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

