### PR TITLE
suitesparse: 5.3.0 -> 5.4.0

### DIFF
--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -1,9 +1,10 @@
 { stdenv, fetchurl, gfortran, openblas, cmake, fixDarwinDylibNames
+, gnum4
 , enableCuda  ? false, cudatoolkit
 }:
 
 let
-  version = "5.3.0";
+  version = "5.4.0";
   name = "suitesparse-${version}";
 
   SHLIB_EXT = stdenv.hostPlatform.extensions.sharedLibrary;
@@ -13,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-${version}.tar.gz";
-    sha256 = "0gcn1xj3z87wpp26gxn11k8073bxv6jswfd8jmddlm64v09rgrlh";
+    sha256 = "1lfvjj787yqyhk25w7brlrkrl7dnnn5dq4ijxws3wrbcd4vd2k9p";
   };
 
   dontUseCmakeConfigure = true;
@@ -119,8 +120,10 @@ stdenv.mkDerivation rec {
     runHook postInstall
     '';
 
-  nativeBuildInputs = [ cmake ]
-    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = [
+    cmake
+    gnum4
+  ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   buildInputs = [ openblas gfortran.cc.lib ]
     ++ stdenv.lib.optional enableCuda cudatoolkit;


### PR DESCRIPTION
###### Motivation for this change

Latest upstream release, maybe/hopefully a fix for #52709.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

