### PR TITLE
gitlab-workhorse: migrate to using buildGoPackage

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchFromGitLab, git, go }:
+{ stdenv, lib, fetchFromGitLab, buildGoPackage }:
 
-stdenv.mkDerivation rec {
+with lib;
+
+buildGoPackage rec {
   name = "gitlab-workhorse-${version}";
-
   version = "7.1.3";
 
   src = fetchFromGitLab {
@@ -11,12 +12,20 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1r75jj0xb4jv5fq2ihxk0vlv43gsk523zx86076mwph1g75gi1nz";
   };
-
-  buildInputs = [ git go ];
+  goPackagePath = "gitlab.com/gitlab-org/gitlab-workhorse";
 
   patches = [ ./remove-hardcoded-paths.patch ];
 
-  makeFlags = [ "PREFIX=$(out)" "VERSION=${version}" ];
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    make VERSION=${version}
+  '';
+
+  installPhase = ''
+    for b in gitlab-*; do
+      install -Dm555 $b $bin/bin/$b
+    done
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://www.gitlab.com/;


### PR DESCRIPTION
###### Motivation for this change

Part of #52469, make the `gitlab-workhorst` derivation using `buildGoPackage` :angel: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

