### PR TITLE
patchutils: various fixes

### DIFF
--- a/pkgs/tools/text/patchutils/default.nix
+++ b/pkgs/tools/text/patchutils/default.nix
@@ -15,6 +15,19 @@ stdenv.mkDerivation rec {
     perl
   ];
 
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  # The different tools depend on each other, for example `splitdiff` calls
+  # `lsdiff`.
+  postInstall = ''
+    for bin in $out/bin/*; do
+      wrapProgram "$bin" \
+        --prefix PATH : "$out/bin"
+    done
+  '';
+
   hardeningDisable = [ "format" ];
 
   doCheck = false; # fails

--- a/pkgs/tools/text/patchutils/default.nix
+++ b/pkgs/tools/text/patchutils/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchurl, perl, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "patchutils-0.3.3";
+  pname = "patchutils";
+  version = "0.3.4";
 
   src = fetchurl {
-    url = "http://cyberelk.net/tim/data/patchutils/stable/${name}.tar.xz";
-    sha256 = "0g5df00cj4nczrmr4k791l7la0sq2wnf8rn981fsrz1f3d2yix4i";
+    url = "http://cyberelk.net/tim/data/patchutils/stable/${pname}-${version}.tar.xz";
+    sha256 = "0xp8mcfyi5nmb5a2zi5ibmyshxkb1zv1dgmnyn413m7ahgdx8mfg";
   };
-
-  patches = [ ./drop-comments.patch ]; # we would get into a cycle when using fetchpatch on this one
 
   buildInputs = [
     # necessary for ./configure to generate the correct shebangs

--- a/pkgs/tools/text/patchutils/default.nix
+++ b/pkgs/tools/text/patchutils/default.nix
@@ -29,7 +29,15 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  doCheck = false; # fails
+  doCheck = true;
+  preCheck = ''
+    find tests -type f -name 'run-test' \
+      -exec echo "Patching {}" \; \
+      -exec sed -i '{}' -e 's|/bin/echo|echo|g' \;
+
+    patchShebangs tests
+    chmod a+x scripts/*
+  '';
 
   meta = with stdenv.lib; {
     description = "Tools to manipulate patch files";

--- a/pkgs/tools/text/patchutils/default.nix
+++ b/pkgs/tools/text/patchutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
   name = "patchutils-0.3.3";
@@ -9,6 +9,11 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./drop-comments.patch ]; # we would get into a cycle when using fetchpatch on this one
+
+  buildInputs = [
+    # necessary for ./configure to generate the correct shebangs
+    perl
+  ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change

Some of the patchutils scripts weren't working because the perl-shebang wasn't generated properly. When that was fixed, they still didn't work because they depended on each other.

This fixes those issues by adding perl to build inputs and wrapping the scripts with `PATH`. While at it, I also update patchutils to the latest version which makes the patch unnecessary and fixed the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

