### PR TITLE
Fix builds for pythonPackages.azure-mgmt-*

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-common/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-common/default.nix
@@ -5,6 +5,7 @@
 , azure-common
 , azure-mgmt-nspkg
 , requests
+, msrestazure
 }:
 
 buildPythonPackage rec {
@@ -17,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "1rmzpz3733wv31rsnqpdy4bbafvk5dhbqx7q0xf62dlz7p0i4f66";
   };
 
-  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg requests ];
+  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg requests msrestazure ];
 
   postInstall = ''
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -15,12 +15,6 @@ buildPythonPackage rec {
     sha256 = "356219a354140ea26e6b4f4be4f855f1ffaf63af60de24cd2ca335b4ece9db00";
   };
 
-  preConfigure = ''
-    # Patch to make this package work on requests >= 2.11.x
-    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/compute/computemanagement.py
-  '';
-
   postInstall = ''
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -16,12 +16,6 @@ buildPythonPackage rec {
     sha256 = "aef8573066026db04ed3e7c5e727904e42f6462b6421c2e8a3646e4c4f8128be";
   };
 
-  preConfigure = ''
-    # Patch to make this package work on requests >= 2.11.x
-    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/resource/resourcemanagement.py
-  '';
-
   postInstall = ''
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -1,0 +1,28 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, certifi
+, requests_oauthlib
+, typing
+, isodate
+}:
+
+buildPythonPackage rec {
+  version = "0.6.2";
+  pname = "msrest";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0icklfjaagk0j9iwq897avmqhwwmgs7c5yy5jw3ppdqz6h0sm38v";
+  };
+
+  propagatedBuildInputs = [ certifi requests_oauthlib typing isodate ];
+
+  meta = with pkgs.lib; {
+    description = "The runtime library 'msrest' for AutoRest generated Python clients.";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bendlas ];
+  };
+}

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -1,0 +1,26 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, adal
+, msrest
+}:
+
+buildPythonPackage rec {
+  version = "0.6.0";
+  pname = "msrestazure";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06s04f6nng4na2663kc12a3skiaqb631nscjfwpsrx4lzkf8bccr";
+  };
+
+  propagatedBuildInputs = [ adal msrest ];
+
+  meta = with pkgs.lib; {
+    description = "The runtime library 'msrestazure' for AutoRest generated Python clients.";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bendlas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -498,6 +498,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  msrest = callPackage ../development/python-modules/msrest { };
+
   multiset = callPackage ../development/python-modules/multiset { };
 
   mwclient = callPackage ../development/python-modules/mwclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -498,6 +498,7 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  msrestazure = callPackage ../development/python-modules/msrestazure { };
   msrest = callPackage ../development/python-modules/msrest { };
 
   multiset = callPackage ../development/python-modules/multiset { };


### PR DESCRIPTION
# ~~Don't merge until nixops is updated!~~

__EDIT__ Nixops has received a [package-private, pinned version](https://github.com/NixOS/nixpkgs/pull/56775) of `azure-mgmt-*`, so this can be merged at leisure

###### Motivation for this change

Followup to the reverts in https://github.com/NixOS/nixpkgs/issues/52547

Revert the reverted updates and apply some build fixes on top

~~With this, `nixops` still fails, because it can't work with these versions, so this will need to wait until nixops is updated:~~

```
Traceback (most recent call last):
  File "/nix/store/jsnrx8ggppa9q7iiry88s763y0p2qhb5-nixops-1.6.1pre2706_d5ad09c/bin/..nixops-wrapped-wrapped", line 5, in <module>
    from nixops import deployment
  File "/nix/store/jsnrx8ggppa9q7iiry88s763y0p2qhb5-nixops-1.6.1pre2706_d5ad09c/lib/python2.7/site-packages/nixops/deployment.py", line 1275, in <module>
    _load_modules_from("backends")
  File "/nix/store/jsnrx8ggppa9q7iiry88s763y0p2qhb5-nixops-1.6.1pre2706_d5ad09c/lib/python2.7/site-packages/nixops/deployment.py", line 1273, in _load_modules_from
    importlib.import_module("nixops." + dir + "." + module[:-3])
  File "/nix/store/w30zkhdjf6qp4ppx9xzffsh9dic31aq8-python-2.7.15/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/nix/store/jsnrx8ggppa9q7iiry88s763y0p2qhb5-nixops-1.6.1pre2706_d5ad09c/lib/python2.7/site-packages/nixops/backends/azure_vm.py", line 23, in <module>
    from nixops.azure_common import ResourceDefinition, ResourceState, ResId, normalize_location
  File "/nix/store/jsnrx8ggppa9q7iiry88s763y0p2qhb5-nixops-1.6.1pre2706_d5ad09c/lib/python2.7/site-packages/nixops/azure_common.py", line 19, in <module>
    from azure.mgmt.network import NetworkResourceProviderClient
ImportError: cannot import name NetworkResourceProviderClient
```

cc @olcai @FRidh


