### PR TITLE
datadog-agent: 6.4.2 -> 6.8.3

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -186,7 +186,7 @@ in {
       type = types.attrs;
       default = {
         init_config = {};
-        instances = [ { use-mount = "no"; } ];
+        instances = [ { use_mount = "false"; } ];
       };
     };
 

--- a/pkgs/tools/networking/dd-agent/6.nix
+++ b/pkgs/tools/networking/dd-agent/6.nix
@@ -6,14 +6,14 @@ let
 
 in buildGoPackage rec {
   name = "datadog-agent-${version}";
-  version = "6.4.2";
+  version = "6.8.3";
   owner   = "DataDog";
   repo    = "datadog-agent";
 
   src = fetchFromGitHub {
     inherit owner repo;
-    rev    = "155fddb3547919bd54530dfdb250e0cb2defae7d";
-    sha256 = "0l7ic0p2h27x386k1gzzm20af2s06cpalmqz0h0c5zq4wszmw5zy";
+    rev    = "${version}";
+    sha256 = "18kk3f10pbcxplshxzbblga6bqlkk5mgy536yy27j463l4xps92q";
   };
 
   subPackages = [
@@ -57,7 +57,7 @@ in buildGoPackage rec {
   # into standard paths.
   postInstall = ''
     mkdir -p $bin/${python.sitePackages} $bin/share/datadog-agent
-    cp -R $src/cmd/agent/dist/{conf.d,trace-agent.conf} $bin/share/datadog-agent
+    cp -R $src/cmd/agent/dist/conf.d $bin/share/datadog-agent
     cp -R $src/cmd/agent/dist/{checks,utils,config.py} $bin/${python.sitePackages}
 
     cp -R $src/pkg/status/dist/templates $bin/share/datadog-agent


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

