### PR TITLE
vim-parinfer: init

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2801,6 +2801,16 @@
     };
   };
 
+  vim-parinfer = buildVimPluginFrom2Nix {
+    name = "vim-parinfer-2018-08-31";
+    src = fetchFromGitHub {
+      owner = "bhurlow";
+      repo = "vim-parinfer";
+      rev = "d599e41dd1b9034059524af8156dcbebe68d96d2";
+      sha256 = "0h4zw1yfnrbb3w5brcsy2l43jk7569dhslpkahczqxj6wr6hsxcc";
+    };
+  };
+
   vim-pathogen = buildVimPluginFrom2Nix {
     name = "vim-pathogen-2018-12-12";
     src = fetchFromGitHub {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -16,6 +16,7 @@ bazelbuild/vim-bazel
 bbchung/clighter8
 benekastah/neomake
 benmills/vimux
+bhurlow/vim-parinfer
 bitc/vim-hdevtools
 bling/vim-bufferline
 bronson/vim-trailing-whitespace


### PR DESCRIPTION
###### Motivation for this change

https://github.com/bhurlow/vim-parinfer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

