### PR TITLE
git: 2.19.2 -> 2.20.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./docbook2texi.patch
-    #./git-sh-i18n.patch
+    ./git-sh-i18n.patch
     ./ssh-path.patch
     ./git-send-email-honor-PATH.patch
     ./installCheck-path.patch

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -20,7 +20,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.19.2";
+  version = "2.20.1";
   svn = subversionClient.override { perlBindings = perlSupport; };
 in
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "1scbggzghkzzfqg4ky3qh7h9w87c3zya4ls5disz7dbx56is7sgw";
+    sha256 = "1sf3h6ms43k15h01ln8lcf24vx9n7c11s83h1ax63sm2zbi92blx";
   };
 
   outputs = [ "out" ] ++ stdenv.lib.optional perlSupport "gitweb";
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./docbook2texi.patch
-    ./git-sh-i18n.patch
+    #./git-sh-i18n.patch
     ./ssh-path.patch
     ./git-send-email-honor-PATH.patch
     ./installCheck-path.patch

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./docbook2texi.patch
-    ./git-sh-i18n.patch
+    #./git-sh-i18n.patch
     ./ssh-path.patch
     ./git-send-email-honor-PATH.patch
     ./installCheck-path.patch

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -6,7 +6,7 @@
 
 -# First decide what scheme to use...
 -GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
--if test -n "$GIT_TEST_GETTEXT_POISON"
+-if test -n "$GIT_GETTEXT_POISON"
 -then
 -	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
 -elif test -n "@@USE_GETTEXT_SCHEME@@"

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -6,7 +6,7 @@
 
 -# First decide what scheme to use...
 -GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
--if test -n "$GIT_GETTEXT_POISON"
+-if test -n "$GIT_TEST_GETTEXT_POISON"
 -then
 -	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
 -elif test -n "@@USE_GETTEXT_SCHEME@@"

--- a/pkgs/applications/version-management/git-and-tools/git/installCheck-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/installCheck-path.patch
@@ -5,7 +5,7 @@ diff --git a/t/test-lib.sh b/t/test-lib.sh
  then
  	GIT_EXEC_PATH=$($GIT_TEST_INSTALLED/git --exec-path)  ||
  	error "Cannot run git from $GIT_TEST_INSTALLED."
--	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR:$PATH
+-	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR/t/helper:$PATH
 +	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR/t/helper:$GIT_BUILD_DIR:$PATH
  	GIT_EXEC_PATH=${GIT_TEST_EXEC_PATH:-$GIT_EXEC_PATH}
  else # normal case, use ../bin-wrappers only unless $with_dashes:


### PR DESCRIPTION
https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.20.1.txt
https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.20.0.txt

###### Motivation for this change

Commits can (should?) be squashed, but wanted to show the path taken
and be sure to draw attention to the git-sh-i18n bits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---