### PR TITLE
pyre: fix watchman references

### DIFF
--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, makeWrapper, writeScript
-, dune, python3, rsync, fetchpatch, buck }:
+{ stdenv, fetchFromGitHub, ocamlPackages, writeScript
+, dune, python3, rsync, buck, watchman }:
 let
   # Manually set version - the setup script requires
   # hg and git + keeping the .git directory around.
@@ -103,6 +103,12 @@ in python3.pkgs.buildPythonApplication rec {
     substituteInPlace scripts/build-pypi-package.sh \
         --replace 'NIX_BINARY_FILE' '${pyre-bin}/bin/pyre.bin' \
         --replace 'BUILD_ROOT="$(mktemp -d)"' "BUILD_ROOT=$PWD/build"
+    substituteInPlace client/pyre.py \
+        --replace '"watchman"' '"${watchman}/bin/watchman"'
+    substituteInPlace client/commands/initialize.py \
+        --replace '"watchman"' '"${watchman}/bin/watchman"'
+    substituteInPlace client/commands/tests/initialize_test.py \
+        --replace '"watchman"' '"${watchman}/bin/watchman"'
     substituteInPlace client/buck.py \
         --replace '"buck"' '"${buck}/bin/buck"'
     substituteInPlace client/tests/buck_test.py \


### PR DESCRIPTION
###### Motivation for this change
Otherwise it will throw `/bin/sh: watchman: command not found` on `pyre start`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

