### PR TITLE
udisks1: drop lvm2 support, fix build

### DIFF
--- a/pkgs/os-specific/linux/udisks/1-default.nix
+++ b/pkgs/os-specific/linux/udisks/1-default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  configureFlags = [ "--localstatedir=/var" "--enable-lvm2" ];
+  configureFlags = [ "--localstatedir=/var" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/udisks;


### PR DESCRIPTION
Recent lvm2 upgrade broke the build. According to fedora, upstream recommends
against using lvm2 support.

Note, we still need lvm2 as a dependency as it contains devmapper.