### PR TITLE
fsarchiver: init at 0.8.5

### DIFF
--- a/pkgs/tools/archivers/fsarchiver/default.nix
+++ b/pkgs/tools/archivers/fsarchiver/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, zlib, bzip2, lzma, lzo, lz4, zstd, xz
+, libgcrypt, e2fsprogs, utillinux, libgpgerror }:
+
+let
+  version = "0.8.5";
+
+in stdenv.mkDerivation {
+  name = "fsarchiver-${version}";
+
+  src = fetchFromGitHub {
+    owner = "fdupoux";
+    repo = "fsarchiver";
+    rev = version;
+    sha256 = "1rvwq5v3rl14bqxjm1ibfapyicf0sa44nw7451v10kx39lp56ylp";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook pkgconfig
+  ];
+
+  buildInputs = [
+    zlib bzip2 lzma lzo lz4 zstd xz
+    libgcrypt e2fsprogs utillinux libgpgerror
+  ];
+
+  meta = with stdenv.lib; {
+    description = "File system archiver for linux";
+    longDescription = ''
+      FSArchiver is a system tool that allows you to save the contents of a
+      file-system to a compressed archive file. The file-system can be restored
+      on a partition which has a different size and it can be restored on a
+      different file-system. Unlike tar/dar, FSArchiver also creates the
+      file-system when it extracts the data to partitions. Everything is
+      checksummed in the archive in order to protect the data. If the archive is
+      corrupt, you just loose the current file, not the whole archive.
+    '';
+    homepage = http://www.fsarchiver.org/;
+    license = licenses.lgpl2;
+    maintainers = [ maintainers.etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2783,6 +2783,8 @@ in
 
   ftop = callPackage ../os-specific/linux/ftop { };
 
+  fsarchiver = callPackage ../tools/archivers/fsarchiver { };
+
   fsfs = callPackage ../tools/filesystems/fsfs { };
 
   fstl = qt5.callPackage ../applications/graphics/fstl { };


### PR DESCRIPTION
###### Motivation for this change
Powerful and flexible filesystem archiver: http://www.fsarchiver.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

