### PR TITLE
libdeflate: init at 1.1

### DIFF
--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "libdeflate-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "ebiggers";
+    repo = "libdeflate";
+    rev = "v${version}";
+    sha256 = "1wqxwza6rwmhrsy9sw86pdcd0w742gbzsy9qxnq6kk59m6h1dbsb";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace /usr $out
+  '';
+
+  configurePhase = ''
+    make programs/config.h
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Fast DEFLATE/zlib/gzip compressor and decompressor";
+    license = licenses.mit;
+    homepage = https://github.com/ebiggers/libdeflate;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10700,6 +10700,8 @@ in
 
   libde265 = callPackage ../development/libraries/libde265 {};
 
+  libdeflate = callPackage ../development/libraries/libdeflate { };
+
   libdevil = callPackage ../development/libraries/libdevil {
     inherit (darwin.apple_sdk.frameworks) OpenGL;
   };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).