### PR TITLE
Switch default linux package to the new LTS, 4.19

### DIFF
--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, kernel }:
 
 stdenv.mkDerivation rec {
-  version = "1.5.2";
+  version = "2.0.2";
   name = "ena-${version}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "amzn";
     repo = "amzn-drivers";
     rev = "ena_linux_${version}";
-    sha256 = "18wf36092kr3zlpnqdkcdlim3vvjxy5f24zzsv4fwa7xg12mcfjm";
+    sha256 = "0vb8s0w7ddwajk5gj5nqqlqc63p8p556f9ccwviwda2zvgqmk2pb";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "pgiri";
     repo = "ndiswrapper";
-    rev = "f4d16afb29ab04408d02e38d4ea1148807778e21";
-    sha256 = "0iaw0vhchmqf1yh14v4a6whnbg4sx1hag8a4hrsh4fzgw9fx0ij4";
+    rev = "5e29f6a9d41df949b435066c173e3b1947f179d3";
+    sha256 = "0sprrmxxkf170bmh1nz9xw00gs89dddr84djlf666bn5bhy6jffi";
   };
 
   buildInputs = [ perl libelf ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14683,7 +14683,7 @@ in
   });
 
   # The current default kernel / kernel modules.
-  linuxPackages = linuxPackages_4_14;
+  linuxPackages = linuxPackages_4_19;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!


### PR DESCRIPTION
> Version | Maintainer | Released | Projected EOL
> -- | -- | -- | --
> 4.19 | Greg Kroah-Hartman | 2018-10-22 | Dec, 2020

 * https://www.kernel.org/category/releases.html

#### Motivation for this change

An unwritten rule, but as far as I know, `linuxPackages` always points to the most recent LTS by the time the next NixOS release is made. Let's do this, especially since 4.20 is now released.

This branch also fixes the [two failing modules](https://hydra.nixos.org/jobset/nixos/trunk-combined/jobs-tab?filter=linuxPackages_4_19). As far as **building** is concerned, nothing is broken currently. As far as *testing* and using things built with 4.19, I hope that those using `_latest` and `_testing` got enough testing done that we won't see any issues for most commonly used packages.

An additional motivation is [to ensure `sd_image` won't hold back the channel](https://github.com/NixOS/nixpkgs/pull/52721#issuecomment-449833856) when the latest kernel version is released. This ensures that, at least, the kernel won't be downgraded from the sd image. #52886 makes it use the default kernel and adds a new `sd_image_new_kernel` mirroring the existing `iso_minimal_new_kernel`. (Here it's not aarch64 at fault, but the fact that there's a moving target into the tested path.)

#### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @NeQuissimus our kernel wizard

cc @vcunat who was involved in the last `linuxPackages` change.

##### `linuxPackages.ena`

cc @edolstra, maintainer of it. Looks fine, but it's a major upgrade which I cannot test.
