### PR TITLE
Bump teamviewer version to 14

### DIFF
--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, autoPatchelfHook, makeWrapper, xdg_utils, dbus, qtbase, qtwebkit, qtx11extras, qtquickcontrols, glibc, libXrandr, libX11 }:
+{ stdenv, fetchurl, autoPatchelfHook, makeWrapper, xdg_utils, dbus, qt56, glibc, libXrandr, libX11 }:
 
 
 stdenv.mkDerivation rec {
   name = "teamviewer-${version}";
-  version = "13.1.3026";
+  version = "14.1.3399";
 
   src = fetchurl {
-    url = "https://dl.tvcdn.de/download/linux/version_13x/teamviewer_${version}_amd64.deb";
-    sha256 = "14zaa1xjdfmgbbq40is5mllqcd9zan03sblkzajswd5gps7crsik";
+    url = "https://dl.tvcdn.de/download/linux/version_14x/teamviewer_${version}_amd64.deb";
+    sha256 = "45f341f07240e2f84e054d5a56f818db140d5bb6da1a3abe53230a1d656cd698";
   };
 
   unpackPhase = ''
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
-  buildInputs = [ dbus qtbase qtwebkit qtx11extras libX11 ];
-  propagatedBuildInputs = [ qtquickcontrols ];
+  buildInputs = [ dbus qt56.qtbase qt56.qtwebkit qt56.qtx11extras libX11 ];
+  propagatedBuildInputs = [ qt56.qtquickcontrols ];
 
   installPhase = ''
     mkdir -p $out/share/teamviewer $out/bin $out/share/applications


### PR DESCRIPTION
###### Motivation for this change
Upgrade teamviewer from version 13 to version 14
Fixes https://github.com/NixOS/nixpkgs/issues/51059

NOTE: TeamViewer segfaults with newer Qt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

