### PR TITLE
kbdd: bump revision

### DIFF
--- a/pkgs/applications/window-managers/kbdd/default.nix
+++ b/pkgs/applications/window-managers/kbdd/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchgit, pkgconfig, dbus-glib, autoreconfHook, xorg }:
+{ stdenv, fetchFromGitHub, pkgconfig, dbus-glib, autoreconfHook, xorg }:
 
 stdenv.mkDerivation rec {
-  name = "kbdd";
+  pname = "kbdd";
+  version = "unstable-2017-01-30";
 
-  src = fetchgit {
-    url = https://github.com/qnikst/kbdd;
-    rev = "47dee0232f157cd865e43d92005a2ba107f6fd75";
-    sha256 = "1ys9w1lncsfg266g9sfnm95an2add3g51mryg0hnrzcqa4knz809";
+  src = fetchFromGitHub {
+    owner = "qnikst";
+    repo = "kbdd";
+    rev = "0e1056f066ab6e3c74fd0db0c9710a9a2b2538c3";
+    sha256 = "068iqkqxh7928xlmz2pvnykszn9bcq2qgkkiwf37k1vm8fdmgzlj";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update kbdd to the latest revision.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

