### PR TITLE
fflas-ffpack: add patch to fix flaky test

### DIFF
--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, givaro, pkgconfig, blas
+, fetchpatch
 , gmpxx
 , optimize ? false # impure
 }:
@@ -13,6 +14,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1cqhassj2dny3gx0iywvmnpq8ca0d6m82xl5rz4mb8gaxr2kwddl";
   };
+
+  patches = [
+    # https://github.com/linbox-team/fflas-ffpack/issues/146
+    (fetchpatch {
+      name = "fix-flaky-test-fgemm-check.patch";
+      url = "https://github.com/linbox-team/fflas-ffpack/commit/d8cd67d91a9535417a5cb193cf1540ad6758a3db.patch";
+      sha256 = "1gnfc616fvnlr0smvz6lb2d445vn8fgv6vqcr6pwm3dj4wa6v3b3";
+    })
+  ];
 
   checkInputs = [
     gmpxx


### PR DESCRIPTION
###### Motivation for this change

Fix https://github.com/linbox-team/fflas-ffpack/issues/146 which will also be fixed in the next release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

