### PR TITLE
nixos/cpufreq: Remove the alias to set the cpu frequency governor

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -408,16 +408,6 @@
        from nixpkgs due to the lack of maintainers.
      </para>
    </listitem>
-   <listitem>
-    <para>
-       The <option>powerManagement.cpuFreqGovernor</option> option has been
-       aliased to <option>powerManagement.cpufreq.governor</option>.  On laptops,
-       <option>powerManagement.cpuFreqGovernor</option> is sometimes set in
-       <literal>/etc/nixos/hardware-configuration.nix</literal>, so you can
-       rename it to the new name, or run
-       <literal>nixos-generate-config</literal> again.
-    </para>
-   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -104,7 +104,7 @@ if (-e "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors") {
 
     foreach $e (@desired_governors) {
         if (index($governors, $e) != -1) {
-            last if (push @attrs, "powerManagement.cpufreq.governor = lib.mkDefault \"$e\";");
+            last if (push @attrs, "powerManagement.cpuFreqGovernor = lib.mkDefault \"$e\";");
         }
     }
 }

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -286,9 +286,6 @@ with lib;
     (mkRenamedOptionModule [ "hardware" "ckb" "enable" ] [ "hardware" "ckb-next" "enable" ])
     (mkRenamedOptionModule [ "hardware" "ckb" "package" ] [ "hardware" "ckb-next" "package" ])
 
-    # cpufeq
-    (mkAliasOptionModule [ "powerManagement" "cpuFreqGovernor" ] [ "powerManagement" "cpufreq" "governor" ])
-
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"
                    "snmpExporter" "unifiExporter" "varnishExporter" ]

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -55,7 +55,7 @@ in
   config = mkIf cfg.enable {
 
     powerManagement.scsiLinkPolicy = null;
-    powerManagement.cpufreq.governor = null;
+    powerManagement.cpuFreqGovernor = null;
     powerManagement.cpufreq.max = null;
     powerManagement.cpufreq.min = null;
 


### PR DESCRIPTION
This PR temporarily fixes the issue with PR 53041 as explained here:

https://github.com/NixOS/nixpkgs/pull/53041#commitcomment-31825338

The alias `powerManagement.cpufreq.governor` to `powerManagement.cpuFreqGovernor` has been removed.

###### Motivation for this change

This fixes a bad interaction between the TLP module and `powerManagement.cpuFreqGovernor` which has been set in `nixos-generate-config`.

Pinging @Infinisil because of his suggestion to revert this change, as well as @eadwu since he originally reported the error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

