### PR TITLE
WIP: buildPython*: enable `strictDeps`

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -87,6 +87,9 @@ let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attr
   # Propagate python and setuptools. We should stop propagating setuptools.
   propagatedBuildInputs = propagatedBuildInputs ++ [ python setuptools ];
 
+  # Enabled to detect some (native)BuildInputs mistakes
+  strictDeps = true;
+
   # Python packages don't have a checkPhase, only an installCheckPhase
   doCheck = false;
   doInstallCheck = doCheck;


### PR DESCRIPTION
###### Motivation for this change

Enable `strictDeps` to check whether we're using (native)BuildInputs correctly or not. Fixing the fall-out of enabling this would be a huge step forward for cross-compiling Python packages.

Python cross-compilation issue https://github.com/NixOS/nixpkgs/issues/53320

This PR includes a stdenv change for which a separate PR exists https://github.com/NixOS/nixpkgs/pull/53440. When that's accepted, the majority of changes will be ensuring the test dependencies are in the `checkInputs`.

To do:
- [ ] document `strictDeps` is enabled and clarify the inputs situation regarding Python packages
- [ ] changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

