### PR TITLE
uhd: 3.12.0.0 -> 3.13.0.1

### DIFF
--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -12,12 +12,12 @@ let
 
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf... style keeps changing
-  version = "3.12.0.0";
+  version = "3.13.0.1";
 
   # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
     url = "https://github.com/EttusResearch/uhd/releases/download/${uhdVer}/uhd-images_${version}.tar.xz";
-    sha256 = "1glf2qay4asajbl92fy432idqk0sj5h603najr8sgkbdyyyr933p";
+    sha256 = "0y9i93z188ch0hdlkvv0k9m0k7vns7rbxaqsnk35xnlqlxxgqdvj";
   };
 
 in stdenv.mkDerivation {
@@ -27,7 +27,7 @@ in stdenv.mkDerivation {
     owner = "EttusResearch";
     repo = "uhd";
     rev = "${uhdVer}";
-    sha256 = "0m7vw7dmvn7d01kkzphayzi0bk50m5v9a17rpnxhn0bqhw282ksv";
+    sha256 = "0si49qk96zhpanmcrzlr3igc5s1y30x4p0z973q60dx9fhqsbb6k";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
UHD fails auto update due to multiple sources
CC @bjornfor @fpletz @tomberek for testing

Changelog: https://github.com/EttusResearch/uhd/releases/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

