### PR TITLE
riko4: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/curlpp/default.nix
+++ b/pkgs/development/libraries/curlpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, curl }:
+
+stdenv.mkDerivation rec {
+  name = "curlpp-${version}";
+  version = "0.8.1";
+  src = fetchFromGitHub {
+    owner = "jpbarrette";
+    repo = "curlpp";
+    rev = "v${version}";
+    sha256 = "1b0ylnnrhdax4kwjq64r1fk0i24n5ss6zfzf4hxwgslny01xiwrk";
+  };
+
+  buildInputs = [ curl ];
+  nativeBuildInputs = [ cmake ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://www.curlpp.org/;
+    description = "C++ wrapper around libcURL";
+    license = licenses.mit;
+    maintainers = with maintainers; [ CrazedProgrammer ];
+  };
+}

--- a/pkgs/games/riko4/default.nix
+++ b/pkgs/games/riko4/default.nix
@@ -1,0 +1,68 @@
+{ stdenv, fetchFromGitHub, cmake, SDL2, libGLU, luajit, curl, curlpp }:
+
+let
+  # Newer versions of sdl-gpu don't work with Riko4 (corrupted graphics),
+  # and this library does not have a proper release version, so let the
+  # derivation for this stay next to the Riko4 derivation for now.
+  sdl-gpu = stdenv.mkDerivation rec {
+    name = "sdl-gpu-${version}";
+    version = "2018-11-01";
+    src = fetchFromGitHub {
+      owner = "grimfang4";
+      repo = "sdl-gpu";
+      rev = "a4ff1ab02410f154b004c29ec46e07b22890fa1f";
+      sha256 = "1wdwg331s7r4dhq1l8w4dvlqf4iywskpdrscgbwrz9j0c6nqqi3v";
+    };
+    buildInputs = [ SDL2 libGLU ];
+    nativeBuildInputs = [ cmake ];
+    enableParallelBuilding = true;
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/grimfang4/sdl-gpu;
+      description = "A library for high-performance, modern 2D graphics with SDL written in C";
+      license = licenses.mit;
+      maintainers = with maintainers; [ CrazedProgrammer ];
+    };
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "riko4-${version}";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    owner = "incinirate";
+    repo = "Riko4";
+    rev = "v${version}";
+    sha256 = "008i9991sn616dji96jfwq6gszrspbx4x7cynxb1cjw66phyy5zp";
+  };
+
+  buildInputs = [ SDL2 luajit sdl-gpu curl curlpp ];
+  nativeBuildInputs = [ cmake ];
+
+  hardeningDisable = [ "fortify" ];
+  cmakeFlags = [ "-DSDL2_gpu_INCLUDE_DIR=\"${sdl-gpu}/include\"" ];
+
+  # Riko4 needs the data/ and scripts/ directories to be in its PWD.
+  installPhase = ''
+    install -Dm0755 riko4 $out/bin/.riko4-unwrapped
+    mkdir -p $out/lib/riko4
+    cp -r ../data $out/lib/riko4
+    cp -r ../scripts $out/lib/riko4
+    cat > $out/bin/riko4 <<EOF
+    #!/bin/sh
+    pushd $out/lib/riko4 > /dev/null
+    exec $out/bin/.riko4-unwrapped "\$@"
+    popd > /dev/null
+    EOF
+    chmod +x $out/bin/riko4
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/incinirate/Riko4;
+    description = "Fantasy console for pixel art game development";
+    license = licenses.mit;
+    maintainers = with maintainers; [ CrazedProgrammer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20894,6 +20894,8 @@ in
     };
   };
 
+  riko4 = callPackage ../games/riko4 { };
+
   rili = callPackage ../games/rili { };
 
   rimshot = callPackage ../games/rimshot { love = love_0_7; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9535,6 +9535,8 @@ in
 
   curlcpp = callPackage ../development/libraries/curlcpp { };
 
+  curlpp = callPackage ../development/libraries/curlpp { };
+
   cutee = callPackage ../development/libraries/cutee { };
 
   cutelyst = libsForQt5.callPackage ../development/libraries/cutelyst { };


### PR DESCRIPTION
###### Motivation for this change

[Riko4](https://github.com/incinirate/Riko4) is a fantasy game console inspired by TIC-80 and PICO-8.

This PR also adds `curlpp: init at 0.8.1`, a dependency of Riko4.
There is also the dependency `sdl-gpu`, but this library does not have a dependable release, and the newest commit does not work with Riko4, so I included this in the Riko4 expression.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

