### PR TITLE
pythonPackages.pyu2f: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/pyu2f/default.nix
+++ b/pkgs/development/python-modules/pyu2f/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, buildPythonPackage,
+  six, mock, pyfakefs, unittest2, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pyu2f";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = version;
+    sha256 = "0waxdydvxn05a8ab9j235mz72x7p4pwa59pnxyk1zzbwxnpxb3p9";
+  };
+
+  # Platform detection for linux fails
+  postPatch = lib.optionalString stdenv.isLinux ''
+    rm pyu2f/tests/hid/macos_test.py
+  '';
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytest six mock pyfakefs unittest2 ];
+
+  checkPhase = ''
+    pytest pyu2f/tests
+  '';
+
+  meta = with lib; {
+    description = "U2F host library for interacting with a U2F device over USB";
+    homepage = https://github.com/google/pyu2f/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3729,6 +3729,8 @@ in {
 
   pyls-mypy = callPackage ../development/python-modules/pyls-mypy {};
 
+  pyu2f = callPackage ../development/python-modules/pyu2f { };
+
   pyudev = callPackage ../development/python-modules/pyudev {
     inherit (pkgs) systemd;
   };


### PR DESCRIPTION
###### Motivation for this change

This commit adds new package pyu2f which is very useful for people developing with U2F protocol.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

