### PR TITLE
rofimoji: init at 2017-10-31

### DIFF
--- a/pkgs/applications/misc/rofimoji/default.nix
+++ b/pkgs/applications/misc/rofimoji/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, rofi, xdotool
+, xsel, python3, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "rofimoji";
+  version = "unstable-2017-10-31";
+
+  src = fetchFromGitHub {
+    owner = "fdw";
+    repo = "rofimoji";
+    rev = "8c2278b29b0f982936027022cab37e67d0811144";
+    sha256 = "18h901i1pqs3n4y3pl3aj5n0j694xlwrxrk742qy0mggh9r4djnc";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [ python3 ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -vD rofimoji.py $out/bin/rofimoji
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/rofimoji \
+      --prefix PATH : ${lib.makeBinPath [ xdotool xsel ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/fdw/rofimoji;
+    description = "A simple emoji picker for rofi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wedens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19081,6 +19081,8 @@ in
 
   rofi-menugen = callPackage ../applications/misc/rofi-menugen { };
 
+  rofimoji = callPackage ../applications/misc/rofimoji { };
+
   rofi-systemd = callPackage ../tools/system/rofi-systemd { };
 
   rpcs3 = libsForQt5.callPackage ../misc/emulators/rpcs3 { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

