### PR TITLE
deadbeef/plugins: add the waveform seekbar plugin 

### DIFF
--- a/pkgs/applications/audio/deadbeef/plugins/waveform.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/waveform.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "cboxdoerfer";
     repo = "ddb_waveform_seekbar";
     rev = "v${version}";
-#    sha256 = "1v1schvnps7ypjqgcbqi74a45w8r2gbhrawz7filym22h1qr9wn0";
+    sha256 = "1v1schvnps7ypjqgcbqi74a45w8r2gbhrawz7filym22h1qr9wn0";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/audio/deadbeef/plugins/waveform.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/waveform.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, deadbeef, pkgconfig, glib, gtk3, sqlite }:
+
+stdenv.mkDerivation rec {
+  name = "deadbeef-waveform-seekbar-gtk3-plugin-${version}";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "cboxdoerfer";
+    repo = "ddb_waveform_seekbar";
+    rev = "v${version}";
+#    sha256 = "1v1schvnps7ypjqgcbqi74a45w8r2gbhrawz7filym22h1qr9wn0";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ deadbeef glib gtk3 sqlite ];
+
+  buildFlags = [ "gtk3" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/deadbeef
+    cp gtk3/ddb_misc_waveform_GTK3.so $out/lib/deadbeef
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Waveform Seekbar plugin for DeaDBeeF audio player";
+    homepage = https://github.com/cboxdoerfer/ddb_waveform_seekbar;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16436,6 +16436,7 @@ in
     infobar = callPackage ../applications/audio/deadbeef/plugins/infobar.nix { };
     mpris2 = callPackage ../applications/audio/deadbeef/plugins/mpris2.nix { };
     opus = callPackage ../applications/audio/deadbeef/plugins/opus.nix { };
+    waveform = callPackage ../applications/audio/deadbeef/plugins/waveform.nix { };
   };
 
   deadbeef-with-plugins = callPackage ../applications/audio/deadbeef/wrapper.nix {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/52612.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know how to do `nix-build` of a deadbeef plugin.