### PR TITLE
eaglemode: 0.86.0 -> 0.94.0

### DIFF
--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -1,35 +1,36 @@
-{ stdenv, fetchurl, perl, libX11, libjpeg, libpng, libtiff, pkgconfig,
-librsvg, glib, gtk2, libXext, libXxf86vm, poppler, xineLib }:
+{ stdenv, fetchurl, perl, libX11, libXinerama, libjpeg, libpng, libtiff, pkgconfig,
+librsvg, glib, gtk2, libXext, libXxf86vm, poppler, xineLib, ghostscript, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "eaglemode-0.86.0";
+  name = "eaglemode-${version}";
+  version = "0.94.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/eaglemode/${name}.tar.bz2";
-    sha256 = "1a2hzyck95g740qg4p4wd4fjwsmlknh75i9sbx5r5v9pyr4i3m4f";
+    sha256 = "1sr3bd9y9j2svqvdwhrak29yy9cxf92w9vq2cim7a8hzwi9qfy9k";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ perl libX11 libjpeg libpng libtiff
-    librsvg glib gtk2 libXxf86vm libXext poppler xineLib ];
+  buildInputs = [ perl libX11 libXinerama libjpeg libpng libtiff
+    librsvg glib gtk2 libXxf86vm libXext poppler xineLib ghostscript makeWrapper ];
 
-  # The program tries to dlopen both Xxf86vm and Xext, so we use the
+  # The program tries to dlopen Xxf86vm, Xext and Xinerama, so we use the
   # trick on NIX_LDFLAGS and dontPatchELF to make it find them.
   # I use 'yes y' to skip a build error linking with xineLib,
   # because xine stopped exporting "_x_vo_new_port"
   #  https://sourceforge.net/projects/eaglemode/forums/forum/808824/topic/5115261
   buildPhase = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lXxf86vm -lXext"
+    export NIX_LDFLAGS="$NIX_LDFLAGS -lXxf86vm -lXext -lXinerama"
     perl make.pl build
   '';
 
   dontPatchELF = true;
+  # eaglemode expects doc to be in the root directory
+  forceShare = [ "man" "info" ];
 
   installPhase = ''
     perl make.pl install dir=$out
-    # I don't like this... but it seems the way they plan to run it by now.
-    # Run 'eaglemode.sh', not 'eaglemode'.
-    ln -s $out/eaglemode.sh $out/bin/eaglemode.sh
+    wrapProgram $out/bin/eaglemode --set EM_DIR "$out" --prefix LD_LIBRARY_PATH : "$out/lib" --prefix PATH : "${ghostscript}/bin"
   '';
 
   meta = with stdenv.lib; {
@@ -38,6 +39,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
The build is no longer breaking so this derivation is no longer marked
broken.

###### Motivation for this change

Existing version if marked broken and there have been a lot of releases since.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

