### PR TITLE
pythonPackages.pybotvac: init at 0.0.12

### DIFF
--- a/pkgs/development/python-modules/pybotvac/default.nix
+++ b/pkgs/development/python-modules/pybotvac/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "pybotvac";
+  version = "0.0.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12qm4w883nb6fwff6sch5l133g3irqjcrgkjhh4mz1mmz7n6xzjh";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = with stdenv.lib; {
+    description = "Python package for controlling Neato pybotvac Connected vacuum robot";
+    homepage = https://github.com/stianaske/pybotvac;
+    license = licenses.mit;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -198,7 +198,7 @@
     "camera.logi_circle" = ps: with ps; [  ];
     "camera.mjpeg" = ps: with ps; [  ];
     "camera.mqtt" = ps: with ps; [ paho-mqtt ];
-    "camera.neato" = ps: with ps; [  ];
+    "camera.neato" = ps: with ps; [ pybotvac ];
     "camera.nest" = ps: with ps; [  ];
     "camera.netatmo" = ps: with ps; [  ];
     "camera.onvif" = ps: with ps; [ ha-ffmpeg ];
@@ -743,7 +743,7 @@
     "mysensors.handler" = ps: with ps; [  ];
     "mysensors.helpers" = ps: with ps; [  ];
     "namecheapdns" = ps: with ps; [  ];
-    "neato" = ps: with ps; [  ];
+    "neato" = ps: with ps; [ pybotvac ];
     "nest" = ps: with ps; [  ];
     "nest.config_flow" = ps: with ps; [  ];
     "nest.const" = ps: with ps; [  ];
@@ -1265,7 +1265,7 @@
     "switch.mqtt" = ps: with ps; [ paho-mqtt ];
     "switch.mysensors" = ps: with ps; [  ];
     "switch.mystrom" = ps: with ps; [  ];
-    "switch.neato" = ps: with ps; [  ];
+    "switch.neato" = ps: with ps; [ pybotvac ];
     "switch.netio" = ps: with ps; [ aiohttp-cors ];
     "switch.orvibo" = ps: with ps; [  ];
     "switch.pilight" = ps: with ps; [  ];
@@ -1369,7 +1369,7 @@
     "vacuum.dyson" = ps: with ps; [  ];
     "vacuum.ecovacs" = ps: with ps; [  ];
     "vacuum.mqtt" = ps: with ps; [ paho-mqtt ];
-    "vacuum.neato" = ps: with ps; [  ];
+    "vacuum.neato" = ps: with ps; [ pybotvac ];
     "vacuum.roomba" = ps: with ps; [  ];
     "vacuum.xiaomi_miio" = ps: with ps; [ construct ];
     "velbus" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5145,6 +5145,8 @@ in {
 
   pyatv = callPackage ../development/python-modules/pyatv { };
 
+  pybotvac = callPackage ../development/python-modules/pybotvac { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
neato botvac connectivity for home-assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
