### PR TITLE
mesa_noglu: fix build

### DIFF
--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -13,7 +13,8 @@
 , fetchpatch
 , debugVersion ? false
 , enableManpages ? false
-, enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform ]
+# Mesa requires AMDGPU target
+, enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform "AMDGPU" ]
 , enableSharedLibraries ? true
 }:
 

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -14,7 +14,8 @@
 , debugVersion ? false
 , enableManpages ? false
 , enableSharedLibraries ? true
-, enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform ]
+# Mesa requires AMDGPU target
+, enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform "AMDGPU" ]
 , enablePFM ? !stdenv.isDarwin
 }:
 

--- a/pkgs/development/compilers/llvm/common.nix
+++ b/pkgs/development/compilers/llvm/common.nix
@@ -2,7 +2,9 @@
 
 rec {
   llvmBackend = platform:
-    if platform.parsed.cpu.family == "x86" then
+    if builtins.typeOf platform == "string" then
+      platform
+    else if platform.parsed.cpu.family == "x86" then
       "X86"
     else if platform.parsed.cpu.name == "aarch64" then
       "AArch64"


### PR DESCRIPTION
###### Motivation for this change
LLVM’s `LLVM_TARGETS_TO_BUILD` build flag defauls to `all`, which contains `AMDGPU` [among others][1]. [Changes in llvm][2] switched to explicitly listing host and target platforms, excluding the AMDGPU target, which is required for Mesa to build.

[1]: https://github.com/llvm-mirror/llvm/blob/db50b6fe399b8ad8caef80fd8ee77607fb051fa5/CMakeLists.txt#L286-L302
[2]: https://github.com/NixOS/nixpkgs/pull/52031

I am not sure if passing the extra targets as a string is a good idea but other than keeping a list of all supported targets, I do not really see a solution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

