### PR TITLE
[18.09] urn: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/development/compilers/urn/default.nix
+++ b/pkgs/development/compilers/urn/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "0.7.1";
+  version = "0.7.2";
   # Build a sort of "union package" with all the native dependencies we
   # have: Lua (or LuaJIT), readline, etc. Then, we can depend on this
   # and refer to ${urn-rt} instead of ${lua}, ${readline}, etc.
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "urn";
     repo = "urn";
     rev = "v${version}";
-    sha256 = "1vw0sljrczbwl7fl5d3frbpklb0larzyp7s7mwwprkb07b027sd5";
+    sha256 = "0nclr3d8ap0y5cg36i7g4ggdqci6m5q27y9f26b57km8p266kcpy";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Backport update to version [0.7.2](https://github.com/SquidDev/urn/releases/tag/v0.7.2) (bugfix update).
Original PR: #53014 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

