### PR TITLE
xpointerbarrier: 17.11 -> 18.06

### DIFF
--- a/pkgs/tools/X11/xpointerbarrier/default.nix
+++ b/pkgs/tools/X11/xpointerbarrier/default.nix
@@ -1,13 +1,11 @@
-{ stdenv, xorg, fetchFromGitHub }:
+{ stdenv, xorg, fetchgit }:
 stdenv.mkDerivation rec {
   name = "xpointerbarrier-${version}";
-  version = "17.11";
-
-  src = fetchFromGitHub {
-    owner = "vain";
-    repo = "xpointerbarrier";
+  version = "18.06";
+  src = fetchgit {
+    url = "https://www.uninformativ.de/git/xpointerbarrier.git";
     rev = "v${version}";
-    sha256 = "0s6bd58xjyc2nqzjq6aglx6z64x9xavda3i6p8vrmxqmcpik54nm";
+    sha256 = "1k7i641x18qhjm0llsaqn2h2g9k31kgv6p8sildllmbvgxyrgvq7";
   };
 
   buildInputs = [ xorg.libX11 xorg.libXfixes xorg.libXrandr ];
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
   makeFlags = "prefix=$(out)";
 
   meta = {
-    homepage = https://github.com/vain/xpointerbarrier;
+    homepage = https://uninformativ.de/git/xpointerbarrier;
     description = "Create X11 pointer barriers around your working area";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.xzfc ];


### PR DESCRIPTION
###### Motivation for this change

As stated on https://github.com/vain/xpointerbarrier, the project has moved from GitHub to https://uninformativ.de/git/xpointerbarrier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

