### PR TITLE
pythonPackages.cli-helpers: fix missing dependencies

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, configobj
 , terminaltables
 , tabulate
 , backports_csv
 , wcwidth
 , pytest
+, mock
 , isPy27
 }:
 
@@ -19,12 +21,13 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    configobj
     terminaltables
     tabulate
     wcwidth
   ] ++ (lib.optionals isPy27 [ backports_csv ]);
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest mock ];
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
###### Motivation for this change

I tried to update pgcli and noticed that cli-helpers were not being built, e.g.

```
Collecting configobj>=5.0.5 (from cli-helpers==1.1.0)
  Could not find a version that satisfies the requirement configobj>=5.0.5 (from cli-helpers==1.1.0) (from versions: )
No matching distribution found for configobj>=5.0.5 (from cli-helpers==1.1.0)
builder for '/nix/store/85x4157vczhfkfi1dcsvka68zkhsi9cw-python3.7-cli_helpers-1.1.0.drv' failed with exit code 1
```

This commit introduces two new dependencies for this package, configobj and mock. I have tested the modified package against pgcli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

