### PR TITLE
python36,python37: fix darwin build

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -69,12 +69,6 @@ in stdenv.mkDerivation {
 
   patches = [
     ./no-ldconfig.patch
-  ] ++ optionals stdenv.isDarwin [
-    # Fix for https://bugs.python.org/issue24658
-    (fetchpatch {
-      url = "https://bugs.python.org/file45178/issue24658-3-3.6.diff";
-      sha256 = "1x060hs80nl34mcl2ji2i7l4shxkmxwgq8h8lcmav8rjqqz1nb4a";
-    })
   ] ++ optionals (x11Support && stdenv.isDarwin) [
     ./use-correct-tcl-tk-on-darwin.patch
   ] ++ optionals hasDistutilsCxxPatch [
@@ -83,8 +77,8 @@ in stdenv.mkDerivation {
     # only works for GCC and Apple Clang. This makes distutils to call C++
     # compiler when needed.
     (fetchpatch {
-      url = "https://bugs.python.org/file47669/python-3.8-distutils-C++.patch";
-      sha256 = "0s801d7ww9yrk6ys053jvdhl0wicbznx08idy36f1nrrxsghb3ii";
+      url = "https://bugs.python.org/file48016/python-3.x-distutils-C++.patch";
+      sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
     })
   ];
 

--- a/pkgs/development/interpreters/python/cpython/3.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.7/default.nix
@@ -74,8 +74,8 @@ in stdenv.mkDerivation {
     # only works for GCC and Apple Clang. This makes distutils to call C++
     # compiler when needed.
     (fetchpatch {
-      url = "https://bugs.python.org/file47669/python-3.8-distutils-C++.patch";
-      sha256 = "0s801d7ww9yrk6ys053jvdhl0wicbznx08idy36f1nrrxsghb3ii";
+      url = "https://bugs.python.org/file48016/python-3.x-distutils-C++.patch";
+      sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Python 3.6
+ Remove issue24658 patch because is already fixed and backported to
Python 3.6 https://github.com/python/cpython/commit/a5ebc205beea2bf1501e4ac33ed6e81732dd0604
+ Adapted python-3.8-distutils-C++.patch because collied with the recent changes on upstream
https://github.com/python/cpython/commit/a21bedf9edeacce6f0de3b2df0783e2ad6aa3b18

Python3.7
+ Remove issue24658 patch because is already fixed and backported to
Python 3.7 https://github.com/python/cpython/commit/178d1c07778553bf66e09fe0bb13796be3fb9abf
+ Adapted python-3.8-distutils-C++.patch because collied with the recent changes on upstream
https://github.com/python/cpython/commit/f14087a4a96bb3f500e2d2bbc36c1124e90d5f73

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

