### PR TITLE
containerd: migrate to using buildGoPackage

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo
-, go, btrfs-progs }:
+{ stdenv, lib, fetchFromGitHub, buildGoPackage, btrfs-progs, go-md2man, utillinux }:
 
 with lib;
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "containerd-${version}";
   version = "1.2.1";
 
@@ -14,34 +13,37 @@ stdenv.mkDerivation rec {
     sha256 = "16zn6p1ky3yrgn53z8h9wza53ch91fj47wj5xgz6w4c57j30f66p";
   };
 
+  goPackagePath = "github.com/containerd/containerd";
+  outputs = [ "bin" "out" "man" ];
+
   hardeningDisable = [ "fortify" ];
 
-  buildInputs = [ removeReferencesTo go btrfs-progs ];
+  buildInputs = [ btrfs-progs go-md2man utillinux ];
   buildFlags = "VERSION=v${version}";
 
   BUILDTAGS = []
     ++ optional (btrfs-progs == null) "no_btrfs";
 
-  preConfigure = ''
-    # Extract the source
-    cd "$NIX_BUILD_TOP"
-    mkdir -p "go/src/github.com/containerd"
-    mv "$sourceRoot" "go/src/github.com/containerd/containerd"
-    export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
-'';
-
-  preBuild = ''
-    cd go/src/github.com/containerd/containerd
+  buildPhase = ''
+    cd go/src/${goPackagePath}
     patchShebangs .
+    make binaries
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp bin/* $out/bin
-  '';
+    for b in bin/*; do
+      install -Dm555 $b $bin/$b
+    done
 
-  preFixup = ''
-    find $out -type f -exec remove-references-to -t ${go} '{}' +
+    make man
+    manRoot="$man/share/man"
+    mkdir -p "$manRoot"
+    for manFile in man/*; do
+      manName="$(basename "$manFile")" # "docker-build.1"
+      number="$(echo $manName | rev | cut -d'.' -f1 | rev)"
+      mkdir -p "$manRoot/man$number"
+      gzip -c "$manFile" > "$manRoot/man$number/$manName.gz"
+    done
   '';
 
   meta = {

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -28,7 +28,7 @@ rec {
       patches = [];
     });
 
-    docker-containerd = (containerd.override { inherit go; }).overrideAttrs (oldAttrs: rec {
+    docker-containerd = containerd.overrideAttrs (oldAttrs: rec {
       name = "docker-containerd-${version}";
       inherit version;
       src = fetchFromGitHub {
@@ -39,8 +39,6 @@ rec {
       };
 
       hardeningDisable = [ "fortify" ];
-
-      buildInputs = [ removeReferencesTo go btrfs-progs ];
     });
 
     docker-tini = tini.overrideAttrs  (oldAttrs: rec {


### PR DESCRIPTION
###### Motivation for this change

Part of #52469, make the `runc` derivation using `buildGoPackage` :angel: 

… and add man pages, which means `containerd` becomes a multi-output
derivation : `containerd.bin` and `containerd.man`.


cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

