### PR TITLE
lib/make-ext4-fs: more efficient store maker

### DIFF
--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -9,6 +9,7 @@
 , e2fsprogs
 , libfaketime
 , perl
+, lkl
 }:
 
 let
@@ -18,15 +19,12 @@ in
 pkgs.stdenv.mkDerivation {
   name = "ext4-fs.img";
 
-  nativeBuildInputs = [e2fsprogs.bin libfaketime perl];
+  nativeBuildInputs = [e2fsprogs.bin libfaketime perl lkl];
 
   buildCommand =
     ''
       # Add the closures of the top-level store objects.
       storePaths=$(cat ${sdClosureInfo}/store-paths)
-
-      # Also include a manifest of the closures in a format suitable for nix-store --load-db.
-      cp ${sdClosureInfo}/registration nix-path-registration
 
       # Make a crude approximation of the size of the target image.
       # If the script starts failing, increase the fudge factors here.
@@ -38,55 +36,16 @@ pkgs.stdenv.mkDerivation {
       truncate -s $bytes $out
       faketime -f "1970-01-01 00:00:01" mkfs.ext4 -L ${volumeLabel} -U ${uuid} $out
 
-      # Populate the image contents by piping a bunch of commands to the `debugfs` tool from e2fsprogs.
-      # For example, to copy /nix/store/abcd...efg-coreutils-8.23/bin/sleep:
-      #   cd /nix/store/abcd...efg-coreutils-8.23/bin
-      #   write /nix/store/abcd...efg-coreutils-8.23/bin/sleep sleep
-      #   sif sleep mode 040555
-      #   sif sleep gid 30000
-      # In particular, debugfs doesn't handle absolute target paths; you have to 'cd' in the virtual
-      # filesystem first. Likewise the intermediate directories must already exist (using `find`
-      # handles that for us). And when setting the file's permissions, the inode type flags (__S_IFDIR,
-      # __S_IFREG) need to be set as well.
-      (
-        echo write nix-path-registration nix-path-registration
-        echo mkdir nix
-        echo cd /nix
-        echo mkdir store
+      # Also include a manifest of the closures in a format suitable for nix-store --load-db.
+      cp ${sdClosureInfo}/registration nix-path-registration
+      cptofs -t ext4 -i $out nix-path-registration /
 
-        # XXX: This explodes in exciting ways if anything in /nix/store has a space in it.
-        find $storePaths -printf '%y %f %h %m\n'| while read -r type file dir perms; do
-          # echo "TYPE=$type DIR=$dir FILE=$file PERMS=$perms" >&2
+      # Create nix/store before copying paths
+      faketime -f "1970-01-01 00:00:01" mkdir -p nix/store
+      cptofs -t ext4 -i $out nix /
 
-          echo "cd $dir"
-          case $type in
-            d)
-              echo "mkdir $file"
-              echo sif $file mode $((040000 | 0$perms)) # magic constant is __S_IFDIR
-              ;;
-            f)
-              echo "write $dir/$file $file"
-              echo sif $file mode $((0100000 | 0$perms)) # magic constant is __S_IFREG
-              ;;
-            l)
-              echo "symlink $file $(readlink "$dir/$file")"
-              ;;
-            *)
-              echo "Unknown entry: $type $dir $file $perms" >&2
-              exit 1
-              ;;
-          esac
-
-          echo sif $file gid 30000 # chgrp to nixbld
-        done
-      ) | faketime -f "1970-01-01 00:00:01" debugfs -w $out -f /dev/stdin > errorlog 2>&1
-
-      # The debugfs tool doesn't terminate on error nor exit with a non-zero status. Check manually.
-      if egrep -q 'Could not allocate|File not found' errorlog; then
-        cat errorlog
-        echo "--- Failed to create EXT4 image of $bytes bytes (numInodes=$numInodes, numDataBlocks=$numDataBlocks) ---"
-        return 1
-      fi
+      echo "copying store paths to image..."
+      cptofs -t ext4 -i $out $storePaths /nix/store/
 
       # I have ended up with corrupted images sometimes, I suspect that happens when the build machine's disk gets full during the build.
       if ! fsck.ext4 -n -f $out; then


### PR DESCRIPTION
###### Motivation for this change

Currently making ext4 for sd_image is too slowly and breaks at paths with spaces. In this proposal I use lkl tool `cptofs` for ext4 content population.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

