### PR TITLE
aws-sam-cli: 0.5.0 > 0.10.0

### DIFF
--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -6,33 +6,44 @@ with python.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "0.5.0";
+  version = "0.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2acf9517f467950adb4939746658091e60cf60ee80093ffd0d3d821cb8a1f9fc";
+    sha256 = "523cd125bd89cd1d42559101a8500f74f88067fd9b26f72b1d05c5d00a76bed9";
   };
 
-  # Tests are not included in the PyPI package
+   # Tests are not included in the PyPI package
   doCheck = false;
 
   propagatedBuildInputs = [
     aws-sam-translator
+    six
+    chevron
+    click
+    flask
     boto3
     click
+    pyyaml
     cookiecutter
+    aws-sam-translator
     dateparser
     docker
+    python-dateutil
+    requests
+    aws-lambda-builders
+    serverlessrepo
     enum34
     flask
     python-dateutil
     pyyaml
     six
+    pathlib2
   ];
 
   postPatch = ''
-    substituteInPlace ./requirements/base.txt \
-      --replace 'aws-sam-translator==1.6.0' 'aws-sam-translator>=1.6.0';
+    substituteInPlace ./requirements/base.txt --replace 'click~=6.7' 'click>=6.7';
+    substituteInPlace ./requirements/base.txt --replace 'serverlessrepo==0.1.5' 'serverlessrepo>=0.1.5';
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Upgrades aws-sam-cli python program, as this is needed for the Jetbrains plugins to work.

This merge will fail until the following PR's are merged:
https://github.com/NixOS/nixpkgs/pull/53094
https://github.com/NixOS/nixpkgs/pull/53095
https://github.com/NixOS/nixpkgs/pull/53097
https://github.com/NixOS/nixpkgs/pull/53098

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

