### PR TITLE
clang-tools: 5 -> 7

### DIFF
--- a/pkgs/development/tools/clang-tools/default.nix
+++ b/pkgs/development/tools/clang-tools/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, makeWrapper, writeScript, llvmPackages }:
+{ stdenv, writeScript, llvmPackages_latest }:
 
 let
-  clang = llvmPackages.clang-unwrapped;
+  clang = llvmPackages_latest.clang-unwrapped;
   version = stdenv.lib.getVersion clang;
 in
 
 stdenv.mkDerivation {
   name = "clang-tools-${version}";
-  builder = writeScript "builder" ''
-    source $stdenv/setup
+  unpackPhase = ":";
+  installPhase = ''
+    mkdir -p $out/bin
     for tool in \
       clang-apply-replacements \
       clang-check \
@@ -16,11 +17,9 @@ stdenv.mkDerivation {
       clang-rename \
       clang-tidy
     do
-      makeWrapper $clang/bin/$tool $out/bin/$tool --argv0 $tool
+      ln -s ${clang}/bin/$tool $out/bin/$tool
     done
   '';
-  buildInputs = [ makeWrapper ];
-  inherit clang;
   meta = clang.meta // {
     description = "Standalone command line tools for C++ development";
     maintainers = with stdenv.lib.maintainers; [ aherrmann ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7349,6 +7349,8 @@ in
     stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
+  llvmPackages_latest = llvmPackages_7;
+
   manticore = callPackage ../development/compilers/manticore { };
 
   mercury = callPackage ../development/compilers/mercury { };


### PR DESCRIPTION
Since this not typically used as build dependencies, just use the latest
and greatest.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

