### PR TITLE
virtmanager-qt: 0.60.88 -> 0.70.91

### DIFF
--- a/pkgs/applications/virtualization/virt-manager/qt.nix
+++ b/pkgs/applications/virtualization/virt-manager/qt.nix
@@ -1,17 +1,18 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
 , qtbase, qtmultimedia, qtsvg, qttools, krdc
 , libvncserver, libvirt, pcre, pixman, qtermwidget, spice-gtk, spice-protocol
+, libselinux, libsepol, utillinux
 }:
 
 mkDerivation rec {
   name = "virt-manager-qt-${version}";
-  version = "0.60.88";
+  version = "0.70.91";
 
   src = fetchFromGitHub {
     owner  = "F1ash";
     repo   = "qt-virt-manager";
     rev    = "${version}";
-    sha256 = "0hd5d8zdghc5clv8pa4h9zigshdrarfpmzyvrq56rjkm13lrdz52";
+    sha256 = "1z2kq88lljvr24z1kizvg3h7ckf545h4kjhhrjggkr0w4wjjwr43";
   };
 
   cmakeFlags = [
@@ -22,6 +23,7 @@ mkDerivation rec {
   buildInputs = [
     qtbase qtmultimedia qtsvg krdc
     libvirt libvncserver pcre pixman qtermwidget spice-gtk spice-protocol
+    libselinux libsepol utillinux
   ];
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];


### PR DESCRIPTION
###### Motivation for this change

New version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

