### PR TITLE
source-sans-pro: 2.010 -> 2.040

### DIFF
--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchzip }:
 
 fetchzip {
-  name = "source-sans-pro-2.010";
+  name = "source-sans-pro-2.040";
 
-  url = "https://github.com/adobe-fonts/source-sans-pro/archive/2.010R-ro/1.065R-it.zip";
+  url = "https://github.com/adobe-fonts/source-sans-pro/releases/download/2.040R-ro%2F1.090R-it/source-sans-pro-2.040R-ro-1.090R-it.zip";
 
   postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    mkdir -p $out/share/fonts/opentype $out/share/fonts/truetype $out/share/fonts/variable
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
   '';
 
-  sha256 = "17rgkh54arybmcdg750ynw32x2sps7p9vrvq9kpih8vdghwrh9k2";
+  sha256 = "1n7z9xpxls74xxjsa61df1ln86y063m07w1f4sbxpjaa0frim4pp";
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/adobe/sourcesans;


### PR DESCRIPTION
###### Motivation for this change

Font was significantly upgraded, variable fonts added. Also unpack TTF fonts.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

