### PR TITLE
python: trezor: 0.10.2 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "trezor";
-  version = "0.10.2";
+  version = "0.11.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4dba4d5c53d3ca22884d79fb4aa68905fb8353a5da5f96c734645d8cf537138d";
+    sha256 = "1132f6a97afb0979c5018b067494bc8917b881c02d965f991270a70543b5050c";
   };
 
   propagatedBuildInputs = [ protobuf hidapi ecdsa mnemonic requests pyblake2 click libusb1 rlp ];
@@ -19,9 +19,9 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    description = "Python library for communicating with TREZOR Bitcoin Hardware Wallet";
+    description = "Python library for communicating with TREZOR Hardware Wallet";
     homepage = https://github.com/trezor/python-trezor;
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ np ];
+    maintainers = with lib.maintainers; [ np maintainers."1000101"];
   };
 }


### PR DESCRIPTION
(cherry picked from commit 17bf4ab22d8e14387a3cc0589879f8957722b85c)

###### Motivation for this change
Package update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

