### PR TITLE
 mesa: 18.1.7 -> 18.3.1 [backport]

### DIFF
--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libpthreadstubs, libpciaccess, valgrind-light }:
 
 stdenv.mkDerivation rec {
-  name = "libdrm-2.4.93";
+  name = "libdrm-2.4.96";
 
   src = fetchurl {
     url = "https://dri.freedesktop.org/libdrm/${name}.tar.bz2";
-    sha256 = "0g6d9wsnb7lx8r1m4kq8js0wsc5jl20cz1csnlh6z9s8jpfd313f";
+    sha256 = "14xkip83qgljjaahzq40qgl60j54q7k00la1hbf5kk5lgg7ilmhd";
   };
 
   outputs = [ "out" "dev" "bin" ];

--- a/pkgs/development/libraries/mesa/darwin-clock-gettime.patch
+++ b/pkgs/development/libraries/mesa/darwin-clock-gettime.patch
@@ -1,0 +1,76 @@
+diff --git a/include/c11/threads_posix.h b/include/c11/threads_posix.h
+index 45cb6075e6..62937311b9 100644
+--- a/include/c11/threads_posix.h
++++ b/include/c11/threads_posix.h
+@@ -36,6 +36,11 @@
+ #include <sched.h>
+ #include <stdint.h> /* for intptr_t */
+ 
++#ifdef __MACH__
++#include <mach/clock.h>
++#include <mach/mach.h>
++#endif
++
+ /*
+ Configuration macro:
+ 
+@@ -383,12 +388,25 @@ tss_set(tss_t key, void *val)
+ /*-------------------- 7.25.7 Time functions --------------------*/
+ // 7.25.6.1
+ #ifndef HAVE_TIMESPEC_GET
++
+ static inline int
+ timespec_get(struct timespec *ts, int base)
+ {
+     if (!ts) return 0;
+     if (base == TIME_UTC) {
++#ifdef __MACH__
++        if (ts != NULL) {
++            clock_serv_t cclock;
++            mach_timespec_t mts;
++            host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
++            clock_get_time(cclock, &mts);
++            mach_port_deallocate(mach_task_self(), cclock);
++            ts->tv_sec = mts.tv_sec;
++            ts->tv_nsec = mts.tv_nsec;
++        }
++#else
+         clock_gettime(CLOCK_REALTIME, ts);
++#endif
+         return base;
+     }
+     return 0;
+diff --git a/src/egl/drivers/dri2/egl_dri2.c b/src/egl/drivers/dri2/egl_dri2.c
+index 1208ebb315..e1378fb1f0 100644
+--- a/src/egl/drivers/dri2/egl_dri2.c
++++ b/src/egl/drivers/dri2/egl_dri2.c
+@@ -65,6 +65,11 @@
+ #include "util/u_vector.h"
+ #include "mapi/glapi/glapi.h"
+ 
++#ifdef __MACH__
++#include <mach/clock.h>
++#include <mach/mach.h>
++#endif
++
+ #define NUM_ATTRIBS 12
+ 
+ static void
+@@ -3092,7 +3097,17 @@ dri2_client_wait_sync(_EGLDriver *drv, _EGLDisplay *dpy, _EGLSync *sync,
+ 
+             /* We override the clock to monotonic when creating the condition
+              * variable. */
++#ifdef __MACH__
++            clock_serv_t cclock;
++            mach_timespec_t mts;
++            host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
++            clock_get_time(cclock, &mts);
++            mach_port_deallocate(mach_task_self(), cclock);
++            current.tv_sec = mts.tv_sec;
++            current.tv_nsec = mts.tv_nsec;
++#else
+             clock_gettime(CLOCK_MONOTONIC, &current);
++#endif
+ 
+             /* calculating when to expire */
+             expire.tv_nsec = timeout % 1000000000L;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -2,12 +2,14 @@
 , pkgconfig, intltool, autoreconfHook
 , file, expat, libdrm, xorg, wayland, wayland-protocols, openssl
 , llvmPackages, libffi, libomxil-bellagio, libva-minimal
-, libelf, libvdpau, valgrind-light, python2
+, libelf, libvdpau, valgrind-light, python2, python2Packages
 , libglvnd
 , enableRadv ? true
 , galliumDrivers ? null
 , driDrivers ? null
 , vulkanDrivers ? null
+, eglPlatforms ? [ "x11" ] ++ lib.optionals stdenv.isLinux [ "wayland" "drm" ]
+, OpenGL, Xplugin
 }:
 
 /** Packaging design:
@@ -23,25 +25,27 @@
 
 with stdenv.lib;
 
-if ! lists.elem stdenv.hostPlatform.system platforms.mesaPlatforms then
+if ! elem stdenv.hostPlatform.system platforms.mesaPlatforms then
   throw "unsupported platform for Mesa"
 else
 
 let
   defaultGalliumDrivers =
-    if stdenv.isAarch32
+    optionals (elem "drm" eglPlatforms)
+    (if stdenv.isAarch32
     then ["virgl" "nouveau" "freedreno" "vc4" "etnaviv" "imx"]
     else if stdenv.isAarch64
     then ["virgl" "nouveau" "vc4" ]
-    else ["virgl" "svga" "i915" "r300" "r600" "radeonsi" "nouveau"];
+    else ["virgl" "svga" "i915" "r300" "r600" "radeonsi" "nouveau"]);
   defaultDriDrivers =
-    if (stdenv.isAarch32 || stdenv.isAarch64)
+    optionals (elem "drm" eglPlatforms)
+    (if (stdenv.isAarch32 || stdenv.isAarch64)
     then ["nouveau"]
-    else ["i915" "i965" "nouveau" "radeon" "r200"];
+    else ["i915" "i965" "nouveau" "radeon" "r200"]);
   defaultVulkanDrivers =
-    if (stdenv.isAarch32 || stdenv.isAarch64)
+    optionals stdenv.isLinux (if (stdenv.isAarch32 || stdenv.isAarch64)
     then []
-    else ["intel"] ++ lib.optional enableRadv "radeon";
+    else ["intel"] ++ lib.optional enableRadv "radeon");
 in
 
 let gallium_ = galliumDrivers; dri_ = driDrivers; vulkan_ = vulkanDrivers; in
@@ -51,11 +55,11 @@ let
     (if gallium_ == null
           then defaultGalliumDrivers
           else gallium_)
-    ++ ["swrast" "virgl"];
+    ++ lib.optional stdenv.isLinux "swrast";
   driDrivers =
     (if dri_ == null
-      then defaultDriDrivers
-      else dri_) ++ ["swrast"];
+      then optionals (elem "drm" eglPlatforms) defaultDriDrivers
+      else dri_) ++ lib.optional stdenv.isLinux "swrast";
   vulkanDrivers =
     if vulkan_ == null
     then defaultVulkanDrivers
@@ -63,7 +67,7 @@ let
 in
 
 let
-  version = "18.1.7";
+  version = "18.3.1";
   branch  = head (splitString "." version);
 in
 
@@ -77,7 +81,7 @@ let self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "655e3b32ce3bdddd5e6e8768596e5d4bdef82d0dd37067c324cc4b2daa207306";
+    sha256 = "0qyw9dj2p9n91qzc4ylck2an7ibssjvzi2bjcpv2ajk851yq47sv";
   };
 
   prePatch = "patchShebangs .";
@@ -89,9 +93,10 @@ let self = stdenv.mkDerivation {
     ./symlink-drivers.patch
     ./missing-includes.patch # dev_t needs sys/stat.h, time_t needs time.h, etc.-- fixes build w/musl
     ./disk_cache-include-dri-driver-path-in-cache-key.patch
-  ];
+  ] ++ lib.optional stdenv.isDarwin ./darwin-clock-gettime.patch;
 
-  outputs = [ "out" "dev" "drivers" "osmesa" ];
+  outputs = [ "out" "dev" "drivers" ]
+            ++ lib.optional (elem "swrast" galliumDrivers) "osmesa";
 
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   configureFlags = [
@@ -99,19 +104,11 @@ let self = stdenv.mkDerivation {
     "--localstatedir=/var"
     "--with-dri-driverdir=$(drivers)/lib/dri"
     "--with-dri-searchpath=${libglvnd.driverLink}/lib/dri"
-    "--with-platforms=x11,wayland,drm"
+    "--with-platforms=${concatStringsSep "," eglPlatforms}"
+    "--with-gallium-drivers=${concatStringsSep "," galliumDrivers}"
+    "--with-dri-drivers=${concatStringsSep "," driDrivers}"
+    "--with-vulkan-drivers=${concatStringsSep "," vulkanDrivers}"
     "--enable-texture-float"
-  ]
-  ++ (optional (galliumDrivers != [])
-      ("--with-gallium-drivers=" +
-        builtins.concatStringsSep "," galliumDrivers))
-  ++ (optional (driDrivers != [])
-      ("--with-dri-drivers=" +
-        builtins.concatStringsSep "," driDrivers))
-  ++ (optional (vulkanDrivers != [])
-      ("--with-vulkan-drivers=" +
-        builtins.concatStringsSep "," vulkanDrivers))
-  ++ [
     (enableFeature stdenv.isLinux "dri3")
     (enableFeature stdenv.isLinux "nine") # Direct3D in Wine
     "--enable-libglvnd"
@@ -122,34 +119,39 @@ let self = stdenv.mkDerivation {
     "--enable-glx"
     # https://bugs.freedesktop.org/show_bug.cgi?id=35268
     (enableFeature (!stdenv.hostPlatform.isMusl) "glx-tls")
-    "--enable-gallium-osmesa" # used by wine
+    # used by wine
+    (enableFeature (elem "swrast" galliumDrivers) "gallium-osmesa")
     "--enable-llvm"
-    "--enable-egl"
-    "--enable-xa" # used in vmware driver
-    "--enable-gbm"
+    (enableFeature stdenv.isLinux "egl")
+    (enableFeature stdenv.isLinux "xa") # used in vmware driver
+    (enableFeature stdenv.isLinux "gbm")
     "--enable-xvmc"
     "--enable-vdpau"
     "--enable-shared-glapi"
     "--enable-llvm-shared-libs"
-    "--enable-omx-bellagio"
-    "--enable-va"
+    (enableFeature stdenv.isLinux "omx-bellagio")
+    (enableFeature stdenv.isLinux "va")
     "--disable-opencl"
   ];
 
-  nativeBuildInputs = [ autoreconfHook intltool pkgconfig file ];
+  nativeBuildInputs = [
+    autoreconfHook intltool pkgconfig file
+    python2 python2Packages.Mako
+  ];
 
-  propagatedBuildInputs = with xorg;
-    [ libXdamage libXxf86vm ]
-    ++ optional stdenv.isLinux libdrm;
+  propagatedBuildInputs = with xorg; [
+    libXdamage libXxf86vm
+  ] ++ optional stdenv.isLinux libdrm
+    ++ optionals stdenv.isDarwin [ OpenGL Xplugin ];
 
   buildInputs = with xorg; [
     expat llvmPackages.llvm libglvnd
     glproto dri2proto dri3proto presentproto
-    libX11 libXext libxcb libXt libXfixes libxshmfence
-    libffi wayland wayland-protocols libvdpau libelf libXvMC
-    libomxil-bellagio libva-minimal libpthreadstubs openssl/*or another sha1 provider*/
-    valgrind-light python2 python2.pkgs.Mako
-  ];
+    libX11 libXext libxcb libXt libXfixes libxshmfence libXrandr
+    libffi libvdpau libelf libXvMC
+    libpthreadstubs openssl /*or another sha1 provider*/
+  ] ++ lib.optionals (elem "wayland" eglPlatforms) [ wayland wayland-protocols ]
+    ++ lib.optionals stdenv.isLinux [ valgrind-light libomxil-bellagio libva-minimal ];
 
   enableParallelBuilding = true;
   doCheck = false;
@@ -161,7 +163,7 @@ let self = stdenv.mkDerivation {
   ];
 
   # TODO: probably not all .la files are completely fixed, but it shouldn't matter;
-  postInstall = ''
+  postInstall = optionalString (galliumDrivers != []) ''
     # move gallium-related stuff to $drivers, so $out doesn't depend on LLVM
     mv -t "$drivers/lib/"    \
       $out/lib/libXvMC*      \
@@ -215,7 +217,7 @@ let self = stdenv.mkDerivation {
   # TODO:
   #  check $out doesn't depend on llvm: builder failures are ignored
   #  for some reason grep -qv '${llvmPackages.llvm}' -R "$out";
-  postFixup = ''
+  postFixup = optionalString (galliumDrivers != []) ''
     # add RPATH so the drivers can find the moved libgallium and libdricore9
     # moved here to avoid problems with stripping patchelfed files
     for lib in $drivers/lib/*.so* $drivers/lib/*/*.so*; do
@@ -235,7 +237,9 @@ let self = stdenv.mkDerivation {
 
       # Use stub libraries from libglvnd and headers from Mesa.
       buildCommand = ''
-        ln -s ${libglvnd.out} $out
+        mkdir -p $out/nix-support
+        ln -s ${libglvnd.out}/lib $out/lib
+
         mkdir -p $dev/{,lib/pkgconfig,nix-support}
         echo "$out" > $dev/nix-support/propagated-build-inputs
         ln -s ${self.dev}/include $dev/include
@@ -257,6 +261,8 @@ let self = stdenv.mkDerivation {
         genPkgConfig egl EGL
         genPkgConfig glesv1_cm GLESv1_CM
         genPkgConfig glesv2 GLESv2
+      '' + lib.optionalString stdenv.isDarwin ''
+        echo ${OpenGL} > $out/nix-support/propagated-build-inputs
       '';
     };
   };
@@ -265,7 +271,7 @@ let self = stdenv.mkDerivation {
     description = "An open source implementation of OpenGL";
     homepage = https://www.mesa3d.org/;
     license = licenses.mit; # X11 variant, in most files
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ vcunat ];
   };
 };

--- a/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -1,4 +1,4 @@
-From 9c9df280b318c26aece9873cf77b32e4f95634c1 Mon Sep 17 00:00:00 2001
+From 2a1e32b4105fe95413a615a44d40938920ea1a19 Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Mon, 6 Aug 2018 15:52:11 -0300
 Subject: [PATCH] disk_cache: include dri driver path in cache key
@@ -11,10 +11,10 @@ timestamps in /nix/store are zero.
  2 files changed, 6 insertions(+)
 
 diff --git a/src/util/Makefile.am b/src/util/Makefile.am
-index 07bf052175..aea09f60b3 100644
+index bafb57439a..a22e2e41eb 100644
 --- a/src/util/Makefile.am
 +++ b/src/util/Makefile.am
-@@ -30,6 +30,9 @@ noinst_LTLIBRARIES = \
+@@ -35,6 +35,9 @@ noinst_LTLIBRARIES = \
  	libmesautil.la \
  	libxmlconfig.la
  
@@ -25,28 +25,28 @@ index 07bf052175..aea09f60b3 100644
  	$(PTHREAD_CFLAGS) \
  	-I$(top_srcdir)/include
 diff --git a/src/util/disk_cache.c b/src/util/disk_cache.c
-index 4a762eff20..8086c0be75 100644
+index 368ec41792..071220b2ba 100644
 --- a/src/util/disk_cache.c
 +++ b/src/util/disk_cache.c
-@@ -388,8 +388,10 @@ disk_cache_create(const char *gpu_name, const char *timestamp,
+@@ -388,8 +388,10 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
  
     /* Create driver id keys */
-    size_t ts_size = strlen(timestamp) + 1;
+    size_t id_size = strlen(driver_id) + 1;
 +   size_t key_size = strlen(DISK_CACHE_KEY) + 1;
     size_t gpu_name_size = strlen(gpu_name) + 1;
-    cache->driver_keys_blob_size += ts_size;
+    cache->driver_keys_blob_size += id_size;
 +   cache->driver_keys_blob_size += key_size;
     cache->driver_keys_blob_size += gpu_name_size;
  
     /* We sometimes store entire structs that contains a pointers in the cache,
-@@ -410,6 +412,7 @@ disk_cache_create(const char *gpu_name, const char *timestamp,
+@@ -410,6 +412,7 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
     uint8_t *drv_key_blob = cache->driver_keys_blob;
     DRV_KEY_CPY(drv_key_blob, &cache_version, cv_size)
-    DRV_KEY_CPY(drv_key_blob, timestamp, ts_size)
+    DRV_KEY_CPY(drv_key_blob, driver_id, id_size)
 +   DRV_KEY_CPY(drv_key_blob, DISK_CACHE_KEY, key_size)
     DRV_KEY_CPY(drv_key_blob, gpu_name, gpu_name_size)
     DRV_KEY_CPY(drv_key_blob, &ptr_size, ptr_size_size)
     DRV_KEY_CPY(drv_key_blob, &driver_flags, driver_flags_size)
 -- 
-2.18.0
+2.19.1
 

--- a/pkgs/development/libraries/mesa/missing-includes.patch
+++ b/pkgs/development/libraries/mesa/missing-includes.patch
@@ -32,16 +32,6 @@
  #include <unistd.h>
  #include <fcntl.h>
  #else
---- ./src/mesa/drivers/dri/i965/brw_bufmgr.h
-+++ ./src/mesa/drivers/dri/i965/brw_bufmgr.h
-@@ -37,6 +37,7 @@
- #include <stdbool.h>
- #include <stdint.h>
- #include <stdio.h>
-+#include <time.h>
- #include "util/u_atomic.h"
- #include "util/list.h"
-
 --- ./src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
 +++ ./src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
 @@ -28,6 +28,8 @@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11228,37 +11228,32 @@ with pkgs;
   ## libGL/libGLU/Mesa stuff
 
   # Default libGL implementation, should provide headers and libGL.so/libEGL.so/... to link agains them
-  libGL = libGLDarwinOr mesa_noglu.stubs;
+  libGL = mesa_noglu.stubs;
 
   # Default libGLU
-  libGLU = libGLDarwinOr mesa_glu;
+  libGLU = mesa_glu;
 
   # Combined derivation, contains both libGL and libGLU
   # Please, avoid using this attribute.  It was meant as transitional hack
   # for packages that assume that libGLU and libGL live in the same prefix.
   # libGLU_combined propagates both libGL and libGLU
-  libGLU_combined = libGLDarwinOr (buildEnv {
+  libGLU_combined = buildEnv {
     name = "libGLU-combined";
     paths = [ libGL libGLU ];
     extraOutputsToInstall = [ "dev" ];
-  });
+  };
 
   # Default derivation with libGL.so.1 to link into /run/opengl-drivers (if need)
-  libGL_driver = libGLDarwinOr mesa_drivers;
+  libGL_driver = mesa_drivers;
 
   libGLSupported = lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms;
 
-  libGLDarwin = callPackage ../development/libraries/mesa-darwin {
-    inherit (darwin.apple_sdk.frameworks) OpenGL;
-    inherit (darwin.apple_sdk.libs) Xplugin;
-    inherit (darwin) apple_sdk;
-  };
-
-  libGLDarwinOr = alternative: if stdenv.isDarwin then libGLDarwin else alternative;
-
   mesa_noglu = callPackage ../development/libraries/mesa {
     llvmPackages = llvmPackages_6;
+    inherit (darwin.apple_sdk.frameworks) OpenGL;
+    inherit (darwin.apple_sdk.libs) Xplugin;
   };
+  mesa = mesa_noglu;
 
   mesa_glu =  callPackage ../development/libraries/mesa-glu { };
 


### PR DESCRIPTION
###### Motivation for this change
18.3.1 brings openGL 4.5 compatibility profile to the radeonsi and 4.3 to virgl besides many bugfixes.
I don't know if this is allowed to be backported since it's a major update and could potentially break stuff. Anyway, I have been running this on my system for a couple of weeks with no issues.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change (mass rebuild)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

