### PR TITLE
fish: do not use internal wcwidth

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -102,7 +102,7 @@ let
 
     nativeBuildInputs = [ cmake ];
     buildInputs = [ ncurses libiconv pcre2 ];
-    configureFlags = [ "--without-included-pcre2" ];
+    cmakeFlags = [ "-DINTERNAL_WCWIDTH=OFF" ];
 
     preConfigure = ''
       patchShebangs ./build_tools/git_version_gen.sh


### PR DESCRIPTION
###### Motivation for this change

Disables the internal wcwidth implementation of fish.  This is important when typing characters such as ⚡ (U+26A1 HIGH VOLTAGE SIGN), otherwise fish computes a different character width than the terminal.  See https://github.com/fish-shell/fish-shell/pull/4816 and https://github.com/NixOS/nixpkgs/pull/53022#issuecomment-450523009

Before (comparison with alacritty):
![fish-before](https://user-images.githubusercontent.com/313929/50545869-bca49b80-0c1d-11e9-9ab9-33335e30f14c.png)

After:
![fish-after](https://user-images.githubusercontent.com/313929/50545872-c5956d00-0c1d-11e9-8c27-d58d327c1c12.png)

cc @jtojnar @adisbladis @ocharles 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

