### PR TITLE
terminus-font: 4.46 -> 4.47

### DIFF
--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, python3, bdftopcf, mkfontdir, mkfontscale }:
 
 stdenv.mkDerivation rec {
-  name = "terminus-font-4.47";
+  pname = "terminus-font";
+  version = "4.47";
+  name = "${pname}-${version}"; # set here for use in URL below
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/terminus-font/${name}/${name}.tar.gz";
+    url = "mirror://sourceforge/project/${pname}/${name}/${name}.tar.gz";
     sha256 = "15qjcpalcxjiwsjgjg5k88vkwp56cs2nnx4ghya6mqp4i1c206qg";
   };
 

--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -1,26 +1,22 @@
 { stdenv, fetchurl, python3, bdftopcf, mkfontdir, mkfontscale }:
 
 stdenv.mkDerivation rec {
-  name = "terminus-font-4.46";
+  name = "terminus-font-4.47";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/terminus-font/${name}/${name}.tar.gz";
-    sha256 = "1kavqw38aarz0vpwz4b7l6l8xkyc5096zaf9ypqnvdwraqz46aaf";
+    sha256 = "15qjcpalcxjiwsjgjg5k88vkwp56cs2nnx4ghya6mqp4i1c206qg";
   };
 
-  buildInputs = [ python3 bdftopcf mkfontdir mkfontscale ];
+  nativeBuildInputs = [ python3 bdftopcf mkfontdir mkfontscale ];
 
   patchPhase = ''
     substituteInPlace Makefile --replace 'fc-cache' '#fc-cache'
   '';
 
-  configurePhase = ''
-    sh ./configure --prefix=$out
-  '';
+  enableParallelBuilding = true;
 
-  installPhase = ''
-    make install fontdir
-  '';
+  installTargets = [ "install" "fontdir" ];
 
   meta = with stdenv.lib; {
     description = "A clean fixed width font";
@@ -36,7 +32,7 @@ stdenv.mkDerivation rec {
       16x32. The styles are normal and bold (except for 6x12), plus
       EGA/VGA-bold for 8x14 and 8x16.
     '';
-    homepage = http://www.is-vn.bg/hamster/;
+    homepage = http://terminus-font.sourceforge.net/;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.linux;


### PR DESCRIPTION
http://terminus-font.sourceforge.net/

Also cleanup/modernize a bit.
Replace homepage (dead?) with SF url.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---