### PR TITLE
Add nixos cpufreq max min options

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -408,6 +408,16 @@
        from nixpkgs due to the lack of maintainers.
      </para>
    </listitem>
+   <listitem>
+    <para>
+       The <option>powerManagement.cpuFreqGovernor</option> option has been
+       aliased to <option>powerManagement.cpufreq.governor</option>.  On laptops,
+       <option>powerManagement.cpuFreqGovernor</option> is sometimes set in
+       <literal>/etc/nixos/hardware-configuration.nix</literal>, so you can
+       rename it to the new name, or run
+       <literal>nixos-generate-config</literal> again.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -104,7 +104,7 @@ if (-e "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors") {
 
     foreach $e (@desired_governors) {
         if (index($governors, $e) != -1) {
-            last if (push @attrs, "powerManagement.cpuFreqGovernor = lib.mkDefault \"$e\";");
+            last if (push @attrs, "powerManagement.cpufreq.governor = lib.mkDefault \"$e\";");
         }
     }
 }

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -286,6 +286,9 @@ with lib;
     (mkRenamedOptionModule [ "hardware" "ckb" "enable" ] [ "hardware" "ckb-next" "enable" ])
     (mkRenamedOptionModule [ "hardware" "ckb" "package" ] [ "hardware" "ckb-next" "package" ])
 
+    # cpufeq
+    (mkAliasOptionModule [ "powerManagement" "cpuFreqGovernor" ] [ "powerManagement" "cpufreq" "governor" ])
+
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"
                    "snmpExporter" "unifiExporter" "varnishExporter" ]

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -55,7 +55,9 @@ in
   config = mkIf cfg.enable {
 
     powerManagement.scsiLinkPolicy = null;
-    powerManagement.cpuFreqGovernor = null;
+    powerManagement.cpufreq.governor = null;
+    powerManagement.cpufreq.max = null;
+    powerManagement.cpufreq.min = null;
 
     systemd.sockets."systemd-rfkill".enable = false;
 

--- a/nixos/modules/tasks/cpu-freq.nix
+++ b/nixos/modules/tasks/cpu-freq.nix
@@ -4,22 +4,43 @@ with lib;
 
 let
   cpupower = config.boot.kernelPackages.cpupower;
-  cfg = config.powerManagement;
+  cfg = config.powerManagement.cpufreq;
 in
 
 {
   ###### interface
 
-  options = {
+  options.powerManagement.cpufreq = {
 
-    powerManagement.cpuFreqGovernor = mkOption {
+    governor = mkOption {
       type = types.nullOr types.str;
       default = null;
       example = "ondemand";
       description = ''
         Configure the governor used to regulate the frequence of the
         available CPUs. By default, the kernel configures the
-        performance governor.
+        performance governor, although this may be overwriten in your
+        hardware-configuration.nix file.
+
+        Often used values: "ondemand", "powersave", "performance"
+      '';
+    };
+
+    max = mkOption {
+      type = types.nullOr types.ints.unsigned;
+      default = null;
+      example = 2200000;
+      description = ''
+        The maximum frequency the CPU will use.  Defaults to the maximum possible.
+      '';
+    };
+
+    min = mkOption {
+      type = types.nullOr types.ints.unsigned;
+      default = null;
+      example = 800000;
+      description = ''
+        The minimum frequency the CPU will use.
       '';
     };
 
@@ -28,25 +49,37 @@ in
 
   ###### implementation
 
-  config = mkIf (!config.boot.isContainer && config.powerManagement.cpuFreqGovernor != null) {
+  config =
+    let
+      governorEnable = cfg.governor != null;
+      maxEnable = cfg.max != null;
+      minEnable = cfg.min != null;
+      enable =
+        !config.boot.isContainer &&
+        (governorEnable || maxEnable || minEnable);
+    in
+    mkIf enable {
 
-    boot.kernelModules = [ "cpufreq_${cfg.cpuFreqGovernor}" ];
+      boot.kernelModules = optional governorEnable "cpufreq_${cfg.governor}";
 
-    environment.systemPackages = [ cpupower ];
+      environment.systemPackages = [ cpupower ];
 
-    systemd.services.cpufreq = {
-      description = "CPU Frequency Governor Setup";
-      after = [ "systemd-modules-load.service" ];
-      wantedBy = [ "multi-user.target" ];
-      path = [ cpupower pkgs.kmod ];
-      unitConfig.ConditionVirtualization = false;
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = "yes";
-        ExecStart = "${cpupower}/bin/cpupower frequency-set -g ${cfg.cpuFreqGovernor}";
-        SuccessExitStatus = "0 237";
+      systemd.services.cpufreq = {
+        description = "CPU Frequency Setup";
+        after = [ "systemd-modules-load.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ cpupower pkgs.kmod ];
+        unitConfig.ConditionVirtualization = false;
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = "yes";
+          ExecStart = "${cpupower}/bin/cpupower frequency-set " +
+            optionalString governorEnable "--governor ${cfg.governor} " +
+            optionalString maxEnable "--max ${toString cfg.max} " +
+            optionalString minEnable "--min ${toString cfg.min} ";
+          SuccessExitStatus = "0 237";
+        };
       };
-    };
 
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This adds a NixOS option for setting the CPU max and min frequencies with `cpufreq`.  The two options that have been added are:

- `powerManagement.cpufreq.max`
- `powerManagement.cpufreq.min`

It also renames the `powerManagement.cpuFreqGovernor` option to `powerManagement.cpufreq.governor`.  I could update this to be a module alias instead of a module rename if that would be preferred.

This updates the installer to use the new option name.  It also updates the manual for with a note about the new name.

I think it makes the most sense to have `powerManagement.cpufreq.{governor, max, min}` instead of the options `powerManagement.{cpuFreqGovernor, cpuFreqMax, cpuFreqMin}`, but I'd be okay with either one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

