### PR TITLE
pcap: Add missing include, fix w/musl

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, flex, bison }:
+{ stdenv, fetchurl, fetchpatch, flex, bison }:
 
 stdenv.mkDerivation rec {
   name = "libpcap-1.9.0";
@@ -25,11 +25,16 @@ stdenv.mkDerivation rec {
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
-  '' + ''
-    sed -i '1i#include <limits.h>' pcap-usb-linux.c
   '';
 
-  preInstall = ''mkdir -p $out/bin'';
+  patches = [
+    # https://github.com/the-tcpdump-group/libpcap/pull/735
+    (fetchpatch {
+      name = "add-missing-limits-h-include-pr735.patch";
+      url = https://github.com/the-tcpdump-group/libpcap/commit/aafa3512b7b742f5e66a5543e41974cc5e7eebfa.patch;
+      sha256 = "05zb4hx9g24gx07bi02rprk2rn7fdc1ss3249dv5x36qkasnfhvf";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://www.tcpdump.org;

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
+  '' + ''
+    sed -i '1i#include <limits.h>' pcap-usb-linux.c
   '';
 
   preInstall = ''mkdir -p $out/bin'';


### PR DESCRIPTION
###### Motivation for this change

Sending to staging due to rebuilds,
instead of limiting to musl.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---