### PR TITLE
gcc: 7.3 -> 7.4

### DIFF
--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -37,7 +37,7 @@ assert langGo -> langCC;
 with stdenv.lib;
 with builtins;
 
-let version = "7.3.0";
+let version = "7.4.0";
 
     inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
@@ -138,7 +138,7 @@ stdenv.mkDerivation ({
 
   src = fetchurl {
     url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
-    sha256 = "0p71bij6bfhzyrs8676a8jmpjsfz392s2rg862sdnsk30jpacb43";
+    sha256 = "0lgy170b0pp60j9cczqkmaqyjjb584vfamj4c30swd7k0j6y5pgd";
   };
 
   inherit patches;


### PR DESCRIPTION
https://gcc.gnu.org/gcc-7/changes.html

###### Motivation for this change

Revisiting previous update PR, #51633 .  GitHub isn't letting me reopen (since branch was recreated or force-pushed, apparently, which are both true) so making new PR for this.

Previously observed ICE re:LLVM7 no longer occurs as tested by myself and @vcunat (not using this exact commit however).  I'm building system with this-- which has been chugging away all afternoon-- which is only to help ensure not entirely broken ;).  Testing help/jobset/thoughts appreciated :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

