### PR TITLE
weechat-matrix-bridge: 2018-05-29 -> 2018-11-19

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
@@ -1,12 +1,12 @@
 { stdenv, curl, fetchFromGitHub, cjson, olm, luaffi }:
 
 stdenv.mkDerivation {
-  name = "weechat-matrix-bridge-2018-05-29";
+  name = "weechat-matrix-bridge-2018-11-19";
   src = fetchFromGitHub {
     owner = "torhve";
     repo = "weechat-matrix-protocol-script";
-    rev = "ace3fefc0e35a627f8a528032df2e3111e41eb1b";
-    sha256 = "1snf8vn5n9wzrnqnvdrcli4199s5p114jbjlgrj5c27i53173wqw";
+    rev = "8d32e90d864a8f3f09ecc2857cd5dd6e39a8c3f7";
+    sha256 = "0qqd6qmkrdc0r3rnl53c3yp93fbcz7d3mdw3vq5gmdqxyym4s9lj";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Updated the package to get upstream fix for HTTP/2 proxies which was affecting me. I think this would be a good candidate for backporting to release-18.09 (?), as it's a leaf package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

