### PR TITLE
fix firefox sync-server

### DIFF
--- a/pkgs/development/python-modules/mozsvc/default.nix
+++ b/pkgs/development/python-modules/mozsvc/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchgit
-, fetchurl
+, fetchFromGitHub
 , pyramid
 , simplejson
 , konfig
@@ -9,24 +8,20 @@
 
 buildPythonPackage rec {
   pname = "mozsvc";
-  version = "0.8";
+  version = "0.10";
 
-  src = fetchgit {
-    url = https://github.com/mozilla-services/mozservices.git;
-    rev = "refs/tags/${version}";
-    sha256 = "1zci2ikk83mf7va88c83dr6snfh4ddjqw0lsg3y29qk5nxf80vx2";
+  src = fetchFromGitHub {
+    owner = "mozilla-services";
+    repo = "mozservices";
+    rev = version;
+    sha256 = "0a0558g8j55pd1nnhnnf3k377jv6cah8lxb24v98rq8kxr5960cg";
   };
-
-  patches = stdenv.lib.singleton (fetchurl {
-    url = https://github.com/nbp/mozservices/commit/f86c0b0b870cd8f80ce90accde9e16ecb2e88863.diff;
-    sha256 = "1lnghx821f6dqp3pa382ka07cncdz7hq0mkrh44d0q3grvrlrp9n";
-  });
 
   doCheck = false; # lazy packager
   propagatedBuildInputs = [ pyramid simplejson konfig ];
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/mozilla-services/mozservices;
+    homepage = "https://github.com/mozilla-services/mozservices";
     description = "Various utilities for Mozilla apps";
     license = licenses.mpl20;
   };

--- a/pkgs/development/python-modules/syncserver/default.nix
+++ b/pkgs/development/python-modules/syncserver/default.nix
@@ -1,5 +1,6 @@
-{ buildPythonPackage
-, fetchgit
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
 , isPy27
 , unittest2
 , cornice
@@ -16,18 +17,26 @@
 
 buildPythonPackage rec {
   pname = "syncserver";
-  version = "1.6.0";
+  version = "1.8.0";
   disabled = ! isPy27;
 
-  src = fetchgit {
-    url = https://github.com/mozilla-services/syncserver.git;
-    rev = "refs/tags/${version}";
-    sha256 = "1fsiwihgq3z5b5kmssxxil5g2abfvsf6wfikzyvi4sy8hnym77mb";
+  src = fetchFromGitHub {
+    owner = "mozilla-services";
+    repo = "syncserver";
+    rev = version;
+    sha256 = "0hxjns9hz7a8r87iqr1yfvny4vwj1rlhwcf8bh7j6lsf92mkmgy8";
   };
 
-  buildInputs = [ unittest2 ];
+  checkInputs = [ unittest2 ];
   propagatedBuildInputs = [
     cornice gunicorn pyramid requests simplejson sqlalchemy mozsvc tokenserver
     serversyncstorage configparser
   ];
+
+  meta = with stdenv.lib; {
+    description = "Run-Your-Own Firefox Sync Server";
+    homepage = "https://github.com/mozilla-services/syncserver";
+    platforms = platforms.unix;
+    license = licenses.mpl20;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

`pythonPackages.serversyncstorage` has been broken,
this PR fixes it by disabling tests and removing a conflicting WSGIProxy dependency only used by tests

tested running `services.firefox.syncserver`, the service starts and shows the 'it works' status page

fixes #38830

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

