### PR TITLE
nomachine-client: Fix audio support and update 6.3.6_1 -> 6.4.6_1

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, file, fetchurl, makeWrapper, autoPatchelfHook, jsoncpp }:
 let
-  versionMajor = "6.3";
+  versionMajor = "6.4";
   versionMinor = "6_1";
 in
   stdenv.mkDerivation rec {
@@ -11,12 +11,12 @@ in
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_x86_64.tar.gz";
-          sha256 = "1035j2z2rqmdfb8cfm1pakd05c575640604b8lkljmilpky9mw5d";
+          sha256 = "141pv277kl5ij1pmc0iadc0hnslxri2qaqvsjkmmvls4432jh0yi";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_i686.tar.gz";
-          sha256 = "07j9f6mlq9m01ch8ik5dybi283vrp5dlv156jr5n7n2chzk34kf3";
+          sha256 = "0a2vi4ygw34yw8rcjhw17mqx5qbjnym4jkap8paik8lisb5mhnyj";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";

--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, file, fetchurl, makeWrapper, autoPatchelfHook, jsoncpp }:
+{ stdenv, lib, file, fetchurl, makeWrapper,
+  autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
   versionMajor = "6.4";
   versionMinor = "6_1";
@@ -31,7 +32,7 @@ in
     '';
   
     nativeBuildInputs = [ file makeWrapper autoPatchelfHook ];
-    buildInputs = [ jsoncpp ];
+    buildInputs = [ jsoncpp libpulseaudio ];
 
     installPhase = ''
       rm bin/nxplayer bin/nxclient
@@ -63,6 +64,10 @@ in
     postFixup = ''
       makeWrapper $out/bin/nxplayer.bin $out/bin/nxplayer --set NX_SYSTEM $out/NX
       makeWrapper $out/bin/nxclient.bin $out/bin/nxclient --set NX_SYSTEM $out/NX
+
+      # libnxcau.so needs libpulse.so.0 for audio to work, but doesn't
+      # have a DT_NEEDED entry for it.
+      patchelf --add-needed libpulse.so.0 $out/NX/lib/libnxcau.so
     '';
   
     dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change

- Fix audio support, closing #52507.
- Update from version 6.3.6_1 to 6.4.6_1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

