### PR TITLE
home-assistant-cli: init at 0.3.0

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -4,6 +4,7 @@ let
   configDir = "/var/lib/foobar";
   apiPassword = "some_secret";
   mqttPassword = "another_secret";
+  hassCli = "hass-cli --server http://hass:8123 --password '${apiPassword}'";
 
 in {
   name = "home-assistant";
@@ -16,7 +17,7 @@ in {
       { pkgs, ... }:
       {
         environment.systemPackages = with pkgs; [
-          mosquitto
+          mosquitto home-assistant-cli
         ];
         services.home-assistant = {
           inherit configDir;
@@ -70,6 +71,11 @@ in {
     $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"off\"'");
     $hass->waitUntilSucceeds("mosquitto_pub -V mqttv311 -t home-assistant/test -u homeassistant -P '${mqttPassword}' -m let_there_be_light");
     $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"on\"'");
+
+    # Toggle a binary sensor using hass-cli
+    $hass->succeed("${hassCli} entity get binary_sensor.mqtt_binary_sensor | grep -qF '\"state\": \"on\"'");
+    $hass->succeed("${hassCli} entity edit binary_sensor.mqtt_binary_sensor --json='{\"state\": \"off\"}'");
+    $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"off\"'");
 
     # Print log to ease debugging
     my $log = $hass->succeed("cat ${configDir}/home-assistant.log");

--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -1,0 +1,35 @@
+{ lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "homeassistant-cli";
+  version = "0.3.0";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "42d7cb008801d7a448b62aed1fc46dd450ee67397bf16faabb02f691417db4b2";
+  };
+
+  postPatch = ''
+    # Ignore pinned versions
+    sed -i "s/'\(.*\)==.*'/'\1'/g" setup.py
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    requests pyyaml netdisco click click-log tabulate idna jsonpath_rw jinja2
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest requests-mock
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Command-line tool for Home Asssistant";
+    homepage = https://github.com/home-assistant/home-assistant-cli;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13553,6 +13553,8 @@ in
     python = python36;
   };
 
+  home-assistant-cli = callPackage ../servers/home-assistant/cli.nix { };
+
   hydron = callPackage ../servers/hydron { };
 
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg @fpletz 
Feel free to notify other Home Assistant users, this seems like a nice addition to the ecosystem.