### PR TITLE
fakeroot: Add sed dependency.

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, getopt, libcap }:
+{ stdenv, fetchurl, fetchpatch, getopt, libcap, gnused }:
 
 stdenv.mkDerivation rec {
   version = "1.23";
@@ -29,14 +29,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ getopt ]
+  buildInputs = [ getopt gnused ]
     ++ stdenv.lib.optional (!stdenv.isDarwin) libcap
     ;
 
   postUnpack = ''
-    for prog in getopt; do
-      sed -i "s@getopt@$(type -p getopt)@g" ${name}/scripts/fakeroot.in
-    done
+    sed -i -e "s@getopt@$(type -p getopt)@g" -e "s@sed@$(type -p sed)@g" ${name}/scripts/fakeroot.in
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
If fakeroot is used in a build script, fakeroot fails to do its job.

###### Things done
Hardcode dependency.
Run resulting "fakeroot"

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

