### PR TITLE
luakit: add HTTPS support

### DIFF
--- a/pkgs/applications/networking/browsers/luakit/default.nix
+++ b/pkgs/applications/networking/browsers/luakit/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchFromGitHub, pkgconfig, wrapGAppsHook, makeWrapper
 ,help2man, lua5, luafilesystem, luajit, sqlite
-,webkitgtk, gtk3, gst_all_1}:
+,webkitgtk, gtk3, gst_all_1, glib-networking}:
 
 let
   lualibs = [luafilesystem];
@@ -27,7 +27,8 @@ in stdenv.mkDerivation rec {
     gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly
     gst_all_1.gst-libav
-                ];
+    glib-networking
+  ];
 
   postPatch =
     #Kind of ugly seds here. There must be a better solution.

--- a/pkgs/applications/networking/browsers/luakit/default.nix
+++ b/pkgs/applications/networking/browsers/luakit/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
     gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly
     gst_all_1.gst-libav
-    glib-networking
+    glib-networking # TLS support
   ];
 
   postPatch =


### PR DESCRIPTION
###### Motivation for this change

The current `luakit` package doesn't include `glib-networking` as a dependency. Thus when accessing HTTPS sites `luakit` blocks the site, claiming it's _untrusted_.

This change adds `glib-networking` so that `luakit` supports HTTPS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~
   - [x] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after): previous package 968318936, new package 1068268984
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

