### PR TITLE
licenses.nasa13: mark as free

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -508,7 +508,6 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
   nasa13 = spdx {
     spdxId = "NASA-1.3";
     fullName = "NASA Open Source Agreement 1.3";
-    free = false;
   };
 
   ncsa = spdx {


### PR DESCRIPTION
###### Motivation for this change

NASA-1.3 allows distribution

https://opensource.org/licenses/NASA-1.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

