### PR TITLE
gping: init at 1.1

### DIFF
--- a/pkgs/tools/networking/gping/default.nix
+++ b/pkgs/tools/networking/gping/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, iputils
+, python3
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gping";
+  version = "1.1";
+
+  propagatedBuildInputs = with python3Packages; [ colorama ];
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname  = "pinggraph";
+    sha256 = "0q5ma98457zb6vxsnhmrr3p38j1vg0gl155y0adzfg67wlniac92";
+  };
+
+  # Make path to ping explicit
+  postFixup = ''
+    substituteInPlace $out/${python3.sitePackages}/gping/pinger.py \
+      --replace 'subprocess.getoutput("ping ' 'subprocess.getoutput("${iputils}/bin/ping ' \
+      --replace 'args = ["ping"]' 'args = ["${iputils}/bin/ping"]'
+  '';
+
+  meta = with lib; {
+    description = "Ping, but with a graph";
+    homepage = https://github.com/orf/gping;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ andrew-d ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1477,6 +1477,8 @@ in
 
   gosu = callPackage ../tools/misc/gosu { };
 
+  gping = callPackage ../tools/networking/gping { };
+
   greg = callPackage ../applications/audio/greg {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change
[gping](https://github.com/orf/gping) is a utility to display a graph of ping timing in a terminal.  It looks like this:
![screencast](https://github.com/orf/gping/raw/master/doc/readme_screencast.gif)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

