### PR TITLE
miniflux: add service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -711,6 +711,7 @@
   ./services/web-apps/codimd.nix
   ./services/web-apps/frab.nix
   ./services/web-apps/mattermost.nix
+  ./services/web-apps/miniflux.nix
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/pgpkeyserver-lite.nix

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -1,0 +1,113 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.miniflux;
+
+  dbUser = "miniflux";
+  dbPassword = "miniflux";
+  dbHost = "localhost";
+  dbName = "miniflux";
+in
+
+{
+  options = {
+    services.miniflux = {
+      enable = mkEnableOption "miniflux";
+      package = mkOption {
+        type = types.package;
+        default = pkgs.miniflux;
+        defaultText = "pkgs.miniflux";
+        description = "Which miniflux package to use.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "miniflux";
+        example = "miniflux";
+        description = ''
+          User account under which miniflux runs.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "miniflux";
+        example = "miniflux";
+        description = ''
+          User group under which miniflux runs.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = ''
+          The host the daemon will listen on.
+        '';
+      };
+
+      listenPort = mkOption  {
+        type = types.int;
+        default = 8080;
+        example = "8080";
+        description = ''
+          The port the daemon will listen on.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.postgresql.enable = mkDefault true;
+
+    users = {
+      users.miniflux = {
+        name = cfg.user;
+        group = cfg.group;
+        description = "miniflux service user";
+        isSystemUser = true;
+        createHome = false;
+      };
+      groups.miniflux = {
+        name = cfg.group;
+      };
+    };
+
+    systemd.services.miniflux = let
+      configFile = pkgs.writeText "miniflux.conf" ''
+        LISTEN_ADDR=${cfg.listenAddress}:${toString cfg.listenPort}
+        DATABASE_URL="postgresql://${dbUser}:${dbPassword}@${dbHost}/${dbName}?sslmode=disable"
+        RUN_MIGRATIONS=1
+      '';
+    in {
+      description = "Miniflux service";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "postgresql.service" ];
+      after = [ "network.target" "postgresql.service" ];
+
+      serviceConfig = {
+        PermissionsStartOnly = true;
+        Type = "simple";
+        PrivateTmp = false;
+        ExecStart = "${cfg.package}/bin/miniflux";
+        EnvironmentFile = configFile;
+        User = cfg.user;
+      };
+
+      preStart = let
+        pgsu = "${pkgs.sudo}/bin/sudo -u ${config.services.postgresql.superUser}";
+        pgbin = "${config.services.postgresql.package}/bin";
+      in ''
+        db_exists() {
+          [ "$(${pgsu} ${pgbin}/psql -Atc "select 1 from pg_database where datname='$1'")" == "1" ]
+        }
+        if ! db_exists "${dbName}"; then
+          ${pgsu} ${pgbin}/psql postgres -c "CREATE ROLE ${dbUser} WITH LOGIN NOCREATEDB NOCREATEROLE ENCRYPTED PASSWORD '${dbPassword}'"
+          ${pgsu} ${pgbin}/createdb --owner "${dbUser}" "${dbName}"
+          ${pgsu} ${pgbin}/psql "${dbName}" -c "CREATE EXTENSION IF NOT EXISTS hstore"
+        fi
+      '';
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

miniflux package already exists, this adds a service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm new at this! Please let me know if I've done something silly :)