### PR TITLE
[r18.09 backport] cloudfoundry-cli: fix build on multiple platforms, notably darwin, to produce correct binary for target…

### DIFF
--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -17,9 +17,20 @@ buildGoPackage rec {
 
   outputs = [ "out" ];
 
+  makeTarget = let hps = stdenv.hostPlatform.system; in
+    if hps == "x86_64-darwin" then
+      "out/cf-cli_osx"
+    else if hps == "x86_64-linux" then
+      "out/cf-cli_linux_x86-64"
+    else if hps == "i686-linux" then
+      "out/cf-cli_linux_i686"
+    else
+      throw "make target for this platform unknown";
+
   buildPhase = ''
     cd go/src/${goPackagePath}
-    CF_BUILD_DATE="1970-01-01" make build
+    CF_BUILD_DATE="1970-01-01" make $makeTarget
+    cp $makeTarget out/cf
   '';
 
   installPhase = ''
@@ -33,5 +44,6 @@ buildGoPackage rec {
     homepage = https://github.com/cloudfoundry/cli;
     maintainers = with maintainers; [ ris ];
     license = licenses.asl20;
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
cherry-picked from commit 61fad2cdceb6dc6181d3208fc5acced2515f36e0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

