### PR TITLE
soapysdr: fix extraPackages support

### DIFF
--- a/pkgs/applications/misc/soapysdr/default.nix
+++ b/pkgs/applications/misc/soapysdr/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libusb ncurses numpy swig2 python ];
+  buildInputs = [ libusb ncurses numpy swig2 python makeWrapper ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
@@ -33,8 +33,8 @@ in stdenv.mkDerivation {
     done
 
     # Needed for at least the remote plugin server
-    for file in out/bin/*; do
-        ${makeWrapper}/bin/wrapProgram "$file" \
+    for file in $out/bin/*; do
+        wrapProgram "$file" \
             --prefix SOAPY_SDR_PLUGIN_PATH : ${lib.makeSearchPath "lib/SoapySDR/modules0.6" extraPackages}
     done
   '';


### PR DESCRIPTION
###### Motivation for this change
I needed limesuite support. saw it was already there. noticed it was broken

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

