### PR TITLE
dmrconfig: 1.0 -> 1.1

### DIFF
--- a/pkgs/applications/misc/dmrconfig/default.nix
+++ b/pkgs/applications/misc/dmrconfig/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "dmrconfig-${version}";
-  version = "1.0";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "sergev";
     repo = "dmrconfig";
     rev = version;
-    sha256 = "1bb3hahfdb5phxyzp1m5ibqwz3mcqplzaibb1aq7w273xcfrd9l9";
+    sha256 = "1qwix75z749628w583fwp7m7kxbj0k3g159sxb7vgqxbadqqz1ab";
   };
 
   buildInputs = [
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace Makefile \
-      --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig \
-      --replace "\$(shell git describe --tags --abbrev=0)" ${version} \
-      --replace "\$(shell git rev-list HEAD --count)" 0
+      --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig
   '';
+
+  makeFlags = "VERSION=${version} GITCOUNT=0";
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/udev/rules.d


### PR DESCRIPTION
###### Motivation for this change
Changes: https://github.com/sergev/dmrconfig/releases/tag/1.1

Also removed some half shady replacements and supplied arguments for the same purpose.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

