### PR TITLE
libpfm: use placeholder for PREFIX

### DIFF
--- a/pkgs/development/libraries/libpfm/default.nix
+++ b/pkgs/development/libraries/libpfm/default.nix
@@ -9,9 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0jabhjx77yppr7x38bkfww6n2a480gj62rw0qp7prhdmg19mf766";
   };
 
-  installFlags = "DESTDIR=\${out} PREFIX= LDCONFIG=true";
-
   makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "LDCONFIG=true"
     "ARCH=${stdenv.targetPlatform.uname.processor}"
     "SYS=${stdenv.targetPlatform.uname.system}"
   ];


### PR DESCRIPTION
###### Motivation for this change

Enables cross-compilation of libpfm.

###### Things done

libpfm has its own `ARCH` strings, which are detailed in [config.mk](https://sourceforge.net/p/perfmon2/libpfm4/ci/master/tree/config.mk#l33). This PR generates the correct string from the `hostPlatform`.

I tested cross builds for armv6l, armv7l and aarch64 as well as a native build on x86_64.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

