### PR TITLE
cbor: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/cbor/default.nix
+++ b/pkgs/development/python-modules/cbor/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "cbor";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dmv163cnslyqccrybkxn0c9s1jk1mmafmgxv75iamnz5lk5l8hk";
+  };
+
+  # Tests are excluded from PyPI and four unit tests are also broken:
+  # https://github.com/brianolson/cbor_py/issues/6
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/bodhisnarkva/cbor;
+    description = "Concise Binary Object Representation (CBOR) library";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1170,6 +1170,8 @@ in {
 
   case = callPackage ../development/python-modules/case {};
 
+  cbor = callPackage ../development/python-modules/cbor {};
+
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };
 
   cccolutils = callPackage ../development/python-modules/cccolutils {};


### PR DESCRIPTION
###### Motivation for this change
Introduces the `cbor` library for Python.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

