### PR TITLE
ed: 1.14.2 -> 1.15

### DIFF
--- a/pkgs/applications/editors/ed/default.nix
+++ b/pkgs/applications/editors/ed/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation (rec {
   name = "ed-${version}";
-  version = "1.14.2";
+  version = "1.15";
 
   src = fetchurl {
     url = "mirror://gnu/ed/${name}.tar.lz";
-    sha256 = "1nqhk3n1s1p77g2bjnj55acicsrlyb2yasqxqwpx0w0djfx64ygm";
+    sha256 = "0x6ivy5k0d7dy5z9g8q8nipr89m4qbk2ink2898qq43smp08ji5d";
   };
 
   nativeBuildInputs = [ lzip ];


### PR DESCRIPTION
###### Motivation for this change
Release announcement: http://lists.gnu.org/archive/html/info-gnu/2019-01/msg00003.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
