### PR TITLE
cpython: Un-remove some test data

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -133,6 +133,7 @@ in stdenv.mkDerivation {
     for item in $out/lib/python${majorVersion}/test/*; do
       if [[ "$item" != */test_support.py*
          && "$item" != */test/support
+         && "$item" != */test/*.pem
          && "$item" != */test/libregrtest
          && "$item" != */test/regrtest.py* ]]; then
         rm -rf "$item"

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -148,6 +148,7 @@ in stdenv.mkDerivation {
     for item in $out/lib/python${majorVersion}/test/*; do
       if [[ "$item" != */test_support.py*
          && "$item" != */test/support
+         && "$item" != */test/*.pem
          && "$item" != */test/libregrtest
          && "$item" != */test/regrtest.py* ]]; then
         rm -rf "$item"

--- a/pkgs/development/interpreters/python/cpython/3.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.7/default.nix
@@ -115,6 +115,7 @@ in stdenv.mkDerivation {
     for item in $out/lib/python${majorVersion}/test/*; do
       if [[ "$item" != */test_support.py*
          && "$item" != */test/support
+         && "$item" != */test/*.pem
          && "$item" != */test/libregrtest
          && "$item" != */test/regrtest.py* ]]; then
         rm -rf "$item"


### PR DESCRIPTION
These certificates are used in asyncio's tests in a way that doesn't
affect CPython directly, but does affect some dependencies, in
particular txaio.

Fixes NixOS/nixpkgs#53474.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

