### PR TITLE
python: init easywatch and staticjinja

### DIFF
--- a/pkgs/development/python-modules/easywatch/default.nix
+++ b/pkgs/development/python-modules/easywatch/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, watchdog
+}:
+
+buildPythonPackage rec {
+  pname = "easywatch";
+  version = "0.0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b40cjigv7s9qj8hxxy6yhwv0320z7qywrigwgkasgh80q0xgphc";
+  };
+
+  propagatedBuildInputs = [ watchdog ];
+
+  # There are no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Dead-simple way to watch a directory";
+    homepage = https://github.com/Ceasar/easywatch;
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/development/python-modules/staticjinja/default.nix
+++ b/pkgs/development/python-modules/staticjinja/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, docopt
+, easywatch
+, jinja2
+}:
+
+buildPythonPackage rec {
+  pname = "staticjinja";
+  version = "0.3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mxv7yy35657mfxx9xhbzihh10m5lb29fmscfh9q455zd4ikr032";
+  };
+
+  propagatedBuildInputs = [ jinja2 docopt easywatch ];
+
+  # There are no tests on pypi
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A library and cli tool that makes it easy to build static sites using Jinja2";
+    homepage = https://staticjinja.readthedocs.io/en/latest/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4002,6 +4002,8 @@ in {
 
   sqlalchemy_migrate = callPackage ../development/python-modules/sqlalchemy-migrate { };
 
+  staticjinja = callPackage ../development/python-modules/staticjinja { };
+
   statsmodels = callPackage ../development/python-modules/statsmodels { };
 
   structlog = callPackage ../development/python-modules/structlog { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2295,6 +2295,8 @@ in {
 
   dtopt = callPackage ../development/python-modules/dtopt { };
 
+  easywatch = callPackage ../development/python-modules/easywatch { };
+
   ecdsa = callPackage ../development/python-modules/ecdsa { };
 
   effect = callPackage ../development/python-modules/effect {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with both python 2 and 3