### PR TITLE
sublime3-dev: 3183 -> 3184

### DIFF
--- a/pkgs/applications/editors/sublime/3/packages.nix
+++ b/pkgs/applications/editors/sublime/3/packages.nix
@@ -5,9 +5,9 @@ let
 in
   rec {
     sublime3-dev = common {
-      buildVersion = "3183";
-      x32sha256 = "0rgah7iq9y3afbawcb723d2b7m56lz0ji5l8klxvkp59c9rphqxh";
-      x64sha256 = "1n3zarkhs22p2vi32fswb0fvcn9fzivmziw6zcvjy02c0rmxmdkz";
+      buildVersion = "3184";
+      x32sha256 = "1b6f1fid75g5z247dbnyyj276lrlv99scrdk1vvfcr6vyws77vzr";
+      x64sha256 = "03127jhfjr17ai96p3axh5b5940fds8jcw6vkid8y6dmvd2dpylz";
     } {};
 
     sublime3 = common {


### PR DESCRIPTION
###### Motivation for this change

Version bump

http://www.sublimetext.com/3dev

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested the 64-bit version on NixOS and Debian 9.6 and it seemed to work fine.