### PR TITLE
minishift: 1.27.0 -> 1.29.0

### DIFF
--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -4,10 +4,9 @@
 }:
 
 let
-  version = "1.27.0";
+  version = "1.29.0";
 
   # Update these on version bumps according to Makefile
-  b2dIsoVersion = "v1.3.0";
   centOsIsoVersion = "v1.13.0";
   openshiftVersion = "v3.11.0";
 
@@ -19,7 +18,7 @@ in buildGoPackage rec {
     owner = "minishift";
     repo = "minishift";
     rev = "v${version}";
-    sha256 = "1zd9fjw90h8dlr5w7pdf1agvm51b1zckf3grwwjdg64jqpzdwg9f";
+    sha256 = "17scvv60hgk7s9fy4s9z26sc8a69ryh33rhr1f7p92kb5wfh2x40";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];
@@ -41,7 +40,6 @@ in buildGoPackage rec {
   buildFlagsArray = ''
     -ldflags=
       -X ${goPackagePath}/pkg/version.minishiftVersion=${version}
-      -X ${goPackagePath}/pkg/version.b2dIsoVersion=${b2dIsoVersion}
       -X ${goPackagePath}/pkg/version.centOsIsoVersion=${centOsIsoVersion}
       -X ${goPackagePath}/pkg/version.openshiftVersion=${openshiftVersion}
   '';
@@ -65,7 +63,7 @@ in buildGoPackage rec {
       or develop with it, day-to-day, on your local host.
     '';
     homepage = https://github.com/minishift/minishift;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz vdemeester ];
     platforms = platforms.linux;
     license = licenses.asl20;
   };


### PR DESCRIPTION
###### Motivation for this change

Bump minishift to latest release :angel: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

