### PR TITLE
chevron: init at 0.13.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2087,6 +2087,11 @@
     github = "jmettes";
     name = "Jonathan Mettes";
   };
+  jnsaff = {
+    email = "jaanus@saun.ee";
+    github = "jnsaff";
+    name = "Jaanus Torp";
+  };
   Jo = {
     email = "0x4A6F@shackspace.de";
     name = "Joachim Ernst";

--- a/pkgs/development/python-modules/chevron/default.nix
+++ b/pkgs/development/python-modules/chevron/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "chevron";
+  version = "0.13.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f95054a8b303268ebf3efd6bdfc8c1b428d3fc92327913b4e236d062ec61c989";
+  };
+
+  meta = with lib; {
+    description = "Mustache templating language renderer";
+    homepage = https://github.com/noahmorrison/chevron;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jnsaff ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -290,6 +290,8 @@ in {
 
   chalice = callPackage ../development/python-modules/chalice { };
 
+  chevron = callPackage ../development/python-modules/chevron { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cozy = callPackage ../development/python-modules/cozy { };


### PR DESCRIPTION
###### Motivation for this change
Added Python pypi package chevron that is needed for the upgrade of aws-sam-cli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

