### PR TITLE
pytest: introduce runTests function

### DIFF
--- a/pkgs/development/python-modules/astor/default.nix
+++ b/pkgs/development/python-modules/astor/default.nix
@@ -9,11 +9,18 @@ buildPythonPackage rec {
     sha256 = "95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d";
   };
 
-  # disable tests broken with python3.6: https://github.com/berkerpeksag/astor/issues/89
   checkInputs = [ pytest ];
-  checkPhase = ''
-    py.test -k 'not check_expressions and not check_astunparse and not test_convert_stdlib and not test_codegen_as_submodule and not test_codegen_from_root'
-  '';
+
+  # disable tests broken with python3.6: https://github.com/berkerpeksag/astor/issues/89
+  checkPhase = pytest.runTests {
+    disabledTests = [
+      "check_expressions"
+      "check_astunparse"
+      "test_convert_stdlib"
+      "test_codegen_as_submodule"
+      "test_codegen_from_root"
+    ];
+  };
 
   meta = with stdenv.lib; {
     description = "Library for reading, writing and rewriting python AST";

--- a/pkgs/development/python-modules/datashape/default.nix
+++ b/pkgs/development/python-modules/datashape/default.nix
@@ -31,11 +31,19 @@ in buildPythonPackage rec {
   checkInputs = [ pytest mock ];
   propagatedBuildInputs = [ numpy multipledispatch dateutil ];
 
-  # Disable several tests
-  # https://github.com/blaze/datashape/issues/232
-  checkPhase = ''
-    py.test -k "not test_validate and not test_nested_iteratables and not test_validate_dicts and not test_tuples_can_be_records_too" datashape/tests
-  '';
+  checkPhase = pytest.runTests {
+    # Disable several tests
+    # https://github.com/blaze/datashape/issues/232
+    disabledTests = [
+      "test_validate"
+      "test_nested_iteratables"
+      "test_validate_dicts"
+      "test_tuples_can_be_records_too"
+    ];
+    targets = [
+      "datashape/tests"
+    ];
+  };
 
   meta = {
     homepage = https://github.com/ContinuumIO/datashape;

--- a/pkgs/development/python-modules/libarchive-c/default.nix
+++ b/pkgs/development/python-modules/libarchive-c/default.nix
@@ -25,9 +25,13 @@ buildPythonPackage rec {
       "find_library('archive')" "'${libarchive.lib}/lib/libarchive${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
-  checkPhase = ''
-    py.test tests -k 'not test_check_archiveentry_with_unicode_entries_and_name_zip and not test_check_archiveentry_using_python_testtar'
-  '';
+  checkPhase = pytest.runTests {
+    targets = [ "tests "];
+    disabledTests = [
+      "test_check_archiveentry_with_unicode_entries_and_name_zip"
+      "test_check_archiveentry_using_python_testtar"
+    ];
+  };
 
   meta = with stdenv.lib; {
     homepage = https://github.com/Changaco/python-libarchive-c;

--- a/pkgs/development/python-modules/odo/default.nix
+++ b/pkgs/development/python-modules/odo/default.nix
@@ -26,18 +26,19 @@ buildPythonPackage rec {
   checkInputs = [ pytest dask ];
   propagatedBuildInputs = [ datashape numpy pandas toolz multipledispatch networkx ];
 
-  # Disable failing tests
-  # https://github.com/blaze/odo/issues/609
-  checkPhase = ''
-    py.test -k "not test_numpy_asserts_type_after_dataframe" odo/tests
-  '';
+  checkPhase = pytest.runTests {
+    targets = [ "odo/tests" ];
+    # Disable failing tests
+    # https://github.com/blaze/odo/issues/609
+    disabledTests = [ "test_numpy_asserts_type_after_dataframe" ];
+  };
 
   meta = {
     homepage = https://github.com/ContinuumIO/odo;
     description = "Data migration utilities";
     license = lib.licenses.bsdOriginal;
     maintainers = with lib.maintainers; [ fridh ];
-    # incomaptible with Networkx 2
+    # incompatible with Networkx 2
     # see https://github.com/blaze/odo/pull/601
     broken = true;
   };

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -15,27 +15,28 @@ buildPythonPackage rec {
   checkInputs = [ pytest git glibcLocales mock ];
   propagatedBuildInputs = [ pip click six first setuptools_scm ];
 
-  disabledTests = stdenv.lib.concatMapStringsSep " and " (s: "not " + s) [
-    # Depend on network tests:
-    "test_editable_package_vcs"
-    "test_generate_hashes_all_platforms"
-    "test_generate_hashes_without_interfering_with_each_other"
-    "test_realistic_complex_sub_dependencies"
-    "test_generate_hashes_with_editable"
-    "test_filter_pip_markes"
-    "test_get_hashes_local_repository_cache_miss"
-    # Expect specific version of "six":
-    "test_editable_package"
-    "test_input_file_without_extension"
-    "test_locally_available_editable_package_is_not_archived_in_cache_dir"
-    "test_no_candidates"
-    "test_no_candidates_pre"
-  ];
-
-  checkPhase = ''
-    export HOME=$(mktemp -d) VIRTUAL_ENV=1
-    py.test -k "${disabledTests}"
-  '';
+  checkPhase = pytest.runTests {
+    variables = {
+      HOME = "$(mktemp -d)";
+      VIRTUAL_ENV = "1";
+    };
+    disabledTests = [
+      # Depend on network tests:
+      "test_editable_package_vcs"
+      "test_generate_hashes_all_platforms"
+      "test_generate_hashes_without_interfering_with_each_other"
+      "test_realistic_complex_sub_dependencies"
+      "test_generate_hashes_with_editable"
+      "test_filter_pip_markes"
+      "test_get_hashes_local_repository_cache_miss"
+      # Expect specific version of "six":
+      "test_editable_package"
+      "test_input_file_without_extension"
+      "test_locally_available_editable_package_is_not_archived_in_cache_dir"
+      "test_no_candidates"
+      "test_no_candidates_pre"
+    ];
+  };
 
   meta = with stdenv.lib; {
     description = "Keeps your pinned dependencies fresh";

--- a/pkgs/development/python-modules/prompt_toolkit/1.nix
+++ b/pkgs/development/python-modules/prompt_toolkit/1.nix
@@ -16,10 +16,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917";
   };
-  checkPhase = ''
+
+  postPatch = ''
     rm prompt_toolkit/win32_types.py
-    py.test -k 'not test_pathcompleter_can_expanduser'
   '';
+
+  checkPhase = pytest.runTests {
+    disabledTests = [ "test_pathcompleter_can_expanduser" ];
+  };
 
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ docopt six wcwidth pygments ];

--- a/pkgs/development/python-modules/prompt_toolkit/default.nix
+++ b/pkgs/development/python-modules/prompt_toolkit/default.nix
@@ -14,9 +14,10 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0fgacqk73w7s932vy46pan2yp8rvjmlkag20xvaydh9mhf6h85zx";
   };
-  checkPhase = ''
-    py.test -k 'not test_pathcompleter_can_expanduser'
-  '';
+
+  checkPhase = pytest.runTests {
+    disabledTests = [ "test_pathcompleter_can_expanduser" ];
+  };
 
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ six wcwidth ];

--- a/pkgs/development/python-modules/pyocr/default.nix
+++ b/pkgs/development/python-modules/pyocr/default.nix
@@ -26,38 +26,31 @@ buildPythonPackage rec {
 
   postPatch = ''
     echo 'version = "${version}"' > src/pyocr/_version.py
-
-    # Disable specific tests that are probably failing because of this issue:
-    # https://github.com/jflesch/pyocr/issues/52
-    for test in $disabledTests; do
-      file="''${test%%:*}"
-      fun="''${test#*:}"
-      echo "import pytest" >> "tests/tests_$file.py"
-      echo "$fun = pytest.mark.skip($fun)" >> "tests/tests_$file.py"
-    done
   '';
-
-  disabledTests = [
-    "cuneiform:TestTxt.test_basic"
-    "cuneiform:TestTxt.test_european"
-    "cuneiform:TestTxt.test_french"
-    "cuneiform:TestWordBox.test_basic"
-    "cuneiform:TestWordBox.test_european"
-    "cuneiform:TestWordBox.test_french"
-    "libtesseract:TestBasicDoc.test_basic"
-    "libtesseract:TestDigitLineBox.test_digits"
-    "libtesseract:TestLineBox.test_japanese"
-    "libtesseract:TestTxt.test_japanese"
-    "libtesseract:TestWordBox.test_japanese"
-    "libtesseract:TestTxt.test_multi"
-    "tesseract:TestTxt.test_multi"
-    "tesseract:TestDigitLineBox.test_digits"
-    "tesseract:TestTxt.test_japanese"
-  ];
 
   propagatedBuildInputs = [ pillow six ];
   checkInputs = [ pytest tox ];
-  checkPhase = "pytest";
+  checkPhase = pytest.runTests {
+    # Disable specific tests that are probably failing because of this issue:
+    # https://github.com/jflesch/pyocr/issues/52
+    disabledTestIds = [
+      "cuneiform:TestTxt.test_basic"
+      "cuneiform:TestTxt.test_european"
+      "cuneiform:TestTxt.test_french"
+      "cuneiform:TestWordBox.test_basic"
+      "cuneiform:TestWordBox.test_european"
+      "cuneiform:TestWordBox.test_french"
+      "libtesseract:TestBasicDoc.test_basic"
+      "libtesseract:TestDigitLineBox.test_digits"
+      "libtesseract:TestLineBox.test_japanese"
+      "libtesseract:TestTxt.test_japanese"
+      "libtesseract:TestWordBox.test_japanese"
+      "libtesseract:TestTxt.test_multi"
+      "tesseract:TestTxt.test_multi"
+      "tesseract:TestDigitLineBox.test_digits"
+      "tesseract:TestTxt.test_japanese"
+    ];
+  };
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -39,14 +39,7 @@ let
     "test_fallback_default_verify_paths"
   ] ++ (optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests);
 
-  # Compose the final string expression, including the "-k" and the single quotes.
-  testExpression = optionalString (disabledTests != [])
-    "-k 'not ${concatStringsSep " and not " disabledTests}'";
-
-in
-
-
-buildPythonPackage rec {
+in buildPythonPackage rec {
   pname = "pyOpenSSL";
   version = "18.0.0";
 
@@ -57,12 +50,10 @@ buildPythonPackage rec {
 
   outputs = [ "out" "dev" ];
 
-  checkPhase = ''
-    runHook preCheck
-    export LANG="en_US.UTF-8"
-    py.test tests ${testExpression}
-    runHook postCheck
-  '';
+  checkPhase = pytest.runTests {
+    variables.LANG = "en_US.UTF-8";
+    inherit disabledTests;
+  };
 
   # Seems to fail unpredictably on Darwin. See http://hydra.nixos.org/build/49877419/nixlog/1
   # for one example, but I've also seen ContextTests.test_set_verify_callback_exception fail.

--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -20,14 +20,17 @@ buildPythonPackage rec {
   buildInputs = [ zeromq ];
   propagatedBuildInputs = [ py ];
 
-  # test_socket.py seems to be hanging
-  # others fail
-  checkPhase = ''
-    py.test $out/${python.sitePackages}/zmq/ -k "not test_socket \
-      and not test_current \
-      and not test_instance \
-      and not test_callable_check \
-      and not test_on_recv_basic \
-      and not test_on_recv_wake"
-  '';
+  checkPhase = pytest.runTests {
+    targets = [ "$out/${python.sitePackages}/zmq/" ];
+    # test_socket.py seems to be hanging
+    # others fail
+    disabledTests = [
+      "test_socket"
+      "test_current"
+      "test_instance"
+      "test_callable_check"
+      "test_on_recv_basic"
+      "test_on_recv_wake"
+    ];
+  };
 }

--- a/pkgs/development/python-modules/toolz/default.nix
+++ b/pkgs/development/python-modules/toolz/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, nose
+, pytest
 }:
 
 buildPythonPackage rec{
@@ -13,13 +13,8 @@ buildPythonPackage rec{
     sha256 = "929f0a7ea7f61c178bd951bdae93920515d3fbdbafc8e6caf82d752b9b3b31c9";
   };
 
-  checkInputs = [ nose ];
-
-  checkPhase = ''
-    # https://github.com/pytoolz/toolz/issues/357
-    rm toolz/tests/test_serialization.py
-    nosetests toolz/tests
-  '';
+  checkInputs = [ pytest ];
+  checkPhase = pytest.runTests {};
 
   meta = with lib; {
     homepage = https://github.com/pytoolz/toolz;

--- a/pkgs/development/python-modules/traitlets/default.nix
+++ b/pkgs/development/python-modules/traitlets/default.nix
@@ -23,11 +23,9 @@ buildPythonPackage rec {
   checkInputs = [ glibcLocales pytest mock ];
   propagatedBuildInputs = [ ipython_genutils decorator six ] ++ lib.optional (pythonOlder "3.4") enum34;
 
-  checkPhase = ''
-    LC_ALL="en_US.UTF-8" py.test
-  '';
-
-#   doCheck = false;
+  checkPhase = pytest.runTests {
+    variables.LC_ALL = "en_US.UTF-8";
+  };
 
   meta = {
     description = "Traitlets Python config system";

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -25,9 +25,16 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest pyopenssl trustme jedi pylint ];
   # It appears that the build sandbox doesn't include /etc/services, and these tests try to use it.
-  checkPhase = ''
-    HOME="$(mktemp -d)" py.test -k 'not test_getnameinfo and not test_SocketType_resolve and not test_getprotobyname and not test_waitpid'
-  '';
+  checkPhase = pytest.runTests {
+    variables.HOME = "$(mktemp -d)";
+    disabledTests = [
+      "test_getnameinfo"
+      "test_SocketType_resolve"
+      "test_getprotobyname"
+      "test_waitpid"
+    ];
+  };
+
   propagatedBuildInputs = [
     attrs
     sortedcontainers


### PR DESCRIPTION
###### Motivation for this change

A simple function that generates a `checkPhase`. It includes a
`disabledTests` parameter to conveniently disable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

