### PR TITLE
zsh: fix zprofile configure flag

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -34,10 +34,8 @@ stdenv.mkDerivation {
     "--enable-multibyte"
     "--with-tcsetpgrp"
     "--enable-pcre"
+    "--enable-zprofile=${placeholder "out"}/etc/zprofile"
   ];
-  preConfigure = ''
-    configureFlagsArray+=(--enable-zprofile=$out/etc/zprofile)
-  '';
 
   # the zsh/zpty module is not available on hydra
   # so skip groups Y Z


### PR DESCRIPTION
    This doesn't work on distros like Gentoo that put zprofile under
    /etc/zsh. We have overrideAttrs now, too, so the obvious solution would
    be overriding configureFlags, but then preConfigure would override on top
    of that…

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

