### PR TITLE
pythonPackages.pg8000: fix build

### DIFF
--- a/pkgs/development/python-modules/pg8000/default.nix
+++ b/pkgs/development/python-modules/pg8000/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pytz
+, six
 }:
 
 buildPythonPackage rec {
@@ -13,10 +14,10 @@ buildPythonPackage rec {
     sha256 = "18192d90409a3037619ef17f1924e3fd9c7169c9c1b3277cec1982116ec2b6de";
   };
 
-  propagatedBuildInputs = [ pytz ];
+  propagatedBuildInputs = [ pytz six ];
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/realazthat/aiopg8000;
+    homepage = https://github.com/mfenniak/pg8000;
     description = "PostgreSQL interface library, for asyncio";
     maintainers = with maintainers; [ garbas domenkozar ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Fix error:
```
builder for '/nix/store/l9z1mns0jngdsjhcv19ws1id5c46z51m-python2.7-pg8000-1.12.3.drv' failed with exit code 1; last 10 log lines:
  adding 'pg8000-1.12.3.dist-info/WHEEL'
  adding 'pg8000-1.12.3.dist-info/top_level.txt'
  adding 'pg8000-1.12.3.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  installing
  /build/pg8000-1.12.3/dist /build/pg8000-1.12.3
  Processing ./pg8000-1.12.3-py2.py3-none-any.whl
  Collecting six>=1.10.0 (from pg8000==1.12.3)
    Could not find a version that satisfies the requirement six>=1.10.0 (from pg8000==1.12.3) (from versions: )
  No matching distribution found for six>=1.10.0 (from pg8000==1.12.3)
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/l9z1mns0jngdsjhcv19ws1id5c46z51m-python2.7-pg8000-1.12.3.drv' failed

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

