### PR TITLE
cni: migrate to using buildGoPackage

### DIFF
--- a/pkgs/applications/networking/cluster/cni/default.nix
+++ b/pkgs/applications/networking/cluster/cni/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, go, removeReferencesTo }:
+{ stdenv, fetchFromGitHub, buildGoPackage }:
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "cni-${version}";
   version = "0.6.0";
 
@@ -11,29 +11,23 @@ stdenv.mkDerivation rec {
     sha256 = "00ajs2r5r2z3l0vqwxrcwhjfc9px12qbcv5vnvs2mdipvvls1y2y";
   };
 
-  buildInputs = [ removeReferencesTo go ];
-
-  GOCACHE = "off";
+  goPackagePath = "github.com/containernetworking/cni";
 
   buildPhase = ''
+    cd "go/src/${goPackagePath}"
     patchShebangs build.sh
     ./build.sh
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv bin/cnitool $out/bin
-  '';
-
-  preFixup = ''
-    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
+    install -Dm555 bin/cnitool $bin/bin/cnitool
   '';
 
   meta = with stdenv.lib; {
     description = "Container Network Interface - networking for Linux containers";
     license = licenses.asl20;
     homepage = https://github.com/containernetworking/cni;
-    maintainers = with maintainers; [offline];
+    maintainers = with maintainers; [ offline vdemeester ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Part of #52469, make the `cni` derivation using `buildGoPackage` :angel: 

cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

