### PR TITLE
pythonPackages.manhole: disable tests

### DIFF
--- a/pkgs/development/python-modules/manhole/default.nix
+++ b/pkgs/development/python-modules/manhole/default.nix
@@ -19,7 +19,10 @@ buildPythonPackage rec {
   #
   # {test_locals,test_socket_path} fail to remove /tmp/manhole-socket
   # on the x86_64-darwin builder.
-  doCheck = stdenv.isLinux;
+  #
+  # TODO: change this back to `doCheck = stdenv.isLinux` after
+  # https://github.com/ionelmc/python-manhole/issues/54 is fixed
+  doCheck = false;
 
   checkInputs = [ pytest requests process-tests ];
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

nixpkgs 5ab476f186028493f1b4922b26d46408599eb616 `python: process-tests: 1.2.1 -> 2.0.0`  included the change https://github.com/ionelmc/python-process-tests/commit/e6d4f4db27f61ebeb9dc451c12b8fb846d0f3728 which removed `setup_coverage` and thus [broke manhole's tests](https://github.com/ionelmc/python-manhole/issues/54).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

