### PR TITLE
lighttpd: Unbreak on darwin, enable tests

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   '';
 
   checkInputs = [ perl ];
-  doCheck = false; # fails 2 tests
+  doCheck = true;
 
   postInstall = ''
     mkdir -p "$out/share/lighttpd/doc/config"

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, pcre, libxml2, zlib, attr, bzip2, which, file
+{ stdenv, fetchurl, pkgconfig, pcre, libxml2, zlib, bzip2, which, file
 , openssl, enableMagnet ? false, lua5_1 ? null
 , enableMysql ? false, mysql ? null
 , enableLdap ? false, openldap ? null
 , enableWebDAV ? false, sqlite ? null, libuuid ? null
+, enableExtendedAttrs ? false, attr ? null
 , perl
 }:
 
@@ -11,6 +12,7 @@ assert enableMysql -> mysql != null;
 assert enableLdap -> openldap != null;
 assert enableWebDAV -> sqlite != null;
 assert enableWebDAV -> libuuid != null;
+assert enableExtendedAttrs -> attr != null;
 
 stdenv.mkDerivation rec {
   name = "lighttpd-1.4.52";
@@ -25,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ pcre libxml2 zlib attr bzip2 which file openssl ]
+  buildInputs = [ pcre libxml2 zlib bzip2 which file openssl ]
              ++ stdenv.lib.optional enableMagnet lua5_1
              ++ stdenv.lib.optional enableMysql mysql.connector-c
              ++ stdenv.lib.optional enableLdap openldap
@@ -37,7 +39,8 @@ stdenv.mkDerivation rec {
                 ++ stdenv.lib.optional enableMysql "--with-mysql"
                 ++ stdenv.lib.optional enableLdap "--with-ldap"
                 ++ stdenv.lib.optional enableWebDAV "--with-webdav-props"
-                ++ stdenv.lib.optional enableWebDAV "--with-webdav-locks";
+                ++ stdenv.lib.optional enableWebDAV "--with-webdav-locks"
+                ++ stdenv.lib.optional enableExtendedAttrs "--with-attr";
 
   preConfigure = ''
     sed -i "s:/usr/bin/file:${file}/bin/file:g" configure
@@ -59,7 +62,7 @@ stdenv.mkDerivation rec {
     description = "Lightweight high-performance web server";
     homepage = http://www.lighttpd.net/;
     license = stdenv.lib.licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -2,7 +2,7 @@
 , openssl, enableMagnet ? false, lua5_1 ? null
 , enableMysql ? false, mysql ? null
 , enableLdap ? false, openldap ? null
-, enableWebDAV ? true, sqlite ? null, libuuid ? null
+, enableWebDAV ? false, sqlite ? null, libuuid ? null
 , perl
 }:
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---