### PR TITLE
shairport-sync: don't daemonize

### DIFF
--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -27,7 +27,7 @@ in
       };
 
       arguments = mkOption {
-        default = "-v -d pulse";
+        default = "-v pulse";
         description = ''
           Arguments to pass to the daemon. Defaults to a local pulseaudio
           server.


### PR DESCRIPTION
###### Motivation for this change

As is, the shairport-sync service immediately exits after boot with the following message:
```
Dec 19 22:26:25 nixos shairport-sync[11226]: shutdown requested...
```
It looks like this is emitted when shairport-sync receives SIGINT or SIGTERM. My guess is that this is coming from systemd, though I don't understand much about the details.

The [upstream systemd unit](https://github.com/mikebrady/shairport-sync/blob/master/scripts/shairport-sync.service.in#L10) doesn't pass `-d`.

Removing `-d` from the arguments list by overriding it in my local configuration fixes the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

