### PR TITLE
neovim: generate remote plugin manifest

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -20,6 +20,13 @@ let
       sha256 = "07ncvgp6xfhiwc6hd7qf7zk28n3yj47p26qj1ji29vqkwnk28y3s";
     };
 
+    patches = [
+      # introduce a system-wide rplugin.vim in addition to the user one
+      # necessary so that nix can handle `UpdateRemotePlugins` for the plugins
+      # it installs. See https://github.com/neovim/neovim/issues/9413.
+      ./system_rplugin_manifest.patch
+    ];
+
     enableParallelBuilding = true;
 
     buildInputs = [

--- a/pkgs/applications/editors/neovim/system_rplugin_manifest.patch
+++ b/pkgs/applications/editors/neovim/system_rplugin_manifest.patch
@@ -1,0 +1,29 @@
+diff --git a/runtime/autoload/remote/host.vim b/runtime/autoload/remote/host.vim
+index 6266b312b..965fabf1e 100644
+--- a/runtime/autoload/remote/host.vim
++++ b/runtime/autoload/remote/host.vim
+@@ -71,7 +71,8 @@ function! remote#host#RegisterPlugin(host, path, specs) abort
+ 
+   for plugin in plugins
+     if plugin.path == a:path
+-      throw 'Plugin "'.a:path.'" is already registered'
++      " plugin already registered
++      return
+     endif
+   endfor
+ 
+diff --git a/runtime/plugin/rplugin.vim b/runtime/plugin/rplugin.vim
+index 122d8d47f..83fbf8b57 100644
+--- a/runtime/plugin/rplugin.vim
++++ b/runtime/plugin/rplugin.vim
+@@ -54,6 +54,10 @@ function! s:GetManifest() abort
+ endfunction
+ 
+ function! s:LoadRemotePlugins() abort
++  if exists('$NVIM_SYSTEM_RPLUGIN_MANIFEST')
++    let g:system_remote_plugins = fnamemodify($NVIM_SYSTEM_RPLUGIN_MANIFEST, ':p')
++    execute 'source' fnameescape(g:system_remote_plugins)
++  endif
+   let g:loaded_remote_plugins = s:GetManifest()
+   if filereadable(g:loaded_remote_plugins)
+     execute 'source' fnameescape(g:loaded_remote_plugins)

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -72,7 +72,6 @@ let
         --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
         --suffix PATH : ${binPath} \
         ${optionalString withRuby '' --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
-
       ''
       + optionalString (!stdenv.isDarwin) ''
         # copy and patch the original neovim.desktop file
@@ -92,7 +91,29 @@ let
       '' + optionalString viAlias ''
         ln -s $out/bin/nvim $out/bin/vi
       '' + optionalString (configure != {}) ''
-        wrapProgram $out/bin/nvim --add-flags "-u ${vimUtils.vimrcFile configure}"
+        echo "Generating remote plugin manifest"
+        export NVIM_RPLUGIN_MANIFEST=$out/rplugin.vim
+        # Launch neovim with a vimrc file containing only the generated plugin
+        # code. Pass various flags to disable temp file generation
+        # (swap/viminfo) and redirect errors to stderr.
+        # Only display the log on error since it will contain a few normally
+        # irrelevant messages.
+        if ! $out/bin/nvim \
+          -u ${vimUtils.vimrcFile (configure // { customRC = ""; })} \
+          -i NONE -n \
+          -E -V1rplugins.log -s \
+          +UpdateRemotePlugins +quit! > outfile 2>&1; then
+          cat outfile
+          echo -e "\nGenerating rplugin.vim failed!"
+          exit 1
+        fi
+        unset NVIM_RPLUGIN_MANIFEST
+
+        # this relies on a patched neovim, see
+        # https://github.com/neovim/neovim/issues/9413
+        wrapProgram $out/bin/nvim \
+          --set NVIM_SYSTEM_RPLUGIN_MANIFEST $out/rplugin.vim \
+          --add-flags "-u ${vimUtils.vimrcFile configure}"
       '';
 
     preferLocalBuild = true;

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -83,18 +83,17 @@ let
       ''
       + optionalString withPython ''
         makeWrapper ${pythonEnv}/bin/python $out/bin/nvim-python --unset PYTHONPATH
-    '' + optionalString withPython3 ''
+      '' + optionalString withPython3 ''
         makeWrapper ${python3Env}/bin/python3 $out/bin/nvim-python3 --unset PYTHONPATH
-    '' + optionalString withRuby ''
-      ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
-    '' + optionalString vimAlias ''
-      ln -s $out/bin/nvim $out/bin/vim
-    '' + optionalString viAlias ''
-      ln -s $out/bin/nvim $out/bin/vi
-    '' + optionalString (configure != {}) ''
-    wrapProgram $out/bin/nvim --add-flags "-u ${vimUtils.vimrcFile configure}"
-    ''
-    ;
+      '' + optionalString withRuby ''
+        ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
+      '' + optionalString vimAlias ''
+        ln -s $out/bin/nvim $out/bin/vim
+      '' + optionalString viAlias ''
+        ln -s $out/bin/nvim $out/bin/vi
+      '' + optionalString (configure != {}) ''
+        wrapProgram $out/bin/nvim --add-flags "-u ${vimUtils.vimrcFile configure}"
+      '';
 
     preferLocalBuild = true;
 

--- a/pkgs/misc/vim-plugins/build-vim-plugin.nix
+++ b/pkgs/misc/vim-plugins/build-vim-plugin.nix
@@ -37,7 +37,7 @@ rec {
         # build help tags
         if [ -d "$target/doc" ]; then
           echo "Building help tags"
-          if ! ${vim}/bin/vim -N -u NONE -i NONE -n -E -s -c "helptags $target/doc" +quit!; then
+          if ! ${vim}/bin/vim -N -u NONE -i NONE -n -E -s -V1 -c "helptags $target/doc" +quit!; then
             echo "Failed to build help tags!"
             exit 1
           fi

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -486,4 +486,12 @@ rec {
       });
     vimrcConfig.vam.pluginDictionaries = [ { names = [ "vim-trailing-whitespace" ]; } ];
   };
+
+  # system remote plugin manifest should be generated, deoplete should be usable
+  # without the user having to do `UpdateRemotePlugins`. To test, launch neovim
+  # and do `:call deoplete#enable()`. It will print an error if the remote
+  # plugin is not registered.
+  test_nvim_with_remote_plugin = neovim.override {
+    configure.pathogen.pluginNames = with vimPlugins; [ deoplete-nvim ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

This makes sure the user doesn't have to call `UpdateRemotePlugins` manually for plugins installed through nix. A minor patch to neovim is necessary, but it should be harmless. See neovim/neovim#9413 for a discussion about the patch.

cc @Mic92 @rvolosatovs 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

