### PR TITLE
libsigcxx: 2.10.0 → 2.10.1

### DIFF
--- a/pkgs/development/libraries/libsigcxx/default.nix
+++ b/pkgs/development/libraries/libsigcxx/default.nix
@@ -1,19 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, gnum4 }:
-let
-  ver_maj = "2.10"; # odd major numbers are unstable
-  ver_min = "0";
-in
+{ stdenv, fetchurl, pkgconfig, gnum4, gnome3 }:
+
 stdenv.mkDerivation rec {
-  name = "libsigc++-${ver_maj}.${ver_min}";
+  pname = "libsigc++";
+  version = "2.10.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libsigc++/${ver_maj}/${name}.tar.xz";
-    sha256 = "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "00v08km4wwzbh6vjxb21388wb9dm6g2xh14rgwabnv4c2wk5z8n9";
   };
 
   nativeBuildInputs = [ pkgconfig gnum4 ];
 
   doCheck = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "libsigcxx";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://libsigcplusplus.github.io/libsigcplusplus/;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

