### PR TITLE
vimUtils: apply pluginToDrv recursively

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -152,15 +152,21 @@ vim_with_plugins can be installed like any other application within Nix.
 let
   inherit (stdenv) lib;
 
-  # make sure a plugin is a derivation. If plugin already is a derivation, this
-  # is a no-op. If it is a string, it is looked up in knownPlugins.
+  # make sure a plugin is a derivation and its dependencies are derivations. If
+  # plugin already is a derivation, this is a no-op. If it is a string, it is
+  # looked up in knownPlugins.
   pluginToDrv = knownPlugins: plugin:
-    if builtins.isString plugin then
-      # make sure `pname` is set to that we are able to convert the derivation
-      # back to a string.
-      ( knownPlugins.${plugin} // { pname = plugin; })
-    else
-      plugin;
+  let
+    drv =
+      if builtins.isString plugin then
+        # make sure `pname` is set to that we are able to convert the derivation
+        # back to a string.
+        ( knownPlugins.${plugin} // { pname = plugin; })
+      else
+        plugin;
+  in
+    # make sure all the dependencies of the plugin are also derivations
+    drv // { dependencies = map (pluginToDrv knownPlugins) (drv.dependencies or []); };
 
   # transitive closure of plugin dependencies (plugin needs to be a derivation)
   transitiveClosure = plugin:
@@ -169,14 +175,6 @@ let
     );
 
   findDependenciesRecursively = plugins: lib.concatMap transitiveClosure plugins;
-
-  attrnamesToPlugins = { knownPlugins, names }:
-    map (name: if builtins.isString name then knownPlugins.${name} else name) knownPlugins;
-
-  pluginToAttrname = plugin:
-    plugin.pname;
-
-  pluginsToAttrnames = plugins: map pluginToAttrname plugins;
 
   vamDictToNames = x:
       if builtins.isString x then [x]
@@ -482,7 +480,8 @@ rec {
             rev = "4c596548216b7c19971f8fc94e38ef1a2b55fee6";
             sha256 = "0f1cpnp1nxb4i5hgymjn2yn3k1jwkqmlgw1g02sq270lavp2dzs9";
           };
-          dependencies = [];
+          # make sure string dependencies are handled
+          dependencies = [ "vim-nix" ];
         };
       });
     vimrcConfig.vam.pluginDictionaries = [ { names = [ "vim-trailing-whitespace" ]; } ];

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -427,7 +427,7 @@ rec {
                      if vam != null && vam ? knownPlugins then vam.knownPlugins else
                      if pathogen != null && pathogen ? knownPlugins then pathogen.knownPlugins else
                      vimPlugins;
-      pathogenPlugins = findDependenciesRecursively ((map pluginToDrv knownPlugins) pathogen.pluginNames);
+      pathogenPlugins = findDependenciesRecursively (map (pluginToDrv knownPlugins) pathogen.pluginNames);
       vamPlugins = findDependenciesRecursively (map (pluginToDrv knownPlugins) (lib.concatMap vamDictToNames vam.pluginDictionaries));
       nonNativePlugins = (lib.optionals (pathogen != null) pathogenPlugins)
                       ++ (lib.optionals (vam != null) vamPlugins)


### PR DESCRIPTION
###### Motivation for this change

According to a bug report I got from @MarcWeber via email, my fix in #53112 wasn't complete. When a plugin had string dependencies, evaluation would break. To fix this, this now applies `pluginToDrv` recursively and adds a test covering this case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

