### PR TITLE
ngspice: 29 -> 30

### DIFF
--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,12 +1,13 @@
 {stdenv, fetchurl, bison, flex
 , readline, libX11, libICE, libXaw, libXmu, libXext, libXt, fftw }:
 
-stdenv.mkDerivation {
-  name = "ngspice-29";
+stdenv.mkDerivation rec {
+  name = "ngspice-${version}";
+  version = "30";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ngspice/ngspice-29.tar.gz";
-    sha256 = "0jjwz73naq7l9yhwdqbpnrfckywp2ffkppivxjv8w92zq7xhyvcd";
+    url = "mirror://sourceforge/ngspice/ngspice-${version}.tar.gz";
+    sha256 = "15v0jdfy2a2zxp8dmy04fdp7w7a4vwvffcwa688r81b86wphxzh8";
   };
 
   nativeBuildInputs = [ flex bison ];

--- a/pkgs/development/libraries/libngspice/default.nix
+++ b/pkgs/development/libraries/libngspice/default.nix
@@ -2,12 +2,13 @@
 
 # Note that this does not provide the ngspice command-line utility. For that see
 # the ngspice derivation.
-stdenv.mkDerivation {
-  name = "libngspice-29";
+stdenv.mkDerivation rec {
+  name = "libngspice-${version}";
+  version = "30";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ngspice/ngspice-29.tar.gz";
-    sha256 = "0jjwz73naq7l9yhwdqbpnrfckywp2ffkppivxjv8w92zq7xhyvcd";
+    url = "mirror://sourceforge/ngspice/ngspice-${version}.tar.gz";
+    sha256 = "15v0jdfy2a2zxp8dmy04fdp7w7a4vwvffcwa688r81b86wphxzh8";
   };
 
   nativeBuildInputs = [ flex bison ];


### PR DESCRIPTION

###### Motivation for this change

Just a simple bump.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

