### PR TITLE
junkie: init at 2.8.0

### DIFF
--- a/pkgs/tools/networking/junkie/default.nix
+++ b/pkgs/tools/networking/junkie/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig, libpcap, guile, openssl }:
+
+stdenv.mkDerivation rec {
+  name = "junkie-${version}";
+  version = "2.8.0";
+
+  src = fetchurl {
+    url = https://github.com/rixed/junkie/archive/v2.8.0.tar.gz;
+    sha256 = "c9b57bd6e06d4f90e6a88b775f33fa00f66313ba0f663df70198eddf1d4be298";
+  };
+  buildInputs = [ pkgconfig libpcap guile openssl ];
+  configureFlags = [
+    "GUILELIBDIR=\${out}/share/guile/site"
+    "GUILECACHEDIR=\${out}/lib/guile/ccache"
+  ];
+
+  meta = {
+    description = "Deep packet inspection swiss-army knife";
+    homepage = "https://github.com/rixed/junkie";
+    license = stdenv.lib.licenses.agpl3Plus;
+    maintainers = [ "rixed-github@happyleptic.org" ];
+    platforms = stdenv.lib.platforms.unix;
+    longDescription = ''
+      Junkie is a network sniffer like Tcpdump or Wireshark, but designed to
+      be easy to program and extend.
+
+      It comes with several command line tools to demonstrate this:
+      - a packet dumper;
+      - a nettop tool;
+      - a tool listing TLS certificates...
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3598,6 +3598,8 @@ in
 
   jnettop = callPackage ../tools/networking/jnettop { };
 
+  junkie = callPackage ../tools/networking/junkie { };
+
   go-jira = callPackage ../applications/misc/go-jira { };
 
   john = callPackage ../tools/security/john { };


### PR DESCRIPTION
###### Motivation for this change

Addition of a new networking tool: a programmable sniffer/DPI

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

