### PR TITLE
snscrape: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/snscrape/default.nix
+++ b/pkgs/development/python-modules/snscrape/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, requests
+, lxml
+, beautifulsoup4
+}:
+
+buildPythonPackage rec {
+  pname = "snscrape";
+  version = "0.1.3";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mnhqqc7xfwg2wrzpj1pjbcisjjwxrgmy21f53p80xbx2iz8b9n1";
+  };
+
+  # There are no tests; make sure the executable works.
+  checkPhase = ''
+    export PATH=$PATH:$out/bin
+    snscrape --help
+  '';
+
+  propagatedBuildInputs = [ requests lxml beautifulsoup4 ];
+
+  meta = with lib; {
+    homepage = https://github.com/JustAnotherArchivist/snscrape;
+    description = "A social networking service scraper in Python";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ivan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22816,6 +22816,8 @@ in
 
   snapraid = callPackage ../tools/filesystems/snapraid { };
 
+  snscrape = with python3Packages; toPythonApplication snscrape;
+
   soundOfSorting = callPackage ../misc/sound-of-sorting { };
 
   sourceAndTags = callPackage ../misc/source-and-tags {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3938,6 +3938,8 @@ in {
 
   snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
 
+  snscrape = callPackage ../development/python-modules/snscrape { };
+
   snug = callPackage ../development/python-modules/snug { };
 
   snuggs = callPackage ../development/python-modules/snuggs { };


### PR DESCRIPTION
###### Motivation for this change

[snscrape](https://github.com/JustAnotherArchivist/snscrape) is a social networking service scraper that discovers URLs on Twitter, Instagram, Google Plus, and Facebook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I manually tested that this works:

```
snscrape twitter-user patio11
```