### PR TITLE
linux_hardkernel_4_14: 4.14.85-152 -> 4.14.87-153

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,10 +1,10 @@
 { stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.14.85-152";
+  version = "4.14.87-153";
 
   # modDirVersion needs to be x.y.z.
-  modDirVersion = "4.14.85";
+  modDirVersion = "4.14.87";
 
   # branchVersion needs to be x.y.
   extraMeta.branch = "4.14";
@@ -13,7 +13,7 @@ buildLinux (args // rec {
     owner = "hardkernel";
     repo = "linux";
     rev = version;
-    sha256 = "1bpsxrbsdygnk2414ajf2za7rnb6xxnjngkzrg060c4i3bcrwrzf";
+    sha256 = "1aj3l8pf3nl0mm4m5z4z4iqd72b0nqip4cajmhpfjmq8vkygcw5c";
   };
 
   defconfig = "odroidxu4_defconfig";


### PR DESCRIPTION
###### Motivation for this change

Updates `linux_hardkernel_4_14` to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

