### PR TITLE
Add a callHackage variant that doesn't require all-cabal-hashes

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -176,6 +176,17 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
 
     callHackage = name: version: callPackageKeepDeriver (self.hackage2nix name version);
 
+    # This function does not depend on all-cabal-hashes and therefore will work
+    # for any version that has been released on hackage as opposed to only
+    # versions released before whatever version of all-cabal-hashes you happen
+    # to be currently using.
+    callHackageDirect = {pkg, ver, sha256}@args:
+      let pkgver = "${pkg}-${ver}";
+      in self.callCabal2nix pkg (pkgs.fetchzip {
+           url = "http://hackage.haskell.org/package/${pkgver}/${pkgver}.tar.gz";
+           inherit sha256;
+         }) {};
+
     # Creates a Haskell package from a source package by calling cabal2nix on the source.
     callCabal2nixWithOptions = name: src: extraCabal2nixOptions: args:
       let

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -185,7 +185,7 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
       in self.callCabal2nix pkg (pkgs.fetchzip {
            url = "http://hackage.haskell.org/package/${pkgver}/${pkgver}.tar.gz";
            inherit sha256;
-         }) {};
+         });
 
     # Creates a Haskell package from a source package by calling cabal2nix on the source.
     callCabal2nixWithOptions = name: src: extraCabal2nixOptions: args:


### PR DESCRIPTION
###### Motivation for this change

Because callHackage uses all-cabal-hashes to avoid requiring the user to specify a hash, it does not work for any package versions that have been uploaded after the version of all-cabal-hashes that you happen to have.  In my experience this means that probably greater than half the time `callHackage` doesn't work for me, and I have to fall back to `fetchFromGitHub`.  This is a pretty poor user experience and is also less reliable because github packages can be deleted, but hackage releases cannot.

This function works for any package that has been released on hackage.  I have been using it recently in some of my production projects and it has been working fine.  It would be really nice to have it available in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

