### PR TITLE
dropbox: 55.4.171 -> 63.4.107

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -7,7 +7,7 @@ assert lib.elem stdenv.hostPlatform.system platforms;
 # Dropbox client to bootstrap installation.
 # The client is self-updating, so the actual version may be newer.
 let
-  version = "55.4.171";
+  version = "63.4.107";
 
   arch = {
     "x86_64-linux" = "x86_64";


### PR DESCRIPTION
###### Motivation for this change

Current Dropbox version is too old.  When installing it and linking your
account there is an error message from Dropbox saying the version is too old, prevents
the client from starting.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
       - Debian Stretch
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - No such tests found. 
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
    - Got a "Nothing changed" output
- [X] Tested execution of all binary files (usually in `./result/bin/`)
    - Tested the executable by using Dropbox and syncing.
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    - Before and after sizes were identical.
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---