### PR TITLE
pythonPackages.behave: fix build on Python 2.7

### DIFF
--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi
+{ stdenv, fetchPypi, fetchpatch
 , buildPythonApplication, python, pythonOlder
 , mock, nose, pathpy, pyhamcrest, pytest
 , glibcLocales, parse, parse-type, six
@@ -12,6 +12,14 @@ buildPythonApplication rec {
     inherit pname version;
     sha256 = "11hsz365qglvpp1m1w16239c3kiw15lw7adha49lqaakm8kj6rmr";
   };
+
+  patches = [
+    # Fix tests on Python 2.7
+    (fetchpatch {
+      url = https://github.com/behave/behave/commit/0a9430a94881cd18437deb03d2ae23afea0f009c.patch;
+      sha256 = "1nrh9ii6ik6gw2kjh8a6jk4mg5yqw3jfjfllbyxardclsab62ydy";
+    })
+  ];
 
   checkInputs = [ mock nose pathpy pyhamcrest pytest ];
   buildInputs = [ glibcLocales ];


### PR DESCRIPTION
###### Motivation for this change

behave does not currently build on Python 2.7.15.

###### Things done

Applied an upstream patch to fix compatibility with Python 2.7.15.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

