### PR TITLE
lxqt-archiver: init at 0.0.96

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1973,6 +1973,11 @@
     github = "jbgi";
     name = "Jean-Baptiste Giraudeau";
   };
+  jchw = {
+    email = "johnwchadwick@gmail.com";
+    github = "jchv";
+    name = "John Chadwick";
+  };
   jcumming = {
     email = "jack@mudshark.org";
     name = "Jack Cummings";

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -45,6 +45,7 @@ let
     qps = callPackage ./qps { };
     screengrab = callPackage ./screengrab { };
     qlipper = callPackage ./qlipper { };
+    lxqt-archiver = callPackage ./lxqt-archiver { };
 
     preRequisitePackages = [
       pkgs.gvfs # virtual file systems support for PCManFM-QT
@@ -93,6 +94,7 @@ let
       compton-conf
       obconf-qt
       lximage-qt
+      lxqt-archiver
 
       ### QtDesktop project
       qps

--- a/pkgs/desktops/lxqt/lxqt-archiver/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-archiver/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, json-glib, libfm-qt, qtbase, qttools, qtx11extras }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "lxqt-archiver";
+  version = "0.0.96";
+
+  src = fetchFromGitHub {
+    owner = "lxqt";
+    repo = pname;
+    rev = version;
+    sha256 = "1vc9pzxrhznp65gdkzj3fzzivfqy712mwcxp3r25ar59d54alfpj";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    lxqt-build-tools
+  ];
+
+  buildInputs = [
+    json-glib
+    libfm-qt
+    qtbase
+    qttools
+    qtx11extras
+  ];
+
+  cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    description = "Archive tool for the LXQt desktop environment";
+    homepage = https://github.com/lxqt/lxqt-archiver/;
+    license = licenses.gpl2;
+    platforms = with platforms; unix;
+    maintainers = with maintainers; [ jchw ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

New-ish LXQt application. Fork of engrampa (which is the Mate fork of file-roller) ported to Qt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---