### PR TITLE
pythonPackages.pyatv: init at 0.3.12

### DIFF
--- a/pkgs/development/python-modules/curve25519-donna/default.nix
+++ b/pkgs/development/python-modules/curve25519-donna/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "curve25519-donna";
+  version = "1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w0vkjyh4ki9n98lr2hg09f1lr1g3pz48kshrlic01ba6pasj60q";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper for the portable curve25519-donna implementation";
+    homepage = http://code.google.com/p/curve25519-donna/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, srptools, aiohttp, zeroconf
+, ed25519, cryptography, curve25519-donna, pytest, pytestrunner
+, netifaces, asynctest, virtualenv, toml, filelock, tox }:
+
+buildPythonPackage rec {
+  pname = "pyatv";
+  version = "0.3.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "135xvy1nn0x5knc7l05amfs837xkx2gcg3lpp69ya9kqs8j6brgp";
+  };
+
+  propagatedBuildInputs = [ srptools aiohttp zeroconf ed25519 cryptography curve25519-donna tox ];
+
+  checkInputs = [ pytest pytestrunner netifaces asynctest virtualenv toml filelock ];
+
+  meta = with stdenv.lib; {
+    description = "A python client library for the Apple TV";
+    homepage = https://github.com/postlund/pyatv;
+    license = licenses.mit;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/development/python-modules/srptools/default.nix
+++ b/pkgs/development/python-modules/srptools/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, pytest, pytestrunner }:
+
+buildPythonPackage rec {
+  pname = "srptools";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g0jdkblnd3wv5xgb33g6sfgqnhdcs8a3gqzp5gshq2vawdh8p37";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytest pytestrunner ];
+
+  meta = with stdenv.lib; {
+    description = "Python-Tools to implement Secure Remote Password (SRP) authentication";
+    homepage = https://github.com/idlesign/srptools;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -44,7 +44,7 @@
     "android_ip_webcam" = ps: with ps; [  ];
     "apcupsd" = ps: with ps; [  ];
     "api" = ps: with ps; [ aiohttp-cors ];
-    "apple_tv" = ps: with ps; [  ];
+    "apple_tv" = ps: with ps; [ pyatv ];
     "aqualogic" = ps: with ps; [  ];
     "arduino" = ps: with ps; [  ];
     "arlo" = ps: with ps; [  ];
@@ -658,7 +658,7 @@
     "media_extractor" = ps: with ps; [ aiohttp-cors youtube-dl-light ];
     "media_player" = ps: with ps; [ aiohttp-cors ];
     "media_player.anthemav" = ps: with ps; [  ];
-    "media_player.apple_tv" = ps: with ps; [  ];
+    "media_player.apple_tv" = ps: with ps; [ pyatv ];
     "media_player.aquostv" = ps: with ps; [  ];
     "media_player.blackbird" = ps: with ps; [  ];
     "media_player.bluesound" = ps: with ps; [ xmltodict ];
@@ -850,7 +850,7 @@
     "recorder.util" = ps: with ps; [  ];
     "remember_the_milk" = ps: with ps; [ httplib2 ];
     "remote" = ps: with ps; [  ];
-    "remote.apple_tv" = ps: with ps; [  ];
+    "remote.apple_tv" = ps: with ps; [ pyatv ];
     "remote.demo" = ps: with ps; [  ];
     "remote.harmony" = ps: with ps; [  ];
     "remote.itach" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5139,6 +5139,8 @@ in {
 
   importlib-resources = callPackage ../development/python-modules/importlib-resources {};
 
+  srptools = callPackage ../development/python-modules/srptools { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5143,7 +5143,7 @@ in {
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 
-  pyatv = callPackage ../development/python-modules/curve25519-donna { };
+  pyatv = callPackage ../development/python-modules/pyatv { };
 
 });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5141,6 +5141,8 @@ in {
 
   srptools = callPackage ../development/python-modules/srptools { };
 
+  curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5143,6 +5143,8 @@ in {
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 
+  pyatv = callPackage ../development/python-modules/curve25519-donna { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
apple tv connectivity for home-assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

