### PR TITLE
pythonPackages.pathpy: skip performance test

### DIFF
--- a/pkgs/development/python-modules/path.py/default.nix
+++ b/pkgs/development/python-modules/path.py/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
   checkPhase = ''
     # Ignore pytest configuration
     rm pytest.ini
-    py.test test_path.py
+    # ignore performance test which may fail when the system is under load
+    py.test -v -k 'not TestPerformance' test_path.py
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

The test may fail non-deterministically, as it does right now on hydra.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

