### PR TITLE
gitlab: 11.5.4 -> 11.5.5 (CVE-2018-20229)

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,12 +1,12 @@
 {
   "ce": {
-    "version": "11.5.4",
-    "repo_hash": "1mk7zj79cz9g8y6b5p4cznv90h94mwgy14w9vdvmqbgbnx9bayc8",
-    "deb_hash": "18i3w1k8l5hj3732w3adw3cma78l9hx77wlrgvssg9gz609kqvx6",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.5.4-ce.0_amd64.deb/download.deb",
+    "version": "11.5.5",
+    "repo_hash": "1dxky06im18s4kxbb33qwm22pkkhgvyjggx31164iy71zcxxj1jr",
+    "deb_hash": "0wnyfl1bb5wb8kdyarjk9y4ydla84f3alnk3m3zwmdqfg9jsqgb8",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.5.5-ce.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ce",
-    "rev": "v11.5.4",
+    "rev": "v11.5.5",
     "passthru": {
       "GITALY_SERVER_VERSION": "0.129.0",
       "GITLAB_PAGES_VERSION": "1.3.1",

--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -15,13 +15,13 @@
     }
   },
   "ee": {
-    "version": "11.5.4",
-    "repo_hash": "1rpj34wblhk6yirix16grrlhg4dfna3mjvhn8bz82m94dkhx06lc",
-    "deb_hash": "05lizhf45xv4j0y0yafrpcrqmav1xmncxxgsm97s2mlhdwn5rfnd",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.5.4-ee.0_amd64.deb/download.deb",
+    "version": "11.5.5",
+    "repo_hash": "1j5g0x7rxrdb39b12psjirsa3s0lhqgnxh0q3r22cgzgxv0332b8",
+    "deb_hash": "193s1f7w9lcamqnmrc7c3klmybqqra7yr16x6ay0cznwcdgirisp",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.5.5-ee.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ee",
-    "rev": "v11.5.4-ee",
+    "rev": "v11.5.5-ee",
     "passthru": {
       "GITALY_SERVER_VERSION": "0.129.0",
       "GITLAB_PAGES_VERSION": "1.3.1",


### PR DESCRIPTION
###### Motivation for this change
This bumps gitlab from 11.5.4 to 11.5.5, fixing [CVE-2018-20229](https://about.gitlab.com/2018/12/20/critical-security-release-gitlab-11-dot-5-dot-5-released/)

Needs backport to 18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

