### PR TITLE
getdns: 1.4.2 -> 1.5.0, stubby: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/development/libraries/getdns/default.nix
+++ b/pkgs/development/libraries/getdns/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   pname = "getdns";
   name = "${pname}-${version}";
-  version = "1.4.2";
+  version = "1.5.0";
 
   src = fetchurl {
-    url = "https://getdnsapi.net/releases/${pname}-1-4-2/${pname}-${version}.tar.gz";
-    sha256 = "100fzjpvajvnv0kym8g5lkwyv8w8vhy7g2p0pb2gyz19zqnvi18n";
+    url = "https://getdnsapi.net/releases/${pname}-1-5-0/${pname}-${version}.tar.gz";
+    sha256 = "577182c3ace919ee70cee5629505581a10dc530bd53fe5c241603ea91c84fa84";
   };
 
   nativeBuildInputs = [ libtool m4 autoreconfHook automake file ];

--- a/pkgs/tools/networking/stubby/default.nix
+++ b/pkgs/tools/networking/stubby/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   pname = "stubby";
   name = "${pname}-${version}";
-  version = "0.2.3";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "getdnsapi";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1n02dj1hvh0aml54asxj42f0j9wfgiyavbh0gr0j9lm4f2xcd60w";
+    sha256 = "1c0jqbxcrwc8kvpx7v0bmdladf20myyi2672r2r87m2q0jvsmgpr";
   };
 
   nativeBuildInputs = [ libtool m4 libbsd libyaml autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Bumping together since getdns apparently includes
stubby 0.2.4 for whatever reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---