### PR TITLE
recutils: 1.7 -> 1.8

### DIFF
--- a/pkgs/tools/misc/recutils/default.nix
+++ b/pkgs/tools/misc/recutils/default.nix
@@ -1,11 +1,11 @@
 { fetchurl, stdenv, emacs, curl, check, bc }:
 
 stdenv.mkDerivation rec {
-  name = "recutils-1.7";
+  name = "recutils-1.8";
 
   src = fetchurl {
     url = "mirror://gnu/recutils/${name}.tar.gz";
-    sha256 = "0cdwa4094x3yx7vn98xykvnlp9rngvd58d19vs3vh5hrvggccg93";
+    sha256 = "14xiln4immfsw8isnvwvq0h23f6z0wilpgsc4qzabnrzb5lsx3nz";
   };
 
   hardeningDisable = [ "format" ];
@@ -14,11 +14,6 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ check bc ];
   doCheck = true;
-
-  # one file fails to compile with emacs 26
-  postInstall = ''
-    ${emacs}/bin/emacs -Q -batch -f batch-byte-compile $out/share/emacs/site-lisp/*.el || true
-  '';
 
   meta = {
     description = "Tools and libraries to access human-editable, text-based databases";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---