### PR TITLE
nix-universal-prefetch: init at 0.2.0

### DIFF
--- a/pkgs/tools/package-management/nix-universal-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-universal-prefetch/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, ruby
+}:
+
+# No gems used, so mkDerivation is fine.
+stdenv.mkDerivation rec {
+  pname = "nix-universal-prefetch";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "samueldr";
+    repo = "nix-universal-prefetch";
+    rev = "v${version}";
+    sha256 = "1id9iaibrm2d3fa9dkcxnb3sd0j1vh502181gdd199a1cfsmzh1i";
+  };
+
+  installPhase = ''
+    mkdir -pv $out/bin
+    cp nix-universal-prefetch $out/bin/nix-universal-prefetch
+    substituteInPlace "$out/bin/nix-universal-prefetch" \
+      --replace "/usr/bin/env nix-shell" "${ruby}/bin/ruby"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Uses nixpkgs fetchers to figure out hashes";
+    homepage = https://github.com/samueldr/nix-universal-prefetch;
+    license = licenses.mit;
+    maintainers = with maintainers; [ samueldr ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22614,6 +22614,8 @@ in
 
   nix-top = callPackage ../tools/package-management/nix-top { };
 
+  nix-universal-prefetch = callPackage ../tools/package-management/nix-universal-prefetch { };
+
   nix-repl = throw (
     "nix-repl has been removed because it's not maintained anymore, " +
     (lib.optionalString (! lib.versionAtLeast "2" (lib.versions.major builtins.nixVersion))


### PR DESCRIPTION
Upstream URL: https://github.com/samueldr/nix-universal-prefetch

###### Motivation for this change

Let's hopefully have users use this!

This software is intended to resolve once and for all the question "but I don't want to TOFU?" (which isn't even a question!) when end-users want to get the hash to use with a specific fetcher.

> For anyone confused by TOFU, one of the quick replies on IRC is:
> > To get a sha256 hash of a new source, you can use the Trust On First Use model: use probably-wrong hash (for example: 0000000000000000000000000000000000000000000000000000) then replace it with the correct hash Nix expected.

This, in addition, could be used with automated scripts to reduce hand-holding when the fetchers aren't simple underneath.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Additionally, I ate my own dogfood when making this PR, and did **not** TOFU the hash, but instead ran:

 ```
nix-universal-prefetch fetchFromGitHub --owner samueldr --repo nix-universal-prefetch --rev v0.1.0
```

---

