### PR TITLE
vivaldi: 2.1.1337.51-1 -> 2.2.1388.37-1; vivaldi-ffmpeg-codecs: 70.0.3538.77 -> 71.0.3578.98

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -4,7 +4,7 @@
 , freetype, fontconfig, libXft, libXrender, libxcb, expat
 , libuuid
 , gstreamer, gst-plugins-base, libxml2
-, glib, gtk3, pango, gdk_pixbuf, cairo, atk, at-spi2-atk, gnome2
+, glib, gtk3, pango, gdk_pixbuf, cairo, atk, at-spi2-atk, at-spi2-core, gnome2
 , nss, nspr
 , patchelf, makeWrapper
 , proprietaryCodecs ? false, vivaldi-ffmpeg-codecs ? null
@@ -13,11 +13,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "2.1.1337.51-1";
+  version = "2.2.1388.37-1";
 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "00rxp6rardxjg17g2b28y2rj8szqlainp4ga6c58z981zkxvdlls";
+    sha256 = "07q04lvwnjn5kprlwyndv9h2s25637ngchch26ka8lry1lxkdv55";
   };
 
   unpackPhase = ''
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     stdenv.cc.cc stdenv.cc.libc zlib libX11 libXt libXext libSM libICE libxcb
     libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
-    atk at-spi2-atk alsaLib dbus cups gtk3 gdk_pixbuf libexif ffmpeg systemd
+    atk at-spi2-atk at-spi2-core alsaLib dbus cups gtk3 gdk_pixbuf libexif ffmpeg systemd
     freetype fontconfig libXrender libuuid expat glib nss nspr
     gstreamer libxml2 gst-plugins-base pango cairo gnome2.GConf
   ] ++ stdenv.lib.optional proprietaryCodecs vivaldi-ffmpeg-codecs;

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchurl
 , dbus-glib, gtk3, libexif, libXScrnSaver, ninja, nss
-, pciutils, pkgconfig, python2, xdg_utils, gn
+, pciutils, pkgconfig, python2, xdg_utils, gn, at-spi2-core
 }:
 
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi-ffmpeg-codecs";
-  version = "70.0.3538.77";
+  version = "71.0.3578.98";
 
   src = fetchurl {
     url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-    sha512 = "128hvkcbyw70j31dj4jviqqjrzyfx38689nb8v0kk5vi2zlgfy5ibz2gyrv4bvrb53ld262y9pvam51nbdmrx2vqd9xrs173py7v0a0";
+    sha512 = "3baldqqdm8jzrs37w756ijgzwpmvma73rqbpnfkf0j41rmikrjdl6w7ycll98jch8rhzpgz3yfb9nk0gmsgxs233wn441bcdkhr1syv";
   };
 
   buildInputs = [ ];
 
   nativeBuildInputs = [
     gtk3 libexif libXScrnSaver ninja nss pciutils python2 xdg_utils gn
-    pkgconfig dbus-glib
+    pkgconfig dbus-glib at-spi2-core.dev
   ];
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Update vivaldi.

- vivaldi: 2.1.1337.51-1 -> 2.2.1388.37-1
- vivaldi-ffmpeg-codecs: 70.0.3538.77 -> 71.0.3578.98

[Minor update for Vivaldi 2.2](https://vivaldi.com/blog/minor-update-for-vivaldi-2-2/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).