### PR TITLE
python.pkgs.cysignals: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -9,11 +9,11 @@ assert pariSupport -> pari != null;
 
 buildPythonPackage rec {
   pname = "cysignals";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1yh4lyrinhxxra42p0k4hiyjdrqjmifg4gnmf4bky5wa0mqnyai6";
+    sha256 = "1hnkcrrxgh6g8a197v2yw61xz43iyv81jbl6jpy19ql3k66w81zx";
   };
 
   # explicit check:
@@ -22,9 +22,9 @@ buildPythonPackage rec {
     "fortify"
   ];
 
-  # currently fails, probably because of formatting changes in gdb 8.0
-  # https://trac.sagemath.org/ticket/24692
+  # known failure: https://github.com/sagemath/cysignals/blob/582dbf6a7b0f9ade0abe7a7b8720b7fb32435c3c/testgdb.py#L5
   doCheck = false;
+  checkTarget = "check-install";
 
   preCheck = ''
     # Make sure cysignals-CSI is in PATH


### PR DESCRIPTION
###### Motivation for this change

Latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

