### PR TITLE
ocamlPackages.resource-pooling: init at 0.5.2

### DIFF
--- a/pkgs/development/ocaml-modules/resource-pooling/default.nix
+++ b/pkgs/development/ocaml-modules/resource-pooling/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, lwt_log }:
+
+let pname = "resource-pooling"; in
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.5.2";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = pname;
+    rev = version;
+    sha256 = "00rz1i61w2dy108hzv38rblnsv6b56b5a1mk5h3zddpivcljp2dh";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+  propagatedBuildInputs = [ lwt_log ];
+
+  configurePhase = "ocaml setup.ml -configure --prefix $out";
+  buildPhase = "ocaml setup.ml -build";
+  createFindlibDestdir = true;
+  installPhase = "ocaml setup.ml -install";
+
+  meta = {
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+    description = "A library for pooling resources like connections, threads, or similar";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -592,6 +592,8 @@ let
 
     re2_p4 = callPackage ../development/ocaml-modules/re2 { };
 
+    resource-pooling = callPackage ../development/ocaml-modules/resource-pooling { };
+
     result = callPackage ../development/ocaml-modules/ocaml-result { };
 
     seq = callPackage ../development/ocaml-modules/seq { };


### PR DESCRIPTION
A library for pooling resources like connections, threads, or similar.

Homepage: https://github.com/ocsigen/resource-pooling

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

