### PR TITLE
check-esxi-hardware: 20161013 -> 20181001

### DIFF
--- a/pkgs/servers/monitoring/plugins/esxi.nix
+++ b/pkgs/servers/monitoring/plugins/esxi.nix
@@ -6,13 +6,13 @@ let
 
 in python2Packages.buildPythonApplication rec {
   name = "${pName}-${version}";
-  version = "20161013";
+  version = "20181001";
 
   src = fetchFromGitHub {
     owner  = "Napsty";
     repo   = bName;
     rev    = version;
-    sha256 = "19zybcg62dqcinixnp1p8zw916x3w7xvy6dlsmn347iigfa5s55s";
+    sha256 = "0azfacxcnnxxfqzrhh29k8cnjyr88gz35bi6h8fq931fl3plv10l";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

