### PR TITLE
anki: 2.1.6-beta2 -> 2.1.7

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -26,17 +26,17 @@
 }:
 
 buildPythonApplication rec {
-    version = "2.1.6-beta2";
+    version = "2.1.7";
     name = "anki-${version}";
 
     src = fetchurl {
       urls = [
-        "https://apps.ankiweb.net/downloads/beta/${name}-source.tgz"
+        "https://apps.ankiweb.net/downloads/current/${name}-source.tgz"
         # "https://apps.ankiweb.net/downloads/current/${name}-source.tgz"
         # "http://ankisrs.net/download/mirror/${name}.tgz"
         # "http://ankisrs.net/download/mirror/archive/${name}.tgz"
       ];
-      sha256 = "0h71s1j1269x0b8481z8xf019caqglcjs32xlpzk72087ps169fa";
+      sha256 = "0cvlimfxb7kficlf20hg7a345pahvr093b7yqvssww15h4y4va9d";
     };
 
     propagatedBuildInputs = [ pyqt5 sqlalchemy
@@ -54,16 +54,6 @@ buildPythonApplication rec {
     patches = [
       # Disable updated version check.
       ./no-version-check.patch
-
-      # This is needed to fix python 3.7 compatibilty, where the
-      # behaviour of `re.escape()` was changed in a way that it no
-      # longer escapes `%`. This patch detects this difference at
-      # runtime and makes anki work with any python version.
-      # Upstream PR: https://github.com/dae/anki/pull/266
-      (fetchpatch {
-        url = "https://github.com/dae/anki/commit/3d69aa9ce454a151ba75deafd7de117af2c7307d.patch";
-        sha256 = "0kf9gajhy0wcajp24xfia71z6gn1mc4vl37svvq4sqbhj3gigd0h";
-      })
     ];
 
     buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://apps.ankiweb.net/docs/changes.html#latestv21).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

