### PR TITLE
gnused: 4.5 -> 4.7

### DIFF
--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnused-${version}";
-  version = "4.6";
+  version = "4.7";
 
   src = fetchurl {
     url = "mirror://gnu/sed/sed-${version}.tar.xz";
-    sha256 = "17mv15mmjbqmfp6x600ypp9jyvkh9sk47l8l4xrcqf3q3k7nmzxy";
+    sha256 = "0smxcx66vx29djzb542nxcynl7qnzxqa5032ibazi7x2s267d198";
   };
 
   outputs = [ "out" "info" ];

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnused-${version}";
-  version = "4.5";
+  version = "4.6";
 
   src = fetchurl {
     url = "mirror://gnu/sed/sed-${version}.tar.xz";
-    sha256 = "0h3b2jfj57wmz680vkbyavlsrkak556qhvs7m7fdlawwhg477bbs";
+    sha256 = "17mv15mmjbqmfp6x600ypp9jyvkh9sk47l8l4xrcqf3q3k7nmzxy";
   };
 
   outputs = [ "out" "info" ];


### PR DESCRIPTION
https://savannah.gnu.org/forum/forum.php?forum_id=9331

Mirrors didn't seem to have it, hash obtained via

$ nix-prefetch-url https://ftp.gnu.org/gnu/sed/sed-4.6.tar.xz


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---