### PR TITLE
aspell: add all missing official dictionaries

### DIFF
--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -2,6 +2,17 @@
 , searchNixProfiles ? true
 }:
 
+let
+
+  # Source for u-deva.cmap and u-deva.cset: use the Marathi
+  # dictionary like Debian does.
+  devaMapsSource = fetchTarball {
+    url = "ftp://ftp.gnu.org/gnu/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2";
+    sha256 = "1v8cdl8x2j1d4vbvsq1xrqys69bbccd6mi03fywrhkrrljviyri1";
+  };
+
+in
+
 stdenv.mkDerivation rec {
   name = "aspell-0.60.6.1";
 
@@ -31,6 +42,13 @@ stdenv.mkDerivation rec {
       --enable-pkglibdir=$out/lib/aspell
       --enable-pkgdatadir=$out/lib/aspell
     );
+  '';
+
+  # Include u-deva.cmap and u-deva.cset in the aspell package
+  # to avoid conflict between 'mr' and 'hi' dictionaries as they
+  # both include those files.
+  postInstall = ''
+    cp ${devaMapsSource}/u-deva.{cmap,cset} $out/lib/aspell/
   '';
 
   meta = {

--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, perl
+{ stdenv, fetchurl, fetchpatch, fetchzip, perl
 , searchNixProfiles ? true
 }:
 
@@ -6,7 +6,8 @@ let
 
   # Source for u-deva.cmap and u-deva.cset: use the Marathi
   # dictionary like Debian does.
-  devaMapsSource = fetchTarball {
+  devaMapsSource = fetchzip {
+    name = "aspell-u-deva";
     url = "ftp://ftp.gnu.org/gnu/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2";
     sha256 = "1v8cdl8x2j1d4vbvsq1xrqys69bbccd6mi03fywrhkrrljviyri1";
   };

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -57,8 +57,6 @@ let
   buildOfficialDict =
     {language, version, filename, fullName, sha256, ...}@args:
     let buildArgs = {
-      name = "aspell-dict-${language}";
-
       shortName = "${language}-${version}";
 
       src = fetchurl {

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, aspell, which}:
+{lib, stdenv, fetchurl, aspell, which, writeScript}:
 
 with lib;
 
@@ -52,6 +52,55 @@ let
         platforms = stdenv.lib.platforms.all;
       } // (args.meta or {});
     } // removeAttrs args [ "meta" ]);
+
+
+  buildOfficialDict =
+    {language, version, filename, fullName, sha256, ...}@args:
+    let buildArgs = {
+      name = "aspell-dict-${language}";
+
+      shortName = "${language}-${version}";
+
+      src = fetchurl {
+        url = "mirror://gnu/aspell/dict/${language}/${filename}-${language}-${version}.tar.bz2";
+        inherit sha256;
+      };
+
+      /* Remove any instances of u-deva.cmap and u-deva.cset since
+         they are included in the main aspell package and can
+         cause conflicts otherwise. */
+      postInstall = ''
+        rm -f $out/lib/aspell/u-deva.{cmap,cset}
+      '';
+
+      passthru.updateScript = writeScript "update-aspellDict-${language}" ''
+        #!/usr/bin/env nix-shell
+        #!nix-shell -i bash -p nix curl gnused common-updater-scripts
+        set -eu -o pipefail
+
+        # List tarballs in the dictionary's subdirectory via FTP.
+        #
+        # Catalan dictionary has an exception where an earlier version
+        # compares as newer because the versioning scheme has changed.
+        versions=$(
+            echo '[';
+            curl -sl ftp://ftp.gnu.org/gnu/aspell/dict/${language}/ | \
+                sed -r "s/^${filename}-${language}-(.+)\.tar\.bz2$/\"\1\"/;t;d" | \
+                if [ "${language}" = "ca" ]; then grep -v 20040130-1; else cat; fi; \
+            echo ']')
+
+        # Sort versions in descending order and take the first as the latest.
+        latestVersion=$(nix eval --raw "(with builtins; head (sort (a: b: compareVersions a b > 0) $versions))")
+
+        update-source-version aspellDicts.${language} "$latestVersion"
+      '';
+
+      meta = {
+        homepage = "http://ftp.gnu.org/gnu/aspell/dict/0index.html";
+      } // (args.meta or {});
+
+    } // removeAttrs args [ "language" "filename" "sha256" ];
+    in buildDict buildArgs;
 
   /* Function to compile txt dict files into Aspell dictionaries. */
   buildTxtDict =
@@ -109,206 +158,736 @@ in rec {
 
   ### Languages
 
-  ca = buildDict rec {
-    shortName = "ca-2.1.5-1";
+  af = buildOfficialDict rec {
+    language = "af";
+    version = "0.50-0";
+    fullName = "Afrikaans";
+    filename = "aspell";
+    sha256 = "00p6k2ndi0gzfr5fkbvx4hkcpj223pidjvmxg0r384arrap00q4x";
+  };
+
+  am = buildOfficialDict rec {
+    language = "am";
+    version = "0.03-1";
+    fullName = "Amharic";
+    filename = "aspell6";
+    sha256 = "11ylp7gjq94wfacyawvp391lsq26rl1b84f268rjn7l7z0hxs9xz";
+  };
+
+  ar = buildOfficialDict rec {
+    language = "ar";
+    version = "1.2-0";
+    fullName = "Arabic";
+    filename = "aspell6";
+    sha256 = "1avw40bp8yi5bnkq64ihm2rldgw34lk89yz281q9bmndh95a47h4";
+  };
+
+  ast = buildOfficialDict rec {
+    language = "ast";
+    version = "0.01";
+    fullName = "Asturian";
+    filename = "aspell6";
+    sha256 = "14hg85mxcyvdigf96yvslk7f3v9ngdsxn85qpgwkg31k3k83xwj3";
+  };
+
+  az = buildOfficialDict rec {
+    language = "az";
+    version = "0.02-0";
+    fullName = "Azerbaijani";
+    filename = "aspell6";
+    sha256 = "1hs4h1jscpxf9f9iyk6mvjqsnhkf0yslkbjhjkasqqcx8pn7cc86";
+  };
+
+  be = buildOfficialDict rec {
+    language = "be";
+    version = "0.01";
+    fullName = "Belarusian";
+    filename = "aspell5";
+    sha256 = "1svls9p7rsfi3hs0afh0cssj006qb4v1ik2yzqgj8hm10c6as2sm";
+  };
+
+  bg = buildOfficialDict rec {
+    language = "bg";
+    version = "4.1-0";
+    fullName = "Bulgarian";
+    filename = "aspell6";
+    sha256 = "1alacmgpfk0yrgq83y23d16fhav1bxmb98kg8d2a5r9bvh2h0mvl";
+  };
+
+  bn = buildOfficialDict rec {
+    language = "bn";
+    version = "0.01.1-1";
+    fullName = "Bengali";
+    filename = "aspell6";
+    sha256 = "1nc02jd67iggirwxnhdvlvaqm0xfyks35c4psszzj3dhzv29qgxh";
+  };
+
+  br = buildOfficialDict rec {
+    language = "br";
+    version = "0.50-2";
+    fullName = "Breton";
+    filename = "aspell";
+    sha256 = "0fradnm8424bkq9a9zhpl2132dk7y95xmw45sy1c0lx6rinjl4n2";
+  };
+
+  ca = buildOfficialDict rec {
+    language = "ca";
+    version = "2.1.5-1";
     fullName = "Catalan";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/ca/aspell6-${shortName}.tar.bz2";
-      sha256 = "1fb5y5kgvk25nlsfvc8cai978hg66x3pbp9py56pldc7vxzf9npb";
-    };
+    filename = "aspell6";
+    sha256 = "1fb5y5kgvk25nlsfvc8cai978hg66x3pbp9py56pldc7vxzf9npb";
   };
 
-  cs = buildDict rec {
-    shortName = "cs-20040614-1";
+  cs = buildOfficialDict rec {
+    language = "cs";
+    version = "20040614-1";
     fullName = "Czech";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/cs/aspell6-${shortName}.tar.bz2";
-      sha256 = "0rihj4hsw96pd9casvmpvw3r8040pfa28p1h73x4vyn20zwr3h01";
-    };
+    filename = "aspell6";
+    sha256 = "0rihj4hsw96pd9casvmpvw3r8040pfa28p1h73x4vyn20zwr3h01";
   };
 
-  da = buildDict rec {
-    shortName = "da-1.4.42-1";
+  csb = buildOfficialDict rec {
+    language = "csb";
+    version = "0.02-0";
+    fullName = "Kashubian";
+    filename = "aspell6";
+    sha256 = "1612ypkm684wjvc7n081i87mlrrzif9simc7kyn177hfsl3ssrn1";
+  };
+
+  cy = buildOfficialDict rec {
+    language = "cy";
+    version = "0.50-3";
+    fullName = "Welsh";
+    filename = "aspell";
+    sha256 = "15vq601lzz1gi311xym4bv9lv1k21xcfn50jmzamw7h6f36rsffm";
+  };
+
+  da = buildOfficialDict rec {
+    language = "da";
+    version = "1.4.42-1";
     fullName = "Danish";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/da/aspell5-${shortName}.tar.bz2";
-      sha256 = "1hfkmiyhgrx5lgrb2mffjbdn1hivrm73wcg7x0iid74p2yb0fjpp";
-    };
+    filename = "aspell5";
+    sha256 = "1hfkmiyhgrx5lgrb2mffjbdn1hivrm73wcg7x0iid74p2yb0fjpp";
   };
 
-  de = buildDict rec {
-    shortName = "de-20030222-1";
+  de = buildOfficialDict rec {
+    language = "de";
+    version = "20030222-1";
     fullName = "German";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/de/aspell6-${shortName}.tar.bz2";
-      sha256 = "01p92qj66cqb346gk7hjfynaap5sbcn85xz07kjfdq623ghr8v5s";
-    };
+    filename = "aspell6";
+    sha256 = "01p92qj66cqb346gk7hjfynaap5sbcn85xz07kjfdq623ghr8v5s";
   };
 
-  en = buildDict rec {
-    shortName = "en-2018.04.16-0";
+  de-alt = buildOfficialDict rec {
+    language = "de-alt";
+    version = "2.1-1";
+    fullName = "German - Old Spelling";
+    filename = "aspell6";
+    sha256 = "0wwc2l29svv3fv041fh6vfa5m3hi9q9pkbxibzq1ysrsfin3rl9n";
+  };
+
+  el = buildOfficialDict rec {
+    language = "el";
+    version = "0.08-0";
+    fullName = "Greek";
+    filename = "aspell6";
+    sha256 = "1ljcc30zg2v2h3w5h5jr5im41mw8jbsgvvhdd2cii2yzi8d0zxja";
+  };
+
+  en = buildOfficialDict rec {
+    language = "en";
+    version = "2018.04.16-0";
     fullName = "English";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/en/aspell6-${shortName}.tar.bz2";
-      sha256 = "0bxxdzkk9g27plg22y9qzsx9cfjw3aa29w5bmzs561qc9gkp247i";
-    };
+    filename = "aspell6";
+    sha256 = "0bxxdzkk9g27plg22y9qzsx9cfjw3aa29w5bmzs561qc9gkp247i";
   };
 
-  es = buildDict rec {
-    shortName = "es-1.11-2";
-    fullName = "Spanish";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/es/aspell6-${shortName}.tar.bz2";
-      sha256 = "1k5g328ac1hdpp6fsg57d8md6i0aqcwlszp3gbmp5706wyhpydmd";
-    };
-  };
-
-  eo = buildDict rec {
-    shortName = "eo-2.1.20000225a-2";
+  eo = buildOfficialDict rec {
+    language = "eo";
+    version = "2.1.20000225a-2";
     fullName = "Esperanto";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/eo/aspell6-${shortName}.tar.bz2";
-      sha256 = "09vf0mbiicbmyb4bwb7v7lgpabnylg0wy7m3hlhl5rjdda6x3lj1";
-    };
+    filename = "aspell6";
+    sha256 = "09vf0mbiicbmyb4bwb7v7lgpabnylg0wy7m3hlhl5rjdda6x3lj1";
   };
 
-  fr = buildDict rec {
-    shortName = "fr-0.50-3";
+  es = buildOfficialDict rec {
+    language = "es";
+    version = "1.11-2";
+    fullName = "Spanish";
+    filename = "aspell6";
+    sha256 = "1k5g328ac1hdpp6fsg57d8md6i0aqcwlszp3gbmp5706wyhpydmd";
+  };
+
+  et = buildOfficialDict rec {
+    language = "et";
+    version = "0.1.21-1";
+    fullName = "Estonian";
+    filename = "aspell6";
+    sha256 = "0jdjfa2fskirhnb70fy86xryp9r6gkl729ib8qcjmsma7nm5gs5i";
+  };
+
+  fa = buildOfficialDict rec {
+    language = "fa";
+    version = "0.11-0";
+    fullName = "Persian";
+    filename = "aspell6";
+    sha256 = "0nz1ybwv56q7nl9ip12hfmdch1vyyq2j55bkjcns13lshzm2cba8";
+  };
+
+  fi = buildOfficialDict rec {
+    language = "fi";
+    version = "0.7-0";
+    fullName = "Finnish";
+    filename = "aspell6";
+    sha256 = "07d5s08ba4dd89cmwy9icc01i6fjdykxlb9ravmhdrhi8mxz1mzq";
+  };
+
+  fo = buildOfficialDict rec {
+    language = "fo";
+    version = "0.2.16-1";
+    fullName = "Faroese";
+    filename = "aspell5";
+    sha256 = "022yz5lll20xrzizcyb7wksm3fgwklnvgnir5la5qkxv770dvq7p";
+  };
+
+  fr = buildOfficialDict rec {
+    language = "fr";
+    version = "0.50-3";
     fullName = "French";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/fr/aspell-${shortName}.tar.bz2";
-      sha256 = "14ffy9mn5jqqpp437kannc3559bfdrpk7r36ljkzjalxa53i0hpr";
-    };
+    filename = "aspell";
+    sha256 = "14ffy9mn5jqqpp437kannc3559bfdrpk7r36ljkzjalxa53i0hpr";
   };
 
-  it = buildDict rec {
-    shortName = "it-2.2_20050523-0";
+  fy = buildOfficialDict rec {
+    language = "fy";
+    version = "0.12-0";
+    fullName = "Frisian";
+    filename = "aspell6";
+    sha256 = "1almi6n4ni91d0rzrk8ig0473m9ypbwqmg56hchz76j51slwyirl";
+  };
+
+  ga = buildOfficialDict rec {
+    language = "ga";
+    version = "4.5-0";
+    fullName = "Irish";
+    filename = "aspell5";
+    sha256 = "0y869mmvfb3bzadfgajwa2rfb0xfhi6m9ydwgxkb9v2claydnps5";
+  };
+
+  gd = buildOfficialDict rec {
+    language = "gd";
+    version = "0.1.1-1";
+    fullName = "Scottish Gaelic";
+    filename = "aspell5";
+    sha256 = "0a89irv5d65j5m9sb0k36851x5rs0wij12gb2m6hv2nsfn5a05p3";
+  };
+
+  gl = buildOfficialDict rec {
+    language = "gl";
+    version = "0.5a-2";
+    fullName = "Galician";
+    filename = "aspell6";
+    sha256 = "12pwghmy18fcdvf9hvhb4q6shi339hb1kwxpkz0bhw0yjxjwzkdk";
+  };
+
+  grc = buildOfficialDict rec {
+    language = "grc";
+    version = "0.02-0";
+    fullName = "Ancient Greek";
+    filename = "aspell6";
+    sha256 = "1zxr8958v37v260fkqd4pg37ns5h5kyqm54hn1hg70wq5cz8h512";
+  };
+
+  gu = buildOfficialDict rec {
+    language = "gu";
+    version = "0.03-0";
+    fullName = "Gujarati";
+    filename = "aspell6";
+    sha256 = "04c38jnl74lpj2jhjz4zpqbs2623vwc71m6wc5h4b1karid14b23";
+  };
+
+  gv = buildOfficialDict rec {
+    language = "gv";
+    version = "0.50-0";
+    fullName = "Manx Gaelic";
+    filename = "aspell";
+    sha256 = "1rknf4yaw9s29c77sdzg98nhnmjwpicdb69igmz1n768npz2drmv";
+  };
+
+  he = buildOfficialDict rec {
+    language = "he";
+    version = "1.0-0";
+    fullName = "Hebrew";
+    filename = "aspell6";
+    sha256 = "13bhbghx5b8g0119g3wxd4n8mlf707y41vlf59irxjj0kynankfn";
+  };
+
+  hi = buildOfficialDict rec {
+    language = "hi";
+    version = "0.02-0";
+    fullName = "Hindi";
+    filename = "aspell6";
+    sha256 = "0drs374qz4419zx1lf2k281ydxf2750jk5ailafj1x0ncz27h1ys";
+  };
+
+  hil = buildOfficialDict rec {
+    language = "hil";
+    version = "0.11-0";
+    fullName = "Hiligaynon";
+    filename = "aspell5";
+    sha256 = "1s482fsfhzic9qa80al4418q3ni3gfn2bkwkd2y46ydrs17kf2jp";
+  };
+
+  hr = buildOfficialDict rec {
+    language = "hr";
+    version = "0.51-0";
+    fullName = "Croatian";
+    filename = "aspell";
+    sha256 = "09aafyf1vqhaxvcf3jfzf365k394b5pf0iivsr2ix5npah1h7i1a";
+  };
+
+  hsb = buildOfficialDict rec {
+    language = "hsb";
+    version = "0.02-0";
+    fullName = "Upper Sorbian";
+    filename = "aspell6";
+    sha256 = "0bi2vhz7n1vmg43wbbh935pmzihv80iyz9z65j94lxf753j2m7wd";
+  };
+
+  hu = buildOfficialDict rec {
+    language = "hu";
+    version = "0.99.4.2-0";
+    fullName = "Hungarian";
+    filename = "aspell6";
+    sha256 = "1d9nybip2k1dz69zly3iv0npbi3yxgfznh1py364nxzrbjsafd9k";
+  };
+
+  hus = buildOfficialDict rec {
+    language = "hus";
+    version = "0.03-1";
+    fullName = "Huastec";
+    filename = "aspell6";
+    sha256 = "09glipfpkz9xch17z11zw1yn2z7jx1f2svfmjn9l6wm1s5qz6a3d";
+  };
+
+  hy = buildOfficialDict rec {
+    language = "hy";
+    version = "0.10.0-0";
+    fullName = "Armenian";
+    filename = "aspell6";
+    sha256 = "1w5wq8lfl2xp1nid30b1j5qmya4vjyidq0vpr4y3gf53jc08vsid";
+  };
+
+  ia = buildOfficialDict rec {
+    language = "ia";
+    version = "0.50-1";
+    fullName = "Interlingua";
+    filename = "aspell";
+    sha256 = "0bqcpgsa72pga24fv4fkw38b4qqdvqsw97jvzvw7q03dc1cwp5sp";
+  };
+
+  id = buildOfficialDict rec {
+    language = "id";
+    version = "1.2-0";
+    fullName = "Indonesian";
+    filename = "aspell5";
+    sha256 = "023knfg0q03f7y5w6xnwa1kspnrcvcnky8xvdms93n2850414faj";
+  };
+
+  is = buildOfficialDict rec {
+    language = "is";
+    version = "0.51.1-0";
+    fullName = "Icelandic";
+    filename = "aspell";
+    sha256 = "1mp3248lhbr13cj7iq9zs7h5ix0dcwlprp5cwrkcwafrv8lvsd9h";
+  };
+
+  it = buildOfficialDict rec {
+    language = "it";
+    version = "2.2_20050523-0";
     fullName = "Italian";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/it/aspell6-${shortName}.tar.bz2";
-      sha256 = "1gdf7bc1a0kmxsmphdqq8pl01h667mjsj6hihy6kqy14k5qdq69v";
-    };
+    filename = "aspell6";
+    sha256 = "1gdf7bc1a0kmxsmphdqq8pl01h667mjsj6hihy6kqy14k5qdq69v";
   };
 
-  la = buildDict rec {
-    shortName = "la-20020503-0";
+  kn = buildOfficialDict rec {
+    language = "kn";
+    version = "0.01-1";
+    fullName = "Kannada";
+    filename = "aspell6";
+    sha256 = "10sk0wx4x4ds1403kf9dqxv9yjvh06w8qqf4agx57y0jlws0n0fb";
+  };
+
+  ku = buildOfficialDict rec {
+    language = "ku";
+    version = "0.20-1";
+    fullName = "Kurdi";
+    filename = "aspell5";
+    sha256 = "09va98krfbgdaxl101nmd85j3ysqgg88qgfcl42c07crii0pd3wn";
+  };
+
+  ky = buildOfficialDict rec {
+    language = "ky";
+    version = "0.01-0";
+    fullName = "Kirghiz";
+    filename = "aspell6";
+    sha256 = "0kzv2syjnnn6pnwx0d578n46hg2l0j62977al47y6wabnhjjy3z1";
+  };
+
+  la = buildOfficialDict rec {
+    language = "la";
+    version = "20020503-0";
     fullName = "Latin";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/la/aspell6-${shortName}.tar.bz2";
-      sha256 = "1199inwi16dznzl087v4skn66fl7h555hi2palx6s1f3s54b11nl";
-    };
+    filename = "aspell6";
+    sha256 = "1199inwi16dznzl087v4skn66fl7h555hi2palx6s1f3s54b11nl";
   };
 
-  nb = buildDict rec {
-    shortName = "nb-0.50.1-0";
+  lt = buildOfficialDict rec {
+    language = "lt";
+    version = "1.2.1-0";
+    fullName = "Lithuanian";
+    filename = "aspell6";
+    sha256 = "1asjck911l96q26zj36lmz0jp4b6pivvrf3h38zgc8lc85p3pxgn";
+  };
+
+  lv = buildOfficialDict rec {
+    language = "lv";
+    version = "0.5.5-1";
+    fullName = "Latvian";
+    filename = "aspell6";
+    sha256 = "12pvs584a6437ijndggdqpp5s7d0w607cimpkxsjwasnx83f4c1w";
+  };
+
+  mg = buildOfficialDict rec {
+    language = "mg";
+    version = "0.03-0";
+    fullName = "Malagasy";
+    filename = "aspell5";
+    sha256 = "0hdhbk9b5immjp8l5h4cy82gwgsqzcqbb0qsf7syw333w4rgi0ji";
+  };
+
+  mi = buildOfficialDict rec {
+    language = "mi";
+    version = "0.50-0";
+    fullName = "Maori";
+    filename = "aspell";
+    sha256 = "12bxplpd348yx8d2q8qvahi9dlp7qf28qmanzhziwc7np8rixvmy";
+  };
+
+  mk = buildOfficialDict rec {
+    language = "mk";
+    version = "0.50-0";
+    fullName = "Macedonian";
+    filename = "aspell";
+    sha256 = "0wcr9n882xi5b7a7ln1hnhq4vfqd5gpqqp87v01j0gb7zf027z0m";
+  };
+
+  ml = buildOfficialDict rec {
+    language = "ml";
+    version = "0.03-1";
+    fullName = "Malayalam";
+    filename = "aspell6";
+    sha256 = "1zcn4114gwia085fkz77qk13z29xrbp53q2qvgj2cvcbalg5bkg4";
+  };
+
+  mn = buildOfficialDict rec {
+    language = "mn";
+    version = "0.06-2";
+    fullName = "Mongolian";
+    filename = "aspell6";
+    sha256 = "150j9y5c9pw80fwp5rzl5q31q9vjbxixaqljkfwxjb5q93fnw6rg";
+  };
+
+  mr = buildOfficialDict rec {
+    language = "mr";
+    version = "0.10-0";
+    fullName = "Marathi";
+    filename = "aspell6";
+    sha256 = "0cvgb2l40sppqbi842ivpznsh2xzp1d4hxc371dll8z0pr05m8yk";
+  };
+
+  ms = buildOfficialDict rec {
+    language = "ms";
+    version = "0.50-0";
+    fullName = "Malay";
+    filename = "aspell";
+    sha256 = "0vr4vhipcfhsxqfs8dim2ph7iiixn22gmlmlb375bx5hgd9y7i1w";
+  };
+
+  mt = buildOfficialDict rec {
+    language = "mt";
+    version = "0.50-0";
+    fullName = "Maltese";
+    filename = "aspell";
+    sha256 = "1d2rl1nlfjq6rfywblvx8m88cyy2x0mzc0mshzbgw359c2nwl3z0";
+  };
+
+  nb = buildOfficialDict rec {
+    language = "nb";
+    version = "0.50.1-0";
     fullName = "Norwegian Bokmal";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/nb/aspell-${shortName}.tar.bz2";
-      sha256 = "12i2bmgdnlkzfinb20j2a0j4a20q91a9j8qpq5vgabbvc65nwx77";
-    };
+    filename = "aspell";
+    sha256 = "12i2bmgdnlkzfinb20j2a0j4a20q91a9j8qpq5vgabbvc65nwx77";
   };
 
-  nl = buildDict rec {
-    shortName = "nl-0.50-2";
+  nds = buildOfficialDict rec {
+    language = "nds";
+    version = "0.01-0";
+    fullName = "Low Saxon";
+    filename = "aspell6";
+    sha256 = "1nkjhwzn45dizi89d19q4bqyd87cim8xyrgr655fampgkn31wf6f";
+  };
+
+  nl = buildOfficialDict rec {
+    language = "nl";
+    version = "0.50-2";
     fullName = "Dutch";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/nl/aspell-${shortName}.tar.bz2";
-      sha256 = "0ffb87yjsh211hllpc4b9khqqrblial4pzi1h9r3v465z1yhn3j4";
-    };
+    filename = "aspell";
+    sha256 = "0ffb87yjsh211hllpc4b9khqqrblial4pzi1h9r3v465z1yhn3j4";
     # Emacs expects a language called "nederlands".
     postInstall = ''
       echo "add nl.rws" > $out/lib/aspell/nederlands.multi
     '';
   };
 
-  nn = buildDict rec {
-    shortName = "nn-0.50.1-1";
+  nn = buildOfficialDict rec {
+    language = "nn";
+    version = "0.50.1-1";
     fullName = "Norwegian Nynorsk";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/nn/aspell-${shortName}.tar.bz2";
-      sha256 = "0w2k5l5rbqpliripgqwiqixz5ghnjf7i9ggbrc4ly4vy1ia10rmc";
-    };
+    filename = "aspell";
+    sha256 = "0w2k5l5rbqpliripgqwiqixz5ghnjf7i9ggbrc4ly4vy1ia10rmc";
   };
 
-  pl = buildDict rec {
-    shortName = "pl-6.0_20061121-0";
+  ny = buildOfficialDict rec {
+    language = "ny";
+    version = "0.01-0";
+    fullName = "Chichewa";
+    filename = "aspell5";
+    sha256 = "0gjb92vcg60sfgvrm2f6i89sfkgb179ahvwlgs649fx3dc7rfvqp";
+  };
+
+  or = buildOfficialDict rec {
+    language = "or";
+    version = "0.03-1";
+    fullName = "Oriya";
+    filename = "aspell6";
+    sha256 = "0kzj9q225z0ccrlbkijsrafy005pbjy14qcnxb6p93ciz1ls7zyn";
+  };
+
+  pa = buildOfficialDict rec {
+    language = "pa";
+    version = "0.01-1";
+    fullName = "Punjabi";
+    filename = "aspell6";
+    sha256 = "0if93zk10pyrs38wwj3vpcdm01h51m5z9gm85h3jxrpgqnqspwy7";
+  };
+
+  pl = buildOfficialDict rec {
+    language = "pl";
+    version = "6.0_20061121-0";
     fullName = "Polish";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/pl/aspell6-${shortName}.tar.bz2";
-      sha256 = "0kap4kh6bqbb22ypja1m5z3krc06vv4n0hakiiqmv20anzy42xq1";
-    };
+    filename = "aspell6";
+    sha256 = "0kap4kh6bqbb22ypja1m5z3krc06vv4n0hakiiqmv20anzy42xq1";
   };
 
-  pt_BR = buildDict rec {
-    shortName = "pt_BR-20090702-0";
+  pt_BR = buildOfficialDict rec {
+    language = "pt_BR";
+    version = "20090702-0";
     fullName = "Brazilian Portuguese";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/pt_BR/aspell6-${shortName}.tar.bz2";
-      sha256 = "1y09lx9zf2rnp55r16b2vgj953l3538z1vaqgflg9mdvm555bz3p";
-    };
+    filename = "aspell6";
+    sha256 = "1y09lx9zf2rnp55r16b2vgj953l3538z1vaqgflg9mdvm555bz3p";
   };
 
-  pt_PT = buildDict rec {
-    shortName = "pt_PT-20070510-0";
+  pt_PT = buildOfficialDict rec {
+    language = "pt_PT";
+    version = "20070510-0";
     fullName = "Portuguese";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/pt_PT/aspell6-${shortName}.tar.bz2";
-      sha256 = "1mnr994cwlag6shy8865ky99lymysiln07mbldcncahg90dagdxq";
-    };
+    filename = "aspell6";
+    sha256 = "1mnr994cwlag6shy8865ky99lymysiln07mbldcncahg90dagdxq";
   };
 
-  ro = buildDict rec {
-    shortName = "ro-3.3-2";
+  qu = buildOfficialDict rec {
+    language = "qu";
+    version = "0.02-0";
+    fullName = "Quechua";
+    filename = "aspell6";
+    sha256 = "009z0zsvzq7r3z3m30clyibs94v77b92h5lmzmzxlns2p0lpd5w0";
+  };
+
+  ro = buildOfficialDict rec {
+    language = "ro";
+    version = "3.3-2";
     fullName = "Romanian";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/ro/aspell5-${shortName}.tar.bz2";
-      sha256 = "0gb8j9iy1acdl11jq76idgc2lbc1rq3w04favn8cyh55d1v8phsk";
-    };
+    filename = "aspell5";
+    sha256 = "0gb8j9iy1acdl11jq76idgc2lbc1rq3w04favn8cyh55d1v8phsk";
   };
 
-  ru = buildDict rec {
-    shortName = "ru-0.99f7-1";
+  ru = buildOfficialDict rec {
+    language = "ru";
+    version = "0.99f7-1";
     fullName = "Russian";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/ru/aspell6-${shortName}.tar.bz2";
-      sha256 = "0ip6nq43hcr7vvzbv4lwwmlwgfa60hrhsldh9xy3zg2prv6bcaaw";
-    };
+    filename = "aspell6";
+    sha256 = "0ip6nq43hcr7vvzbv4lwwmlwgfa60hrhsldh9xy3zg2prv6bcaaw";
   };
 
-  sv = buildDict rec {
-    shortName = "sv-0.51-0";
-    fullName = "Swedish";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/sv/aspell-${shortName}.tar.bz2";
-      sha256 = "02jwkjhr32kvyibnyzgx3smbnm576jwdzg3avdf6zxwckhy5fw4v";
-    };
+  rw = buildOfficialDict rec {
+    language = "rw";
+    version = "0.50-0";
+    fullName = "Kinyarwanda";
+    filename = "aspell";
+    sha256 = "10gh8g747jbrvfk2fn3pjxy1nhcfdpwgmnvkmrp4nd1k1qp101il";
   };
 
-  sk = buildDict rec {
-    shortName = "sk-2.01-2";
+  sc = buildOfficialDict rec {
+    language = "sc";
+    version = "1.0";
+    fullName = "Sardinian";
+    filename = "aspell5";
+    sha256 = "0hl7prh5rccsyljwrv3m1hjcsphyrrywk2qvnj122irbf4py46jr";
+  };
+
+  sk = buildOfficialDict rec {
+    language = "sk";
+    version = "2.01-2";
     fullName = "Slovak";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/sk/aspell6-${shortName}.tar.bz2";
-      sha256 = "19k0m1v5pcf7xr4lxgjkzqkdlks8nyb13bvi1n7521f3i4lhma66";
-    };
+    filename = "aspell6";
+    sha256 = "19k0m1v5pcf7xr4lxgjkzqkdlks8nyb13bvi1n7521f3i4lhma66";
   };
 
-  tr = buildDict rec {
-    shortName = "tr-0.50-0";
+  sl = buildOfficialDict rec {
+    language = "sl";
+    version = "0.50-0";
+    fullName = "Slovenian";
+    filename = "aspell";
+    sha256 = "1l9kc5g35flq8kw9jhn2n0bjb4sipjs4qkqzgggs438kywkx2rp5";
+  };
+
+  sr = buildOfficialDict rec {
+    language = "sr";
+    version = "0.02";
+    fullName = "Serbian";
+    filename = "aspell6";
+    sha256 = "12cj01p4nj80cpf7m3s4jsaf0rsfng7s295j9jfchcq677xmhpkh";
+  };
+
+  sv = buildOfficialDict rec {
+    language = "sv";
+    version = "0.51-0";
+    fullName = "Swedish";
+    filename = "aspell";
+    sha256 = "02jwkjhr32kvyibnyzgx3smbnm576jwdzg3avdf6zxwckhy5fw4v";
+  };
+
+  sw = buildOfficialDict rec {
+    language = "sw";
+    version = "0.50-0";
+    fullName = "Swahili";
+    filename = "aspell";
+    sha256 = "15zjh7hdj2b4dgm5bc12w1ims9q357p1q3gjalspnyn5gl81zmby";
+  };
+
+  ta = buildOfficialDict rec {
+    language = "ta";
+    version = "20040424-1";
+    fullName = "Tamil";
+    filename = "aspell6";
+    sha256 = "0sj8ygjsyvnr93cs6324y7az7k2vyw7rjxdc9vnm7z60lbqm5xaj";
+  };
+
+  te = buildOfficialDict rec {
+    language = "te";
+    version = "0.01-2";
+    fullName = "Telugu";
+    filename = "aspell6";
+    sha256 = "0pgcgxz7dz34zxp9sb85jjzbg3ky6il5wmhffz6ayrbsfn5670in";
+  };
+
+  tet = buildOfficialDict rec {
+    language = "tet";
+    version = "0.1.1";
+    fullName = "Tetum";
+    filename = "aspell5";
+    sha256 = "17n0y4fhjak47j9qnqf4m4z6zra6dn72rwhp7ig0hhlgqk4ldmcx";
+  };
+
+  tk = buildOfficialDict rec {
+    language = "tk";
+    version = "0.01-0";
+    fullName = "Turkmen";
+    filename = "aspell5";
+    sha256 = "02vad4jqhr0xpzqi5q5z7z0xxqccbn8j0c5dhpnm86mnr84l5wl6";
+  };
+
+  tl = buildOfficialDict rec {
+    language = "tl";
+    version = "0.02-1";
+    fullName = "Tagalog";
+    filename = "aspell5";
+    sha256 = "1kca6k7qnpfvvwjnq5r1n242payqsjy96skmw78m7ww6d0n5vdj8";
+  };
+
+  tn = buildOfficialDict rec {
+    language = "tn";
+    version = "1.0.1-0";
+    fullName = "Setswana";
+    filename = "aspell5";
+    sha256 = "0q5x7c6z88cn0kkpk7q1craq34g4g03v8x3xcj5a5jia3l7c5821";
+  };
+
+  tr = buildOfficialDict rec {
+    language = "tr";
+    version = "0.50-0";
     fullName = "Turkish";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/tr/aspell-${shortName}.tar.bz2";
-      sha256 = "0jpvpm96ga7s7rmsm6rbyrrr22b2dicxv2hy7ysv5y7bbq757ihb";
-    };
+    filename = "aspell";
+    sha256 = "0jpvpm96ga7s7rmsm6rbyrrr22b2dicxv2hy7ysv5y7bbq757ihb";
   };
 
-  uk = buildDict rec {
-    shortName = "uk-1.4.0-0";
+  uk = buildOfficialDict rec {
+    language = "uk";
+    version = "1.4.0-0";
     fullName = "Ukrainian";
-    src = fetchurl {
-      url = "mirror://gnu/aspell/dict/uk/aspell6-${shortName}.tar.bz2";
-      sha256 = "137i4njvnslab6l4s291s11xijr5jsy75lbdph32f9y183lagy9m";
-    };
+    filename = "aspell6";
+    sha256 = "137i4njvnslab6l4s291s11xijr5jsy75lbdph32f9y183lagy9m";
+  };
+
+  uz = buildOfficialDict rec {
+    language = "uz";
+    version = "0.6-0";
+    fullName = "Uzbek";
+    filename = "aspell6";
+    sha256 = "0sg3wlyply1idpq5ypyj7kgnaadaiskci1sqs811yhg2gzyc3092";
+  };
+
+  vi = buildOfficialDict rec {
+    language = "vi";
+    version = "0.01.1-1";
+    fullName = "Vietnamese";
+    filename = "aspell6";
+    sha256 = "05vwgvf1cj45azhflywx69javqdvqd1f20swrc2d3c32pd9mvn1w";
+  };
+
+  wa = buildOfficialDict rec {
+    language = "wa";
+    version = "0.50-0";
+    fullName = "Walloon";
+    filename = "aspell";
+    sha256 = "1r1zwz7xkx40dga9vf5wc9ja3jwk1dkpcr1kaa7wryvslf5al5ss";
+  };
+
+  yi = buildOfficialDict rec {
+    language = "yi";
+    version = "0.01.1-1";
+    fullName = "Yiddish";
+    filename = "aspell6";
+    sha256 = "0mi842l4038bx3ll2wx9nz44nqrg1x46h5b02zigi1hbbddd6ycq";
+  };
+
+  zu = buildOfficialDict rec {
+    language = "zu";
+    version = "0.50-0";
+    fullName = "Zulu";
+    filename = "aspell";
+    sha256 = "15k7gaxrnqnssdyk9l6g27dq317dqp9jz5yzafd25ri01g6mb8iz";
   };
 
   ### Jargons

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -83,9 +83,9 @@ let
         # compares as newer because the versioning scheme has changed.
         versions=$(
             echo '[';
-            lynx -dump "https://ftp.gnu.org/gnu/aspell/dict/${language}/?F=0" | \
-                sed -r "s/^ +\* \[[0-9]+\]${filename}-${language}-([A-Za-z0-9_+.-]+)\.tar\.bz2$/\"\1\"/;t;d" | \
-                if [ "${language}" = "ca" ]; then grep -v 20040130-1; else cat; fi; \
+            curl -s 'https://ftp.gnu.org/gnu/aspell/dict/${language}/?F=0' | \
+                sed -r 's/.* href="${filename}-${language}-([A-Za-z0-9_+.-]+)\.tar\.bz2".*/"\1"/;t;d' | \
+                if [ '${language}' = "ca" ]; then grep -v 20040130-1; else cat; fi; \
             echo ']')
 
         # Sort versions in descending order using Nix's and take the first as the latest.

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -73,22 +73,26 @@ let
 
       passthru.updateScript = writeScript "update-aspellDict-${language}" ''
         #!/usr/bin/env nix-shell
-        #!nix-shell -i bash -p nix curl gnused common-updater-scripts
+        #!nix-shell -i bash -p nix lynx gnused common-updater-scripts
         set -eu -o pipefail
 
-        # List tarballs in the dictionary's subdirectory via FTP.
+        # List tarballs in the dictionary's subdirectory via HTTPS and
+        # the simple list method of Apache's mod_autoindex.
         #
         # Catalan dictionary has an exception where an earlier version
         # compares as newer because the versioning scheme has changed.
         versions=$(
             echo '[';
-            curl -sl ftp://ftp.gnu.org/gnu/aspell/dict/${language}/ | \
-                sed -r "s/^${filename}-${language}-(.+)\.tar\.bz2$/\"\1\"/;t;d" | \
+            lynx -dump "https://ftp.gnu.org/gnu/aspell/dict/${language}/?F=0" | \
+                sed -r "s/^ +\* \[[0-9]+\]${filename}-${language}-([A-Za-z0-9_+.-]+)\.tar\.bz2$/\"\1\"/;t;d" | \
                 if [ "${language}" = "ca" ]; then grep -v 20040130-1; else cat; fi; \
             echo ']')
 
-        # Sort versions in descending order and take the first as the latest.
-        latestVersion=$(nix eval --raw "(with builtins; head (sort (a: b: compareVersions a b > 0) $versions))")
+        # Sort versions in descending order using Nix's and take the first as the latest.
+        sortVersions="(with builtins; head (sort (a: b: compareVersions a b > 0) $versions))"
+        # nix-instantiate outputs Nix strings (with quotes), so remove them to get
+        # a result similar to `nix eval --raw`.
+        latestVersion=$(nix-instantiate --eval --expr "$sortVersions" | tr -d '"')
 
         update-source-version aspellDicts.${language} "$latestVersion"
       '';
@@ -97,7 +101,7 @@ let
         homepage = "http://ftp.gnu.org/gnu/aspell/dict/0index.html";
       } // (args.meta or {});
 
-    } // removeAttrs args [ "language" "filename" "sha256" ];
+    } // removeAttrs args [ "language" "filename" "sha256" "meta" ];
     in buildDict buildArgs;
 
   /* Function to compile txt dict files into Aspell dictionaries. */

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -73,7 +73,7 @@ let
 
       passthru.updateScript = writeScript "update-aspellDict-${language}" ''
         #!/usr/bin/env nix-shell
-        #!nix-shell -i bash -p nix lynx gnused common-updater-scripts
+        #!nix-shell -i bash -p nix curl gnused common-updater-scripts
         set -eu -o pipefail
 
         # List tarballs in the dictionary's subdirectory via HTTPS and


### PR DESCRIPTION
From:

  ftp://ftp.gnu.org/gnu/aspell/dict/0index.html

Also sets the default homepage of the dictionaries to
the above URL.

The Marathi and Hindi dictionaries both contain `u-deva.{cmap,cset}` files, which cause a conflict. This patch adds those files from the Marathi dictionary into the main aspell package like [Debian does](https://sources.debian.org/src/aspell/0.60.7%7E20110707-5/debian/patches/02_u-deva_common_data.diff).

###### Motivation for this change

I intended to add the Finnish dictionary to `aspellDicts` but noticed there’s a fairly large bunch of official ones not included so why not add them all in one go?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
