### PR TITLE
pythonPackages.github3_py: cleanup

### DIFF
--- a/pkgs/development/python-modules/github3_py/default.nix
+++ b/pkgs/development/python-modules/github3_py/default.nix
@@ -1,18 +1,19 @@
-{ stdenv
+{ lib
+, pythonOlder
 , buildPythonPackage
 , fetchPypi
-, unittest2
-, pytest
-, mock
 , betamax
+, pytest
 , betamax-matchers
-, dateutil
+, unittest2
+, mock
 , requests
-, pyopenssl
 , uritemplate
+, dateutil
+, jwcrypto
+, pyopenssl
 , ndg-httpsclient
 , pyasn1
-, jwcrypto
 }:
 
 buildPythonPackage rec {
@@ -24,18 +25,19 @@ buildPythonPackage rec {
     sha256 = "35fea5bf3567a8e88d3660686d83f96ef164e698ce6fb30f9e2b0edded7357af";
   };
 
-  buildInputs = [ unittest2 pytest mock betamax betamax-matchers dateutil ];
+  checkInputs = [ betamax pytest betamax-matchers ]
+    ++ lib.optional (pythonOlder "3") unittest2
+    ++ lib.optional (pythonOlder "3.3") mock;
   propagatedBuildInputs = [ requests uritemplate dateutil jwcrypto pyopenssl ndg-httpsclient pyasn1 ];
 
   postPatch = ''
-    sed -i -e 's/mock ==1.0.1/mock>=1.0.1/' setup.py
     sed -i -e 's/unittest2 ==0.5.1/unittest2>=0.5.1/' setup.py
   '';
 
   # TODO: only disable the tests that require network
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://github3py.readthedocs.org/en/master/;
     description = "A wrapper for the GitHub API written in python";
     license = licenses.bsd3;


### PR DESCRIPTION
###### Things done

Cleanup the dependencies, making some of them conditional on different python versions as specified in the setup.py. I also moved the test dependencies from `buildInputs` to `checkInputs`, so that they are not pulled in because the tests are currently disabled.

I also removed a sed patch that is no longer needed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

