### PR TITLE
qogir-theme: init at 2018-11-12

### DIFF
--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  pname = "qogir";
+  pname = "qogir-theme";
   version = "2018-11-12";
 
   src = fetchFromGitHub {

--- a/pkgs/data/themes/qogir/default.nix
+++ b/pkgs/data/themes/qogir/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, gdk_pixbuf, librsvg, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "qogir";
+  version = "2018-11-12";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "16hzgdl7d6jrd3gq0kmxad46gijc4hlxzy2rs3gqsfxqfj32nhqz";
+  };
+
+  buildInputs = [ gdk_pixbuf librsvg ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    patchShebangs .
+    mkdir -p $out/share/themes
+    name= ./Install -d $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A flat Design theme for GTK based desktop environments";
+    homepage = https://vinceliuice.github.io/Qogir-theme;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15718,6 +15718,8 @@ in
 
   proggyfonts = callPackage ../data/fonts/proggyfonts { };
 
+  qogir-theme = callPackage ../data/themes/qogir { };
+
   route159 = callPackage ../data/fonts/route159 { };
 
   sampradaya = callPackage ../data/fonts/sampradaya { };


### PR DESCRIPTION
###### Motivation for this change

Add [qogir-theme](https://github.com/vinceliuice/Qogir-theme)

>[Qogir](https://www.gnome-look.org/p/1230631/) is a flat Design theme for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Unity, Budgie, Pantheon, XFCE, Mate, etc.

![qogir](https://user-images.githubusercontent.com/1217934/50442082-85b04c00-08e4-11e9-9b2f-a1aab4987ae9.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).