### PR TITLE
xkb-switch: 1.3.1 -> 1.5.0

### DIFF
--- a/pkgs/tools/X11/xkb-switch/default.nix
+++ b/pkgs/tools/X11/xkb-switch/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchgit, cmake, libX11 }:
+{ stdenv, fetchFromGitHub, cmake, libX11, libxkbfile }:
 
 stdenv.mkDerivation rec {
   name = "xkb-switch-${version}";
-  version = "1.3.1";
+  version = "1.5.0";
 
-  src = fetchgit {
-    url = https://github.com/ierton/xkb-switch.git;
-    rev = "351c84370ad0fa4aaaab9a32817859b1d5fb2a11";
-    sha256 = "0ilj3amwidi7imjvi8hr62y7j8zl809r5xhs7kv816773x32gpxq";
+  src = fetchFromGitHub {
+    owner = "ierton";
+    repo = "xkb-switch";
+    rev = version;
+    sha256 = "03wk2gg3py97kx0kjzbjrikld1sa55i6mgi398jbcbiyx2gjna78";
   };
 
-  buildInputs = [ cmake libX11 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libX11 libxkbfile ];
 
   meta = with stdenv.lib; {
     description = "Switch your X keyboard layouts from the command line";
-
     homepage = https://github.com/ierton/xkb-switch;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13798,7 +13798,7 @@ let
     base14Fonts = "${ghostscript}/share/ghostscript/fonts";
   };
 
-  xkb_switch = callPackage ../tools/X11/xkb-switch { };
+  xkb-switch = callPackage ../tools/X11/xkb-switch { };
 
   xkblayout-state = callPackage ../applications/misc/xkblayout-state { };
 


### PR DESCRIPTION
###### Motivation for this change

Update xkb-switch to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

