### PR TITLE
python3Packages: add Sanic HTTP Server (and dependencies)

### DIFF
--- a/pkgs/development/python-modules/httptools/default.nix
+++ b/pkgs/development/python-modules/httptools/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname   = "httptools";
+  version = "0.0.11";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1idps97v4ssk9v10vdza942w5ixqa9rm84cqn0lcms7hpqxp1iq4";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Fast HTTP Parser";
+    homepage    = https://github.com/MagicStack/httptools;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, aiofiles, websockets, multidict, ujson, uvloop, httptools
+}:
+
+let
+  # Ideally, websockets 7.0 will be supported in the future, but
+  # for now, sanic requires 6.x
+  ws = websockets.overrideAttrs (_: {
+    src = fetchPypi {
+      pname   = "websockets";
+      version = "6.0";
+      sha256  = "0v3iqdqizwxajpwasyngkhdfwfqxvh864wl2cch03cy525nrafwg";
+    };
+  });
+in
+buildPythonPackage rec {
+  pname   = "sanic";
+  version = "18.12.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q1z6f5ra5ra194080ps6vld0qyjg2sg982dhkzwlmw5b3czzrac";
+  };
+
+  propagatedBuildInputs = [ aiofiles uvloop ujson ws multidict httptools ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Fast, asynchronous Python 3 webserver";
+    homepage    = https://sanicframework.org/;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname   = "uvloop";
+  version = "0.11.3";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1apis7yw1i78w8liigzj3kiwv4gb3xqzg4111qnvj1zalb844l7x";
+  };
+
+  buildInputs = [ pkgs.libuv ];
+  setupPyBuildFlags = [ "--use-system-libuv" ];
+
+  # tests seem to trigger some failure in the sandbox due to pipe requirements,
+  # and also requirements on e.g. psutils
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python interface for libuv";
+    homepage    = https://github.com/saghul/pyuv;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5143,6 +5143,8 @@ in {
 
   httptools = callPackage ../development/python-modules/httptools { };
 
+  sanic = callPackage ../development/python-modules/sanic { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5141,6 +5141,8 @@ in {
 
   uvloop = callPackage ../development/python-modules/uvloop { };
 
+  httptools = callPackage ../development/python-modules/httptools { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5139,6 +5139,8 @@ in {
 
   importlib-resources = callPackage ../development/python-modules/importlib-resources {};
 
+  uvloop = callPackage ../development/python-modules/uvloop { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

