### PR TITLE
trilium: init at 0.26.1

### DIFF
--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, p7zip, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem }:
+
+let
+  description = "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases.";
+  desktopItem = makeDesktopItem {
+    name = "Trilium";
+    exec = "trilium";
+    icon = "trilium";
+    comment = description;
+    desktopName = "Trilium Notes";
+    categories = "Office";
+  };
+
+in stdenv.mkDerivation rec {
+  name = "trilium-${version}";
+  version = "0.26.1";
+
+  src = fetchurl {
+    url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.7z";
+    sha256 = "184b0b0s8q32h1mpkrin8x1q0kjvard7r7xqrclziwwxg4khp3cz";
+  };
+
+  nativeBuildInputs = [
+    p7zip /* for unpacking */
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = atomEnv.packages;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/trilium
+    mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
+
+    cp -r ./* $out/share/trilium
+    ln -s $out/share/trilium/trilium $out/bin/trilium
+
+    ln -s $out/share/trilium/resources/app/src/public/images/trilium.svg $out/share/icons/hicolor/scalable/apps/trilium.svg
+    cp ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+
+  # This "shouldn't" be needed, remove when possible :)
+  preFixup = ''
+    wrapProgram $out/bin/trilium --prefix LD_LIBRARY_PATH : "${atomEnv.libPath}"
+  '';
+
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    inherit description;
+    homepage = https://github.com/zadam/trilium;
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ emmanuelrosa dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5874,6 +5874,8 @@ in
 
   triggerhappy = callPackage ../tools/inputmethods/triggerhappy {};
 
+  trilium = callPackage ../applications/office/trilium { };
+
   trousers = callPackage ../tools/security/trousers { };
 
   tryton = callPackage ../applications/office/tryton { };


### PR DESCRIPTION
###### Motivation for this change

Closes #51355.

Building from source would be better,
but looks to require significant effort at best.

Until a brave hero overcomes this fearsome challenge
patching up the binary isn't too bad
and has worked well enough for at least
light use by myself and another user
over the past few weeks.

Aspiring heroes should note this is low-glory
and are encouraged to apply themselves elsewhere instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---