### PR TITLE
pkgs/tcl: Allow cross-compilation

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
 
   setOutputFlags = false;
 
+  # These defines are needed for cross-compiling. See https://groups.google.com/forum/#!topic/comp.lang.tcl/P56Gge5_3Z8
+  ac_cv_func_strtod = if stdenv.hostPlatform.config != stdenv.buildPlatform.config then "yes" else null;
+  tcl_cv_strtod_buggy = if stdenv.hostPlatform.config != stdenv.buildPlatform.config then "1" else null;
+
   preConfigure = ''
     # Note: using $out instead of $man to prevent a runtime dependency on $man.
     configureFlagsArray+=(--mandir=$out/share/man --enable-man-symlinks)


### PR DESCRIPTION
###### Motivation for this change

TCL needs some environment variables to cross-compile successfully

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

