### PR TITLE
runc: migrate to using buildGoPackage

### DIFF
--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo, go-md2man
-, go, pkgconfig, libapparmor, apparmor-parser, libseccomp }:
+{ stdenv, lib, fetchFromGitHub, buildGoPackage, go-md2man
+, pkgconfig, libapparmor, apparmor-parser, libseccomp, which }:
 
 with lib;
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "runc-${version}";
   version = "1.0.0-rc6";
 
@@ -14,32 +14,26 @@ stdenv.mkDerivation rec {
     sha256 = "1jwacb8xnmx5fr86gximhbl9dlbdwj3rpf27hav9q1si86w5pb1j";
   };
 
-  outputs = [ "out" "man" ];
+  goPackagePath = "github.com/opencontainers/runc";
+  outputs = [ "bin" "out" "man" ];
 
   hardeningDisable = ["fortify"];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ removeReferencesTo go-md2man go libseccomp libapparmor apparmor-parser ];
+  buildInputs = [ go-md2man libseccomp libapparmor apparmor-parser which ];
 
   makeFlags = ''BUILDTAGS+=seccomp BUILDTAGS+=apparmor'';
 
-  preConfigure = ''
-    # Extract the source
-    cd "$NIX_BUILD_TOP"
-    mkdir -p "go/src/github.com/opencontainers"
-    mv "$sourceRoot" "go/src/github.com/opencontainers/runc"
-    export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
-  '';
-
-  preBuild = ''
-    cd go/src/github.com/opencontainers/runc
+  buildPhase = ''
+    cd go/src/${goPackagePath}
     patchShebangs .
     substituteInPlace libcontainer/apparmor/apparmor.go \
       --replace /sbin/apparmor_parser ${apparmor-parser}/bin/apparmor_parser
+    make ${makeFlags} runc
   '';
 
   installPhase = ''
-    install -Dm755 runc $out/bin/runc
+    install -Dm755 runc $bin/bin/runc
 
     # Include contributed man pages
     man/md2man-all.sh -q
@@ -53,10 +47,6 @@ stdenv.mkDerivation rec {
         gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
       done
     done
-  '';
-
-  preFixup = ''
-    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Part of #52469, make the `runc` derivation using `buildGoPackage` :angel: 
This means `runc` becomes a multi-output derivation : `runc.bin` and `runc.man`.

cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

