### PR TITLE
qolibri: init at 2018-11-14

### DIFF
--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, libeb, lzo, qtbase
+, qtmultimedia, qttools, qtwebengine }:
+
+stdenv.mkDerivation rec {
+  name = "qolibri-${version}";
+  version = "2018-11-14";
+
+  src = fetchFromGitHub {
+    owner = "ludios";
+    repo = "qolibri";
+    rev = "133a1c33e74d931ad54407f70d84a0016d96981f";
+    sha256 = "16ifix0q8ww4l3xflgxr9j81c0lzlnkjr8fj961x3nxz7288pdg2";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [
+    libeb lzo qtbase qtmultimedia qttools qtwebengine
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ludios/qolibri;
+    description = "EPWING reader for viewing Japanese dictionaries";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ivan ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12102,6 +12102,8 @@ in
 
   qoauth = callPackage ../development/libraries/qoauth { };
 
+  qolibri = libsForQt5.callPackage ../applications/misc/qolibri { };
+
   qt3 = callPackage ../development/libraries/qt-3 {
     openglSupport = libGLSupported;
     libpng = libpng12;


### PR DESCRIPTION
###### Motivation for this change

This adds [qolibri](https://github.com/ludios/qolibri), an EPWING viewer that can search and render Japanese [EPWING](https://ja.wikipedia.org/wiki/EPWING) dictionaries.

This renders some EPWING dictionaries more correctly than GoldenDict; e.g. qolibri renders the entries in NHKACT ("ＮＨＫ 日本語発音アクセント辞典") correctly, while GoldenDict stacks the embedded kana images vertically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested that this works on NixOS with an empty `~/.config/qolibri` as well as an existing config.

This package does not work on other Linux distributions because something in Qt requires libGL https://github.com/NixOS/nixpkgs/issues/9415

Platform is set to `linux` because the build fails on Darwin (tested unsandboxed macOS 10.14) with

<details><summary>
Log
</summary>

```
installing 'qolibri-2018-11-14'
these derivations will be built:
  /nix/store/0af4ja5haps3s7l24wnixf8rjn4ncb44-qolibri-2018-11-14.drv
building '/nix/store/0af4ja5haps3s7l24wnixf8rjn4ncb44-qolibri-2018-11-14.drv'...
unpacking sources
unpacking source archive /nix/store/c6sw7y737dwfy6k3zbaadifb2n02anq4-source
source root is source
patching sources
configuring
fixing cmake files...
cmake flags: -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/2lc0lf78s5p56dqimxnss5y1f1xwhwzk-qolibri-2018-11-14/include -DCMAKE_INSTALL_LIBDIR=/nix/store/2lc0lf78s5p56dqimxnss5y1f1xwhwzk-qolibri-2018-11-14/lib -DCMAKE_INSTALL_NAME_DIR=/nix/store/2lc0lf78s5p56dqimxnss5y1f1xwhwzk-qolibri-2018-11-14/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_DEPLOYMENT_TARGET= -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=last -DCMAKE_STRIP=/nix/store/k8d4p5889qg0smgcgbwp1apy6zm102qh-cctools-binutils-darwin/bin/strip -DCMAKE_RANLIB=/nix/store/k8d4p5889qg0smgcgbwp1apy6zm102qh-cctools-binutils-darwin/bin/ranlib -DCMAKE_AR=/nix/store/k8d4p5889qg0smgcgbwp1apy6zm102qh-cctools-binutils-darwin/bin/ar -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/nix/store/2lc0lf78s5p56dqimxnss5y1f1xwhwzk-qolibri-2018-11-14
-- The C compiler identification is Clang 5.0.2
-- The CXX compiler identification is Clang 5.0.2
-- Check for working C compiler: /nix/store/vcgm727r50w7mwy7fxmswhq4ffj2qqf0-clang-wrapper-5.0.2/bin/clang
-- Check for working C compiler: /nix/store/vcgm727r50w7mwy7fxmswhq4ffj2qqf0-clang-wrapper-5.0.2/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /nix/store/vcgm727r50w7mwy7fxmswhq4ffj2qqf0-clang-wrapper-5.0.2/bin/clang++
-- Check for working CXX compiler: /nix/store/vcgm727r50w7mwy7fxmswhq4ffj2qqf0-clang-wrapper-5.0.2/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /nix/store/jnlskid65f1wsq8zws61cdwyalsxdc1w-qtbase-5.11.1-dev/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  By not providing "FindQt5WebEngine.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "Qt5WebEngine", but CMake did not find one.

  Could not find a package configuration file provided by "Qt5WebEngine" with
  any of the following names:

    Qt5WebEngineConfig.cmake
    qt5webengine-config.cmake

  Add the installation prefix of "Qt5WebEngine" to CMAKE_PREFIX_PATH or set
  "Qt5WebEngine_DIR" to a directory containing one of the above files.  If
  "Qt5WebEngine" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:16 (find_package)


-- Configuring incomplete, errors occurred!
See also "/private/var/folders/v2/6gkg_95d1pzcvkj7xnx2wgzr0000gn/T/nix-build-qolibri-2018-11-14.drv-0/source/build/CMakeFiles/CMakeOutput.log".
builder for '/nix/store/0af4ja5haps3s7l24wnixf8rjn4ncb44-qolibri-2018-11-14.drv' failed with exit code 1
error: build of '/nix/store/0af4ja5haps3s7l24wnixf8rjn4ncb44-qolibri-2018-11-14.drv' failed
```

</details>