### PR TITLE
pyflame: fix the build on machines with kernel.yama.ptrace_scope > 0

### DIFF
--- a/pkgs/development/tools/profiling/pyflame/default.nix
+++ b/pkgs/development/tools/profiling/pyflame/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, autoreconfHook, coreutils, fetchFromGitHub, fetchpatch, pkgconfig
+{ stdenv, autoreconfHook, coreutils, fetchFromGitHub, fetchpatch, pkgconfig, procps
 # pyflame needs one python version per ABI
 # are currently supported
 # * 2.6 or 2.7 for 2.x ABI
@@ -67,11 +67,12 @@ stdenv.mkDerivation rec {
     full-ptrace-seize-errors
   ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig procps ];
   buildInputs = [ python37 python36 python2 python35 ];
 
   postPatch = ''
     patchShebangs .
+
     # some tests will fail in the sandbox
     substituteInPlace tests/test_end_to_end.py \
       --replace 'skipif(IS_DOCKER' 'skipif(True'
@@ -79,6 +80,32 @@ stdenv.mkDerivation rec {
     # don't use patchShebangs here to be explicit about the python version
     substituteInPlace utils/flame-chart-json \
       --replace '#!usr/bin/env python' '#!${python3.interpreter}'
+
+    # Many tests require the build machine to have kernel.yama.ptrace_scope = 0,
+    # but hardened machines have it set to 1. On build machines that cannot run
+    # these tests, skip them to avoid breaking the build.
+    if [[ $(sysctl -n kernel.yama.ptrace_scope || echo 0) != "0" ]]; then
+      for test in \
+        test_monitor \
+        test_non_gil \
+        test_threaded \
+        test_unthreaded \
+        test_legacy_pid_handling \
+        test_exclude_idle \
+        test_exit_early \
+        test_sample_not_python \
+        test_include_ts \
+        test_include_ts_exclude_idle \
+        test_thread_dump \
+        test_no_line_numbers \
+        test_utf8_output; do
+
+        substituteInPlace tests/test_end_to_end.py \
+          --replace "def $test(" "\
+@pytest.mark.skip('build machine had kernel.yama.ptrace_scope != 0')
+def $test("
+      done
+    fi
   '';
 
   postInstall = ''

--- a/pkgs/development/tools/profiling/pyflame/default.nix
+++ b/pkgs/development/tools/profiling/pyflame/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
       PYMAJORVERSION=${lib.substring 0 1 python.version} \
         PATH=${lib.makeBinPath [ coreutils ]}\
         PYTHONPATH= \
-        ${python.pkgs.pytest}/bin/pytest tests/
+        ${python.pkgs.pytest}/bin/pytest -v tests/
       set +x
     '') (lib.filter (x: x != null) buildInputs);
 


### PR DESCRIPTION
###### Motivation for this change

This fixes #52827. cc'ing maintainer @symphorien for feedback.

Users of pyflame [need to have `kernel.yama.ptrace_scope = 0`](https://github.com/uber/pyflame/blob/d67c353b13b6950b48bbb8fcb1dde498637a4e28/docs/faq.rst#what-are-these-ptrace-permissions-errors) anyway, but it still seems useful for a machine with a hardened profile to be able to build it.

I considered asking upstream to add some `skipIf` when `ptrace_scope > 1`, but it doesn't look like they're working on pyflame right now.

I tested this PR with `kernel.yama.ptrace_scope = 0` and ` = 1`:

with `ptrace_scope = 0`:

```
============================= test session starts ==============================
platform linux -- Python 3.5.6, pytest-3.9.3, py-1.7.0, pluggy-0.8.0 -- /nix/store/zj4rl3lpr79hlzc8hqz2pwdb6zwbdpbn-python3-3.5.6/bin/python3.5m
cachedir: .pytest_cache
rootdir: /build/source, inifile:
collecting ... collected 37 items

tests/test_end_to_end.py::test_travis_build_environment SKIPPED          [  2%]
tests/test_end_to_end.py::test_rpm_build_environment PASSED              [  5%]
tests/test_end_to_end.py::test_monitor PASSED                            [  8%]
tests/test_end_to_end.py::test_non_gil PASSED                            [ 10%]
tests/test_end_to_end.py::test_threaded PASSED                           [ 13%]
tests/test_end_to_end.py::test_unthreaded PASSED                         [ 16%]
tests/test_end_to_end.py::test_legacy_pid_handling PASSED                [ 18%]
tests/test_end_to_end.py::test_legacy_pid_handling_too_many_pids PASSED  [ 21%]
tests/test_end_to_end.py::test_dash_t_and_dash_p PASSED                  [ 24%]
tests/test_end_to_end.py::test_unsupported_abi PASSED                    [ 27%]
tests/test_end_to_end.py::test_exclude_idle PASSED                       [ 29%]
tests/test_end_to_end.py::test_utf8_output SKIPPED                       [ 32%]
tests/test_end_to_end.py::test_exit_early PASSED                         [ 35%]
tests/test_end_to_end.py::test_sample_not_python PASSED                  [ 37%]
tests/test_end_to_end.py::test_trace[False-False] PASSED                 [ 40%]
tests/test_end_to_end.py::test_trace[False-True] PASSED                  [ 43%]
tests/test_end_to_end.py::test_trace[True-False] PASSED                  [ 45%]
tests/test_end_to_end.py::test_trace[True-True] PASSED                   [ 48%]
tests/test_end_to_end.py::test_trace_not_python PASSED                   [ 51%]
tests/test_end_to_end.py::test_pyflame_a_pyflame PASSED                  [ 54%]
tests/test_end_to_end.py::test_pyflame_nonexistent_file PASSED           [ 56%]
tests/test_end_to_end.py::test_trace_no_arg PASSED                       [ 59%]
tests/test_end_to_end.py::test_sample_no_arg PASSED                      [ 62%]
tests/test_end_to_end.py::test_sample_extra_args PASSED                  [ 64%]
tests/test_end_to_end.py::test_permission_error SKIPPED                  [ 67%]
tests/test_end_to_end.py::test_invalid_pid[-1] PASSED                    [ 70%]
tests/test_end_to_end.py::test_invalid_pid[0] PASSED                     [ 72%]
tests/test_end_to_end.py::test_invalid_pid[1606938044258990275541962092341162602522202993782792835301376] PASSED [ 75%]
tests/test_end_to_end.py::test_invalid_pid[not a pid] PASSED             [ 78%]
tests/test_end_to_end.py::test_include_ts PASSED                         [ 81%]
tests/test_end_to_end.py::test_include_ts_exclude_idle PASSED            [ 83%]
tests/test_end_to_end.py::test_version[-v] PASSED                        [ 86%]
tests/test_end_to_end.py::test_version[--version] PASSED                 [ 89%]
tests/test_end_to_end.py::test_trace_forker PASSED                       [ 91%]
tests/test_end_to_end.py::test_sigchld PASSED                            [ 94%]
tests/test_end_to_end.py::test_thread_dump PASSED                        [ 97%]
tests/test_end_to_end.py::test_no_line_numbers PASSED                    [100%]

==================== 34 passed, 3 skipped in 21.90 seconds =====================
```

with `ptrace_scope = 1`:

```
============================= test session starts ==============================
platform linux -- Python 3.5.6, pytest-3.9.3, py-1.7.0, pluggy-0.8.0 -- /nix/store/zj4rl3lpr79hlzc8hqz2pwdb6zwbdpbn-python3-3.5.6/bin/python3.5m
cachedir: .pytest_cache
rootdir: /build/source, inifile:
collecting ... collected 37 items

tests/test_end_to_end.py::test_travis_build_environment SKIPPED          [  2%]
tests/test_end_to_end.py::test_rpm_build_environment PASSED              [  5%]
tests/test_end_to_end.py::test_monitor SKIPPED                           [  8%]
tests/test_end_to_end.py::test_non_gil SKIPPED                           [ 10%]
tests/test_end_to_end.py::test_threaded SKIPPED                          [ 13%]
tests/test_end_to_end.py::test_unthreaded SKIPPED                        [ 16%]
tests/test_end_to_end.py::test_legacy_pid_handling SKIPPED               [ 18%]
tests/test_end_to_end.py::test_legacy_pid_handling_too_many_pids PASSED  [ 21%]
tests/test_end_to_end.py::test_dash_t_and_dash_p PASSED                  [ 24%]
tests/test_end_to_end.py::test_unsupported_abi PASSED                    [ 27%]
tests/test_end_to_end.py::test_exclude_idle SKIPPED                      [ 29%]
tests/test_end_to_end.py::test_utf8_output SKIPPED                       [ 32%]
tests/test_end_to_end.py::test_exit_early SKIPPED                        [ 35%]
tests/test_end_to_end.py::test_sample_not_python SKIPPED                 [ 37%]
tests/test_end_to_end.py::test_trace[False-False] PASSED                 [ 40%]
tests/test_end_to_end.py::test_trace[False-True] PASSED                  [ 43%]
tests/test_end_to_end.py::test_trace[True-False] PASSED                  [ 45%]
tests/test_end_to_end.py::test_trace[True-True] PASSED                   [ 48%]
tests/test_end_to_end.py::test_trace_not_python PASSED                   [ 51%]
tests/test_end_to_end.py::test_pyflame_a_pyflame PASSED                  [ 54%]
tests/test_end_to_end.py::test_pyflame_nonexistent_file PASSED           [ 56%]
tests/test_end_to_end.py::test_trace_no_arg PASSED                       [ 59%]
tests/test_end_to_end.py::test_sample_no_arg PASSED                      [ 62%]
tests/test_end_to_end.py::test_sample_extra_args PASSED                  [ 64%]
tests/test_end_to_end.py::test_permission_error SKIPPED                  [ 67%]
tests/test_end_to_end.py::test_invalid_pid[-1] PASSED                    [ 70%]
tests/test_end_to_end.py::test_invalid_pid[0] PASSED                     [ 72%]
tests/test_end_to_end.py::test_invalid_pid[1606938044258990275541962092341162602522202993782792835301376] PASSED [ 75%]
tests/test_end_to_end.py::test_invalid_pid[not a pid] PASSED             [ 78%]
tests/test_end_to_end.py::test_include_ts SKIPPED                        [ 81%]
tests/test_end_to_end.py::test_include_ts_exclude_idle SKIPPED           [ 83%]
tests/test_end_to_end.py::test_version[-v] PASSED                        [ 86%]
tests/test_end_to_end.py::test_version[--version] PASSED                 [ 89%]
tests/test_end_to_end.py::test_trace_forker PASSED                       [ 91%]
tests/test_end_to_end.py::test_sigchld PASSED                            [ 94%]
tests/test_end_to_end.py::test_thread_dump SKIPPED                       [ 97%]
tests/test_end_to_end.py::test_no_line_numbers SKIPPED                   [100%]

==================== 22 passed, 15 skipped in 12.10 seconds ====================
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS not supported
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

