### PR TITLE
otter-browser: 0.9.99.3 -> 1.0.01

### DIFF
--- a/pkgs/applications/networking/browsers/otter/default.nix
+++ b/pkgs/applications/networking/browsers/otter/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation {
   buildInputs = [ qtbase qtmultimedia qtwebengine ];
 
   meta = with stdenv.lib; {
+    homepage = https://otter-browser.org;
     license = licenses.gpl3Plus;
     description = "Browser aiming to recreate the best aspects of the classic Opera (12.x) UI using Qt5";
     maintainers = with maintainers; [ lheckemann ];

--- a/pkgs/applications/networking/browsers/otter/default.nix
+++ b/pkgs/applications/networking/browsers/otter/default.nix
@@ -1,7 +1,7 @@
 { stdenv, cmake, fetchFromGitHub
 , qtbase, qtmultimedia, qtwebengine
-, version ? "0.9.99.3"
-, sourceSha ? "0dkismjs3daz5afx6s5arwvynsw5qpvv2rqbzvmpihn6khnhap55"
+, version ? "1.0.01"
+, sourceSha ? "1jw8bj3lcqngr0mqwvz1gf47qjxbwiyda7x4sm96a6ckga7pcwyb"
 }:
 stdenv.mkDerivation {
   name = "otter-browser-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---