### PR TITLE
git-secret: Add gawk to wrapper

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secret/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, git, gnupg }:
+{ stdenv, lib, fetchFromGitHub, makeWrapper, git, gnupg, gawk }:
 
 let
   version = "0.2.4";
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
     install -D git-secret $out/bin/git-secret
 
     wrapProgram $out/bin/git-secret \
-      --prefix PATH : "${lib.makeBinPath [ git gnupg ]}"
+      --prefix PATH : "${lib.makeBinPath [ git gnupg gawk ]}"
 
     mkdir $out/share
     cp -r man $out/share


### PR DESCRIPTION
###### Motivation for this change

The `git-secret` script(s) use `gawk`. Before this change:

```
$ nix-env -f ~/code/nixpkgs -iA git-secret # master branch of nixpkgs
installing 'git-secret-0.2.4'
$ git secret init
/nix/store/i5xpjcrjvsh89ckkw470c94561nzw948-git-secret-0.2.4/bin/.git-secret-wrapped: line 129: gawk: command not found
'/home/aiken/code/git-secret-test/.gitsecret/' created.
/nix/store/i5xpjcrjvsh89ckkw470c94561nzw948-git-secret-0.2.4/bin/.git-secret-wrapped: line 254: gawk: command not found
```

@lo1tuma 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

