### PR TITLE
pythonPackages.jupytext: init at 0.8.4

### DIFF
--- a/pkgs/development/python-modules/jupytext/default.nix
+++ b/pkgs/development/python-modules/jupytext/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, testfixtures
+, pyyaml
+, mock
+, nbformat
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "jupytext";
+  version = "0.8.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m35m9z4vy480d2200nd4lk9n5s4z3zcnq0d9rdlh4yv5264mrgf";
+  };
+
+  propagatedBuildInputs = [
+    pyyaml
+    nbformat
+    testfixtures
+  ];
+  checkInputs = [
+    pytest
+  ];
+  # setup.py checks for those even though they're not needed at runtime (only
+  # for tests), thus not propagated
+  buildInputs = [
+    mock
+    pytest
+  ];
+
+  # requires test notebooks which are not shipped with the pypi release
+  doCheck = false;
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Jupyter notebooks as Markdown documents, Julia, Python or R scripts";
+    homepage = https://github.com/mwouts/jupytext;
+    license = licenses.mit;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1871,6 +1871,8 @@ in {
 
   jupyterlab = callPackage ../development/python-modules/jupyterlab {};
 
+  jupytext = callPackage ../development/python-modules/jupytext { };
+
   PyLTI = callPackage ../development/python-modules/pylti { };
 
   lmdb = callPackage ../development/python-modules/lmdb { };


### PR DESCRIPTION
###### Motivation for this change

Trying to work with a jupyter notebook without having to deal with the web interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

