### PR TITLE
ledger-autosync: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1275,6 +1275,11 @@
     github = "eadwu";
     name = "Edmund Wu";
   };
+  eamsden = {
+    email = "edward@blackriversoft.com";
+    github = "eamsden";
+    name = "Edward Amsden";
+  };
   earldouglas = {
     email = "james@earldouglas.com";
     github = "earldouglas";

--- a/pkgs/applications/office/ledger-autosync/default.nix
+++ b/pkgs/applications/office/ledger-autosync/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, python3Packages, fetchFromGitHub, ledger, hledger, useLedger ? true, useHledger ? true }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ledger-autosync";
+  version = "1.0.0";
+
+# no tests included in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "egh";
+    repo = "ledger-autosync";
+    rev = "v${version}";
+    sha256 = "1fn32c02idccdmf9906pxn248qc9basjy2kr2g600806k3qvw84a";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    asn1crypto
+    beautifulsoup4
+    cffi
+    cryptography
+    entrypoints
+    fuzzywuzzy
+    idna
+    jeepney
+    keyring
+    lxml
+    mock
+    nose
+    ofxclient
+    ofxhome
+    ofxparse
+    pbr
+    pycparser
+    secretstorage
+    six
+  ] ++ stdenv.lib.optional useLedger ledger
+    ++ stdenv.lib.optional useHledger hledger;
+
+  # Checks require ledger as a python package,
+  # ledger does not support python3 while ledger-autosync requires it.
+  checkInputs = with python3Packages; [ ledger hledger nose mock ];
+  checkPhase = ''
+    nosetests -a generic -a ledger -a hledger
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/egh/ledger-autosync;
+    description = "OFX/CSV autosync for ledger and hledger";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ eamsden ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18044,6 +18044,9 @@ in
     boost = boost15x;
   };
   ledger = ledger3;
+
+  ledger-autosync = callPackage  ../applications/office/ledger-autosync { };
+
   ledger-web = callPackage ../applications/office/ledger-web { };
 
   lighthouse = callPackage ../applications/misc/lighthouse { };


### PR DESCRIPTION
###### Motivation for this change
ledger-autosync is a useful utility for ledger and hledger which allows journal files to be synchronized with OFX and CSV transaction data without duplication.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

