### PR TITLE
fffuu: init at unstable-2018-05-26

### DIFF
--- a/pkgs/tools/misc/fffuu/default.nix
+++ b/pkgs/tools/misc/fffuu/default.nix
@@ -1,0 +1,51 @@
+{ mkDerivation, haskellPackages, fetchFromGitHub, lib }:
+
+mkDerivation rec {
+  pname = "fffuu";
+  version = "unstable-2018-05-26";
+
+  src = fetchFromGitHub {
+    owner = "diekmann";
+    repo = "Iptables_Semantics";
+    rev = "e0a2516bd885708fce875023b474ae341cbdee29";
+    sha256 = "1qc7p44dqja6qrjbjdc2xn7n9v41j5v59sgjnxjj5k0mxp58y1ch";
+  };
+
+  postPatch = ''
+    substituteInPlace haskell_tool/fffuu.cabal \
+      --replace "containers >=0.5 && <0.6" "containers >= 0.6" \
+      --replace "optparse-generic >= 1.2.3 && < 1.3" "optparse-generic >= 1.2.3"
+  '';
+
+  preCompileBuildDriver = ''
+    cd haskell_tool
+  '';
+
+  isLibrary = false;
+
+  isExecutable = true;
+
+  # fails with sandbox
+  doCheck = false;
+
+  libraryHaskellDepends = with haskellPackages; [
+    base
+    containers
+    split
+    parsec
+    optparse-generic
+  ];
+
+  executableHaskellDepends = with haskellPackages; [ base ];
+
+  testHaskellDepends = with haskellPackages; [
+    tasty
+    tasty-hunit
+    tasty-golden
+  ];
+
+  description = "Fancy Formal Firewall Universal Understander";
+  homepage = https://github.com/diekmann/Iptables_Semantics/tree/master/haskell_tool;
+  license = lib.licenses.bsd2;
+  maintainers = [ lib.maintainers.marsam ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9389,6 +9389,8 @@ in
 
   flootty = callPackage ../development/tools/flootty { };
 
+  fffuu = haskell.lib.justStaticExecutables (haskellPackages.callPackage ../tools/misc/fffuu { });
+
   flow = callPackage ../development/tools/analysis/flow {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/52468

cc: @CMCDragonkai 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

