### PR TITLE
pythonPackages.Kajiki: fix build

### DIFF
--- a/pkgs/development/python-modules/kajiki/default.nix
+++ b/pkgs/development/python-modules/kajiki/default.nix
@@ -4,6 +4,7 @@
 , Babel
 , pytz
 , nine
+, nose
 }:
 
 buildPythonPackage rec {
@@ -16,6 +17,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ Babel pytz nine ];
+  checkInputs = [ nose ];
 
   meta = with stdenv.lib; {
     description = "Kajiki provides fast well-formed XML templates";


### PR DESCRIPTION
###### Motivation for this change

The test suite broke as `nose` wasn't supplied as check input.

See also https://hydra.nixos.org/build/86294591

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

