### PR TITLE
Fix sfml build on Darwin

### DIFF
--- a/pkgs/development/libraries/sfml/default.nix
+++ b/pkgs/development/libraries/sfml/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, cmake, libX11, freetype, libjpeg, openal, flac, libvorbis
 , glew, libXrandr, libXrender, udev, xcbutilimage
-, IOKit, Foundation, AppKit, OpenAL
+, darwin, IOKit, Foundation, AppKit, OpenAL
 }:
 
 let
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 freetype libjpeg openal flac libvorbis glew
                   libXrandr libXrender xcbutilimage
                 ] ++ stdenv.lib.optional stdenv.isLinux udev
-                  ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL ];
+                  ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL darwin.cf-private ];
 
   cmakeFlags = [ "-DSFML_INSTALL_PKGCONFIG_FILES=yes"
                  "-DSFML_MISC_INSTALL_PREFIX=share/SFML"

--- a/pkgs/development/libraries/sfml/default.nix
+++ b/pkgs/development/libraries/sfml/default.nix
@@ -16,10 +16,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libX11 freetype libjpeg openal flac libvorbis glew
-                  libXrandr libXrender xcbutilimage
-                ] ++ stdenv.lib.optional stdenv.isLinux udev
-                  ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL darwin.cf-private ];
+  buildInputs = [ freetype libjpeg openal flac libvorbis glew ]
+    ++ stdenv.lib.optional stdenv.isLinux udev
+    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXrandr libXrender xcbutilimage ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL darwin.cf-private ];
 
   cmakeFlags = [ "-DSFML_INSTALL_PKGCONFIG_FILES=yes"
                  "-DSFML_MISC_INSTALL_PREFIX=share/SFML"

--- a/pkgs/development/libraries/sfml/default.nix
+++ b/pkgs/development/libraries/sfml/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, cmake, libX11, freetype, libjpeg, openal, flac, libvorbis
 , glew, libXrandr, libXrender, udev, xcbutilimage
-, darwin, IOKit, Foundation, AppKit, OpenAL
+, cf-private, IOKit, Foundation, AppKit, OpenAL
 }:
 
 let
@@ -19,7 +19,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ freetype libjpeg openal flac libvorbis glew ]
     ++ stdenv.lib.optional stdenv.isLinux udev
     ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXrandr libXrender xcbutilimage ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL darwin.cf-private ];
+    ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit Foundation AppKit OpenAL
+    # Needed for _NSDefaultRunLoopMode, _OBJC_CLASS_$_NSArray, _OBJC_CLASS_$_NSDate
+    cf-private
+    ];
 
   cmakeFlags = [ "-DSFML_INSTALL_PKGCONFIG_FILES=yes"
                  "-DSFML_MISC_INSTALL_PREFIX=share/SFML"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12491,6 +12491,7 @@ in
 
   sfml = callPackage ../development/libraries/sfml {
     inherit (darwin.apple_sdk.frameworks) IOKit Foundation AppKit OpenAL;
+    inherit (darwin) cf-private;
   };
   csfml = callPackage ../development/libraries/csfml { };
 


### PR DESCRIPTION
###### Motivation for this change

Building sfml fails on Darwin at link stage:

```
[ 48%] Linking CXX shared library ../../../lib/libsfml-window.dylib
Undefined symbols for architecture x86_64:
  "_NSDefaultRunLoopMode", referenced from:
      +[SFApplication processEvent] in SFApplication.m.o
  "_OBJC_CLASS_$_NSArray", referenced from:
      objc-class-ref in ClipboardImpl.mm.o
      objc-class-ref in SFOpenGLView+keyboard.mm.o
  "_OBJC_CLASS_$_NSDate", referenced from:
      objc-class-ref in SFApplication.m.o
ld: symbol(s) not found for architecture x86_64
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/SFML/Window/CMakeFiles/sfml-window.dir/build.make:655: lib/libsfml-window.2.5.1.dylib] Error 1
make[1]: *** [CMakeFiles/Makefile2:176: src/SFML/Window/CMakeFiles/sfml-window.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
