### PR TITLE
OpenCV: 3.4.5 & 4.0.1

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -35,20 +35,20 @@
 }:
 
 let
-  version = "3.4.4";
+  version = "3.4.5";
 
   src = fetchFromGitHub {
     owner  = "opencv";
     repo   = "opencv";
     rev    = version;
-    sha256 = "1xzbv0922r2zq4fgpkc1ldyq3kxp4c6x6dizydbspka18jrrxqlr";
+    sha256 = "0hz9316ys2qi0lx9dcbsk3mkn8cn08q12hc96p6zz2d4is6d5wsc";
   };
 
   contribSrc = fetchFromGitHub {
     owner  = "opencv";
     repo   = "opencv_contrib";
     rev    = version;
-    sha256 = "0ylsljkmgfj5vam05cv0z3qwkqwjwz5fs5f5yif3pwvb99lxlbib";
+    sha256 = "1fw7qwgibiznqal2dg4alkw8hrrrpjc0jaicf2406604rjm2lx6h";
   };
 
   # Contrib must be built in order to enable Tesseract support:
@@ -146,21 +146,6 @@ stdenv.mkDerivation rec {
   postUnpack = lib.optionalString buildContrib ''
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/opencv_contrib"
   '';
-
-  patches = [
-    # https://github.com/opencv/opencv/pull/13232
-    # This also fixes the test of haskell-opencv HEAD where we got the following error:
-    # libgomp: Out of memory allocating 927712937064 bytes
-    (fetchpatch {
-      url = https://github.com/opencv/opencv/commit/e1ac8589f8a19b9bf5598bbae073ae12721c541d.patch;
-      sha256 = "1ap2818lixjhc5jgf779c57kwacafc0ap40lqrx6nqfz31silglj";
-    })
-  ] ++
-    # https://github.com/opencv/opencv/pull/13254
-    lib.optional enablePython (fetchpatch {
-      url = https://github.com/opencv/opencv/commit/ad35b79e3f98b4ce30481e0299cca550ed77aef0.patch;
-      sha256 = "0rkvg6wm5fyncszfpd83wa4lvsb8srvk21r1jcld758i4f334sws";
-    });
 
   # This prevents cmake from using libraries in impure paths (which
   # causes build failure on non NixOS)

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -35,19 +35,21 @@
 }:
 
 let
-  version = "4.0.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner  = "opencv";
     repo   = "opencv";
     rev    = version;
-    sha256 = "1r2hszm4044dfx65wv69rcs419jjd7bqllhnpcwk3n28f5ahln50";
+    sha256 = "1f0n2a57sn47w55vaxlwhr3g6xgchvr3gxicxbkyzai3pvj55k48";
   };
 
   contribSrc = fetchFromGitHub {
     owner  = "opencv";
     repo   = "opencv_contrib";
-    rev    = version;
+    # TODO: set to `version` when opencv_contrib-4.0.1 is released;
+    # See: http://answers.opencv.org/question/205793/will-there-be-a-opencv_contrib-401-release-now-that-opencv-401-is-out/
+    rev    = "4.0.0";
     sha256 = "1g4pzw7hv1v9jp1nrqjxqwpi1byl3mxkj6w6ibq6ydsn0138p66z";
   };
 
@@ -160,15 +162,7 @@ stdenv.mkDerivation rec {
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/source/opencv_contrib"
   '';
 
-  patches = [
-    # https://github.com/opencv/opencv/pull/13232
-    # This also fixes the test of haskell-opencv HEAD where we got the following error:
-    # libgomp: Out of memory allocating 927712937064 bytes
-    (fetchpatch {
-      url = https://github.com/opencv/opencv/commit/e1ac8589f8a19b9bf5598bbae073ae12721c541d.patch;
-      sha256 = "1ap2818lixjhc5jgf779c57kwacafc0ap40lqrx6nqfz31silglj";
-    })
-  ] ++
+  patches =
     # Fixes issue: https://github.com/opencv/opencv_contrib/issues/1923
     # PR: https://github.com/opencv/opencv_contrib/pull/1913
     lib.optional buildContrib (fetchpatch {
@@ -176,11 +170,6 @@ stdenv.mkDerivation rec {
       sha256 = "102mq1qgmla40hhj8mda70inhakdazm9agyah98kq9931scvf0c9";
       stripLen = 2;
       extraPrefix = "opencv_contrib/";
-    }) ++
-    # https://github.com/opencv/opencv/pull/13254
-    lib.optional enablePython (fetchpatch {
-      url = https://github.com/opencv/opencv/commit/ad35b79e3f98b4ce30481e0299cca550ed77aef0.patch;
-      sha256 = "0rkvg6wm5fyncszfpd83wa4lvsb8srvk21r1jcld758i4f334sws";
     });
 
   # This prevents cmake from using libraries in impure paths (which


### PR DESCRIPTION
###### Motivation for this change

https://github.com/opencv/opencv/releases
https://github.com/opencv/opencv_contrib/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

