### PR TITLE
pythonPackages.Pweave: fix build

### DIFF
--- a/pkgs/development/python-modules/pweave/default.nix
+++ b/pkgs/development/python-modules/pweave/default.nix
@@ -4,6 +4,9 @@
 , mock
 , matplotlib
 , pkgs
+, nbconvert
+, markdown
+, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -15,8 +18,10 @@ buildPythonPackage rec {
     sha256 = "5e5298d90e06414a01f48e0d6aa4c36a70c5f223d929f2a9c7e2d388451c7357";
   };
 
+  disabled = !isPy3k;
+
   buildInputs = [ mock pkgs.glibcLocales ];
-  propagatedBuildInputs = [ matplotlib ];
+  propagatedBuildInputs = [ matplotlib nbconvert markdown ];
 
   # fails due to trying to run CSS as test
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Version 0.30 was missing the Python dependencies `nbconvert` and `markdown`.

Also Python 2 isn't supported any more since 0.30
(https://github.com/mpastell/Pweave/blob/master/CHANGELOG.txt) and can
therefore be dropped.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

