### PR TITLE
pythonPackages.cfn-lip: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/cfn-flip/default.nix
+++ b/pkgs/development/python-modules/cfn-flip/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, six, pyyaml, click, pytestrunner }:
+
+buildPythonPackage rec {
+  pname = "cfn-flip";
+  version = "1.1.0.post1";
+
+  src = fetchPypi {
+    pname = "cfn_flip";
+    inherit version;
+    sha256 = "16r01ijjwnq06ax5xrv6mq9l00f6sgzw776kr43zjai09xsbwwck";
+  };
+
+  propagatedBuildInputs = [ six pyyaml click ];
+  nativeBuildInputs = [ pytestrunner ];
+
+  # No tests in Pypi
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tool for converting AWS CloudFormation templates between JSON and YAML formats";
+    homepage = https://github.com/awslabs/aws-cfn-template-flip;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -298,6 +298,8 @@ in {
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
+  cfn-flip = callPackage ../development/python-modules/cfn-flip { };
+ 
   chalice = callPackage ../development/python-modules/chalice { };
 
   cleo = callPackage ../development/python-modules/cleo { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

