### PR TITLE
vim-lsc: init at fe6d3bd

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2621,6 +2621,16 @@
     };
   };
 
+  vim-lsc = buildVimPluginFrom2Nix {
+    name = "vim-lsc-2018-12-12";
+    src = fetchFromGitHub {
+      owner = "natebosch";
+      repo = "vim-lsc";
+      rev = "fe6d3bd6328d60cfe8c799a10c35f11153c082c9";
+      sha256 = "03rjbgj8647pvr1p2dqrp13z5793ivkb0ajwc65r604wgr5nva8j";
+    };
+  };
+
   vim-maktaba = buildVimPluginFrom2Nix {
     name = "vim-maktaba-2018-12-13";
     src = fetchFromGitHub {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -191,6 +191,7 @@ mkasa/lushtags
 morhetz/gruvbox
 motus/pig.vim
 mpickering/hlint-refactor-vim
+natebosch/vim-lsc
 nathanaelkane/vim-indent-guides
 navicore/vissort.vim
 nbouscal/vim-stylish-haskell


### PR DESCRIPTION
`natebosch/vim-lsc` is a language server client plugin for vim/neovim. This commit
adds it to the `vim-plugin-names` file and the generated vim-plugins
file.

###### Motivation for this change

`vim-lsc` is the preferred LSP client for use with the Scala language server [metals](https://scalameta.org/metals/).

This is a reboot of #52407 that doesn't call the `update.py` script for
vim plugins, because doing so led to quick merge conflicts. Let me know
if there is a preferred way to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

