### PR TITLE
security.pam: make pam_unix.so required, not sufficient

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -318,6 +318,22 @@
      case.
    </para>
   </listitem>
+  <listitem>
+   <para>
+     The <literal>pam_unix</literal> account module is now loaded with its
+     control field set to <literal>required</literal> instead of
+     <literal>sufficient</literal>, so that later pam account modules that
+     might do more extensive checks are being executed.
+     Previously, the whole account module verification was exited prematurely
+     in case a nss module provided the account name to
+     <literal>pam_unix</literal>.
+     The LDAP and SSSD NixOS modules already add their NSS modules when
+     enabled. In case your setup breaks due to some later pam account module
+     previosuly shadowed, or failing NSS lookups, please file a bug. You can
+     get back the old behaviour by manually setting
+     <literal><![CDATA[security.pam.services.<name?>.text]]></literal>.
+   </para>
+  </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -269,7 +269,7 @@ let
       text = mkDefault
         (''
           # Account management.
-          account ${if cfg.sssdStrictAccess then "required" else "sufficient"} pam_unix.so
+          account required pam_unix.so
           ${optionalString use_ldap
               "account sufficient ${pam_ldap}/lib/security/pam_ldap.so"}
           ${optionalString (config.services.sssd.enable && cfg.sssdStrictAccess==false)


### PR DESCRIPTION
Having pam_unix set to "sufficient" means early-succeeding account
management group, as soon as pam_unix.so is succeeding.

This is not sufficient. For example, nixos modules might install nss
modules for user lookup, so pam_unix.so succeeds, and we end the stack
successfully, even though other pam account modules might want to do
more extensive checks.

Other distros seem to set pam_unix.so to 'required', so if there are
other pam modules in that management group, they get a chance to do some
validation too.

For SSSD, @PsyanticY already added a workaround knob in
https://github.com/NixOS/nixpkgs/pull/31969, while stating this should
be the default anyway.

I did some thinking in what could break - after this commit, we require
pam_unix to succeed, means we require `getent passwd $username` to
return something.
This is the case for all local users due to the passwd nss module, and
also the case for all modules installing their nss module to
nsswitch.conf - true for ldap (if not explicitly disabled) and sssd.

I'm not so sure about krb5, cc @eqyiel for opinions. Is there some nss
module loaded? Should the pam account module be placed before pam_unix?

We don't drop the `security.pam.services.<name?>.sssdStrictAccess`
option, as it's also used some lines below to tweak error behaviour
inside the pam sssd module itself (by changing it's 'control' field).

This is also required to get admin login for Google OS Login working
(#51566), as their pam_oslogin_admin accounts module takes care of sudo
configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

