### PR TITLE
yadm: install bash and zsh completions

### DIFF
--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -14,9 +14,13 @@ stdenv.mkDerivation {
   buildCommand = ''
     mkdir -p $out/bin
     mkdir -p $out/share/man/man1
+    mkdir -p $out/share/zsh/site-functions
+    mkdir -p $out/share/bash-completion/completions
     sed -e 's:/bin/bash:/usr/bin/env bash:' $src/yadm > $out/bin/yadm
     chmod 755 $out/bin/yadm
     install -m 644 $src/yadm.1 $out/share/man/man1/yadm.1
+    install -m644 $src/completion/yadm.zsh_completion $out/share/zsh/site-functions/_yadm
+    install -m644 $src/completion/yadm.bash_completion $out/share/bash-completion/completions/yadm.bash
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Updates yadm to install it's existing bash and zsh completions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
(I expect no documentation change)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

