### PR TITLE
ocamlPackages.lablgtk3: 3.0.β2 → 3.0.β3

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, pkgconfig, ocaml, findlib, gtk3, gtkspell3, gtksourceview }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !stdenv.lib.versionAtLeast ocaml.version "4.05"
 then throw "lablgtk3 is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "3.0.beta2";
+  version = "3.0.beta3";
   name = "ocaml${ocaml.version}-lablgtk3-${version}";
   src = fetchurl {
-    url = https://forge.ocamlcore.org/frs/download.php/1774/lablgtk-3.0.beta2.tar.gz;
-    sha256 = "1v4qj07l75hqis4j9bx8x1cfn7scqi6nmp4j5jx41x94ws7hp2ch";
+    url = https://forge.ocamlcore.org/frs/download.php/1775/lablgtk-3.0.beta3.tar.gz;
+    sha256 = "174mwwdz1s91a6ycbas7nc0g87c2l6zqv68zi5ab33yb76l46a6w";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

https://inbox.ocaml.org/caml-list/469F118B-9478-4F84-B8B9-48A2B34285A1@math.nagoya-u.ac.jp/T/#u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

