### PR TITLE
elixir_1_8: init at 1.8.0-rc.1

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -69,6 +69,9 @@ let
           debugInfo = true;
         };
 
+        # Remove old versions of elixir, when the supports fades out:
+        #   https://hexdocs.pm/elixir/compatibility-and-deprecations.html
+
         lfe = lfe_1_2;
         lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };
 

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -44,6 +44,11 @@ let
         # BEAM-based languages.
         elixir = elixir_1_7;
 
+        elixir_1_8 = lib.callElixir ../interpreters/elixir/1.8.nix {
+          inherit rebar erlang;
+          debugInfo = true;
+        };
+
         elixir_1_7 = lib.callElixir ../interpreters/elixir/1.7.nix {
           inherit rebar erlang;
           debugInfo = true;

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -69,11 +69,6 @@ let
           debugInfo = true;
         };
 
-        elixir_1_3 = lib.callElixir ../interpreters/elixir/1.3.nix {
-          inherit rebar erlang;
-          debugInfo = true;
-        };
-
         lfe = lfe_1_2;
         lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };
 

--- a/pkgs/development/interpreters/elixir/1.3.nix
+++ b/pkgs/development/interpreters/elixir/1.3.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation rec {
-  version = "1.3.4";
-  sha256 = "01qqv1ghvfadcwcr5p88w8j217cgaf094pmpqllij3l0q1yg104l";
-  minimumOTPVersion = "18";
-}

--- a/pkgs/development/interpreters/elixir/1.8.nix
+++ b/pkgs/development/interpreters/elixir/1.8.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.8.0-rc.1";
+  sha256 = "06k9q46cwn79ic6kw0b0mskf9rqlgm02jb8n1ajz55kmw134kq6m";
+  minimumOTPVersion = "20";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7697,7 +7697,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
+    elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
     lfe lfe_1_2;
 
   inherit (beam.packages.erlang)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7697,7 +7697,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
+    elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4
     lfe lfe_1_2;
 
   inherit (beam.packages.erlang)

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -61,7 +61,8 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang) elixir elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
+    inherit (packages.erlang)
+      elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -61,8 +61,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang)
-      elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
+    inherit (packages.erlang) elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };


### PR DESCRIPTION
###### Motivation for this change

A new Elixir minor version is available in release candidate. I’ve added it as an option for those who want to start using it early, however `elixir_1_7` remains the current default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

