### PR TITLE
nodejs: 6.14.4 -> 6.15.1, 8.12.0 -> 8.14.1

### DIFF
--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "6.14.4";
-    sha256 = "03zc6jhid6jyi871zlcrkjqffmrpxh01z2xfsl3xp2vzg2czqjws";
+    version = "6.15.1";
+    sha256 = "1hi9h54ni7m1lmhfqvwxdny969j31mixxlxsiyl00l2bj25fbgf3";
   }

--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "8.12.0";
-    sha256 = "16j1rrxkhmvpcw689ndw1raql1gz4jqn7n82z55zn63c05cgz7as";
+    version = "8.14.1";
+    sha256 = "16vb5baw6nk71n7jfbyd9x8qi0kbkzv2bw1rczy7dyyz7n08gpxi";
   }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/nixos/nixpkgs/commit/75b894af0f0 needs to be backported to 18.09 because includes a fix for CVE-2018-12122 https://nodejs.org/en/blog/release/v6.15.1/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

