### PR TITLE
nixos/release-combined: adds aarch64-linux as supported

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -4,7 +4,7 @@
 
 { nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
-, supportedSystems ? [ "x86_64-linux" ]
+, supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
 , limitedSupportedSystems ? [ "i686-linux" ]
 }:
 

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -46,7 +46,9 @@ in rec {
     };
     constituents =
       let
-        all = x: map (system: x.${system}) supportedSystems;
+        # Except for the given systems, return the system-specific constituent
+        except = systems: x: map (system: x.${system}) (pkgs.lib.subtractLists systems supportedSystems);
+        all = x: except [] x;
       in [
         nixos.channel
         (all nixos.dummy)
@@ -63,24 +65,24 @@ in rec {
         nixos.tests.chromium.x86_64-linux or []
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
-        (all nixos.tests.gnome3)
+        (except ["aarch64-linux"] nixos.tests.gnome3)
         nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
-        (all nixos.tests.installer.lvm)
-        (all nixos.tests.installer.luksroot)
-        (all nixos.tests.installer.separateBoot)
-        (all nixos.tests.installer.separateBootFat)
-        (all nixos.tests.installer.simple)
-        (all nixos.tests.installer.simpleLabels)
-        (all nixos.tests.installer.simpleProvided)
-        (all nixos.tests.installer.simpleUefiSystemdBoot)
-        (all nixos.tests.installer.swraid)
-        (all nixos.tests.installer.btrfsSimple)
-        (all nixos.tests.installer.btrfsSubvols)
-        (all nixos.tests.installer.btrfsSubvolDefault)
-        (all nixos.tests.boot.biosCdrom)
-        #(all nixos.tests.boot.biosUsb) # disabled due to issue #15690
-        (all nixos.tests.boot.uefiCdrom)
-        (all nixos.tests.boot.uefiUsb)
+        (except ["aarch64-linux"] nixos.tests.installer.lvm)
+        (except ["aarch64-linux"] nixos.tests.installer.luksroot)
+        (except ["aarch64-linux"] nixos.tests.installer.separateBoot)
+        (except ["aarch64-linux"] nixos.tests.installer.separateBootFat)
+        (except ["aarch64-linux"] nixos.tests.installer.simple)
+        (except ["aarch64-linux"] nixos.tests.installer.simpleLabels)
+        (except ["aarch64-linux"] nixos.tests.installer.simpleProvided)
+        (except ["aarch64-linux"] nixos.tests.installer.simpleUefiSystemdBoot)
+        (except ["aarch64-linux"] nixos.tests.installer.swraid)
+        (except ["aarch64-linux"] nixos.tests.installer.btrfsSimple)
+        (except ["aarch64-linux"] nixos.tests.installer.btrfsSubvols)
+        (except ["aarch64-linux"] nixos.tests.installer.btrfsSubvolDefault)
+        (except ["aarch64-linux"] nixos.tests.boot.biosCdrom)
+        #(except ["aarch64-linux"] nixos.tests.boot.biosUsb) # disabled due to issue #15690
+        (except ["aarch64-linux"] nixos.tests.boot.uefiCdrom)
+        (except ["aarch64-linux"] nixos.tests.boot.uefiUsb)
         (all nixos.tests.boot-stage1)
         (all nixos.tests.hibernate)
         nixos.tests.docker.x86_64-linux or []
@@ -132,7 +134,8 @@ in rec {
 
         nixpkgs.tarball
         (all allSupportedNixpkgs.emacs)
-        (all allSupportedNixpkgs.jdk)
+        # The currently available aarch64 JDK is unfree
+        (except ["aarch64-linux"] allSupportedNixpkgs.jdk)
       ];
   });
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -157,7 +157,7 @@ in rec {
 
   # A variant with a more recent (but possibly less stable) kernel
   # that might support more hardware.
-  iso_minimal_new_kernel = forMatchingSystems [ "x86_64-linux" ] (system: makeIso {
+  iso_minimal_new_kernel = forMatchingSystems [ "x86_64-linux" "aarch64-linux" ] (system: makeIso {
     module = ./modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix;
     type = "minimal-new-kernel";
     inherit system;


### PR DESCRIPTION
###### Motivation for this change

This was previously removed in 74c4e30 .

This will allow hydra to build iso and sd images for aarch64-linux, and share a common channel with the x86-based platforms.

Additionally build `iso_minimal_new_kernel` on aarch64-linus too.

With #51397 merged, the UEFI iso images build for aarch64-linux too.

 * [short `#nixos-dev` discussion](https://logs.nix.samueldr.com/nixos-dev/2018-12-19#1545242351-1545243048;)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

* * *

Tested this way:

```
~/tmp/nixpkgs/nixpkgs $ time nix-instantiate nixos/release-combined.nix --show-trace
warning: dumping very large path (> 256 MiB); this may run out of memory
trace: Default desktop manager (gnome-xorg) not found at evaluation time.
These are the known valid session names:
  services.xserver.desktopManager.default = "xterm";
  services.xserver.desktopManager.default = "none";
It's also possible the default can be found in one of these packages:
  gnome-session-3.30.1

warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/nyii59byg1fs2isl3vbhxdhf88vz96g9-nixos-19.03pre56789.gfedcba.drv

 → exit status: 0
 → user: 439.03, system: 17.78, elapsed: 6:19.25
 → cpu: 120%, max mem: 12231108, avg mem: 0, unshared: 0
 → I/O: <I:0 O:0>, sock: <r:0 s:0>
```

The trace seen here is also present on the branch this is based-off from. The time it took, though, was *4:33.09*.

---

cc @edolstra 