### PR TITLE
efitools: init at v1.8.1

### DIFF
--- a/pkgs/tools/system/efitools/default.nix
+++ b/pkgs/tools/system/efitools/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, gnu-efi, sbsigntool, openssl, perl, perlPackages, help2man, fetchgit}:
+
+stdenv.mkDerivation {
+  name = "efitools";
+  buildInputs = [ gnu-efi sbsigntool openssl perl perlPackages.FileSlurp help2man];
+
+  preConfigure = ''
+    sed -i 's@-I/usr/include/efi@-I${gnu-efi}/include/efi@g' Make.rules
+    sed -i 's@^CRTPATHS\s*=.*$@CRTPATHS=${gnu-efi}/lib@' Make.rules
+    sed -i "s@\$(DESTDIR)/usr@$out@" Make.rules
+    sed -i "s@\$(DESTDIR)/usr@$out@" Make.rules
+    sed -i 's,#!/usr/bin/env perl,#!${perl}/bin/perl,g' xxdi.pl
+  '';
+
+  src = fetchgit {
+    url = https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;
+    rev = "v1.8.1";
+    sha256 = "1ssx0bw5adb8ja5hszkbi1c9v9hgzhhnwcysbv9g9lgr70459gz6";
+  };
+  
+  meta = with stdenv.lib; {
+    description = "Useful tools for manipulating UEFI secure boot platforms";
+    homepage = https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/about/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ redfish64 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2467,6 +2467,8 @@ in
 
   efibootmgr = callPackage ../tools/system/efibootmgr { };
 
+  efitools = callPackage ../tools/system/efitools { };
+  
   efivar = callPackage ../tools/system/efivar { };
 
   evemu = callPackage ../tools/system/evemu { };


### PR DESCRIPTION
###### Motivation for this change

Add efitools to nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
 (originally written by anonymous user https://github.com/edef , I just made a small fix)
