### PR TITLE
pythonPackages.update-copyright: init at 0.6.2

### DIFF
--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "update-copyright";
+  version = "0.6.2";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17ybdgbdc62yqhda4kfy1vcs1yzp78d91qfhj5zbvz1afvmvdk7z";
+  };
+
+  meta = with lib; {
+    description = "An automatic copyright update tool";
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4049,6 +4049,8 @@ in {
 
   update_checker = callPackage ../development/python-modules/update_checker {};
 
+  update-copyright = callPackage ../development/python-modules/update-copyright {};
+
   uritemplate = callPackage ../development/python-modules/uritemplate { };
 
   uproot = callPackage ../development/python-modules/uproot {};


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)

