### PR TITLE
skopeo: 0.1.32 -> 0.1.34

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 
 let
-  version = "0.1.32";
+  version = "0.1.34";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "containers";
     repo = "skopeo";
-    sha256 = "0pyii4z9xf23lsdx4d3m5pkdyrsi4v1pbjj8l7fjgyfv8ncrjyn8";
+    sha256 = "1drbbjqih69nvgynjcz0js0vi6sgsax8565zbrmf8fkbk609c7r3";
   };
 
   defaultPolicyFile = runCommand "skopeo-default-policy.json" {} "cp ${src}/default-policy.json $out";


### PR DESCRIPTION
###### Motivation for this change

Update skopeo from 0.1.32 to 0.1.34

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
---

