### PR TITLE
bzflag: enable on darwin

### DIFF
--- a/pkgs/games/bzflag/default.nix
+++ b/pkgs/games/bzflag/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, pkgconfig
-, curl, SDL2, libGLU_combined, glew, ncurses, c-ares }:
+, curl, SDL2, libGLU_combined, glew, ncurses, c-ares
+, Carbon, CoreServices }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -12,13 +13,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ curl SDL2 libGLU_combined glew ncurses c-ares ];
+  buildInputs = [ curl SDL2 libGLU_combined glew ncurses c-ares ]
+    ++ lib.optionals stdenv.isDarwin [ Carbon CoreServices ];
 
   meta = with lib; {
     description = "Multiplayer 3D Tank game";
     homepage = https://bzflag.org/;
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20460,7 +20460,9 @@ in
 
   btanks = callPackage ../games/btanks { };
 
-  bzflag = callPackage ../games/bzflag { };
+  bzflag = callPackage ../games/bzflag {
+    inherit (darwin.apple_sdk.frameworks) Carbon CoreServices;
+  };
 
   cataclysm-dda = callPackage ../games/cataclysm-dda {
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

