### PR TITLE
hubstaff: 1.3.1 → 1.4.5

### DIFF
--- a/pkgs/applications/misc/hubstaff/default.nix
+++ b/pkgs/applications/misc/hubstaff/default.nix
@@ -5,7 +5,9 @@
 
 let
 
-  version = "1.3.1-ff75f26";
+  data = builtins.fromJSON (builtins.readFile ./revision.json);
+
+  inherit (data) version url sha256;
 
   rpath = stdenv.lib.makeLibraryPath
     [ libX11 zlib libSM libICE libXext freetype libXrender fontconfig libXft
@@ -17,10 +19,7 @@ in
 stdenv.mkDerivation {
   name = "hubstaff-${version}";
 
-  src = fetchurl {
-    url = "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/${version}/Hubstaff-${version}.sh";
-    sha256 = "0jm5l34r6lkfkg8vsdfqbr0axngxznhagwcl9y184lnyji91fmdl";
-  };
+  src = fetchurl { inherit sha256 url; };
 
   nativeBuildInputs = [ unzip makeWrapper ];
 

--- a/pkgs/applications/misc/hubstaff/revision.json
+++ b/pkgs/applications/misc/hubstaff/revision.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.4.3-b4b3cb24/Hubstaff-1.4.3-b4b3cb24.sh",
+  "version": "1.4.3-b4b3cb24",
+  "sha256": "0wy8pn6m5pxiv1lgilni9z8hc62j72gfrrbj4yhmxph0jf1afrv9"
+}

--- a/pkgs/applications/misc/hubstaff/revision.json
+++ b/pkgs/applications/misc/hubstaff/revision.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.4.3-b4b3cb24/Hubstaff-1.4.3-b4b3cb24.sh",
-  "version": "1.4.3-b4b3cb24",
-  "sha256": "0wy8pn6m5pxiv1lgilni9z8hc62j72gfrrbj4yhmxph0jf1afrv9"
+  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.4.5-c5b459ea/Hubstaff-1.4.5-c5b459ea.sh",
+  "version": "1.4.5-c5b459ea",
+  "sha256": "180qglbj175wln0kh8d5czhjvy7z503zxn4w6522hkz4ddz201nz"
 }

--- a/pkgs/applications/misc/hubstaff/update.sh
+++ b/pkgs/applications/misc/hubstaff/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-prefetch-git curl
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+
+installation_script_url=$(curl --fail --head --location --silent --output /dev/null --write-out %{url_effective} https://app.hubstaff.com/download/linux)
+
+version=$(echo "$installation_script_url" | sed -r 's/^https:\/\/hubstaff\-production\.s3\.amazonaws\.com\/downloads\/HubstaffClient\/Builds\/Release\/([^\/]+)\/Hubstaff.+$/\1/')
+
+sha256=$(nix-prefetch-url "$installation_script_url")
+
+cat <<EOT > $SCRIPT_DIR/revision.json
+{
+  "url": "$installation_script_url",
+  "version": "$version",
+  "sha256": "$sha256"
+}
+EOT


### PR DESCRIPTION
###### Motivation for this change
Hubstaff version 1.4.3 compiled atop of nixpkgs master is broken because of `segmentation fault  HubstaffClient` 
full log https://pastebin.com/raw/4K6r5CLr

Compiled atop of nixpkgs release-18.03 - broken too with `locale::facet::_S_create_c_locale name not valid` error https://github.com/NixOS/nixpkgs/issues/38988


But update script is working, can be merged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

