### PR TITLE
serverlessrepo: init at 0.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2087,6 +2087,11 @@
     github = "jmettes";
     name = "Jonathan Mettes";
   };
+  jnsaff = {
+    email = "jaanus@saun.ee";
+    github = "jnsaff";
+    name = "Jaanus Torp";
+  };
   Jo = {
     email = "0x4A6F@shackspace.de";
     name = "Joachim Ernst";

--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyyaml
+, boto3
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "serverlessrepo";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "384dc37394ffe1c8036f79a78b15bada4cb954a39f07bdf68f123c1a191fd0b2";
+  };
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    pyyaml
+    boto3
+    six
+  ];
+
+  meta = with lib; {
+    description = "A Python library with convenience helpers for working with the AWS Serverless Application Repository.";
+    homepage = https://github.com/awslabs/aws-serverlessrepo-python;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jnsaff ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -220,6 +220,8 @@ in {
 
   aws-adfs = callPackage ../development/python-modules/aws-adfs { };
 
+  serverlessrepo = callPackage ../development/python-modules/serverlessrepo { };
+
   atomman = callPackage ../development/python-modules/atomman { };
 
   # packages defined elsewhere


### PR DESCRIPTION
###### Motivation for this change
Added Python pypi package serverlessrepo that is needed for the upgrade of aws-sam-cli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

