### PR TITLE
pypy3: remove runtime-wrapper

### DIFF
--- a/pkgs/development/interpreters/python/pypy/3/default.nix
+++ b/pkgs/development/interpreters/python/pypy/3/default.nix
@@ -1,13 +1,10 @@
 { stdenv, substituteAll, fetchurl
-, zlib ? null, zlibSupport ? true, bzip2, pkgconfig, libffi
-, sqlite, openssl, ncurses, python, expat, tcl, tk, tix, xlibsWrapper, libX11
-, makeWrapper, callPackage, self, gdbm, db, lzma
-, python-setup-hook
+, zlib, bzip2, pkgconfig, libffi, gdbm, db, lzma
+, sqlite, openssl, ncurses, expat, tcl, tk, tix, xlibsWrapper, libX11
+, python, python-setup-hook, makeWrapper, callPackage
 # For the Python package set
-, packageOverrides ? (self: super: {})
+, self, packageOverrides ? (self: super: {})
 }:
-
-assert zlibSupport -> zlib != null;
 
 let
   version = "6.0.0";
@@ -26,17 +23,14 @@ in stdenv.mkDerivation rec {
     sha256 = "0lwq8nn0r5yj01bwmkk5p7xvvrp4s550l8184mkmn74d3gphrlwg";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ pkgconfig makeWrapper pythonForPypy ];
   buildInputs = [
-    bzip2 openssl pythonForPypy libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 gdbm db lzma
-  ] ++ stdenv.lib.optional (stdenv ? cc && stdenv.cc.libc != null) stdenv.cc.libc
-    ++ stdenv.lib.optional zlibSupport zlib;
+    bzip2 openssl libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 gdbm db lzma zlib
+  ];
 
   hardeningDisable = stdenv.lib.optional stdenv.isi686 "pic";
 
-  C_INCLUDE_PATH = stdenv.lib.makeSearchPathOutput "dev" "include" buildInputs;
-  LIBRARY_PATH = stdenv.lib.makeLibraryPath buildInputs;
-  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath (stdenv.lib.filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs);
+  LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath buildInputs;
 
   patches = [
     (substituteAll {
@@ -50,72 +44,45 @@ in stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace "lib-python/3/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
-
-    # hint pypy to find nix ncurses
-    substituteInPlace pypy/module/_minimal_curses/fficurses.py \
-      --replace "/usr/include/ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
-      --replace "ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
-      --replace "ncurses/term.h" "${ncurses.dev}/include/term.h" \
-      --replace "libraries=['curses']" "libraries=['ncurses']"
-
-    sed -i "s@libraries=\['sqlite3'\]\$@libraries=['sqlite3'], include_dirs=['${sqlite.dev}/include'], library_dirs=['${sqlite.out}/lib']@" lib_pypy/_sqlite3_build.py
+    substituteInPlace "lib-python/3/tkinter/tix.py" \
+      --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY', '${tix}/lib')"
   '';
 
   buildPhase = ''
-    ${pythonForPypy.interpreter} rpython/bin/rpython \
+    pushd pypy/goal
+    # TODO: this will not work for the cross-compiling case
+    ${pythonForPypy.interpreter} ../../rpython/bin/rpython \
       --make-jobs="$NIX_BUILD_CORES" \
-      -Ojit \
-      --batch pypy/goal/targetpypystandalone.py
+      -Ojit --shared \
+      targetpypystandalone
+    PYTHONPATH=../.. ./pypy3-c ../tool/build_cffi_imports.py
+    popd
   '';
 
   setupHook = python-setup-hook sitePackages;
 
-  doCheck = true;
-  checkPhase = ''
-    export TERMINFO="${ncurses.out}/share/terminfo/";
-    export TERM="xterm";
-    export HOME="$TMPDIR";
-    # disable asyncio due to https://github.com/NixOS/nix/issues/1238
-    # disable os due to https://github.com/NixOS/nixpkgs/issues/10496
-    # disable pathlib due to https://bitbucket.org/pypy/pypy/pull-requests/594
-    # disable shutils because it assumes gid 0 exists
-    # disable socket because it has two actual network tests that fail
-    # disable tarfile because it assumes gid 0 exists
-    ${pythonForPypy.interpreter} ./pypy/test_all.py --pypy=./pypy3-c -k 'not ( test_asyncio or test_os or test_pathlib or test_shutil or test_socket or test_tarfile )' lib-python
-  '';
-
   installPhase = ''
-    mkdir -p $out/{bin,include,lib,pypy3-c}
+    ${pythonForPypy.interpreter} pypy/tool/release/package.py --archive-name pypy --targetdir .
+    mkdir -p $out/{bin,include,lib,share/pypy}
+    tar xf pypy.tar.bz2 -C $out/share/
 
-    cp -R {include,lib_pypy,lib-python,pypy3-c} $out/pypy3-c
-    cp libpypy3-c.so $out/lib/
-    ln -s $out/pypy3-c/pypy3-c $out/bin/pypy3
-
+    ln -s $out/share/pypy/bin/pypy3 $out/bin/pypy3
+    ln -s $out/share/pypy/lib/libpypy3-c.so $out/lib/libpypy3-c.so
     # other packages expect to find stuff according to libPrefix
-    ln -s $out/pypy3-c/include $out/include/${libPrefix}
-    ln -s $out/pypy3-c/lib-python/3 $out/lib/${libPrefix}
-
-    # We must wrap the original, not the symlink.
-    # PyPy uses argv[0] to find its standard library, and while it knows
-    # how to follow symlinks, it doesn't know about wrappers. So, it
-    # will think the wrapper is the original. As long as the wrapper has
-    # the same path as the original, this is OK.
-    wrapProgram "$out/pypy3-c/pypy3-c" \
-      --set LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:$out/lib" \
-      --set LIBRARY_PATH "${LIBRARY_PATH}:$out/lib"
+    ln -s $out/share/pypy/include $out/include/${libPrefix}
+    ln -s $out/share/pypy/lib-python/3 $out/lib/${libPrefix}
 
     # verify cffi modules
-    $out/bin/pypy3 -c "import tkinter;import sqlite3;import curses;import lzma"
+    LD_LIBRARY_PATH= $out/bin/pypy3 -c "import tkinter;import sqlite3;import curses;import lzma"
 
-    # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
+    ## Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
 
   passthru = let
     pythonPackages = callPackage ../../../../../top-level/python-packages.nix {python=self; overrides=packageOverrides;};
   in rec {
-    inherit zlibSupport libPrefix sitePackages;
+    inherit libPrefix sitePackages;
     executable = "pypy3";
     isPypy = true;
     isPy3 = true;


### PR DESCRIPTION
LD_LIBRARY_PATH can break executables of child processes that are linked
against different libc versions. Since pypy uses cffi for all c-extensions
we no longer need this mechanism as our cc wrapper will set rpath on all
shared objects properly. This makes the build a lot simpler.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

