### PR TITLE
 thunderbird: 60.3.3 -> 60.4.0 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -21,9 +21,12 @@
 , libX11
 , libXScrnSaver
 , libXcomposite
+, libxcb
+, libXcursor
 , libXdamage
 , libXext
 , libXfixes
+, libXi
 , libXinerama
 , libXrender
 , libXt
@@ -99,10 +102,13 @@ stdenv.mkDerivation {
       kerberos
       libX11
       libXScrnSaver
+      libxcb
       libXcomposite
+      libXcursor
       libXdamage
       libXext
       libXfixes
+      libXi
       libXinerama
       libXrender
       libXt

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "60.3.3";
+  version = "60.4.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ar/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ar/thunderbird-60.4.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "701dd700115a8e869a1231e54b333398a5a393ffca431dfba69bfff7b2e3bfbf5ce3cbef0b40feec8263cd8e93b34704b0ace27694823c8ae7e03bee170a94e5";
+      sha512 = "a019b303ba8a8e7023aac5dadd3d98d6a037fbcd45068a569c4bd1ebf076c057380b358953f9f183dec72264deb5967577e7e1c5a163cfc7813c20c00057a9b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ast/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ast/thunderbird-60.4.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "e3de7987dfbf61df4da34e875ade4e6a9a98fb8405a219dd747a021777b0436b1eb817756e56e35e83206c22ec34820fdca813c5d7b0346d4a0d6b3341d7989c";
+      sha512 = "972929dab62b8ec2d5a96502807e5fcfd3f98bac80d59bcf831d58b0801ae5d3fb9eb8be7df0df97b3d0ea9ba971947ef6f4915444cd3a7904b3cf4ecd0a6af9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/be/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/be/thunderbird-60.4.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "c5695799bf141feb01c5d6cf6bec96c09608512bf182f3f39da394cb5841aea6ba8c7fc5f730d20425598b036b58391a28fffa63f13d77f2f9bdc7151ba4a9c6";
+      sha512 = "f6fdd25e7db61d901d19d0b5801e6bad335d31cc86efa36e0355541d4c5d23e43d8fd6250c37ee121a83133ff5744c52a8db49bedf2d5489e2a7de3bf9885e08";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/bg/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/bg/thunderbird-60.4.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "0f45d0174871d71199299a4d7e9202b3ff17839ac324fe1e66b5c5ec57841f576e97311ccd6a70b1734afca8a8b1d3e2c42703f161b2a93bccabdea9de5a708a";
+      sha512 = "b0f58772f9c9eff3f46f09f65cef3ceeb73d222bb6d7cd8b5869a93f9d82ac5cf0aac4a0b5b03db3f876b16b29ece73f5093c84b358d05c99eede0b9f3ccf8e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/br/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/br/thunderbird-60.4.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "3926254e1d17e67735e48b49afb94a8bdfcea7ee393696058c6775319e3bffed72d1bc5df9e05a07afdbae166a13e4f218dd519a4d6c65f6bb3ca2cd85d19710";
+      sha512 = "748ee265bae785c4507c092c908ceaa8cacf6ae999fe736378592e5befeadee2935e080a6b497af501253073b4ce33805bbe86c711345a716fcd2fb59dd0ca0b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ca/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ca/thunderbird-60.4.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "14e37769be837288dbd72b25d7c714e524289051ea2c01ce1900f1b8198d22f17f8cc8cea0c45739e72fd0fade7f0e18755955a627e837c01258508647afc89c";
+      sha512 = "13826093a503248b7b240752d94476eb83a69726550333d348d4adba9a30424afcbed0274e9b2f1cac02351a401c88d96d2069afbf4b648e873c6e8b9521fe2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/cs/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/cs/thunderbird-60.4.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "e57008bc903675fa2b90c34b4fce32d4534789ccb5779573812e435b1b0c26f0a223364ec0624b8c14082961444b0abc2c56763295d986d9ee7d3276f7ef56c8";
+      sha512 = "bc92d55b8d19072cedff98ae53df9fa62035072b1b80096fc8d5e41768540a2fd26d5918751754157f6fee00e392f436a1ef81614e68b65b1d7a02bc24f49d26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/cy/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/cy/thunderbird-60.4.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "67a2602230acb81d2e0d72ae266e1dba18a3f31a87f770e6f8e454c9acf6ae7def7db334cedcf8e4ea766a116998d0dbbeb05116674af692c96a9c2295b1d5fc";
+      sha512 = "c84df29c23943f9e48e9a89ea3e882c944709edab523b51477cef5a5a96789f4e458b6494f8da1d3763aeb804370bd07c2bf54b97db119b1b12e5545b2970c7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/da/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/da/thunderbird-60.4.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "729b8230f1699bef030c69903ef9d8e1104f9941deeb539d1ab4d340b76ac276ce9024ae5aec8dc8b7b1077afa3a5f5bdea2cb0f709ae5a4fa95e08af1d6cc7f";
+      sha512 = "eba14388e67188ac737593b5dc3588af8a3fcbed8bf39b0bd7b39aa1fe2ab67c2d50dc15eb4393ef45c1118a4993368d5d1077067741bad787cd228cd77ee03e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/de/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/de/thunderbird-60.4.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "25b89e8434f887268b25a6a29f39c685eb20fd46a8c5b171cd21fc1229db4ef24a6a864c4eaf51d7e07494c96f5f3b8a86e03c1a8d6a98f92e24f964e83cc7ca";
+      sha512 = "d1211046c3e90e639d8a8b467186fee08bbcbdc1f86653a5e40e5959e0f0b951f7d2b7fe16a658f5ace6bbc588eeb31b3372a7216f38bb837e74d1b9333c1c15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/dsb/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/dsb/thunderbird-60.4.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "9c8436699fd04b7a7b0cd52c63711f313e43799f4ac13672a8f320cf805c9c580b3dc686c66eef3d547e268f25ce0532c1456a012b0165886b1c8476ba41e464";
+      sha512 = "94c0eb7d40c5e8f9900e914fb39f2ff098d5fc3e9e07c57c1c704e12636929777afa18bc2069dea272f1d06d682dbc248fd607aaf888116e7ac1412de1331801";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/el/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/el/thunderbird-60.4.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "8db67ce9fec63f21decaa02f739db70e0d3a6adc4787925c8be91f9b8450d9e264a236c81e6e80c41a5955a8dcc52ebcafbee959eeb8d6a461057ba2c118ae14";
+      sha512 = "cddc236e7462a979b7b5f3cd256d0cc1866900544babd254b6dc6c685b778bfcd4138586108d9a4a2299912e6a22b8b695920dd1d5fe629b8a003c79fa011aec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/en-GB/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/en-GB/thunderbird-60.4.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "a901a62b44e0ef53fa66cd81e94fe6c6b044829d95020aa8e2d8ffc88e71e650fa564cea217de2fd2a18859b67275640021a8828e2684f9475a31e6131f10b7f";
+      sha512 = "29e9de49a648bcfd21754839b5c2d046efbf3a364471d8b616bd229a134e0cc9033f8be0b43261e470511049d6785903a6120e06ef1b3e3f6338d8fff91f73a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/en-US/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/en-US/thunderbird-60.4.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "a57f55f3383d1e584db53ff45a6bcfc8135eaea5976066bcddb4b2ac12eaaf5c5751b1d0a3f771177123ff359a0e1bfdc904a2c1252a2762e440089c8e1271f3";
+      sha512 = "801676c0c93fd0d6730b5c4719a45888916210d8f65b06eb7b416dc596bed7a0ad2ae79cf11307167c0918b5a60ccbb4ba62e4e1c891c831817d3748f91d7221";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/es-AR/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/es-AR/thunderbird-60.4.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "55f301cce9dabc9708ae4b7b9c033ee1856b9e0eeb9cf95d745c710bc15d1b15fcd8a079c20c3b58418fc05175e39e8e68e6bde3788d540ef660fb6ad41e5276";
+      sha512 = "0ef743e0ffd7066d939d790c6353da95f3dd50e2f8b06c2b55a35e0a2e4a7ff0cb5b0259d3053582c4158894a24576818177c027dfce9e46099247985665abd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/es-ES/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/es-ES/thunderbird-60.4.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "cbdad6a6941058963d5be128b4bc54c529474d6fb1b3597d2f26d153724bdba3001369286baa010c3e2743b53c17ecc92885182b9d3a8914630d429f07f47589";
+      sha512 = "72bfecb6beb6593682b802ffeb4b6d0a966d29b4fa7fd963a8777c8c93a4d885eb4e8b23a92b1cd80c9eca393ec4f61ce5d98a81ab1e1884dbd17ac1507687da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/et/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/et/thunderbird-60.4.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "5fbe4472969925bf0990c18e9189f7b4c2fa80746556368f70a42d9f89ada51238db58577cd79931a52669ea899c8d976267e25fd3efb5987a74153953ff5b4f";
+      sha512 = "04705b753aa58d6cab34930afc29732f258f5ae469380e069e25ead1a4ab23b22e57078423fb72c52fc0c1aa50b640dc3a1d68964d9a2f85dc6a5b231438dfcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/eu/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/eu/thunderbird-60.4.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "efec50555d94f74e4f45352be31665c25ee1fa115101eb847dee9e4552b7725f4d9f3c04f4d20fce3bb3b12d8b2e4f27761d412237e47f5a7476adc13085b282";
+      sha512 = "a712556ed8c5c51c9ca7395a9efcdff777aadab376a4427b4c65e364735e615f8ab80212f8edcc04c7b94a3fea95f8714f9ddf74d3d3036ed1d9761b44e3602d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/fi/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/fi/thunderbird-60.4.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "b16e7d32b7eedd42e6cb253227b7266d1ad6fd96e9c875bd1a3d5184e01ee8016a0aaf9569183055c0044997464ad076b25f83a2b786945cc97a5415b04557ee";
+      sha512 = "570177aaa32070f1dff8b3e6c011fe57946604b67aab53caf075110df6f3fd3fdfc42da25688ba3a07deadae31467377e147ab2cbd1a17fa182316584b9e1fb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/fr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/fr/thunderbird-60.4.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "719a81fedd43423beac6ddf1c9fdf13af7e9c784639f018483dd11a72d07c1c5249e8878c0c40a31ec95f7eca417121bde466e78d8fcc54ebeb67f50bf8d0a9f";
+      sha512 = "9785db7b9466417a4c9db7272ca8f94fe74bc02cfa6e40c4a8bea4efeb83b121f392c5f16225856cc0e4b59f874653b43a00ac06e3727d9e0ad385b7cdb5f68c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/fy-NL/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/fy-NL/thunderbird-60.4.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "92850ab9e552ea81de90c2973e819bf55bba46dfbf05c665188e119e6720258eabc3031318163e83490a50f749b079471de783efd3e6eec535795c71bdc9437f";
+      sha512 = "d2b514b072b4a3437d4258ae280526f1a32ed3fd9b44dd53f3765e7423807e79305f39df42f55e84a2379a3391e76f07f54d06e3a6dbe300f7997db5a50e2699";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ga-IE/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ga-IE/thunderbird-60.4.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "711463c9179391eae973ba28be2e8a9c86063788f197d97774fc678e1264bb248425b16b51cd1bfb52c3ca9bcf30e1c3ccaba6afa64805400355d9e69cf84e12";
+      sha512 = "a1c257e97fda208236ecb3e894d7a644ef022d7b20f9aa93e038f6d3b1251b2d81da1b4ab8d4154048fa5b6938f623ed3d4c20faf85497b982851232e23f833e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/gd/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/gd/thunderbird-60.4.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "4b6417e50491e424297321f01d57c3117b99326a0c789821fae2c1ab6d2d08c9a7cb5be95dfddf6d6ba8ef2fbc65f20f51fade5905ad441403d36a513ac39352";
+      sha512 = "7585d60bc9a4c09ab4f07eb84e448b2e5b1a8aaceec274aba5e373fd5c60a464a66f907c6e6e828f767d746cdb9ef93220c5dbdb91e0acdfdff2f55946ee3f7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/gl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/gl/thunderbird-60.4.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "ed1667b91c509d08d732661acac86fdca2a3ea0cea4b3b79b283f713669b971afc6dcf72f7f82946eaf115ae51ac16a30e3804bab2a0723b17f4323c3a3d2b8f";
+      sha512 = "e4919333b959597a77aa1bf3b62acaad4b8054743dd2ede3c91ffd52b2fc2a28d40cb4dc98c2ecf8e22012ec3435df0dde1f2e5306c2240adb967d3bc4f7914c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/he/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/he/thunderbird-60.4.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "37502da5dfa5ae9b0751e17c44e217e28572492474cd9e3d913bf93bd48b6a0478a9d9ab3968ef7c18fc396b4eb5d80bdbd2ffdbb5fa5ab4d577792a4bb65257";
+      sha512 = "9c938d49b2a2264a04d35c0940743792d7c6f3be716b54922cad166a5550828f91ea3cc1fdf3e5375c0f2ec7c5ff2152c0883da3e6499f87aec127b92a279b58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/hr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/hr/thunderbird-60.4.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "8852bfda07df16ee1efc1a11b670ca1be2a6ab52696d7b1e0e9ca481cf6ed766c79f7c3eca5e4ea3a62b96b8edd669c4f36617dff062c121506fa59778de580e";
+      sha512 = "f1f56e61775331602788eeee5d9a7d1b612c2618afa18d024b694859a8d19cb0c51425736bc7ada62297f129a41bd5788511afa52ebe393b8d1a452025d4a273";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/hsb/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/hsb/thunderbird-60.4.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "4d9ef9914bc58096e47d3a36dd9c5a618f9f559da4753670607a7121dfd626261712bc668388d6ab78248e089b50291968275cb10c6279442fd6c8b4dfee55e6";
+      sha512 = "ffef22e9ca45dcde83d288d02bcaa132768ec63f73aa9e2c517c5438aa0ce5cced73ac18abd4084d70349b4d8a5bcadef9cff376ad82866807228c982a229bad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/hu/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/hu/thunderbird-60.4.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "4d3e6dc8fa59ba91687612ab8b643629cd28e4474b3d33ee9d8911245c8a65c9a197a5102702a8b0fffae74969ae7d3fb7346da9e8f72c55811115667dc1d289";
+      sha512 = "a8d9fa686546dd86135d62bece772773486df999af266144e581c0e1aec6ba815a549c2bd042f5aa480270cf9d8fc5bf6fe8c875a99ab16dceb276f44eb45f76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/hy-AM/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/hy-AM/thunderbird-60.4.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "cd392f821439c31ff6eb23329bf59a484a8dfc5bd3755c16e5d40b7e870cc228a4ef7f5022b826786ccc03c827bad2d26997b3ef50483de341384903ffd63d42";
+      sha512 = "d6951e1839b728a603604b3b82556079f933474e25dba69a8227d6acb651d10a3f30c4157f8ba4a2f27127b155e8cc4b86ff35db1df4b594a18bf85c1ab81fb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/id/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/id/thunderbird-60.4.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "0cc11617865d196ee6e693881beaa7535940d8b3a6a4d622912c5925d1f75358c8c6e5a1a9898b1cce08fde343c8cee71bb52713c4f34f5dc5b1df7b1870bad6";
+      sha512 = "458389e7f105ec2e2737dce80b0bc73368f0333104bf1f7b5deb579658ac28e7afd970d4b3b3deeea42150d78b6a091f9249fb1dd9c41a24486381b66992e3a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/is/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/is/thunderbird-60.4.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "5f38c7e43a5fd40b7c54a601ac8604e943c60eff907414b5b3c7537381b9dbeaefac496c351191a29396f7b0ff7be6ddccf059768a488f44f0d41dbace282edc";
+      sha512 = "34e940c7773ab363306f537a02d8fea4051bda5607c1153605867ed084a37109267e97b78572895e1623396bbc55df6aab16d2d4c42840562ace04ee688e650f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/it/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/it/thunderbird-60.4.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "fdb8ea55a3bb7264308113a3efdb18e4d5d6e85bf34a3ca37cad8bc77d9b8d68c1a19443d56f7affc8bf53eec1f799a4afef40e29ee05584d4848ad2ee7de433";
+      sha512 = "9d9f8c1603f6601b4bced591561a83daadf4cb0b0c9626c30b5de6c340332bb7efdcd247c664b5aeab006ec1fd3b345950b9e2cb7cf8a328181ae8d83ad20e6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ja/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ja/thunderbird-60.4.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "e6d9766ce3e6d3252f1ee69314ed7c8431947971fb7cf30fe6917969f5e8a4d98d3840606cf74ed8a37122e6a4ffb68f3a1d3dafe8055a4733881438220336be";
+      sha512 = "c0aa7beff6e4a800af6668d550b5d86cfc7fbb56295c3a6e1d60e1edde509c448fe25eb7e501dc76eb84f9d2e54fca91525cebf38ee62fe383c4f477bffaa64a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/kab/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/kab/thunderbird-60.4.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "0abb97159627d30bcd5eb2ff5765ea7b108c52cf95b43b2e06c3a7b793a07956eac63f31adc6ee9655958ec4dc4c27de777705eb7dc0be2f9d8cb3fa6d733fc6";
+      sha512 = "37cd893e7338fd9f231166fbca5be4afdc799d99f7ce7ee438c79246374b7d32463cdf0dc4c5e549d45789744c8aecb79c05ed6804a0bb494b901bd9b1bfdf8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/kk/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/kk/thunderbird-60.4.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "3def422ec663c376dc3c3d79b139933dee1a720447c965d59b46f6e45e0adb7b3435dd6cafd1be842486d68e2b84e0fd245768082fa3d9cb82b120929a6f2290";
+      sha512 = "ea67e30da91c0e7b00b00819e9cc4ac422bd27acba891fe7fd4a4d01873d2e8f78eb290d94c6448fedd41a13d3cd384af88f5f0104644234904315b49893afe3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ko/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ko/thunderbird-60.4.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "27d16aaa29ee4bc0a70b4b19752df46358231f27066e6c3d9f65eb26c7d1ae02ed6f6b7e53dc26e69f554755f7614ece7b87d819c1139f3666206df3080515f3";
+      sha512 = "977840d0ad8dc9b5c150c88b5efb71f7e6680c293a9a8e3818c1017839428c6f95f23e55d1d11e0ab7a4857fe6b903dd6fd53d6bf613b9e6d2484a3d18b8aa7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/lt/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/lt/thunderbird-60.4.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "7d789bdc48e1dc105224b74db02dcdf95471c1eb40f7b7cff292c3547ac0004fcf7639bfbb7d55ae8620451cb1cd41c614780ce73e563f39d5554d2962cc4f4c";
+      sha512 = "bae16fb6b6313a674caedb23e72a405cf6c593c6a78ac17499d8933b7e7b2e6c574f8e741a3e9938f9cfe08de42161b8fb48a3e1f89d8909ad637b60cca02068";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ms/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ms/thunderbird-60.4.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "8fa38bf73b041117c847138d7ece1d6ef894456c07c38fcb637154f05a060fcd4b3ec818aa0e9e2f2df574e76a36139731b76c6a3c33a210347665a085379368";
+      sha512 = "9190663d68659c2cff0035f8e3529af319319d52d52428309dd4db1b126cd8d50430a4d0dc53871f2fd2655481cb2a686d3783557d1fe56a3372ffbf87768f0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/nb-NO/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/nb-NO/thunderbird-60.4.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "4efab83bb702d0e18f99ee35ac198d3c3fd1fd21c7779fec5f3472c97cdd1794d574af6c1dbfe92318a070cfc4a07b8c757a0b105c4eac7a6cdf458c37de243f";
+      sha512 = "329e16a7ea6c276fb440c7520630ce0efb4bafc839bf7f76623dd7760945ea1de4e90a11c693103af01c9028b1d25855c8714d657054ff5c87c6583f4f46155f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/nl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/nl/thunderbird-60.4.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "1fbc90399a8a082dd256a37eaa3aab8acbec6ec7558d08421dc74c00f185f026e2e470e15257f7150a11c4540e47c0494ea6b80718eac510d5c3811ce19a52ea";
+      sha512 = "c436254eb879af47190943b506540b6a189c15032a9cda570170460a050157b3d1117583d3d6bf280ec3f8445d7852a99fe57a1f19b489d48d137af74e00f375";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/nn-NO/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/nn-NO/thunderbird-60.4.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "df80568600dd2ceecdb0ecaeec17223a54bf2f0bfb1ebf081628294329c3b14f4e190f9678c661d61cd2d9dbbb3b61b8eda82ae25268a88aad719110bf566b62";
+      sha512 = "0a28f44223c884720d2abc4790300c23743f641b26bd0c5e0b1554c81dd903d603ad5c6b41d408a1409304b8ac87c36d25581d0791e2804e4488429c8e3cdd82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/pl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/pl/thunderbird-60.4.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "4c705c98abad6160f39aa8ab80296e9c69a5abc830f72d52538941460e793f63442df84f3d20762c605202f3e18b7cad3638b99c34af4c7acdaec04ab3868ac8";
+      sha512 = "5a1b28f24365193621cf8eef065df9e12f7af7b5cccf100d9b4bd2c5d1bcaa3cb5bea598fbf28e49ffb7c3f7207c8dad361da87ddcebc6014d75381dcdc19afe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/pt-BR/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/pt-BR/thunderbird-60.4.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "c1d22acb77d39b3085d8f03755877d2f075805bee3d926ecf11f71c93d4b88237bc0dd377ebd3c512d46470f98cfb7d112301d576c71f07ad922a52943188873";
+      sha512 = "08419a174a58adce9b10f899bb51789a3d1e9278980680aae1d7af8eeccd9af55572e716ef5085b04a611528398a64739de3c62b10d26c8027bc6d8b6e83b921";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/pt-PT/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/pt-PT/thunderbird-60.4.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "1809f4b6bd289c394393af2302722afaae025c07699ed5e5815fbf946c0fad516316610ebf7ee90f9c0f0bf98a502c93bf206b4f151121e10cf295ed9d0f048b";
+      sha512 = "e576600a0ef18277283da642f3bc2340387e0c778807eed362df9e24db84c133bfc9531b03749fa437e0fde4284bc9d537dafa10e8e810af9038ae6d712548e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/rm/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/rm/thunderbird-60.4.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "552086eef3449a1dfab00c817197a0fd2c5a31c84f6cdc26600075939c356713c8bd955517bff00f29a80b43c7e9d508693b52803c356f794efb9d503ce2b6d6";
+      sha512 = "ae787ff0eb4f4de7595761f0326dba3e0cd545a80ea3871e527abe87f5da6d63fa5fb043cac17e43eabbd99529c67769aa274b998ffc0965c0643a556054566c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ro/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ro/thunderbird-60.4.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "6b1f5c3627d8599345ddbdbec602d9dc92163caf31c213a8f274f5cf57225d9045d67627c2b66fc8c74685bc4c0b5b24f3b5712b521dac47024ce0bba1baeac2";
+      sha512 = "f59048b2ed7c32092a7de5a3b29f030647e50e4aeac8a6c273cb32435a60e3eeab880a48e4c02bc5047f4c8e7b932a2ba0575f634c8ffcffcadf4a55c855267a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/ru/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/ru/thunderbird-60.4.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "0578f3158c0d4ccadfb73abbc6703ce6ae32b243c17381ed7f1ba1dcc3105dfa125aea8548d43e3548f5dd8d52ff7ead859b997295b2ce2a4be46688eedc49ad";
+      sha512 = "6a112f9c9bcb1dcba2d2c48d4325bf1eaf0408f3e02c65e513b490b5d366486f5a9990f6e923f4c9521e64e46bc08b72cc5d6baf3e90d08eb0c543418c6d0612";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/si/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/si/thunderbird-60.4.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "03e357657c37c4215ded0a88741adfc7fe515060611ac861d1f12a81f6221d2dec0d9b928f94034c4078077487b8f181dbb51b8d6add51efbf3c47631f38cb67";
+      sha512 = "b3426b68261a54099323f92dff8532736b8e38514f36b664a578c17f7573d39c27f49d92011964af1283b1a6e1f7892d8576aa8513bbf2df89ba849a529f7816";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/sk/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/sk/thunderbird-60.4.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "b80f81cf6d280eab59abb353a75eb284336bed01bd22ae043822d006771b65a52751366f107cd2de3bb4e1a2972b095a97fd8aad77ce3ce153b46af6d517eb07";
+      sha512 = "b8eea191124ae45528e03cb93ade924cb250df28ed113c14034f2872d74d21371131a1c2fccb13fef8169c6b1ad17d08f684aaacb157f2cb26c6cc456f4977f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/sl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/sl/thunderbird-60.4.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "ea22e62825deeddf5c9ad9d98fa74917db8fca235683b5ede13415873a9e90994f7cebff6819bf63c8122c20055a88b40c446094f49fbd1bd4d52671cdde8bd2";
+      sha512 = "763cb3a62e3a2f8b3c916cd920bd0ea32a9d07ef52deb7a2cd370baeac275ebe6c6ddd2b10322e39056dc8833e990dfd9d0c26f82d8bfb53fcb68b5ea8e7c609";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/sq/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/sq/thunderbird-60.4.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "f84b93f1a4f8834494c1c289b7089070583e15d21c7b190696b28168ae40bf8d9d52f795ad0613655c156271a85ffdb942a6fb582d4dcbd46c51a4657683222b";
+      sha512 = "21e4119153520abd899bba446e4c4dd2255fb8f6502937f37ce072ed6f877aca970ca1a64c7d5d1203f2e4d7af54e395da560cf8f62390bd91616c795f9827f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/sr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/sr/thunderbird-60.4.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "e89deae4b166f56f4e0c81651ec4a36fdf8b83cae086af87b60c7cf27dd0f484d114212fce130e7c62a144c8977665709c4add6d3782aa13cfb8a9f295f29362";
+      sha512 = "d86cb8354f65052d9ad169b40543a23cf8a97f0d33ba087c4781e8aa0ed33e41ab60be9c2c3bbbf330f26d848dd7fe63e853b85a20a167b06bd0f253cf74bb70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/sv-SE/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/sv-SE/thunderbird-60.4.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "899c76665d3b363bb239066d71aefd5920fa6f4382cae7ac5c6bd3a5ac96817791b8cf73597b2d388798b69229411fd97cd792b6caaaaf2b7bd87fb26344f3e4";
+      sha512 = "77317de5aee20e50d9b03db205f5832f83ad07653e0988ec028efc70076bcf60893938c9d3b7e81acc114a8ce7439c46c1966a9fd4b4103f2b2d9292a561309e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/tr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/tr/thunderbird-60.4.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "eded23fa5fc82fa0a9e2365e4323aa73cd00daa67fef6e752dafe6de1022240cea72ee7f5dafcf6283c629955899fdab21a38313130c9efdb472ae8bab447691";
+      sha512 = "db997b92ac47658c35781e69cb61f1c7e39a66e67654d98ef3f9f350f76434fbf7083485cced00b2774e6b03da01ee01e0ad1eda24ea149e1e7e8eca996fbb9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/uk/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/uk/thunderbird-60.4.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "e4c98d96fc418463a1ff53d12443c42bbd8f3bbed0fe48d18d0ebdc79e6cd792453def505dd42b0e8937be4d52034a3dd92041e2181a588d16535b74e7de791e";
+      sha512 = "dd66ced2e96702a799f574fca486e6cb2e66077fd3a8516b0321bff5d5fa01ec47e9867a14bb3dfdf22c1d8477ed899b18239f405aa2fb8c8fd6e2cff1214509";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/vi/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/vi/thunderbird-60.4.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "98c22a356777c45176390f62043599a43e22e9c8f5f9215180d5f5e760214b16efc48a79463e5b8a0cd08a7d512ae3d9203a8ec30b3e8bfdab910ad93a183a64";
+      sha512 = "98210d47bb00031a423aadcc3b859a90fe5103e533a956a930b2989c285371b40333d46f3a280a44475fe82bc2ca14f0983fc24dc4ccc6515dbe8322f4d583f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/zh-CN/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/zh-CN/thunderbird-60.4.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "a8be99254b5d392b7236189c3633e5408ed1672ad4a69def12e0a75992f4f3dabe7f91cff840f01701bfb3e13bb2e188d3b8e396926fcadb16fcc03b257d62f0";
+      sha512 = "92843406622c3dbce9785eb52ce7e89864ad3808496ea8c2f1e146cd36cda2b207bc147689f45e23bff4c562c48ddca37874feeaa2abb807d4fb40549240b634";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-x86_64/zh-TW/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-x86_64/zh-TW/thunderbird-60.4.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "491d5da4f4cb4eb1be71d1d3b1b9fcfaa2195d244c1837edd284d95b730e85658cc46bb2f6bb2b70f774e539d52be94e28cdfb45800d8d7ea02044d48ebedfaa";
+      sha512 = "136e8324199d030395fbca71792477dc514dc2e540883a5c11989aa624418cc66b1aabae01fa3d017c65e66b08546fda892bf8be0b0adf346c22a049c96a6e16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ar/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ar/thunderbird-60.4.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "ff9a44f119b9004b6dd194d17f4b4e6bf7b32072d1cc9e69380e95ff9909ba427afba0b32cd33a8d0be2454b47363c1601e5a14ae03181d4cd45a166f267965f";
+      sha512 = "038918c1b477db9e7ad5bffb452501740ddb56a7e77bb650f9d36a4800078ac62908ee55dd7ebe9a6f2cf11d6a120dd72a3b2d9e7312cf209b4b827ba4ba5efd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ast/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ast/thunderbird-60.4.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "16c2801b70a2ec756a9d3fcc8a315dbe3521d7740d98b59273a0aa80facbfac0a92ec6e3b753f0813da24229fb137ba284b9a71fe7b0dcca057768b8a23037b3";
+      sha512 = "bae91990800d7d6998a6d9012681e79cae2801de623b30d05ea7926d9ab68ce62135d6191d56a8a802001e9abb589d0a50782482ed0233e6c2850a68322a4f3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/be/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/be/thunderbird-60.4.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "11abaf405de5025589e6ba4051c64c08e280ae49e06d610d30594925f018cea19521c75a1cae350ece37520b1108245a2c18dfdf69ddbf18ff5908c3dc4a9de2";
+      sha512 = "726d38b4dd7b4447ee05706fd7bec4f06fa726661ff4fb8effde3d109f8ea359cd8ce3e5629664aba450674656909d164f0e9b0225c470c9cb227c6eb943bdbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/bg/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/bg/thunderbird-60.4.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "569b3fbb5856a7b2862d99e08d056c5cc2b0deac9ddc642e4c604c2217d5228545e1f7a5b2accbd43ad55d2d56b2233d02f640073f1c5e4aebf33f4ce439ccd8";
+      sha512 = "3d53be16fa04928a15b8f675a7cc616dd8bb69db0cc6855f1d153d89f2c2ed65a6ca0b5dff80c85d07b3ea17e35f52aac5b88f50ae23ac56528618dc3fb2752f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/br/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/br/thunderbird-60.4.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "6d70a1d2fd59ce5b63c597abf8bd204fe6324a6fb59c29fc45a4dced31cf84b7375642a0d60d79ee7650a4f07dcea79d20d9f82d239f75884750f70da9816a29";
+      sha512 = "00b72a2a3511157cc9aeecad799c167718d1c4342392254a017457390269da96442e8d02bbd3883997feb772104a3e570cd3fb035c166545acb5f88ca4a70480";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ca/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ca/thunderbird-60.4.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "8e76fc4ec337b8a900a65cb57b53d38ade3b69b818837cab82a3e37a16ad830bf2ce89b03d1560b4b4263fb1bb149d47d5d54dc67cf77b9a3097d59d45d83759";
+      sha512 = "d3b60c1c7d5714802c80e86996f035afe3ce3f1b0fc784f1a334556880c177a3ba3b1cd4344e24bb8f7dd94de6ab9a2e451819fe5ea29dbeda1db67d64d3fcd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/cs/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/cs/thunderbird-60.4.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "96e33b1ffc95b52bbb81543a46691bfd20eb0a76006524719bda85649cd7f3f3793a0911dce73c3b820201590ea901d1b093a3fab58fe780820bee08c0c32425";
+      sha512 = "dc857c295a157a00c99bc873301c5589c2ca2ec378a50ac3e039cc578e1a4bb5c262c1c9c18ad24203687ceec58b052f670faa6907e2a7b724e6836cb0d717b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/cy/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/cy/thunderbird-60.4.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "5dc24c92c939389347a4baab7dcb228535f740f3e606f9f6b2d8d7cd581d5ee2f1999966ae77b8004604b00aa673a99a821a61fa81102308e11d36daea587a8c";
+      sha512 = "a9b5cdb1c8c42f0c605ed703cdfee95fd4e7945e74cbb8ed7dd3ee50db44bcf2f0219567cdadd7049e46b6c119f1d32270edcf59c4d749c10cfe87b847606fbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/da/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/da/thunderbird-60.4.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "edd5d16951cf209e6375723a679fefe2d25f9cd1c84b22b860336cbadbdd5f1b404c12fc52bc0b1e7671c5691d6de0ffdcb61c553295d339f0ea456a6a95be74";
+      sha512 = "0725b71ff25e40b5e1ef8c9c3138de82415bc3195606df72399dfa943a97b9955021f6e95c62991b0c8b7ec57562f41cd1cb075095dc412991b49705238cc42d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/de/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/de/thunderbird-60.4.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "ac5a4fb5c3f4085000c5c3b7fe2cd9a2562757932b430f089d59b41f406b7d5dc86bcb9d0f6aa636f96a0151f120469ea31b0f9a692f56d82d45e77cde2c397e";
+      sha512 = "f68590658998a3895d4c060c2c694638d05c8f3fbede53f4a65dba6f080db51b308afb258ee636749812f747a9f3fad808412089a9e3677e3310b7db93a67310";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/dsb/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/dsb/thunderbird-60.4.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "9afdceba205d37309df67623b3ab4ad517d9c405bbe407070291b7b3b4982d42260da7b76967027cfe4eb8ba8288d5f5286c62e0e981e9a046ae57cbbd6939dd";
+      sha512 = "d21397e14d46bdfa3b6d9cce36bcf483bfb13bbe831bb6a94ebc74a8608b6259757dc9e8818bf10bbc591949164f17477650948b83d5048f49b84187b2429067";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/el/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/el/thunderbird-60.4.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "6ba2d44c94edc89fadac86574b868595eaa5320a31a219e2c62e957f6c7fb770454a41f3eb1ed9118e26f846d60efe706b5a4d83cccc2e0bc81da5fda3e22bbb";
+      sha512 = "a14d60e7a6cb7b101d27204e894e912e416f814edf548042dec11313e3a40e1a01f0509fd652da8da0acd4dcc99c53c85c44fe2c949ce924df36e0b1ceb4f114";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/en-GB/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/en-GB/thunderbird-60.4.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "257ca0e5adff187fb13494d4c2dcb8c707afbb834d3bb77a81bf48efefaf3538a53f2578a8a8fbc427cd56076a1af8b7ea184fa860571781c77cf791b9262e05";
+      sha512 = "fa50c17000fd228bb0fa5db055ed1d966c9e0cf42ef3e3a18ed975e1bc4e1025e9edbc840f3dfa67fab80951184666012bd5bdb2db5e852fcadc7ea6ac675242";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/en-US/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/en-US/thunderbird-60.4.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "5f7f396026a73577fbc37626f07d57fd56bf2b2f10e2bd7ee0ceab1c8d241fd498fae590929300660d3452e4fb24af1bb2b29a8e8fbbd94a6c9f42c67904b133";
+      sha512 = "48b15f12274818477d6618f3d184239789b8538d63b995d48992ef170224b2ad254cabc02330e7ef9e0e4190c17663fa78489226f9cb280d38211cc6431cf413";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/es-AR/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/es-AR/thunderbird-60.4.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "0b79a226eb36758eb132675b79fe88a620422030772fa9fea6db3c822c98dfd5b62d8041e744ca35c93c7bb181091a869cc65abaa06e068561f4c7a1396b2c1b";
+      sha512 = "7c921f2986b3bed8fd33daedd8abc6f66559eee798b03b5922775419ef1b5b7f40c53e0d9a84e711c15231bcd000331fd7ec2792ae5d8b8c747625fc041a68ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/es-ES/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/es-ES/thunderbird-60.4.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "7f37d63cedb27a6d0ba99617d1a8aa13a858fdf1315681d3f605c3199eded5d4cff57326b33364f5cc90cfd35494fa5e3ee0e8e3a02f7167f670d7b4ab0a20bf";
+      sha512 = "6a298a18485c380b43d9d1a592a5235b588670556d65a1ec7430dd0b627859c6020bfd5865ef605eba20d51309fd83a0acfd62b4978f47340a29ef3a899b77d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/et/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/et/thunderbird-60.4.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "48596be9c361f301c062e955a67a46375bcfa6444188f6285dd3557e45f423a0ec6dc7e4c29aeb7a8ae8f05dd52ab3ba0a224c1fa094f6b5e7ed5a060b653a3c";
+      sha512 = "2b2c1fb8de1aa2a41bef15530d3ab4f499a3217e1eb79a5e5baac466ee3c26e0569cacad25720971e0400f16abc29e771ff9a3ec562b36ff384f010600f9d3f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/eu/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/eu/thunderbird-60.4.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "f6f01952eee94db359ad1042a5343d77cdd4df1f41b38530ff4a9ce2cbabd14683eb7937724e34e276ac1ecc4ffc1dcc85bf2462cb071627ef490f2aed915f63";
+      sha512 = "e2ccad6693d63d8f8f6f8841d898cf047d609607dedf6324a441a949bb8d15101192e08a6b62e7336f55774525bc2490d17eca10057adbe3f9c88b23f678c630";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/fi/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/fi/thunderbird-60.4.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "58c885494a9db36ebfb89207dee0e1bfd284760baa6d8bc0e351b9f4157a6bf826c20e33729a9d4661c146f40545e2228b916f9f6fb059da9558a5ba438f7a14";
+      sha512 = "ff53f6c60476eeeb4acbe5b5179578488da03c5206d2ee8cbde4a6e4d3ab9311040e4e66b40f7647128632fc736185b88d832871767d19d91f18fac89d778147";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/fr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/fr/thunderbird-60.4.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "205c540dc890bfa8a8514ed7d32e1599b21b3bea504594c99ddafed00b6341b23b767bead4ce47193929e8175424625a84f436ae36572209a3acf66cb395ef3a";
+      sha512 = "43833b08275e68740eff244c4abc39b3c28fe413860c2b07a872de2fbc7456d7def928fbff6e5ddab097b305b4407e50b40982853ea738dfec36917b83b31904";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/fy-NL/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/fy-NL/thunderbird-60.4.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "03e206b3373b45004ba90e973af4020c7956fa2b783ffe8a5f38ea695cf8d729598052413c993d3c57f449c81779775dc4b8988a1d4919a6460a519c89b0652e";
+      sha512 = "cda8524e845d1bc4ea9e2456d9043e1984c06d7aaba6463953aff2afa4fcb27bd87e25d42cfab9e364fcbb10a8517516ed268f68f82996f3dd11798dc52d5712";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ga-IE/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ga-IE/thunderbird-60.4.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "16846e5317f98dc77ca0185384f677befe9ea1f395c85560fd5ac14e4af28694e62e85a958d98adf39500a736b7a6689a9ee81d51d3e5497df2e02ba7043bd7b";
+      sha512 = "3eefaf30b930185413dffe4a99f20c5bd36c682be33328ed2ea25a97c18609c6cd96f87255798c2eaf15b946e9ab5667ae23ed0c1b7beb9ec5438bf5959ee59e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/gd/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/gd/thunderbird-60.4.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "b0c58bddde3c41c0ae591a0981dd9f97eef0abf0aa76839c3bab8e8206f011510a944a3fb396f0b211f64c311e4a43cc694a95cf89c8f76666366d1858bc63e9";
+      sha512 = "f543922b437525d7f45b74660cc33f9913da412eda4190493ff3d5c11bc0050303664f1242d1151fe699d43c1245c9070e53a6fb794a414175cdc9f792c6c0d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/gl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/gl/thunderbird-60.4.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "515ea18d83c3bd0630510331fa05b8ec8795657b5b175967ec893ad88c96ce5d91f20e52a3977aa4d601e67a198a8e9e1d8278cc4ef569066f8d3a56c0e7a6a9";
+      sha512 = "34b8c59b8a0f369a74364cbe05a57d6e848b51136744d0ebc6e6bc0caf8f86cb460cd0d88ff6e7a216d1f133de8b8728021ef41eee05606faa224e18def3390f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/he/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/he/thunderbird-60.4.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "fc08ef178d41664279bb5dc3dfcefb16ab341775ae4179b5dd78ce4518bd05ad4a08487160ea7e2a53f53334c999841f1436e3a3e2ff2b77787b98d598c3d446";
+      sha512 = "fe90e4a6f12450302b57a31172918121d4cc9b99b67ae3904e1e605aca8b3cebde5c4c213d05559008cd062d2e6a9b49c1ca5f940dedb2a76724226e9b04ec81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/hr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/hr/thunderbird-60.4.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "7538f66ddd8b224d7aa8fa933dce4b77c2af55521dc7649eba585d4c3881a4db213848da52c3e3dc1c40ecbe563427786dc4fe07b582ccfdc18bdbe2165112c2";
+      sha512 = "6fe947f785959f108fcdcb99f8fc7df0fe056025d42a1fcd54b93c366b06e1f153837363275f734f495072dacb4143294e1689b1ce248f9362cff5c71594edab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/hsb/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/hsb/thunderbird-60.4.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "84e3c382a911300076409fbbbe799b7852539a051e9153abd86e8f2a94542f95e1f2674e29b66b0a794063268fca6ee0eb1da150d5b1145adac0d75debfa3615";
+      sha512 = "7c5487b182fee7f030db905d0170cfd719a06d6d1adc031f10c2fcab4640b5802d3af89992aa645c131e476c0154d32463bf88224ad7915ac9ce4e7643f297a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/hu/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/hu/thunderbird-60.4.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "18c2cabb2de1b26e60f9e3c12e9ef7d12a11f47a28d2f866b477abff51dc455040887000dc562aac20c58e71b7f30514edf3faa0c7e35f9864a5784c8ca777c0";
+      sha512 = "580f45e3f4f9972eb664b1dab03c37c32ab4a757034b23849c5537aec503637839f5f44e5e7a070d1851fe5853bead36655fa4e92f30547fbd2560035eddc565";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/hy-AM/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/hy-AM/thunderbird-60.4.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "01b27fff2282402476ea54e7fade1ec9ffc18e2b310e008a327f4a12ae109bbe093b4cbff034e5f474f840c2f8969bcbcc3c0cb1810b5245785c24dbaf7d1a74";
+      sha512 = "37a47ee18b1f45edb494fc048066628f174ca19b59a241f548460565db8af6075c61402ca268cd772b9fdf1fa3ebbc618900668f50fedf9420c57e16ce949416";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/id/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/id/thunderbird-60.4.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "134ec9f6c468d6e389b2b0147b623b814f6bdf5115d55215cd2f6a3873f435f9fae08c4426b701aa7854344896c2216cdf7c8b62056aed552bef23fe6a31f14d";
+      sha512 = "7692be83b855a1aca54785173fd1f070c6bdfded5dcc827e67aad6deabd80076ef872d14261db65e885337f5e263b4efb3aed317e58941a037eb1296c4043e1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/is/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/is/thunderbird-60.4.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "0795c91a48811491809166dc5cfa772f3243ab0e8b462a49745b892fa49db891f8c6638ba6fddcbeb434130c5ce92a997719aa573350d6e5b20ac28c99653396";
+      sha512 = "07bd805596e0e64b4f5d4cebba16bf0d45ad9ecb6717daac6feb553c2412638089503dbc0afda2beeb349e59d81bd4016cc3912822e09d65753192240ff1f9b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/it/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/it/thunderbird-60.4.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "8ac5bd2df3f0fedfbe3e0a75f8798fbe4e2c405910619cbaea137ca522a59fcad9ee932463ab4042d70fe9f9e37d8a0a99c1c45216c125155aeb364f9e85c236";
+      sha512 = "c33ad01f192280005c8d65d63ca302a934f7114a3e899cadae1aa2538bdf708b942a57febe07bd135162198a6b0ad6ee83cd4ec98e24ce1fbcbe28bf8460d852";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ja/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ja/thunderbird-60.4.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "cc459b44a9ced486d090b78a547442e181ed556036197b9770c3e441976a867ebebbe9297cf8413ba5408e2181089a4850a68d18211d314d071d4a249f524173";
+      sha512 = "bf9eefd0ad8bd2762f011f0a45d73a2f32b4cbc93aaf8509698ed3bbc57aa4e6ac793abe32f3bf824226ad547a3ee24fb46c4f7196da1289a36e74b88451c138";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/kab/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/kab/thunderbird-60.4.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "0771159f455a9417c8322ca09d6f01e823095b8c5d87933e95152b0690bdaf1f935a9ea84c7fe6e669773c54ae84e7f51e22aee2376f41e546035cffbd4f2550";
+      sha512 = "6fac50fe0b8551cde345038892ed83db7d35ed903e7f30e30d61586f75963145291e3c0b6c77c999364719532798addca0d60a5d26c2c8820b6d47f58b7319d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/kk/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/kk/thunderbird-60.4.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "6462ce8dad2f34108c9e08d9d891911e5a3093b49040df9e657b07abc123e01713ee8bf0a83437cc0835bef2085b29899dc70400ca0ed0cd65160ff32cf76090";
+      sha512 = "1ae2a07dfc904e48239326f370a3600af731fbbf3fd6d2705576b4e53ace32c1ff58b7d5eb6f4f1a08954ceabfb1eec5a04396d7857e428c040f1557462a56f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ko/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ko/thunderbird-60.4.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "bacc91e37c658b0671b9fcd0f7efedea1b05ec2fe7b18ac989d2a282c8151d5d76de2ef6e381f4e8346d651c500b7f4374a5baf312fa70613550b01c5b440118";
+      sha512 = "3976180a5d3b654d02c40a1abf417bdddb17459e9e25e5df11f6a08168b9990fc352f78a4738ea311d1f0ddbf9244c32adea1d11a8ca782320aea0f93cf864e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/lt/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/lt/thunderbird-60.4.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "9218310de664035a0fbb70e579a2c34294f0b38f4a3787da7dc73018c3103ea23a8b3978ee8f2d7131aa67c2ed5858984d4e7eadf0f4987bfce5b8b0e23c89a0";
+      sha512 = "98f8fd4b19e873a770ad16d2c03f006d1c9d757f191d8070926b18d790ff7843801eb9abd41de4d4bb1d275c664d58d5de6225edb342b2aea9a5acdd8507d7d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ms/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ms/thunderbird-60.4.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "1df6d4e8aae46d1b97142c975a1f7c9e3cdc7ea00b3693af2442468d712338519857e8ee8fca66dbddae2b0f28972e7fd077e20c237bb214c3f37ab66fb2ec86";
+      sha512 = "981d698f433d2c8f56cfadf98c0121fc85c35ccbe67a50f3bf69649df66f297e78d148e7272f60a93884ba5d3cf40c466c91ec1b52b2696681e17908c13a47ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/nb-NO/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/nb-NO/thunderbird-60.4.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "2527fe96bbdf9c827baf2fa86d526b274f4c72800d6ab4233544537ceda5a8b1bb284d5e141d1a09e05727f5b2b6c2b3d413d7d4c9a974b29537c6102935ed74";
+      sha512 = "1f7ccd8e6abb503f66481741bd74911f073c43231f1088041d56754e236417dfd8ff2119e844bda5ed35e9a1e273063437b9b5170fa833e4a6360386bcd2b6e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/nl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/nl/thunderbird-60.4.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "3d69a82dc64321111bd3971e984414336cfda3def779aed1a683bc65c02dfa4ae913b1ff2a1e5e13e31100719ae002b2efebc3854075e315a76bef84fca2dd5a";
+      sha512 = "41638ad8bc5f2b2929839824ddae90404a9e4bce1fb92bb1631f65a3af0202be81564364b5ea21033ba95d1e86506553a201872db5c6e7601a56061ad686a09b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/nn-NO/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/nn-NO/thunderbird-60.4.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "533740fc37bd06eeead741afb6e13965f029c6996704c307c793cefcb4f38a4b3d2d4b9ec1aa934df95291c6b2d9965955333b3fc541806ae38226b119c7bec6";
+      sha512 = "76b5ceefeffc0a17e648f1eecf2f7e66251283488a319804e0a7ca2d5ac50a71170a67805c7485135b817f4d8ebbbcffda113596010cb8ca7b2762e7be994907";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/pl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/pl/thunderbird-60.4.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "e1984be8836f63d91656618509dad6ad34de544d6bbe49c0dac2649c01dd0dd4b8db88f05b08b8425e34548c7bc45ce10e69278eb840f061b4f0e88f40ec1515";
+      sha512 = "379a0afa068d7a303ffd41146402b275833f4d01a80f2ad8065ce3558d5af27f7bda1ed8b0047b3ffe7453bfdb5ac14bd0c2e8f2b956497cc1af282d8e2bcf36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/pt-BR/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/pt-BR/thunderbird-60.4.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "0eda97e4fefe23af3126f9639358e3c0bb4a462bac2a64561bec0437cce426f61d995dfb8a081ab84101279a24f6d539338056d2a81f9c5aa157f61babea017b";
+      sha512 = "22e94bf8b6313665613f706626e707121a04f339c9b73ff5a1a3aa4788e58812ac65bd8c379c92da32252790a56f009462d6346d564ad03169ce30ed55724431";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/pt-PT/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/pt-PT/thunderbird-60.4.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "11ddef47843f68a72322e5750e4a3ccd09c21e768aa2a726cf48bf03a67c47cdbd83b886a50d82312d9472c198813d66b29baa98715cd564c89dfacdcbca0e41";
+      sha512 = "421f41bd94db7fc825e98cf568da493125e8562b492b579de1ceceb4fa18e7db326ee63cae98998b20b98fec87e472dde56cb7b9931e3b01b89eb82bbcbba02d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/rm/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/rm/thunderbird-60.4.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "b004eac3d9cf2c59a2531b39927a646dcd43638d97f306ba25b58fb9629d7f091c54d69aab623f2699b3063832afac7d6dbcc6d8c5d472f9aa12d150edabc834";
+      sha512 = "bc27f0b3f233bc69c718a3abd6900ebddecf9d9bfe48206573fe91a88ff426a579cad5c6df8f95dc17866be5040b6527ab71a251e712e656c71ad20942c9d3f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ro/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ro/thunderbird-60.4.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "fc034eb4bc0335cd1d8c23d97ec046a735c8a43caba1989698ab84e6f317e3d12e9f82e22c55a2357eea87495863d3e9458690fae366c20bfb86ce5a717d6a16";
+      sha512 = "97781f1f6237901ac657395c4e0485f7db435d97b05b9f598cd03091311981e68a169aca2140a456a2750dfba599d4e81150c6335e0a5f46c1a72b643c99c423";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/ru/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/ru/thunderbird-60.4.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "d78dc34620e193620e07f3041bbc4a3751bade9b0f2f66b34f37e57cb67a52b64746d6beed566452f0f27928bf58429c7ae99756a2328781b0ee6a981669aeef";
+      sha512 = "03eb1f5404f2f94739ea660410822b04a151e3a3b2014dc059bba9ac0e66f69ff8bd6dfa76f4645791d12da4e3876dfc31f18148eee23594df23ecc2fb733556";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/si/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/si/thunderbird-60.4.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "76d20ae74e5aee5c1f86d5f7b3fe780acb8021f442038dc4193bda59adb0de274a6fec14be90ee244eb91987cb73cf313e06c1f87d33789418158a78d455ce14";
+      sha512 = "f7cca4e6976494dac25f37724a1b388605365ab3bc473943b9318fb71d1d4da848db686695bd220e5b39155b928307a8773561f3f938976fae0c56c0ab441d3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/sk/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/sk/thunderbird-60.4.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "86cf766b5260a03a57cc2d9a8e7308badbc2488219627445b6f08bb92e0008c708b9b542a2a4b99e6210f8b461c5520385b2549d3f47ba1d8b3759fd364f79bf";
+      sha512 = "033be48abad3f91a216034cd491b038ae6edd1fe4b8b6eef187faa1c0213d1c0829318137db97202c09d5f458ccf3c451e85913e8eea4bf5b62923b4cfe93498";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/sl/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/sl/thunderbird-60.4.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "ca377881fb35c95e3a9bd3807a0ab227bb1a899406fc2c99c0a42e31702e6271379afb1197ebb53dbbf11d163c346ac664c056c02761653e56c445df1d066ccf";
+      sha512 = "36c4f2ccf438257ae193e857aab4f7c0fd0a18c5e32eb8428808651d9cd6b0f4eb50c41dd49af5407ca72962a58ff0ee76fac5d3878061f3bd427650db4321d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/sq/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/sq/thunderbird-60.4.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "b46f45d78295999c489b72114290ce38617d87011743d276a6ff90f575205f8e473ba68a9b080e622fd5350b8574f1602edf085ca30aec9f64801df5aa937d2b";
+      sha512 = "4b20493c0a154d5766baebe0e0db43dc8c2bb809d162798cb7b907049d54ca24deac609e252d7ac0129a22fa06329e4c9d0c28524f9085e459c38ca6998caece";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/sr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/sr/thunderbird-60.4.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "1952cb0e645f0bf4f6473cf2e01b3ab3b30deea450545d4027f2c8cd037016296ca08f14d80d2d47fab4ac1bd69e9177b3eb2e73a861e5da5d14f660f9ae7534";
+      sha512 = "9d713163d319321c305b717fafd6a50965266f8af4be826be934da90901a13af182f34c6105c4903f13f3540df5eef5228e3355c429541c69fd33ce97426d931";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/sv-SE/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/sv-SE/thunderbird-60.4.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "fabc6da07f9269c7404b341b63e7377b94d481f96b8dd66b19bceb8e4b18e6ce99a75cac20e7952df900c5921b701e3f2d4f0e245dbf2f760a6d933730f6007b";
+      sha512 = "dbce9bb1e4699e3a6e1d06fa5304afa28201b6b9e0573a94c7c90b6bf2b80343b57295d7e854d7387198222c8e36708b10886ab98c973e948370d2b2af9e90f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/tr/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/tr/thunderbird-60.4.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "4e4136596cbbb50719219c9b1aaafa9fbdc9464750317b1e1f0f6c3a8289a1a11bb472b7f781081386a81f36411d04be91acdf8374c1870dd5fa65f171391a1f";
+      sha512 = "dceb8295f434d2af52b95fc59d4f9f1c49e3a1bf694f4d66f94d6e93667de4328e114423cbbbdb2ce463df7a05a77a7490bfee2d38f90161c0ba879180026e7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/uk/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/uk/thunderbird-60.4.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "a378b4d0107c8d16a40a934e898190d0e26593c7efcb3ad7338e95ccae88d00e7b1d5a7d54cdc063ef8423edf65f875688f3a96e60c36499c708dc642d11f14f";
+      sha512 = "79b3c62b305b5a8a8a5eda43d69556357836c2442fd38ffaded437430f1b432ef0dc9dcd9d080d30850f471f15244616340037a222cd5438f42b059af7fbba0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/vi/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/vi/thunderbird-60.4.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "a02360132303d533abeb1bf82e318a416bac192a5ff017a3a7300cf0f062f0e165a8be1355b2d2cdcf8aee8e293ca615923ca97a6f6b9df054a93e57eeceb620";
+      sha512 = "f9303d5850ae7fd4c356eeb831b8031f90d4226bc7d933007a2cf36772edb3caf5bcb02752a4bf6ed7a7aec481d2f62f20fd8be9272011f0aa365fa0395c532c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/zh-CN/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/zh-CN/thunderbird-60.4.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "9125c4078b4c0de07ff161cf468c0efa5d61a2df42f8237e9d54a4c2996ef769e810116fea7fc69b44f6688525860dc3821621b63355b83e61e08cbdaba0f2a6";
+      sha512 = "6908fac5ce6349a510cd95463e7bceaa016e18ac7a26f977da2ed56e38e152d127d5cf2630db8ea9dcdd052c95a6aa8706a35a237afb257362fae13e5c7afa4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.3.3/linux-i686/zh-TW/thunderbird-60.3.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.4.0/linux-i686/zh-TW/thunderbird-60.4.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "0a692b8bc5731bc2d656e1f1ac8a5c841885e4412f94bba325ae9a0396bdcd092eb5e31ea5dcde6774745e0edeecabdb3642f062f2bbe9c6ec4b66e7e362302b";
+      sha512 = "85c81e79726c5011bafd555d4329876d48f2edf709ed32b025e97c7c1c2f625d92978f8c710f0ee0e2a6f261de881424f2bbcf1b44c6d0045275597f14763122";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -24,11 +24,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "60.3.3";
+  version = "60.4.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "04m6mgm4nfnq3nfkv0d1al5b7bw95kfcjpyd7aschqi6wnn21g8qacx42ynj89i5l9vc1jx8nz0wy266sy6x5iv9q585c6l6j9gvkrh";
+    sha512 = "0flg3j0bvgpyk4wbb8d17yl8rddww7q9m9n5brqx1jlj0vjk8lrf8awvxxhn5ssyhy2ys2sklnw75y35hnws3hijs8l9l8ahznfqjq8";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
###### Motivation for this change

NOTE: `thunderbird-bin` is broken in my environment. If you cannot run it, please merge only `thunderbird` package.

- bugfixes and other updates

https://www.thunderbird.net/en-US/thunderbird/60.4.0/releasenotes/

Running `thunderbird-bin` results in the following error:
```
ExceptionHandler::GenerateDump cloned child 25218
ExceptionHandler::SendContinueSignalToChild sent continue signal to child
ExceptionHandler::WaitForContinueSignal waiting for continue signal...
```

Adding `libxcb`, `ibXcursor`, and `libXi` doesn't help.  It doesn't work with a fresh profile. With `--headless` option, the error is not produced. 

The `thunderbird` package works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

