### PR TITLE
pythonPackages.sip: make sip-module name overridable

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -8,7 +8,9 @@ let
   pname = "PyQt";
   version = "5.11.3";
 
-  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python sip enum34;
+  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34;
+
+  sip = pythonPackages.sip.override { sip-module = "PyQt5.sip"; };
 
 in buildPythonPackage {
   pname = pname;
@@ -32,10 +34,10 @@ in buildPythonPackage {
 
   nativeBuildInputs = [ pkgconfig qmake lndir ];
 
-  buildInputs = [ dbus ];
+  buildInputs = [ dbus sip ];
 
   propagatedBuildInputs = [
-    sip qtbase qtsvg qtwebkit qtwebengine
+    qtbase qtsvg qtwebkit qtwebengine
   ] ++ lib.optional (!isPy3k) enum34 ++ lib.optional withWebSockets qtwebsockets ++ lib.optional withConnectivity qtconnectivity;
 
   configurePhase = ''
@@ -65,7 +67,7 @@ in buildPythonPackage {
   '';
 
   postInstall = ''
-    ln -s ${sip}/${python.sitePackages}/PyQt5/* $out/${python.sitePackages}/PyQt5
+    ln -s ${sip}/${python.sitePackages}/PyQt5/sip.* $out/${python.sitePackages}/PyQt5/
     for i in $out/bin/*; do
       wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
     done

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -1,20 +1,20 @@
-{ lib, fetchurl, buildPythonPackage, python, isPyPy }:
+{ lib, fetchurl, buildPythonPackage, python, isPyPy, sip-module ? "sip" }:
 
 buildPythonPackage rec {
-  pname = "sip";
+  pname = sip-module;
   version = "4.19.13";
   format = "other";
 
   disabled = isPyPy;
 
   src = fetchurl {
-    url = "mirror://sourceforge/pyqt/sip/${pname}-${version}/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/pyqt/sip/sip-${version}/sip-${version}.tar.gz";
     sha256 = "0pniq03jk1n5bs90yjihw3s3rsmjd8m89y9zbnymzgwrcl2sflz3";
   };
 
   configurePhase = ''
     ${python.executable} ./configure.py \
-      --sip-module PyQt5.sip \
+      --sip-module ${sip-module} \
       -d $out/lib/${python.libPrefix}/site-packages \
       -b $out/bin -e $out/include
   '';


### PR DESCRIPTION
###### Motivation for this change

This is an alternative to #52897 that trades patching pyqt5 for building another copy of sip.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).