### PR TITLE
Fix pysnmp derivation

### DIFF
--- a/pkgs/development/python-modules/pysnmp/default.nix
+++ b/pkgs/development/python-modules/pysnmp/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pyasn1
-, pycrypto
+, pycryptodomex
 , pysmi
 }:
 
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   # NameError: name 'mibBuilder' is not defined
   doCheck = false;
 
-  propagatedBuildInputs = [ pyasn1 pycrypto pysmi ];
+  propagatedBuildInputs = [ pyasn1 pycryptodomex pysmi ];
 
   meta = with stdenv.lib; {
     homepage = http://pysnmp.sf.net;


### PR DESCRIPTION
###### Motivation for this change

`pysnmp` derivation currently does not build:

```
Collecting pycryptodomex (from pysnmp==4.4.6)
  Could not find a version that satisfies the requirement pycryptodomex (from pysnmp==4.4.6) (from versions: )
No matching distribution found for pycryptodomex (from pysnmp==4.4.6)
```
This change fixes it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

