### PR TITLE
fuse: allow user configuration of fuse.conf

### DIFF
--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -5,6 +5,8 @@
 , meson, ninja, pkgconfig
 , autoreconfHook
 , python3Packages, which
+, userAllowOther ? false
+, mountMax ? null
 }:
 
 let
@@ -73,7 +75,11 @@ in stdenv.mkDerivation rec {
   '' else ''
     cp ${fusePackages.fuse_3.common}/etc/fuse.conf etc/fuse.conf
     cp ${fusePackages.fuse_3.common}/etc/udev/rules.d/99-fuse.rules etc/udev/rules.d/99-fuse.rules
-  '');
+  '') + stdenv.lib.optionalString userAllowOther ''
+    sed -e 's@#user_allow_other@user_allow_other@' -i $out/etc/fuse.conf
+  '' + stdenv.lib.optionalString (mountMax != null) ''
+    sed -e 's@#mount_max = 1000@mount_max = ${mountMax}@' -i $out/etc/fuse.conf
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/53072 requires user_allow_other in fuse.conf to work, this PR makes it user configurable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

