### PR TITLE
offlineimap: provide "OS-DEFAULT" CA certificates

### DIFF
--- a/pkgs/tools/networking/offlineimap/default.nix
+++ b/pkgs/tools/networking/offlineimap/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, python2Packages,
-  asciidoc, libxml2, libxslt, docbook_xsl }:
+  asciidoc, cacert, libxml2, libxslt, docbook_xsl }:
 
 python2Packages.buildPythonApplication rec {
   version = "7.2.2";
@@ -15,6 +15,9 @@ python2Packages.buildPythonApplication rec {
   postPatch = ''
     # Skip xmllint to stop failures due to no network access
     sed -i docs/Makefile -e "s|a2x -v -d |a2x -L -v -d |"
+
+    # Provide CA certificates (Used when "sslcacertfile = OS-DEFAULT" is configured")
+    sed -i offlineimap/utils/distro.py -e '/def get_os_sslcertfile():/a\ \ \ \ return "${cacert}/etc/ssl/certs/ca-bundle.crt"'
   '';
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Using SSL requires specifying path to certificates in .offlineimaprc like:
```
sslcacertfile = /home/user/.nix-profile/etc/ssl/certs/ca-bundle.crt
```
this allows to just use
```
sslcacertfile = OS-DEFAULT
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
