### PR TITLE
wsjtx: 1.9.1 -> 2.0.0

### DIFF
--- a/pkgs/applications/misc/wsjtx/default.nix
+++ b/pkgs/applications/misc/wsjtx/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   name = "wsjtx-${version}";
-  version = "1.9.1";
+  version = "2.0.0";
 
-  # This is a composite source tarball containing both wsjtx and a hamlib fork
+  # This is a "superbuild" tarball containing both wsjtx and a hamlib fork
   src = fetchurl {
-    url = "http://physics.princeton.edu/pulsar/K1JT/wsjtx-${version}.tgz";
-    sha256 = "143r17fri08mwz28g17wcfxy60h3xgfk46mln5lmdr9k6355aqqc";
+    url = "http://physics.princeton.edu/pulsar/k1jt/wsjtx-${version}.tgz";
+    sha256 = "66434f69f256742da1fe057ec51e4464cab2614f0bfb1a310c04a385b77bd014";
   };
 
   # Hamlib builds with autotools, wsjtx builds with cmake
@@ -20,7 +20,10 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [ fftw fftwFloat libusb1 qtbase qtmultimedia qtserialport ];
 
-  # Composite build has its own patch step after it extracts the inner archives
+  # Remove Git dependency from superbuild since sources are included
+  patches = [ ./super.patch ];
+
+  # Superbuild has its own patch step after it extracts the inner archives
   postPatch = "cp ${./wsjtx.patch} wsjtx.patch";
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/wsjtx/super.patch
+++ b/pkgs/applications/misc/wsjtx/super.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3bf97a4..2c9dce5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,7 +23,6 @@ source tarball." )
+ #
+ # Find_library (USB_LIBRARY NAMES libusb.a usb)
+ Find_program (PATCH_EXECUTABLE patch REQUIRED)
+-Find_package (Git REQUIRED)
+ 
+ #
+ # extra C flags to minimize hamlib excutable sizes

--- a/pkgs/applications/misc/wsjtx/wsjtx.patch
+++ b/pkgs/applications/misc/wsjtx/wsjtx.patch
@@ -1,11 +1,11 @@
-Index: wsjtx/CMakeLists.txt
-===================================================================
---- wsjtx/CMakeLists.txt	(revision 8382)
-+++ wsjtx/CMakeLists.txt	(working copy)
-@@ -866,6 +866,7 @@
- find_package (Qt5Widgets 5 REQUIRED)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e7e816b..e7dbb14a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -860,6 +860,7 @@ find_package (Qt5Widgets 5 REQUIRED)
  find_package (Qt5Multimedia 5 REQUIRED)
  find_package (Qt5PrintSupport 5 REQUIRED)
+ find_package (Qt5Sql 5 REQUIRED)
 +find_package (Qt5SerialPort 5 REQUIRED)
  
  if (WIN32)


### PR DESCRIPTION
###### Motivation for this change

Old version of FT8 protocol was obsoleted on 2019-01-01.

Because of this, it would be useful to cherry-pick this commit onto 18.09 as well. Have tested build and execution against both master and nixos-18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

