### PR TITLE
zsh-command-time: enable work with options customPkgs

### DIFF
--- a/pkgs/shells/zsh/zsh-command-time/default.nix
+++ b/pkgs/shells/zsh/zsh-command-time/default.nix
@@ -2,7 +2,8 @@
 
 # To make use of this plugin, need to add
 #   programs.zsh.interactiveShellInit = ''
-#     source ${pkgs.zsh-command-time}/share/zsh-command-time/command-time.plugin.zsh
+#     source ${pkgs.zsh-command-time}/share/zsh/plugins/command-time/command-time.plugin.zsh
+#     ZSH_COMMAND_TIME_COLOR="yellow"
 #     ZSH_COMMAND_TIME_MIN_SECONDS=3
 #     ZSH_COMMAND_TIME_ECHO=1
 #   '';
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
   phases = [ "installPhase" ];
 
   installPhase = ''
-    install -Dm444 $src/command-time.plugin.zsh --target-directory=$out/share/zsh-command-time
+    install -Dm0444 $src/command-time.plugin.zsh --target-directory=$out/share/zsh/plugins/command-time
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Enable work plugin zsh-command-time with options 
`programs.zsh.ohMyZsh.customPkgs = with pkgs; [ zsh-command-time ];`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

