### PR TITLE
system-path: set implicitly installed packages to be low-priority

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -7,7 +7,7 @@ with lib;
 
 let
 
-  requiredPackages =
+  requiredPackages = map lib.lowPrio
     [ config.nix.package
       pkgs.acl
       pkgs.attr


### PR DESCRIPTION
The aim is to minimize surprises: when the user explicitly installs a package in their configuration, it should override any package implicitly installed by NixOS.

I'm half-wondering whether this should go through the RFC process, but I'd guess it's not of a large enough change to deserve it. If you think it should, please say so :)