### PR TITLE
trx: init at 2018-01-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1750,6 +1750,11 @@
     github = "hamhut1066";
     name = "Hamish Hutchings";
   };
+  hansjoergschurr = {
+    email = "commits@schurr.at";
+    github = "hansjoergschurr";
+    name = "Hans-Jörg Schurr";
+  };
   haslersn = {
     email = "haslersn@fius.informatik.uni-stuttgart.de";
     github = "haslersn";

--- a/pkgs/tools/audio/trx/default.nix
+++ b/pkgs/tools/audio/trx/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchgit, alsaLib, libopus, ortp, bctoolbox }:
+
+stdenv.mkDerivation rec {
+  name = "trx-unstable-${version}";
+  version = "2018-01-23";
+
+  src = fetchgit {
+    url = "http://www.pogo.org.uk/~mark/trx.git";
+    rev = "66b4707a24172751a131e24d2a800496c699137f";
+    sha256 = "0w0960p25944b30lkc8n4lj14xgsf0fjpmxqwlz2r8wl642bqnfm";
+  };
+
+  buildInputs = [ alsaLib libopus ortp bctoolbox ];
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A simple toolset for broadcasting live audio using RTP/UDP and Opus";
+    homepage = http://www.pogo.org.uk/~mark/trx/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.hansjoergschurr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/audio/trx/default.nix
+++ b/pkgs/tools/audio/trx/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ alsaLib libopus ortp bctoolbox ];
-  makeFlags = [ "DESTDIR=$(out)" ];
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A simple toolset for broadcasting live audio using RTP/UDP and Opus";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5881,6 +5881,8 @@ in
 
   trousers = callPackage ../tools/security/trousers { };
 
+  trx = callPackage ../tools/audio/trx { };
+
   tryton = callPackage ../applications/office/tryton { };
 
   trytond = callPackage ../applications/office/trytond { };


### PR DESCRIPTION
###### Motivation for this change

This adds a package for a small tool allowing streaming of audio on local networks. Using the current tip of the git repository instead of the latest release because adaptions to newer versions of `ortp` were done after the release.

###### Further work

The produced binaries currently produce a `sched_setscheduler: Operation not permitted` warning since they don't have permission to enable real time scheduling. I'm not sure if this should be allowed in the package, or by the user if needed. They work just fine nevertheless.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

