### PR TITLE
python{2,3}Packages.pytest-repeat: fix build

### DIFF
--- a/pkgs/development/python-modules/pytest-repeat/default.nix
+++ b/pkgs/development/python-modules/pytest-repeat/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , setuptools_scm
 , pytest
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0axbrpqal3cqw9zq6dakdbg49pnf5gvyvq6yn93hp1ayc7fnhzk3";
   };
+
+  # fixes support for pytest >3.6. Should be droppable during the
+  # next bump.
+  patches = [
+    (fetchpatch {
+      url = https://github.com/pytest-dev/pytest-repeat/commit/f94b6940e3651b7593aca5a7a987eb56abe04cb1.patch;
+      sha256 = "00da1gmpq9pslcmm8pw93jcbp8j2zymzqdsm6jq3xinkvjpsbmny";
+    })
+  ];
 
   buildInputs = [ setuptools_scm pytest ];
 


### PR DESCRIPTION
###### Motivation for this change

Test suite and build environment had several issues with Pytest >3.6
which can be fixed by applying the (yet unreleased) upstream patch from
https://github.com/pytest-dev/pytest-repeat/commit/f94b6940e3651b7593aca5a7a987eb56abe04cb1.patch


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

