### PR TITLE
init openra-mods

### DIFF
--- a/pkgs/games/openra-mods/Makefile-ca.patch
+++ b/pkgs/games/openra-mods/Makefile-ca.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index ea94401..a91dc32 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,11 +37,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+ 
+ check-sdk-scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -95,7 +92,6 @@ check-variables:
+ 	fi
+ 
+ engine: check-variables check-sdk-scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+ 
+ utility: engine

--- a/pkgs/games/openra-mods/Makefile-d2.patch
+++ b/pkgs/games/openra-mods/Makefile-d2.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index ea94401..a91dc32 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,11 +37,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+
+ check-sdk-scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -95,7 +92,6 @@ check-variables:
+ 	fi
+
+ engine: check-variables check-sdk-scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine

--- a/pkgs/games/openra-mods/Makefile-gen.patch
+++ b/pkgs/games/openra-mods/Makefile-gen.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index 4ecdb4bc..600660aa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -48,7 +48,6 @@ variables:
+ 		fi
+
+ engine: variables
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine
+@@ -99,4 +98,4 @@ check: utility stylecheck
+
+ test: utility
+ 	@echo "Testing $(MOD_ID) mod MiniYAML..."
+-	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml
+\ No newline at end of file
++	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml

--- a/pkgs/games/openra-mods/Makefile-kknd.patch
+++ b/pkgs/games/openra-mods/Makefile-kknd.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index ea94401..a91dc32 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,11 +37,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+ 
+ check-sdk-scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -95,7 +92,6 @@ check-variables:
+ 	fi
+ 
+ engine: check-variables check-sdk-scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+ 
+ utility: engine

--- a/pkgs/games/openra-mods/Makefile-ra2.patch
+++ b/pkgs/games/openra-mods/Makefile-ra2.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index f903e4c..acd2c2d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -36,11 +36,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+
+ scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -71,7 +68,6 @@ variables:
+ 	fi
+
+ engine: variables scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine
+@@ -129,4 +125,4 @@ check-sequence-sprites: utility
+
+ test: utility
+ 	@echo "Testing $(MOD_ID) mod MiniYAML..."
+-	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml
+\ No newline at end of file
++	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml

--- a/pkgs/games/openra-mods/Makefile-raclassic.patch
+++ b/pkgs/games/openra-mods/Makefile-raclassic.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index ea94401..a91dc32 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,11 +37,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+ 
+ check-sdk-scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -95,7 +92,6 @@ check-variables:
+ 	fi
+ 
+ engine: check-variables check-sdk-scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+ 
+ utility: engine

--- a/pkgs/games/openra-mods/Makefile-rv.patch
+++ b/pkgs/games/openra-mods/Makefile-rv.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index f903e4c..acd2c2d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -36,11 +36,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+
+ scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -71,7 +68,6 @@ variables:
+ 	fi
+
+ engine: variables scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine
+@@ -129,4 +125,4 @@ check-sequence-sprites: utility
+
+ test: utility
+ 	@echo "Testing $(MOD_ID) mod MiniYAML..."
+-	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml
+\ No newline at end of file
++	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml

--- a/pkgs/games/openra-mods/Makefile-sp.patch
+++ b/pkgs/games/openra-mods/Makefile-sp.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index 4ecdb4b..600660a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -48,7 +48,6 @@ variables:
+ 		fi
+ 
+ engine: variables
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+ 
+ utility: engine

--- a/pkgs/games/openra-mods/Makefile-ura.patch
+++ b/pkgs/games/openra-mods/Makefile-ura.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index 076698b..33663b9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,11 +37,8 @@ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_
+
+ check-sdk-scripts:
+ 	@awk '/\r$$/ { exit(1); }' mod.config || (printf "Invalid mod.config format: file must be saved using unix-style (CR, not CRLF) line endings.\n"; exit 1)
+-	@if [ ! -x "fetch-engine.sh" ] || [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
++	@if [ ! -x "launch-dedicated.sh" ] || [ ! -x "launch-game.sh" ] || [ ! -x "utility.sh" ]; then \
+ 		echo "Required SDK scripts are not executable:"; \
+-		if [ ! -x "fetch-engine.sh" ]; then \
+-			echo "   fetch-engine.sh"; \
+-		fi; \
+ 		if [ ! -x "launch-dedicated.sh" ]; then \
+ 			echo "   launch-dedicated.sh"; \
+ 		fi; \
+@@ -95,7 +92,6 @@ check-variables:
+ 	fi
+
+ engine: check-variables check-sdk-scripts
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine

--- a/pkgs/games/openra-mods/Makefile-yr.patch
+++ b/pkgs/games/openra-mods/Makefile-yr.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index e637d82..4440f1d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -40,7 +40,6 @@ LUA_FILES = $(shell find mods/*/maps/* -iname '*.lua')
+ PROJECT_DIRS = $(shell dirname $$(find . -iname "*.csproj" -not -path "$(ENGINE_DIRECTORY)/*"))
+
+ engine:
+-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+ 	@cd $(ENGINE_DIRECTORY) && make core
+
+ utility: engine
+@@ -91,4 +90,4 @@ check: utility stylecheck
+
+ test: utility
+ 	@echo "Testing $(MOD_ID) mod MiniYAML..."
+-	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml
+\ No newline at end of file
++	@MOD_SEARCH_PATHS="$(MOD_SEARCH_PATHS)" mono --debug "$(ENGINE_DIRECTORY)/OpenRA.Utility.exe" $(MOD_ID) --check-yaml

--- a/pkgs/games/openra-mods/default.nix
+++ b/pkgs/games/openra-mods/default.nix
@@ -1,0 +1,166 @@
+# Based on: pkgs/games/openra/default.nix
+# Based on: https://build.opensuse.org/package/show/home:fusion809/openra-ura
+{ stdenv, fetchFromGitHub, dos2unix, pkgconfig, makeWrapper
+, lua, mono, dotnetPackages, python
+, libGL, openal, SDL2
+, zenity ? null
+, mod
+, engine
+, engineMods ? []
+}:
+
+with stdenv.lib;
+
+let
+  path = makeBinPath ([ mono python ] ++ optional (zenity != null) zenity);
+  rpath = makeLibraryPath [ lua openal SDL2 ];
+
+in stdenv.mkDerivation rec {
+  name = "openra-${mod.name}-${mod.version}";
+
+  srcs = [
+    mod.src
+    engine.src
+  ];
+
+  sourceRoot = ".";
+
+  buildInputs = with dotnetPackages; [
+    FuzzyLogicLibrary
+    MaxMindDb
+    MaxMindGeoIP2
+    MonoNat
+    NewtonsoftJson
+    NUnit3
+    NUnitConsole
+    OpenNAT
+    RestSharp
+    SharpFont
+    SharpZipLib
+    SmartIrc4net
+    StyleCopMSBuild
+    StyleCopPlusMSBuild
+  ] ++ [
+    dos2unix
+    pkgconfig
+    makeWrapper
+    lua
+    mono
+    python
+    libGL
+    openal
+    SDL2
+  ];
+
+  postUnpack = ''
+    mv ${engine.src.name} mod
+    cd mod
+  '';
+
+  prePatch = ''
+    dos2unix Makefile
+  '';
+
+  patches = [ mod.makefilePatch ];
+
+  postPatch = ''
+    sed -i 's/^VERSION.*/VERSION = ${mod.version}/g' Makefile
+
+    dos2unix *.md
+
+    sed -i \
+      -e 's/^VERSION.*/VERSION = ${engine.version}/g' \
+      -e '/fetch-geoip-db/d' \
+      -e '/GeoLite2-Country.mmdb.gz/d' \
+      ${engine.src.name}/Makefile
+
+    sed -i 's|locations=.*|locations=${lua}/lib|' ${engine.src.name}/thirdparty/configure-native-deps.sh
+  '';
+
+  configurePhase = ''
+    make version VERSION=${escapeShellArg mod.version}
+    ( cd ${engine.src.name}; make version VERSION=${escapeShellArg engine.version} )
+  '';
+
+  makeFlags = "PREFIX=$(out)";
+
+  doCheck = true;
+  checkTarget = "test";
+
+  installPhase = ''
+    mkdir -p $out/lib/openra-${mod.name}
+    substitute ${./launch-game.sh} $out/lib/openra-${mod.name}/launch-game.sh \
+      --subst-var out \
+      --subst-var-by name ${escapeShellArg mod.name} \
+      --subst-var-by title ${escapeShellArg mod.title}
+    chmod +x $out/lib/openra-${mod.name}/launch-game.sh
+
+    # Setting TERM=xterm fixes an issue with terminfo in mono: System.Exception: Magic number is wrong: 542
+    # https://github.com/mono/mono/issues/6752#issuecomment-365212655
+    wrapProgram $out/lib/openra-${mod.name}/launch-game.sh \
+      --prefix PATH : "${path}" \
+      --prefix LD_LIBRARY_PATH : "${rpath}" \
+      --set TERM xterm
+
+    mkdir -p $out/bin
+    makeWrapper $out/lib/openra-${mod.name}/launch-game.sh $out/bin/openra-${mod.name} \
+      --run "cd $out/lib/openra-${mod.name}"
+
+    cp -r ${engine.src.name}/{${concatStringsSep "," [
+      "glsl"
+      "lua"
+      "AUTHORS"
+      "COPYING"
+      "Eluant.dll*"
+      "FuzzyLogicLibrary.dll"
+      "'global mix database.dat'"
+      "ICSharpCode.SharpZipLib.dll"
+      "MaxMind.Db.dll"
+      "OpenAL-CS.dll"
+      "OpenAL-CS.dll.config"
+      "Open.Nat.dll"
+      "OpenRA.Game.exe"
+      "OpenRA.Platforms.Default.dll"
+      "OpenRA.Server.exe"
+      "OpenRA.Utility.exe"
+      "rix0rrr.BeaconLib.dll"
+      "SDL2-CS.dll"
+      "SDL2-CS.dll.config"
+      "SharpFont.dll"
+      "SharpFont.dll.config"
+      "VERSION"
+    ]}} $out/lib/openra-${mod.name}
+
+    mkdir $out/lib/openra-${mod.name}/mods
+    cp -r ${engine.src.name}/mods/{common${concatStrings (map (s: "," + s) engineMods)},modcontent} $out/lib/openra-${mod.name}/mods
+    cp -r mods/${mod.name} $out/lib/openra-${mod.name}/mods
+
+    mkdir -p $out/share/applications
+    substitute ${./openra-mod.desktop} $out/share/applications/openra-${mod.name}.desktop \
+      --subst-var-by name ${escapeShellArg mod.name} \
+      --subst-var-by title ${escapeShellArg mod.title}
+
+    mkdir -p $out/share/doc/packages/openra-${mod.name}
+    cp README.md $out/share/doc/packages/openra-${mod.name}/README.md
+
+    mkdir -p $out/share/pixmaps
+    [[ -e mods/${mod.name}/icon.png ]] && mod_icon=mods/${mod.name}/icon.png || mod_icon=packaging/linux/mod_256x256.png
+    cp "$mod_icon" $out/share/pixmaps/openra-${mod.name}.png
+
+    mkdir -p $out/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256}/apps
+    for size in 16 32 48 64 128 256; do
+      size=''${size}x''${size}
+      cp packaging/linux/mod_''${size}.png "$out/share/icons/hicolor/''${size}/apps/openra-${mod.name}.png"
+    done
+  '';
+
+  dontStrip = true;
+
+  meta = {
+    description = mod.description;
+    homepage = mod.homepage;
+    maintainers = with maintainers; [ msteen ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/openra-mods/launch-game.sh
+++ b/pkgs/games/openra-mods/launch-game.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+cd "@out@/lib/openra-@name@"
+
+# Run the game
+mono --debug OpenRA.Game.exe Game.Mod=@name@ Engine.LaunchPath="@out@/bin/openra-@name@" Engine.ModSearchPaths="@out@/lib/openra-@name@/mods" "$@"
+
+# Show a crash dialog if something went wrong
+if [ $? != 0 ] && [ $? != 1 ]; then
+  error_message="OpenRA - @title@ has encountered a fatal error.\nPlease refer to the crash logs for more information.\n\nLog files are located in ~/.openra/Logs\n"
+  if command -v zenity > /dev/null; then
+    zenity --no-wrap --error --title "OpenRA - @title@" --text "$error_message" 2>/dev/null
+  else
+    printf "${error_message}\n" >&2
+  fi
+  exit 1
+fi

--- a/pkgs/games/openra-mods/mods.nix
+++ b/pkgs/games/openra-mods/mods.nix
@@ -1,0 +1,293 @@
+{ fetchFromGitHub }:
+
+let
+  extraPostFetch = ''
+    sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
+    $out/thirdparty/fetch-thirdparty-deps.sh
+  '';
+
+in [
+  {
+    mod = {
+      name = "ca";
+      version = "93";
+      title = "Combined Arms";
+      description = "Re-imaginging of the original Command & Conquer: Red Alert game";
+      homepage = https://github.com/Inq8/CAmod;
+      src = fetchFromGitHub {
+        owner = "Inq8";
+        repo = "CAmod";
+        rev = "16fb77d037be7005c3805382712c33cec1a2788c";
+        sha256 = "11fjyr3692cy2a09bqzk5ya1hf6plh8hmdrgzds581r9xbj0q4pr";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-ca.patch;
+    };
+    engine = rec {
+      version = "b8a7dd5";
+      src = fetchFromGitHub {
+        owner = "Inq8";
+        repo = "CAengine" ;
+        rev = version;
+        sha256 = "0dyk861qagibx8ldshz7d2nrki9q550f6f0wy8pvayvf1gv1dbxj";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+  {
+    mod = {
+      name = "d2";
+      version = "124";
+      title = "Dune II";
+      description = "Re-imaginging of the original Command & Conquer: Red Alert 2 game";
+      homepage = https://github.com/OpenRA/d2;
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "d2";
+        rev = "30ab6e1c2489594000639416fb8099995f4ec657";
+        sha256 = "06mjy8330fqkvfmdmj1mw0qd4mkg0zgi0f1nfb5qjj9a272v4vsb";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-d2.patch;
+    };
+    engine = rec {
+      version = "release-20181215";
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+    engineMods = [ "cnc" "d2k" "ra" ];
+  }
+  {
+    mod = {
+      name = "gen";
+      version = "1133";
+      title = "Generals Alpha";
+      description = "Re-imaginging of the original Command & Conquer: Generals game";
+      homepage = https://github.com/MustaphaTR/Generals-Alpha;
+      src = fetchFromGitHub {
+        owner = "MustaphaTR";
+        repo = "Generals-Alpha";
+        rev = "277d20d5a8b5e11eac9443031af133dc110c653f";
+        sha256 = "1k37545l99q7zphnh1ykvimsyp5daykannps07d4dgr2w9l7bmhg";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-gen.patch;
+    };
+    engine = rec {
+      version = "gen-20180905";
+      src = fetchFromGitHub {
+        owner = "MustaphaTR";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "0wy1h7fg0n8dpy6y91md7x0qnr9rk4xf6155jali4bi8gghw2g5v";
+        name = "generals-alpha-engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+  {
+    mod = {
+      name = "kknd";
+      version = "136";
+      title = "Krush, Kill n' Destroy";
+      description = "Re-imaginging of the original Krush, Kill n' Destroy game";
+      homepage = https://kknd-game.com/;
+      src = fetchFromGitHub {
+        owner = "IceReaper";
+        repo = "KKnD";
+        rev = "fcf0f93e7d5cdb4e7884c7dcb8bca51486c60a15";
+        sha256 = "0ncdhgn9qwa2ca8pkhyy8q4jb8g2nig793i7nvxygbnh2lb233xg";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-kknd.patch;
+    };
+    engine = rec {
+      version = "84936abee6d5d287104f40b7cfcb43b8d7f8b52b";
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "1lr8aindnx91ywgz1sapb448k7kgjisz94l31q87s1bf59h3xw4d";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+  {
+    mod = {
+      name = "ra2";
+      version = "874";
+      title = "Red Alert 2";
+      description = "Re-imaginging of the original Command & Conquer: Red Alert 2 game";
+      homepage = https://github.com/OpenRA/ra2;
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "ra2";
+        rev = "05b1b7633d45a0d92d7a081303e2e1544d1f5a02";
+        sha256 = "0wwn7pipk87pwwlyfp0b19phldfy393lmbkxibkhccgsvh58y46n";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-ra2.patch;
+    };
+    engine = rec {
+      version = "release-20180923";
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+  {
+    mod = {
+      name = "raclassic";
+      version = "171";
+      title = "Red Alert Classic";
+      description = "A modernization of the original Command & Conquer: Red Alert game";
+      homepage = https://github.com/OpenRA/raclassic;
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "raclassic";
+        rev = "a2319b3dfb367a8d4278bf7baf55a10abf615fbc";
+        sha256 = "1k67fx4d9hg8mckzp7pp8lxa6ngqxnnrnbqyfls99dqc4df1iw0a";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-raclassic.patch;
+    };
+    engine = rec {
+      version = "release-20181215";
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+  {
+    mod = {
+      name = "rv";
+      version = "1250";
+      title = "Romanov's Vengeance";
+      description = "Re-imaginging of the original Command & Conquer: Red Alert 2 game";
+      homepage = https://github.com/MustaphaTR/Romanovs-Vengeance;
+      src = fetchFromGitHub {
+        owner = "MustaphaTR";
+        repo = "Romanovs-Vengeance";
+        rev = "c8cd7491c0f14681fcd63b021cdd0e66aec8b936";
+        sha256 = "0hnxwdf1wryhz0hfjwhds46npw9rkryv3r86r43njmzsrllq8xvz";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-rv.patch;
+    };
+    engine = rec {
+      version = "810d59c";
+      src = fetchFromGitHub {
+        owner = "GraionDilach";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "0q201x6yc5i0z05048cr9mc43n3df5nzk8425d22rnjanin9jhbd";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+    engineMods = [ "as" ];
+  }
+  {
+    mod = {
+      name = "sp";
+      version = "153";
+      title = "Shattered Paradise";
+      description = "Re-imaginging of the original Command & Conquer: Tiberian Sun game";
+      homepage = https://github.com/ABrandau/Shattered-Paradise;
+      src = fetchFromGitHub {
+        owner = "ABrandau";
+        repo = "OpenRAModSDK";
+        rev = "89148b8cf89bf13911fafb74a1aa2b4cacf027e0";
+        sha256 = "1bb8hzd3mhnn76iqiah1161qz98f0yvyryhmrghq03xlbin3mhbi";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-sp.patch;
+    };
+    engine = rec {
+      version = "NAs-Test-Build";
+      src = fetchFromGitHub {
+        owner = "ABrandau";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "1nl3brvx1bikxm5rmpc7xmd32n722jiyjh86pnar6b6idr1zj2ws";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+    engineMods = [ "as" "ts" ];
+  }
+  {
+    mod = {
+      name = "ura";
+      version = "431";
+      title = "Red Alert Unplugged";
+      description = "Re-imaginging of the original Command & Conquer: Red Alert game";
+      homepage = http://redalertunplugged.com/;
+      src = fetchFromGitHub {
+        owner = "RAunplugged";
+        repo = "uRA";
+        rev = "128dc53741fae923f4af556f2293ceaa0cf571f0";
+        sha256 = "1mhr8kyh313z52gdrqv31d6z7jvdldiajalca5mcr8gzg6mph66p";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-ura.patch;
+    };
+    engine = rec {
+      version = "unplugged-cd82382";
+      src = fetchFromGitHub {
+        owner = "RAunplugged";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "1p5hgxxvxlz8480vj0qkmnxjh7zj3hahk312m0zljxfdb40652w1";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+  {
+    mod = {
+      name = "yr";
+      version = "114";
+      homepage = https://github.com/cookgreen/yr;
+      title = "Yuri's Revenge";
+      description = "Re-imaginging of the original Command & Conquer: Yuri's Revenge game";
+      src = fetchFromGitHub {
+        owner = "cookgreen";
+        repo = "yr";
+        rev = "a9150114808dc2823b47b97e39969bdb6b27cf98";
+        sha256 = "1bjagkbqlkw6djxv86h1wfhnj6n2ggmfd5qp1b444inxblgk8wrf";
+        name = "mod";
+      };
+      makefilePatch = ./Makefile-yr.patch;
+    };
+    engine = rec {
+      version = "release-20180923";
+      src = fetchFromGitHub {
+        owner = "OpenRA";
+        repo = "OpenRA" ;
+        rev = version;
+        sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
+        name = "engine";
+        inherit extraPostFetch;
+      };
+    };
+  }
+]

--- a/pkgs/games/openra-mods/openra-mod.desktop
+++ b/pkgs/games/openra-mods/openra-mod.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=OpenRA - @title@
+GenericName=Real Time Strategy Game
+GenericName[de]=Echtzeit-Strategiespiel
+Comment=@description@
+Icon=openra-@name@
+Exec=openra-@name@
+Terminal=false
+Categories=Game;StrategyGame;X-RTS;X-RealTimeStrategy;X-RealTimeStrategyGame;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20807,6 +20807,14 @@ in
 
   openra = callPackage ../games/openra { lua = lua5_1; };
 
+  openra-mods = builtins.listToAttrs (map (attrs: {
+    inherit (attrs.mod) name;
+    value = callPackage ../games/openra-mods ({
+      lua = lua5_1;
+      inherit (gnome3) zenity;
+    } // attrs);
+  }) (import ../games/openra-mods/mods.nix { inherit fetchFromGitHub; }));
+
   openrw = callPackage ../games/openrw { };
 
   openspades = callPackage ../games/openspades {


### PR DESCRIPTION
###### Motivation for this change
There are many more OpenRA mods than those supplied by default in the OpenRA engine, 10 of those are included in this PR (thanks to @fusion809). All of the included mods follow the same structure, so a generic package definitions has been defined.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

