### PR TITLE
betaflight-configurator: init at 10.5.1

### DIFF
--- a/pkgs/applications/science/robotics/betaflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/betaflight-configurator/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, unzip, runtimeShell, makeDesktopItem, nwjs }:
+{stdenv, fetchurl, unzip, runtimeShell, makeDesktopItem, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
 
 let
   strippedName = "betaflight-configurator";

--- a/pkgs/applications/science/robotics/betaflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/betaflight-configurator/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, unzip, runtimeShell, makeDesktopItem, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
+{stdenv, fetchurl, unzip, runtimeShell, makeDesktopItem, makeWrapper, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
 
 let
   strippedName = "betaflight-configurator";
@@ -32,12 +32,7 @@ stdenv.mkDerivation rec {
     cp icon/*_icon_128.png $out/share/icons/${strippedName}-icon.png
     cp -r ${desktopItem}/share/applications $out/share/
 
-    cat >$out/bin/${strippedName}<<EOL
-    #!${runtimeShell}
-
-    ${nwjs}/bin/nw $out/opt/${strippedName} 
-    EOL
-    chmod +x $out/bin/${strippedName}
+    makeWrapper ${nwjs}/bin/nw $out/bin/${strippedName} --add-flags $out/opt/${strippedName}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/robotics/betaflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/betaflight-configurator/default.nix
@@ -19,7 +19,9 @@ stdenv.mkDerivation rec {
     sha256 = "1l4blqgaqfrnydk05q6pwdqdhcly2f8nwzrv0749cqmfiinh8ygc";
   };
 
-  buildInputs = [ unzip ];
+  nativeBuildInputs = [ wrapGAppsHook ];
+  
+  buildInputs = [ unzip gsettings-desktop-schemas gtk3 ];
   
   installPhase = ''
     mkdir -p $out/bin \

--- a/pkgs/applications/science/robotics/betaflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/betaflight-configurator/default.nix
@@ -1,0 +1,53 @@
+{stdenv, fetchurl, unzip, runtimeShell, makeDesktopItem, nwjs }:
+
+let
+  strippedName = "betaflight-configurator";
+  desktopItem = makeDesktopItem {
+    name = strippedName;
+    exec = strippedName;
+    icon = "${strippedName}-icon.png";
+    comment = "Betaflight configuration tool";
+    desktopName = "Betaflight Configurator";
+    genericName = "Flight controller configuration tool";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "${strippedName}-${version}";
+  version = "10.5.1";
+  src = fetchurl {
+    url = "https://github.com/betaflight/betaflight-configurator/releases/download/${version}/${strippedName}_${version}_linux64.zip";
+    sha256 = "1l4blqgaqfrnydk05q6pwdqdhcly2f8nwzrv0749cqmfiinh8ygc";
+  };
+
+  buildInputs = [ unzip ];
+  
+  installPhase = ''
+    mkdir -p $out/bin \
+             $out/opt/${strippedName} \
+             $out/share/icons
+
+    cp -r . $out/opt/${strippedName}/
+    cp icon/*_icon_128.png $out/share/icons/${strippedName}-icon.png
+    cp -r ${desktopItem}/share/applications $out/share/
+
+    cat >$out/bin/${strippedName}<<EOL
+    #!${runtimeShell}
+
+    ${nwjs}/bin/nw $out/opt/${strippedName} 
+    EOL
+    chmod +x $out/bin/${strippedName}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Betaflight flight control system configuration tool";
+    longDescription = ''
+      A crossplatform configuration tool for the Betaflight flight control system.
+      Various types of aircraft are supported by the tool and by Betaflight, e.g. 
+      quadcopters, hexacopters, octocopters and fixed-wing aircraft.
+    '';
+    homepage    = https://github.com/betaflight/betaflight/wiki;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ wucke13 ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22983,6 +22983,8 @@ in
 
   apmplanner2 = libsForQt511.callPackage ../applications/science/robotics/apmplanner2 { };
 
+  betaflight-configurator = callPackage ../applications/science/robotics/betaflight-configurator { };
+
   ### MISC
 
   acpilight = callPackage ../misc/acpilight { };


### PR DESCRIPTION
###### Motivation for this change

Adding more GCS/Drone Configuration tools to the nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

