### PR TITLE
Revert "neopg: 0.0.4 -> 0.0.5"

### DIFF
--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   name = "neopg-${version}";
-  version = "0.0.5";
+  version = "0.0.4";
 
   src = fetchFromGitHub {
     owner = "das-labor";
     repo = "neopg";
     rev = "v${version}";
-    sha256 = "1ky3pwg6w8kyaa9iksfx6rryva87mbj1h3yi2mrzp2h7jhrfffpp";
+    sha256 = "0hhkl326ff6f76k8pwggpzmivbm13fz497nlyy6ybn5bmi9xfblm";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This broke the build, as the bump introduced test failures. Revert to a
working version.

I'm aware of the problem, but haven't found a solution to it yet.

@schneefux Could you please test the build before bumping the package? Also a mention of the package maintainer (in this case me) would have been nice (but not necessary imho).

Thanks to @Mic92, who just informed me in #37700 about the breakage.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

