### PR TITLE
glib: 2.58.1 -> 2.58.2

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gettext, meson, ninja, pkgconfig, perl, python3, glibcLocales
+{ stdenv, fetchurl, fetchpatch, gettext, meson, ninja, pkgconfig, perl, python3, glibcLocales
 , libiconv, zlib, libffi, pcre, libelf, gnome3, libselinux, bash, gnum4, gtk-doc, docbook_xsl, docbook_xml_dtd_45
 # use utillinuxMinimal to avoid circular dependency (utillinux, systemd, glib)
 , utillinuxMinimal ? null
@@ -44,7 +44,7 @@ let
     ln -sr -t "''${!outputInclude}/include/" "''${!outputInclude}"/lib/*/include/* 2>/dev/null || true
   '';
 
-  version = "2.58.1";
+  version = "2.58.2";
 in
 
 stdenv.mkDerivation rec {
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1mnp4vankish8bqxymdl591p9v1ynk7pfc5dmpx3vamn4vcskmlp";
+    sha256 = "0jrxfm4gn1qz3y1450z709v74ys2bkjr8yffkgy106kgagb4xcn7";
   };
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch
@@ -64,6 +64,12 @@ stdenv.mkDerivation rec {
       ./schema-override-variable.patch
       # Require substituteInPlace in postPatch
       ./fix-gio-launch-desktop-path.patch
+      # https://gitlab.gnome.org/GNOME/glib/issues/1626
+      # https://gitlab.gnome.org/GNOME/glib/merge_requests/557
+      (fetchpatch {
+        url = https://gitlab.gnome.org/GNOME/glib/commit/85c4031696add9797e2334ced20678edcd96c869.patch;
+        sha256 = "1hmyvhx89wip2a26gk1rvd87k0pjfia51s0ysybjyzf5f1pzw877";
+      })
     ];
 
   outputs = [ "bin" "out" "dev" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

At least works properly with the gnome-y bits I used on my laptop, FWIW.