### PR TITLE
vimUtils.buildVimPlugin: fix helptag generation

### DIFF
--- a/pkgs/misc/vim-plugins/build-vim-plugin.nix
+++ b/pkgs/misc/vim-plugins/build-vim-plugin.nix
@@ -36,7 +36,13 @@ rec {
 
         # build help tags
         if [ -d "$target/doc" ]; then
-          ${vim}/bin/vim -N -u NONE -i NONE -n -E -s -c "helptags $1/doc" +quit! || echo "docs to build failed"
+          echo "Building help tags"
+          if ! ${vim}/bin/vim -N -u NONE -i NONE -n -E -s -c "helptags $target/doc" +quit!; then
+            echo "Failed to build help tags!"
+            exit 1
+          fi
+        else
+          echo "No docs available"
         fi
 
         if [ -n "$addonInfo" ]; then


### PR DESCRIPTION
###### Motivation for this change

I messed that up in my refactoring in #52767, since I moved the relevant
bash code out of a function and failed to adjust the shell variable
name. Now the plugin build will fail loudly when help tag generation
fails to make sure this doesn't happen again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

