### PR TITLE
amazon-ecs-cli: init at 1.12.1

### DIFF
--- a/pkgs/tools/virtualization/amazon-ecs-cli/default.nix
+++ b/pkgs/tools/virtualization/amazon-ecs-cli/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "amazon-ecs-cli-${version}";
+  version = "1.12.1";
+
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v${version}";
+    sha256 = "100iv4cchnxl1s02higga5v3hvawi4c7sqva97x34qigr4r7fxwm";
+  };
+
+  unpackPhase = ":";
+
+  installPhase =
+    ''
+      mkdir -p $out/bin
+      cp $src $out/bin/ecs-cli
+      chmod +x $out/bin/ecs-cli
+    '';  # */
+
+  meta = with stdenv.lib; {
+    homepage = https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI.html;
+    description = "The Amazon ECS command line interface";
+    longDescription = "The Amazon Elastic Container Service (Amazon ECS) command line interface (CLI) provides high-level commands to simplify creating, updating, and monitoring clusters and tasks from a local development environment.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Scriptkiddi ];
+    platforms = [ "x86_64-linux" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -528,6 +528,8 @@ in
     inherit (darwin.apple_sdk.frameworks) AppKit CoreFoundation CoreGraphics CoreServices CoreText Foundation OpenGL;
   };
 
+  amazon-ecs-cli = callPackage ../tools/virtualization/amazon-ecs-cli { };
+
   amazon-glacier-cmd-interface = callPackage ../tools/backup/amazon-glacier-cmd-interface { };
 
   ammonite = callPackage ../development/tools/ammonite {};


### PR DESCRIPTION
###### Motivation for this change
SInce we needed this for the deployment process I figured I push it upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

