### PR TITLE
WIP: EDK2, OVMF.fd: fixes for cross-compilation + dependencies + armv7l

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, edk2, seabios, openssl, secureBoot ? false }:
+{ stdenv, lib, buildPackages, edk2, seabios, openssl, iasl, nasm, secureBoot ? false }:
 
 let
   projectDscPath = if stdenv.isi686 then
@@ -30,7 +30,7 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
   # TODO: properly include openssl for secureBoot
   buildInputs = [ ] ++ stdenv.lib.optionals (secureBoot == true) [ openssl ];
 
-  nativeBuildInputs = [ buildPackages.iasl ];
+  nativeBuildInputs = [ iasl nasm ];
 
   hardeningDisable = [ "stackprotector" "pic" "fortify" ];
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, edk2, nasm, iasl, seabios, openssl, secureBoot ? false }:
+{ stdenv, lib, buildPackages, edk2, seabios, openssl, secureBoot ? false }:
 
 let
   projectDscPath = if stdenv.isi686 then
@@ -28,7 +28,9 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
   outputs = [ "out" "fd" ];
 
   # TODO: properly include openssl for secureBoot
-  buildInputs = [nasm iasl] ++ stdenv.lib.optionals (secureBoot == true) [ openssl ];
+  buildInputs = [ ] ++ stdenv.lib.optionals (secureBoot == true) [ openssl ];
+
+  nativeBuildInputs = [ buildPackages.iasl ];
 
   hardeningDisable = [ "stackprotector" "pic" "fortify" ];
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
     export EDK2_TOOLCHAIN=GCC49
 
     # Configures for cross-compiling
-    export ''${EDK2_TOOLCHAIN}_${hostArch}_PREFIX=${stdenv.targetPlatform.config}-
+    export ''${EDK2_TOOLCHAIN}_${hostArch}_PREFIX=${stdenv.cc.targetPrefix}
     export EDK2_HOST_ARCH=${hostArch}
 
     build \

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, edk2, nasm, iasl, seabios, openssl, secureBoot ? false }:
+{ stdenv, lib, buildPackages, edk2, nasm, iasl, seabios, openssl, secureBoot ? false }:
 
 let
   projectDscPath = if stdenv.isi686 then
@@ -14,7 +14,8 @@ let
 
   version = (builtins.parseDrvName edk2.name).version;
 
-  inherit (edk2) src targetArch;
+  inherit (edk2) src;
+  hostArch = buildPackages.edk2.targetArch;
 
   buildFlags = if stdenv.isAarch64 then ""
     else if seabios == null then ''${lib.optionalString secureBoot "-DSECURE_BOOT_ENABLE=TRUE"}''
@@ -68,13 +69,13 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
     export EDK2_TOOLCHAIN=GCC49
 
     # Configures for cross-compiling
-    export ''${EDK2_TOOLCHAIN}_${targetArch}_PREFIX=${stdenv.targetPlatform.config}-
-    export EDK2_HOST_ARCH=${targetArch}
+    export ''${EDK2_TOOLCHAIN}_${hostArch}_PREFIX=${stdenv.targetPlatform.config}-
+    export EDK2_HOST_ARCH=${hostArch}
     '' + ''
     build \
       -n $NIX_BUILD_CORES \
       ${buildFlags} \
-      -a ${targetArch} \
+      -a ${hostArch} \
       ${lib.optionalString crossCompiling "-t $EDK2_TOOLCHAIN"}
   '';
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -10,8 +10,6 @@ let
   else
     throw "Unsupported architecture";
 
-  crossCompiling = stdenv.buildPlatform != stdenv.hostPlatform;
-
   version = (builtins.parseDrvName edk2.name).version;
 
   inherit (edk2) src;
@@ -64,19 +62,19 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
     ''}
   '';
 
-  buildPhase = lib.optionalString crossCompiling ''
+  buildPhase = ''
     # This is required, even though it is set in target.txt in edk2/default.nix.
     export EDK2_TOOLCHAIN=GCC49
 
     # Configures for cross-compiling
     export ''${EDK2_TOOLCHAIN}_${hostArch}_PREFIX=${stdenv.targetPlatform.config}-
     export EDK2_HOST_ARCH=${hostArch}
-    '' + ''
+
     build \
       -n $NIX_BUILD_CORES \
       ${buildFlags} \
       -a ${hostArch} \
-      ${lib.optionalString crossCompiling "-t $EDK2_TOOLCHAIN"}
+      -t $EDK2_TOOLCHAIN
   '';
 
   postFixup = if stdenv.isAarch64 || stdenv.isAarch32 then ''

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -72,11 +72,8 @@ edk2 = stdenv.mkDerivation {
   passthru = {
     inherit targetArch hostArch;
     setup = projectDscPath: attrs: {
-      buildInputs = stdenv.lib.optionals (attrs ? buildInputs) attrs.buildInputs;
-      nativeBuildInputs = [ buildPythonEnv ] ++
-        stdenv.lib.optionals (attrs ? nativeBuildInputs) attrs.nativeBuildInputs;
-
-      depsBuildBuild = [ buildPackages.iasl ];
+      buildInputs = [] ++ attrs.buildInputs or [];
+      nativeBuildInputs = [ buildPythonEnv buildPackages.iasl ] ++ attrs.nativeBuildInputs or [];
 
       configurePhase = ''
         mkdir -v Conf
@@ -108,7 +105,7 @@ edk2 = stdenv.mkDerivation {
       ";
 
       installPhase = "mv -v Build/*/* $out";
-    } // (removeAttrs attrs [ "buildInputs" ] );
+    } // (removeAttrs attrs [ "buildInputs" "nativeBuildInputs" ] );
   };
 };
 

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -19,7 +19,7 @@ buildPythonEnv = buildPackages.python2.withPackages(ps: [ps.tkinter]);
 pythonEnv = python2.withPackages(ps: [ps.tkinter]);
 
 targetArch = envToArch targetPlatform;
-hostArch = envToArch buildPlatform;
+hostArch = envToArch hostPlatform;
 
 edk2 = stdenv.mkDerivation {
   name = "edk2-2017-12-05";

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -39,9 +39,9 @@ edk2 = stdenv.mkDerivation {
     })
   ];
 
-  buildInputs = [ libuuid ];
+  nativeBuildInputs = [ libuuid buildPythonEnv ];
 
-  depsBuildBuild = [ buildPackages.stdenv.cc buildPackages.libuuid buildPythonEnv ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   makeFlags = [
     "-C" "BaseTools"

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildPackages, targetPlatform, buildPlatform, fetchFromGitHub, fetchpatch, libuuid, python2 }:
 
 let
-# Given a stdenv, returns the edk2-valid arch.
+# Given a platform, returns the edk2-valid arch.
 envToArch = env:
   if env.isi686 then
     "IA32"

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, targetPlatform, buildPlatform, fetchFromGitHub, fetchpatch, libuuid, python2 }:
+{ stdenv, buildPackages, targetPlatform, hostPlatform, fetchFromGitHub, fetchpatch, libuuid, python2 }:
 
 let
 # Given a platform, returns the edk2-valid arch.
@@ -72,7 +72,6 @@ edk2 = stdenv.mkDerivation {
   passthru = {
     inherit targetArch hostArch;
     setup = projectDscPath: attrs: {
-      nativeBuildInputs = [ buildPythonEnv buildPackages.iasl ] ++ attrs.nativeBuildInputs or [];
       nativeBuildInputs = [ buildPythonEnv ] ++ attrs.nativeBuildInputs or [];
 
       configurePhase = ''
@@ -81,15 +80,9 @@ edk2 = stdenv.mkDerivation {
         cp ${edk2}/BaseTools/Conf/target.template Conf/target.txt
         sed -i Conf/target.txt \
           -e 's|Nt32Pkg/Nt32Pkg.dsc|${projectDscPath}|' \
-          -e 's|MYTOOLS|GCC49|' \
-          -e 's|IA32|${targetArch}|' \
-          -e 's|DEBUG|RELEASE|'\
+          -e 's|DEBUG|RELEASE|'
 
         cp ${edk2}/BaseTools/Conf/tools_def.template Conf/tools_def.txt
-        sed -i Conf/tools_def.txt \
-          -e 's|DEFINE GCC48_IA32_PREFIX       = /usr/bin/|DEFINE GCC48_IA32_PREFIX       = ""|' \
-          -e 's|DEFINE GCC48_X64_PREFIX        = /usr/bin/|DEFINE GCC48_X64_PREFIX        = ""|' \
-          -e 's|DEFINE UNIX_IASL_BIN           = /usr/bin/iasl|DEFINE UNIX_IASL_BIN           = ${buildPackages.iasl}/bin/iasl|'
 
         export WORKSPACE="$PWD"
         export EFI_SOURCE="$PWD/EdkCompatibilityPkg"

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -72,8 +72,8 @@ edk2 = stdenv.mkDerivation {
   passthru = {
     inherit targetArch hostArch;
     setup = projectDscPath: attrs: {
-      buildInputs = [] ++ attrs.buildInputs or [];
       nativeBuildInputs = [ buildPythonEnv buildPackages.iasl ] ++ attrs.nativeBuildInputs or [];
+      nativeBuildInputs = [ buildPythonEnv ] ++ attrs.nativeBuildInputs or [];
 
       configurePhase = ''
         mkdir -v Conf
@@ -105,7 +105,7 @@ edk2 = stdenv.mkDerivation {
       ";
 
       installPhase = "mv -v Build/*/* $out";
-    } // (removeAttrs attrs [ "buildInputs" "nativeBuildInputs" ] );
+    } // (removeAttrs attrs [ "nativeBuildInputs" ] );
   };
 };
 

--- a/pkgs/development/compilers/iasl/default.nix
+++ b/pkgs/development/compilers/iasl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, bison, flex}:
+{stdenv, fetchurl, bison, flex, m4}:
 
 stdenv.mkDerivation rec {
   name = "iasl-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildFlags = "iasl";
 
-  buildInputs = [ bison flex ];
+  nativeBuildInputs = [ m4 bison flex ];
 
   installPhase =
     ''

--- a/pkgs/development/interpreters/python/build-python-package.nix
+++ b/pkgs/development/interpreters/python/build-python-package.nix
@@ -2,6 +2,7 @@
 # and can build packages that use distutils, setuptools or flit.
 
 { lib
+, buildPackages
 , config
 , python
 , wrapPython
@@ -24,6 +25,7 @@ let
   mkPythonDerivation = import ./mk-python-derivation.nix {
     inherit lib config python wrapPython setuptools unzip ensureNewerSourcesForZipFilesHook;
     inherit toPythonModule namePrefix writeScript update-python-libraries;
+    inherit buildPackages;
   };
 in
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -1,6 +1,7 @@
 # Generic builder.
 
 { lib
+, buildPackages
 , config
 , python
 , wrapPython
@@ -100,7 +101,7 @@ let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attr
     # Check if we have two packages with the same name in the closure and fail.
     # If this happens, something went wrong with the dependencies specs.
     # Intentionally kept in a subdirectory, see catch_conflicts/README.md.
-    ${python.interpreter} ${./catch_conflicts}/catch_conflicts.py
+    ${buildPackages.python.interpreter} ${./catch_conflicts}/catch_conflicts.py
   '' + attrs.postFixup or '''';
 
   meta = {

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, buildPackages
 , fetchPypi
 , python
 , wrapPython
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
       dst=$out/${python.sitePackages}
       mkdir -p $dst
       export PYTHONPATH="$dst:$PYTHONPATH"
-      ${python.interpreter} setup.py install --prefix=$out
+      ${buildPackages.python.interpreter} setup.py install --prefix=$out
       wrapPythonPrograms
   '';
 


### PR DESCRIPTION
**THIS NEEDS FIXES CURRENTLY IN STAGING TO BUILD**. It is why this is based on staging.

This also needs a good review by the peeps that know more about cross-compilation. Some of the fixes, especially the python-touching fixes, may not be optimal.

###### Motivation for this change

Well, get the OVMF EFI "floppy disks" (that's what .fd stands for?) for aarch64 and armv7l buildable with cross-compilation. Furthermore, get the armv7l build going too.

This is prep work for personal stuff, but hey, nixpkgs gets better here!

This was verified to work using `qemu-system-*` and the x86_64, aarch64 and armv7l NixOS iso. (The NixOS armv7l iso is another WIP thing, but it's really not good now.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

