### PR TITLE
xfce4-13.xfce4-panel: 4.13.3 -> 4.13.4

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-panel/default.nix
@@ -3,9 +3,9 @@
 mkXfceDerivation rec {
   category = "xfce";
   pname = "xfce4-panel";
-  version = "4.13.3";
+  version = "4.13.4";
 
-  sha256 = "00b2b16wqwzdbh1vsnpl2kasa7f9i1hr1wkkjmvzmy2v7bmkygr0";
+  sha256 = "13hnzh31d2b1331lnsbfaxg4fqhqa7hmdwkiqsl9hyr8pqimjb2g";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ exo garcon gtk2 gtk3 libxfce4ui libxfce4util libwnck3 xfconf ];


### PR DESCRIPTION
###### Motivation for this change

4.13.4 unbreaks the very top row of pixels in the Window Buttons plugin: they can now be clicked to switch to that window.

Other changes: https://simon.shimmerproject.org/2019/01/02/new-xfce4-panel-development-release/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

