### PR TITLE
client-ip-echo: 0.1.0.3 -> 0.1.0.4

### DIFF
--- a/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
+++ b/pkgs/servers/misc/client-ip-echo/client-ip-echo.nix
@@ -1,12 +1,12 @@
 { mkDerivation, fetchFromGitHub, base, bytestring, network, stdenv }:
 mkDerivation {
   pname = "client-ip-echo";
-  version = "0.1.0.3";
+  version = "0.1.0.4";
   src = fetchFromGitHub {
     owner = "jerith666";
     repo = "client-ip-echo";
-    rev = "8d1a79d94a962b3266c1db51200913c2295d8922";
-    sha256 = "1g1s7i68n3906m3yjfygw96j64n8nh88lmf77blnz0xzrq4y3bgf";
+    rev = "58d1bc627c21008236afb1af4c09ba8153c95dad";
+    sha256 = "153fab87qq080a819bqbdan925045icqwxldwj3ps40w2ssn7a53";
   };
   isLibrary = false;
   isExecutable = true;


### PR DESCRIPTION
###### Motivation for this change

needed for GHC 8.6.3 compatibility

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).