### PR TITLE
pythonPackages.dockerfile-parse: init at 0.0.13

### DIFF
--- a/pkgs/development/python-modules/dockerfile-parse/default.nix
+++ b/pkgs/development/python-modules/dockerfile-parse/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, six, pytestcov, pytest }:
+
+buildPythonPackage rec {
+  version = "0.0.13";
+  pname = "dockerfile-parse";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p0x81q3m3nlj4rqal9a959xcbjhncb548wd4wr3l7dpiajqqc9c";
+  };
+
+  postPatch = ''
+    echo " " > tests/requirements.txt \
+  '';
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytestcov pytest ];
+
+  meta = with stdenv.lib; {
+    description = "Python library for parsing Dockerfile files";
+    homepage = https://github.com/DBuildService/dockerfile-parse;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1699,6 +1699,8 @@ in {
 
   docker = callPackage ../development/python-modules/docker {};
 
+  dockerfile-parse = callPackage ../development/python-modules/dockerfile-parse {};
+
   docker-py = disabledIf isPy27 (callPackage ../development/python-modules/docker-py {});
 
   dockerpty = callPackage ../development/python-modules/dockerpty {};


### PR DESCRIPTION
###### Motivation for this change

A generally useful library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

