### PR TITLE
bfs: 1.2.4 -> 1.3.1

### DIFF
--- a/pkgs/tools/system/bfs/default.nix
+++ b/pkgs/tools/system/bfs/default.nix
@@ -1,23 +1,17 @@
-{ stdenv, fetchFromGitHub, bash }:
+{ stdenv, fetchFromGitHub, libcap, acl }:
 
 stdenv.mkDerivation rec {
   name = "bfs-${version}";
-  version = "1.2.4";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     repo = "bfs";
     owner = "tavianator";
     rev = version;
-    sha256 = "0nxx2njjp04ik6msfmf07hprw0j88wg04m0q1sf17mhkliw2d78s";
+    sha256 = "0gv9hrcsz7miv40v6wmkmb1a58ji5d1dlgwq6gwczd8rzlmhddmc";
   };
 
-  postPatch = ''
-    # Patch tests (both shebangs and usage in scripts)
-    for f in $(find -type f -name '*.sh'); do
-      substituteInPlace $f --replace "/bin/bash" "${bash}/bin/bash"
-    done
-  '';
-  doCheck = true;
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ libcap acl ];
 
   makeFlags = [ "PREFIX=$(out)" ];
   buildFlags = [ "release" ]; # "release" enables compiler optimizations
@@ -30,7 +24,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/tavianator/bfs;
     license = licenses.bsd0;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ yesbox ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

disabled checkPhase because fails in sandboxed builds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

