### PR TITLE
 neovim-qt: wrap in separate derivation

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -46,6 +46,21 @@ neovim.override {
 }
 ```
 
+If you want to use `neovim-qt` as a graphical editor, you can configure it by overriding neovim in an overlay
+or passing it an overridden neovimn:
+
+```
+neovim-qt.override {
+  neovim = neovim.override {
+    configure = {
+      customRC = ''
+        # your custom configuration
+      '';
+    };
+  };
+}
+```
+
 ## Managing plugins with Vim packages
 
 To store you plugins in Vim packages (the native vim plugin manager, see `:help packages`) the following example can be used:

--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -1,62 +1,74 @@
 { stdenv, fetchFromGitHub, cmake, doxygen, makeWrapper
 , msgpack, neovim, pythonPackages, qtbase }:
 
-stdenv.mkDerivation rec {
-  name = "neovim-qt-${version}";
-  version = "0.2.11";
+let
+  unwrapped = stdenv.mkDerivation rec {
+    pname = "neovim-qt-unwrapped";
+    version = "0.2.11";
 
-  src = fetchFromGitHub {
-    owner  = "equalsraf";
-    repo   = "neovim-qt";
-    rev    = "v${version}";
-    sha256 = "0pc1adxc89p2rdvb6nxyqr9sjzqz9zw2dg7a4ardxsl3a8jga1wh";
+    src = fetchFromGitHub {
+      owner  = "equalsraf";
+      repo   = "neovim-qt";
+      rev    = "v${version}";
+      sha256 = "0pc1adxc89p2rdvb6nxyqr9sjzqz9zw2dg7a4ardxsl3a8jga1wh";
+    };
+
+    cmakeFlags = [
+      "-DUSE_SYSTEM_MSGPACK=1"
+    ];
+
+    buildInputs = [
+      neovim.unwrapped # only used to generate help tags at build time
+      qtbase
+    ] ++ (with pythonPackages; [
+      jinja2 python msgpack
+    ]);
+
+    nativeBuildInputs = [ cmake doxygen makeWrapper ];
+
+    enableParallelBuilding = true;
+
+    preCheck = ''
+      # The GUI tests require a running X server, disable them
+      sed -i ../test/CMakeLists.txt \
+        -e '/^add_xtest_gui/d'
+    '';
+
+    doCheck = true;
+
+    meta = with stdenv.lib; {
+      description = "Neovim client library and GUI, in Qt5";
+      license     = licenses.isc;
+      maintainers = with maintainers; [ peterhoeg ];
+      inherit (neovim.meta) platforms;
+      inherit version;
+    };
   };
+in
+  stdenv.mkDerivation {
+    pname = "neovim-qt";
+    version = unwrapped.version;
+    buildCommand = if stdenv.isDarwin then ''
+      mkdir -p $out/Applications
+      cp -r ${unwrapped}/bin/nvim-qt.app $out/Applications
 
-  cmakeFlags = [
-    "-DUSE_SYSTEM_MSGPACK=1"
-  ];
+      chmod -R a+w "$out/Applications/nvim-qt.app/Contents/MacOS"
+      wrapProgram "$out/Applications/nvim-qt.app/Contents/MacOS/nvim-qt" \
+        --prefix PATH : "${neovim}/bin"
+    '' else ''
+      makeWrapper '${unwrapped}/bin/nvim-qt' "$out/bin/nvim-qt" \
+        --prefix PATH : "${neovim}/bin"
+    '';
 
-  buildInputs = with pythonPackages; [
-    neovim qtbase msgpack
-  ] ++ (with pythonPackages; [
-    jinja2 msgpack python
-  ]);
+    preferLocalBuild = true;
 
-  nativeBuildInputs = [ cmake doxygen makeWrapper ];
+    nativeBuildInputs = [
+      makeWrapper
+    ];
 
-  enableParallelBuilding = true;
+    passthru = {
+      inherit unwrapped;
+    };
 
-  preConfigure = ''
-    # we rip out a number of tests that fail in the build env
-    # the GUI tests will never work but the others should - they did before neovim 0.2.0
-    # was released
-    sed -i test/CMakeLists.txt \
-      -e '/^add_xtest_gui/d' \
-      -e '/tst_neovimobject/d' \
-      -e '/tst_neovimconnector/d' \
-      -e '/tst_callallmethods/d' \
-      -e '/tst_encoding/d'
-  '';
-
-  doCheck = true;
-
-  postInstall = if stdenv.isDarwin then ''
-    mkdir -p $out/Applications
-    mv $out/bin/nvim-qt.app $out/Applications
-    rmdir $out/bin || :
-
-    wrapProgram "$out/Applications/nvim-qt.app/Contents/MacOS/nvim-qt" \
-      --prefix PATH : "${neovim}/bin"
-  '' else ''
-    wrapProgram "$out/bin/nvim-qt" \
-      --prefix PATH : "${neovim}/bin"
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Neovim client library and GUI, in Qt5";
-    license     = licenses.isc;
-    maintainers = with maintainers; [ peterhoeg ];
-    inherit (neovim.meta) platforms;
-    inherit version;
-  };
-}
+    inherit (unwrapped) meta;
+  }


### PR DESCRIPTION
###### Motivation for this change

This makes it possible to swap out the (wrapped) neovim without
recompiling neovim-qt. In particular, the user can use `neovim.override`
to configure their neovim and then use that same configuration for
neovim-qt, without having to give up binary caching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

