### PR TITLE
pythonPackages.sip: rename the module from PyQt5.sip back to sip

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -28,6 +28,8 @@ in buildPythonPackage {
     sha256 = "0wqh4srqkcc03rvkwrcshaa028psrq58xkys6npnyhqxc0apvdf9";
   };
 
+  patches = [ ./sip.patch ];
+
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig qmake lndir ];
@@ -61,7 +63,6 @@ in buildPythonPackage {
   '';
 
   postInstall = ''
-    ln -s ${sip}/${python.sitePackages}/PyQt5/* $out/${python.sitePackages}/PyQt5
     for i in $out/bin/*; do
       wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
     done

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -47,10 +47,6 @@ in buildPythonPackage {
 
     export PYTHONPATH=$PYTHONPATH:$out/${python.sitePackages}
 
-    substituteInPlace configure.py \
-      --replace 'install_dir=pydbusmoddir' "install_dir='$out/${python.sitePackages}/dbus/mainloop'" \
-      --replace "ModuleMetadata(qmake_QT=['webkitwidgets'])" "ModuleMetadata(qmake_QT=['webkitwidgets', 'printsupport'])"
-
     ${python.executable} configure.py  -w \
       --confirm-license \
       --dbus=${dbus.dev}/include/dbus-1.0 \

--- a/pkgs/development/python-modules/pyqt/sip.patch
+++ b/pkgs/development/python-modules/pyqt/sip.patch
@@ -1,0 +1,36 @@
+--- a/configure.py
++++ b/configure.py
+@@ -2440,7 +2440,7 @@ def get_sip_flags(target_config):
+     the target configuration.
+     """
+ 
+-    sip_flags = ['-n', 'PyQt5.sip']
++    sip_flags = []
+ 
+     # If we don't check for signed interpreters, we exclude the 'VendorID'
+     # feature
+--- a/designer/pluginloader.cpp
++++ b/designer/pluginloader.cpp
+@@ -167,7 +167,7 @@ bool PyCustomWidgets::importPlugins(const QString &dir, const QStringList &plugi
+     // Make sure we have sip.unwrapinstance.
+     if (!sip_unwrapinstance)
+     {
+-        sip_unwrapinstance = getModuleAttr("PyQt5.sip", "unwrapinstance");
++        sip_unwrapinstance = getModuleAttr("sip", "unwrapinstance");
+ 
+         if (!sip_unwrapinstance)
+             return true;
+--- a/qmlscene/pluginloader.cpp
++++ b/qmlscene/pluginloader.cpp
+@@ -412,9 +412,9 @@ PyObject *PyQt5QmlPlugin::getModuleAttr(const char *module, const char *attr)
+ void PyQt5QmlPlugin::getSipAPI()
+ {
+ #if defined(SIP_USE_PYCAPSULE)
+-    sip = (const sipAPIDef *)PyCapsule_Import("PyQt5.sip._C_API", 0);
++    sip = (const sipAPIDef *)PyCapsule_Import("sip._C_API", 0);
+ #else
+-    PyObject *c_api = getModuleAttr("PyQt5.sip", "_C_API");
++    PyObject *c_api = getModuleAttr("sip", "_C_API");
+ 
+     if (c_api)
+     {

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -14,7 +14,6 @@ buildPythonPackage rec {
 
   configurePhase = ''
     ${python.executable} ./configure.py \
-      --sip-module PyQt5.sip \
       -d $out/lib/${python.libPrefix}/site-packages \
       -b $out/bin -e $out/include
   '';


### PR DESCRIPTION
###### Motivation for this change

PyQt5 5.11 wants a copy of sip in PyQt5.sip to ensure that sip-generated PyQt5 modules have the correct sip runtime version. This issue is not relevant to Nixpkgs, therefore PyQt5 may be reverted to use the common sip runtime.

This is an alternative to #52613 that does not break packages that need to import sip.

Fixes the build of tortoisehg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).