### PR TITLE
mirrors.nix: remove bad cpan mirrors

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -159,12 +159,8 @@ rec {
 
   # CPAN mirrors.
   cpan = [
-    https://ftp.gwdg.de/pub/languages/perl/CPAN/
-    https://download.xs4all.nl/mirror/CPAN/
     https://cpan.metacpan.org/
     https://cpan.perl.org/
-    http://ftp.tuwien.ac.at/pub/CPAN/
-    http://ftp.funet.fi/pub/CPAN/
     http://backpan.perl.org/  # for old releases
   ];
 


### PR DESCRIPTION
###### Motivation for this change

 *   https://ftp.gwdg.de/pub/languages/perl/CPAN/ <- out of sync, 404 on some files (example: https://ftp.gwdg.de/pub/languages/perl/CPAN/src/5.0/perl-5.29.6.tar.gz)
 *   https://download.xs4all.nl/mirror/CPAN/            <- out of sync, 404 on some files (example: https://download.xs4all.nl/mirror/CPAN/src/5.0/perl-5.29.6.tar.gz)
 *   http://ftp.tuwien.ac.at/pub/CPAN/                      <- domain name not resolved
 *   http://ftp.funet.fi/pub/CPAN/ <- nix fails with "unknown compression method 'x-gzip'" when using this mirror (nix does not like its 'Content-Encoding: x-gzip' in http headers)
