### PR TITLE
patchbay, patchwork: init with appimage-run

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -391,6 +391,11 @@
     github = "asppsa";
     name = "Alastair Pharo";
   };
+  astro = {
+    email = "astro@spaceboyz.net";
+    github = "astro";
+    name = "Astro";
+  };
   astsmtl = {
     email = "astsmtl@yandex.ru";
     github = "astsmtl";

--- a/pkgs/applications/networking/ssb/patchbay/default.nix
+++ b/pkgs/applications/networking/ssb/patchbay/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, makeWrapper, appimage-run, fetchurl }:
+
+let
+  version = "7.15.6";
+
+  plat = {
+    "x86_64-linux" = "x86_64";
+  }.${stdenv.hostPlatform.system};
+
+  sha256 = {
+    "x86_64-linux" = "14za07sxfgi7ixjbqrgwfx2rcxwlgi98k5bwn434aqy55rxvmlqb";
+  }.${stdenv.hostPlatform.system};
+in
+
+stdenv.mkDerivation rec {
+  name = "patchbay-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/ssbc/patchbay/releases/download/v${version}/patchbay-linux-${version}-${plat}.AppImage";
+    inherit sha256;
+  };
+
+  buildInputs = [ makeWrapper appimage-run ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp $src $out/share/patchbay.AppImage
+    chmod +x $out/share/patchbay.AppImage
+
+    ln -s ${appimage-run}/bin/appimage-run $out/bin/patchbay
+    wrapProgram $out/bin/patchbay \
+        --add-flags $out/share/patchbay.AppImage
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An alternative Secure Scuttlebutt client interface that is fully compatible with Patchwork";
+    longDescription = ''
+        Patchbay is a scuttlebutt client designed to be easy to modify
+        and extend. It uses the same database as Patchwork and
+        Patchfoo, so you can easily take it for a spin with your
+        existing identity.
+    '';
+    homepage = http://www.scuttlebutt.nz/;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ astro ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/ssb/patchwork/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, makeWrapper, appimage-run, fetchurl }:
+
+let
+  version = "3.11.4";
+
+  plat = {
+    "x86_64-linux" = "x86_64";
+  }.${stdenv.hostPlatform.system};
+
+  sha256 = {
+    "x86_64-linux" = "1blsprpkvm0ws9b96gb36f0rbf8f5jgmw4x6dsb1kswr4ysf591s";
+  }.${stdenv.hostPlatform.system};
+in
+
+stdenv.mkDerivation rec {
+  name = "patchwork-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/patchwork-${version}-linux-${plat}.AppImage";
+    inherit sha256;
+  };
+
+  buildInputs = [ makeWrapper appimage-run ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp $src $out/share/patchwork.AppImage
+    chmod +x $out/share/patchwork.AppImage
+
+    ln -s ${appimage-run}/bin/appimage-run $out/bin/patchwork
+    wrapProgram $out/bin/patchwork \
+        --add-flags $out/share/patchwork.AppImage
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A decentralized messaging and sharing app built on top of Secure Scuttlebutt";
+    homepage = http://www.scuttlebutt.nz/;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ astro ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4776,7 +4776,7 @@ in
 
   patchbay = callPackage ../applications/networking/ssb/patchbay { };
 
-  patchwork = callPackage ../applications/networking/ssb/patchwork { };
+  ssb-patchwork = callPackage ../applications/networking/ssb/patchwork { };
 
   patchwork-classic = callPackage ../applications/networking/ssb/patchwork-classic { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4774,6 +4774,10 @@ in
 
   patchage = callPackage ../applications/audio/patchage { };
 
+  patchbay = callPackage ../applications/networking/ssb/patchbay { };
+
+  patchwork = callPackage ../applications/networking/ssb/patchwork { };
+
   patchwork-classic = callPackage ../applications/networking/ssb/patchwork-classic { };
 
   pcapfix = callPackage ../tools/networking/pcapfix { };


### PR DESCRIPTION
###### Motivation for this change

Template: `standardnotes`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

