### PR TITLE
cardpeek: init at 0.8.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1250,6 +1250,11 @@
     github = "edef1c";
     name = "edef";
   };
+  embr = {
+    email = "hi@liclac.eu";
+    github = "liclac";
+    name = "embr";
+  };
   ederoyd46 = {
     email = "matt@ederoyd.co.uk";
     github = "ederoyd46";

--- a/pkgs/applications/misc/cardpeek/default.nix
+++ b/pkgs/applications/misc/cardpeek/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, autoreconfHook,
+  glib, gtk3, pcsclite, lua5_2, curl, readline }:
+let
+  version = "0.8.4";
+in
+  stdenv.mkDerivation {
+    name = "cardpeek-${version}";
+
+    src = fetchFromGitHub {
+      owner = "L1L1";
+      repo = "cardpeek";
+      rev = "cardpeek-${version}";
+      sha256 = "1ighpl7nvcvwnsd6r5h5n9p95kclwrq99hq7bry7s53yr57l6588";
+    };
+
+    nativeBuildInputs = [ pkgconfig autoreconfHook ];
+    buildInputs = [ glib gtk3 pcsclite lua5_2 curl readline ];
+
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/L1L1/cardpeek;
+      description = "A tool to read the contents of ISO7816 smart cards";
+      license = licenses.gpl3;
+      platforms = with platforms; linux ++ darwin;
+      maintainers = with maintainers; [ embr ];
+    };
+  }

--- a/pkgs/applications/misc/cardpeek/default.nix
+++ b/pkgs/applications/misc/cardpeek/default.nix
@@ -21,7 +21,7 @@ in
     meta = with stdenv.lib; {
       homepage = https://github.com/L1L1/cardpeek;
       description = "A tool to read the contents of ISO7816 smart cards";
-      license = licenses.gpl3;
+      license = licenses.gpl3Plus;
       platforms = with platforms; linux ++ darwin;
       maintainers = with maintainers; [ embr ];
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1130,6 +1130,8 @@ in
 
   catclock = callPackage ../applications/misc/catclock { };
 
+  cardpeek = callPackage ../applications/misc/cardpeek { };
+
   cde = callPackage ../tools/package-management/cde { };
 
   cdemu-daemon = callPackage ../misc/emulators/cdemu/daemon.nix { };


### PR DESCRIPTION
###### Motivation for this change

Cardpeek is a handy tool for working with smartcards.

###### Things done

Added a package for Cardpeek 0.8.4.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). 

---

