### PR TITLE
sd-image-aarch64: use default (LTS) kernel

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64-new-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64-new-kernel.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  imports = [ ./sd-image-aarch64.nix ];
+
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+}

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -26,7 +26,6 @@ in
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;
-  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # The serial ports listed here are:
   # - ttyS0: for Tegra (Jetson TX1)

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -172,6 +172,14 @@ in rec {
     inherit system;
   });
 
+  sd_image_new_kernel = forMatchingSystems [ "aarch64-linux" ] (system: makeSdImage {
+    module = {
+        aarch64-linux = ./modules/installer/cd-dvd/sd-image-aarch64-new-kernel.nix;
+      }.${system};
+    type = "minimal-new-kernel";
+    inherit system;
+  });
+
   # A bootable VirtualBox virtual appliance as an OVA file (i.e. packaged OVF).
   ova = forMatchingSystems [ "x86_64-linux" ] (system:
 


### PR DESCRIPTION
###### Motivation for this change

A follow-up to #52863 and https://github.com/NixOS/nixpkgs/pull/52721#issuecomment-449833856.

With this merged, please only paired with #52863 (so no sd-image with a regressed kernel gets built), this will fix the current issue holding back channel updates.

This uses the same kernel as it does for `iso-image`, the default kernel, usually the most recent LTS. This also adds a new attribute on `release.nix` `sd_image_new_kernel` which is like `iso_minimal_new_kernel`.

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Do note that `sd_image_new_kernel` currently doesn't build, for the same reason `sd_image` currently doesn't. When the `zfs` issues for Linux 4.20 will be fixed, it should be fixed as well.