### PR TITLE
rsync: Enable the --ignore-case patch

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, perl, libiconv, zlib, popt
 , enableACLs ? true, acl ? null
 , enableCopyDevicesPatch ? false
+, enableIgnoreCasePatch  ? true
 }:
 
 assert enableACLs -> acl != null;
@@ -15,8 +16,9 @@ stdenv.mkDerivation rec {
 
   patchesSrc = base.upstreamPatchTarball;
 
-  srcs = [mainSrc] ++ stdenv.lib.optional enableCopyDevicesPatch patchesSrc;
-  patches = stdenv.lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff";
+  srcs = [mainSrc patchesSrc];
+  patches = stdenv.lib.optional enableCopyDevicesPatch "./patches/copy-devices.diff"
+    ++ stdenv.lib.optional enableIgnoreCasePatch "./patches/ignore-case.diff";
 
   buildInputs = [libiconv zlib popt] ++ stdenv.lib.optional enableACLs acl;
   nativeBuildInputs = [perl];


### PR DESCRIPTION
###### Motivation for this change

--ignore-case is a useful rsync option, performing a function that people keep asking for. There should be no downside to applying it by default, as it's still gated behind a flag.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

