### PR TITLE
pythonPackages.tinyprog: init at 1.0.21

### DIFF
--- a/pkgs/development/python-modules/intelhex/default.nix
+++ b/pkgs/development/python-modules/intelhex/default.nix
@@ -6,17 +6,17 @@
 
 buildPythonPackage rec {
   pname = "intelhex";
-  version = "2.1";
+  version = "2.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0k5l1mn3gv1vb0jd24ygxksx8xqr57y1ivgyj37jsrwpzrp167kw";
+    sha256 = "009d8511e0d50639230c39af9607deee771cf026f67ef7507a8c3fd4fa927832";
   };
 
   patches = [
     (fetchurl {
-      url = https://github.com/bialix/intelhex/commit/f251aef214daa2116e15ff7f7dcec1639eb12d5b.patch;
-      sha256 = "02i15qjmcz7mwbwvyj3agl5y7098rag2iwypdilkaadhbslsl9b9";
+      url = https://github.com/bialix/intelhex/commit/1597874d2bce3e5cefa1c0bf10cf2e98b6181337.patch;
+      sha256 = "19a5b535brgpsm1y9b37i4465k0z7skxijw44ykv7kpirh8mzxaq";
     })
   ];
 

--- a/pkgs/development/python-modules/jsonmerge/default.nix
+++ b/pkgs/development/python-modules/jsonmerge/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, jsonschema }:
+
+buildPythonPackage rec {
+  pname = "jsonmerge";
+  version = "1.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c05229545d55c1bbfdb3fa11c7f8a1c9868c713af209059ac48e7d86fa9c6a1f";
+  };
+
+  propagatedBuildInputs = [ jsonschema ];
+
+  meta = with stdenv.lib; {
+    description = "Merge a series of JSON documents";
+    homepage = "https://github.com/avian2/jsonmerge";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/tinyprog/default.nix
+++ b/pkgs/development/python-modules/tinyprog/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, intelhex
+, jsonmerge
+, packaging  
+, pyserial
+, pyusb
+, six
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "tinyprog";
+  version = "1.0.21";
+  format = "wheel";
+
+  src = fetchPypi ({
+    inherit pname version format;
+  } // (if isPy3k then {
+    python = "py3";
+    sha256 = "f347e97a0f2cd67b6cc0331f6b64b284c45e644e12cd4183fa84919c1ea0e151";
+  } else {
+    python = "py2";
+    sha256 = "1987dffe4d17e9bdb03db17e70a0a0e713b2b8c3a523b57ecc8b1bd5e9091a68";  
+  }));
+
+  propagatedBuildInputs = [ pyusb tqdm six jsonmerge pyserial intelhex packaging ];
+
+  meta = with stdenv.lib; {
+    description = "Programmer for FPGA boards using the TinyFPGA USB Bootloader";
+    homepage = "https://github.com/tinyfpga/TinyFPGA-Bootloader/";
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2757,6 +2757,8 @@ in {
 
   jsondiff = callPackage ../development/python-modules/jsondiff { };
 
+  jsonmerge = callPackage ../development/python-modules/jsonmerge { };
+
   jsonnet = buildPythonPackage {
     inherit (pkgs.jsonnet) name src;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4010,6 +4010,8 @@ in {
 
   texttable = callPackage ../development/python-modules/texttable { };
 
+  tinyprog = callPackage ../development/python-modules/tinyprog {};
+
   tiros = callPackage ../development/python-modules/tiros { };
 
   tifffile = callPackage ../development/python-modules/tifffile { };


### PR DESCRIPTION
###### Motivation for this change

Add python lib. This required to add `jsonmerge` library and bump version for `intelhex` (done in separate commits).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

