### PR TITLE
gcompris: 0.91 -> 0.95

### DIFF
--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -1,11 +1,11 @@
 {stdenv, qtdeclarative, fetchFromGitHub, qmake }:
 stdenv.mkDerivation rec {
-  name = "qml-box2d-2018-03-16";
+  name = "qml-box2d-2018-04-06";
   src = fetchFromGitHub {
     owner = "qml-box2d";
     repo = "qml-box2d";
-    sha256 = "1fbsvv28b4r0szcv8bk5gxpf8v534jp2axyfp438384sy757wsq2";
-    rev = "21e57f1";
+    sha256 = "0gb8limy6ck23z3k0k2j7c4c4s95p40f6lbzk4szq7fjnnw22kb7";
+    rev = "b7212d5640701f93f0cd88fbd3a32c619030ae62";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/games/gcompris/default.nix
+++ b/pkgs/games/gcompris/default.nix
@@ -2,12 +2,12 @@
   gst_all_1, ninja
 }:
 stdenv.mkDerivation rec {
-  version = "0.91";
+  version = "0.95";
   name = "gcompris-${version}";
 
   src = fetchurl {
     url = "http://gcompris.net/download/qt/src/gcompris-qt-${version}.tar.xz";
-    sha256 = "09h098w9q79hnzla1pcpqlnnr6dbafm4q6zmdp7wlk11ym8n9kvg";
+    sha256 = "1aaijjx2b7k1cyx59jhs64hlp1sppw1faa81qxl5lxc79vifrlrl";
   };
 
   cmakeFlags = "-DQML_BOX2D_LIBRARY=${qmlbox2d}/${qtbase.qtQmlPrefix}/Box2D.2.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20613,7 +20613,7 @@ in
 
   gcs = callPackage ../games/gcs { };
 
-  gcompris = libsForQt59.callPackage ../games/gcompris { };
+  gcompris = libsForQt5.callPackage ../games/gcompris { };
 
   gemrb = callPackage ../games/gemrb { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12243,7 +12243,7 @@ in
     qmltermwidget = callPackage ../development/libraries/qmltermwidget {
       inherit (darwin.apple_sdk.libs) utmp;
     };
-    qmlbox2d = libsForQt59.callPackage ../development/libraries/qmlbox2d { };
+    qmlbox2d = libsForQt5.callPackage ../development/libraries/qmlbox2d { };
 
     qscintilla = callPackage ../development/libraries/qscintilla {
       withQt5 = true;


### PR DESCRIPTION
###### Motivation for this change

Bump version to 0.95.

Previous version (0.91) was not properly working with qt > 5.9, it seems fixed now, so I removed the custom pinning to qt 5.9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

