### PR TITLE
shades-of-gray-theme: 1.1.1 -> 1.1.3

### DIFF
--- a/pkgs/data/themes/shades-of-gray/default.nix
+++ b/pkgs/data/themes/shades-of-gray/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "shades-of-gray-theme-${version}";
-  version = "1.1.1";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "WernerFP";
     repo = "Shades-of-gray-theme";
     rev = version;
-    sha256 = "1m75m6aq4hh39m8qrmbkaw31j4gzkh63ial4xnhw2habf31av682";
+    sha256 = "14p1s1pmzqnn9j9vwqfxfd4i045p356a6d9rwzzs0gx3c6ibqx3a";
   };
 
   buildInputs = [ gtk_engines ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/themes
-    cp -a Shades-of-gray* README.md preview_01.png $out/share/themes/
+    cp -a Shades-of-gray* $out/share/themes/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15708,6 +15708,8 @@ in
 
   shaderc = callPackage ../development/compilers/shaderc { };
 
+  shades-of-gray-theme = callPackage ../data/themes/shades-of-gray { };
+
   mime-types = callPackage ../data/misc/mime-types { };
 
   shared-mime-info = callPackage ../data/misc/shared-mime-info { };
@@ -22775,8 +22777,6 @@ in
     libselinux = libselinux.override { python = python3; };
     libsemanage = libsemanage.override { python = python3; };
   };
-
-  shades-of-gray-theme = callPackage ../misc/themes/shades-of-gray { };
 
   sierra-gtk-theme = callPackage ../misc/themes/sierra { };
 


### PR DESCRIPTION
###### Motivation for this change

- Update to version [1.1.3](https://github.com/WernerFP/Shades-of-gray-theme/releases/tag/1.1.3)
- Move to `pkgs/data/themes`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).