### PR TITLE
anki: 2.1.7 -> 2.1.8

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -26,7 +26,7 @@
 }:
 
 buildPythonApplication rec {
-    version = "2.1.7";
+    version = "2.1.8";
     name = "anki-${version}";
 
     src = fetchurl {
@@ -36,7 +36,7 @@ buildPythonApplication rec {
         # "http://ankisrs.net/download/mirror/${name}.tgz"
         # "http://ankisrs.net/download/mirror/archive/${name}.tgz"
       ];
-      sha256 = "0cvlimfxb7kficlf20hg7a345pahvr093b7yqvssww15h4y4va9d";
+      sha256 = "08wb9hwpmbq7636h7sinim33qygdwwlh3frqqh2gfgm49f46di2p";
     };
 
     propagatedBuildInputs = [ pyqt5 sqlalchemy

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -20,6 +20,7 @@
 , glibcLocales
 , nose
 , send2trash
+, CoreAudio
 # This little flag adds a huge number of dependencies, but we assume that
 # everyone wants Anki to draw plots with statistics by default.
 , plotsSupport ? true
@@ -39,9 +40,13 @@ buildPythonApplication rec {
       sha256 = "08wb9hwpmbq7636h7sinim33qygdwwlh3frqqh2gfgm49f46di2p";
     };
 
-    propagatedBuildInputs = [ pyqt5 sqlalchemy
-      beautifulsoup4 send2trash pyaudio requests decorator markdown ]
-                            ++ lib.optional plotsSupport matplotlib;
+    propagatedBuildInputs = [
+      pyqt5 sqlalchemy beautifulsoup4 send2trash pyaudio requests decorator
+      markdown
+    ]
+      ++ lib.optional plotsSupport matplotlib
+      ++ lib.optional stdenv.isDarwin [ CoreAudio ]
+      ;
 
     checkInputs = [ pytest glibcLocales nose ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20430,7 +20430,9 @@ in
 
   angband = callPackage ../games/angband { };
 
-  anki = python3Packages.callPackage ../games/anki { };
+  anki = python3Packages.callPackage ../games/anki {
+    inherit (darwin.apple_sdk.frameworks) CoreAudio;
+  };
 
   armagetronad = callPackage ../games/armagetronad { };
 


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://apps.ankiweb.net/docs/changes.html#changes-in-2.1.8).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

