### PR TITLE
mcfly: init at v0.3.1

### DIFF
--- a/pkgs/tools/misc/mcfly/default.nix
+++ b/pkgs/tools/misc/mcfly/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  name = "mcfly-${version}";
+  version = "v0.3.1";
+  rev = "${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "cantino";
+    repo = "mcfly";
+    sha256 = "0pmyw21zns4zn7pffji4yvbj63fx3g15cx81pk4bs6lzyz5zbdc2";
+  };
+
+  preInstall = ''
+    mkdir -p $out/share/mcfly
+    cp mcfly.bash $out/share/mcfly/
+    chmod +x $out/share/mcfly/mcfly.bash
+  '';
+
+  cargoSha256 = "0asldrf6s23f9aylk9f8zimmaskgqv3vkdhfnrd26zl9axm0a0ap";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/cantino/mcfly;
+    description = "An upgraded ctrl-r for Bash whose history results make sense for what you're working on right now.";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.melkor333 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3793,6 +3793,8 @@ in
 
   mautrix-whatsapp = callPackage ../servers/mautrix-whatsapp { };
 
+  mcfly = callPackage ../tools/misc/mcfly { };
+
   mdbook = callPackage ../tools/text/mdbook {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change

[mcfly](https://github.com/cantino/mcfly) is a very nice ctrl+r replacement that takes into account your working directory and the context of recently executed commands.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

