### PR TITLE
Re-add security features based on GCC plugins in 4.18+ hardened kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -4,6 +4,9 @@
 , perl
 , bison ? null
 , flex ? null
+, gmp ? null
+, libmpc ? null
+, mpfr ? null
 , stdenv
 
 , # The kernel source tarball.
@@ -89,7 +92,7 @@ let
     passAsFile = [ "kernelConfig" ];
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
-    nativeBuildInputs = [ perl ]
+    nativeBuildInputs = [ perl gmp libmpc mpfr ]
       ++ lib.optionals (stdenv.lib.versionAtLeast version "4.16") [ bison flex ];
 
     platformName = stdenv.hostPlatform.platform.name;
@@ -112,7 +115,10 @@ let
       export buildRoot="''${buildRoot:-build}"
 
       # Get a basic config file for later refinement with $generateConfig.
-      make HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc -C . O="$buildRoot" $kernelBaseConfig ARCH=$kernelArch
+      make -C .  O="$buildRoot" $kernelBaseConfig \
+          ARCH=$kernelArch \
+          HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc \
+          HOSTCXX=${buildPackages.stdenv.cc.targetPrefix}g++
 
       # Create the config file.
       echo "generating kernel configuration..."

--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -113,6 +113,9 @@ ${optionalString (versionAtLeast version "4.11") ''
 ${optionalString (versionAtLeast version "4.14") ''
   GCC_PLUGIN_STRUCTLEAK_BYREF_ALL y # Also cover structs passed by address
 ''}
+${optionalString (versionAtLeast version "4.20") ''
+  GCC_PLUGIN_STACKLEAK y # A port of the PaX stackleak plugin
+''}
 
 # Disable various dangerous settings
 ACPI_CUSTOM_METHOD n # Allows writing directly to physical memory

--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -103,17 +103,15 @@ PAGE_POISONING_ZERO y
 PANIC_ON_OOPS y
 PANIC_TIMEOUT -1
 
-${optionalString (versionOlder version "4.18") ''
-  GCC_PLUGINS y # Enable gcc plugin options
-  # Gather additional entropy at boot time for systems that may not have appropriate entropy sources.
-  GCC_PLUGIN_LATENT_ENTROPY y
+GCC_PLUGINS y # Enable gcc plugin options
+# Gather additional entropy at boot time for systems that may not have appropriate entropy sources.
+GCC_PLUGIN_LATENT_ENTROPY y
 
-  ${optionalString (versionAtLeast version "4.11") ''
-    GCC_PLUGIN_STRUCTLEAK y # A port of the PaX structleak plugin
-  ''}
-  ${optionalString (versionAtLeast version "4.14") ''
-    GCC_PLUGIN_STRUCTLEAK_BYREF_ALL y # Also cover structs passed by address
-  ''}
+${optionalString (versionAtLeast version "4.11") ''
+  GCC_PLUGIN_STRUCTLEAK y # A port of the PaX structleak plugin
+''}
+${optionalString (versionAtLeast version "4.14") ''
+  GCC_PLUGIN_STRUCTLEAK_BYREF_ALL y # Also cover structs passed by address
 ''}
 
 # Disable various dangerous settings


### PR DESCRIPTION
###### Motivation for this change
92369900575c581ce9e9d70f23d39cf08943ad2f disabled GCC plugins in 4.18+ in NixOS hardened kernels. This is undesirable given that tons of nice PaX features are getting ported through these plugins -- for example, STACKLEAK in 4.20.

This PR attempts to re-enable plugins + adds STACKLEAK to the hardened config on 4.20+.

@joachifm @NeQuissimus 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

