### PR TITLE
pasystray: 0.7.0 -> 0.7.1, cleanup

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -1,37 +1,25 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, makeWrapper, pkgconfig
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, wrapGAppsHook
 , gnome3, avahi, gtk3, libappindicator-gtk3, libnotify, libpulseaudio
 , xlibsWrapper
 }:
 
 stdenv.mkDerivation rec {
   name = "pasystray-${version}";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "christophgysin";
     repo = "pasystray";
     rev = name;
-    sha256 = "0cc9hjyw4gr4ip4lw74pzb1l9sxs3ffhf0xn0m1fhmyfbjyixwkh";
+    sha256 = "0xx1bm9kimgq11a359ikabdndqg5q54pn1d1dyyjnrj0s41168fk";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook wrapGAppsHook ];
   buildInputs = [
-    autoconf automake makeWrapper
     gnome3.defaultIconTheme
     avahi gtk3 libappindicator-gtk3 libnotify libpulseaudio xlibsWrapper
+    gnome3.gsettings-desktop-schemas
   ];
-
-  preConfigure = ''
-    aclocal
-    autoconf
-    autoheader
-    automake --add-missing
-  '';
-
-  preFixup = ''
-    wrapProgram "$out/bin/pasystray" \
-      --prefix XDG_DATA_DIRS : "${gnome3.defaultIconTheme}/share:$GSETTINGS_SCHEMAS_PATH"
-  '';
 
   meta = with stdenv.lib; {
     description = "PulseAudio system tray";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---