### PR TITLE
osquery: fix build

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -4,7 +4,7 @@
 , beecrypt, augeas, libxml2, sleuthkit, yara, lldpd, google-gflags
 , thrift, boost, rocksdb_lite, glog, gbenchmark, snappy
 , openssl, file, doxygen
-, gtest, sqlite, fpm, zstd, rdkafka, rapidjson
+, gtest, sqlite, fpm, zstd, rdkafka, rapidjson, fetchgit
 }:
 
 let
@@ -43,6 +43,20 @@ stdenv.mkDerivation rec {
     gflags' = google-gflags.overrideAttrs (old: {
       cmakeFlags = stdenv.lib.filter (f: isNull (builtins.match ".*STATIC.*" f)) old.cmakeFlags;
     });
+
+    # use older `lvm2` source for osquery, the 2.03 sourcetree
+    # will break osquery due to the lacking header `lvm2app.h`.
+    #
+    # https://github.com/NixOS/nixpkgs/pull/51756#issuecomment-446035295
+    lvm2' = lvm2.overrideAttrs (old: rec {
+      name = "lvm2-${version}";
+      version = "2.02.183";
+      src = fetchgit {
+        url = "git://sourceware.org/git/lvm2.git";
+        rev = "v${version}";
+        sha256 = "1ny3srcsxd6kj59zq1cman5myj8kzw010wbyc6mrpk4kp823r5nx";
+      };
+    });
   in [
     udev audit
 
@@ -51,7 +65,7 @@ stdenv.mkDerivation rec {
       customMemoryManagement = false;
     })
 
-    lvm2 libgcrypt libarchive libgpgerror libuuid iptables dpkg
+    lvm2' libgcrypt libarchive libgpgerror libuuid iptables dpkg
     lzma bzip2 rpm beecrypt augeas libxml2 sleuthkit
     yara lldpd gflags' thrift boost
     glog gbenchmark snappy openssl


### PR DESCRIPTION
###### Motivation for this change

As discussed in #51756, recently packaged versions of `lvm2` miss the
`lvm2app.h` header which breaks the osquery build.

Please note that this simply fixes the build and is not an upgrade. The
CMake patches are fairly diverged in constrast to the current upstream
packaging which requires a lot more effort I can't provide ATM.

cc @markuskowa @hedning

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

