### PR TITLE
Update Powder Toy to version 93.3

### DIFF
--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -5,17 +5,11 @@ stdenv.mkDerivation rec {
   version = "93.3";
 
   src = fetchFromGitHub {
-    owner = "simtr";
+    owner = "ThePowderToy";
     repo = "The-Powder-Toy";
     rev = "v${version}";
-    sha256 = "1n15kgl4qnz55b32ddgmhrv64cl3awbds8arycn7mkf7akwdg1g6";
+    sha256 = "1bg1y13kpqxx4mpncxvmg8w02dyqyd9hl43rwnys3sqrjdm9k02j";
   };
-
-  patches = [ ./fix-env.patch ];
-
-  postPatch = ''
-    sed -i 's,lua5.1,lua,g' SConscript
-  '';
 
   nativeBuildInputs = [ scons pkgconfig ];
 

--- a/pkgs/games/the-powder-toy/default.nix
+++ b/pkgs/games/the-powder-toy/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "the-powder-toy-${version}";
-  version = "92.5";
+  version = "93.3";
 
   src = fetchFromGitHub {
     owner = "simtr";


### PR DESCRIPTION
Update Powder Toy to version 93.3, fix build stage and relocate Git repository.