### PR TITLE
mupdf: fix CVE-2018-18662

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkgconfig, freetype, harfbuzz, openjpeg
+{ stdenv, lib, fetchurl, fetchpatch, pkgconfig, freetype, harfbuzz, openjpeg
 , jbig2dec, libjpeg , darwin
 , enableX11 ? true, libX11, libXext, libXi, libXrandr
 , enableCurl ? true, curl, openssl
@@ -24,7 +24,14 @@ in stdenv.mkDerivation rec {
 
   patches =
     # Use shared libraries to decrease size
-       stdenv.lib.optional (!stdenv.isDarwin) ./mupdf-1.14-shared_libs.patch
+    [( fetchpatch
+      {
+          name = "CVE-2018-18662";
+          url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=164ddc22ee0d5b63a81d5148f44c37dd132a9356";
+          sha256 = "1jkzh20n3b854871h86cy5y7fvy0d5wyqy51b3fg6gj3a0jqpzzd";
+      }
+    )]
+    ++ stdenv.lib.optional (!stdenv.isDarwin) ./mupdf-1.14-shared_libs.patch
     ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch
   ;
 


### PR DESCRIPTION
###### Motivation for this change

Closes #51740

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

