### PR TITLE
davmail: fix homepage domain name

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://davmail.sourceforce.net/;
+    homepage = http://davmail.sourceforge.net/;
     description = "A Java application which presents a Microsoft Exchange server as local CALDAV, IMAP and SMTP servers";
     maintainers = [ maintainers.hinton ];
     platforms = platforms.all;


### PR DESCRIPTION
(corresponding PR for `release-18.09`: #53310)

This (presumed) typo has been introduced with the original addition of davmail in f6ba040bdce2, but to enable clean merging with `master` and `release-18.09`, I'm basing this fix on the more current 20fea7f4491919e93dae9b83e861b4bab881f568.

###### Motivation for this change

<code>sourcefor**c**e.net</code> is for sale. This project's website resides on a <code>sourcefor**g**e.net</code> subdomain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

