### PR TITLE
Fixes eval issues in hydra by setting AArch64 as limited support

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -4,8 +4,8 @@
 
 { nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
-, supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
-, limitedSupportedSystems ? [ "i686-linux" ]
+, supportedSystems ? [ "x86_64-linux" ]
+, limitedSupportedSystems ? [ "i686-linux" "aarch64-linux" ]
 }:
 
 let

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -54,10 +54,12 @@ in rec {
         (all nixos.dummy)
         (all nixos.manual)
 
-        nixos.iso_minimal.x86_64-linux or []
-        nixos.iso_minimal.i686-linux or []
         nixos.iso_graphical.x86_64-linux or []
+        nixos.iso_minimal.aarch64-linux or []
+        nixos.iso_minimal.i686-linux or []
+        nixos.iso_minimal.x86_64-linux or []
         nixos.ova.x86_64-linux or []
+        nixos.sd_image.aarch64-linux or []
 
         #(all nixos.tests.containers)
         (all nixos.tests.containers-imperative)


### PR DESCRIPTION
### Motivation for this change

 **nixos/release-combined.nix: Adds missing aarch64 constituents**

This will block channel advancing, even if it is limited support.

**nixos/release-combined.nix: makes aarch64-linux limited support**

This is because it will not eval properly with `hydra-eval-jobs`.

```
$ ...hydra/result/bin/hydra-eval-jobs \
    --arg nixpkgs '{ outPath = ./.; revCount = 123; shortRev = "4567"; }' \
    -I "$PWD" \
    nixos/release-combined.nix
```

It fails with:

```
Too many heap sections: Increase MAXHINCR or MAX_HEAP_SECTS
```

### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

