### PR TITLE
musescore: 2.3.2 -> 3.0

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig
 , alsaLib, freetype, libjack2, lame, libogg, libpulseaudio, libsndfile, libvorbis
 , portaudio, portmidi, qtbase, qtdeclarative, qtscript, qtsvg, qttools
-, qtwebkit, qtxmlpatterns
+, qtwebengine, qtxmlpatterns
 }:
 
 stdenv.mkDerivation rec {
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "0g8n8xpw5d6wh8bwbvy12sinl9i0ir009sr28i4izr28lr4x8v50";
   };
 
+  patches = [
+    ./remove_qtwebengine_install_hack.patch
+  ];
+
   cmakeFlags = [
   ] ++ lib.optional (lib.versionAtLeast freetype.version "2.5.2") "-DUSE_SYSTEM_FREETYPE=ON";
 
@@ -23,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsaLib libjack2 freetype lame libogg libpulseaudio libsndfile libvorbis
     portaudio portmidi # tesseract
-    qtbase qtdeclarative qtscript qtsvg qttools qtwebkit qtxmlpatterns
+    qtbase qtdeclarative qtscript qtsvg qttools qtwebengine qtxmlpatterns
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "musescore-${version}";
-  version = "2.3.2";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner  = "musescore";
     repo   = "MuseScore";
     rev    = "v${version}";
-    sha256 = "0ncv0xfmq87plqa43cm0fpidlwzz1nq5s7h7139llrbc36yp3pr1";
+    sha256 = "0g8n8xpw5d6wh8bwbvy12sinl9i0ir009sr28i4izr28lr4x8v50";
   };
 
   cmakeFlags = [

--- a/pkgs/applications/audio/musescore/remove_qtwebengine_install_hack.patch
+++ b/pkgs/applications/audio/musescore/remove_qtwebengine_install_hack.patch
@@ -1,0 +1,25 @@
+--- a/mscore/CMakeLists.txt
++++ b/mscore/CMakeLists.txt
+@@ -660,22 +660,6 @@ if (MINGW)
+ else (MINGW)
+
+    if ( NOT MSVC )
+-## install qwebengine core
+-      if (NOT APPLE AND USE_WEBENGINE)
+-         install(FILES
+-            ${QT_INSTALL_LIBEXECS}/QtWebEngineProcess
+-            DESTINATION bin
+-            )
+-         install(DIRECTORY
+-            ${QT_INSTALL_DATA}/resources
+-            DESTINATION lib/qt5
+-            )
+-         install(DIRECTORY
+-            ${QT_INSTALL_TRANSLATIONS}/qtwebengine_locales
+-            DESTINATION lib/qt5/translations
+-            )
+-      endif(NOT APPLE AND USE_WEBENGINE)
+-
+       target_link_libraries(mscore
+          ${ALSA_LIB}
+          ${QT_LIBRARIES}


### PR DESCRIPTION

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

