### PR TITLE
localtime: migrate to using buildGoPackage

### DIFF
--- a/pkgs/tools/system/localtime/default.nix
+++ b/pkgs/tools/system/localtime/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, go, systemd, polkit, fetchFromGitHub, m4, removeReferencesTo }:
+{ stdenv, systemd, polkit, fetchFromGitHub, buildGoPackage, m4}:
 
-stdenv.mkDerivation {
+buildGoPackage rec {
   name = "localtime-2017-11-07";
 
   src = fetchFromGitHub {
@@ -9,14 +9,20 @@ stdenv.mkDerivation {
     rev = "2e7b4317c723406bd75b2a1d640219ab9f8090ce";
     sha256 = "04fyna8p7q7skzx9fzmncd6gx7x5pwa9jh8a84hpljlvj0kldfs8";
   };
+  goPackagePath = "github.com/Stebalien/localtime";
 
-  buildInputs = [ go systemd polkit m4 removeReferencesTo ];
-  disallowedRequisites = [ go ];
+  buildInputs = [ systemd polkit m4 ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  preFixup = ''
-    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    make localtimed
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin
+    install -Dm555 localtimed $bin/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Part of #52469, make the `localtime` derivation using `buildGoPackage` :angel: 

cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

