### PR TITLE
pythonPackges.flask-jwt-extended: 3.13.1 -> 3.14.0

### DIFF
--- a/pkgs/development/python-modules/flask-jwt-extended/default.nix
+++ b/pkgs/development/python-modules/flask-jwt-extended/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "Flask-JWT-Extended";
-  version = "3.13.1";
+  version = "3.14.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "10qz3ljr2kpd93al2km6iijxp23z33kvvwd0y5bc840f86b4mra8";
+    sha256 = "133s9js7j1b2m6vv56a2xd9in0rmx5zrdp4r005qwbvr5qxld39s";
   };
 
   propagatedBuildInputs = [ flask pyjwt werkzeug ];


### PR DESCRIPTION
###### Motivation for this change

Update package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

