### PR TITLE
pythonPackages.dependency-injector: 3.14.2 -> 3.14.3

### DIFF
--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -1,19 +1,26 @@
-{ stdenv, buildPythonPackage, fetchPypi, six, unittest2 }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k, six, unittest2 }:
+
+let
+  testPath =
+    if isPy3k
+    then "test_*_py3.py"
+    else "test_*_py2_py3.py";
+in
 
 buildPythonPackage rec {
   pname = "dependency-injector";
-  version = "3.14.2";
+  version = "3.14.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f478a26e9bf3111ce98bbfb8502af274643947f87a7e12a6481a35eaa693062b";
+    sha256 = "07366palyav9bawyq2b1gi76iamjkq6r5akzzbqv8s930sxq6yim";
   };
 
   propagatedBuildInputs = [ six ];
   checkInputs = [ unittest2 ];
 
   checkPhase = ''
-    unit2 discover tests/unit
+    unit2 discover -s tests/unit -p "${testPath}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

