### PR TITLE
pythonPackages.pytado: init at 0.2.7

### DIFF
--- a/pkgs/development/python-modules/pytado/default.nix
+++ b/pkgs/development/python-modules/pytado/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "PyTado";
+  version = "0.2.7";
+
+  src = fetchFromGitHub {
+    owner = "wmalgadey";
+    repo = pname;
+    rev = "79a5dfdf75cd9a3e1a1ee8a8ff0d08923aebda7b";
+    sha256 = "14xdfw4913g4j4h576hjbigm7fiw8k0dc8s98gh2ag9xrc2ifgr0";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python binding for Tado web API. Pythonize your central heating!";
+    homepage = https://github.com/wmalgadey/PyTado;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/development/python-modules/pytado/default.nix
+++ b/pkgs/development/python-modules/pytado/default.nix
@@ -7,6 +7,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "wmalgadey";
     repo = pname;
+    # Upstream hasn't tagged this release yet. This commit fixes the build.
     rev = "79a5dfdf75cd9a3e1a1ee8a8ff0d08923aebda7b";
     sha256 = "14xdfw4913g4j4h576hjbigm7fiw8k0dc8s98gh2ag9xrc2ifgr0";
   };

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -251,7 +251,7 @@
     "climate.radiotherm" = ps: with ps; [  ];
     "climate.sensibo" = ps: with ps; [  ];
     "climate.spider" = ps: with ps; [  ];
-    "climate.tado" = ps: with ps; [  ];
+    "climate.tado" = ps: with ps; [ pytado ];
     "climate.tesla" = ps: with ps; [  ];
     "climate.toon" = ps: with ps; [  ];
     "climate.touchline" = ps: with ps; [  ];
@@ -375,7 +375,7 @@
     "device_tracker.sky_hub" = ps: with ps; [  ];
     "device_tracker.snmp" = ps: with ps; [ pysnmp ];
     "device_tracker.swisscom" = ps: with ps; [  ];
-    "device_tracker.tado" = ps: with ps; [  ];
+    "device_tracker.tado" = ps: with ps; [ pytado ];
     "device_tracker.tesla" = ps: with ps; [  ];
     "device_tracker.thomson" = ps: with ps; [  ];
     "device_tracker.tile" = ps: with ps; [  ];
@@ -1124,7 +1124,7 @@
     "sensor.synologydsm" = ps: with ps; [  ];
     "sensor.systemmonitor" = ps: with ps; [ psutil ];
     "sensor.sytadin" = ps: with ps; [ beautifulsoup4 ];
-    "sensor.tado" = ps: with ps; [  ];
+    "sensor.tado" = ps: with ps; [ pytado ];
     "sensor.tahoma" = ps: with ps; [  ];
     "sensor.tank_utility" = ps: with ps; [  ];
     "sensor.tautulli" = ps: with ps; [  ];
@@ -1321,7 +1321,7 @@
     "switch.zoneminder" = ps: with ps; [  ];
     "switch.zwave" = ps: with ps; [  ];
     "system_log" = ps: with ps; [ aiohttp-cors ];
-    "tado" = ps: with ps; [  ];
+    "tado" = ps: with ps; [ pytado ];
     "tahoma" = ps: with ps; [  ];
     "telegram_bot" = ps: with ps; [ python-telegram-bot ];
     "telegram_bot.broadcast" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5147,6 +5147,8 @@ in {
 
   pybotvac = callPackage ../development/python-modules/pybotvac { };
 
+  pytado = callPackage ../development/python-modules/pytado { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
tado connectivity for home-assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
