### PR TITLE
virtscreen: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/quamash/default.nix
+++ b/pkgs/development/python-modules/quamash/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytest, isPy3k, pyqt5, pyqt ? pyqt5 }:
+
+buildPythonPackage rec {
+  pname = "quamash";
+  version = "0.6.1";
+
+  disabled = !isPy3k;
+
+  # No tests in PyPi tarball
+  src = fetchFromGitHub {
+    owner = "harvimt";
+    repo = "quamash";
+    rev = "version-${version}";
+    sha256 = "117rp9r4lz0kfz4dmmpa35hp6nhbh6b4xq0jmgvqm68g9hwdxmqa";
+  };
+
+  propagatedBuildInputs = [ pyqt ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+     pytest -k 'test_qthreadexec.py' # the others cause the test execution to be aborted, I think because of asyncio
+  '';
+
+  meta = with lib; {
+    description = "Implementation of the PEP 3156 event-loop (asyncio) api using the Qt Event-Loop";
+    homepage = https://github.com/harvimt/quamash;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ borisbabic ];
+  };
+}

--- a/pkgs/tools/admin/virtscreen/default.nix
+++ b/pkgs/tools/admin/virtscreen/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, python3Packages, x11vnc, xrandr, libGL }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "virtscreen";
+  version = "0.3.1";
+
+  disabled = python3Packages.pythonOlder "3.6";
+
+  # No tests
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "kbumsik";
+    repo = pname;
+    rev = version;
+    sha256 = "005qach6phz8w17k8kqmyd647c6jkfybczybxq0yxi5ik0s91a08";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    netifaces
+    pyqt5
+    quamash
+    x11vnc
+    xrandr
+  ];
+
+  postPatch = let
+    ext = stdenv.hostPlatform.extensions.sharedLibrary; in ''
+    substituteInPlace virtscreen/__main__.py \
+      --replace "'GL'" "'${libGL}/lib/libGL${ext}'" \
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Make your iPad/tablet/computer as a secondary monitor on Linux";
+    homepage = https://github.com/kbumsik/VirtScreen;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ borisbabic ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19827,6 +19827,8 @@ in
 
   virtinst = callPackage ../applications/virtualization/virtinst {};
 
+  virtscreen = callPackage ../tools/admin/virtscreen {};
+
   virtualbox = callPackage ../applications/virtualization/virtualbox {
     stdenv = stdenv_32bit;
     inherit (gnome2) libIDL;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3919,6 +3919,8 @@ in {
 
   retry_decorator = callPackage ../development/python-modules/retry_decorator { };
 
+  quamash = callPackage ../development/python-modules/quamash { };
+
   quandl = callPackage ../development/python-modules/quandl { };
   # alias for an older package which did not support Python 3
   Quandl = callPackage ../development/python-modules/quandl { };


### PR DESCRIPTION
###### Motivation for this change
Add [virtscreen](https://github.com/kbumsik/VirtScreen), a tool to help use another device (ex. tablet) as an external display over vnc. 
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Along with virtscreen this pull request also adds a dependency, [Quamash](https://github.com/harvimt/quamash). 

I'm not sure if I packaged it the best way. It depends on one of pyqt4/pyqt5/pyside and won't build without one of them and I'm not sure if I handled that in the best way.