### PR TITLE
dtc: 1.4.5 -> 1.4.7

### DIFF
--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -2,23 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "dtc-${version}";
-  version = "1.4.5";
+  version = "1.4.7";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git";
     rev = "refs/tags/v${version}";
-    sha256 = "10y5pbkcj5gkijcgnlvrh6q2prpnvsgihb9asz3zfp66mcjwzsy3";
+    sha256 = "0l787g1wmd4d6izsp91m5r2qms2h2jg2hhzllfi9qkbnplyz21wn";
   };
 
   nativeBuildInputs = [ flex bison pkgconfig swig which ];
   buildInputs = [ python2 ];
 
   patches = [
-    # Fix 32-bit build
-    (fetchpatch {
-      url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/patch/?id=497432fd2131967f349e69dc5d259072151cc4b4";
-      sha256 = "1hrvhvz0qkck53mhacrc4rxjrvp34d8dkw7xb5lr4gpg32grvkpq";
-    })
     # Fix setup.py
     (fetchpatch {
       url = "https://github.com/dezgeg/dtc/commit/d94a745148ba5c9198143ccc0f7d877fe498ab73.patch";


### PR DESCRIPTION
###### Motivation for this change

Updates dtc from 1.4.5 to 1.4.7.

###### Things done

One of the patches is no longer needed because it was applied upstream.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

