### PR TITLE
fix fetchFromGitLab to use repository archive downloads

### DIFF
--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -3,8 +3,11 @@
 # gitlab example
 { owner, repo, rev, domain ? "gitlab.com", name ? "source", group ? null
 , ... # For hash agility
-}@args: fetchzip ({
+}@args: fetchzip (
+let
+  repo-url = "https://${domain}/${lib.optionalString (group != null) "${group}/"}${owner}/${repo}/";
+in {
   inherit name;
-  url = "https://${domain}/api/v4/projects/${lib.optionalString (group != null) "${lib.replaceStrings ["."] ["%2E"] group}%2F"}${lib.replaceStrings ["."] ["%2E"] owner}%2F${lib.replaceStrings ["."] ["%2E"] repo}/repository/archive.tar.gz?sha=${rev}";
-  meta.homepage = "https://${domain}/${lib.optionalString (group != null) "${group}/"}${owner}/${repo}/";
+  url = "${repo-url}-/archive/${rev}/${repo}.${rev}.tar.gz";
+  meta.homepage = repo-url;
 } // removeAttrs args [ "domain" "owner" "group" "repo" "rev" ]) // { inherit rev; }


### PR DESCRIPTION
* aligns with fetchFromGitHub's use of repository archive links

* fixes broken archive fetching due to GitLab API issues

Avoids GitLab API issues such as
<https://gitlab.com/gitlab-org/gitlab-ce/issues/38537> (see also
<https://gitlab.com/gitlab-org/gitlab-ce/issues/47336#note_103430000>,
<https://gitlab.com/gitlab-com/support-forum/issues/4015>, et al)

* fixes #48215

* Allows many emacsMelpa packages to be built (e.g. shrink-path)

###### Motivation for this change

Derivations such as shrink-path.el from emacsMelpa will not build without addressing being unable to download archives from GitLab. The method of using the GitLab API which does not correctly handle repository names simply fails, whereas use of the normal GitLab repository archives works as intended and matches the usage of the GitHub archives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

