### PR TITLE
fuse-overlayfs: init at 0.2

### DIFF
--- a/pkgs/tools/filesystems/fuse-overlayfs/default.nix
+++ b/pkgs/tools/filesystems/fuse-overlayfs/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, autoreconfHook, pkgconfig, fuse3 }:
+
+let
+  version = "0.2";
+in
+  pkgs.stdenv.mkDerivation {
+    name = "fuse-overlayfs-${version}";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "containers";
+      repo = "fuse-overlayfs";
+      rev = "1e2b65baa2f75eea0e4bab90b5ac81dd8471256c";
+      sha256 = "0a9ix8rqjs5r28jsriyiv4yq7iilmv69x05kf23s1ihzrvrfkl08";
+    };
+
+    nativeBuildInputs = [ autoreconfHook pkgconfig ];
+    buildInputs = [ fuse3 ];
+
+    meta = with lib; {
+      homepage = https://github.com/containers/fuse-overlayfs;
+      description = "FUSE implementation for overlayfs";
+      longDescription = "An implementation of overlay+shiftfs in FUSE for rootless containers.";
+      license = licenses.gpl3;
+      platforms = platforms.unix;
+      maintainers = [ maintainers.ma9e ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2813,6 +2813,8 @@ in
 
   fuse-7z-ng = callPackage ../tools/filesystems/fuse-7z-ng { };
 
+  fuse-overlayfs = callPackage ../tools/filesystems/fuse-overlayfs {};
+
   fusee-launcher = callPackage ../development/tools/fusee-launcher { };
 
   fwknop = callPackage ../tools/security/fwknop { };


### PR DESCRIPTION
###### Motivation for this change

Add the fuse-overlayfs package to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

