### PR TITLE
squashfs: 4.4dev -> 4.4dev-20180612

### DIFF
--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -1,18 +1,20 @@
 { stdenv, fetchFromGitHub, zlib, xz
 , lz4 ? null
 , lz4Support ? false
+, zstd
 }:
 
 assert lz4Support -> (lz4 != null);
 
 stdenv.mkDerivation rec {
-  name = "squashfs-4.4dev";
+  name = "squashfs-${version}";
+  version = "4.4dev_20180612";
 
   src = fetchFromGitHub {
     owner = "plougher";
     repo = "squashfs-tools";
-    sha256 = "059pa2shdysr3zfmwrhq28s12zbi5nyzbpzyaf5lmspgfh1493ks";
-    rev = "9c1db6d13a51a2e009f0027ef336ce03624eac0d";
+    sha256 = "1y53z8dkph3khdyhkmkmy0sg9p1n8czv3vj4l324nj8kxyih3l2c";
+    rev = "6e242dc95485ada8d1d0b3dd9346c5243d4a517f";
   };
 
   patches = [
@@ -28,14 +30,14 @@ stdenv.mkDerivation rec {
     ./squashfs-tools-4.3-4k-align.patch
   ] ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
 
-  buildInputs = [ zlib xz ]
+  buildInputs = [ zlib xz zstd ]
     ++ stdenv.lib.optional lz4Support lz4;
 
   preBuild = "cd squashfs-tools";
 
   installFlags = "INSTALL_DIR=\${out}/bin";
 
-  makeFlags = [ "XZ_SUPPORT=1" ]
+  makeFlags = [ "XZ_SUPPORT=1" "ZSTD_SUPPORT=1" ]
     ++ stdenv.lib.optional lz4Support "LZ4_SUPPORT=1";
 
   meta = {

--- a/pkgs/tools/filesystems/squashfs/squashfs-tools-4.3-4k-align.patch
+++ b/pkgs/tools/filesystems/squashfs/squashfs-tools-4.3-4k-align.patch
@@ -27,11 +27,12 @@ index 8b1376f..683973d 100644
  int use_regex = FALSE;
  int nopad = FALSE;
  int exit_on_error = FALSE;
+ static off_t squashfs_start_offset = 0;
 +int do_4k_align = FALSE;
 +#define ALIGN_UP(bytes, size) (bytes = (bytes + size - 1) & ~(size - 1))
- 
+
  long long global_uid = -1, global_gid = -1;
- 
+
 @@ -1513,6 +1515,9 @@ void unlock_fragments()
  	 * queue at this time.
  	 */
@@ -40,7 +41,7 @@ index 8b1376f..683973d 100644
 +		if(do_4k_align)
 +			ALIGN_UP(bytes, 4096);
  		write_buffer = queue_get(locked_fragment);
- 		frg = write_buffer->block;	
+ 		frg = write_buffer->block;
  		size = SQUASHFS_COMPRESSED_SIZE_BLOCK(fragment_table[frg].size);
 @@ -2420,6 +2420,9 @@
  	compressed_size = SQUASHFS_COMPRESSED_SIZE_BLOCK(c_byte);
@@ -55,18 +56,18 @@ index 8b1376f..683973d 100644
 @@ -2761,6 +2769,10 @@ int write_file_blocks(squashfs_inode *inode, struct dir_ent *dir_ent,
  	long long sparse = 0;
  	struct file_buffer *fragment_buffer = NULL;
- 
+
 +	// 4k align the start of each file.
 +	if(do_4k_align)
 +		ALIGN_UP(bytes, 4096);
 +
  	if(pre_duplicate(read_size))
  		return write_file_blocks_dup(inode, dir_ent, read_buffer, dup);
- 
+
 @@ -4692,6 +4704,7 @@ void write_filesystem_tables(struct squashfs_super_block *sBlk, int nopad)
  		"compressed", no_fragments ? "no" : noF ? "uncompressed" :
  		"compressed", no_xattrs ? "no" : noX ? "uncompressed" :
- 		"compressed");
+ 		"compressed", noI || noId ? "uncompressed" : "compressed");
 +	printf("\t4k %saligned\n", do_4k_align ? "" : "un");
  	printf("\tduplicates are %sremoved\n", duplicate_checking ? "" :
  		"not ");
@@ -88,5 +89,5 @@ index 8b1376f..683973d 100644
  			ERROR("\nFilesystem filter options:\n");
  			ERROR("-p <pseudo-definition>\tAdd pseudo file "
  				"definition\n");
--- 
+--
 2.14.1.480.gb18f417b89-goog (previously; hand-patched by charles-dyfis-net)


### PR DESCRIPTION
This squashfstools release finally has `zstd` support.

Inspired by https://discourse.nixos.org/t/install-nixos-on-512-mb-ram/1713/5. Building zstd-compressed squashfs is much faster than xz or zlib

Done a few tests over installation CD squashfs.
- command: `nix-build -A config.system.build.squashfsStore -I nixos-config=modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix <nixpkgs/nixos>`
- XZ (default): `-comp xz -Xdict-size 100%`
- zstd: `-comp zstd -Xcompression-level 6`
- gzip: `-comp gzip -Xcompression-level 6`
- zstd1: `-comp zstd -Xcompression-level 1`
- gzip1: `-comp gzip -Xcompression-level 1`

```
XZ:    time 4m41,017s, size 497Mb
zstd:  time 35s, size 529Mb
gzip:  time 59s, size 585Mb
zstd1: time 15s, size 609Mb
gzip1: time 31s, size 639Mb
```
Is 32Mb (`zstd -6`) too much to change default compressor?

cc @Mic92 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).