### PR TITLE
nmfd: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -231,6 +231,11 @@
     github = "ambrop72";
     name = "Ambroz Bizjak";
   };
+  amelorate = {
+    email = "ameilorate2+nixos@gmail.com";
+    github = "Ameliorate";
+    name = "Amelorate";
+  };
   amiddelk = {
     email = "amiddelk@gmail.com";
     github = "amiddelk";

--- a/pkgs/tools/misc/nmfd/default.nix
+++ b/pkgs/tools/misc/nmfd/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/nmfd/default.nix
+++ b/pkgs/tools/misc/nmfd/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "nmfd";
+  version = "1.1.3";
+  src = fetchFromGitHub {
+    owner = "Ameliorate";
+    repo = "nmfd";
+    rev = "v${version}";
+    sha256 = "1gk3kz9m8547yn9w7cr4a3nlg5pq7z86mksv2ayrmvcicm6m0ifc";
+  };
+
+  makeFlags = [ "INSTALL_PATH=$(out)/bin/" "MANUAL_PATH=$(out)/share/man/man1" ];
+
+  preBuild = ''
+    mkdir -p $out/bin
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A simple utility to watch the state of the side-buttons on most models of Razer Naga mice";
+    homepage = https://github.com/Ameliorate/nmfd;
+    license = licenses.mit;
+    maintainers = [ maintainers.amelorate ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3867,6 +3867,8 @@ in
 
   nixnote2 = libsForQt5.callPackage ../applications/misc/nixnote2 { };
 
+  nmfd = callPackage ../tools/misc/nmfd { };
+
   nodejs = hiPrio nodejs-8_x;
 
   nodejs-slim = nodejs-slim-6_x;


### PR DESCRIPTION
###### Motivation for this change
nmfd is a simple helper program that watches the status of the side buttons on a Razer Naga mouse and prints the keypress events to stdout, allowing the easy creation of macro scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

