### PR TITLE
solc: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
 
 let
-  version = "0.5.1";
-  rev = "c8a2cb62832afb2dc09ccee6fd42c1516dfdb981";
-  sha256 = "0d6mfnixlr9m5yr3r4p6cv6vwrrivcamyar5d0f9rvir9w9ypzrr";
+  version = "0.5.2";
+  rev = "1df8f40cd2fd7b47698d847907b8ca7b47eb488d";
+  sha256 = "009kjyb3r2p64wpdzfcmqr9swm5haaixbzvsbw1nd4wipwbp66y0";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;

--- a/pkgs/development/compilers/solc/patches/shared-libs-install.patch
+++ b/pkgs/development/compilers/solc/patches/shared-libs-install.patch
@@ -57,11 +57,10 @@ index 0bdec4b4..e876177e 100644
    target_link_libraries(solidity PUBLIC ${Z3_LIBRARY})
 --- a/libyul/CMakeLists.txt
 +++ b/libyul/CMakeLists.txt
-@@ -42,3 +42,4 @@ endif()
+@@ -43,3 +43,4 @@ endif()
  	optimiser/VarDeclPropagator.cpp
  )
--target_link_libraries(yul PUBLIC devcore)
-+target_link_libraries(yul PUBLIC evmasm devcore langutil)
+ target_link_libraries(yul PUBLIC evmasm devcore langutil)
 +install(TARGETS yul LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 --- a/liblangutil/CMakeLists.txt
 +++ b/liblangutil/CMakeLists.txt


### PR DESCRIPTION
###### Motivation for this change

[Release notes](https://github.com/ethereum/solidity/releases/tag/v0.5.2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

