### PR TITLE
gap: 4r8p10 -> 4.10.0

### DIFF
--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -1,6 +1,8 @@
 { stdenv
+, lib
 , fetchurl
 , fetchpatch
+, makeWrapper
 , m4
 , gmp
 # don't remove any packages -- results in a ~1.3G size increase
@@ -11,24 +13,17 @@
 stdenv.mkDerivation rec {
   pname = "gap";
   # https://www.gap-system.org/Releases/
-  # newer versions (4.9.0) are available, but still considered beta (https://github.com/gap-system/gap/wiki/GAP-4.9-release-notes)
-  version = "4r8p10";
-  pkgVer = "2018_01_15-13_02";
-  name = "${pname}-${version}";
+  version = "4.10.0";
 
-  src = let
-    # 4r8p10 -> 48
-    majorminor = stdenv.lib.replaceStrings ["r"] [""] (
-      builtins.head (stdenv.lib.splitString "p" version) # 4r8p10 -> 4r8
-    );
-  in
-    fetchurl {
-    url = "https://www.gap-system.org/pub/gap/gap${majorminor}/tar.bz2/gap${version}_${pkgVer}.tar.bz2";
-    sha256 = "0wzfdjnn6sfiaizbk5c7x44rhbfayis4lf57qbqqg84c7dqlwr6f";
+  src = fetchurl {
+    url = "https://www.gap-system.org/pub/gap/gap-${lib.versions.major version}.${lib.versions.minor version}/tar.bz2/gap-${version}.tar.bz2";
+    sha256 = "1dmb8v4p7j1nnf7sx8sg54b49yln36bi9acwp7w1d3a1nxj17ird";
   };
 
   # remove all non-essential packages (which take up a lot of space)
-  preConfigure = stdenv.lib.optionalString (!keepAllPackages) ''
+  preConfigure = ''
+    patchShebangs .
+  '' + lib.optionalString (!keepAllPackages) ''
     find pkg -type d -maxdepth 1 -mindepth 1 \
        -not -name 'GAPDoc-*' \
        -not -name 'autpgrp*' \
@@ -37,26 +32,63 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [ "--with-gmp=system" ];
-  buildInputs = [ m4 gmp ];
+
+  buildInputs = [
+    m4
+    gmp
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   patches = [
-    #  fix infinite loop in writeandcheck() when writing an error message fails.
+    # bugfix: https://github.com/gap-system/gap/pull/3102
     (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/gap/patches/writeandcheck.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "1r1511x4kc2i2mbdq1b61rb6p3misvkf1v5qy3z6fmn6vqwziaz1";
+      name = "fix-infinite-loop-in-writeandcheck.patch";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/gap/patches/0001-a-version-of-the-writeandcheck.patch-from-Sage-that-.patch?id=5e61d7b6a0da3aa53d8176fa1fb9353cc559b098";
+      sha256 = "1zkv8bbiw3jdn54sqqvfkdkfsd7jxzq0bazwsa14g4sh2265d28j";
+    })
+
+    # needed for libgap (sage): https://github.com/gap-system/gap/pull/3043
+    (fetchpatch {
+      name = "add-error-messages-helper.patch";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/gap/patches/0002-kernel-add-helper-function-for-writing-error-message.patch?id=5e61d7b6a0da3aa53d8176fa1fb9353cc559b098";
+      sha256 = "0c4ry5znb6hwwp8ld6k62yw8w6cqldflw3x49bbzizbmipfpidh5";
+    })
+
+    # needed for libgap (sage): https://github.com/gap-system/gap/pull/3096
+    (fetchpatch {
+      name = "gap-enter.patch";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/gap/patches/0003-Prototype-for-GAP_Enter-Leave-macros-to-bracket-use-.patch?id=5e61d7b6a0da3aa53d8176fa1fb9353cc559b098";
+      sha256 = "12fg8mb8rm6khsz1r4k3k26jrkx4q1rv13hcrfnlhn0m7iikvc3q";
     })
   ];
 
-  doCheck = true;
-  checkTarget = "testinstall";
   # "teststandard" is a superset of testinstall. It takes ~1h instead of ~1min.
   # tests are run twice, once with all packages loaded and once without
   # checkTarget = "teststandard";
 
-  preCheck = ''
+  doInstallCheck = true;
+  installCheckTarget = "testinstall";
+
+  preInstallCheck = ''
     # gap tests check that the home directory exists
     export HOME="$TMP/gap-home"
     mkdir -p "$HOME"
+
+    # make sure gap is in PATH
+    export PATH="$out/bin:$PATH"
+
+    # make sure we don't accidentally use the wrong gap binary
+    rm -r bin
+
+    # like the defaults the Makefile, but use gap from PATH instead of the
+    # one from builddir
+    installCheckFlagsArray+=(
+      "TESTGAP=gap --quitonbreak -b -m 100m -o 1g -q -x 80 -r -A"
+      "TESTGAPauto=gap --quitonbreak -b -m 100m -o 1g -q -x 80 -r"
+    )
   '';
 
   postCheck = ''
@@ -78,14 +110,20 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin" "$out/share/gap/"
 
-    cp -r . "$out/share/gap/build-dir"
+    mkdir -p "$out/share/gap"
+    echo "Copying files to target directory"
+    cp -ar . "$out/share/gap/build-dir"
 
-    sed -e "/GAP_DIR=/aGAP_DIR='$out/share/gap/build-dir/'" -i "$out/share/gap/build-dir/bin/gap.sh"
-
-    ln -s "$out/share/gap/build-dir/bin/gap.sh" "$out/bin/gap"
+    makeWrapper "$out/share/gap/build-dir/bin/gap.sh" "$out/bin/gap" \
+      --set GAP_DIR $out/share/gap/build-dir
   '';
 
-  meta = with stdenv.lib; {
+  preFixup = ''
+    # patchelf won't strip references to the build dir if it still exists
+    rm -rf pkg
+  '';
+
+  meta = with lib; {
     description = "Computational discrete algebra system";
     maintainers = with maintainers;
     [
@@ -96,7 +134,7 @@ stdenv.mkDerivation rec {
     # keeping all packages increases the package size considerably, wchich
     # is why a local build is preferable in that situation. The timeframe
     # is reasonable and that way the binary cache doesn't get overloaded.
-    hydraPlatforms = stdenv.lib.optionals (!keepAllPackages) meta.platforms;
+    hydraPlatforms = lib.optionals (!keepAllPackages) meta.platforms;
     license = licenses.gpl2;
     homepage = http://gap-system.org/;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10806,11 +10806,17 @@ in
         url = "https://www.gap-system.org/pub/gap/gap48/tar.bz2/gap${version}_${pkgVer}.tar.bz2";
         sha256 = "19n2p1mdg33s2x9rs51iak7rgndc1cwr56jyqnah0g1ydgg1yh6b";
       };
-      patches = (oldAttrs.patches or []) ++ [
+      patches = [
         # don't install any packages by default (needed for interop with libgap, probably obsolete  with 4r10
         (fetchpatch {
           url = "https://git.sagemath.org/sage.git/plain/build/pkgs/gap/patches/nodefaultpackages.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
           sha256 = "1xwj766m3axrxbkyx13hy3q8s2wkqxy3m6mgpwq3c3n4vk3v416v";
+        })
+
+        #  fix infinite loop in writeandcheck() when writing an error message fails.
+        (fetchpatch {
+          url = "https://git.sagemath.org/sage.git/plain/build/pkgs/gap/patches/writeandcheck.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+          sha256 = "1r1511x4kc2i2mbdq1b61rb6p3misvkf1v5qy3z6fmn6vqwziaz1";
         })
       ];
   });


### PR DESCRIPTION
###### Motivation for this change

This new version also has a libgap replacement, so after the next sage
update gap-libgap-compatible and libgap won't be necessary anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

