### PR TITLE
cryptominisat: 5.0.1 -> 5.6.6

### DIFF
--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -1,24 +1,18 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, python, xxd }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, python, xxd, boost }:
 
 stdenv.mkDerivation rec {
   name = "cryptominisat-${version}";
-  version = "5.0.1";
+  version = "5.6.6";
 
   src = fetchFromGitHub {
     owner  = "msoos";
     repo   = "cryptominisat";
     rev    = version;
-    sha256 = "0cpw5d9vplxvv3aaplhnga55gz1hy29p7s4pkw1306knkbhlzvkb";
+    sha256 = "1a1494gj4j73yij0hjbzsn2hglk9zy5c5wfwgig3j67cis28saf5";
   };
 
-  buildInputs = [ python xxd ];
-  nativeBuildInputs = [ cmake ];
-
-  patches = [(fetchpatch rec {
-    name = "fix-exported-library-name.patch";
-    url = "https://github.com/msoos/cryptominisat/commit/7a47795cbe5ad5a899731102d297f234bcade077.patch";
-    sha256 = "11hf3cfqs4cykn7rlgjglq29lzqfxvlm0f20qasi0kdrz01cr30f";
-  })];
+  buildInputs = [ python boost ];
+  nativeBuildInputs = [ cmake xxd ];
 
   meta = with stdenv.lib; {
     description = "An advanced SAT Solver";

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, python, xxd, boost }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, python3, xxd, boost }:
 
 stdenv.mkDerivation rec {
   name = "cryptominisat-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a1494gj4j73yij0hjbzsn2hglk9zy5c5wfwgig3j67cis28saf5";
   };
 
-  buildInputs = [ python boost ];
+  buildInputs = [ python3 boost ];
   nativeBuildInputs = [ cmake xxd ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

