### PR TITLE
freerdp: Add support for USB redirection

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -4,12 +4,14 @@
 , libxkbcommon, libxkbfile
 , wayland
 , gstreamer, gst-plugins-base, gst-plugins-good, libunwind, orc
+, libuuid, dbus-glib, libusb1
 , libpulseaudio ? null
 , cups ? null
 , pcsclite ? null
 , systemd ? null
 , buildServer ? true
 , optimize ? true
+, buildUsbRedirect ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +42,8 @@ stdenv.mkDerivation rec {
     libX11 libXcursor libXdamage libXext libXi libXinerama libXrandr libXrender libXv
     libxkbcommon libxkbfile
     wayland
-  ] ++ optional stdenv.isLinux systemd;
+  ] ++ (optional stdenv.isLinux [ systemd ])
+    ++ (optional buildUsbRedirect [ libuuid dbus-glib libusb1 ]);
 
   nativeBuildInputs = [
     cmake pkgconfig
@@ -58,7 +61,8 @@ stdenv.mkDerivation rec {
     ++ optional (cups != null)                "-DWITH_CUPS=ON"
     ++ optional (pcsclite != null)            "-DWITH_PCSC=ON"
     ++ optional buildServer                   "-DWITH_SERVER=ON"
-    ++ optional (optimize && stdenv.isx86_64) "-DWITH_SSE2=ON";
+    ++ optional (optimize && stdenv.isx86_64) "-DWITH_SSE2=ON"
+    ++ optional buildUsbRedirect              "-DCHANNEL_URBDRC_CLIENT=ON";
 
   meta = with lib; {
     description = "A Remote Desktop Protocol Client";


### PR DESCRIPTION
###### Motivation for this change

I needed USB redirection

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

