### PR TITLE
fwts: 18.11.00 -> 18.12.00

### DIFF
--- a/pkgs/os-specific/linux/fwts/default.nix
+++ b/pkgs/os-specific/linux/fwts/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/lib/include/fwts_binpaths.h --replace "/usr/bin/iasl"       "${iasl}/bin/iasl"
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = "https://wiki.ubuntu.com/FirmwareTestSuite";
     description = "Firmware Test Suite";

--- a/pkgs/os-specific/linux/fwts/default.nix
+++ b/pkgs/os-specific/linux/fwts/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "fwts-${version}";
-  version = "18.11.00";
+  version = "18.12.00";
 
   src = fetchzip {
     url = "http://fwts.ubuntu.com/release/fwts-V${version}.tar.gz";
-    sha256 = "14dxw0ny5z681kz4dpm2phyanr2q4c8fqml3mhdr1mb2ndrrwqgz";
+    sha256 = "10kzn5r099i4b8m5l7s68fs885d126l9cingq9gj1g574c18hg2s";
     stripRoot = false;
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---