### PR TITLE
argp-standalone: add x86_64-linux support

### DIFF
--- a/pkgs/development/libraries/argp-standalone/default.nix
+++ b/pkgs/development/libraries/argp-standalone/default.nix
@@ -1,5 +1,24 @@
 { stdenv, fetchurl, fetchpatch }:
 
+let
+  patch-argp-fmtstream = fetchpatch {
+    name = "patch-argp-fmtstream.h";
+    url = "https://raw.githubusercontent.com/Homebrew/formula-patches/b5f0ad3/argp-standalone/patch-argp-fmtstream.h";
+    sha256 = "5656273f622fdb7ca7cf1f98c0c9529bed461d23718bc2a6a85986e4f8ed1cb8";
+  };
+
+  patch-throw-in-funcdef = fetchpatch {
+    name = "argp-standalone-1.3-throw-in-funcdef.patch";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/argp-standalone/files/argp-standalone-1.3-throw-in-funcdef.patch?id=409d0e2a9c9c899fb1fb04cc808fe0aff3f745ca";
+    sha256 = "0b2b4l1jkvmnffl22jcn4ydzxy2i7fnmmnfim12f0yg5pb8fs43c";
+  };
+
+  patch-shared = fetchpatch {
+    name = "argp-standalone-1.3-shared.patch";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/argp-standalone/files/argp-standalone-1.3-shared.patch?id=409d0e2a9c9c899fb1fb04cc808fe0aff3f745ca";
+    sha256 = "1xx2zdc187a1m2x6c1qs62vcrycbycw7n0q3ks2zkxpaqzx2dgkw";
+  };
+in
 stdenv.mkDerivation rec {
   name = "argp-standalone-1.3";
 
@@ -8,24 +27,19 @@ stdenv.mkDerivation rec {
     sha256 = "dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be";
   };
 
-  patches = [
-    (if stdenv.hostPlatform.isDarwin then
-    fetchpatch {
-      name = "patch-argp-fmtstream.h";
-      url = "https://raw.githubusercontent.com/Homebrew/formula-patches/b5f0ad3/argp-standalone/patch-argp-fmtstream.h";
-      sha256 = "5656273f622fdb7ca7cf1f98c0c9529bed461d23718bc2a6a85986e4f8ed1cb8";
-    }
-    else null)
-  ];
+  patches =
+       stdenv.lib.optionals stdenv.hostPlatform.isDarwin [ patch-argp-fmtstream ]
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isLinux [ patch-throw-in-funcdef patch-shared ];
 
-  patchFlags = "-p0";
+  patchFlags = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "-p0";
 
-  postInstall = 
-    ''
-      mkdir -p $out/lib $out/include
-      cp libargp.a $out/lib
-      cp argp.h $out/include
-    '';
+  preConfigure = stdenv.lib.optionalString stdenv.hostPlatform.isLinux "export CFLAGS='-fgnu89-inline'";
+
+  postInstall = ''
+    mkdir -p $out/lib $out/include
+    cp libargp.a $out/lib
+    cp argp.h $out/include
+  '';
 
   doCheck = true;
 
@@ -34,8 +48,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://www.lysator.liu.se/~nisse/misc/";
     description = "Standalone version of arguments parsing functions from GLIBC";
-    platforms = platforms.darwin;
+    platforms = with platforms; darwin ++ [ "x86_64-linux" ];
     maintainers = with maintainers; [ amar1729 ];
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I submitted this package a while ago for macOS; this PR adds linux (testing on Ubuntu 18) functionality. Only testing with nix on Ubuntu and macOS so far but I think it should work on other linux flavors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

