### PR TITLE
edbrowse: Fix compilation against newer libcurl

### DIFF
--- a/pkgs/applications/editors/edbrowse/default.nix
+++ b/pkgs/applications/editors/edbrowse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, duktape, curl, pcre, readline, openssl, perl, html-tidy }:
+{ stdenv, fetchFromGitHub, fetchpatch, duktape, curl, pcre, readline, openssl, perl, html-tidy }:
 
 stdenv.mkDerivation rec {
   name = "edbrowse-${version}";
@@ -6,7 +6,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ curl pcre readline openssl duktape perl html-tidy ];
 
-  patchPhase = ''
+  patches = [
+    # Fix build against recent libcurl
+    (fetchpatch {
+      url = https://github.com/CMB/edbrowse/commit/5d2b9e21fdf019f461ebe62738d615428d5db963.diff;
+      sha256 = "167q8n0syj3iv6lxrbpv4kvb63j4byj4qxrxayy08bah3pss3gky";
+    })
+  ];
+
+  postPatch = ''
     for i in ./tools/*.pl
     do
       substituteInPlace $i --replace "/usr/bin/perl" "${perl}/bin/perl"


### PR DESCRIPTION
###### Motivation for this change

Fixes #53426.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

