### PR TITLE
newsboat: 2.13 -> 2.14

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, stfl, sqlite, curl, gettext, pkgconfig, libxml2, json_c, ncurses
-, asciidoc, docbook_xml_dtd_45, libxslt, docbook_xsl, libiconv, makeWrapper }:
+{ stdenv, rustPlatform, fetchurl, stfl, sqlite, curl, gettext, pkgconfig, libxml2, json_c, ncurses
+, asciidoc, docbook_xml_dtd_45, libxslt, docbook_xsl, libiconv, Security, makeWrapper }:
 
-stdenv.mkDerivation rec {
+rustPlatform.buildRustPackage rec {
   name = "newsboat-${version}";
-  version = "2.13";
+  version = "2.14";
 
   src = fetchurl {
     url = "https://newsboat.org/releases/${version}/${name}.tar.xz";
-    sha256 = "0pik1d98ydzqi6055vdbkjg5krwifbk2hy2f5jp5p1wcy2s16dn7";
+    sha256 = "13bdwnwxa66c69lqhb02basff0aa6q1jhl7fgahcxmdy7snbmg37";
   };
+
+  cargoSha256 = "11s50qy1b833r2b5kr1wx9imi9h7s00c0hs36ricgbd0xw7n76hd";
 
   prePatch = ''
     substituteInPlace Makefile --replace "|| true" ""
@@ -18,18 +20,25 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig asciidoc docbook_xml_dtd_45 libxslt docbook_xsl ]
-                      ++ stdenv.lib.optional stdenv.isDarwin [ makeWrapper libiconv ];
+    ++ stdenv.lib.optional stdenv.isDarwin [ makeWrapper libiconv ];
 
-  buildInputs = [ stfl sqlite curl gettext libxml2 json_c ncurses ];
+  buildInputs = [ stfl sqlite curl gettext libxml2 json_c ncurses ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
 
-  makeFlags = [ "prefix=$(out)" ];
-
-  doCheck = true;
-  checkTarget = "test";
+  postBuild = ''
+    make
+  '';
 
   NIX_CFLAGS_COMPILE = "-Wno-error=sign-compare";
 
+  doCheck = true;
+
+  checkPhase = ''
+    make test
+  '';
+
   postInstall = ''
+    make prefix="$out" install
     cp -r contrib $out
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     for prog in $out/bin/*; do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4427,7 +4427,9 @@ in
 
   networkmanager_dmenu = callPackage ../tools/networking/network-manager/dmenu.nix  { };
 
-  newsboat = callPackage ../applications/networking/feedreaders/newsboat { };
+  newsboat = callPackage ../applications/networking/feedreaders/newsboat {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   nextcloud = callPackage ../servers/nextcloud { };
 


### PR DESCRIPTION
Starting with this release, they also use Rust: https://github.com/newsboat/newsboat/blob/master/CHANGELOG.md#214---2018-12-29
Someone familiar with Nixpkgs' Rust infrastructure should have a look at this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

