### PR TITLE
soapysdr: fix modules-directory for extraPackages

### DIFF
--- a/pkgs/applications/misc/soapysdr/default.nix
+++ b/pkgs/applications/misc/soapysdr/default.nix
@@ -6,7 +6,11 @@
 } :
 
 let
+
   version = "0.7.0";
+  modulesVersion = with lib; versions.major version + "." + versions.minor version;
+  modulesPath = "lib/SoapySDR/modules" + modulesVersion;
+  extraPackagesSearchPath = lib.makeSearchPath modulesPath extraPackages;
 
 in stdenv.mkDerivation {
   name = "soapysdr-${version}";
@@ -18,8 +22,8 @@ in stdenv.mkDerivation {
     sha256 = "14fjwnfj7jz9ixvim2gy4f52y6s7d4xggzxn2ck7g4q35d879x13";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libusb ncurses numpy swig2 python makeWrapper ];
+  nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
+  buildInputs = [ libusb ncurses numpy python swig2 ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
@@ -31,11 +35,9 @@ in stdenv.mkDerivation {
     for i in ${toString extraPackages}; do
       ${lndir}/bin/lndir -silent $i $out
     done
-
     # Needed for at least the remote plugin server
     for file in $out/bin/*; do
-        wrapProgram "$file" \
-            --prefix SOAPY_SDR_PLUGIN_PATH : ${lib.makeSearchPath "lib/SoapySDR/modules0.6" extraPackages}
+        wrapProgram "$file" --prefix SOAPY_SDR_PLUGIN_PATH : ${extraPackagesSearchPath}
     done
   '';
 
@@ -47,4 +49,3 @@ in stdenv.mkDerivation {
     platforms = platforms.linux;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

