### PR TITLE
nodejs: 6.15.1 -> 6.16.0, 8.14.1 -> 8.15.0, 10.12.0 -> 10.15.0, 11.5.0 -> 11.6.0

### DIFF
--- a/pkgs/development/web/nodejs/v10.nix
+++ b/pkgs/development/web/nodejs/v10.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "10.12.0";
-    sha256 = "1r0aqcxafha13ks8586x77n77zi88db259cpaix0y1ivdh6qkkfr";
+    version = "10.15.0";
+    sha256 = "0gnygq4n7aar4jrynnnslxhlrlrml9f1n9passvj2fxqfi6b6ykr";
   }

--- a/pkgs/development/web/nodejs/v11.nix
+++ b/pkgs/development/web/nodejs/v11.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "11.5.0";
-    sha256 = "07fdpl8wzkcdd8iyaiwf2ah1rgishk2hrl0g73i8aggwplrl69fx";
+    version = "11.6.0";
+    sha256 = "1czrpxmk6calqn0p92rm0bv2vlgbnx6q4z7n2j8r7aw0khwbxwll";
   }

--- a/pkgs/development/web/nodejs/v6.nix
+++ b/pkgs/development/web/nodejs/v6.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "6.15.1";
-    sha256 = "1hi9h54ni7m1lmhfqvwxdny969j31mixxlxsiyl00l2bj25fbgf3";
+    version = "6.16.0";
+    sha256 = "0ikmpn1kvp5q8andmiyhpr99zniqs86sdlfk31sj3k0wvalq420d";
   }

--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "8.14.1";
-    sha256 = "16vb5baw6nk71n7jfbyd9x8qi0kbkzv2bw1rczy7dyyz7n08gpxi";
+    version = "8.15.0";
+    sha256 = "0cy6lzk9sn545kkc0jviv0k0hn30kindrpkkkmv3zk2774rj71cn";
   }


### PR DESCRIPTION
###### Motivation for this change
Node 6.16.0: https://nodejs.org/en/blog/release/v6.16.0/
Node 8.15.0: https://nodejs.org/en/blog/release/v8.15.0/
Node 10.15.0: https://nodejs.org/en/blog/release/v10.15.0/
Node 11.6.0: https://nodejs.org/en/blog/release/v11.6.0/

because some breaking changes in the previous releases, these commits need to be backported to 18.09

Pointing to staging because requires https://github.com/nixos/nixpkgs/commit/5b9ad12e7be

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

