### PR TITLE
polybar: 3.2.1 -> 3.3.0

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -26,11 +26,11 @@ assert i3GapsSupport -> ! i3Support     && jsoncpp != null && i3-gaps != null;
 
 stdenv.mkDerivation rec {
     name = "polybar-${version}";
-    version = "3.2.1";
+    version = "3.3.0";
     src = fetchgit {
       url = "https://github.com/jaagr/polybar";
       rev = version;
-      sha256 = "1z45swj2l0h8x8li7prl963cgl6zm3birsswpij8qwcmjaj5l8vz";
+      sha256 = "18hrsbq62na2i4rlwbs2ih7v9shnayg76nw14i6az28wpf8kx4rr";
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update polybar from 3.2.1 to [3.2.1](https://github.com/jaagr/polybar/releases/tag/3.3.0)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions