### PR TITLE
tup: 0.7.5 -> 0.7.8

### DIFF
--- a/pkgs/development/tools/build-managers/tup/default.nix
+++ b/pkgs/development/tools/build-managers/tup/default.nix
@@ -1,21 +1,22 @@
-{ stdenv, fetchFromGitHub, fuse, pkgconfig }:
+{ stdenv, fetchFromGitHub, fuse, pkgconfig, pcre }:
 
 stdenv.mkDerivation rec {
   name = "tup-${version}";
-  version = "0.7.5";
+  version = "0.7.8";
 
   src = fetchFromGitHub {
     owner = "gittup";
     repo = "tup";
     rev = "v${version}";
-    sha256 = "0jzp1llq6635ldb7j9qb29j2k0x5mblimdqg3179dvva1hv0ia23";
+    sha256 = "07dmz712zbs5kayf98kywp7blssgh0y2gc1623jbsynmqwi77mcb";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ fuse ];
+  buildInputs = [ fuse pcre ];
 
   configurePhase = ''
-    sed -i 's/`git describe`/v${version}/g' Tupfile
+    sed -i 's/`git describe`/v${version}/g' src/tup/link.sh
+    sed -i 's/pcre-confg/pkg-config pcre/g' Tupfile Tuprules.tup
   '';
 
   # Regular tup builds require fusermount to have suid, which nix cannot
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
   # generate' instead
   buildPhase = ''
     ./build.sh
+    ./build/tup init
     ./build/tup generate script.sh
     ./script.sh
   '';


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [+] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [+] other Linux distributions (Debian GNU/Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [+] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [+] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [+] Assured whether relevant documentation is up to date
- [+] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---