### PR TITLE
vscode backports: 12-18-18

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -12,9 +12,9 @@ let
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    "i686-linux" = "0bd2jdn67vnbhrsqy54bymz4di3fw3p18ni5j2wikqkl4d9h4jj1";
-    "x86_64-linux" = "1zbnyff0q15xkvkrs14rfgyn6xb9v0xivcnbl8yckl71s45vb2l1";
-    "x86_64-darwin" = "1qgzhpfzcwym1qyzx2v14336l106hzhs7ii84g356vxkm219x7kw";
+    "i686-linux" = "1xadkgqfwsl53blm2f0kdvczwmag47585dswa1hpafzc8i86009b";
+    "x86_64-linux" = "0h77kc6z9c5bkkb8svjxjabnbbv0lb835kzd1c2yypamkhag9j4a";
+    "x86_64-darwin" = "1f8grgav5capd2mm1nx0416na8c6qjh91680cfvf1jh4pjihs6g4";
   }.${stdenv.hostPlatform.system};
 
   archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";
@@ -31,7 +31,7 @@ let
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
-    version = "1.30.0";
+    version = "1.30.1";
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";

--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -68,7 +68,7 @@ runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}" {
 
   ln -sT "${vscode}/share/pixmaps/code.png" "$out/share/pixmaps/code.png"
   ln -sT "${vscode}/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
-  makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" \
-    --add-flags \
-      "--extensions-dir ${combinedExtensionsDrv}/share/${wrappedPkgName}/extensions"
+  makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" ${lib.optionalString (vscodeExtensions != []) ''
+    --add-flags "--extensions-dir ${combinedExtensionsDrv}/share/${wrappedPkgName}/extensions"
+  ''}
 ''

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -20,8 +20,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.11.0";
-    sha256 = "0z9ca14qzy6zw0cfir7hdnhin01c1wsr6lbb2xp6rpq06vh7nivl";
+    version = "2018.12.1";
+    sha256 = "1cf3yll2hfililcwq6avscgi35caccv8m8fdsvzqdfrggn5h41h4";
   };
 
   postPatch = ''

--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -7,8 +7,8 @@ in
     mktplcRef = {
       name = "vscode-wakatime";
       publisher = "WakaTime";
-      version = "1.2.4";
-      sha256 = "0qghn4kakv0jrjcl65p1v5r6j7608269zyhh75b15p12mdvi21vb";
+      version = "1.2.5";
+      sha256 = "011yx3pwqbcz5fmzani57k0axgh458r4ipqwbjlklnrwbrkjhzra";
     };
 
     postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Cherry-picked from PRs in the following order: #52298, #52422, #52420, #52503.

Omitted optional dependency upgrade for WakaTime.vscode-wakatime, PR #52421.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

