### PR TITLE
arrow-cpp: fix build

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, symlinkJoin, fetchurl, fetchFromGitHub, boost, brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest, lz4, perl, python, rapidjson, snappy, thrift, which, zlib, zstd }:
+{ stdenv, symlinkJoin, fetchurl, fetchFromGitHub, boost, brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest_static, lz4, perl, python, rapidjson, snappy, thrift, which, zlib, zstd }:
 
 let
   parquet-testing = fetchFromGitHub {
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   FLATBUFFERS_HOME = flatbuffers;
   GFLAGS_HOME = gflags;
   GLOG_HOME = glog;
-  GTEST_HOME = gtest;
+  GTEST_HOME = symlinkJoin { name="gtest-wrap"; paths = [ gtest_static gtest_static.dev ]; };
   LZ4_HOME = symlinkJoin { name="lz4-wrap"; paths = [ lz4 lz4.dev ]; };
   RAPIDJSON_HOME = rapidjson;
   SNAPPY_HOME = symlinkJoin { name="snappy-wrap"; paths = [ snappy snappy.dev ]; };

--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, cmake, ninja, fetchFromGitHub }:
+{ stdenv, cmake, ninja, fetchFromGitHub
+, static ? false }:
+
 stdenv.mkDerivation rec {
   name = "gtest-${version}";
   version = "1.8.1";
@@ -14,9 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-  ];
+  cmakeFlags = stdenv.lib.optional (!static) "-DBUILD_SHARED_LIBS=ON";
 
   meta = with stdenv.lib; {
     description = "Google's framework for writing C++ tests";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3160,7 +3160,8 @@ in
 
   gt5 = callPackage ../tools/system/gt5 { };
 
-  gtest = callPackage ../development/libraries/gtest {};
+  gtest = callPackage ../development/libraries/gtest { };
+  gtest_static = callPackage ../development/libraries/gtest { static = true; };
   gmock = gtest; # TODO: move to aliases.nix
 
   gbenchmark = callPackage ../development/libraries/gbenchmark {};


### PR DESCRIPTION
Fixes: 1f6b09506145 ('gtest: build shared library')
Closes: #52928

###### Motivation for this change

arrow-cpp is broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
