### PR TITLE
stdenv: assert whether `name` or (`pname` and `version`) are given

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -80,6 +80,8 @@ rec {
 
     , ... } @ attrs:
 
+    assert (name != "") || (attrs?pname && attrs?version);
+
     let
       computedName = if name != "" then name else "${attrs.pname}-${attrs.version}";
 


### PR DESCRIPTION
Without the assertion, when a `pname` was missing, the whole trace was

    error: attribute 'pname' missing, at /home/freddy/Code/libraries/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:84:54

which is pretty useless if you happened to have changed a lot of
expressions.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

