### PR TITLE
Move some gnome libs to toplevel

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-keyring.nix
@@ -33,7 +33,7 @@ with lib;
 
     environment.systemPackages = [ pkgs.gnome3.gnome-keyring ];
 
-    services.dbus.packages = [ pkgs.gnome3.gnome-keyring pkgs.gnome3.gcr ];
+    services.dbus.packages = [ pkgs.gnome3.gnome-keyring pkgs.gcr ];
 
   };
 

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, meson, ninja, pkgconfig
 , python3, gtk3, gst_all_1, libsecret, libsoup
-, appstream-glib, desktop-file-utils, gnome3
+, appstream-glib, desktop-file-utils, totem-pl-parser
 , gobject-introspection, wrapGAppsHook }:
 
 python3.pkgs.buildPythonApplication rec  {
@@ -28,7 +28,6 @@ python3.pkgs.buildPythonApplication rec  {
   ];
 
   buildInputs = with gst_all_1; [
-    gnome3.totem-pl-parser
     gst-libav
     gst-plugins-bad
     gst-plugins-base
@@ -38,6 +37,7 @@ python3.pkgs.buildPythonApplication rec  {
     gtk3
     libsecret
     libsoup
+    totem-pl-parser
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -6,6 +6,7 @@
 , intltool
 , libsoup
 , gnome3
+, totem-pl-parser
 , tdb
 , json-glib
 , itstool
@@ -48,7 +49,7 @@ in stdenv.mkDerivation rec {
 
     gtk3
     gnome3.libpeas
-    gnome3.totem-pl-parser
+    totem-pl-parser
     gnome3.defaultIconTheme
 
     gst_all_1.gstreamer

--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -27,6 +27,7 @@
 , sysprof
 , template-glib
 , vala
+, vte
 , webkitgtk
 , wrapGAppsHook
 }:
@@ -64,7 +65,7 @@ in stdenv.mkDerivation {
     gnome3.devhelp
     libgit2-glib
     gnome3.libpeas
-    gnome3.vte
+    vte
     gspell
     gtk3
     gtksourceview4

--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, meson, ninja, gtk3, libexif, libgphoto2, libsoup, libxml2, vala, sqlite
-, webkitgtk, pkgconfig, gnome3, gst_all_1, libgudev, libraw, glib, json-glib
+, webkitgtk, pkgconfig, gnome3, gst_all_1, libgudev, libraw, glib, json-glib, gcr
 , gettext, desktop-file-utils, gdk_pixbuf, librsvg, wrapGAppsHook
 , gobject-introspection, itstool, libgdata, python3 }:
 
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee
     libgudev gnome3.gexiv2 gnome3.gsettings-desktop-schemas
     libraw json-glib glib gdk_pixbuf librsvg gnome3.rest
-    gnome3.gcr gnome3.defaultIconTheme libgdata
+    gcr gnome3.defaultIconTheme libgdata
   ];
 
   postPatch = ''

--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, vala, atk, cairo, glib, gnome3, gtk3, libwnck3
 , libX11, libXfixes, libXi, pango, intltool, pkgconfig, libxml2
-, bamf, gdk_pixbuf, libdbusmenu-gtk3, file
+, bamf, gdk_pixbuf, libdbusmenu-gtk3, file, gnome-menus
 , wrapGAppsHook, autoreconfHook, gobject-introspection }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     autoreconfHook
   ];
 
-  buildInputs = [ vala atk cairo glib gnome3.gnome-menus
+  buildInputs = [ vala atk cairo glib gnome-menus
                   gtk3 gnome3.libgee libwnck3 libX11 libXfixes
                   libXi pango gnome3.gnome-common bamf gdk_pixbuf
                   libdbusmenu-gtk3 gnome3.dconf ];

--- a/pkgs/applications/misc/pmenu/default.nix
+++ b/pkgs/applications/misc/pmenu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, python2Packages, gnome3 }:
+{ stdenv, fetchFromGitLab, python2Packages, gnome-menus }:
 
 stdenv.mkDerivation rec {
   name = "pmenu-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python2Packages.wrapPython ];
 
-  buildInputs = [ python2Packages.pygtk gnome3.gnome-menus ];
+  buildInputs = [ python2Packages.pygtk gnome-menus ];
 
   pythonPath = [ python2Packages.pygtk ];
     

--- a/pkgs/applications/misc/terminator/default.nix
+++ b/pkgs/applications/misc/terminator/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python2, keybinder3, intltool, file, gtk3, gobject-introspection
-, libnotify, wrapGAppsHook, gnome3
+, libnotify, wrapGAppsHook, vte
 }:
 
 python2.pkgs.buildPythonApplication rec {
@@ -12,7 +12,7 @@ python2.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ file intltool wrapGAppsHook gobject-introspection ];
-  buildInputs = [ gtk3 gnome3.vte libnotify keybinder3 ];
+  buildInputs = [ gtk3 vte libnotify keybinder3 ];
   propagatedBuildInputs = with python2.pkgs; [ pygobject3 psutil pycairo ];
 
   postPatch = ''

--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, vte, gtk3, ncurses, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, pkgconfig, vte-ng, gtk3, ncurses, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "termite-${version}";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "VERSION=v${version}" "PREFIX=" "DESTDIR=$(out)" ];
 
-  buildInputs = [ vte gtk3 ncurses ];
+  buildInputs = [ vte-ng gtk3 ncurses ];
 
   nativeBuildInputs = [ wrapGAppsHook pkgconfig ];
 

--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, ninja, pkgconfig, intltool, vala, wrapGAppsHook
+{ stdenv, fetchurl, cmake, ninja, pkgconfig, intltool, vala, wrapGAppsHook, gcr
 , gtk3, webkitgtk, sqlite, gsettings-desktop-schemas, libsoup, glib-networking, gnome3
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk3 webkitgtk sqlite gsettings-desktop-schemas gnome3.gcr
+    gtk3 webkitgtk sqlite gsettings-desktop-schemas gcr
     (libsoup.override { gnomeSupport = true; }) gnome3.libpeas
     glib-networking
   ];

--- a/pkgs/applications/networking/newsreaders/pan/default.nix
+++ b/pkgs/applications/networking/newsreaders/pan/default.nix
@@ -2,7 +2,7 @@
 , stdenv, fetchurl, pkgconfig, gtk3, gtkspell3 ? null
 , perl, gmime2, gettext, intltool, itstool, libxml2, dbus-glib, libnotify, gnutls
 , makeWrapper, gnupg
-, gnomeSupport ? true, gnome3, libsecret
+, gnomeSupport ? true, libsecret, gcr
 }:
 
 assert spellChecking -> gtkspell3 != null;
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig gettext intltool itstool libxml2 makeWrapper ];
   buildInputs = [ gtk3 gmime2 libnotify gnutls ]
     ++ stdenv.lib.optional spellChecking gtkspell3
-    ++ stdenv.lib.optionals gnomeSupport [ libsecret gnome3.gcr ];
+    ++ stdenv.lib.optionals gnomeSupport [ libsecret gcr ];
 
   configureFlags = [
     "--with-dbus"

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchurl, pkgconfig, intltool, itstool, python3, wrapGAppsHook
 , python3Packages, gst_all_1, gtk3
-, gobject-introspection, librsvg, gnome3, libnotify
+, gobject-introspection, librsvg, gnome3, libnotify, gsound
 , meson, ninja
 }:
 
@@ -47,7 +47,7 @@ in python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [ meson ninja pkgconfig intltool itstool python3 wrapGAppsHook ];
 
   buildInputs = [
-    gobject-introspection gtk3 librsvg gnome3.gnome-desktop gnome3.gsound
+    gobject-introspection gtk3 librsvg gnome3.gnome-desktop gsound
     gnome3.defaultIconTheme
     gnome3.gsettings-desktop-schemas libnotify
     gst-transcoder

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -8,7 +8,7 @@
 , seccompSupport ? stdenv.isLinux, libseccomp
 , pulseSupport ? !stdenv.isDarwin, libpulseaudio
 , sdlSupport ? !stdenv.isDarwin, SDL2
-, gtkSupport ? !stdenv.isDarwin && !xenSupport, gtk3, gettext, gnome3
+, gtkSupport ? !stdenv.isDarwin && !xenSupport, gtk3, gettext, vte
 , vncSupport ? true, libjpeg, libpng
 , smartcardSupport ? true, libcacard
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     ++ optionals numaSupport [ numactl ]
     ++ optionals pulseSupport [ libpulseaudio ]
     ++ optionals sdlSupport [ SDL2 ]
-    ++ optionals gtkSupport [ gtk3 gettext gnome3.vte ]
+    ++ optionals gtkSupport [ gtk3 gettext vte ]
     ++ optionals vncSupport [ libjpeg libpng ]
     ++ optionals smartcardSupport [ libcacard ]
     ++ optionals spiceSupport [ spice-protocol spice ]

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -23,7 +23,7 @@ let
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
     deepin-sound-theme = callPackage ./deepin-sound-theme { };
     deepin-terminal = callPackage ./deepin-terminal {
-      inherit (pkgs.gnome3) libgee vte;
+      inherit (pkgs.gnome3) libgee;
       wnck = pkgs.libwnck3;
     };
     deepin-wallpapers = callPackage ./deepin-wallpapers { };

--- a/pkgs/desktops/gnome-3/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/apps/seahorse/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, vala, meson, ninja
 , pkgconfig, gtk3, glib, gobject-introspection
 , wrapGAppsHook, itstool, gnupg, libsoup
-, gnome3, gpgme, python3, openldap
+, gnome3, gpgme, python3, openldap, gcr
 , libsecret, avahi, p11-kit, openssh }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     python3 gobject-introspection
   ];
   buildInputs = [
-    gtk3 glib gnome3.gcr
+    gtk3 glib gcr
     gnome3.gsettings-desktop-schemas gnupg
     gnome3.defaultIconTheme gpgme
     libsecret avahi libsoup p11-kit

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, substituteAll, pkgconfig, gnome3, python3, gobject-introspection
-, intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3
+, intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3, gcr
 , p11-kit, db, nspr, nss, libical, gperf, wrapGAppsHook, glib-networking, pcre
 , vala, cmake, ninja, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib }:
 

--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, gettext, pkgconfig, spidermonkey_52, glib
-, gnome3, substituteAll }:
+, gnome3, gnome-menus, substituteAll }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extensions-${version}";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix_gmenu.patch;
-      gmenu_path = "${gnome3.gnome-menus}/lib/girepository-1.0";
+      gmenu_path = "${gnome-menus}/lib/girepository-1.0";
     })
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -2,7 +2,7 @@
 , python3Packages, libsoup, polkit, clutter, networkmanager, docbook_xsl , docbook_xsl_ns, at-spi2-core
 , libstartup_notification, telepathy-glib, telepathy-logger, libXtst, unzip, glibcLocales, shared-mime-info
 , libgweather, libcanberra-gtk3, librsvg, geoclue2, perl, docbook_xml_dtd_42, desktop-file-utils
-, libpulseaudio, libical, gobject-introspection, gstreamer, wrapGAppsHook, libxslt
+, libpulseaudio, libical, gobject-introspection, gstreamer, wrapGAppsHook, libxslt, gcr
 , accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet
 , sassc, systemd, gst_all_1 }:
 

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -3,7 +3,7 @@
 , libstartup_notification, telepathy-glib, telepathy-logger, libXtst, unzip, glibcLocales, shared-mime-info
 , libgweather, libcanberra-gtk3, librsvg, geoclue2, perl, docbook_xml_dtd_42, desktop-file-utils
 , libpulseaudio, libical, gobject-introspection, gstreamer, wrapGAppsHook, libxslt, gcr
-, accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet
+, accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet, libgnomekbd
 , sassc, systemd, gst_all_1 }:
 
 # http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/gnome-base/gnome-shell/gnome-shell-3.10.2.1.ebuild?revision=1.3&view=markup
@@ -56,8 +56,7 @@ in stdenv.mkDerivation rec {
     })
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit (gnome3) libgnomekbd;
-      inherit unzip;
+      inherit libgnomekbd unzip;
     })
   ];
 

--- a/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, sqlite
 , gnome3, libxml2, gupnp, gssdp, lua5, liboauth, gupnp-av
-, gmime, json-glib, avahi, tracker, dleyna-server, itstool }:
+, gmime, json-glib, avahi, tracker, dleyna-server, itstool, totem-pl-parser }:
 
 let
   pname = "grilo-plugins";
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     gnome3.grilo libxml2 gupnp gssdp gnome3.libgdata
     lua5 liboauth gupnp-av sqlite gnome3.gnome-online-accounts
-    gnome3.totem-pl-parser gnome3.rest gmime json-glib
+    totem-pl-parser gnome3.rest gmime json-glib
     avahi gnome3.libmediaart tracker dleyna-server
   ];
 

--- a/pkgs/desktops/gnome-3/core/grilo/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, vala, glib, liboauth, gtk3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43
-, libxml2, gnome3, gobject-introspection, libsoup }:
+, libxml2, gnome3, gobject-introspection, libsoup, totem-pl-parser }:
 
 let
   pname = "grilo";
@@ -34,7 +34,7 @@ in stdenv.mkDerivation rec {
     meson ninja pkgconfig gettext gobject-introspection vala
     gtk-doc docbook_xsl docbook_xml_dtd_43
   ];
-  buildInputs = [ glib liboauth gtk3 libxml2 libsoup gnome3.totem-pl-parser ];
+  buildInputs = [ glib liboauth gtk3 libxml2 libsoup totem-pl-parser ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, intltool, gst_all_1
 , clutter-gtk, clutter-gst, python3Packages, shared-mime-info
-, pkgconfig, gtk3, glib, gobject-introspection
+, pkgconfig, gtk3, glib, gobject-introspection, totem-pl-parser
 , wrapGAppsHook, itstool, libxml2, vala, gnome3
 , gdk_pixbuf, tracker, nautilus }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja vala pkgconfig intltool python3Packages.python itstool gobject-introspection wrapGAppsHook ];
   buildInputs = [
-    gtk3 glib gnome3.grilo clutter-gtk clutter-gst gnome3.totem-pl-parser gnome3.grilo-plugins
+    gtk3 glib gnome3.grilo clutter-gtk clutter-gst totem-pl-parser gnome3.grilo-plugins
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly gst_all_1.gst-libav gnome3.libpeas shared-mime-info
     gdk_pixbuf libxml2 gnome3.defaultIconTheme gnome3.gnome-desktop

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -2,7 +2,7 @@
 , meson, ninja, pkgconfig, vala, wrapGAppsHook, bzip2, dbus, evolution-data-server
 , exempi, flac, giflib, glib, gnome3, gst_all_1, icu, json-glib, libcue, libexif
 , libgrss, libgsf, libiptcdata, libjpeg, libpng, libseccomp, libsoup, libtiff, libuuid
-, libvorbis, libxml2, poppler, taglib, upower }:
+, libvorbis, libxml2, poppler, taglib, upower, totem-pl-parser }:
 
 let
   pname = "tracker-miners";
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
     giflib
     glib
     gnome3.gexiv2
-    gnome3.totem-pl-parser
+    totem-pl-parser
     gnome3.tracker
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -73,8 +73,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   evince = callPackage ./core/evince { }; # ToDo: dbus would prevent compilation, enable tests
 
   evolution-data-server = callPackage ./core/evolution-data-server { };
-
-  gcr = callPackage ./core/gcr { }; # ToDo: tests fail
 
   gdm = callPackage ./core/gdm { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -113,8 +113,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   libgnome-keyring = callPackage ./core/libgnome-keyring { };
 
   libgnomekbd = callPackage ./core/libgnomekbd { };
-
-  folks = callPackage ./core/folks { };
 
   gnome-online-accounts = callPackage ./core/gnome-online-accounts { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -109,8 +109,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   gnome-keyring = callPackage ./core/gnome-keyring { };
 
   libgnome-keyring = callPackage ./core/libgnome-keyring { };
-
-  libgnomekbd = callPackage ./core/libgnomekbd { };
 
   gnome-online-accounts = callPackage ./core/gnome-online-accounts { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -202,8 +202,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   sushi = callPackage ./core/sushi { };
 
   totem = callPackage ./core/totem { };
-
-  totem-pl-parser = callPackage ./core/totem-pl-parser { };
 
   tracker = callPackage ./core/tracker { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -147,8 +147,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   grilo-plugins = callPackage ./core/grilo-plugins { };
 
   gsettings-desktop-schemas = callPackage ./core/gsettings-desktop-schemas { };
-
-  gsound = callPackage ./core/gsound { };
 
   gucharmap = callPackage ./core/gucharmap { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd vte vte_290 vte-ng;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd vte vte_290 vte-ng gnome-menus;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -103,8 +103,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   gnome-disk-utility = callPackage ./core/gnome-disk-utility { };
 
   gnome-font-viewer = callPackage ./core/gnome-font-viewer { };
-
-  gnome-menus = callPackage ./core/gnome-menus { };
 
   gnome-keyring = callPackage ./core/gnome-keyring { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -38,7 +38,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd;
+    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd vte vte_290 vte-ng;
 
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
@@ -200,12 +200,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   tracker = callPackage ./core/tracker { };
 
   tracker-miners = callPackage ./core/tracker-miners { };
-
-  vte = callPackage ./core/vte { };
-
-  vte_290 = callPackage ./core/vte/2.90.nix { };
-
-  vte-ng = callPackage ./core/vte/ng.nix { };
 
   vino = callPackage ./core/vino { };
 

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_40, enchant
 , wrapGAppsHook, gdk_pixbuf, cmake, ninja, desktop-file-utils
 , libnotify, libcanberra-gtk3, libsecret, gmime, isocodes
-, gobject-introspection, libpthreadstubs, sqlite
+, gobject-introspection, libpthreadstubs, sqlite, gcr
 , gnome3, librsvg, gnome-doc-utils, webkitgtk, fetchpatch }:
 
 let
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobject-introspection ];
   buildInputs = [
     gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
-    libpthreadstubs gnome3.gsettings-desktop-schemas gnome3.gcr isocodes
+    libpthreadstubs gnome3.gsettings-desktop-schemas gcr isocodes
     gdk_pixbuf librsvg gnome3.defaultIconTheme
   ];
 

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, itstool, libxml2, mate, gnome3, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, itstool, libxml2, mate, gnome3, gtk3, vte, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-terminal-${version}";
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
 
      mate.mate-desktop
 
-     gnome3.vte
-     gnome3.gtk
+     vte
+     gtk3
      gnome3.dconf
   ];
 

--- a/pkgs/desktops/pantheon/apps/pantheon-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/pantheon-terminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, cmake, vala_0_38, pkgconfig, glib, gtk3, granite, gnome3, libnotify, gettext, wrapGAppsHook, gobject-introspection }:
+{ stdenv, fetchurl, perl, cmake, vala_0_38, pkgconfig, glib, gtk3, granite, gnome3, vte_290, libnotify, gettext, wrapGAppsHook, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   majorVersion = "0.4";

--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -81,9 +81,7 @@ makeScope newScope (self: with self; {
 
   xfce4-taskmanager = callPackage ./xfce4-taskmanager { };
 
-  xfce4-terminal = callPackage ./xfce4-terminal {
-    inherit (gnome3) vte;
-  };
+  xfce4-terminal = callPackage ./xfce4-terminal { };
 
   xfce4-volumed-pulse = callPackage ./xfce4-volumed-pulse { };
 

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -1,20 +1,19 @@
 { fetchurl, stdenv, pkgconfig, glib, gnome3, nspr, intltool, gobject-introspection
-, vala, sqlite, libxml2, dbus-glib, libsoup, nss, dbus
+, vala, sqlite, libxml2, dbus-glib, libsoup, nss, dbus, libgee
 , telepathy-glib, evolution-data-server, libsecret, db }:
 
 # TODO: enable more folks backends
 
-let
+stdenv.mkDerivation rec {
+  pname = "folks";
   version = "0.11.4";
-in stdenv.mkDerivation rec {
-  name = "folks-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/folks/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "16hqh2gxlbx0b0hgq216hndr1m72vj54jvryzii9zqkk0g9kxc57";
   };
 
-  propagatedBuildInputs = [ glib gnome3.libgee sqlite ];
+  propagatedBuildInputs = [ glib libgee sqlite ];
   # dbus_daemon needed for tests
   buildInputs = [
     dbus-glib telepathy-glib evolution-data-server dbus
@@ -33,19 +32,15 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "folks";
-      attrPath = "gnome3.folks";
+      packageName = pname;
       versionPolicy = "none";
     };
   };
 
   meta = {
-    description = "Folks";
-
+    description = "A library that aggregates people from multiple sources to create metacontacts";
     homepage = https://wiki.gnome.org/Projects/Folks;
-
     license = stdenv.lib.licenses.lgpl2Plus;
-
     maintainers = gnome3.maintainers;
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
   };

--- a/pkgs/development/libraries/gcr/default.nix
+++ b/pkgs/development/libraries/gcr/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnupg, p11-kit, glib
-, libgcrypt, libtasn1, dbus-glib, gtk, pango, gdk_pixbuf, atk
+, libgcrypt, libtasn1, dbus-glib, gtk3, pango, gdk_pixbuf, atk
 , gobject-introspection, makeWrapper, libxslt, vala, gnome3
 , python2 }:
 
 stdenv.mkDerivation rec {
-  name = "gcr-${version}";
+  pname = "gcr";
   version = "3.28.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gcr/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "02xgky22xgvhgd525khqh64l5i21ca839fj9jzaqdi3yvb8pbq8m";
   };
 
   passthru = {
-    updateScript = gnome3.updateScript { packageName = "gcr"; attrPath = "gnome3.gcr"; };
+    updateScript = gnome3.updateScript { packageName = pname; };
   };
 
   postPatch = ''
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     gpg libgcrypt libtasn1 dbus-glib pango gdk_pixbuf atk
   ];
 
-  propagatedBuildInputs = [ glib gtk p11-kit ];
+  propagatedBuildInputs = [ glib gtk3 p11-kit ];
 
   checkInputs = [ python2 ];
   doCheck = false; # fails 21 out of 603 tests, needs dbus daemon

--- a/pkgs/development/libraries/gnome-menus/default.nix
+++ b/pkgs/development/libraries/gnome-menus/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, intltool, pkgconfig, glib, gobject-introspection }:
 
 stdenv.mkDerivation rec {
-  name = "gnome-menus-${version}";
+  pname = "gnome-menus";
   version = "3.10.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-menus/3.10/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0wcacs1vk3pld8wvrwq7fdrm11i56nrajkrp6j1da6jc4yx0m5a6";
   };
 
@@ -16,8 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://www.gnome.org;
-    description = "Gnome menu specification";
-
+    description = "Library that implements freedesktops's Desktop Menu Specification in GNOME";
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/gsound/default.nix
+++ b/pkgs/development/libraries/gsound/default.nix
@@ -1,13 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, libcanberra, gobject-introspection, libtool, gnome3 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "gsound";
   version = "1.0.2";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "bba8ff30eea815037e53bee727bbd5f0b6a2e74d452a7711b819a7c444e78e53";
   };
 
@@ -17,7 +15,6 @@ in stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;
-      attrPath = "gnome3.${pname}";
     };
   };
 

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, atk, cairo, dmd, gdk_pixbuf, gnome3, gst_all_1, librsvg
-, pango, pkgconfig, which }:
+, pango, pkgconfig, which, vte }:
 
 stdenv.mkDerivation rec {
   name = "gtkd-${version}";
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   inherit atk cairo gdk_pixbuf librsvg pango;
-  inherit (gnome3) glib gtk3 gtksourceview libgda libpeas vte;
+  inherit (gnome3) glib gtk3 gtksourceview libgda libpeas;
   inherit (gst_all_1) gstreamer;
   gst_plugins_base = gst_all_1.gst-plugins-base;
 

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -2,7 +2,7 @@
 , glib, libgudev, udisks2, libgcrypt, libcap, polkit
 , libgphoto2, avahi, libarchive, fuse, libcdio
 , libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, samba, libmtp
-, gnomeSupport ? false, gnome, makeWrapper
+, gnomeSupport ? false, gnome, makeWrapper, gcr
 , libimobiledevice, libbluray, libcdio-paranoia, libnfs, openssh
 , libsecret, libgdata, python3
 }:

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxml2, glib, json-glib
+{ stdenv, fetchurl, pkgconfig, intltool, libxml2, glib, json-glib, gcr
 , gobject-introspection, liboauth, gnome3, p11-kit, openssl, uhttpmock }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0fj54yqxdapdppisqm1xcyrpgcichdmipq0a0spzz6009ikzgi45";
   };
 
-  NIX_CFLAGS_COMPILE = "-I${gnome3.libsoup.dev}/include/libsoup-gnome-2.4/ -I${gnome3.gcr}/include/gcr-3 -I${gnome3.gcr}/include/gck-1";
+  NIX_CFLAGS_COMPILE = "-I${gnome3.libsoup.dev}/include/libsoup-gnome-2.4/ -I${gcr}/include/gcr-3 -I${gcr}/include/gck-1";
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
 

--- a/pkgs/development/libraries/libgnomekbd/default.nix
+++ b/pkgs/development/libraries/libgnomekbd/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, pkgconfig, file, intltool, glib, gtk3, libxklavier, makeWrapper, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "libgnomekbd-${version}";
+  pname = "libgnomekbd";
   version = "3.26.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libgnomekbd/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "ea3b418c57c30615f7ee5b6f718def7c9d09ce34637324361150744258968875";
   };
 
   passthru = {
-    updateScript = gnome3.updateScript { packageName = "libgnomekbd"; attrPath = "gnome3.libgnomekbd"; };
+    updateScript = gnome3.updateScript { packageName = pname; };
   };
 
   nativeBuildInputs = [ pkgconfig file intltool makeWrapper ];

--- a/pkgs/development/libraries/totem-pl-parser/default.nix
+++ b/pkgs/development/libraries/totem-pl-parser/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gmime, libxml2, gobject-introspection, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "totem-pl-parser-${version}";
+  pname = "totem-pl-parser";
   version = "3.26.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/totem-pl-parser/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0k5pnka907invgds48d73c1xx1a366v5dcld3gr2l1dgmjwc9qka";
   };
 
   passthru = {
-    updateScript = gnome3.updateScript { packageName = "totem-pl-parser"; attrPath = "gnome3.totem-pl-parser"; };
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext gobject-introspection ];

--- a/pkgs/development/libraries/vte/2.90.nix
+++ b/pkgs/development/libraries/vte/2.90.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gnome3, ncurses, gobject-introspection }:
+{ stdenv, fetchurl, intltool, pkgconfig, gnome3, glib, gtk3, ncurses, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   versionMajor = "0.36";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gobject-introspection intltool gnome3.glib gnome3.gtk3 ncurses ];
+  buildInputs = [ gobject-introspection intltool glib gtk3 ncurses ];
 
   configureFlags = [ "--enable-introspection" ];
 

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -1,27 +1,27 @@
 { stdenv, fetchurl, intltool, pkgconfig
-, gnome3, ncurses, gobject-introspection, vala, libxml2, gnutls
+, gnome3, glib, gtk3, ncurses, gobject-introspection, vala, libxml2, gnutls
 , gperf, pcre2
 }:
 
 stdenv.mkDerivation rec {
-  name = "vte-${version}";
+  pname = "vte";
   version = "0.54.3";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/vte/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1zgb8jgi6sr4km58zfml8zkm24qipbngl2h7s5razhi5a0a84dk9";
   };
 
   passthru = {
-    updateScript = gnome3.updateScript { packageName = "vte"; attrPath = "gnome3.vte"; };
+    updateScript = gnome3.updateScript { packageName = pname; };
   };
 
   nativeBuildInputs = [ gobject-introspection intltool pkgconfig vala gperf libxml2 ];
-  buildInputs = [ gnome3.glib gnome3.gtk3 ncurses ];
+  buildInputs = [ glib gtk3 ncurses ];
 
   propagatedBuildInputs = [
     # Required by vte-2.91.pc.
-    gnome3.gtk3
+    gtk3
     gnutls
     pcre2
   ];

--- a/pkgs/development/libraries/vte/ng.nix
+++ b/pkgs/development/libraries/vte/ng.nix
@@ -1,6 +1,6 @@
-{ gnome3, fetchFromGitHub, autoconf, automake, gtk-doc, gettext, libtool, gperf }:
+{ vte, fetchFromGitHub, autoconf, automake, gtk-doc, gettext, libtool, gperf }:
 
-gnome3.vte.overrideAttrs (oldAttrs: rec {
+vte.overrideAttrs (oldAttrs: rec {
   name = "vte-ng-${version}";
   version = "0.50.2.a";
 

--- a/pkgs/tools/networking/network-manager/applet.nix
+++ b/pkgs/tools/networking/network-manager/applet.nix
@@ -2,7 +2,7 @@
 , libnotify, libsecret, polkit, isocodes, modemmanager, libxml2, docbook_xsl, docbook_xml_dtd_43
 , mobile-broadband-provider-info, glib-networking, gsettings-desktop-schemas
 , libgudev, jansson, wrapGAppsHook, gobject-introspection, python3
-, libappindicator-gtk3, withGnome ? false }:
+, libappindicator-gtk3, withGnome ? false, gcr }:
 
 let
   pname = "network-manager-applet";
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
     polkit isocodes mobile-broadband-provider-info libgudev
     modemmanager jansson glib-networking
     libappindicator-gtk3 gnome3.defaultIconTheme
-  ] ++ stdenv.lib.optionals withGnome [ gnome3.gcr ]; # advanced certificate chooser
+  ] ++ stdenv.lib.optionals withGnome [ gcr ]; # advanced certificate chooser
 
   nativeBuildInputs = [ meson ninja intltool pkgconfig wrapGAppsHook gobject-introspection python3 gtk-doc docbook_xsl docbook_xml_dtd_43 libxml2 ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9752,6 +9752,8 @@ in
 
   folly = callPackage ../development/libraries/folly { };
 
+  folks = callPackage ../development/libraries/folks { };
+
   makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
     callPackage ../development/libraries/fontconfig/make-fonts-conf.nix {
       inherit fontconfig fontDirectories;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12886,6 +12886,12 @@ in
 
   vsqlite = callPackage ../development/libraries/vsqlite { };
 
+  vte = callPackage ../development/libraries/vte { };
+
+  vte_290 = callPackage ../development/libraries/vte/2.90.nix { };
+
+  vte-ng = callPackage ../development/libraries/vte/ng.nix { };
+
   vtk = callPackage ../development/libraries/vtk {
     inherit (darwin) cf-private libobjc;
     inherit (darwin.apple_sdk.libs) xpc;
@@ -17439,9 +17445,7 @@ in
     inherit (gnome2) gtk;
   };
 
-  guake = callPackage ../applications/misc/guake {
-    inherit (gnome3) vte;
-  };
+  guake = callPackage ../applications/misc/guake { };
 
   guitone = callPackage ../applications/version-management/guitone {
     graphviz = graphviz_2_32;
@@ -19114,9 +19118,7 @@ in
 
   udiskie = python3Packages.callPackage ../applications/misc/udiskie { };
 
-  sakura = callPackage ../applications/misc/sakura {
-    vte = gnome3.vte;
-  };
+  sakura = callPackage ../applications/misc/sakura { };
 
   sayonara = callPackage ../applications/audio/sayonara { };
 
@@ -19201,7 +19203,6 @@ in
   ssvnc = callPackage ../applications/networking/remote/ssvnc { };
 
   stupidterm = callPackage ../applications/misc/stupidterm {
-    vte = gnome3.vte;
     gtk = gtk3;
   };
 
@@ -19504,18 +19505,14 @@ in
 
   terminus = callPackage ../applications/misc/terminus { };
 
-  lxterminal = callPackage ../applications/misc/lxterminal {
-    vte = gnome3.vte;
-  };
+  lxterminal = callPackage ../applications/misc/lxterminal { };
 
   aminal = callPackage ../applications/misc/aminal {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa Kernel;
     inherit (darwin) cf-private;
   };
 
-  termite-unwrapped = callPackage ../applications/misc/termite {
-    vte = gnome3.vte-ng;
-  };
+  termite-unwrapped = callPackage ../applications/misc/termite { };
 
   termite = callPackage ../applications/misc/termite/wrapper.nix { termite = termite-unwrapped; };
 
@@ -19551,7 +19548,6 @@ in
   tig = gitAndTools.tig;
 
   tilda = callPackage ../applications/misc/tilda {
-    vte = gnome3.vte;
     gtk = gtk3;
   };
 
@@ -19759,7 +19755,6 @@ in
   virt-what = callPackage ../applications/virtualization/virt-what { };
 
   virtmanager = callPackage ../applications/virtualization/virt-manager {
-    vte = gnome3.vte;
     dconf = gnome3.dconf;
     system-libvirt = libvirt;
   };
@@ -20261,13 +20256,12 @@ in
   xterm = callPackage ../applications/misc/xterm { };
 
   mlterm = callPackage ../applications/misc/mlterm {
-    vte = gnome3.vte;
     libssh2 = null;
     openssl = null;
   };
 
   roxterm = callPackage ../applications/misc/roxterm {
-    inherit (gnome3) gsettings-desktop-schemas vte;
+    inherit (gnome3) gsettings-desktop-schemas;
   };
 
   termonad-with-packages = callPackage ../applications/misc/termonad {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10145,6 +10145,8 @@ in
 
   gnome-sharp = callPackage ../development/libraries/gnome-sharp { mono = mono4; };
 
+  gnome-menus = callPackage ../development/libraries/gnome-menus { };
+
   granite = callPackage ../development/libraries/granite { };
   elementary-cmake-modules = callPackage ../development/libraries/elementary-cmake-modules { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12773,6 +12773,8 @@ in
 
   torch-hdf5 = callPackage ../development/libraries/torch-hdf5 {};
 
+  totem-pl-parser = callPackage ../development/libraries/totem-pl-parser { };
+
   tremor = callPackage ../development/libraries/tremor { };
 
   twolame = callPackage ../development/libraries/twolame { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10786,6 +10786,8 @@ in
   libgnome-keyring = callPackage ../development/libraries/libgnome-keyring { };
   libgnome-keyring3 = gnome3.libgnome-keyring;
 
+  libgnomekbd = callPackage ../development/libraries/libgnomekbd { };
+
   libglvnd = callPackage ../development/libraries/libglvnd { };
 
   libgnurl = callPackage ../development/libraries/libgnurl { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10089,6 +10089,8 @@ in
 
   gsoap = callPackage ../development/libraries/gsoap { };
 
+  gsound = callPackages ../development/libraries/gsound { };
+
   gss = callPackage ../development/libraries/gss { };
 
   gtkimageview = callPackage ../development/libraries/gtkimageview { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4834,7 +4834,7 @@ in
   };
 
   pinentry_gnome = res.pinentry.override {
-    gcr = gnome3.gcr;
+    inherit gcr;
   };
 
   pinentry_qt4 = res.pinentry.override {
@@ -9786,6 +9786,8 @@ in
   ganv = callPackage ../development/libraries/ganv { };
 
   gcab = callPackage ../development/libraries/gcab { };
+
+  gcr = callPackages ../development/libraries/gcr { };
 
   gdome2 = callPackage ../development/libraries/gdome2 {
     inherit (gnome2) gtkdoc;


### PR DESCRIPTION
###### Motivation for this change
cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

