### PR TITLE
Geany: Support for GTK2 and GTK3

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file, libintl, hicolor-icon-theme }:
+{ stdenv
+, gtk
+, fetchurl
+, which
+, pkgconfig
+, intltool
+, file
+, libintl
+, hicolor-icon-theme
+}:
 
 with stdenv.lib;
 
@@ -15,7 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig intltool libintl ];
-  buildInputs = [ gtk2 which file hicolor-icon-theme ];
+  buildInputs = [ gtk which file hicolor-icon-theme ];
 
   doCheck = true;
 
@@ -29,7 +38,7 @@ stdenv.mkDerivation rec {
       Geany is a small and lightweight Integrated Development Environment.
       It was developed to provide a small and fast IDE, which has only a few dependencies from other packages.
       Another goal was to be as independent as possible from a special Desktop Environment like KDE or GNOME.
-      Geany only requires the GTK2 runtime libraries.
+      Geany only requires the GTK2/GTK3 runtime libraries.
       Some basic features of Geany:
       - Syntax highlighting
       - Code folding

--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -1,8 +1,15 @@
-{ runCommand, makeWrapper, geany, gnome2 }:
-let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
+{ runCommand
+, makeWrapper
+, geany
+, gnome
+}:
+
+let
+  name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
 in
+
 runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; inherit (geany.meta); } "
    mkdir -p $out
    ln -s ${geany}/share $out
-   makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome2.vte}/lib
+   makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome.vte}/lib
 "

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17004,7 +17004,7 @@ in
 
   gcal = callPackage ../applications/misc/gcal { };
 
-  geany = callPackage ../applications/editors/geany { };
+  geany = callPackage ../applications/editors/geany { gtk=gtk2; };
   geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { };
 
   ghostwriter = libsForQt5.callPackage ../applications/editors/ghostwriter { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17005,7 +17005,7 @@ in
   gcal = callPackage ../applications/misc/gcal { };
 
   geany = callPackage ../applications/editors/geany { gtk=gtk2; };
-  geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { };
+  geany-with-vte = callPackage ../applications/editors/geany/with-vte.nix { gnome=gnome2; };
 
   ghostwriter = libsForQt5.callPackage ../applications/editors/ghostwriter { };
 


### PR DESCRIPTION
###### Motivation for this change

Support both GTK2 as well as GTK3 for Geany.

###### Things done

The change keeps the current defaults for both used GTK as well as VTE. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

