### PR TITLE
smartmontools: 6.6 -> 7.0

### DIFF
--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -2,13 +2,13 @@
 , IOKit ? null , ApplicationServices ? null }:
 
 let
-  version = "6.6";
+  version = "7.0";
 
-  dbrev = "4852";
+  dbrev = "4883";
   drivedbBranch = "RELEASE_${builtins.replaceStrings ["."] ["_"] version}_DRIVEDB";
   driverdb = fetchurl {
     url    = "https://sourceforge.net/p/smartmontools/code/${dbrev}/tree/branches/${drivedbBranch}/smartmontools/drivedb.h?format=raw";
-    sha256 = "15gbwiw38yzl3cdvys6r7wknv5zdycm7zbswa2p9vzxlc8s63rlr";
+    sha256 = "07x3haz65jyhj579h4z17v6jkw6bbyid34442gl4qddmgv2qzvwx";
     name   = "smartmontools-drivedb.h";
   };
 
@@ -17,17 +17,10 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/smartmontools/${name}.tar.gz";
-    sha256 = "0m1hllbb78rr6cxkbalmz1gqkl0psgq8rrmv4gwcmz34n07kvx2i";
+    sha256 = "077nx2rn9szrg6isdh0938zbp7vr3dsyxl4jdyyzv1xwhqksrqg5";
   };
 
-  patches = [ ./smartmontools.patch ]
-    # https://www.smartmontools.org/changeset/4603
-    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
-      name = "musl-canonicalize_file_name.patch";
-      url = "https://www.smartmontools.org/changeset/4603?format=diff&new=4603";
-      sha256 = "06s9pcd95snjkrbfrsjby2lln3lnwjd21bgabmvr4p7fx19b75zp";
-      stripLen = 2;
-    });
+  patches = [ ./smartmontools.patch ];
   postPatch = "cp -v ${driverdb} drivedb.h";
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

https://listi.jpberlin.de/pipermail/smartmontools-announce/2018-December/000001.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---