### PR TITLE
ugtrain: init at 0.4.1

### DIFF
--- a/pkgs/development/tools/misc/ugtrain/default.nix
+++ b/pkgs/development/tools/misc/ugtrain/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchFromGitHub
+, autoreconfHook, pkgconfig
+, glib, enableGlib ? true
+, stdenv_32bit, enableMultiLib ? false # probably you should install pkgsi686Linux.ugtrain instead of setting this true
+}@args:
+
+let
+  inherit (stdenv.lib) optional;
+  stdenv = if enableMultiLib then stdenv_32bit else args.stdenv;
+  version = "0.4.1";
+in
+
+stdenv.mkDerivation {
+
+  name = "ugtrain-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ugtrain";
+    repo = "ugtrain";
+    rev = "v${version}";
+    sha256 = "0pw9lm8y83mda7x39874ax2147818h1wcibi83pd2x4rp1hjbkkn";
+  };
+
+  buildInputs = [
+    autoreconfHook
+    pkgconfig
+  ] ++ optional enableGlib glib;
+
+  configureFlags = optional enableGlib     "--enable-glib"
+                ++ optional enableMultiLib "--enable-multilib";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "The ugtrain (say You-Gee-train) is an advanced free and universal game trainer for the command line";
+    longDescription = ''
+      It is a research project and a tool for advanced users who want latest
+      and really working Linux game cheating methods at the cost of no GUI and
+      limited usability.
+
+      The **dynamic memory support** sets ugtrain apart. An integrated
+      preloader, a memory discovery, and a memory hacking library are included
+      for this.  It uses one simple **config file per game** which can be
+      exchanged with others. **Example configs** for games which allow cheating
+      are included.  These also come with **automatic adaptation** for dynamic
+      memory so that you can use them right away on your system after executing
+      it.
+
+      Furthermore, security measures like **ASLR/PIC/PIE are bypassed**.
+      Together with **universal checks**, reliable and stable static memory
+      cheating is provided.  Ugtrain works with most C/C++ games on Linux this
+      way. With **scanmem** it integrates the best memory search on Linux and
+      there is even **no need for root privileges**.
+    '';
+    homepage = https://github.com/ugtrain/ugtrain;
+    license = licenses.gpl3;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ elitak ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9173,6 +9173,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 
+  ugtrain = callPackage ../development/tools/misc/ugtrain { };
+
   uhd = callPackage ../development/tools/misc/uhd { };
 
   uisp = callPackage ../development/tools/misc/uisp { };


### PR DESCRIPTION
###### Motivation for this change

Adding ugtrain. The `--enable-glib` option is on by default, but `--enable-multilib` is not, because I wasn't familiar with the idiom for including the linux-686 libs as  buildInputs. Here is what's printed by configure when they're expected and absent:
```
checking for PTHREAD_PRIO_INHERIT... yes
checking whether the C++ compiler accepts -m32... yes
checking whether the C++ compiler accepts -m64... yes
checking whether gcc -m32 works... no
configure: error: You need to install 32-bit C development libraries.
```
Does anybody have any hints, like another package derivation to look at?

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

