### PR TITLE
cutelyst: fix build

### DIFF
--- a/pkgs/development/libraries/cutelyst/default.nix
+++ b/pkgs/development/libraries/cutelyst/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig, makeWrapper
-, qtbase, libuuid, libcap, uwsgi, grantlee }:
+, qtbase, libuuid, libcap, uwsgi, grantlee, pcre
+}:
 
 stdenv.mkDerivation rec {
   name = "cutelyst-${version}";
@@ -13,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
-  buildInputs = [ qtbase libuuid libcap uwsgi grantlee ];
+  buildInputs = [ qtbase libuuid libcap uwsgi grantlee pcre ];
 
   cmakeFlags = [
     "-DPLUGIN_UWSGI=ON"


### PR DESCRIPTION
###### Motivation for this change

Cutelyst misses `pcre.h` to compile, adding `pkgs.pcre` as build input
fixes the compilation.

This unbreaks `virtlyst` and the corresponding module as well.

See also https://hydra.nixos.org/build/86293236

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

