### PR TITLE
Liquidwar6

### DIFF
--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, xproto, libX11, libXrender
-, gmp, libGLU_combined, libjpeg, libpng
+, gmp, libjpeg, libpng
 , expat, gettext, perl, guile
 , SDL, SDL_image, SDL_mixer, SDL_ttf
 , curl, sqlite, libtool, readline
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     xproto libX11 gmp guile
-    libGLU_combined libjpeg libpng
+    libjpeg libpng
     expat gettext perl
     SDL SDL_image SDL_mixer SDL_ttf
     curl sqlite

--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -27,7 +27,11 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  NIX_CFLAGS_COMPILE =
+    "-Wno-error=deprecated-declarations" +
+    # Avoid GL_GLEXT_VERSION double definition
+    " -DNO_SDL_GLEXT"
+  ;
 
   # To avoid problems finding SDL_types.h.
   configureFlags = [ "CFLAGS=-I${SDL.dev}/include/SDL" ];


### PR DESCRIPTION
###### Motivation for this change

fix double definition of GL_GLEXT_VERSION

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @7c6f434c 
