### PR TITLE
[18.09] wget: disable feature responsible for CVE-2018-20483

### DIFF
--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isDarwin perl;
 
   configureFlags = [
+    (stdenv.lib.enableFeature false "xattr")  # CVE-2018-20483 fixed in 1.20.1
     (stdenv.lib.withFeatureAs (openssl != null) "ssl" "openssl")
   ];
 


### PR DESCRIPTION
###### Motivation for this change

wget release 1.20.1 to address CVE-2018-20483. The 1.19 branch used in 18.09 did not receive a new point release fixing the issue. We can just "work around" the problem by disabling xattr support at build time.

Alternatively we could also just rebase the CVE fix onto 1.19.5 ourselves -- I went for the simpler option, let me know if you have a strong preference for the latter option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

