### PR TITLE
mesa: 18.2.6 -> 18.3.1

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -67,7 +67,7 @@ let
 in
 
 let
-  version = "18.2.6";
+  version = "18.3.1";
   branch  = head (splitString "." version);
 in
 
@@ -81,7 +81,7 @@ let self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "04nwxykmc80gicmal0zkk8is34rmbqawmfckirqhrps9h97zmfly";
+    sha256 = "0qyw9dj2p9n91qzc4ylck2an7ibssjvzi2bjcpv2ajk851yq47sv";
   };
 
   prePatch = "patchShebangs .";


### PR DESCRIPTION
###### Motivation for this change
Mesa finally has openGL 4.5 compatibility profile for radeon cards.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change
- [ ] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I haven't tested this version yet, mainly because the method I've used before doesn't seem to work anymore. Overriding mesa_drivers with
```
  mesa_drivers = (unstable.mesa_noglu.overrideDerivation (old: rec {
    name = "mesa-noglu-18.3.1";
    version = "18.3.1";
    src = fetchurl {
      url = "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz";
      sha256 = "0qyw9dj2p9n91qzc4ylck2an7ibssjvzi2bjcpv2ajk851yq47sv";
    };
  })).drivers;
```
doesn't seem to work. glxinfo displays the right version but programs can't find libGL.