### PR TITLE
openspades: Fix Darwin build

### DIFF
--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchurl, fetchFromGitHub, cmake, unzip, zip, file
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, cmake, unzip, zip, file
 , curl, glew , libGL, SDL2, SDL2_image, zlib, freetype, imagemagick
 , openal , opusfile, libogg
+, Cocoa
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +20,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     freetype SDL2 SDL2_image libGL zlib curl glew opusfile openal libogg
+  ] ++ stdenv.lib.optionals stdenv.hostPlatform.isDarwin [
+    Cocoa
+  ];
+
+  patches = [
+    # https://github.com/yvt/openspades/pull/793 fix Darwin build
+    (fetchpatch {
+      url = "https://github.com/yvt/openspades/commit/2d13704fefc475b279337e89057b117f711a35d4.diff";
+      sha256 = "1i7rcpjzkjhbv5pp6byzrxv7sb1iamqq5k1vyqlvkbr38k2dz0rv";
+    })
   ];
 
   cmakeFlags = [
@@ -43,6 +54,6 @@ stdenv.mkDerivation rec {
     description = "A compatible client of Ace of Spades 0.75";
     homepage    = "https://github.com/yvt/openspades/";
     license     = licenses.gpl3;
-    platforms   = platforms.linux;
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20034,7 +20034,9 @@ with pkgs;
 
   openrw = callPackage ../games/openrw { };
 
-  openspades = callPackage ../games/openspades { };
+  openspades = callPackage ../games/openspades {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   openttd = callPackage ../games/openttd {
     zlib = zlibStatic;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

