### PR TITLE
pipreqs: init at 0.4.9 | pythonPackage.yarg: init at 0.1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3505,7 +3505,7 @@
   };
   psyanticy = {
     email = "iuns@outlook.fr";
-    github = "Assassinkin";
+    github = "PsyanticY";
     name = "Psyanticy";
   };
   puffnfresh = {

--- a/pkgs/development/python-modules/yarg/default.nix
+++ b/pkgs/development/python-modules/yarg/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests, nose, mock }:
+
+buildPythonPackage rec {
+  pname = "yarg";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "kura";
+    repo = pname;
+    rev = version;
+    sha256 = "1isq02s404fp9whkm8w2kvb2ik1sz0r258iby0q532zw81lga0d0";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ nose mock ];
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    description = "An easy to use PyPI client";
+    homepage = https://yarg.readthedocs.io;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}

--- a/pkgs/tools/misc/pipreqs/default.nix
+++ b/pkgs/tools/misc/pipreqs/default.nix
@@ -1,0 +1,24 @@
+{ lib, python2Packages }:
+
+# Using python 2 because when packaging with python 3 pipreqs fails to parse python 2 code.
+python2Packages.buildPythonApplication rec {
+  pname = "pipreqs";
+  version = "0.4.9";
+
+  src = python2Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "cec6eecc4685967b27eb386037565a737d036045f525b9eb314631a68d60e4bc";
+  };
+
+  propagatedBuildInputs = with python2Packages; [ yarg docopt ];
+
+  # Tests requires network access. Works fine without sandboxing
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Generate requirements.txt file for any project based on imports";
+    homepage = https://github.com/bndr/pipreqs;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4857,6 +4857,8 @@ with pkgs;
 
   pirate-get = callPackage ../tools/networking/pirate-get { };
 
+  pipreqs = callPackage ../tools/misc/pipreqs { };
+
   pius = callPackage ../tools/security/pius { };
 
   pixiewps = callPackage ../tools/networking/pixiewps {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -748,6 +748,8 @@ in {
 
   WazeRouteCalculator = callPackage ../development/python-modules/WazeRouteCalculator { };
 
+  yarg = callPackage ../development/python-modules/yarg { };
+
   # packages defined here
 
   aafigure = callPackage ../development/python-modules/aafigure { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (ubuntu 18.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) (pipreqs)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

