### PR TITLE
pythonPackages.connexion

### DIFF
--- a/pkgs/development/python-modules/aiohttp-swagger/default.nix
+++ b/pkgs/development/python-modules/aiohttp-swagger/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, flake8
+, jinja2
+, pytestCheckHook
+, pytest-aiohttp
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "aiohttp-swagger";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "cr0hn";
+    repo = pname;
+    rev = "5a59e86f8c5672d2cc97dd35dc730c2f809d95ce"; # corresponds to 1.0.5 on PyPi, no tag on GitHub
+    sha256 = "1vpfk5b3f7s9qzr2q48g776f39xzqppjwm57scfzqqmbldkk5nv7";
+  };
+
+  propagatedBuildInputs = [ aiohttp jinja2 pyyaml ];
+
+  checkInputs = [ flake8 pytestCheckHook pytest-aiohttp ];
+
+  meta = with lib; {
+    description = "Swagger API Documentation builder for aiohttp";
+    homepage = https://github.com/cr0hn/aiohttp-swagger;
+    license = licenses.mit;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/development/python-modules/clickclick/default.nix
+++ b/pkgs/development/python-modules/clickclick/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, isPy36, flake8, click, pyyaml, six, pytestCheckHook, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "clickclick";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "hjacobs";
+    repo = "python-clickclick";
+    rev = version;
+    sha256 = "1rij9ws9nhsmagiy1vclzliiqfkxi006rf65qvrw1k3sm2s8p5g0";
+  };
+
+  checkInputs = [ pytestCheckHook pytestcov ];
+  propagatedBuildInputs = [ flake8 click pyyaml six ];
+
+  disabledTests = lib.optionals isPy36 [
+    "test_cli"
+    "test_choice_default"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Click command line utilities";
+    homepage = https://github.com/hjacobs/python-clickclick/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -1,0 +1,94 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, glibcLocales
+, lib
+, pythonOlder
+
+, aiohttp
+, aiohttp-swagger
+, aiohttp-jinja2
+, clickclick
+, decorator
+, flake8
+, flask
+, gevent
+, inflection
+, jsonschema
+, mock
+, openapi-spec-validator
+, pathlib
+, pytest
+, pytest-aiohttp
+, pytestcov
+, pyyaml
+, requests
+, six
+, swagger-ui-bundle
+, testfixtures
+, typing
+, ujson
+}:
+
+buildPythonPackage rec {
+  pname = "connexion";
+  version = "2.3.0";
+
+  # we're fetching from GitHub because tests weren't distributed on PyPi
+  src = fetchFromGitHub {
+    owner = "zalando";
+    repo = pname;
+    rev = version;
+    sha256 = "1xdm3misxwgrl87ms0vvn0h4rjwzlmmi7kcra2ahs40iaraf33ln";
+  };
+
+  checkInputs = [
+    decorator
+    mock
+    pytest
+    pytestcov
+    testfixtures
+    flask
+    swagger-ui-bundle
+  ]
+  ++ lib.optionals isPy3k [ aiohttp aiohttp-jinja2 aiohttp-swagger ujson pytest-aiohttp ]
+  ++ lib.optional (pythonOlder "3.7") glibcLocales
+  ;
+  propagatedBuildInputs = [
+    clickclick
+    jsonschema
+    pyyaml
+    requests
+    six
+    inflection
+    openapi-spec-validator
+    swagger-ui-bundle
+    flask
+  ]
+  ++ lib.optional (pythonOlder "3.4") pathlib
+  ++ lib.optional (pythonOlder "3.6") typing
+  ++ lib.optionals isPy3k [ aiohttp aiohttp-jinja2 aiohttp-swagger ujson ]
+  ;
+
+  preConfigure = lib.optional (pythonOlder "3.7") ''
+    export LANG=en_US.UTF-8
+  '';
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'aiohttp>=2.3.10,<3.5.2'" "'aiohttp>=2.3.10'"
+  '';
+
+  checkPhase = if isPy3k then ''
+    pytest -k "not test_app_get_root_path and \
+               not test_verify_oauth_scopes_remote and \
+               not test_verify_oauth_scopes_local and \
+               not test_run_with_aiohttp_not_installed"''
+  else "pytest --ignore=tests/aiohttp";
+
+  meta = with lib; {
+    description = "Swagger/OpenAPI First framework on top of Flask";
+    homepage = https://github.com/zalando/connexion/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/development/python-modules/swagger-ui-bundle/default.nix
+++ b/pkgs/development/python-modules/swagger-ui-bundle/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, jinja2, flake8 }:
+
+buildPythonPackage rec {
+  pname = "swagger-ui-bundle";
+  version = "0.0.5";
+
+  src = fetchPypi {
+    pname = "swagger_ui_bundle";
+    inherit version;
+    sha256 = "0v69v94mzzb63ciwpz3n8jwxqcyll3fsyx087s9k9q543zdqzbh1";
+  };
+
+  # patch away unused test requirements since package contains no tests
+  postPatch = ''
+    substituteInPlace setup.py --replace "setup_requires=['pytest-runner', 'flake8']" "setup_requires=[]"
+  '';
+
+  propagatedBuildInputs = [ jinja2 ];
+
+  # package contains no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "bundled swagger-ui pip package";
+    homepage = https://github.com/dtkav/swagger_ui_bundle;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2818,6 +2818,8 @@ in {
 
   starfish = callPackage ../development/python-modules/starfish { };
 
+  swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
+
   multi_key_dict = callPackage ../development/python-modules/multi_key_dict { };
 
   random2 = callPackage ../development/python-modules/random2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -475,6 +475,8 @@ in {
 
   clifford = callPackage ../development/python-modules/clifford { };
 
+  clickclick = callPackage ../development/python-modules/clickclick { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cnvkit = callPackage ../development/python-modules/cnvkit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1307,6 +1307,8 @@ in {
 
   aiohttp-socks = callPackage ../development/python-modules/aiohttp-socks { };
 
+  aiohttp-swagger = callPackage ../development/python-modules/aiohttp-swagger { };
+
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
   aioresponses = callPackage ../development/python-modules/aioresponses { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -481,6 +481,8 @@ in {
 
   cnvkit = callPackage ../development/python-modules/cnvkit { };
 
+  connexion = callPackage ../development/python-modules/connexion { };
+
   cozy = callPackage ../development/python-modules/cozy { };
 
   codespell = callPackage ../development/python-modules/codespell { };


### PR DESCRIPTION
###### Motivation for this change
add the connexion library and dependencies to build nice Flask-API's with Nix

###### Things done
added clickclick, openapi-spec-validator, connexion


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

