### PR TITLE
uboot: add RockPro64 support, fix Rock64 build, misc related changes

### DIFF
--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, fetchpatch, flex, bison, pkgconfig, python2, swig, which }:
 
 stdenv.mkDerivation rec {
-  name = "dtc-${version}";
+  pname = "dtc";
   version = "1.4.7";
 
   src = fetchgit {

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildPackages }:
+{ stdenv, fetchFromGitHub, pkgsCross, buildPackages }:
 
 let
   buildArmTrustedFirmware = { filesToInstall
@@ -21,6 +21,9 @@ let
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+    # For Cortex-M0 firmware in RK3399
+    nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
 
     makeFlags = [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
@@ -80,6 +83,13 @@ in rec {
   armTrustedFirmwareRK3328 = buildArmTrustedFirmware rec {
     extraMakeFlags = [ "bl31" ];
     platform = "rk3328";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = [ "build/${platform}/release/bl31/bl31.elf"];
+  };
+
+  armTrustedFirmwareRK3399 = buildArmTrustedFirmware rec {
+    extraMakeFlags = [ "bl31" ];
+    platform = "rk3399";
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = [ "build/${platform}/release/bl31/bl31.elf"];
   };

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -6,7 +6,7 @@ let
             , platform
             , extraMakeFlags ? []
             , extraMeta ? {}
-            , version ? "1.5"
+            , version ? "2.0"
             , ... } @ args:
            stdenv.mkDerivation (rec {
 
@@ -17,7 +17,7 @@ let
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "refs/tags/v${version}";
-      sha256 = "1gm0bn2llzfzz9bfsz11fhwxj5lxvyrq7bc13fjj033nljzxn7k8";
+      sha256 = "087pkwa6slxff0aiz3v42gww007nww97bl1p96fvvs7rr1y14gjx";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/misc/rkdeveloptool/default.nix
+++ b/pkgs/misc/rkdeveloptool/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1 }:
+
+stdenv.mkDerivation {
+  pname = "rkdeveloptool";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "rockchip-linux";
+    repo = "rkdeveloptool";
+    rev = "081d237ad5bf8f03170c9d60bd94ceefa0352aaf";
+    sha256 = "05hh7j3xgb8l1k1v2lis3nvlc0gp87ihzg6jci7m5lkkm5qgv3ji";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ libusb1 ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rockchip-linux/rkdeveloptool;
+    description = "A tool from Rockchip to communicate with Rockusb devices";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.lopsided98 ];
+  };
+}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -4,7 +4,8 @@
 }:
 
 let
-  buildUBoot = { filesToInstall
+  buildUBoot = { version ? "2018.09"
+            , filesToInstall
             , installDir ? "$out"
             , defconfig
             , extraConfig ? ""
@@ -14,8 +15,8 @@ let
             , ... } @ args:
            stdenv.mkDerivation (rec {
 
-    name = "uboot-${defconfig}-${version}";
-    version = args.version or "2018.09";
+    pname = "uboot-${defconfig}";
+    inherit version;
 
     src = fetchurl {
       url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, bc, bison, dtc, flex, openssl, python2, swig
+{ stdenv, lib, fetchurl, fetchpatch, bc, bison, dtc, flex, openssl, swig
 , armTrustedFirmwareAllwinner
 , buildPackages
 }:

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -7,6 +7,7 @@ let
   buildUBoot = { filesToInstall
             , installDir ? "$out"
             , defconfig
+            , extraConfig ? ""
             , extraPatches ? []
             , extraMakeFlags ? []
             , extraMeta ? {}
@@ -50,10 +51,14 @@ let
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ] ++ extraMakeFlags;
 
+    passAsFile = [ "extraConfig" ];
+
     configurePhase = ''
       runHook preConfigure
 
       make ${defconfig}
+
+      cat $extraConfigPath >> .config
 
       runHook postConfigure
     '';
@@ -242,10 +247,8 @@ in rec {
     extraMeta.platforms = ["armv7l-linux"];
     filesToInstall = ["u-boot-with-nand-spl.imx"];
     buildFlags = "u-boot-with-nand-spl.imx";
-    postConfigure = ''
-      cat >> .config << EOF
+    extraConfig = ''
       CONFIG_CMD_SETEXPR=y
-      EOF
     '';
     # sata init; load sata 0 $loadaddr u-boot-with-nand-spl.imx
     # sf probe; sf update $loadaddr 0 80000

--- a/pkgs/misc/uboot/rock64.nix
+++ b/pkgs/misc/uboot/rock64.nix
@@ -6,7 +6,6 @@
     sha256 = "189f7h6wj2yrcc5ga103jnyysykf9j3j9p1vcy7791bxwxqxnggf";
   };
 in buildUBoot rec {
-  name = "uboot-${defconfig}-${version}";
   version = "2017.09";
 
   src = fetchFromGitHub {

--- a/pkgs/misc/uboot/rockpro64.nix
+++ b/pkgs/misc/uboot/rockpro64.nix
@@ -6,7 +6,6 @@
     sha256 = "189f7h6wj2yrcc5ga103jnyysykf9j3j9p1vcy7791bxwxqxnggf";
   };
 in buildUBoot rec {
-  name = "uboot-${defconfig}-${version}";
   version = "2017.09";
 
   src = fetchFromGitHub {

--- a/pkgs/misc/uboot/rockpro64.nix
+++ b/pkgs/misc/uboot/rockpro64.nix
@@ -1,4 +1,4 @@
-{ lib, buildUBoot, fetchFromGitHub, armTrustedFirmwareRK3328 }: let
+{ lib, buildUBoot, fetchFromGitHub }: let
   rkbin = fetchFromGitHub {
     owner = "ayufan-rock64";
     repo = "rkbin";
@@ -16,22 +16,22 @@ in buildUBoot rec {
     sha256 = "0gclcd034qfhfbabrdqmky08i0hlwmn63n0zg6mndplms5qpcx75";
   };
 
-  extraMakeFlags = [ "BL31=${armTrustedFirmwareRK3328}/bl31.elf" "u-boot.itb" "all" ];
+  # Upstream ATF hangs in SPL
+  extraMakeFlags = [ "BL31=${rkbin}/rk33/rk3399_bl31_v1.17.elf" "u-boot.itb" "all" ];
 
-  # Close to being blob free, but the U-Boot TPL causes the kernel to hang after a few minutes
   postBuild = ''
-    ./tools/mkimage -n rk3328 -T rksd -d ${rkbin}/rk33/rk3328_ddr_786MHz_v1.13.bin idbloader.img
+    ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_933MHz_v1.13.bin idbloader.img
     cat spl/u-boot-spl.bin >> idbloader.img
     dd if=u-boot.itb of=idbloader.img seek=448 conv=notrunc
   '';
 
-  defconfig = "rock64-rk3328_defconfig";
-  filesToInstall = [ "spl/u-boot-spl.bin" "tpl/u-boot-tpl.bin" "u-boot.itb" "idbloader.img"];
+  defconfig = "rockpro64-rk3399_defconfig";
+  filesToInstall = [ "spl/u-boot-spl.bin" "u-boot.itb" "idbloader.img"];
 
   extraMeta = with lib; {
     maintainers = [ maintainers.lopsided98 ];
     platforms = ["aarch64-linux"];
-    # Because of the TPL blob
+    # Because of the TPL and ATF (BL31) blobs
     license = licenses.unfreeRedistributableFirmware;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15304,6 +15304,8 @@ in
 
   ubootRock64 = callPackage ../misc/uboot/rock64.nix { };
 
+  ubootRockPro64 = callPackage ../misc/uboot/rockpro64.nix { };
+
   uclibc = callPackage ../os-specific/linux/uclibc { };
 
   uclibcCross = callPackage ../os-specific/linux/uclibc {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14254,6 +14254,7 @@ in
     armTrustedFirmwareAllwinner
     armTrustedFirmwareQemu
     armTrustedFirmwareRK3328
+    armTrustedFirmwareRK3399
     ;
 
   microcodeAmd = callPackage ../os-specific/linux/microcode/amd.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19093,6 +19093,8 @@ in
 
   rkt = callPackage ../applications/virtualization/rkt { };
 
+  rkdeveloptool = callPackage ../misc/rkdeveloptool { };
+
   rofi-unwrapped = callPackage ../applications/misc/rofi { };
   rofi = callPackage ../applications/misc/rofi/wrapper.nix { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1551,6 +1551,10 @@ in {
 
   libais = callPackage ../development/python-modules/libais { };
 
+  libfdt = disabledIf isPy3k (toPythonModule (pkgs.dtc.override {
+    python2 = python;
+  }));
+
   libtmux = callPackage ../development/python-modules/libtmux { };
 
   libusb1 = callPackage ../development/python-modules/libusb1 { inherit (pkgs) libusb1; };


### PR DESCRIPTION
###### Motivation for this change

This PR started as an attempt to add RockPro64 support to U-Boot in Nix, but a bunch of other related changes accumulated along the way.

###### Things done

* Add `rkdeveloptool` package. This is a tool for communicating with Rockchip devices over their USB OTG port, allowing flashing the eMMC/SD and SPI flash.
*  Upgrade ARM trusted firmware from 1.5 to 2.0. This works correctly in the Rock64 U-Boot.
* Add RK3399 support to ATF. This was supposed to be for the RockPro64, but it caused U-Boot to hang in the SPL.
* Add libfdt Python package. This is just `toPythonModule dtc`.
* Add RockPro64 U-Boot support. This uses a [downstream version of 2017.09](https://github.com/ayufan-rock64/linux-u-boot) (maintained by ayufan), which is the best supported U-Boot tree for this board. This uses a binary blob for ATF as well as the TPL.
* Fix Rock64 U-Boot build. This switches from ayufan's `mainline-master` branch to `rockchip-master`, which is better maintained (even though it is older). This is the same branch I use for the RockPro64. I attempted to get rid of the TPL blob, but using U-Boot's TPL causes the board to hang after a few minutes (previously it would not even finish booting before hanging).

I got rid of the pythonpath patch in U-Boot, because I could not see why it was necessary and it was annoying to have to maintain a separate backport for 2017.09. Most builds don't use any Python libraries, so the PYTHONPATH doesn't matter. The Rock64 build requires libfdt, but the patch didn't seem to fix the build, I had to use `withPackages`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

