### PR TITLE
wsjtx: 1.9.1 -> 2.0.0

### DIFF
--- a/pkgs/applications/misc/wsjtx/default.nix
+++ b/pkgs/applications/misc/wsjtx/default.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchurl, asciidoc, asciidoctor, autoconf, automake, cmake,
-  docbook_xsl, fftw, fftwFloat, gfortran, libtool, qtbase,
+  docbook_xsl, fftw, fftwFloat, gfortran, git, libtool, qtbase,
   qtmultimedia, qtserialport, texinfo, libusb1 }:
 
 stdenv.mkDerivation rec {
   name = "wsjtx-${version}";
-  version = "1.9.1";
+  version = "2.0.0";
 
   # This is a composite source tarball containing both wsjtx and a hamlib fork
   src = fetchurl {
     url = "http://physics.princeton.edu/pulsar/K1JT/wsjtx-${version}.tgz";
-    sha256 = "143r17fri08mwz28g17wcfxy60h3xgfk46mln5lmdr9k6355aqqc";
+    sha256 = "056hgfvqb8q41hqimyqb9xhv5jk48hgcazh5zshjsx2ny9llyhv6";
   };
 
   # Hamlib builds with autotools, wsjtx builds with cmake
   # Omitting pkgconfig because it causes issues locating the built hamlib
   nativeBuildInputs = [
-    asciidoc asciidoctor autoconf automake cmake docbook_xsl gfortran libtool
+    asciidoc asciidoctor autoconf automake cmake docbook_xsl gfortran git libtool
     texinfo
   ];
   buildInputs = [ fftw fftwFloat libusb1 qtbase qtmultimedia qtserialport ];

--- a/pkgs/applications/misc/wsjtx/wsjtx.patch
+++ b/pkgs/applications/misc/wsjtx/wsjtx.patch
@@ -1,11 +1,11 @@
 Index: wsjtx/CMakeLists.txt
 ===================================================================
---- wsjtx/CMakeLists.txt	(revision 8382)
+--- wsjtx/CMakeLists.txt	(784f75)
 +++ wsjtx/CMakeLists.txt	(working copy)
-@@ -866,6 +866,7 @@
- find_package (Qt5Widgets 5 REQUIRED)
+@@ -860,6 +860,7 @@
  find_package (Qt5Multimedia 5 REQUIRED)
  find_package (Qt5PrintSupport 5 REQUIRED)
+ find_package (Qt5Sql 5 REQUIRED)
 +find_package (Qt5SerialPort 5 REQUIRED)
  
  if (WIN32)


### PR DESCRIPTION
###### Motivation for this change
Update wsjtx to version 2.0.0.
There has been a protocol update and wsjtx-1.9.1 has be deprecated and will end to work 2018.

###### Things done
update src and patch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

