### PR TITLE
libuchardet: 0.0.5 → 0.0.6

### DIFF
--- a/pkgs/development/libraries/libuchardet/default.nix
+++ b/pkgs/development/libraries/libuchardet/default.nix
@@ -1,25 +1,31 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "libuchardet-${version}";
+  pname = "uchardet";
+  version = "0.0.6";
 
-  version = "0.0.5";
+  outputs = [ "bin" "out" "man" "dev" ];
 
-  src = fetchFromGitHub {
-    owner  = "BYVoid";
-    repo   = "uchardet";
-    rev    = "v${version}";
-    sha256 = "0rkym5bhq3hn7623fy0fggw0qaghha71k8bi41ywqd2lchpahrrm";
+  src = fetchurl {
+    url = "https://www.freedesktop.org/software/${pname}/releases/${pname}-${version}.tar.xz";
+    sha256 = "0q9c02b6nmw41yfsiqsnphgc3f0yg3fj31wkccp47cmwvy634lc3";
   };
 
   buildInputs = [ cmake ];
 
-  doCheck = false; # fails all the tests (ctest)
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
+    # TODO: move the following to CMake setup hook
+    "-DCMAKE_INSTALL_BINDIR=${placeholder "bin"}/bin"
+    "-DCMAKE_INSTALL_MANDIR=${placeholder "man"}/share/man"
+  ];
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Mozilla's Universal Charset Detector C/C++ API";
-    homepage    = https://www.byvoid.com/zht/project/uchardet;
-    license     = licenses.mpl11;
+    homepage = https://www.freedesktop.org/wiki/Software/uchardet/;
+    license = licenses.mpl11;
     maintainers = with maintainers; [ cstrahan ];
     platforms = with platforms; unix;
   };


### PR DESCRIPTION
###### Motivation for this change
cc @cstrahan 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

