### PR TITLE
dbus-broker: 13 -> 17

### DIFF
--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -1,27 +1,27 @@
 { stdenv, fetchFromGitHub, docutils, meson, ninja, pkgconfig
-, dbus, glib, linuxHeaders, systemd }:
+, dbus, linuxHeaders, systemd }:
 
 stdenv.mkDerivation rec {
   name = "dbus-broker-${version}";
-  version = "13";
+  version = "17";
 
   src = fetchFromGitHub {
     owner  = "bus1";
     repo   = "dbus-broker";
     rev    = "v${version}";
-    sha256 = "1yjkxpnl54pky6ha3y8dsds57lnk10lmriyzpzy0ha2npng2614x";
+    sha256 = "19q5f1c658jdxvr2k2rb2xsnspybqjii4rifnlkzi1qzh0r152md";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ docutils meson ninja pkgconfig ];
 
-  buildInputs = [ dbus glib linuxHeaders systemd ];
+  buildInputs = [ dbus linuxHeaders systemd ];
 
   PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
   PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
 
   postInstall = ''
-    install -Dm644 ../README $out/share/doc/dbus-broker/README
+    install -Dm644 $src/README.md $out/share/doc/dbus-broker/README
 
     sed -i $out/lib/systemd/{system,user}/dbus-broker.service \
       -e 's,^ExecReload.*busctl,ExecReload=${systemd}/bin/busctl,'


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg
