### PR TITLE
ipxe: Add options to specify trusted root certificate and enable image trust management

### DIFF
--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -1,5 +1,8 @@
 { stdenv, lib, fetchgit, perl, cdrkit, syslinux, xz, openssl
 , embedScript ? null
+, trustedRootCert ? null
+, optionDownloadProtoHttps ? true
+, optionImageTrustCmd ? false
 }:
 
 let
@@ -27,10 +30,12 @@ stdenv.mkDerivation {
     [ "ECHO_E_BIN_ECHO=echo" "ECHO_E_BIN_ECHO_E=echo" # No /bin/echo here.
       "ISOLINUX_BIN_LIST=${syslinux}/share/syslinux/isolinux.bin"
       "LDLINUX_C32=${syslinux}/share/syslinux/ldlinux.c32"
-    ] ++ lib.optional (embedScript != null) "EMBED=${embedScript}";
+    ] ++ lib.optional (trustedRootCert != null) "TRUST=${trustedRootCert}"
+      ++ lib.optional (embedScript != null) "EMBED=${embedScript}";
 
 
-  enabledOptions = [ "DOWNLOAD_PROTO_HTTPS" ];
+  enabledOptions = lib.optional optionDownloadProtoHttps "DOWNLOAD_PROTO_HTTPS"
+    ++ lib.optional optionImageTrustCmd "IMAGE_TRUST_CMD";
 
   configurePhase = ''
     runHook preConfigure


### PR DESCRIPTION

###### Motivation for this change
These changes are necessary for the "Trusted root certificates" and
"Code signing" sections of ipxe's Cryptography configuration guide
(http://ipxe.org/crypto).

"DOWNLOAD_PROTO_HTTPS" is defaulted to `true` for backward
compatibility (it was hard-coded before).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

