### PR TITLE
pythonPackages.sh: fix tests on Python 3.7

### DIFF
--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, coverage }:
+{ stdenv, buildPythonPackage, fetchPypi, python, coverage, lsof, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "sh";
@@ -9,10 +9,15 @@ buildPythonPackage rec {
     sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
   };
 
-  checkInputs = [ coverage ];
+  postPatch = ''
+    sed -i 's#/usr/bin/env python#${python.interpreter}#' test.py
+  '';
+
+  checkInputs = [ coverage lsof glibcLocales ];
 
   # A test needs the HOME directory to be different from $TMPDIR.
   preCheck = ''
+    export LC_ALL="en_US.UTF-8"
     HOME=$(mktemp -d)
   '';
 

--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -9,6 +9,10 @@ buildPythonPackage rec {
     sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
   };
 
+  # Disable tests that fail on Darwin
+  # Some of the failures are due to Nix using GNU coreutils
+  patches = [ ./disable-broken-tests-darwin.patch ];
+
   postPatch = ''
     sed -i 's#/usr/bin/env python#${python.interpreter}#' test.py
   '';

--- a/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
+++ b/pkgs/development/python-modules/sh/disable-broken-tests-darwin.patch
@@ -1,0 +1,49 @@
+From 264f2f6a04d25156bba43524a6b172d2e99c53f4 Mon Sep 17 00:00:00 2001
+From: Ben Wolsieffer <benwolsieffer@gmail.com>
+Date: Fri, 21 Dec 2018 17:39:45 -0500
+Subject: [PATCH] Disable tests that fail on OSX.
+
+Some of the failures are due to the use of GNU ls.
+---
+ test.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/test.py b/test.py
+index 68ef40c..2f53360 100644
+--- a/test.py
++++ b/test.py
+@@ -352,6 +352,7 @@ exit(3)
+         self.assertEqual(sed(_in="one test three", e="s/test/two/").strip(),
+                 "one two three")
+ 
++    @not_osx
+     def test_ok_code(self):
+         from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
+ 
+@@ -498,6 +499,7 @@ while True:
+         self.assertEqual(out, match)
+ 
+ 
++    @not_osx
+     def test_environment(self):
+         """ tests that environments variables that we pass into sh commands
+         exist in the environment, and on the sh module """
+@@ -861,6 +863,7 @@ print(sys.argv[1])
+         self.assertTrue(now - start > sleep_time)
+ 
+ 
++    @not_osx
+     def test_background_exception(self):
+         from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
+         p = ls("/ofawjeofj", _bg=True) # should not raise
+@@ -2036,6 +2039,7 @@ else:
+         self.assertEqual(p, "test")
+ 
+ 
++    @not_osx
+     def test_signal_exception(self):
+         from sh import SignalException_15
+ 
+-- 
+2.20.0
+


### PR DESCRIPTION
There is some new Unicode related issue introduced by Python 3.7, which causes a test to fail. I attempted to fix it using `glibcLocales` and `LC_ALL=en_US.UTF-8`, but this did not work.

Python 3.7 has some [Unicode related changes](https://docs.python.org/3.7/whatsnew/3.7.html#pep-538-legacy-c-locale-coercion), but I don't see how they would cause this problem.

I have been unable to reproduce this error outside of the Nix build, which indicates that this probably won't cause issues for users.

Here is the error message:
```
======================================================================
ERROR: test_unicode_path (test.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/sh-1.12.14/test.py", line 2787, in test_unicode_path
    running = cmd()
  File "/build/sh-1.12.14/sh.py", line 1427, in __call__
    return RunningCommand(cmd, call_args, stdin, stdout, stderr)
  File "/build/sh-1.12.14/sh.py", line 774, in __init__
    self.wait()
  File "/build/sh-1.12.14/sh.py", line 792, in wait
    self.handle_command_exit_code(exit_code)
  File "/build/sh-1.12.14/sh.py", line 815, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_255:

  RAN: /build/字rkwbp4f1

  STDOUT:


  STDERR:


----------------------------------------------------------------------
Ran 156 tests in 44.088s

FAILED (errors=1, skipped=1)
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

