### PR TITLE
pythonPackages.sip: do not build tools for non-default sip module

### DIFF
--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -8,9 +8,9 @@ let
   pname = "PyQt";
   version = "5.11.3";
 
-  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34;
+  inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34 sip;
 
-  sip = pythonPackages.sip.override { sip-module = "PyQt5.sip"; };
+  pyqt5-sip = sip.override { sipModule = "PyQt5.sip"; };
 
 in buildPythonPackage {
   pname = pname;
@@ -32,9 +32,9 @@ in buildPythonPackage {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig qmake lndir ];
+  nativeBuildInputs = [ pkgconfig qmake lndir sip ];
 
-  buildInputs = [ dbus sip ];
+  buildInputs = [ dbus ];
 
   propagatedBuildInputs = [
     qtbase qtsvg qtwebkit qtwebengine
@@ -67,7 +67,7 @@ in buildPythonPackage {
   '';
 
   postInstall = ''
-    ln -s ${sip}/${python.sitePackages}/PyQt5/sip.* $out/${python.sitePackages}/PyQt5/
+    ln -s ${pyqt5-sip}/${python.sitePackages}/PyQt5/* $out/${python.sitePackages}/PyQt5/
     for i in $out/bin/*; do
       wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
     done

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -1,7 +1,11 @@
-{ lib, fetchurl, buildPythonPackage, python, isPyPy, sip-module ? "sip" }:
+{ lib, fetchurl, buildPythonPackage, python, isPyPy
+, sipModule ? "sip"
+, withModule ? true
+, withTools ? sipModule == "sip"
+}:
 
 buildPythonPackage rec {
-  pname = sip-module;
+  pname = sipModule;
   version = "4.19.13";
   format = "other";
 
@@ -12,12 +16,23 @@ buildPythonPackage rec {
     sha256 = "0pniq03jk1n5bs90yjihw3s3rsmjd8m89y9zbnymzgwrcl2sflz3";
   };
 
-  configurePhase = ''
-    ${python.executable} ./configure.py \
-      --sip-module ${sip-module} \
-      -d $out/lib/${python.libPrefix}/site-packages \
-      -b $out/bin -e $out/include
-  '';
+  nativeBuildInputs = [ python ];
+
+  configureScript = "python configure.py";
+
+  configureFlags = (
+    if (!withModule) then [ "--no-module" ] else [
+      "--sip-module" sipModule
+      "-d" "${placeholder "out"}/${python.sitePackages}"
+    ]
+  ) ++ (
+    if (!withTools) then [ "--no-tools" ] else [
+      "-b" "${placeholder "out"}/bin"
+      "-e" "${placeholder "out"}/include"
+    ]
+  );
+
+  dontAddPrefix = true;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

This ensures that the default sip and alternative sips do not have any files in common: https://github.com/NixOS/nixpkgs/pull/52956#issuecomment-450139516

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
