### PR TITLE
rls: init at 1.31.7

### DIFF
--- a/pkgs/development/tools/rust/rls/default.nix
+++ b/pkgs/development/tools/rust/rls/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, rustPlatform
+, openssh, openssl, pkgconfig, cmake, zlib, curl }:
+
+rustPlatform.buildRustPackage rec {
+  name = "rls-${version}";
+  # with rust 1.x you can only build rls version 1.x.y
+  version = "1.31.7";
+
+  src = fetchFromGitHub {
+    owner = "rust-lang";
+    repo = "rls";
+    rev = version;
+    sha256 = "0n33pf7sm31y55rllb8wv3mn75srspr4yj2y6cpcdyf15n47c8cf";
+  };
+
+  cargoSha256 = "0jcsggq4ay8f4vb8n6gh8z995icvvbjkzapxf6jq6qkg6jp3vv17";
+
+  # a nightly compiler is required unless we use this cheat code.
+  RUSTC_BOOTSTRAP=1;
+
+  # clippy is hard to build with stable rust so we disable clippy lints
+  cargoBuildFlags = [ "--no-default-features" ];
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ openssh openssl curl zlib ];
+
+  doCheck = true;
+  # the default checkPhase has no way to pass --no-default-features
+  checkPhase = ''
+    runHook preCheck
+    echo "Running cargo test"
+    cargo test --no-default-features
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Rust Language Server - provides information about Rust programs to IDEs and other tools";
+    homepage = https://github.com/rust-lang/rls/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ symphorien ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7497,6 +7497,7 @@ in
 
   pyo3-pack = callPackage ../development/tools/rust/pyo3-pack { };
   rainicorn = callPackage ../development/tools/rust/rainicorn { };
+  rls = callPackage ../development/tools/rust/rls { };
   rustfmt = callPackage ../development/tools/rust/rustfmt { };
   rustracer = callPackage ../development/tools/rust/racer { };
   rustracerd = callPackage ../development/tools/rust/racerd { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

