### PR TITLE
WIP: Declarative wrappers

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -43,6 +43,9 @@ let
     generators = callLibs ./generators.nix;
     misc = callLibs ./deprecated.nix;
 
+    # declarative wrappers
+    wrappers = callLibs ./wrappers.nix;
+
     # domain-specific
     fetchers = callLibs ./fetchers.nix;
 

--- a/lib/wrappers.nix
+++ b/lib/wrappers.nix
@@ -1,0 +1,250 @@
+{ lib }:
+/* Operations on or within declarative wrappers.
+
+
+A declarative wrapper defines how a wrapper should look. Its an attribute set
+and its attributes represent the arguments passed on to `makeWrapper`.
+
+- `source`          : Wrap program located at `source` to new location. When specified, use `makeWrapper`, otherwise, `wrapProgram`.
+- `argv0`           : Set name of executed process.
+- `vars`            : Environment variables.
+
+It is defined as an attribute set where each value represents an environment value.
+
+For each environment variable, one can define:
+- `value`           : Value of the environment variable. String or list of strings.
+- `valueModifier`   : Function that is applied to `value`. Function.
+- `action`          : What to do when creating a wrapper. E.g. whether the value should be set, unset, appended or prepended. Function.
+- `onMerge`         : What should happen in case of a wrapper merge. Function.
+
+Example of a declarative wrapper:
+
+  with lib.wrappers; with python.pkgs;
+
+  wrapper1 = {
+    flags = [ "--verbose" ];
+    vars = {
+      PYTHONPATH = {
+        value = [ networkx numpy ];
+        valueModifier = makePythonPath;
+#         action = set;
+        onMerge = overwrite;
+      };
+      PATH = {
+        value = [ graphviz ];
+        valueModifier = makeBinPath;
+#         action = prefix ":";
+        onMerge = append;
+#         sep = ":";
+      };
+    };
+  };
+
+
+This wrapper sets `PYTHONPATH` and prefixes `PATH`.
+
+Consider also a second wrapper:
+
+  wrapper2 = {
+    run = [ ];
+    vars =
+      PYTHONPATH = {
+        value = [ scipy ];
+        onMerge = append;
+      };
+    };
+  };
+
+This wrapper also defines `PYTHONPATH`.
+
+These two wrappers can be merged using the `merge` function. E.g., the first wrapper
+can be updated with the second one:
+
+  result = merge wrapper1 wrapper2;
+
+On a merge, the `onMerge` attribute of the environment variable of the second
+wrapper determines what happens. That means, in this case,
+
+  result = {
+    flags = [ "--verbose" ];
+    vars = {
+      PYTHONPATH = {
+        value = [ networkx numpy scipy ];
+        valueModifier = python.pkgs.makePythonPath;
+        action = set;
+        onMerge = append;
+      };
+      PATH = {
+        value = [ graphviz ];
+        valueModifier = makeBinPath;
+        action = prefix ":";
+        onMerge = append;
+        sep = ":";
+      };
+    };
+  };
+
+
+*/
+
+with lib;
+
+let
+
+  hasEqualRequiredAttrs = a: b: let
+    # Attributes to check for
+    attrsRequiredEqual = [ "action" "extension" "sep" "valueModifier" "onMerge" ];
+    # Check whether they are equal, in case they exist in `a`.
+    assertEqualAttrValue = attr: a:  b: a.${attr} == b.${attr};
+  in all (map assertEqualAttrValue attrsRequiredEqual);
+
+  /* Compute the actual value of an environment variable.
+
+  A `valueModifier` is needed in case `attrs.value` is a list.
+  */
+  computeValue = attrs:
+    if isList attrs.value then attrs.valueModifier attrs.value
+    else (attrs.valueModifier or (x: x)) attrs.value;
+
+in rec {
+
+  /* Merge two declarative wrappers.
+  */
+  merge = a: b: let
+    merge_var = envvar: _: b.${envvar}.onMerge a.${envvar} (b.${envvar} or {});
+  in a // (mapAttrs merge_var b);
+
+
+  /* Merge two declarative wrappers using `rules`.
+
+  */
+
+#   mergeUsing = rules: a: b:
+
+
+  /* Merge two declarative wrappers using the default rules.*/
+#   mergeUsingDefaults = mergeUsing defaults;
+
+  /* Generate a list with arguments passed on to `makeWrapper`.*/
+  generateMakeWrapperArgs = wrapper: let
+    addVars = var: attrs: let
+      shouldGenerate = attrs?action && (attrs?value || attrs.action == unset);
+    in [] ++ optional shouldGenerate (attrs.action var attrs);
+  in []
+    ++ optional (hasAttr "argv0" wrapper) "--argv0 ${wrapper.argv0}"
+    ++ optional (hasAttr "run" wrapper) "--run ${concatStringsSep " " wrapper.run}"
+    ++ optional (hasAttr "flags" wrapper) "--add-flags ${concatStringsSep " " wrapper.flags}"
+    ++ optionals (hasAttr "vars" wrapper) (flatten (mapAttrsToList addVars wrapper.vars));
+
+  /* Generate the call(s) to `makeWrapper` or `wrapProgram`.
+
+  Given a wrapper destination, and the wrapper requirements, this function generates
+  the invocations for generating a wrapper.
+
+  We need to support the following cases:
+  - a specific executable, e.g. "bin/git". This will invoke `wrapProgram` exactly once.
+  - a path containing executable, e.g. "bin". This may invoke `wrapProgram` several times.
+  - a specific executable along with a source path. This will invoke `makeWrapper` exactly once.
+
+  Furthermore, multiple outputs need to be considered.
+
+  */
+  makeWrapperCall = dest: wrapper: let
+    empty = list: (length list) == 0;
+    argsList = generateMakeWrapperArgs wrapper;
+    args = concatStringsSep " " argsList;
+  in if (!(empty argsList) || wrapper?source) then
+    if wrapper?source then "makeWrapper ${wrapper.source} ${dest} ${args}"
+    else "find ${dest} -type f -executable -exec sh -c 'wrapProgram \"$0\" ${args}' {} \\;"
+  else "";
+
+
+  /* The following are functions for merging wrapper attributes.*/
+
+  /* Overwrite the first with the second. */
+  overwrite = a: b: b;
+
+  /* Discard the second. */
+  discard = a: b: a;
+
+  /* Append the first with the second.
+
+  Note this only makes sense when the environment variable represents a list.
+  */
+  append = a: b:
+    assert hasEqualRequiredAttrs a b;
+    b // a.value ++ b.value;
+
+  /* Prepend the first with the second.
+
+  Note this only makes sense when the environment variable represents a list.
+  */
+  prepend = a: b:
+    assert hasEqualRequiredAttrs a b;
+    b // a.value ++ b.value;
+
+  /* Throw a message when attempting to merge. */
+  raise = msg: a: b: throw msg;
+
+
+  /* The following functions create, given the environment variable name and its attributes,
+  a string that is used in the actual wrapper.
+  */
+
+  /* Set an environment variable.
+  */
+  set = envvar: attrs: "--set ${envvar} ${computeValue attrs}";
+
+  /* Unset an environment variable.
+  */
+  unset = envvar: attrs: "--unset ${envvar}";
+
+  /* Prefix an environment variable.
+  */
+  prefix = sep: envvar: attrs: "--prefix ${envvar} ${sep} ${computeValue attrs}";
+
+  /* Suffix an environment variable.
+  */
+  suffix = sep: envvar: attrs: "--suffix ${envvar} ${sep} ${computeValue attrs}";
+
+
+  /* The following are default values used throughout Nixpkgs */
+  defaults = {
+    LD_LIBRARY_PATH = {
+      action = set;
+      onMerge = prepend;
+      valueModifier = makeLibraryPath;
+    };
+    JAVA_HOME = {
+      action = set;
+    };
+    LUA_PATH = {
+      action = set;
+      onMerge = prepend;
+    };
+    PERL5LIB = {
+      action = set;
+      onMerge = prepend;
+      valueModifier = makeFullPerlPath;
+    };
+    PYTHONHOME = {
+      action = set;
+#       onMerge = raise "Cannot change PYTHONHOME as it will result in breakage.";
+    };
+#     PYTHONPATH = {
+#       action = set;
+#       onMerge = prepend;
+#     };
+    PATH = {
+      action = prefix ":";
+      onMerge = prepend;
+      valueModifier = makeBinPath;
+    };
+    XDG_DATA_DIRS = {
+      action = prefix ":";
+      onMerge = prepend;
+      valueModifier = drvs: makeSearchPath "share" ":" drvs;
+    };
+  };
+
+}

--- a/pkgs/build-support/setup-hooks/make-declarative-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-declarative-wrapper.sh
@@ -1,0 +1,9 @@
+preFixupPhases+=" makeDeclarativeWrapperPhase"
+
+makeDeclarativeWrapperPhase() {
+    runHook preMakeDeclarativeWrapper
+    echo "Creating a declarative wrapper by evaluating: ${makeWrapperCalls}"
+    export -f assertExecutable makeWrapper wrapProgram
+    eval ${makeWrapperCalls}
+    runHook postMakeDeclarativeWrapper
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -125,6 +125,14 @@ let
       };
     });
 
+
+  # Default values for when generating wrappers.
+  wrapperDefaults.PYTHONPATH = {
+    valueModifier = makePythonPath;
+      action = lib.wrappers.set;
+      onMerge = lib.wrappers.prepend;
+  };
+
   disabledIf = x: drv:
     if x then throw "${removePythonPrefix (drv.pname or drv.name)} not supported for interpreter ${python.executable}" else drv;
 


### PR DESCRIPTION
This commit adds library functions and a setup hook for creating wrappers declaratively.

###### Motivation for this change

To do:
- [ ] Solve multiple outputs. Where does `libexec` go? Do we want to support executables at arbitrary locations and outputs? Hardcode `lib.getOutput "bin"` or introduce an extra level of nesting so we can specify the output? `"wrappers."bin"."bin/foo".PATH.value = [ git ];`
- [ ] Find right location for "lib" code.
- [ ] Consider the default values.
- [ ] Documentation
- [ ] Changelog
- [ ] Use it in several separate commits

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

