### PR TITLE
calibre: 3.31.0 -> 3.36.0

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.31.0";
+  version = "3.36.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1xg1bx0klvrywqry5rhci37fr7shpvb2wbx4bva20vhqkal169rw";
+    sha256 = "0fbf4b29vkka3gg8c5n9dc7qhv43jpw6naz6w83jkz7andypikb8";
   };
 
   patches = [

--- a/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
+++ b/pkgs/applications/misc/calibre/dont_build_unrar_plugin.patch
@@ -6,7 +6,7 @@ index 938ab24..1e095f8 100644
      description = _('Extract common e-book formats from archive files '
          '(ZIP/RAR). Also try to autodetect if they are actually '
          'CBZ/CBR files.')
--    file_types = set(['zip', 'rar'])
-+    file_types = set(['zip'])
+-    file_types = {'zip', 'rar'}
++    file_types = {'zip'}
      supported_platforms = ['windows', 'osx', 'linux']
      on_import = True


### PR DESCRIPTION
###### Motivation for this change

Update requested in #52788

https://calibre-ebook.com/whats-new

https://github.com/kovidgoyal/calibre/compare/v3.31.0...v3.36.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS not supported
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

