### PR TITLE
fwupd: 1.2.1 -> 1.2.3

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -15,6 +15,19 @@ let
       mkName = p: "pki/fwupd/${baseNameOf (toString p)}";
       mkEtcFile = p: nameValuePair (mkName p) { source = p; };
     in listToAttrs (map mkEtcFile cfg.extraTrustedKeys);
+
+  # We cannot include the file in $out and rely on filesInstalledToEtc
+  # to install it because it would create a cyclic dependency between
+  # the outputs. We also need to enable the remote,
+  # which should not be done by default.
+  testRemote = if cfg.enableTestRemote then {
+    "fwupd/remotes.d/fwupd-tests.conf" = {
+      source = pkgs.runCommand "fwupd-tests-enabled.conf" {} ''
+        sed "s,^Enabled=false,Enabled=true," \
+        "${pkgs.fwupd.installedTests}/etc/fwupd/remotes.d/fwupd-tests.conf" > "$out"
+      '';
+    };
+  } else {};
 in {
 
   ###### interface
@@ -55,6 +68,15 @@ in {
           Installing a public key allows firmware signed with a matching private key to be recognized as trusted, which may require less authentication to install than for untrusted files. By default trusted firmware can be upgraded (but not downgraded) without the user or administrator password. Only very few keys are installed by default.
         '';
       };
+
+      enableTestRemote = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable test remote. This is used by
+          <link xlink:href="https://github.com/hughsie/fwupd/blob/master/data/installed-tests/README.md">installed tests</link>.
+        '';
+      };
     };
   };
 
@@ -78,7 +100,7 @@ in {
         '';
       };
 
-    } // originalEtc // extraTrustedKeys;
+    } // originalEtc // extraTrustedKeys // testRemote;
 
     services.dbus.packages = [ pkgs.fwupd ];
 

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -40,7 +40,7 @@ in {
 
       blacklistPlugins = mkOption {
         type = types.listOf types.string;
-        default = [];
+        default = [ "test" ];
         example = [ "udev" ];
         description = ''
           Allow blacklisting specific plugins

--- a/nixos/tests/fwupd.nix
+++ b/nixos/tests/fwupd.nix
@@ -9,6 +9,7 @@ import ./make-test.nix ({ pkgs, ... }: {
   machine = { pkgs, ... }: {
     services.fwupd.enable = true;
     services.fwupd.blacklistPlugins = []; # don't blacklist test plugin
+    services.fwupd.enableTestRemote = true;
     environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
     environment.variables.XDG_DATA_DIRS = [ "${pkgs.fwupd.installedTests}/share" ];
     virtualisation.memorySize = 768;

--- a/nixos/tests/fwupd.nix
+++ b/nixos/tests/fwupd.nix
@@ -8,6 +8,7 @@ import ./make-test.nix ({ pkgs, ... }: {
 
   machine = { pkgs, ... }: {
     services.fwupd.enable = true;
+    services.fwupd.blacklistPlugins = []; # don't blacklist test plugin
     environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
     environment.variables.XDG_DATA_DIRS = [ "${pkgs.fwupd.installedTests}/share" ];
     virtualisation.memorySize = 768;

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -17,7 +17,6 @@ prefix only to `make install`, but Meson does not support anything like that.
 Until we manage to convince Meson to support install flags, we need to create
 our own install flag.
 ---
- data/installed-tests/meson.build | 2 +-
  data/meson.build                 | 4 ++--
  data/pki/meson.build             | 8 ++++----
  data/remotes.d/meson.build       | 6 +++---
@@ -25,19 +24,8 @@ our own install flag.
  meson_options.txt                | 1 +
  plugins/redfish/meson.build      | 2 +-
  plugins/uefi/meson.build         | 2 +-
- 8 files changed, 19 insertions(+), 12 deletions(-)
+ 7 files changed, 18 insertions(+), 11 deletions(-)
 
-diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
-index eb33fa9f..b32ecb30 100644
---- a/data/installed-tests/meson.build
-+++ b/data/installed-tests/meson.build
-@@ -52,5 +52,5 @@ configure_file(
-   output : 'fwupd-tests.conf',
-   configuration : con2,
-   install: true,
--  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
-+  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
- )
 diff --git a/data/meson.build b/data/meson.build
 index 8dd2ac9a..d4ad1cbc 100644
 --- a/data/meson.build

--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,4 +1,4 @@
-From 2fe9625cc6dec10531482a3947ef75009eb21489 Mon Sep 17 00:00:00 2001
+From 44887227f7f617cbf84713ec45685cb4999039ff Mon Sep 17 00:00:00 2001
 From: Jan Tojnar <jtojnar@gmail.com>
 Date: Tue, 30 Oct 2018 22:26:30 +0100
 Subject: [PATCH] build: Add option for installation sysconfdir
@@ -17,17 +17,29 @@ prefix only to `make install`, but Meson does not support anything like that.
 Until we manage to convince Meson to support install flags, we need to create
 our own install flag.
 ---
- data/meson.build            | 4 ++--
- data/pki/meson.build        | 8 ++++----
- data/remotes.d/meson.build  | 6 +++---
- meson.build                 | 6 ++++++
- meson_options.txt           | 1 +
- plugins/redfish/meson.build | 2 +-
- plugins/uefi/meson.build    | 2 +-
- 7 files changed, 18 insertions(+), 11 deletions(-)
+ data/installed-tests/meson.build | 2 +-
+ data/meson.build                 | 4 ++--
+ data/pki/meson.build             | 8 ++++----
+ data/remotes.d/meson.build       | 6 +++---
+ meson.build                      | 6 ++++++
+ meson_options.txt                | 1 +
+ plugins/redfish/meson.build      | 2 +-
+ plugins/uefi/meson.build         | 2 +-
+ 8 files changed, 19 insertions(+), 12 deletions(-)
 
+diff --git a/data/installed-tests/meson.build b/data/installed-tests/meson.build
+index eb33fa9f..b32ecb30 100644
+--- a/data/installed-tests/meson.build
++++ b/data/installed-tests/meson.build
+@@ -52,5 +52,5 @@ configure_file(
+   output : 'fwupd-tests.conf',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
++  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
+ )
 diff --git a/data/meson.build b/data/meson.build
-index 8dd2ac9ad..d4ad1cbc1 100644
+index 8dd2ac9a..d4ad1cbc 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -9,7 +9,7 @@ if get_option('tests') and get_option('daemon')
@@ -49,7 +61,7 @@ index 8dd2ac9ad..d4ad1cbc1 100644
  
  install_data(['metadata.xml'],
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index eefcc9142..dc801fa18 100644
+index eefcc914..dc801fa1 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
 @@ -4,14 +4,14 @@ if get_option('gpg')
@@ -85,7 +97,7 @@ index eefcc9142..dc801fa18 100644
  endif
  
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index 824291fc5..d0599a00a 100644
+index 824291fc..d0599a00 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
 @@ -3,7 +3,7 @@ if get_option('daemon') and get_option('lvfs')
@@ -113,10 +125,10 @@ index 824291fc5..d0599a00a 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build
-index 737841f1a..23bd7a2e3 100644
+index b6df98b3..d672ee37 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -144,6 +144,12 @@ localstatedir = join_paths(prefix, get_option('localstatedir'))
+@@ -145,6 +145,12 @@ localstatedir = join_paths(prefix, get_option('localstatedir'))
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -130,7 +142,7 @@ index 737841f1a..23bd7a2e3 100644
  if gio.version().version_compare ('>= 2.55.0')
    conf.set('HAVE_GIO_2_55_0', '1')
 diff --git a/meson_options.txt b/meson_options.txt
-index 23ef8cdb8..db8f93b6c 100644
+index 23ef8cdb..db8f93b6 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -17,6 +17,7 @@ option('plugin_uefi', type : 'boolean', value : true, description : 'enable UEFI
@@ -142,10 +154,10 @@ index 23ef8cdb8..db8f93b6c 100644
  option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')
  option('efi-cc', type : 'string', value : 'gcc', description : 'the compiler to use for EFI modules')
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index 288f614e4..90cfe6484 100644
+index ef07bd81..d2c7e259 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -22,7 +22,7 @@ shared_module('fu_plugin_redfish',
+@@ -25,7 +25,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
@@ -155,10 +167,10 @@ index 288f614e4..90cfe6484 100644
  
  if get_option('tests')
 diff --git a/plugins/uefi/meson.build b/plugins/uefi/meson.build
-index c037e1b30..a0e8cd3e6 100644
+index 09ebdf82..02fc0661 100644
 --- a/plugins/uefi/meson.build
 +++ b/plugins/uefi/meson.build
-@@ -69,7 +69,7 @@ executable(
+@@ -73,7 +73,7 @@ executable(
  )
  
  install_data(['uefi.conf'],
@@ -167,3 +179,5 @@ index c037e1b30..a0e8cd3e6 100644
  )
  
  if get_option('tests')
+-- 
+2.19.1

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -48,7 +48,6 @@ in stdenv.mkDerivation {
 
     patchShebangs .
     substituteInPlace data/installed-tests/fwupdmgr.test.in --subst-var-by installedtestsdir "$installedTests/share/installed-tests/fwupd"
-    substituteInPlace data/installed-tests/meson.build --replace sysconfdir sysconfdir_install
   '';
 
   # /etc/os-release not available in sandbox

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     sha256 = "11qpgincndahq96rbm2kgcy9kw5n9cmbbilsrqcqcyk7mvv464sl";
   };
 
-  outputs = [ "out" "dev" "devdoc" "man" "installedTests" ];
+  outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
 
   nativeBuildInputs = [
     meson ninja gtk-doc pkgconfig gobject-introspection intltool glibcLocales shared-mime-info
@@ -48,6 +48,9 @@ in stdenv.mkDerivation {
 
     patchShebangs .
     substituteInPlace data/installed-tests/fwupdmgr.test.in --subst-var-by installedtestsdir "$installedTests/share/installed-tests/fwupd"
+    substituteInPlace meson.build \
+      --replace "plugin_dir = join_paths(libdir, 'fwupd-plugins-3')" \
+                "plugin_dir = join_paths('${placeholder "out"}', 'fwupd_plugins-3')"
   '';
 
   # /etc/os-release not available in sandbox

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -8,7 +8,7 @@
 }:
 let
   # Updating? Keep $out/etc synchronized with passthru.filesInstalledToEtc
-  version = "1.2.1";
+  version = "1.2.3";
   python = python3.withPackages (p: with p; [ pygobject3 pycairo pillow ]);
   installedTestsPython = python3.withPackages (p: with p; [ pygobject3 requests ]);
 
@@ -19,10 +19,10 @@ in stdenv.mkDerivation {
   name = "fwupd-${version}";
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "126b3lsh4gkyajsqm2c8l6wqr4dd7m26krz2527khmlps0lxdhg1";
+    sha256 = "11qpgincndahq96rbm2kgcy9kw5n9cmbbilsrqcqcyk7mvv464sl";
   };
 
-  outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
+  outputs = [ "out" "dev" "devdoc" "man" "installedTests" ];
 
   nativeBuildInputs = [
     meson ninja gtk-doc pkgconfig gobject-introspection intltool glibcLocales shared-mime-info
@@ -48,6 +48,7 @@ in stdenv.mkDerivation {
 
     patchShebangs .
     substituteInPlace data/installed-tests/fwupdmgr.test.in --subst-var-by installedtestsdir "$installedTests/share/installed-tests/fwupd"
+    substituteInPlace data/installed-tests/meson.build --replace sysconfdir sysconfdir_install
   '';
 
   # /etc/os-release not available in sandbox
@@ -103,6 +104,7 @@ in stdenv.mkDerivation {
       "fwupd/remotes.d/lvfs-testing.conf"
       "fwupd/remotes.d/lvfs.conf"
       "fwupd/remotes.d/vendor.conf"
+      "fwupd/remotes.d/fwupd-tests.conf"
       "pki/fwupd/GPG-KEY-Hughski-Limited"
       "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
       "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk-doc, pkgconfig, gobject-introspection, intltool
+{ stdenv, fetchurl, substituteAll, gtk-doc, pkgconfig, gobject-introspection, intltool
 , libgudev, polkit, libxmlb, gusb, sqlite, libarchive, glib-networking
 , libsoup, help2man, gpgme, libxslt, elfutils, libsmbios, efivar, glibcLocales
 , gnu-efi, libyaml, valgrind, meson, libuuid, colord, docbook_xml_dtd_43, docbook_xsl
@@ -6,17 +6,20 @@
 , shared-mime-info, umockdev, vala, makeFontsConf, freefont_ttf
 , cairo, freetype, fontconfig, pango
 }:
+
+# Updating? Keep $out/etc synchronized with passthru.filesInstalledToEtc
+
 let
-  # Updating? Keep $out/etc synchronized with passthru.filesInstalledToEtc
-  version = "1.2.3";
   python = python3.withPackages (p: with p; [ pygobject3 pycairo pillow ]);
   installedTestsPython = python3.withPackages (p: with p; [ pygobject3 requests ]);
 
   fontsConf = makeFontsConf {
     fontDirectories = [ freefont_ttf ];
   };
-in stdenv.mkDerivation {
-  name = "fwupd-${version}";
+in stdenv.mkDerivation rec {
+  pname = "fwupd";
+  version = "1.2.3";
+
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
     sha256 = "11qpgincndahq96rbm2kgcy9kw5n9cmbbilsrqcqcyk7mvv464sl";
@@ -39,15 +42,24 @@ in stdenv.mkDerivation {
   patches = [
     ./fix-paths.patch
     ./add-option-for-installation-sysconfdir.patch
+
+    # installed tests are installed to different output
+    # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle
+    (substituteAll {
+      src = ./installed-tests-path.patch;
+      # needs a different set of modules than po/make-images
+      inherit installedTestsPython;
+    })
   ];
 
   postPatch = ''
-    # needs a different set of modules than po/make-images
-    escapedInterpreterLine=$(echo "${installedTestsPython}/bin/python3" | sed 's|\\|\\\\|g')
-    sed -i -e "1 s|.*|#\!$escapedInterpreterLine|" data/installed-tests/hardware.py
-
     patchShebangs .
-    substituteInPlace data/installed-tests/fwupdmgr.test.in --subst-var-by installedtestsdir "$installedTests/share/installed-tests/fwupd"
+
+    # we cannot use placeholder in substituteAll
+    # https://github.com/NixOS/nix/issues/1846
+    substituteInPlace data/installed-tests/meson.build --subst-var installedTests
+
+    # install plug-ins to out, they are not really part of the library
     substituteInPlace meson.build \
       --replace "plugin_dir = join_paths(libdir, 'fwupd-plugins-3')" \
                 "plugin_dir = join_paths('${placeholder "out"}', 'fwupd_plugins-3')"
@@ -106,7 +118,6 @@ in stdenv.mkDerivation {
       "fwupd/remotes.d/lvfs-testing.conf"
       "fwupd/remotes.d/lvfs.conf"
       "fwupd/remotes.d/vendor.conf"
-      "fwupd/remotes.d/fwupd-tests.conf"
       "pki/fwupd/GPG-KEY-Hughski-Limited"
       "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
       "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"

--- a/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/installed-tests-path.patch
@@ -1,0 +1,25 @@
+--- a/data/installed-tests/hardware.py
++++ b/data/installed-tests/hardware.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python3
++#!@installedTestsPython@/bin/python3
+ # pylint: disable=wrong-import-position,too-many-locals,unused-argument,wrong-import-order
+ #
+ # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+--- a/data/installed-tests/meson.build
++++ b/data/installed-tests/meson.build
+@@ -1,6 +1,6 @@
+ con2 = configuration_data()
+ con2.set('installedtestsdir',
+-         join_paths(datadir, 'installed-tests', 'fwupd'))
++         join_paths('@installedTests@', 'share', 'installed-tests', 'fwupd'))
+ con2.set('bindir', bindir)
+ 
+ configure_file(
+@@ -52,5 +52,5 @@
+   output : 'fwupd-tests.conf',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
++  install_dir: join_paths('@installedTests@', 'etc', 'fwupd', 'remotes.d'),
+ )


### PR DESCRIPTION
###### Motivation for this change

The fwupd NixOS test passes :).

Also this disables the test plugin by default
for a slightly improved default experience.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---