### PR TITLE
hyperledger-fabric: init at 1.3.0

### DIFF
--- a/pkgs/tools/misc/hyperledger-fabric/default.nix
+++ b/pkgs/tools/misc/hyperledger-fabric/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "hyperledger-fabric";
+  version = "1.3.0";
+
+  goPackagePath = "github.com/hyperledger/fabric";
+
+  # taken from https://github.com/hyperledger/fabric/blob/v1.3.0/Makefile#L108
+  subPackages = [
+    "common/tools/configtxgen"
+    "common/tools/configtxlator"
+    "common/tools/cryptogen"
+    "common/tools/idemixgen"
+    "cmd/discover"
+    "peer"
+    "orderer"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "hyperledger";
+    repo = "fabric";
+    rev = "v${version}";
+    sha256 = "08qrrxzgkqg9v7n3y8f2vggyqx9j65wisxi17hrabz5mzaq299xs";
+  };
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "An implementation of blockchain technology, leveraging familiar and proven technologies";
+    homepage = https://wiki.hyperledger.org/projects/Fabric;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17525,6 +17525,8 @@ in
     extra-packages = [ csound ];
   };
 
+  hyperledger-fabric = callPackage ../tools/misc/hyperledger-fabric { };
+
   jackline = callPackage ../applications/networking/instant-messengers/jackline { };
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };


### PR DESCRIPTION
###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/52542

cc: @rsoeldner

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

