### PR TITLE
tdrop: init at 2018-11-13

### DIFF
--- a/pkgs/applications/misc/tdrop/default.nix
+++ b/pkgs/applications/misc/tdrop/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper
+, xwininfo, xdotool, xprop }:
+
+stdenv.mkDerivation rec {
+  pname = "tdrop";
+  version = "unstable-2018-11-13";
+
+  src = fetchFromGitHub {
+    owner = "noctuid";
+    repo = "tdrop";
+    rev = "198795c0d2573a31979330d6a2ae946eb81deebf";
+    sha256 = "1fhibqgmls64mylcb6q46ipmg1q6pvaqm26vz933gqav6cqsbdzs";
+  };
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/tdrop \
+      --prefix PATH : ${lib.makeBinPath [ xwininfo xdotool xprop ]}
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  meta = with stdenv.lib; {
+    description = "A Glorified WM-Independent Dropdown Creator";
+    homepage = https://github.com/noctuid/tdrop;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wedens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19668,6 +19668,8 @@ in
 
   trayer = callPackage ../applications/window-managers/trayer { };
 
+  tdrop = callPackage ../applications/misc/tdrop { };
+
   tree = callPackage ../tools/system/tree {};
 
   treesheets = callPackage ../applications/office/treesheets { wxGTK = wxGTK31; };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

