### PR TITLE
add sepaxml & fints

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1329,6 +1329,11 @@
     github = "ellis";
     name = "Ellis Whitehead";
   };
+  elohmeier = {
+    email = "elo-nixos@nerdworks.de";
+    github = "elohmeier";
+    name = "Enno Lohmeier";
+  };
   elseym = {
     email = "elseym@me.com";
     github = "elseym";

--- a/pkgs/development/python-modules/fints/default.nix
+++ b/pkgs/development/python-modules/fints/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi,
+  requests, mt-940, sepaxml, bleach, isPy3k }:
+
+buildPythonPackage rec {
+  version = "2.0.0";
+  pname = "fints";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1jja83h0ld55djiphcxdz64z5qp3w94204bfbgg65v5ybw0vpqq1";
+  };
+
+  propagatedBuildInputs = [ requests mt-940 sepaxml bleach ];
+
+  # no tests included in PyPI package
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/raphaelm/python-fints/;
+    description = "Pure-python FinTS (formerly known as HBCI) implementation";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/development/python-modules/sepaxml/default.nix
+++ b/pkgs/development/python-modules/sepaxml/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  version = "2.0.0";
+  pname = "sepaxml";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jhj8fa0lbyaw15q485kyyli9qgrmqr47a6z6pgqm40kwmjghiyc";
+  };
+
+  # no tests included in PyPI package
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/raphaelm/python-sepaxml/;
+    description = "SEPA Direct Debit XML generation in python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -358,6 +358,8 @@ in {
 
   filterpy = callPackage ../development/python-modules/filterpy { };
 
+  fints = callPackage ../development/python-modules/fints { };
+
   fire = callPackage ../development/python-modules/fire { };
 
   fdint = callPackage ../development/python-modules/fdint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -702,6 +702,8 @@ in {
 
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 
+  sepaxml = callPackage ../development/python-modules/sepaxml { };
+
   serversyncstorage = callPackage ../development/python-modules/serversyncstorage {};
 
   shellingham = callPackage ../development/python-modules/shellingham {};


### PR DESCRIPTION
###### Motivation for this change
python modules sepaxml & fints missing in nixpkgs

###### Things done
added the modules, continued on https://github.com/NixOS/nixpkgs/pull/52486

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

