### PR TITLE
vala_0_38, vala_0_40, vala_0_42: add configuration to disable graphviz (to reduce closure size)

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -1,11 +1,46 @@
-{ stdenv, lib, fetchurl, pkgconfig, flex, bison, libxslt, autoconf, automake, graphviz
-, glib, libiconv, libintl, libtool, expat
+{ stdenv, lib, fetchurl, fetchpatch, pkgconfig, flex, bison, libxslt, autoconf, automake, autoreconfHook
+, graphviz, glib, libiconv, libintl, libtool, expat
 }:
 
 let
-  generic = { major, minor, sha256, extraNativeBuildInputs ? [], extraBuildInputs ? [] }:
+  generic = lib.makeOverridable ({
+    major, minor, sha256,
+    extraNativeBuildInputs ? [],
+    extraBuildInputs ? [],
+    withGraphviz ? false
+  }:
   let
     atLeast = lib.versionAtLeast "${major}.${minor}";
+
+    # Patches from the openembedded-core project to build vala without graphviz
+    # support. We need to apply an additional patch to allow building when the
+    # header file isn't available at all, but that patch (./gvc-compat.patch)
+    # can be shared between all versions of Vala so far.
+    graphvizPatch =
+      let
+        fp = { commit, sha256 }: fetchpatch {
+          url = "https://github.com/openembedded/openembedded-core/raw/${commit}/meta/recipes-devtools/vala/vala/disable-graphviz.patch";
+          inherit sha256;
+        };
+
+      in {
+        "0.38" = fp {
+          commit = "2c290f7253bba5ceb0d32e7d0b0ec0d0e81cc263";
+          sha256 = "056ybapfx18d7xw1k8k85nsjrc26qk2q2d9v9nz2zrcwbq5brhkp";
+        };
+
+        # NOTE: the openembedded-core project doesn't have a patch for 0.40.12
+        # or 0.42.4 just yet; we've fixed the single merge conflict in the
+        # patches below and checked them in here.
+        #     0.40.12: https://github.com/openembedded/openembedded-core/raw/8553c52f174af4c8c433c543f806f5ed5c1ec48c/meta/recipes-devtools/vala/vala/disable-graphviz.patch
+        #     0.42.4:  https://github.com/openembedded/openembedded-core/raw/dfbbff39cfd413510abbd60930232a9c6b35d765/meta/recipes-devtools/vala/vala/disable-graphviz.patch
+        "0.40" = ./disable-graphviz-0.40.12.patch;
+        "0.42" = ./disable-graphviz-0.42.4.patch;
+
+      }.${major} or (throw "no graphviz patch for this version of vala");
+
+    disableGraphviz = atLeast "0.38" && !withGraphviz;
+
   in stdenv.mkDerivation rec {
     name = "vala-${version}";
     version = "${major}.${minor}";
@@ -19,16 +54,24 @@ let
       patchShebangs tests
     '';
 
+    # If we're disabling graphviz, apply the patches and corresponding
+    # configure flag. We also need to override the path to the valac compiler
+    # so that it can be used to regenerate documentation.
+    patches        = lib.optionals disableGraphviz [ graphvizPatch ./gvc-compat.patch ];
+    configureFlags = lib.optional  disableGraphviz "--disable-graphviz";
+    preBuild       = lib.optional  disableGraphviz "buildFlagsArray+=(\"VALAC=$(pwd)/compiler/valac\")";
+
     outputs = [ "out" "devdoc" ];
 
     nativeBuildInputs = [
       pkgconfig flex bison libxslt
     ] ++ lib.optional (stdenv.isDarwin && (atLeast "0.38")) expat
+      ++ lib.optional disableGraphviz autoreconfHook # if we changed our ./configure script, need to reconfigure
       ++ extraNativeBuildInputs;
 
     buildInputs = [
       glib libiconv libintl
-    ] ++ lib.optional (atLeast "0.38") graphviz
+    ] ++ lib.optional (atLeast "0.38" && withGraphviz) graphviz
       ++ extraBuildInputs;
 
     enableParallelBuilding = true;
@@ -42,7 +85,7 @@ let
       platforms = platforms.unix;
       maintainers = with maintainers; [ antono jtojnar lethalman peterhoeg ];
     };
-  };
+  });
 
 in rec {
   vala_0_36 = generic {

--- a/pkgs/development/compilers/vala/disable-graphviz-0.40.12.patch
+++ b/pkgs/development/compilers/vala/disable-graphviz-0.40.12.patch
@@ -1,0 +1,208 @@
+diff --git i/configure.ac w/configure.ac
+index 694ffd200..915062053 100644
+--- i/configure.ac
++++ w/configure.ac
+@@ -112,34 +112,38 @@ PKG_CHECK_MODULES(GMODULE, gmodule-2.0 >= $GLIB_REQUIRED)
+ AC_SUBST(GMODULE_CFLAGS)
+ AC_SUBST(GMODULE_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBGVC, libgvc >= $LIBGVC_REQUIRED)
+-AC_MSG_CHECKING([for CGRAPH])
+-cgraph_tmp_LIBADD="$LIBADD"
+-cgraph_tmp_CFLAGS="$CFLAGS"
+-LIBADD="$LIBADD $LIBGVC_LIBS"
+-CFLAGS="$CFLAGS $LIBGVC_CFLAGS"
+-AC_RUN_IFELSE(
+-	[AC_LANG_SOURCE([
+-		#include <gvc.h>
+-
+-		int main(void) {
+-			#ifdef WITH_CGRAPH
+-				return 0;
+-			#else
+-				return -1;
+-			#endif
+-		}
+-	])], [
+-		AC_MSG_RESULT([yes])
+-		VALAFLAGS="$VALAFLAGS -D WITH_CGRAPH"
+-		have_cgraph=yes
+-	], [
+-		AC_MSG_RESULT([no])
+-		have_cgraph=no
+-	]
+-)
+-LIBADD="$cgraph_tmp_LIBADD"
+-CFLAGS="$cgraph_tmp_CFLAGS"
++AC_ARG_ENABLE(graphviz, AS_HELP_STRING([--disable-graphviz], [Disable graphviz usage for valadoc]), enable_graphviz=$enableval, enable_graphviz=yes)
++if test x$enable_graphviz = xyes; then
++	PKG_CHECK_MODULES(LIBGVC, libgvc >= $LIBGVC_REQUIRED)
++	AC_MSG_CHECKING([for CGRAPH])
++	VALAFLAGS="$VALAFLAGS -D HAVE_GRAPHVIZ"
++	cgraph_tmp_LIBADD="$LIBADD"
++	cgraph_tmp_CFLAGS="$CFLAGS"
++	LIBADD="$LIBADD $LIBGVC_LIBS"
++	CFLAGS="$CFLAGS $LIBGVC_CFLAGS"
++	AC_RUN_IFELSE(
++		[AC_LANG_SOURCE([
++			#include <gvc.h>
++			int main(void) {
++				#ifdef WITH_CGRAPH
++					return 0;
++				#else
++					return -1;
++				#endif
++			}
++		])], [
++			AC_MSG_RESULT([yes])
++			VALAFLAGS="$VALAFLAGS -D WITH_CGRAPH"
++			have_cgraph=yes
++		], [
++			AC_MSG_RESULT([no])
++			have_cgraph=no
++		]
++	)
++	LIBADD="$cgraph_tmp_LIBADD"
++	CFLAGS="$cgraph_tmp_CFLAGS"
++fi
++AM_CONDITIONAL(ENABLE_GRAPHVIZ, test x$enable_graphviz = xyes)
+ AM_CONDITIONAL(HAVE_CGRAPH, test "$have_cgraph" = "yes")
+ 
+ AC_PATH_PROG([XSLTPROC], [xsltproc], :)
+diff --git i/libvaladoc/Makefile.am w/libvaladoc/Makefile.am
+index f3f790e76..3c5dc4c80 100644
+--- i/libvaladoc/Makefile.am
++++ w/libvaladoc/Makefile.am
+@@ -128,10 +128,6 @@ libvaladoc_la_VALASOURCES = \
+ 	content/tablerow.vala \
+ 	content/taglet.vala \
+ 	content/text.vala \
+-	charts/chart.vala \
+-	charts/chartfactory.vala \
+-	charts/hierarchychart.vala \
+-	charts/simplechartfactory.vala \
+ 	parser/manyrule.vala \
+ 	parser/oneofrule.vala \
+ 	parser/optionalrule.vala \
+@@ -158,13 +154,24 @@ libvaladoc_la_VALASOURCES = \
+ 	highlighter/codetoken.vala \
+ 	highlighter/highlighter.vala \
+ 	html/basicdoclet.vala \
+-	html/htmlchartfactory.vala \
+ 	html/linkhelper.vala \
+ 	html/cssclassresolver.vala \
+ 	html/htmlmarkupwriter.vala \
+ 	html/htmlrenderer.vala \
+ 	$(NULL)
+ 
++if ENABLE_GRAPHVIZ
++libvaladoc_la_VALASOURCES += \
++	charts/chart.vala \
++	charts/chartfactory.vala \
++	charts/hierarchychart.vala \
++	charts/simplechartfactory.vala \
++	html/htmlchartfactory.vala \
++	$(NULL)
++
++LIBGVC_PKG = --vapidir $(top_srcdir)/vapi --pkg libgvc
++endif
++
+ libvaladoc@PACKAGE_SUFFIX@_la_SOURCES = \
+ 	libvaladoc.vala.stamp \
+ 	$(libvaladoc_la_VALASOURCES:.vala=.c) \
+@@ -184,11 +191,11 @@ libvaladoc.vala.stamp: $(libvaladoc_la_VALASOURCES)
+ 		--library valadoc \
+ 		--vapi valadoc@PACKAGE_SUFFIX@.vapi \
+ 		--vapidir $(top_srcdir)/vapi --pkg gmodule-2.0 \
+-		--vapidir $(top_srcdir)/vapi --pkg libgvc \
+ 		--vapidir $(top_srcdir)/gee --pkg gee \
+ 		--vapidir $(top_srcdir)/vala --pkg vala \
+ 		--vapidir $(top_srcdir)/ccode --pkg ccode \
+ 		--vapidir $(top_srcdir)/codegen --pkg codegen \
++		$(LIBGVC_PKG) \
+ 		--pkg config \
+ 		$(filter %.vala %.c,$^)
+ 	touch $@
+@@ -217,6 +224,9 @@ nodist_pkgconfig_DATA = valadoc@PACKAGE_SUFFIX@.pc
+ 
+ valadoc@PACKAGE_SUFFIX@.pc: valadoc.pc
+ 	cp $< $@
++if !ENABLE_GRAPHVIZ
++	sed -i "s/libgvc //g" $@
++endif
+ 
+ vapidir = $(datadir)/vala/vapi
+ dist_vapi_DATA = valadoc@PACKAGE_SUFFIX@.vapi
+@@ -224,6 +234,9 @@ nodist_vapi_DATA = valadoc@PACKAGE_SUFFIX@.deps
+ 
+ valadoc@PACKAGE_SUFFIX@.deps: valadoc.deps
+ 	cp $< $@
++if !ENABLE_GRAPHVIZ
++	sed -i "s/libgvc//g" $@
++endif
+ 
+ EXTRA_DIST = \
+ 	$(libvaladoc_la_VALASOURCES) \
+diff --git i/libvaladoc/html/basicdoclet.vala w/libvaladoc/html/basicdoclet.vala
+index 192e488cd..ec0960222 100644
+--- i/libvaladoc/html/basicdoclet.vala
++++ w/libvaladoc/html/basicdoclet.vala
+@@ -46,7 +46,11 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 	protected HtmlRenderer _renderer;
+ 	protected Html.MarkupWriter writer;
+ 	protected Html.CssClassResolver cssresolver;
++#if HAVE_GRAPHVIZ
+ 	protected Charts.Factory image_factory;
++#else
++	protected void* image_factory;
++#endif
+ 	protected ErrorReporter reporter;
+ 	protected string package_list_link = "../index.html";
+ 
+@@ -120,7 +124,9 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 		this.linker = new LinkHelper ();
+ 
+ 		_renderer = new HtmlRenderer (settings, this.linker, this.cssresolver);
++#if HAVE_GRAPHVIZ
+ 		this.image_factory = new SimpleChartFactory (settings, linker);
++#endif
+ 	}
+ 
+ 
+@@ -1026,6 +1032,7 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 	}
+ 
+ 	protected void write_image_block (Api.Node element) {
++#if HAVE_GRAPHVIZ
+ 		if (element is Class || element is Interface || element is Struct) {
+ 			unowned string format = (settings.use_svg_images ? "svg" : "png");
+ 			var chart = new Charts.Hierarchy (image_factory, element);
+@@ -1045,6 +1052,7 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 									   this.get_img_path_html (element, format)});
+ 			writer.add_usemap (chart);
+ 		}
++#endif
+ 	}
+ 
+ 	public void write_namespace_content (Namespace node, Api.Node? parent) {
+diff --git i/libvaladoc/html/htmlmarkupwriter.vala w/libvaladoc/html/htmlmarkupwriter.vala
+index dcc4dad76..cf9c860b8 100644
+--- i/libvaladoc/html/htmlmarkupwriter.vala
++++ w/libvaladoc/html/htmlmarkupwriter.vala
+@@ -51,12 +51,16 @@ public class Valadoc.Html.MarkupWriter : Valadoc.MarkupWriter {
+ 		}
+ 	}
+ 
++#if HAVE_GRAPHVIZ
+ 	public MarkupWriter add_usemap (Charts.Chart chart) {
+ 		string? buf = (string?) chart.write_buffer ("cmapx");
+ 		if (buf != null) {
+ 			raw_text ("\n");
+ 			raw_text ((!) buf);
+ 		}
++#else
++	public MarkupWriter add_usemap (void* chart) {
++#endif
+ 
+ 		return this;
+ 	}

--- a/pkgs/development/compilers/vala/disable-graphviz-0.42.4.patch
+++ b/pkgs/development/compilers/vala/disable-graphviz-0.42.4.patch
@@ -1,0 +1,208 @@
+diff --git i/configure.ac w/configure.ac
+index 730c72d7b..af8198637 100644
+--- i/configure.ac
++++ w/configure.ac
+@@ -119,34 +119,38 @@ PKG_CHECK_MODULES(GMODULE, gmodule-2.0 >= $GLIB_REQUIRED)
+ AC_SUBST(GMODULE_CFLAGS)
+ AC_SUBST(GMODULE_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBGVC, libgvc >= $LIBGVC_REQUIRED)
+-AC_MSG_CHECKING([for CGRAPH])
+-cgraph_tmp_LIBADD="$LIBADD"
+-cgraph_tmp_CFLAGS="$CFLAGS"
+-LIBADD="$LIBADD $LIBGVC_LIBS"
+-CFLAGS="$CFLAGS $LIBGVC_CFLAGS"
+-AC_RUN_IFELSE(
+-	[AC_LANG_SOURCE([
+-		#include <gvc.h>
+-
+-		int main(void) {
+-			#ifdef WITH_CGRAPH
+-				return 0;
+-			#else
+-				return -1;
+-			#endif
+-		}
+-	])], [
+-		AC_MSG_RESULT([yes])
+-		VALAFLAGS="$VALAFLAGS -D WITH_CGRAPH"
+-		have_cgraph=yes
+-	], [
+-		AC_MSG_RESULT([no])
+-		have_cgraph=no
+-	]
+-)
+-LIBADD="$cgraph_tmp_LIBADD"
+-CFLAGS="$cgraph_tmp_CFLAGS"
++AC_ARG_ENABLE(graphviz, AS_HELP_STRING([--disable-graphviz], [Disable graphviz usage for valadoc]), enable_graphviz=$enableval, enable_graphviz=yes)
++if test x$enable_graphviz = xyes; then
++	PKG_CHECK_MODULES(LIBGVC, libgvc >= $LIBGVC_REQUIRED)
++	AC_MSG_CHECKING([for CGRAPH])
++	VALAFLAGS="$VALAFLAGS -D HAVE_GRAPHVIZ"
++	cgraph_tmp_LIBADD="$LIBADD"
++	cgraph_tmp_CFLAGS="$CFLAGS"
++	LIBADD="$LIBADD $LIBGVC_LIBS"
++	CFLAGS="$CFLAGS $LIBGVC_CFLAGS"
++	AC_RUN_IFELSE(
++		[AC_LANG_SOURCE([
++			#include <gvc.h>
++			int main(void) {
++				#ifdef WITH_CGRAPH
++					return 0;
++				#else
++					return -1;
++				#endif
++			}
++		])], [
++			AC_MSG_RESULT([yes])
++			VALAFLAGS="$VALAFLAGS -D WITH_CGRAPH"
++			have_cgraph=yes
++		], [
++			AC_MSG_RESULT([no])
++			have_cgraph=no
++		]
++	)
++	LIBADD="$cgraph_tmp_LIBADD"
++	CFLAGS="$cgraph_tmp_CFLAGS"
++fi
++AM_CONDITIONAL(ENABLE_GRAPHVIZ, test x$enable_graphviz = xyes)
+ AM_CONDITIONAL(HAVE_CGRAPH, test "$have_cgraph" = "yes")
+ 
+ AC_PATH_PROG([XSLTPROC], [xsltproc], :)
+diff --git i/libvaladoc/Makefile.am w/libvaladoc/Makefile.am
+index f3f790e76..3c5dc4c80 100644
+--- i/libvaladoc/Makefile.am
++++ w/libvaladoc/Makefile.am
+@@ -128,10 +128,6 @@ libvaladoc_la_VALASOURCES = \
+ 	content/tablerow.vala \
+ 	content/taglet.vala \
+ 	content/text.vala \
+-	charts/chart.vala \
+-	charts/chartfactory.vala \
+-	charts/hierarchychart.vala \
+-	charts/simplechartfactory.vala \
+ 	parser/manyrule.vala \
+ 	parser/oneofrule.vala \
+ 	parser/optionalrule.vala \
+@@ -158,13 +154,24 @@ libvaladoc_la_VALASOURCES = \
+ 	highlighter/codetoken.vala \
+ 	highlighter/highlighter.vala \
+ 	html/basicdoclet.vala \
+-	html/htmlchartfactory.vala \
+ 	html/linkhelper.vala \
+ 	html/cssclassresolver.vala \
+ 	html/htmlmarkupwriter.vala \
+ 	html/htmlrenderer.vala \
+ 	$(NULL)
+ 
++if ENABLE_GRAPHVIZ
++libvaladoc_la_VALASOURCES += \
++	charts/chart.vala \
++	charts/chartfactory.vala \
++	charts/hierarchychart.vala \
++	charts/simplechartfactory.vala \
++	html/htmlchartfactory.vala \
++	$(NULL)
++
++LIBGVC_PKG = --vapidir $(top_srcdir)/vapi --pkg libgvc
++endif
++
+ libvaladoc@PACKAGE_SUFFIX@_la_SOURCES = \
+ 	libvaladoc.vala.stamp \
+ 	$(libvaladoc_la_VALASOURCES:.vala=.c) \
+@@ -184,11 +191,11 @@ libvaladoc.vala.stamp: $(libvaladoc_la_VALASOURCES)
+ 		--library valadoc \
+ 		--vapi valadoc@PACKAGE_SUFFIX@.vapi \
+ 		--vapidir $(top_srcdir)/vapi --pkg gmodule-2.0 \
+-		--vapidir $(top_srcdir)/vapi --pkg libgvc \
+ 		--vapidir $(top_srcdir)/gee --pkg gee \
+ 		--vapidir $(top_srcdir)/vala --pkg vala \
+ 		--vapidir $(top_srcdir)/ccode --pkg ccode \
+ 		--vapidir $(top_srcdir)/codegen --pkg codegen \
++		$(LIBGVC_PKG) \
+ 		--pkg config \
+ 		$(filter %.vala %.c,$^)
+ 	touch $@
+@@ -217,6 +224,9 @@ nodist_pkgconfig_DATA = valadoc@PACKAGE_SUFFIX@.pc
+ 
+ valadoc@PACKAGE_SUFFIX@.pc: valadoc.pc
+ 	cp $< $@
++if !ENABLE_GRAPHVIZ
++	sed -i "s/libgvc //g" $@
++endif
+ 
+ vapidir = $(datadir)/vala/vapi
+ dist_vapi_DATA = valadoc@PACKAGE_SUFFIX@.vapi
+@@ -224,6 +234,9 @@ nodist_vapi_DATA = valadoc@PACKAGE_SUFFIX@.deps
+ 
+ valadoc@PACKAGE_SUFFIX@.deps: valadoc.deps
+ 	cp $< $@
++if !ENABLE_GRAPHVIZ
++	sed -i "s/libgvc//g" $@
++endif
+ 
+ EXTRA_DIST = \
+ 	$(libvaladoc_la_VALASOURCES) \
+diff --git i/libvaladoc/html/basicdoclet.vala w/libvaladoc/html/basicdoclet.vala
+index 192e488cd..ec0960222 100644
+--- i/libvaladoc/html/basicdoclet.vala
++++ w/libvaladoc/html/basicdoclet.vala
+@@ -46,7 +46,11 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 	protected HtmlRenderer _renderer;
+ 	protected Html.MarkupWriter writer;
+ 	protected Html.CssClassResolver cssresolver;
++#if HAVE_GRAPHVIZ
+ 	protected Charts.Factory image_factory;
++#else
++	protected void* image_factory;
++#endif
+ 	protected ErrorReporter reporter;
+ 	protected string package_list_link = "../index.html";
+ 
+@@ -120,7 +124,9 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 		this.linker = new LinkHelper ();
+ 
+ 		_renderer = new HtmlRenderer (settings, this.linker, this.cssresolver);
++#if HAVE_GRAPHVIZ
+ 		this.image_factory = new SimpleChartFactory (settings, linker);
++#endif
+ 	}
+ 
+ 
+@@ -1026,6 +1032,7 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 	}
+ 
+ 	protected void write_image_block (Api.Node element) {
++#if HAVE_GRAPHVIZ
+ 		if (element is Class || element is Interface || element is Struct) {
+ 			unowned string format = (settings.use_svg_images ? "svg" : "png");
+ 			var chart = new Charts.Hierarchy (image_factory, element);
+@@ -1045,6 +1052,7 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 									   this.get_img_path_html (element, format)});
+ 			writer.add_usemap (chart);
+ 		}
++#endif
+ 	}
+ 
+ 	public void write_namespace_content (Namespace node, Api.Node? parent) {
+diff --git i/libvaladoc/html/htmlmarkupwriter.vala w/libvaladoc/html/htmlmarkupwriter.vala
+index 5aa4afdea..e79b0b8f5 100644
+--- i/libvaladoc/html/htmlmarkupwriter.vala
++++ w/libvaladoc/html/htmlmarkupwriter.vala
+@@ -51,12 +51,16 @@ public class Valadoc.Html.MarkupWriter : Valadoc.MarkupWriter {
+ 		}
+ 	}
+ 
++#if HAVE_GRAPHVIZ
+ 	public unowned MarkupWriter add_usemap (Charts.Chart chart) {
+ 		string? buf = (string?) chart.write_buffer ("cmapx");
+ 		if (buf != null) {
+ 			raw_text ("\n");
+ 			raw_text ((!) buf);
+ 		}
++#else
++	public unowned MarkupWriter add_usemap (void* chart) {
++#endif
+ 
+ 		return this;
+ 	}

--- a/pkgs/development/compilers/vala/gvc-compat.patch
+++ b/pkgs/development/compilers/vala/gvc-compat.patch
@@ -1,0 +1,19 @@
+diff --git i/libvaladoc/Makefile.am w/libvaladoc/Makefile.am
+index 8dc398cf1..a5d8a45b4 100644
+--- i/libvaladoc/Makefile.am
++++ w/libvaladoc/Makefile.am
+@@ -176,9 +176,13 @@ endif
+ libvaladoc@PACKAGE_SUFFIX@_la_SOURCES = \
+ 	libvaladoc.vala.stamp \
+ 	$(libvaladoc_la_VALASOURCES:.vala=.c) \
+-	gvc-compat.c \
+ 	$(NULL)
+ 
++if ENABLE_GRAPHVIZ
++libvaladoc@PACKAGE_SUFFIX@_la_SOURCES += \
++	gvc-compat.c
++endif
++
+ valadoc@PACKAGE_SUFFIX@.vapi valadoc.h: libvaladoc.vala.stamp
+ libvaladoc.vala.stamp: $(libvaladoc_la_VALASOURCES)
+ 	$(VALA_V)$(VALAC) \


### PR DESCRIPTION
###### Motivation for this change
This allows building Vala without support for Graphviz; useful for more minimal installs where we don't want to pull it (and transitively, pango, gd, etc.) in as a dependency.

As an example with vala 0.38:

```
# with Graphviz
$ nix path-info -S /nix/store/wy3ajrqhplx7lnh4gnqv2pwd6w7insml-vala-0.38.9
/nix/store/wy3ajrqhplx7lnh4gnqv2pwd6w7insml-vala-0.38.9	  195998064

# without
$ nix path-info -S /nix/store/1nalx8vpq6hzsp40x83wwqqaw8aa3di7-vala-0.38.9   
/nix/store/1nalx8vpq6hzsp40x83wwqqaw8aa3di7-vala-0.38.9	   55116152
```

Or, from ~187MiB to ~53MiB! TBD on whether we want to enable this by default; I've left it as-is for now, and will defer on whether to enable this in more places, or create `valaMinimal`, etc. to any reviewers.  At the very least, we probably want to use this for `libsecret`, which is how I originally noticed this; building libsecret from scratch required building all of X11, since there was the following chain of dependencies:

`vala` :arrow_right: `graphviz` :arrow_right: `libXpm` :arrow_right: `xproto` :arrow_right: `libX11`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

r? @antono @jtojnar @lethalman @peterhoeg (maintainers)