### PR TITLE
gnome3.gvfs: Add TLS support

### DIFF
--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -2,7 +2,7 @@
 , glib, libgudev, udisks2, libgcrypt, libcap, polkit
 , libgphoto2, avahi, libarchive, fuse, libcdio
 , libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, samba, libmtp
-, gnomeSupport ? false, gnome, makeWrapper
+, gnomeSupport ? false, gnome, wrapGAppsHook
 , libimobiledevice, libbluray, libcdio-paranoia, libnfs, openssh
 , libsecret, libgdata, python3
 }:
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja python3
-    pkgconfig gettext makeWrapper
+    pkgconfig gettext wrapGAppsHook
     libxml2 libxslt docbook_xsl docbook_xml_dtd_42
   ];
 
@@ -40,6 +40,7 @@ in stdenv.mkDerivation rec {
     # ToDo: a ligther version of libsoup to have FTP/HTTP support?
   ] ++ stdenv.lib.optionals gnomeSupport (with gnome; [
     libsoup gcr
+    glib-networking # TLS support
     gnome-online-accounts libsecret libgdata
   ]);
 
@@ -56,14 +57,6 @@ in stdenv.mkDerivation rec {
 
   doCheck = false; # fails with "ModuleNotFoundError: No module named 'gi'"
   doInstallCheck = doCheck;
-
-  preFixup = ''
-    for f in $out/libexec/*; do
-      wrapProgram $f \
-        ${stdenv.lib.optionalString gnomeSupport "--prefix GIO_EXTRA_MODULES : \"${stdenv.lib.getLib gnome.dconf}/lib/gio/modules\""} \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-    done
-  '';
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
###### Motivation for this change
GLib Gio’s GFile uses gvfs daemon for opening files over HTTP protocol.
To support HTTPS, we need to include glib-networking.

Closes: https://github.com/NixOS/nixpkgs/issues/52963

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @bjornfor 