### PR TITLE
detect-secrets: init at 0.11.0

### DIFF
--- a/pkgs/development/python-modules/unidiff/default.nix
+++ b/pkgs/development/python-modules/unidiff/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "unidiff";
+  version = "0.5.5";
+
+  # PyPI tarball doesn't ship tests
+  src = fetchFromGitHub {
+    owner = "matiasb";
+    repo = "python-unidiff";
+    rev = "v${version}";
+    sha256 = "1nvi7s1nn5p7j6aql1nkn2kiadnfby98yla5m3jq8xwsx0aplwdm";
+  };
+
+  meta = with lib; {
+    description = "Unified diff python parsing/metadata extraction library";
+    homepage = https://github.com/matiasb/python-unidiff;
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/development/tools/detect-secrets/default.nix
+++ b/pkgs/development/tools/detect-secrets/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonApplication, fetchFromGitHub, isPy27, pyyaml, unidiff, configparser, enum34, future, functools32, mock, pytest }:
+
+buildPythonApplication rec {
+  pname = "detect-secrets";
+  version = "0.11.0";
+
+  # PyPI tarball doesn't ship tests
+  src = fetchFromGitHub {
+    owner = "Yelp";
+    repo = "detect-secrets";
+    rev = "v${version}";
+    sha256 = "11r11q6d8aajqqnhhz4lsa93qf1x745331kl9jd3z4y4w91l4gdz";
+  };
+
+  propagatedBuildInputs = [ pyyaml unidiff ]
+    ++ lib.optionals isPy27 [ configparser enum34 future functools32 ];
+
+  checkInputs = [ mock pytest ];
+
+  # deselect tests which require git setup
+  checkPhase = ''
+    PYTHONPATH=$PWD:$PYTHONPATH pytest \
+      --deselect tests/main_test.py::TestMain \
+      --deselect tests/pre_commit_hook_test.py::TestPreCommitHook \
+      --deselect tests/core/baseline_test.py::TestInitializeBaseline
+  '';
+
+  meta = with lib; {
+    description = "An enterprise friendly way of detecting and preventing secrets in code";
+    homepage = https://github.com/Yelp/detect-secrets;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -700,6 +700,8 @@ in
 
   deskew = callPackage ../applications/graphics/deskew { };
 
+  detect-secrets = python3Packages.callPackage ../development/tools/detect-secrets { };
+
   diskus = callPackage ../tools/misc/diskus {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4382,6 +4382,8 @@ in {
 
   unicodecsv = callPackage ../development/python-modules/unicodecsv { };
 
+  unidiff = callPackage ../development/python-modules/unidiff { };
+
   unittest2 = callPackage ../development/python-modules/unittest2 { };
 
   unittest-xml-reporting = callPackage ../development/python-modules/unittest-xml-reporting { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

