### PR TITLE
cloudfoundry-cli: fix build on multiple platforms, notably darwin. also bump -> 6.41.0

### DIFF
--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -15,8 +15,6 @@ buildGoPackage rec {
     sha256 = "1v4f1fyydpzkfir46g4ppbf3zmk3ym6kxswpkdjls8h3dbb2fbnv";
   };
 
-  outputs = [ "out" ];
-
   makeTarget = let hps = stdenv.hostPlatform.system; in
     if hps == "x86_64-darwin" then
       "out/cf-cli_osx"
@@ -34,9 +32,8 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dm555 out/cf "$out/bin/cf"
-    remove-references-to -t ${go} "$out/bin/cf"
-    install -Dm444 -t "$out/share/bash-completion/completions/" "$src/ci/installers/completion/cf"
+    install -Dm555 out/cf "$bin/bin/cf"
+    install -Dm444 -t "$bin/share/bash-completion/completions/" "$src/ci/installers/completion/cf"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -17,9 +17,20 @@ buildGoPackage rec {
 
   outputs = [ "out" ];
 
+  makeTarget = let hps = stdenv.hostPlatform.system; in
+    if hps == "x86_64-darwin" then
+      "out/cf-cli_osx"
+    else if hps == "x86_64-linux" then
+      "out/cf-cli_linux_x86-64"
+    else if hps == "i686-linux" then
+      "out/cf-cli_linux_i686"
+    else
+      throw "make target for this platform unknown";
+
   buildPhase = ''
     cd go/src/${goPackagePath}
-    CF_BUILD_DATE="1970-01-01" make build
+    CF_BUILD_DATE="1970-01-01" make $makeTarget
+    cp $makeTarget out/cf
   '';
 
   installPhase = ''
@@ -33,5 +44,6 @@ buildGoPackage rec {
     homepage = https://github.com/cloudfoundry/cli;
     maintainers = with maintainers; [ ris ];
     license = licenses.asl20;
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "cloudfoundry-cli-${version}";
-  version = "6.37.0";
+  version = "6.41.0";
 
   goPackagePath = "code.cloudfoundry.org/cli";
 
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "cloudfoundry";
     repo = "cli";
     rev = "v${version}";
-    sha256 = "1v4f1fyydpzkfir46g4ppbf3zmk3ym6kxswpkdjls8h3dbb2fbnv";
+    sha256 = "1dkd0lfq55qpnxsrigffaqm2nlcxr0bm0jsl4rsjlmb8p2vgpx8b";
   };
 
   makeTarget = let hps = stdenv.hostPlatform.system; in


### PR DESCRIPTION
###### Motivation for this change

The `cloudfoundry-cli` package would previously build the linux/amd64 binary on all platforms. This was due to the projects makefiles having specific targets for different platforms.

I'm fairly certain this will also work on most platforms, it's just there isn't a specific makefile target for them and would require us to do some manual tinkering.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

