### PR TITLE
WIP: gitlab-runner: Allow reload instead of restart on configuration change

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -116,10 +116,14 @@ in
         ++ optional hasDocker "docker.service";
       requires = optional hasDocker "docker.service";
       wantedBy = [ "multi-user.target" ];
+      preStart = "cp ${configFile} /var/lib/gitlab-runner/config.toml";
+      reload = "cp ${configFile} /var/lib/gitlab-runner/config.toml";
+      reloadIfChanged = true;
       serviceConfig = {
+        StateDirectory = "gitlab-runner";
         ExecStart = ''${cfg.package.bin}/bin/gitlab-runner run \
           --working-directory ${cfg.workDir} \
-          --config ${configFile} \
+          --config /var/lib/gitlab-runner/config.toml \
           --service gitlab-runner \
           --user gitlab-runner \
         '';


### PR DESCRIPTION
###### Motivation for this change

Allow modification of `gitlab-runner` configuration without losing in-flight jobs due to restart.

We place the configuration in the service's state directory to allow reloading. `gitlab-runner` monitors this file and reloads when it is changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

