### PR TITLE
lib/types: make _module.args a types.args

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -41,7 +41,7 @@ rec {
 
         options = {
           _module.args = mkOption {
-            type = types.attrsOf types.unspecified;
+            type = types.attrsOf types.args;
             internal = true;
             description = "Arguments passed to each module.";
           };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -100,6 +100,11 @@ rec {
       name = "unspecified";
     };
 
+    args = mkOptionType {
+      name = "module arguments";
+      merge = loc: defs: last defs;
+    };
+
     bool = mkOptionType {
       name = "bool";
       description = "boolean";


### PR DESCRIPTION
Currently, `_module.args` is merged according to the default rules,
which produces interesting results if we try to assign an attrset with
`_module.args.name` to an option with type `attrsOf (submodule foo)`
(i.e., one that already has `name` defined).

This adds a new type `args` that will just merge the topmost definition.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

