### PR TITLE
perldevel: 5.29.4 -> 5.29.6

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -42,13 +42,14 @@ let
     patches =
       [
         # Do not look in /usr etc. for dependencies.
-        ./no-sys-dirs-5.26.patch
+        (if (versionOlder version "5.29.6") then ./no-sys-dirs-5.26.patch else ./no-sys-dirs-5.29.patch)
+      ]
+      ++ optional (versionOlder version "5.29.6")
         # Fix parallel building: https://rt.perl.org/Public/Bug/Display.html?id=132360
         (fetchurlBoot {
           url = "https://rt.perl.org/Public/Ticket/Attachment/1502646/807252/0001-Fix-missing-build-dependency-for-pods.patch";
           sha256 = "1bb4mldfp8kq1scv480wm64n2jdsqa3ar46cjp1mjpby8h5dr2r0";
         })
-      ]
       ++ optional stdenv.isSunOS ./ld-shared.patch
       ++ optionals stdenv.isDarwin [ ./cpp-precomp.patch ./sw_vers.patch ]
       ++ optional crossCompiling ./MakeMaker-cross.patch;
@@ -186,7 +187,7 @@ in rec {
 
   # the latest Devel version
   perldevel = common {
-    version = "5.29.4";
-    sha256 = "153r0f6jdqrl7hxrvhfivf5g8ivhbvggfhg841q3hi3db5rc86k4";
+    version = "5.29.6";
+    sha256 = "0wj2bia8s30788f69mf5s533l72zbhqpdr85kkk97yrh1c9sgcd6";
   };
 }

--- a/pkgs/development/interpreters/perl/no-sys-dirs-5.29.patch
+++ b/pkgs/development/interpreters/perl/no-sys-dirs-5.29.patch
@@ -1,0 +1,251 @@
+diff -ru -x '*~' -x '*.rej' perl-5.20.0-orig/Configure perl-5.20.0/Configure
+--- perl-5.20.0-orig/Configure	2014-05-26 15:34:18.000000000 +0200
++++ perl-5.20.0/Configure	2014-06-25 10:43:35.368285986 +0200
+@@ -106,15 +106,7 @@
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
+-paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+-paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+-paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+-paths="$paths /bsd4.3/usr/bin /usr/bsd /bsd43/bin /opt/ansic/bin /usr/ccs/bin"
+-paths="$paths /etc /usr/lib /usr/ucblib /lib /usr/ccs/lib"
+-paths="$paths /sbin /usr/sbin /usr/libexec"
+-paths="$paths /system/gnu_library/bin"
++paths=''
+ 
+ for p in $paths
+ do
+@@ -1337,8 +1329,7 @@
+ archname=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
+-locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
++locincpth=""
+ :
+ : no include file wanted by default
+ inclwanted=''
+@@ -1349,17 +1340,12 @@
+ 
+ libnames=''
+ : change the next line if compiling for Xenix/286 on Xenix/386
+-xlibpth='/usr/lib/386 /lib/386'
++xlibpth=''
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
+-loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
++loclibpth=""
+ 
+ : general looking path for locating libraries
+-glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
+-test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+-test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+-test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"
++glibpth=""
+ 
+ : Private path used by Configure to find libraries.  Its value
+ : is prepended to libpth. This variable takes care of special
+@@ -1391,8 +1377,6 @@
+ libswanted="$libswanted m crypt sec util c cposix posix ucb bsd BSD"
+ : We probably want to search /usr/shlib before most other libraries.
+ : This is only used by the lib/ExtUtils/MakeMaker.pm routine extliblist.
+-glibpth=`echo " $glibpth " | sed -e 's! /usr/shlib ! !'`
+-glibpth="/usr/shlib $glibpth"
+ : Do not use vfork unless overridden by a hint file.
+ usevfork=false
+ 
+@@ -2446,7 +2430,6 @@
+ zip
+ "
+ pth=`echo $PATH | sed -e "s/$p_/ /g"`
+-pth="$pth $sysroot/lib $sysroot/usr/lib"
+ for file in $loclist; do
+ 	eval xxx=\$$file
+ 	case "$xxx" in
+@@ -4936,7 +4919,7 @@
+ : Set private lib path
+ case "$plibpth" in
+ '') if ./mips; then
+-	plibpth="$incpath/usr/lib $sysroot/usr/local/lib $sysroot/usr/ccs/lib"
++	plibpth="$incpath/usr/lib"
+     fi;;
+ esac
+ case "$libpth" in
+@@ -8600,13 +8583,8 @@
+ echo " "
+ case "$sysman" in
+ '')
+-	syspath='/usr/share/man/man1 /usr/man/man1'
+-	syspath="$syspath /usr/man/mann /usr/man/manl /usr/man/local/man1"
+-	syspath="$syspath /usr/man/u_man/man1"
+-	syspath="$syspath /usr/catman/u_man/man1 /usr/man/l_man/man1"
+-	syspath="$syspath /usr/local/man/u_man/man1 /usr/local/man/l_man/man1"
+-	syspath="$syspath /usr/man/man.L /local/man/man1 /usr/local/man/man1"
+-	sysman=`./loc . /usr/man/man1 $syspath`
++	syspath=''
++	sysman=''
+ 	;;
+ esac
+ if $test -d "$sysman"; then
+@@ -19900,9 +19878,10 @@
+ case "$full_ar" in
+ '') full_ar=$ar ;;
+ esac
++full_ar=ar
+ 
+ : Store the full pathname to the sed program for use in the C program
+-full_sed=$sed
++full_sed=sed
+ 
+ : see what type gids are declared as in the kernel
+ echo " "
+Only in perl-5.20.0/: Configure.orig
+diff -ru -x '*~' -x '*.rej' perl-5.20.0-orig/ext/Errno/Errno_pm.PL perl-5.20.0/ext/Errno/Errno_pm.PL
+--- perl-5.20.0-orig/ext/Errno/Errno_pm.PL	2014-05-26 15:34:20.000000000 +0200
++++ perl-5.20.0/ext/Errno/Errno_pm.PL	2014-06-25 10:31:24.317970047 +0200
+@@ -134,12 +126,7 @@
+ 	if ($dep =~ /(\S+errno\.h)/) {
+ 	     $file{$1} = 1;
+ 	}
+-    } elsif ($^O eq 'linux' &&
+-	      $Config{gccversion} ne '' && 
+-	      $Config{gccversion} !~ /intel/i &&
+-	      # might be using, say, Intel's icc
+-	      $linux_errno_h
+-	     ) {
++    } elsif (0) {
+	$file{$linux_errno_h} = 1;
+     } elsif ($^O eq 'haiku') {
+	# hidden in a special place
+Only in perl-5.20.0/ext/Errno: Errno_pm.PL.orig
+diff -ru -x '*~' -x '*.rej' perl-5.20.0-orig/hints/freebsd.sh perl-5.20.0/hints/freebsd.sh
+--- perl-5.20.0-orig/hints/freebsd.sh	2014-01-31 22:55:51.000000000 +0100
++++ perl-5.20.0/hints/freebsd.sh	2014-06-25 10:25:53.263964680 +0200
+@@ -119,21 +119,21 @@
+         objformat=`/usr/bin/objformat`
+         if [ x$objformat = xaout ]; then
+             if [ -e /usr/lib/aout ]; then
+-                libpth="/usr/lib/aout /usr/local/lib /usr/lib"
+-                glibpth="/usr/lib/aout /usr/local/lib /usr/lib"
++                libpth=""
++                glibpth=""
+             fi
+             lddlflags='-Bshareable'
+         else
+-            libpth="/usr/lib /usr/local/lib"
+-            glibpth="/usr/lib /usr/local/lib"
++            libpth=""
++            glibpth=""
+             ldflags="-Wl,-E "
+             lddlflags="-shared "
+         fi
+         cccdlflags='-DPIC -fPIC'
+         ;;
+ *)
+-       libpth="/usr/lib /usr/local/lib"
+-       glibpth="/usr/lib /usr/local/lib"
++       libpth=""
++       glibpth=""
+        ldflags="-Wl,-E "
+         lddlflags="-shared "
+         cccdlflags='-DPIC -fPIC'
+diff -ru -x '*~' -x '*.rej' perl-5.20.0-orig/hints/linux.sh perl-5.20.0/hints/linux.sh
+--- perl-5.20.0-orig/hints/linux.sh	2014-05-26 15:34:20.000000000 +0200
++++ perl-5.20.0/hints/linux.sh	2014-06-25 10:33:47.354883843 +0200
+@@ -150,25 +150,6 @@
+     ;;
+ esac
+ 
+-# Ubuntu 11.04 (and later, presumably) doesn't keep most libraries
+-# (such as -lm) in /lib or /usr/lib.  So we have to ask gcc to tell us
+-# where to look.  We don't want gcc's own libraries, however, so we
+-# filter those out.
+-# This could be conditional on Unbuntu, but other distributions may
+-# follow suit, and this scheme seems to work even on rather old gcc's.
+-# This unconditionally uses gcc because even if the user is using another
+-# compiler, we still need to find the math library and friends, and I don't
+-# know how other compilers will cope with that situation.
+-# Morever, if the user has their own gcc earlier in $PATH than the system gcc,
+-# we don't want its libraries. So we try to prefer the system gcc
+-# Still, as an escape hatch, allow Configure command line overrides to
+-# plibpth to bypass this check.
+-if [ -x /usr/bin/gcc ] ; then
+-    gcc=/usr/bin/gcc
+-else
+-    gcc=gcc
+-fi
+-
+ case "$plibpth" in
+ '') plibpth=`LANG=C LC_ALL=C $gcc $ccflags $ldflags -print-search-dirs | grep libraries |
+ 	cut -f2- -d= | tr ':' $trnl | grep -v 'gcc' | sed -e 's:/$::'`
+@@ -178,32 +159,6 @@
+     ;;
+ esac
+ 
+-case "$libc" in
+-'')
+-# If you have glibc, then report the version for ./myconfig bug reporting.
+-# (Configure doesn't need to know the specific version since it just uses
+-# gcc to load the library for all tests.)
+-# We don't use __GLIBC__ and  __GLIBC_MINOR__ because they
+-# are insufficiently precise to distinguish things like
+-# libc-2.0.6 and libc-2.0.7.
+-    for p in $plibpth
+-    do
+-        for trylib in libc.so.6 libc.so
+-        do
+-            if $test -e $p/$trylib; then
+-                libc=`ls -l $p/$trylib | awk '{print $NF}'`
+-                if $test "X$libc" != X; then
+-                    break
+-                fi
+-            fi
+-        done
+-        if $test "X$libc" != X; then
+-            break
+-        fi
+-    done
+-    ;;
+-esac
+-
+ if ${sh:-/bin/sh} -c exit; then
+   echo ''
+   echo 'You appear to have a working bash.  Good.'
+@@ -367,33 +322,6 @@
+ 	;;
+ esac
+ 
+-# SuSE8.2 has /usr/lib/libndbm* which are ld scripts rather than
+-# true libraries. The scripts cause binding against static
+-# version of -lgdbm which is a bad idea. So if we have 'nm'
+-# make sure it can read the file
+-# NI-S 2003/08/07
+-case "$nm" in
+-    '') ;;
+-    *)
+-    for p in $plibpth
+-    do
+-        if $test -r $p/libndbm.so; then
+-            if $nm $p/libndbm.so >/dev/null 2>&1 ; then
+-                echo 'Your shared -lndbm seems to be a real library.'
+-                _libndbm_real=1
+-                break
+-            fi
+-        fi
+-    done
+-    if $test "X$_libndbm_real" = X; then
+-        echo 'Your shared -lndbm is not a real library.'
+-        set `echo X "$libswanted "| sed -e 's/ ndbm / /'`
+-        shift
+-        libswanted="$*"
+-    fi
+-    ;;
+-esac
+-
+ # Linux on Synology.
+ if [ -f /etc/synoinfo.conf -a -d /usr/syno ]; then
+     # Tested on Synology DS213 and DS413


### PR DESCRIPTION
###### Motivation for this change

update devel branch

```no-sys-dirs-5.29.patch``` is slightly modified copy of ```no-sys-dirs-5.26.patch``` which fails to apply (it is possible to make an universal patch for ```perl``` and ```perldevel``` and reduce lines of code but it would require to rebuild ```perl``` and thus everything)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

