### PR TITLE
chipsec: init at 1.3.7

### DIFF
--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -7,7 +7,7 @@ python27Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "chipsec";
     repo = "chipsec";
-    rev = if (version == "1.3.7") then version else "v${version}";
+    rev = version;
     sha256 = "00hwhi5f24y429zazhm77l1pp31q7fmx7ks3sfm6d16v89zbcp9a";
   };
 
@@ -35,8 +35,6 @@ python27Packages.buildPythonApplication rec {
     license = licenses.gpl2;
     homepage = https://github.com/chipsec/chipsec;
     maintainers = with maintainers; [ johnazoidberg ];
-    # This package description is currently only able to build the Linux driver.
-    # But the other functionality should work on all platforms.
-    platforms = platforms.all;
+    platforms = if withDriver then [ "x86_64-linux" ] else platforms.all;
   };
 }

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub, python27Packages, nasm, libelf
+, kernel ? null, withDriver ? false }:
+python27Packages.buildPythonApplication rec {
+  name = "chipsec-${version}";
+  version = "1.3.6";
+
+  src = fetchFromGitHub {
+    owner = "chipsec";
+    repo = "chipsec";
+    rev = "v${version}";
+    sha256 = "18iwbh74j4igrvfx9cc2bfk014ha0b40mvwnn05yabij22kl9l49";
+  };
+
+  buildInputs = [
+    nasm libelf
+  ];
+
+  setupPyBuildFlags = lib.optional (!withDriver) "--skip-driver";
+
+  checkPhase = "python setup.py build "
+             + lib.optionalString (!withDriver) "--skip-driver "
+             + "test";
+
+  KERNEL_SRC_DIR = lib.optionalString withDriver "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  meta = with stdenv.lib; {
+    description = "Platform Security Assessment Framework";
+    longDescription = ''
+      CHIPSEC is a framework for analyzing the security of PC platforms
+      including hardware, system firmware (BIOS/UEFI), and platform components.
+      It includes a security test suite, tools for accessing various low level
+      interfaces, and forensic capabilities. It can be run on Windows, Linux,
+      Mac OS X and UEFI shell.
+    '';
+    license = licenses.gpl2;
+    homepage = https://github.com/chipsec/chipsec;
+    maintainers = with maintainers; [ johnazoidberg ];
+    # This package description is currently only able to build the Linux driver.
+    # But the other functionality should work on all platforms.
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -2,16 +2,16 @@
 , kernel ? null, withDriver ? false }:
 python27Packages.buildPythonApplication rec {
   name = "chipsec-${version}";
-  version = "1.3.6";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
     owner = "chipsec";
     repo = "chipsec";
-    rev = "v${version}";
-    sha256 = "18iwbh74j4igrvfx9cc2bfk014ha0b40mvwnn05yabij22kl9l49";
+    rev = if (version == "1.3.7") then version else "v${version}";
+    sha256 = "00hwhi5f24y429zazhm77l1pp31q7fmx7ks3sfm6d16v89zbcp9a";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     nasm libelf
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -684,8 +684,10 @@ in
 
   chezmoi = callPackage ../tools/misc/chezmoi { };
 
-  # Without kernel driver, should build and work on non-linux as well
-  chipsec = callPackage ../tools/security/chipsec { };
+  chipsec = callPackage ../tools/security/chipsec {
+    kernel = null;
+    withDriver = false;
+  };
 
   clair = callPackage ../tools/admin/clair { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -684,6 +684,9 @@ in
 
   chezmoi = callPackage ../tools/misc/chezmoi { };
 
+  # Without kernel driver, should build and work on non-linux as well
+  chipsec = callPackage ../tools/security/chipsec { };
+
   clair = callPackage ../tools/admin/clair { };
 
   cloud-sql-proxy = callPackage ../tools/misc/cloud-sql-proxy { };
@@ -14937,6 +14940,11 @@ in
     ati_drivers_x11 = callPackage ../os-specific/linux/ati-drivers { };
 
     blcr = callPackage ../os-specific/linux/blcr { };
+
+    chipsec = callPackage ../tools/security/chipsec {
+      inherit kernel;
+      withDriver = true;
+    };
 
     cryptodev = callPackage ../os-specific/linux/cryptodev { };
 


### PR DESCRIPTION
###### Motivation for this change
The Nix(OS) community should check their firmware and its settings for vulnerabilities!

It's included twice: The top-level attribute doesn't include the kernel driver and can be executed on any OS with Python, and the one in linuxPackages which includes the Linux kernel driver and is therefore able to do more advanced checks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

