### PR TITLE
linuxPackages_4_{19,20}: works around bug with overlayfs

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -58,4 +58,14 @@ rec {
     };
   };
 
+  # Reverts a change related to the overlayfs overhaul in 4.19
+  # https://github.com/NixOS/nixpkgs/issues/48828#issuecomment-445208626
+  revert-vfs-dont-open-real = rec {
+	name = "revert-vfs-dont-open-real";
+	patch = fetchpatch {
+	  name = name + ".patch";
+	  url = https://github.com/samueldr/linux/commit/ee23fa215caaa8102f4ab411d39fcad5858147f2.patch;
+	  sha256 = "0bp4jryihg1y2sl8zlj6w7vvnxj0kmb6xdy42hpvdv43kb6ngiaq";
+	};
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14560,6 +14560,7 @@ in
         # when adding a new linux version
         # kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.revert-vfs-dont-open-real
       ];
   };
 
@@ -14570,6 +14571,7 @@ in
         # when adding a new linux version
         # kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.revert-vfs-dont-open-real
       ];
   };
 


### PR DESCRIPTION
See: https://github.com/NixOS/nixpkgs/issues/48828#issuecomment-445208626

I ran the following:

```
env -i nix-build nixos/release.nix -A tests.boot-stage1.x86_64-linux
```

Both with `linuxPackages` set to 4_19 (current default) and 4_20 (to make sure the other change is good).

The patch is literally the one from @aszlig's comment in the linked thread, but applied as a commit on top of the linux repository; only to get it as a fetchpatch-able artifact. Though I do encourage you to load up and verify the patch.

There is no upstream issue opened yet. I don't think I'm able to work with upstream as I don't really know the details of the issue. [**@aszlig** maybe will handle that](https://logs.nix.samueldr.com/nixos-dev/2018-12-26#1825658;).

###### Things done


- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @domenkozar 