### PR TITLE
pythonPackages.nose-randomly: add checkPhase

### DIFF
--- a/pkgs/development/python-modules/nose-randomly/default.nix
+++ b/pkgs/development/python-modules/nose-randomly/default.nix
@@ -19,6 +19,10 @@ buildPythonPackage rec {
     nose
   ];
 
+  checkPhase = ''
+    nosetests
+  '';
+
   meta = with lib; {
     description = "Nose plugin to randomly order tests and control random.seed";
     homepage = https://github.com/adamchainz/nose-randomly;


### PR DESCRIPTION
###### Motivation for this change
Otherwise timeouts in darwin python2 with the default checkPhase https://hydra.nixos.org/build/86142595

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

