### PR TITLE
lvm2: disable parallel building

### DIFF
--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -40,7 +40,8 @@ stdenv.mkDerivation {
       sed -i /DEFAULT_PROFILE_DIR/d conf/Makefile.in
     '';
 
-  enableParallelBuilding = true;
+  # gcc: error: ../../device_mapper/libdevice-mapper.a: No such file or directory
+  enableParallelBuilding = false;
 
   #patches = [ ./purity.patch ];
   patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [


### PR DESCRIPTION
###### Motivation for this change

I am running into a consistent build failure on armv7l with `enable_dmeventd = true` due to some kind of dependency issue:
```
make[2]: Entering directory '/build/lvm2/daemons/dmeventd'
    [CC] libdevmapper-event.c
    [CC] dmeventd.c
    [CC] libdevmapper-event.so.1.02
    [LN] libdevmapper-event.so.1.02
gcc -O2  -fPIC -L.  -L../../lib -L../../libdaemon/client -L../../daemons/dmeventd -Wl,-z,relro,-z,now -pie -fPIE -Wl,--export-dynamic dmeventd.o \
        -o dmeventd -ldl -ldevmapper-event ../../device_mapper/libdevice-mapper.a ../../base/libbase.a   -L/nix/store/wlfvcw8r3aq71x7llcni2q07l9gj6vi0-systemd-239-lib/lib -ludev -L/nix/store/rks6hmgxz7dpl37x1z8w4nx5ghqka5hr-util-linux-2.33/lib -lblkid  -lm -lpthread -lm
gcc: error: ../../device_mapper/libdevice-mapper.a: No such file or directory
```

I have no idea why this does not occur on other architectures. I attempted to bisect this issue in the lvm2 tree but was unable to reproduce it outside of the package build environment.

###### Things done

Disabled parallel building for lvm2. This causes the package to build on armv7l. If we wanted to, we could only disable parallel building on armv7l.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

