### PR TITLE
abduco: 0.6 -> 2018-05-16

### DIFF
--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -1,29 +1,27 @@
-{ stdenv, fetchurl, writeText, conf? null}:
+{ stdenv, fetchFromGitHub, writeText, conf ? null }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-    name = "abduco-0.6";
+  name = "abduco-2018-05-16";
 
-    meta = {
-        homepage = http://brain-dump.org/projects/abduco;
-        license = licenses.isc;
-        description = "Allows programs to be run independently from its controlling terminal";
-        maintainers = with maintainers; [ pSub ];
-        platforms = platforms.unix;
-    };
+  src = fetchFromGitHub {
+    owner = "martanne";
+    repo = "abduco";
+    rev = "8f80aa8044d7ecf0e43a0294a09007d056b20e4c";
+    sha256 = "0wqcif633nbgnznn46j0sng9l0wncppw1x1c42f75b4p9hrph203";
+  };
 
-    CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
+  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
 
-    src = fetchurl {
-        url = "http://www.brain-dump.org/projects/abduco/${name}.tar.gz";
-        sha256 = "1x1m58ckwsprljgmdy93mvgjyg9x3cqrzdf3mysp0mx97zhhj2f9";
-    };
+  CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
 
-    configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
-    preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
-
-    installPhase = ''
-      make PREFIX=$out install
-    '';
+  meta = {
+    homepage = http://brain-dump.org/projects/abduco;
+    license = licenses.isc;
+    description = "Allows programs to be run independently from its controlling terminal";
+    maintainers = with maintainers; [ pSub ];
+    platforms = platforms.unix;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

There was no release since March 2016, but activity on master till May 2018. I've been using this version without issues, so far.

The messy diff is due to reformatting (meta to the bottom, 2-space indentation).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

