### PR TITLE
udev rules to support U2F security keys

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -510,6 +510,11 @@
     github = "bdimcheff";
     name = "Brandon Dimcheff";
   };
+  benbals = {
+    name = "Ben Justus Bals";
+    github = "BenBals";
+    email = "benbals@posteo.de";
+  };
   bendlas = {
     email = "herwig@bendlas.net";
     github = "bendlas";

--- a/pkgs/tools/security/u2f-udev-rules/default.nix
+++ b/pkgs/tools/security/u2f-udev-rules/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub }:
+
+## Usage
+# In NixOS, simply add this package to services.udev.packages:
+#   services.udev.packages = [ pkgs.u2f-udev-rules ];
+
+stdenv.mkDerivation rec {
+  name = "u2f-udev-rules-${version}";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "Yubico";
+    repo = "libu2f-host";
+    rev = "libu2f-host-" + version;
+    sha256 = "3735fe2e4c763fc998a6a7d8401b26ec0efbae0dfe943bdd521962d07d68c01a";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D 70-u2f.rules $out/lib/udev/rules.d/70-u2f.rules
+  '';
+
+  meta = {
+    homepage = https://support.yubico.com/support/solutions/articles/15000006449-using-your-u2f-yubikey-with-linux;
+    description = "udev rules for your U2F key like a Yubikey";
+    longDescription = ''
+      These udev rules written by Yubico, the makers of the Yubikey add support for the
+      Yubikey, Happlink Security Key, HyperSecu HyperFIDO, Feitian ePass FIDO, JaCarta U2F,
+      U2F Zero, VASCO SecureClick, Bluink Key, Thetis Key, Nitrokey FIDO U2F and the Google Titan U2F.
+      Simply add this to your configuration: services.udev.packages = [ pkgs.u2f-udev-rules ];
+    '';
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ benbals ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5905,6 +5905,8 @@ in
 
   txtw = callPackage ../tools/misc/txtw { };
 
+  u2f-udev-rules = callPackage ../tools/security/u2f-udev-rules { };
+
   u9fs = callPackage ../servers/u9fs { };
 
   ua = callPackage ../tools/networking/ua { };


### PR DESCRIPTION
###### Motivation for this change
Physical security keys like the YubiKey can greatly improve the security of software systems. U2F is an open standard supported by most major internet sites like GitHub, Twitter, Google and others. You can use the physical key just like a normal key. You need to insert it into your computer (most of the time in addition to your password) to login your accounts.

On Linux udev rules are needed to support U2F security keys. Yubico, the makers of the YubiKey, maintain a rules file that supports a number of security keys, namely the following:
Yubikey, Happlink Security Key, HyperSecu HyperFIDO, Feitian ePass FIDO, JaCarta U2F, U2F Zero, VASCO SecureClick, Bluink Key, Thetis Key, Nitrokey FIDO U2F and the Google Titan U2F.

###### Things done
This package gives nixos users a simple way to install the rules file needed for their security key. All one has to to is add it to the udev packages in the nix configuration:
```nix
services.udev.packages = [ pkgs.u2f-udev-rules ];
```

I have tested this package with the YubiKey 5C and I have verified that the rules file is placed in the [correct location](https://support.yubico.com/support/solutions/articles/15000006449-using-your-u2f-yubikey-with-linux), so it should work like the normal place-the-file-here install on other distros.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

