### PR TITLE
Bazel 0.21.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -116,7 +116,10 @@ stdenv.mkDerivation rec {
       done
     '';
     genericPatches = ''
-      find src/main/java/com/google/devtools -type f -print0 | while IFS="" read -r -d "" path; do
+      # substituteInPlace is rather slow, so prefilter the files with grep
+      grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
+        # If you add more replacements here, you must change the grep above!
+        # Only files containing /bin are taken into account.
         substituteInPlace "$path" \
           --replace /bin/bash ${customBash}/bin/bash \
           --replace /usr/bin/env ${coreutils}/bin/env \

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -13,8 +13,8 @@
 let
   srcDeps = lib.singleton (
     fetchurl {
-      url = "https://github.com/google/desugar_jdk_libs/archive/fd937f4180c1b557805219af4482f1a27eb0ff2b.zip";
-      sha256 = "04hs399340xfwcdajbbcpywnb2syp6z5ydwg966if3hqdb2zrf23";
+      url = "https://github.com/google/desugar_jdk_libs/archive/915f566d1dc23bc5a8975320cd2ff71be108eb9c.zip";
+      sha256 = "0b926df7yxyyyiwm9cmdijy6kplf0sghm23sf163zh8wrk87wfi7";
     }
   );
 
@@ -23,12 +23,12 @@ let
     for i in ${builtins.toString srcDeps}; do cp $i $out/$(stripHash $i); done
   '';
 
-  defaultShellPath = lib.makeBinPath [ bash coreutils findutils gnugrep gnused which ];
+  defaultShellPath = lib.makeBinPath [ bash coreutils findutils gnugrep gnused which unzip ];
 
 in
 stdenv.mkDerivation rec {
 
-  version = "0.20.0";
+  version = "0.21.0";
 
   meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "1g9hglly5199gcw929fzc5f0d0dwlharkh387h58p1fq9ylayi8r";
+    sha256 = "1d3x0f1hzaiqq00pd65bks7v8kbv57m13jsing7y0y9id0g87jvc";
   };
 
   sourceRoot = ".";
@@ -78,6 +78,7 @@ stdenv.mkDerivation rec {
   '';
 
   postPatch = let
+
     darwinPatches = ''
       # Disable Bazel's Xcode toolchain detection which would configure compilers
       # and linkers from Xcode instead of from PATH
@@ -115,6 +116,7 @@ stdenv.mkDerivation rec {
         sed -i -e "s,/usr/bin/install_name_tool,${cctools}/bin/install_name_tool,g" $wrapper
       done
     '';
+
     genericPatches = ''
       # substituteInPlace is rather slow, so prefilter the files with grep
       grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
@@ -125,20 +127,34 @@ stdenv.mkDerivation rec {
           --replace /usr/bin/env ${coreutils}/bin/env \
           --replace /bin/true ${coreutils}/bin/true
       done
+
       # Fixup scripts that generate scripts. Not fixed up by patchShebangs below.
       substituteInPlace scripts/bootstrap/compile.sh \
           --replace /bin/sh ${customBash}/bin/bash
 
-      echo "build --experimental_distdir=${distDir}" >> .bazelrc
-      echo "fetch --experimental_distdir=${distDir}" >> .bazelrc
-      echo "build --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\"" >> .bazelrc
-      echo "build --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\"" >> .bazelrc
-      echo "build --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\"" >> .bazelrc
-      echo "build --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\"" >> .bazelrc
-      sed -i -e "420 a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
-      sed -i -e "420 a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
-      sed -i -e "420 a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
-      sed -i -e "420 a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
+      # We only build with JDK8 for now, since JDK11 does not compile bazel
+      substituteInPlace tools/jdk/default_java_toolchain.bzl \
+        --replace '"jvm_opts": JDK9_JVM_OPTS' \
+                  '"jvm_opts": JDK8_JVM_OPTS'
+
+      # add nix environment vars to .bazelrc
+      cat >> .bazelrc <<EOF
+      build --experimental_distdir=${distDir}
+      fetch --experimental_distdir=${distDir}
+      build --copt="$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt="/g')"
+      build --host_copt="$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt="/g')"
+      build --linkopt="-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt="-Wl,/g')"
+      build --host_linkopt="-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt="-Wl,/g')"
+      build --host_javabase='@local_jdk//:jdk'
+      EOF
+
+      # add the same environment vars to compile.sh
+      sed -e "/\$command \\\\$/a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" \
+          -e "/\$command \\\\$/a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" \
+          -e "/\$command \\\\$/a --host_javabase='@local_jdk//:jdk' \\\\" \
+          -i scripts/bootstrap/compile.sh
 
       # --experimental_strict_action_env (which will soon become the
       # default, see bazelbuild/bazel#2574) hardcodes the default
@@ -162,6 +178,8 @@ stdenv.mkDerivation rec {
     buildJdk
   ];
 
+  # when a command can’t be found in a bazel build, you might also
+  # need to add it to `defaultShellPath`.
   nativeBuildInputs = [
     zip
     python


### PR DESCRIPTION
First commit is [a patch created by @dtzWill](https://github.com/dtzWill/nixpkgs/commit/9ed2c64653d4ac45d5978f1926b32c1ebde967c3) to improve the `substituteAll` stuff.

Second commit is my progress of getting 0.21 to run so far. 0.21 removed the bundled openjdk-distribution. Instead, tries to fetch the “right” distribution on-the-fly when building. So we need to provide our own openjdk.

According to https://github.com/bazelbuild/bazel/issues/6865#issuecomment-447261288 we should set `--host_javabase` if we want to do that.

We copy the `buildJdk` nix path to a temporary directory, make it look like a bazel repository (init BUILD and WORKSPACE) and point to it via `local_repository`.
As it turns out, exposing the files via `filegroup` is not enough, the bazel build needs it to expose a `JavaRuntimeInfo` provider:

> ERROR: /tmp/.bazel-1000/bazel_HPQZBqno/out/external/bazel_tools/tools/jdk/BUILD:19:1:
> in :alias attribute of java_host_runtime_alias rule
> @bazel_tools//tools/jdk:current_host_java_runtime:
> '@nix_jdk//:all-files' does not have mandatory providers:
> 'JavaRuntimeInfo'

I am unsure how to achieve that.

This commit also replaces the line-number-based sed invocations with
something more stable.

---

I actually tried to follow the upstream suggestion first and use `--host_javabase='@local_jdk//:jdk'`, but that did not work at all:

```
ERROR: /build/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/BUILD:82:1: error executing shell command: '/nix/store/l04m8mvir9ljd9dngnkxxgmw83wrxzs2-bash/bin/bash -c set -e;rm -rf bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output;mkd...' failed (Exit 127): bash failed: error executing command
  (cd /tmp/.bazel-1000/bazel_18rkBpuk/out/execroot/io_bazel && \
  exec env - \
    PATH=/nix/store/can00lfiynqkbsdkkmgp6qg8p8w92cxa-bash-4.4-p23/bin:/nix/store/0q4i5ll9gxs6giq7kqkniww934j9j8dk-coreutils-8.30/bin:/nix/store/izhcvddpv3n052wp82zm5s8zcg514kr3-findutils-4.6.0/bin:/nix/store/zzzq8a9af192wfsi7lvf0mndpc8ykp4q-gnugrep-3.1/bin:/nix/store/4q0b6gz1yvb4bdzfcbyicz3vmlq05nxa-gnused-4.5/bin:/nix/store/c2czqxjf05amp81si5lvjxswx2bd7j6a-which-2.21/bin \
  /nix/store/l04m8mvir9ljd9dngnkxxgmw83wrxzs2-bash/bin/bash -c 'set -e;rm -rf bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output;mkdir bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/libbootstrap.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/libskylark-deps.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn third_party/auto/auto-value-1.5.4.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn third_party/error_prone/error_prone_annotations-2.2.0.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn third_party/guava/guava-25.1-jre.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn third_party/jcip_annotations/jcip-annotations-1.0-1.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn third_party/jsr305/jsr-305.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
unzip -qn bazel-out/host/bin/src/main/java/com/google/devtools/build/lib/shell/libshell-skylark.jar -d bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
external/local_jdk/bin/jar cmf bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_MANIFEST.MF bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar -C bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output .
touch bazel-out/host/bin/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/bootstrap_deploy.jar.build_output
')
Execution platform: @bazel_tools//platforms:host_platform
```

`@local_jdk` looks like a magic repository, from what I’ve seen it also has special support in bazel source code. Maybe it’s still the way to go.

@mboes @uri-canva @guibou, maybe you can find a way to get this to work.