### PR TITLE
opencv3: fix OpenCV issue 13207

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -147,7 +147,15 @@ stdenv.mkDerivation rec {
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/opencv_contrib"
   '';
 
-  patches =
+  patches = [
+    # https://github.com/opencv/opencv/pull/13232
+    # This also fixes the test of haskell-opencv HEAD where we got the following error:
+    # libgomp: Out of memory allocating 927712937064 bytes
+    (fetchpatch {
+      url = https://github.com/opencv/opencv/commit/e1ac8589f8a19b9bf5598bbae073ae12721c541d.patch;
+      sha256 = "1ap2818lixjhc5jgf779c57kwacafc0ap40lqrx6nqfz31silglj";
+    })
+  ] ++
     # https://github.com/opencv/opencv/pull/13254
     lib.optional enablePython (fetchpatch {
       url = https://github.com/opencv/opencv/commit/ad35b79e3f98b4ce30481e0299cca550ed77aef0.patch;

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -160,7 +160,15 @@ stdenv.mkDerivation rec {
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/source/opencv_contrib"
   '';
 
-  patches =
+  patches = [
+    # https://github.com/opencv/opencv/pull/13232
+    # This also fixes the test of haskell-opencv HEAD where we got the following error:
+    # libgomp: Out of memory allocating 927712937064 bytes
+    (fetchpatch {
+      url = https://github.com/opencv/opencv/commit/e1ac8589f8a19b9bf5598bbae073ae12721c541d.patch;
+      sha256 = "1ap2818lixjhc5jgf779c57kwacafc0ap40lqrx6nqfz31silglj";
+    })
+  ] ++
     # Fixes issue: https://github.com/opencv/opencv_contrib/issues/1923
     # PR: https://github.com/opencv/opencv_contrib/pull/1913
     lib.optional buildContrib (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change

See: https://github.com/opencv/opencv/pull/13232

@nh2 this also fixes the test of `haskell-opencv` HEAD where we got the following error:

```
...
    Feature Detection
      houghLinesP:
libgomp: Out of memory allocating 927712937064 bytes
Test suite test-opencv: FAIL
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

