### PR TITLE
poppler: 0.67.0 → 0.72.0

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -6,6 +6,11 @@ callPackage ./generic.nix (args // rec {
   revision = "v${version}";
   sha256 = "08plxrnfl33sn2vh5nwbsngyv6b1sfpplvx881crm1v1ai10m2lz";
 
+  extraFlags = [
+    "-DOPENJPEG_INSTALL_INCLUDE_DIR=${placeholder "dev"}/include/openjpeg-${branch}"
+    "-DOPENJPEG_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/openjpeg-${branch}"
+  ];
+
   patches = [
     (fetchpatch {
       name = "CVE-2018-7648.patch";
@@ -17,5 +22,10 @@ callPackage ./generic.nix (args // rec {
       url = "https://github.com/uclouvain/openjpeg/commit/92023cd6c377e0384a7725949b25655d4d94dced.patch";
       sha256 = "0rrxxqcp3vjkmvywxj9ac766m3fppy0x0nszrkf8irrqy1gnp38k";
     })
+    (fetchpatch {
+      url = https://github.com/uclouvain/openjpeg/commit/24fd3ce777a64b8b315cfe1ee642ec7b1cc6aa97.patch;
+      sha256 = "1sl5wplgdfiqw8qbd8s5j5hq3ynbwgsnv8nxqfrk5s7vyrzx9pxv";
+    })
+    ./fix-cmake-config-includedir.patch
   ];
 })

--- a/pkgs/development/libraries/openjpeg/fix-cmake-config-includedir.patch
+++ b/pkgs/development/libraries/openjpeg/fix-cmake-config-includedir.patch
@@ -1,0 +1,55 @@
+--- a/cmake/OpenJPEGConfig.cmake.in
++++ b/cmake/OpenJPEGConfig.cmake.in
+@@ -32,7 +32,7 @@
+   set(INC_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_INCLUDE_DIR@")
+   file(RELATIVE_PATH PKG_TO_INC_RPATH "${PKG_DIR}" "${INC_DIR}")
+ 
+-  get_filename_component(OPENJPEG_INCLUDE_DIRS "${SELF_DIR}/${PKG_TO_INC_RPATH}" ABSOLUTE)
++  get_filename_component(OPENJPEG_INCLUDE_DIRS "@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
+ 
+ else()
+   if(EXISTS ${SELF_DIR}/OpenJPEGExports.cmake)
+--- a/src/lib/openjp2/libopenjp2.pc.cmake.in
++++ b/src/lib/openjp2/libopenjp2.pc.cmake.in
+@@ -3,7 +3,7 @@
+ mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+ docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+ libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++includedir=@OPENJPEG_INSTALL_INCLUDE_DIR@
+ 
+ Name: openjp2
+ Description: JPEG2000 library (Part 1 and 2)
+--- a/src/lib/openjp3d/libopenjp3d.pc.cmake.in
++++ b/src/lib/openjp3d/libopenjp3d.pc.cmake.in
+@@ -3,7 +3,7 @@
+ mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+ docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+ libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++includedir=@OPENJPEG_INSTALL_INCLUDE_DIR@
+ 
+ Name: openjp3d
+ Description: JPEG2000 Extensions for three-dimensional data (Part 10)
+--- a/src/lib/openjpip/libopenjpip.pc.cmake.in
++++ b/src/lib/openjpip/libopenjpip.pc.cmake.in
+@@ -3,7 +3,7 @@
+ mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+ docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+ libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++includedir=@OPENJPEG_INSTALL_INCLUDE_DIR@
+ 
+ Name: openjpip
+ Description: JPEG2000 Interactivity tools, APIs and protocols (Part 9)
+--- a/src/lib/openjpwl/libopenjpwl.pc.cmake.in
++++ b/src/lib/openjpwl/libopenjpwl.pc.cmake.in
+@@ -3,7 +3,7 @@
+ mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+ docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+ libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++includedir=@OPENJPEG_INSTALL_INCLUDE_DIR@
+ 
+ Name: openjpwl
+ Description: JPEG2000 Wireless library (Part 11)

--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -11,7 +11,7 @@
 , testsSupport ? false
 , jdk ? null
 # Inherit generics
-, branch, version, revision, sha256, patches ? [], ...
+, branch, version, revision, sha256, patches ? [], extraFlags ? [], ...
 }:
 
 assert jpipServerSupport -> jpipLibSupport && curl != null && fcgi != null;
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     (mkFlag jp3dSupport "BUILD_JP3D")
     (mkFlag thirdPartySupport "BUILD_THIRDPARTY")
     (mkFlag testsSupport "BUILD_TESTING")
-  ];
+  ] ++ extraFlags;
 
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -8,7 +8,7 @@
 }:
 
 let # beware: updates often break cups-filters build
-  version = "0.67.0";
+  version = "0.72.0";
   mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
 in
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";
-    sha256 = "1yb6agmcxf0ixqm65d4aknl0hgmswf94x0k59ic0qqav1wd4yjm3";
+    sha256 = "0lfs1b1jfamxl13zbl5n448dqvl9n8frbv8180y7b7kfyaw7wx61";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -2,7 +2,6 @@
 , libjpeg, libpng, perl, ijs, qpdf, dbus, avahi
 , makeWrapper, coreutils, gnused, bc, gawk, gnugrep, which, ghostscript
 , mupdf
-, fetchpatch
 }:
 
 let
@@ -10,22 +9,12 @@ let
 
 in stdenv.mkDerivation rec {
   name = "cups-filters-${version}";
-  version = "1.20.4";
+  version = "1.21.6";
 
   src = fetchurl {
     url = "https://openprinting.org/download/cups-filters/${name}.tar.xz";
-    sha256 = "0sjkmclcb1r77015wllsyz26272br3s17v6b1q2xwb2nm2gnwx9k";
+    sha256 = "0k0x9p40bahq44189vy9zai2ia9i91h26chrddr0m9agzsy5s3k3";
   };
-
-  patches = [
-    # This patch fixes cups-filters when compiled with poppler-0.67.0.
-    # Issue: https://github.com/OpenPrinting/cups-filters/pull/50
-    # PR: https://github.com/OpenPrinting/cups-filters/pull/51
-    (fetchpatch {
-      url = "https://github.com/OpenPrinting/cups-filters/commit/219de01c61f3b1ec146abf142d0dfc8c560cc58e.patch";
-      sha256 = "0f0lql3rbm2g8mxrpigfyi8fb4i2g4av20g417jzdilp60jq0ny8";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -28,9 +28,19 @@ let
 
     patches = [
       (fetchurl {
-        name = "texlive-poppler-0.64.patch";
-        url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/texlive-poppler-0.64.patch?h=packages/texlive-bin&id=da56abf0f8a1e85daca0ec0f031b8fa268519e6b;
-        sha256 = "0443d074zl3c5raba8jyhavish706arjcd80ibb84zwnwck4ai0w";
+        name = "poppler-compat-fixes-up-to-0.70.patch";
+        url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/poppler-compat-fixes-up-to-0.70.patch?h=packages/texlive-bin&id=85ee0539525d8012f134b76c18dfb10d0837a7e2;
+        sha256 = "0a8bvyl7v6zlyyg3ycl0dmg2g2qahxlq3qmc1nv33r24anzb8xhs";
+      })
+      (fetchurl {
+        name = "luatex-poppler-0.70-const-fixes.patch";
+        url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/luatex-poppler-0.70-const-fixes.patch?h=packages/texlive-bin&id=85ee0539525d8012f134b76c18dfb10d0837a7e2;
+        sha256 = "0yiw2x97whdi23dc10xnqpxqj3aja15alir1byp1y03j60zv5n7i";
+      })
+      (fetchurl {
+        name = "texlive-poppler-0.71.patch";
+        url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/texlive-poppler-0.71.patch?h=packages/texlive-bin&id=85ee0539525d8012f134b76c18dfb10d0837a7e2;
+        sha256 = "164wibyf786gdcb0ij4svsmyi13wvcx0cpdr4flki0lpy3igvlnq";
       })
       (fetchurl {
         name = "synctex-missing-header.patch";
@@ -89,8 +99,10 @@ core = stdenv.mkDerivation rec {
     for i in texk/kpathsea/mktex*; do
       sed -i '/^mydir=/d' "$i"
     done
-    cp -pv texk/web2c/pdftexdir/pdftoepdf{-newpoppler.cc,.cc}
-    cp -pv texk/web2c/pdftexdir/pdftosrc{-newpoppler.cc,.cc}
+    cp -pv texk/web2c/pdftexdir/pdftoepdf{-poppler0.70.0,}.cc
+    cp -pv texk/web2c/pdftexdir/pdftosrc{-newpoppler,}.cc
+    # fix build with poppler 0.71
+    find texk/web2c/{lua,pdf}texdir -type f | xargs sed -e 's|gTrue|true|g' -e 's|gFalse|false|g' -e 's|GBool|bool|g' -e 's|getCString|c_str|g' -i
   '';
 
   preConfigure = ''

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -48,6 +48,17 @@ let
         sha256 = "1c4aq8lk8g3mlfq3mdjnxvmhss3qs7nni5rmw0k054dmj6q1xj5n";
       })
     ];
+
+    postPatch = ''
+      for i in texk/kpathsea/mktex*; do
+        sed -i '/^mydir=/d' "$i"
+      done
+      cp -pv texk/web2c/pdftexdir/pdftoepdf{-poppler0.70.0,}.cc
+      cp -pv texk/web2c/pdftexdir/pdftosrc{-newpoppler,}.cc
+      # fix build with poppler 0.71
+      find texk/web2c/{lua,pdf}texdir -type f | xargs sed -e 's|gTrue|true|g' -e 's|gFalse|false|g' -e 's|GBool|bool|g' -e 's|getCString|c_str|g' -i
+    '';
+
     # remove when removing synctex-missing-header.patch
     preAutoreconf = "pushd texk/web2c";
     postAutoreconf = "popd";
@@ -82,7 +93,7 @@ texliveYear = year;
 core = stdenv.mkDerivation rec {
   name = "texlive-bin-${version}";
 
-  inherit (common) src patches preAutoreconf postAutoreconf;
+  inherit (common) src patches postPatch preAutoreconf postAutoreconf;
 
   outputs = [ "out" "doc" ];
 
@@ -94,16 +105,6 @@ core = stdenv.mkDerivation rec {
   ];
 
   hardeningDisable = [ "format" ];
-
-  postPatch = ''
-    for i in texk/kpathsea/mktex*; do
-      sed -i '/^mydir=/d' "$i"
-    done
-    cp -pv texk/web2c/pdftexdir/pdftoepdf{-poppler0.70.0,}.cc
-    cp -pv texk/web2c/pdftexdir/pdftosrc{-newpoppler,}.cc
-    # fix build with poppler 0.71
-    find texk/web2c/{lua,pdf}texdir -type f | xargs sed -e 's|gTrue|true|g' -e 's|gFalse|false|g' -e 's|GBool|bool|g' -e 's|getCString|c_str|g' -i
-  '';
 
   preConfigure = ''
     rm -r libs/{cairo,freetype2,gd,gmp,graphite2,harfbuzz,icu,libpaper,libpng} \
@@ -184,7 +185,7 @@ inherit (core-big) metafont metapost luatex xetex;
 core-big = stdenv.mkDerivation { #TODO: upmendex
   name = "texlive-core-big.bin-${version}";
 
-  inherit (common) src patches preAutoreconf postAutoreconf;
+  inherit (common) src patches postPatch preAutoreconf postAutoreconf;
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.freedesktop.org/poppler/poppler/blob/poppler-0.72.0/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @codyopel @ttuegel 