### PR TITLE
mojave-gtk-theme: init at 2019-01-02

### DIFF
--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, gtk_engines, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "mojave-gtk-theme";
+  version = "2019-01-02";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "053bfc5pslwpqhn05dzznh236g1z4cnn2dzwvb914f6m855fbxfg";
+  };
+
+  buildInputs = [ gtk_engines ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    patchShebangs .
+    mkdir -p $out/share/themes
+    name= ./install.sh -d $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mac OSX Mojave like theme for GTK based desktop environments";
+    homepage = https://github.com/vinceliuice/Mojave-gtk-theme;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15651,11 +15651,13 @@ in
 
   mobile-broadband-provider-info = callPackage ../data/misc/mobile-broadband-provider-info { };
 
+  mojave-gtk-theme = callPackage ../data/themes/mojave { };
+
+  moka-icon-theme = callPackage ../data/icons/moka-icon-theme { };
+
   monoid = callPackage ../data/fonts/monoid { };
 
   mononoki = callPackage ../data/fonts/mononoki { };
-
-  moka-icon-theme = callPackage ../data/icons/moka-icon-theme { };
 
   montserrat = callPackage ../data/fonts/montserrat { };
 


### PR DESCRIPTION
###### Motivation for this change

Add [mojave-gtk-theme](https://github.com/vinceliuice/Mojave-gtk-theme).

>
![mojave](https://user-images.githubusercontent.com/1217934/50593869-63d53d00-0e81-11e9-91ba-2b8b5a24984a.jpg)
Mojave is a Mac OSX like theme for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Pantheon, XFCE, Mate, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).