### PR TITLE
nixos/xss-lock: specify a default locker

### DIFF
--- a/nixos/modules/programs/xss-lock.nix
+++ b/nixos/modules/programs/xss-lock.nix
@@ -9,7 +9,8 @@ in
   options.programs.xss-lock = {
     enable = mkEnableOption "xss-lock";
     lockerCommand = mkOption {
-      example = "xlock";
+      default = "${pkgs.i3lock}/bin/i3lock";
+      example = literalExample ''''${pkgs.i3lock-fancy}/bin/i3lock-fancy'';
       type = types.string;
       description = "Locker to be used with xsslock";
     };

--- a/nixos/tests/xss-lock.nix
+++ b/nixos/tests/xss-lock.nix
@@ -9,7 +9,6 @@ with lib;
   machine = {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     programs.xss-lock.enable = true;
-    programs.xss-lock.lockerCommand = "${pkgs.xlockmore}/bin/xlock";
     services.xserver.displayManager.auto.user = "alice";
   };
 
@@ -20,6 +19,6 @@ with lib;
 
     $machine->fail("pgrep xlock");
     $machine->succeed("su -l alice -c 'xset dpms force standby'");
-    $machine->waitUntilSucceeds("pgrep xlock");
+    $machine->waitUntilSucceeds("pgrep i3lock");
   '';
 })


### PR DESCRIPTION
Having a default locker is less error-prone and more convenient.
Incorrect values might leave the machine vulnerable since there is no
fallback.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---