### PR TITLE
looking-glass-client: a11 -> a12

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,24 +1,24 @@
 { stdenv, fetchFromGitHub
-, pkgconfig, SDL2, SDL, SDL2_ttf, openssl, spice-protocol, fontconfig
+, cmake, pkgconfig, SDL2, SDL, SDL2_ttf, openssl, spice-protocol, fontconfig
 , libX11, freefont_ttf, nettle, libconfig
 }:
 
 stdenv.mkDerivation rec {
   name = "looking-glass-client-${version}";
-  version = "a11";
+  version = "a12";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "0q4isn86pl5wddf6h8qd62fw3577ns2sd2myzw969sbl796bwcil";
+    sha256 = "0r6bvl9q94039r6ff4f2bg8si95axx9w8bf1h1qr5730d2kv5yxq";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [
     SDL SDL2 SDL2_ttf openssl spice-protocol fontconfig
-    libX11 freefont_ttf nettle libconfig
+    libX11 freefont_ttf nettle libconfig cmake
   ];
 
   enableParallelBuilding = true;
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
   sourceRoot = "source/client";
 
   installPhase = ''
-    mkdir -p $out
-    mv bin $out/
+    mkdir -p $out/bin
+    mv looking-glass-client $out/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
There was a new upstream release. (A very good one, too.)

Looking Glass a12 now uses cmake, so aside from updating the hashes I had to adjust a couple other things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(I'm very new to Nix, sorry if I've not done this correctly.)