### PR TITLE
 granite: 5.2.1 -> 5.2.2 

### DIFF
--- a/pkgs/development/libraries/granite/02-datetime-clock-format-gsettings.patch
+++ b/pkgs/development/libraries/granite/02-datetime-clock-format-gsettings.patch
@@ -1,0 +1,129 @@
+From 698e34dd6e8d98a1818ae00d3313b69a86340771 Mon Sep 17 00:00:00 2001
+From: Fabio Valentini <decathorpe@gmail.com>
+Date: Mon, 17 Dec 2018 14:58:14 +0100
+Subject: DateTime: include "clock-format" gsettings key here
+
+---
+ data/io.elementary.granite.gschema.xml | 15 +++++++++++++++
+ data/meson.build                       |  4 ++++
+ lib/DateTime.vala                      |  4 ++--
+ meson.build                            | 11 +++++++++++
+ meson/post_install.py                  |  5 +++++
+ 5 files changed, 37 insertions(+), 2 deletions(-)
+ create mode 100644 data/io.elementary.granite.gschema.xml
+ create mode 100644 data/meson.build
+
+diff --git a/data/io.elementary.granite.gschema.xml b/data/io.elementary.granite.gschema.xml
+new file mode 100644
+index 0000000..1540fb0
+--- /dev/null
++++ b/data/io.elementary.granite.gschema.xml
+@@ -0,0 +1,15 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<schemalist>
++  <enum id="io.elementary.granite.clock-formats">
++    <value nick="12h" value="0" />
++    <value nick="24h" value="1" />
++    <value nick="ISO8601" value="2" />
++  </enum>
++  <schema id="io.elementary.granite" path="/io/elementary/granite/">
++    <key name="clock-format" enum="io.elementary.granite.clock-formats">
++      <default>"12h"</default>
++      <summary>Whether the clock displays in 12h or 24h format</summary>
++      <description>Whether the clock displays in 12h or 24h format</description>
++    </key>
++  </schema>
++</schemalist>
+diff --git a/data/meson.build b/data/meson.build
+new file mode 100644
+index 0000000..96cc3b1
+--- /dev/null
++++ b/data/meson.build
+@@ -0,0 +1,4 @@
++install_data(
++    rdnn + '.gschema.xml',
++    install_dir: schema_dir
++)
+diff --git a/lib/DateTime.vala b/lib/DateTime.vala
+index aea2ec6..3d81191 100644
+--- a/lib/DateTime.vala
++++ b/lib/DateTime.vala
+@@ -104,13 +104,13 @@ namespace Granite.DateTime {
+     }
+ 
+     /**
+-     * Gets the //clock-format// key from //org.gnome.desktop.interface// schema
++     * Gets the //clock-format// key from //io.elementary.granite// schema
+      * and determines if the clock format is 12h based
+      *
+      * @return true if the clock format is 12h based, false otherwise.
+      */
+     private static bool is_clock_format_12h () {
+-        var h24_settings = new Settings ("io.elementary.desktop.wingpanel.datetime");
++        var h24_settings = new Settings ("io.elementary.granite");
+         var format = h24_settings.get_string ("clock-format");
+         return (format.contains ("12h"));
+     }
+diff --git a/meson.build b/meson.build
+index 8b98eeb..f0abcdf 100644
+--- a/meson.build
++++ b/meson.build
+@@ -4,6 +4,8 @@ project(
+     version: '5.2.2'
+ )
+ 
++rdnn = 'io.elementary.' + meson.project_name()
++
+ if meson.get_compiler('vala').version().version_compare('<0.40.0')
+     error('vala compiler version 0.40.0 or newer is required.')
+ endif
+@@ -52,10 +54,18 @@ icons_dir = join_paths(
+     'hicolor'
+ )
+ 
++schema_dir = join_paths(
++    get_option('prefix'),
++    get_option('datadir'),
++    'glib-2.0',
++    'schemas'
++)
++
+ pkgconfig = import('pkgconfig')
+ i18n = import('i18n')
+ 
+ subdir('lib')
++subdir('data')
+ subdir('demo')
+ subdir('icons')
+ subdir('po')
+@@ -68,5 +78,6 @@ endif
+ meson.add_install_script(
+     join_paths(meson.current_source_dir(), 'meson', 'post_install.py'),
+     '--iconsdir', icons_dir,
++    '--schemadir', schema_dir,
+ )
+ 
+diff --git a/meson/post_install.py b/meson/post_install.py
+index 1864515..5313f96 100755
+--- a/meson/post_install.py
++++ b/meson/post_install.py
+@@ -6,11 +6,16 @@ import subprocess
+ 
+ parser = argparse.ArgumentParser()
+ parser.add_argument("--iconsdir", action="store", required=True)
++parser.add_argument("--schemadir", action="store", required=True)
+ args = vars(parser.parse_args())
+ 
+ icons_dir = args["iconsdir"]
++schema_dir = args["schemadir"]
+ 
+ if not os.environ.get('DESTDIR'):
+     print('Compiling icon cache ...')
+     subprocess.run(['gtk-update-icon-cache', icons_dir])
+ 
++    print('Compiling GSettings schemas ...')
++    subprocess.run(['glib-compile-schemas', schema_dir])
++
+-- 
+2.20.1
+

--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, ninja, vala_0_40, pkgconfig, gobject-introspection, gnome3, gtk3, glib, gettext }:
+{ stdenv, fetchFromGitHub, fetchpatch, python3, meson, ninja, vala_0_40, pkgconfig, gobject-introspection, gnome3, gtk3, glib, gettext, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "granite";
@@ -11,25 +11,43 @@ stdenv.mkDerivation rec {
     sha256 = "1zp0pp5v3j8k6ail724p7h5jj2zmznj0a2ybwfw5sspfdw5bfydh";
   };
 
-  cmakeFlags = [
-    "-DINTROSPECTION_GIRDIR=share/gir-1.0/"
-    "-DINTROSPECTION_TYPELIBDIR=lib/girepository-1.0"
+  patches = [
+    # Add Meson support that hit after 5.2.2
+    (fetchpatch {
+      url = "https://github.com/elementary/granite/commit/2066b377226cf327cb2d5399b6b40a2d36d47b11.patch";
+      sha256 = "1bxjgq8wvl1sb79cwhmh9kwawnkkfn7c5q67cyz1fjxmamwyyi85";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/granite/commit/f1b29f52e3aaf0f5d6bba44c42617da265f679c8.patch";
+      sha256 = "0cdp9ny6fj1lpcirab641p1qn1rbsvnsaa03hnr6zsdpim96jlvs";
+    })
+    # Resolve the circular dependency between granite and the datetime wingpanel indicator
+    # See: https://github.com/elementary/granite/pull/242
+    ./02-datetime-clock-format-gsettings.patch
   ];
 
   nativeBuildInputs = [
-    cmake
     gettext
     gobject-introspection
+    meson
     ninja
     pkgconfig
+    python3
     vala_0_40 # should be `elementary.vala` when elementary attribute set is merged
+    wrapGAppsHook
   ];
 
   buildInputs = [
     glib
-    gnome3.libgee
     gtk3
+    hicolor-icon-theme
+    gnome3.libgee
   ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
 
   meta = with stdenv.lib; {
     description = "An extension to GTK+ used by elementary OS";

--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -2,15 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "granite";
-  version = "5.2.1";
-
-  name = "${pname}-${version}";
+  version = "5.2.2";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "18rw1lv6zk5w2cq8bv6b869z3cdikn9gzk30gw1s9f8n06bh737h";
+    sha256 = "1zp0pp5v3j8k6ail724p7h5jj2zmznj0a2ybwfw5sspfdw5bfydh";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
Closes #52882

Usual update but with stuff that I've already done to granite in https://github.com/NixOS/nixpkgs/pull/48637 that should be on master.
Most importantly this should fix certain elementary third-party applications from breaking.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

