### PR TITLE
ledger: Include info files

### DIFF
--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -22,7 +22,15 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" (stdenv.lib.optionalString usePython "-DUSE_PYTHON=true") ];
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DBUILD_DOCS:BOOL=ON"
+    (stdenv.lib.optionalString usePython "-DUSE_PYTHON=true")
+   ];
+
+  postBuild = ''
+    make doc
+  '';
 
   # Skip byte-compiling of emacs-lisp files because this is currently
   # broken in ledger...


### PR DESCRIPTION
###### Motivation for this change
Currently the ledger info file isn't built/installed. This change builds and installs it.

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

