### PR TITLE
gauche: 0.9.6 -> 0.9.7

### DIFF
--- a/pkgs/development/interpreters/gauche/default.nix
+++ b/pkgs/development/interpreters/gauche/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchurl, pkgconfig, texinfo, libiconv, gdbm, openssl, zlib
-, mbedtls, cacert
+, mbedtls, cacert, libatomic_ops
 }:
 
 stdenv.mkDerivation rec {
   name = "gauche-${version}";
-  version = "0.9.6";
+  version = "0.9.7";
 
   src = fetchurl {
     url = "mirror://sourceforge/gauche/Gauche-${version}.tgz";
-    sha256 = "1bwwwvyxsrp2a4cfib6hn0hcgwzmp2znylm088w09f331miji2fd";
+    sha256 = "181nycikma0rwrb1h6mi3kys11f8628pq8g5r3fg5hiz5sabscrd";
   };
 
   nativeBuildInputs = [ pkgconfig texinfo ];
 
-  buildInputs = [ libiconv gdbm openssl zlib mbedtls cacert ];
+  buildInputs = [ libiconv gdbm openssl zlib mbedtls cacert libatomic_ops ];
 
   postPatch = ''
     patchShebangs .


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

