### PR TITLE
dropbox-cli: 2015.10.28 -> 2018.11.28

### DIFF
--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -1,14 +1,14 @@
 { stdenv, pkgconfig, fetchurl, python, dropbox }:
 let
-  version = "2015.10.28";
+  version = "2018.11.28";
   dropboxd = "${dropbox}/bin/dropbox";
 in
 stdenv.mkDerivation {
   name = "dropbox-cli-${version}";
 
   src = fetchurl {
-    url = "https://linux.dropbox.com/packages/nautilus-dropbox-${version}.tar.bz2";
-    sha256 = "1ai6vi5227z2ryxl403693xi63b42ylyfmzh8hbv4shp69zszm9c";
+    url = "https://linux.dropboxstatic.com/packages/nautilus-dropbox-${version}.tar.bz2";
+    sha256 = "0m1m9c7dfc8nawkcrg88955125sl1jz8mc9bf6wjay9za8014w58";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update dropbox-cli to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

