### PR TITLE
pythonPackages.apio: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/apio/default.nix
+++ b/pkgs/development/python-modules/apio/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, fetchurl
+, click
+, colorama
+, pyjwt
+, pyserial
+, requests
+, semantic-version
+}:
+
+buildPythonPackage rec {
+  pname = "apio";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "25f6a13cf037d60cbf6612311de0f0553c26865d63a2ec7686af428826a90663";
+  };
+
+  patches = [
+    (fetchurl {
+      url = https://github.com/FPGAwars/apio/commit/f8dd8774de0e6f3d57d72214fa6675f0a9c6f310.patch;
+      sha256 = "0yf1shi6bb6cn1ikj1g38hf4752rqi082x0y5q66rm29yjp7jy6r";
+    })
+  ];
+
+  propagatedBuildInputs = [ requests colorama pyjwt pyserial click semantic-version ];
+
+  meta = with stdenv.lib; {
+    description = "Open source ecosystem for open FPGA boards";
+    homepage = "https://github.com/FPGAwars/apio";
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -182,6 +182,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  apio = callPackage ../development/python-modules/apio { };
+
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
###### Motivation for this change

Add new Python library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

