### PR TITLE
xfce.xfce4-timer-plugin: fix description and add longDescription

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
-    description = "Battery plugin for Xfce panel";
+    description = "A simple XFCE panel plugin that lets the user run an alarm at a specified time or at the end of a specified countdown period";
+    longDescription = "The plugin is quite simple – it displays a progressbar showing the percentage of the time elapsed. Left-clicking on the plugin area opens a menu of available alarms. After selecting one, the user can start or stop the timer by selecting “start/stop timer” entry in the same menu. New alarms are added through the preferences window. Each alarm is either a countdown or is run at a specified time. By default a simple dialog pops up at the end of the countdown. The user can choose an external command to be run as the alarm and may also choose to have this repeated a specified number of times with a given interval between repetitions.";
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = [ ];


### PR DESCRIPTION
the package description seems to have been copy pasted from an other plugin

###### Motivation for this change
package description was wrong

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

