### PR TITLE
flexget: 2.17.14 -> 2.17.20

### DIFF
--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -1,8 +1,4 @@
-{ lib, python
-, delugeSupport ? true, deluge ? null
-}:
-
-assert delugeSupport -> deluge != null;
+{ lib, python36 }:
 
 # Flexget have been a trouble maker in the past,
 # if you see flexget breaking when updating packages, don't worry.
@@ -10,17 +6,9 @@ assert delugeSupport -> deluge != null;
 # -- Mic92
 
 let
-  python' = python.override { inherit packageOverrides; };
+  python' = python36.override { inherit packageOverrides; };
 
   packageOverrides = self: super: {
-    sqlalchemy = super.sqlalchemy.overridePythonAttrs (old: rec {
-      version = "1.2.6";
-      src = old.src.override {
-        inherit version;
-        sha256 = "1nwylglh256mbwwnng6n6bzgxshyz18j12hw76sghbprp74hrc3w";
-      };
-    });
-
     guessit = super.guessit.overridePythonAttrs (old: rec {
       version = "3.0.3";
       src = old.src.override {
@@ -36,14 +24,16 @@ with python'.pkgs;
 
 buildPythonApplication rec {
   pname = "FlexGet";
-  version = "2.17.14";
+  version = "2.17.20";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1wh12nspjzsgb0a7qp67s4k8wssbhhf500s8x8mx2smb1mgy4xzz";
+    sha256 = "a09ef9482ed54f7e96eb8b4d08c59687c5c43a3341c9d2675383693e6c3681c3";
   };
 
   postPatch = ''
+    # build for the correct python version
+    substituteInPlace setup.cfg --replace $'[bdist_wheel]\npython-tag = py27' ""
     # remove dependency constraints
     sed 's/==\([0-9]\.\?\)\+//' -i requirements.txt
   '';
@@ -52,25 +42,20 @@ buildPythonApplication rec {
   doCheck = false;
 
   propagatedBuildInputs = [
+    # See https://github.com/Flexget/Flexget/blob/master/requirements.in
     feedparser sqlalchemy pyyaml
-    chardet beautifulsoup4 html5lib
+    beautifulsoup4 html5lib
     PyRSS2Gen pynzb rpyc jinja2
-    jsonschema requests dateutil
+    requests dateutil jsonschema
     pathpy guessit APScheduler
     terminaltables colorclass
     cherrypy flask flask-restful
     flask-restplus flask-compress
-    flask_login flask-cors safe
-    pyparsing future zxcvbn-python
-    werkzeug tempora cheroot rebulk
-    portend transmissionrpc aniso8601
-    babelfish certifi click futures
-    idna itsdangerous markupsafe
-    plumbum pytz six tzlocal urllib3
-    webencodings werkzeug zxcvbn-python
-    backports_functools_lru_cache
-  ] ++ lib.optional (pythonOlder "3.4") pathlib
-    ++ lib.optional delugeSupport deluge;
+    flask_login flask-cors
+    pyparsing zxcvbn-python future
+    # Optional requirements
+    deluge-client
+  ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   meta = with lib; {
     homepage    = https://flexget.com/;


### PR DESCRIPTION
###### Motivation for this change
closes #52529 

I have removed some entries from `propagatedBuildInputs` that can't be found in https://github.com/Flexget/Flexget/blob/2.17.20/requirements.in. However, I'm not sure whether they're just some optional requirements and should be added back.

The `delugeSupport` argument has been removed as deluge support is handled by the `deluge-client` library which we can always install.

I did not test this thoroughly because I'm not a Flexget user. Feel free to do so in my place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @sjau 