### PR TITLE
nixos/nsd: Don't override bind via nixpkgs.config

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -435,7 +435,7 @@ let
 
   dnssecZones = (filterAttrs (n: v: if v ? dnssec then v.dnssec else false) zoneConfigs);
 
-  dnssec = length (attrNames dnssecZones) != 0; 
+  dnssec = dnssecZones != {};
 
   dnssecTools = pkgs.bind.override { enablePython = true; };
 

--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -437,6 +437,8 @@ let
 
   dnssec = length (attrNames dnssecZones) != 0; 
 
+  dnssecTools = pkgs.bind.override { enablePython = true; };
+
   signZones = optionalString dnssec ''
     mkdir -p ${stateDir}/dnssec
     chown ${username}:${username} ${stateDir}/dnssec
@@ -445,8 +447,8 @@ let
     ${concatStrings (mapAttrsToList signZone dnssecZones)}
   '';
   signZone = name: zone: ''
-    ${pkgs.bind}/bin/dnssec-keymgr -g ${pkgs.bind}/bin/dnssec-keygen -s ${pkgs.bind}/bin/dnssec-settime -K ${stateDir}/dnssec -c ${policyFile name zone.dnssecPolicy} ${name}
-    ${pkgs.bind}/bin/dnssec-signzone -S -K ${stateDir}/dnssec -o ${name} -O full -N date ${stateDir}/zones/${name}
+    ${dnssecTools}/bin/dnssec-keymgr -g ${dnssecTools}/bin/dnssec-keygen -s ${dnssecTools}/bin/dnssec-settime -K ${stateDir}/dnssec -c ${policyFile name zone.dnssecPolicy} ${name}
+    ${dnssecTools}/bin/dnssec-signzone -S -K ${stateDir}/dnssec -o ${name} -O full -N date ${stateDir}/zones/${name}
     ${nsdPkg}/sbin/nsd-checkzone ${name} ${stateDir}/zones/${name}.signed && mv -v ${stateDir}/zones/${name}.signed ${stateDir}/zones/${name}
   '';
   policyFile = name: policy: pkgs.writeText "${name}.policy" ''
@@ -951,10 +953,6 @@ in
 
         ${copyKeys}
       '';
-    };
-
-    nixpkgs.config = mkIf dnssec {
-      bind.enablePython = true;
     };
 
     systemd.timers."nsd-dnssec" = mkIf dnssec {


### PR DESCRIPTION
When generating values for the `services.nsd.zones` attribute using values from `pkgs`, we'll run into an infinite recursion because the `nsd` module has a condition on the top-level definition of `nixpkgs.config`.

While it would work to push the definition a few levels down, it will still only work if we don't use bind tools for generating zones.

As far as I could see, Python support for BIND seems to be only needed for the `dnssec-*` tools, so instead of using `nixpkgs.config`, we now directly override `pkgs.bind` instead of globally in `nixpkgs`.

To illustrate the problem with a small test case, instantiating the following Nix expression from the `nixpkgs` source root will cause the mentioned infinite recursion:

```nix
(import ./nixos {
  configuration = { lib, pkgs, ... }: {
    services.nsd.enable = true;
    services.nsd.zones = import (pkgs.writeText "foo.nix" ''
      { "foo.".data = "xyz";
        "foo.".dnssec = true;
      }
    '');
  };
}).vm
```

With this change, generating zones via import-from-derivation is now possible again.

___

@pngwjpgh: Can you please check whether DNSSEC still works after this?

Cc: @hrdinka