### PR TITLE
nixos vdr: introduce option enableLirc

### DIFF
--- a/nixos/modules/services/hardware/lirc.nix
+++ b/nixos/modules/services/hardware/lirc.nix
@@ -33,6 +33,13 @@ in {
         description = "Extra arguments to lircd.";
       };
 
+      socket = mkOption {
+        type = types.path;
+        # default search path of many applications
+        default = "/run/lirc/lircd";
+        description = "Socket path";
+      };
+
     };
   };
 
@@ -49,8 +56,7 @@ in {
       description = "LIRC daemon socket";
       wantedBy = [ "sockets.target" ];
       socketConfig = {
-        # default search path
-        ListenStream = "/run/lirc/lircd";
+        ListenStream = cfg.socket;
         SocketUser = "lirc";
         SocketMode = "0660";
       };

--- a/nixos/modules/services/hardware/lirc.nix
+++ b/nixos/modules/services/hardware/lirc.nix
@@ -32,14 +32,6 @@ in {
         default = [];
         description = "Extra arguments to lircd.";
       };
-
-      socket = mkOption {
-        type = types.path;
-        # default search path of many applications
-        default = "/run/lirc/lircd";
-        description = "Socket path";
-      };
-
     };
   };
 
@@ -50,13 +42,15 @@ in {
     # Note: LIRC executables raises a warning, if lirc_options.conf do not exists
     environment.etc."lirc/lirc_options.conf".text = cfg.options;
 
+    passthru.lirc.socket = "/run/lirc/lircd";
+
     environment.systemPackages = [ pkgs.lirc ];
 
     systemd.sockets.lircd = {
       description = "LIRC daemon socket";
       wantedBy = [ "sockets.target" ];
       socketConfig = {
-        ListenStream = cfg.socket;
+        ListenStream = config.passthru.lirc.socket;
         SocketUser = "lirc";
         SocketMode = "0660";
       };

--- a/nixos/modules/services/hardware/vdr.nix
+++ b/nixos/modules/services/hardware/vdr.nix
@@ -33,12 +33,14 @@ in {
         default = [];
         description = "Additional command line arguments to pass to VDR.";
       };
+
+      enableLirc = mkEnableOption "enable LIRC";
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf cfg.enable (mkMerge [{
     systemd.tmpfiles.rules = [
       "d ${cfg.videoDir} 0755 vdr vdr -"
       "Z ${cfg.videoDir} - vdr vdr -"
@@ -67,5 +69,13 @@ in {
     };
 
     users.groups.vdr = {};
-  };
+  }
+
+  (mkIf cfg.enableLirc {
+    services.lirc.enable = true;
+    users.users.vdr.extraGroups = [ "lirc" ];
+    services.vdr.extraArguments = [
+      "--lirc=${config.services.lirc.socket}"
+    ];
+  })]);
 }

--- a/nixos/modules/services/hardware/vdr.nix
+++ b/nixos/modules/services/hardware/vdr.nix
@@ -75,7 +75,7 @@ in {
     services.lirc.enable = true;
     users.users.vdr.extraGroups = [ "lirc" ];
     services.vdr.extraArguments = [
-      "--lirc=${config.services.lirc.socket}"
+      "--lirc=${config.passthru.lirc.socket}"
     ];
   })]);
 }


### PR DESCRIPTION
also introduce option socket for lirc, to have access to socket path

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

