### PR TITLE
aws-lambda-builders: init at 0.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2087,6 +2087,11 @@
     github = "jmettes";
     name = "Jonathan Mettes";
   };
+  jnsaff = {
+    email = "jaanus@saun.ee";
+    github = "jnsaff";
+    name = "Jaanus Torp";
+  };
   Jo = {
     email = "0x4A6F@shackspace.de";
     name = "Joachim Ernst";

--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, setuptools
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "aws-lambda-builders";
+  version = "0.0.5";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "aws_lambda_builders";
+    sha256 = "4380dd8430f443b46867ff2b03c9673ed6042a3ffc6f05c18764d062d04c4049";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    six
+    setuptools
+    wheel
+  ];
+
+  meta = with lib; {
+    description = "Python library to compile, build & package AWS Lambda functions for several runtimes & frameworks.";
+    homepage = https://github.com/awslabs/aws-lambda-builders;
+    license = lib.licenses.asl20;
+    maintainers = with maintainers; [ jnsaff ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -220,6 +220,8 @@ in {
 
   aws-adfs = callPackage ../development/python-modules/aws-adfs { };
 
+  aws-lambda-builders = callPackage ../development/python-modules/aws-lambda-builders { };
+
   atomman = callPackage ../development/python-modules/atomman { };
 
   # packages defined elsewhere


### PR DESCRIPTION
###### Motivation for this change

Add aws-lamda-builders python package that is needed for the upgrade of aws-sam-cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

