### PR TITLE
qMasterPassword: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4326,6 +4326,11 @@
     github = "t184256";
     name = "Alexander Sosedkin";
   };
+  tadeokondrak = {
+    email = "me@tadeo.ca";
+    github = "tadeokondrak";
+    name = "Tadeo Kondrak";
+  };
   tadfisher = {
     email = "tadfisher@gmail.com";
     github = "tadfisher";

--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, qtbase, qmake, libX11, libXtst, openssl, libscrypt }:
+
+stdenv.mkDerivation rec {
+  name = "qMasterPassword";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "bkueng";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "0l0jarvfdc69rcjl2wa0ixq8gp3fmjsy9n84m38sxf3n9j2bh13c";
+  };
+
+  buildInputs = [ qtbase libX11 libXtst openssl libscrypt ];
+  nativeBuildInputs = [ qmake ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/{applications,doc/qMasterPassword,icons/qmasterpassword,icons/hicolor/512x512/apps}
+    mv qMasterPassword $out/bin
+    mv data/qMasterPassword.desktop $out/share/applications
+    mv LICENSE README.md $out/share/doc/qMasterPassword
+    mv data/icons/app_icon.png $out/share/icons/hicolor/512x512/apps/qmasterpassword.png
+    mv data/icons/* $out/share/icons/qmasterpassword
+  '';
+
+  meta = with stdenv.lib; {
+      description = "Stateless Master Password Manager";
+      homepage = https://github.com/bkueng/qMasterPassword;
+      license = licenses.gpl3;
+      maintainers = [ maintainers.tadeokondrak ];
+      platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -14,7 +14,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase libX11 libXtst openssl libscrypt ];
   nativeBuildInputs = [ qmake ];
 
-  installPhase = ''
+  # Upstream install is mostly defunct. It hardcodes target.path and doesn't
+  # install anything but the binary.
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p "$out"/{Applications,bin}
+    mv qMasterPassword.app "$out"/Applications/
+    ln -s ../Applications/qMasterPassword.app/Contents/MacOS/qMasterPassword "$out"/bin/qMasterPassword
+  '' else ''
     mkdir -p $out/bin
     mkdir -p $out/share/{applications,doc/qMasterPassword,icons/qmasterpassword,icons/hicolor/512x512/apps}
     mv qMasterPassword $out/bin
@@ -25,10 +31,18 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-      description = "Stateless Master Password Manager";
-      homepage = https://github.com/bkueng/qMasterPassword;
-      license = licenses.gpl3;
-      maintainers = [ maintainers.tadeokondrak ];
-      platforms = platforms.all;
+    description = "Stateless Master Password Manager";
+    longDescription = ''
+      Access all your passwords using only a single master password. But in
+      contrast to other managers it does not store any passwords: Unique
+      passwords are generated from the master password and a site name. This
+      means you automatically get different passwords for each account and
+      there is no password file that can be lost or get stolen. There is also
+      no need to trust any online password service.
+    '';
+    homepage = https://github.com/bkueng/qMasterPassword;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.tadeokondrak ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22741,6 +22741,8 @@ in
 
   putty = callPackage ../applications/networking/remote/putty { };
 
+  qMasterPassword = libsForQt5.callPackage ../applications/misc/qMasterPassword { };
+
   redprl = callPackage ../applications/science/logic/redprl { };
 
   retroarchBare = callPackage ../misc/emulators/retroarch {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

