### PR TITLE
Couple of media conteiner descriptions

### DIFF
--- a/pkgs/development/libraries/libmkv/default.nix
+++ b/pkgs/development/libraries/libmkv/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
   preConfigure = "sh bootstrap.sh";
 
   meta = {
+    description = "Abandoned library. Alternative lightweight Matroska muxer written for HandBrake";
+    longDescription = ''
+      Library was meant to be an alternative to the official libmatroska library.
+      It is written in plain C, and intended to be very portable.
+    '';
     homepage = https://github.com/saintdev/libmkv;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.wmertens ];

--- a/pkgs/development/libraries/libogg/default.nix
+++ b/pkgs/development/libraries/libogg/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "doc" ];
 
   meta = with stdenv.lib; {
+    description = "Media container library to manipulate Ogg files";
+    longDescription = ''
+      Library to work with Ogg multimedia container format.
+      Ogg is flexible file storage and streaming format that supports
+      plethora of codecs. Open format free for anyone to use.
+    '';
     homepage = https://xiph.org/ogg/;
     license = licenses.bsd3;
     maintainers = [ maintainers.ehmry ];

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       This container format is derived from Apple's QuickTime format.
     '';
     homepage = https://code.google.com/archive/p/mp4v2/;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.Anton-Latukha ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mpl11;
   };

--- a/pkgs/development/libraries/mp4v2/default.nix
+++ b/pkgs/development/libraries/mp4v2/default.nix
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
+    description = "Abandoned library. Provides functions to read, create, and modify mp4 files";
+    longDescription = ''
+      MP4v2 library provides an API to work with mp4 files
+      as defined by ISO-IEC:14496-1:2001 MPEG-4 Systems.
+      This container format is derived from Apple's QuickTime format.
+    '';
     homepage = https://code.google.com/archive/p/mp4v2/;
     maintainers = [ ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Seen that there is no description for this packages, so provided.
MP4v2 had no maintainer - so, set myself as one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

