### PR TITLE
openblas: fix build on x86_64-darwin

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -89,6 +89,15 @@ stdenv.mkDerivation rec {
 
   inherit blas64;
 
+  patches = [
+    # Fixes build on x86_64-darwin. See:
+    # https://github.com/xianyi/OpenBLAS/issues/1926
+    (fetchpatch {
+      url = https://github.com/xianyi/OpenBLAS/commit/701ea88347461e4c5d896765438dc870281b3834.patch;
+      sha256 = "18rcfgkjsijl9d2510jn961wqvz7zdlz2fgy1yjmax29kvv8fqd9";
+    })
+  ];
+
   # Some hardening features are disabled due to sporadic failures in
   # OpenBLAS-based programs. The problem may not be with OpenBLAS itself, but
   # with how these flags interact with hardening measures used downstream.
@@ -117,8 +126,6 @@ stdenv.mkDerivation rec {
       "NO_STATIC=1"
     ] ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "musl") "NO_AFFINITY=1"
     ++ mapAttrsToList (var: val: var + "=" + val) config;
-
-    patches = [];
 
   doCheck = true;
   checkTarget = "tests";


### PR DESCRIPTION
###### Motivation for this change

@FRidh after upgrading `openblas` from 0.3.3 to 0.3.4 in 4deb04a97ab1cca77f24057d2f6ee9273091316c the [`x86_64-darwin` job](https://hydra.nixos.org/job/nixpkgs/trunk/openblas.x86_64-darwin) started failing.

This PR fixes that.

See: https://github.com/xianyi/OpenBLAS/issues/1926

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build openblas