### PR TITLE
argtable: init at 2.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3781,6 +3781,11 @@
     github = "rprospero";
     name = "Adam Washington";
   };
+  rsoeldner = {
+    email = "r.soeldner@gmail.com";
+    github = "rsoeldner";
+    name = "Robert Soeldner";
+  };
   rszibele = {
     email = "richard@szibele.com";
     github = "rszibele";

--- a/pkgs/tools/misc/argtable2/default.nix
+++ b/pkgs/tools/misc/argtable2/default.nix
@@ -7,13 +7,13 @@ stdenv.mkDerivation rec {
   version = "2.13";
 
   src = fetchurl {
-    url = http://prdownloads.sourceforge.net/argtable/argtable2-13.tar.gz;
+    url = mirror://sourceforge/argtable/argtable2-13.tar.gz;
     sha256 = "1gyxf4bh9jp5gb3l6g5qy90zzcf3vcpk0irgwbv1lc6mrskyhxwg";
   };
 
   meta = with stdenv.lib; {
     homepage = https://www.argtable.org/;
-    description = "A Cross-Platform, Single-File, ANSI C Command-Line Parsing Library";
+    description = "A Cross-Platform, ANSI C Command-Line Parsing Library";
     license = licenses.bsd3;
     maintainers = with maintainers; [ rsoeldner ];
   };

--- a/pkgs/tools/misc/argtable2/default.nix
+++ b/pkgs/tools/misc/argtable2/default.nix
@@ -1,0 +1,21 @@
+{ stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  name = "argtable-${version}";
+  version = "2.13";
+
+  src = fetchurl {
+    url = mirror://sourceforge/argtable/argtable2-13.tar.gz;
+    sha256 = "1gyxf4bh9jp5gb3l6g5qy90zzcf3vcpk0irgwbv1lc6mrskyhxwg";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://www.argtable.org/;
+    description = "A Cross-Platform, ANSI C Command-Line Parsing Library";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rsoeldner ];
+  };
+}
+

--- a/pkgs/tools/misc/argtable2/default.nix
+++ b/pkgs/tools/misc/argtable2/default.nix
@@ -1,0 +1,21 @@
+{ stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  name = "argtable-${version}";
+  version = "2.13";
+
+  src = fetchurl {
+    url = http://prdownloads.sourceforge.net/argtable/argtable2-13.tar.gz;
+    sha256 = "1gyxf4bh9jp5gb3l6g5qy90zzcf3vcpk0irgwbv1lc6mrskyhxwg";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://www.argtable.org/;
+    description = "A Cross-Platform, Single-File, ANSI C Command-Line Parsing Library";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rsoeldner ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -577,6 +577,8 @@ in
 
   argtable = callPackage ../tools/misc/argtable {};
 
+  argtable2 = callPackage ../tools/misc/argtable2 {};
+
   argyllcms = callPackage ../tools/graphics/argyllcms {};
 
   arp-scan = callPackage ../tools/misc/arp-scan { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

