### PR TITLE
python3Packages.pyaxmlparser: fix build

### DIFF
--- a/pkgs/development/python-modules/pyaxmlparser/default.nix
+++ b/pkgs/development/python-modules/pyaxmlparser/default.nix
@@ -1,15 +1,29 @@
-{ buildPythonPackage, stdenv, lxml, click, fetchPypi }:
+{ buildPythonPackage, stdenv, lxml, click, fetchFromGitHub, pytest, isPy3k }:
 
 buildPythonPackage rec {
   version = "0.3.13";
   pname = "pyaxmlparser";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1mzdrifnaky57vkmdvg0rgjss55xkxaramci3wpv4h65lmk95988";
+  # the PyPI tarball doesn't ship tests.
+  src = fetchFromGitHub {
+    owner = "appknox";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0jfjhxc6b57npsidknxmhj1x813scg47aaw90ybyr90fpdz5rlwk";
   };
 
+  disabled = !isPy3k;
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "click==6.7" "click"
+  '';
+
   propagatedBuildInputs = [ lxml click ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    py.test tests/
+  '';
 
   meta = with stdenv.lib; {
     description = "Python3 Parser for Android XML file and get Application Name without using Androguard";


### PR DESCRIPTION
###### Motivation for this change

The build is currently broken on master[1] due to a major bump of
`click` in fe0af1ce777abf99a3fd851a86f2000326153207.

Manually patching `setup.py` temporarily fixes the issue. To ensure that
succeeding builds don't deliver packages breaking at runtime due to
dependency issues I switched to the GitHub archive as source since it
contains tests as well.

Additionally, Python 2.7 support has been dropped. It seems as it
was never intended to support Python3 here, I simply forgot to disable
the Python2 build:

```
TypeError: AXMLParser object is not an iterator
```

[1] https://hydra.nixos.org/build/86108813

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

