### PR TITLE
material-design-icons: init at 3.2.89

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4677,6 +4677,11 @@
     github = "vklquevs";
     name = "vklquevs";
   };
+  vlaci = {
+    email = "laszlo.vasko@outlook.com";
+    github = "vlaci";
+    name = "László Vaskó";
+  };
   vlstill = {
     email = "xstill@fi.muni.cz";
     github = "vlstill";

--- a/pkgs/data/fonts/material-design-icons/default.nix
+++ b/pkgs/data/fonts/material-design-icons/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "material-design-icons-${version}";
+  version = "3.2.89";
+
+  src = fetchFromGitHub {
+    owner  = "Templarian";
+    repo   = "MaterialDesign-Webfont";
+    rev    = "v${version}";
+    sha256 = "1rxaiiij96kqncsrlkyp109m36v28cgxild7z04k4jh79fvmhjvn";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/{eot,svg,truetype,woff,woff2}
+    cp fonts/*.eot $out/share/fonts/eot/
+    cp fonts/*.svg $out/share/fonts/svg/
+    cp fonts/*.ttf $out/share/fonts/truetype/
+    cp fonts/*.woff $out/share/fonts/woff/
+    cp fonts/*.woff2 $out/share/fonts/woff2/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "3200+ Material Design Icons from the Community";
+    longDescription = ''
+      Material Design Icons' growing icon collection allows designers and
+      developers targeting various platforms to download icons in the format,
+      color and size they need for any project.
+    '';
+    homepage = https://materialdesignicons.com;
+    license = with licenses; [
+      asl20  # for icons from: https://github.com/google/material-design-icons
+      ofl
+    ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ vlaci ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15606,6 +15606,8 @@ in
 
   materia-theme = callPackage ../data/themes/materia-theme { };
 
+  material-design-icons = callPackage ../data/fonts/material-design-icons { };
+
   material-icons = callPackage ../data/fonts/material-icons { };
 
   meslo-lg = callPackage ../data/fonts/meslo-lg {};


### PR DESCRIPTION
###### Motivation for this change

Package contains thousands of icons to be used in e.g. status bars in minimalist window managers.

It is a bit unfortunate that the name is so close to material-icons, however it is consistent with the project name and how it is present in AUR (ttf-material-design-icons-git)

###### Open questions

- [x] Should be the webfont stuff installed? I have seen few package doing it (comic-neue, unscii) so I have included them as well. However location off woff and svg files is not consistent across packages. I am happy to leave them out.
  _- They are installed in current revision of the commit_
- [x] Somewhat legal issue: Is it OK that upstream incorporated Google's material-icons (Apache-2.0) and  redistributed them under OFL? I know Apache is not copyleft and OFL seams to offer the same guaranties as Apache. AFAIK it should be OK but I did not want this to go unnoticed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
_Happy Holidays everyone!_