### PR TITLE
lib/modules: Add function to create option alias that respects priority

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -109,7 +109,7 @@ let
       mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
       mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule doRename filterModules;
+      mkAliasOptionModule mkAliasOptionModuleWithPriority doRename filterModules;
     inherit (options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption getValues
       getFiles optionAttrSetToDocList optionAttrSetToDocList'

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -450,8 +450,7 @@ rec {
 
   filterOverrides' = defs:
     let
-      defaultPrio = 100;
-      getPrio = def: if def.value._type or "" == "override" then def.value.priority else defaultPrio;
+      getPrio = def: if def.value._type or "" == "override" then def.value.priority else defaultPriority;
       highestPrio = foldl' (prio: def: min (getPrio def) prio) 9999 defs;
       strip = def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
     in {
@@ -534,6 +533,8 @@ rec {
   mkBefore = mkOrder 500;
   mkAfter = mkOrder 1500;
 
+  # The default priority for things that don't have a priority specified.
+  defaultPriority = 100;
 
   # Convenient property used to transfer all definitions and their
   # properties from one option to another. This property is useful for
@@ -561,11 +562,10 @@ rec {
   # Similar to mkAliasAndWrapDefinitions but copies over the priority from the
   # option as well.
   #
-  # If a priority is not set, it assumes a priority of 100.
+  # If a priority is not set, it assumes a priority of defaultPriority.
   mkAliasAndWrapDefsWithPriority = wrap: option:
     let
-      defaultPrio = 100;
-      prio = option.highestPrio or defaultPrio;
+      prio = option.highestPrio or defaultPriority;
       defsWithPrio = map (mkOverride prio) option.definitions;
     in mkAliasIfDef option (wrap (mkMerge defsWithPrio));
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,6 +149,9 @@ checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-long-list.ni
 # Check loaOf with many merges of lists.
 checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-merges.nix
 
+# Check mkAliasOptionModuleWithPriority.
+checkConfigOutput "true" config.enable ./alias-with-priority.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -151,6 +151,9 @@ checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-me
 
 # Check mkAliasOptionModuleWithPriority.
 checkConfigOutput "true" config.enable ./alias-with-priority.nix
+checkConfigOutput "true" config.enableAlias ./alias-with-priority.nix
+checkConfigOutput "false" config.enable ./alias-with-priority-can-override.nix
+checkConfigOutput "false" config.enableAlias ./alias-with-priority-can-override.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/alias-with-priority-can-override.nix
+++ b/lib/tests/modules/alias-with-priority-can-override.nix
@@ -1,0 +1,52 @@
+# This is a test to show that mkAliasOptionModule sets the priority correctly
+# for aliased options.
+
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+    # A simple boolean option that can be enabled or disabled.
+    enable = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      example = true;
+      description = ''
+        Some descriptive text
+      '';
+    };
+
+    # mkAliasOptionModule sets warnings, so this has to be defined.
+    warnings = mkOption {
+      internal = true;
+      default = [];
+      type = types.listOf types.str;
+      example = [ "The `foo' service is deprecated and will go away soon!" ];
+      description = ''
+        This option allows modules to show warnings to users during
+        the evaluation of the system configuration.
+      '';
+    };
+  };
+
+  imports = [
+    # Create an alias for the "enable" option.
+    (mkAliasOptionModuleWithPriority [ "enableAlias" ] [ "enable" ])
+
+    # Disable the aliased option, but with a default (low) priority so it
+    # should be able to be overridden by the next import.
+    ( { config, lib, ... }:
+      {
+        enableAlias = lib.mkForce false;
+      }
+    )
+
+    # Enable the normal (non-aliased) option.
+    ( { config, lib, ... }:
+      {
+        enable = true;
+      }
+    )
+  ];
+}

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -1,0 +1,52 @@
+# This is a test to show that mkAliasOptionModule sets the priority correctly
+# for aliased options.
+
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+    # A simple boolean option that can be enabled or disabled.
+    enable = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      example = true;
+      description = ''
+        Some descriptive text
+      '';
+    };
+
+    # mkAliasOptionModule sets warnings, so this has to be defined.
+    warnings = mkOption {
+      internal = true;
+      default = [];
+      type = types.listOf types.str;
+      example = [ "The `foo' service is deprecated and will go away soon!" ];
+      description = ''
+        This option allows modules to show warnings to users during
+        the evaluation of the system configuration.
+      '';
+    };
+  };
+
+  imports = [
+    # Create an alias for the "enable" option.
+    (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
+
+    # Disable the aliased option, but with a default (low) priority so it
+    # should be able to be overridden by the next import.
+    ( { config, lib, ... }:
+      {
+        enableAlias = lib.mkDefault false;
+      }
+    )
+
+    # Enable the normal (non-aliased) option.
+    ( { config, lib, ... }:
+      {
+        enable = true;
+      }
+    )
+  ];
+}

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -32,7 +32,7 @@ with lib;
 
   imports = [
     # Create an alias for the "enable" option.
-    (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
+    (mkAliasOptionModuleWithPriority [ "enableAlias" ] [ "enable" ])
 
     # Disable the aliased option, but with a default (low) priority so it
     # should be able to be overridden by the next import.


### PR DESCRIPTION
###### Motivation for this change

This commit adds a function `mkAliasOptionModuleWithPriority`.  This function will make an alias to an existing option and copy over the priority.  (This is in contrast to `mkAliasOptionModule` which does not copy over the priority.)

This functionality is needed for PRs like #53041 (specifically https://github.com/NixOS/nixpkgs/pull/53041#commitcomment-31825338).

Here's the use-case:

There exists an option `powerManagement.cpuFreqGovernor`.  On some systems, this is set in `hardware-configuration.nix` by `nixos-generate-config`:

```nix
{
  powerManagement.cpuFreqGovernor = mkDefault "powersave";
}
```

Note how it gets a low priority.  The end-user (or other modules) should be able to easily override it.

In #53041, I wanted to add options to set the CPU max and min frequency:

```nix
{
  powerManagement.cpufreq.max = 2200000;
  powerManagement.cpufreq.min = 1500000;
}
```

I thought it was silly to have the options called both `powerManagement.cpuFreqGovernor` and `powerManagement.cpufreq.max`, so I renamed `powerManagement.cpuFreqGovernor` to `powerManagement.cpufreq.governor`.  This is fine, but it will break for people that are using `hardware-configuration.nix` generated with an older version of `nixos-generate-config` (since in their config it is called `powerManagement.cpuFreqGovernor`).

In order to accommodate those people, I added the alias `powerManagement.cpuFreqGovernor` to `powerManagement.cpufreq.governor`:

```nix
mkAliasOptionModule [ "powerManagement" "cpuFreqGovernor" ] [ "powerManagement" "cpufreq" "governor" ]
```

This should let people use their older `hardware-configuration.nix` with the `powerManagement.cpuFreqGovernor` option.

However, there is one edge case this doesn't work for.

Imagine that the user has `powerManagement.cpuFreqGovernor` set in `hardware-configuration.nix`:

```nix
{
  powerManagement.cpuFreqGovernor = mkDefault "powersave";
}
```

The user then tries to set `powerManagement.cpufreq.governor` to something else in `configuration.nix`:

```nix
{
  powerManagement.cpufreq.governor = "ondemand";
}
```

This actually will fail.  The user will get an error that `powerManagement.cpufreq.governor` is defined two places (which is true, but the definition in `hardware-configuration.nix` should have low priority).

What's going on here?  Well, the `mkAliasOptionModule` function doesn't actually copy over the priority of the alias option to the normal option.  So to the nix module system, it really does look like `powerManagement.cpufreq.governor` is being set two different places.

This PR adds a function `mkAliasOptionModuleWithPriority` that does correctly(?) copy over the priority from the alias option to the normal option.

Tests have also been added to make sure this is working correctly.

Pinging @Infinisil since he helped a lot with #53041.  Also pinging @edolstra @nbp since they seem to be code-owners of the stuff in `lib/`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

