### PR TITLE
git, gitweb: Fix git-instaweb

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     sha256 = "1scbggzghkzzfqg4ky3qh7h9w87c3zya4ls5disz7dbx56is7sgw";
   };
 
-  outputs = [ "out" ] ++ stdenv.lib.optional perlSupport "gitweb";
+  outputs = [ "out" ];
 
   hardeningDisable = [ "format" ];
 
@@ -87,7 +87,6 @@ stdenv.mkDerivation {
 
   makeFlags = [
     "prefix=\${out}"
-    "gitwebdir=\${gitweb}"  # put in separate package for simpler maintenance
     "SHELL_PATH=${stdenv.shell}"
   ]
   ++ (if perlSupport then ["PERL_PATH=${perlPackages.perl}/bin/perl"] else ["NO_PERL=1"])
@@ -190,11 +189,11 @@ stdenv.mkDerivation {
       # gzip (and optionally bzip2, xz, zip) are runtime dependencies for
       # gitweb.cgi, need to patch so that it's found
       sed -i -e "s|'compressor' => \['gzip'|'compressor' => ['${gzip}/bin/gzip'|" \
-          $gitweb/gitweb.cgi
+          $out/share/gitweb/gitweb.cgi
       # Give access to CGI.pm and friends (was removed from perl core in 5.22)
       for p in ${stdenv.lib.concatStringsSep " " gitwebPerlLibs}; do
           sed -i -e "/use CGI /i use lib \"$p/${perlPackages.perl.libPrefix}\";" \
-              "$gitweb/gitweb.cgi"
+              "$out/share/gitweb/gitweb.cgi"
       done
     ''
 

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -14,6 +14,7 @@
 , darwin
 , withLibsecret ? false
 , pkgconfig, glib, libsecret
+, gzip # needed at runtime by gitweb.cgi
 }:
 
 assert sendEmailSupport -> perlSupport;
@@ -22,6 +23,8 @@ assert svnSupport -> perlSupport;
 let
   version = "2.19.2";
   svn = subversionClient.override { perlBindings = perlSupport; };
+
+  gitwebPerlLibs = with perlPackages; [ CGI HTMLParser CGIFast FCGI FCGIProcManager HTMLTagCloud ];
 in
 
 stdenv.mkDerivation {
@@ -84,6 +87,7 @@ stdenv.mkDerivation {
 
   makeFlags = [
     "prefix=\${out}"
+    "gitwebdir=\${gitweb}"  # put in separate package for simpler maintenance
     "SHELL_PATH=${stdenv.shell}"
   ]
   ++ (if perlSupport then ["PERL_PATH=${perlPackages.perl}/bin/perl"] else ["NO_PERL=1"])
@@ -169,9 +173,6 @@ stdenv.mkDerivation {
       # HTTP(s) transports for pushing
       ln -s $out/libexec/git-core/git-http-backend $out/bin/git-http-backend
     '' + stdenv.lib.optionalString perlSupport ''
-      # put in separate package for simpler maintenance
-      mv $out/share/gitweb $gitweb/
-
       # wrap perl commands
       makeWrapper "$out/share/git/contrib/credential/netrc/git-credential-netrc" $out/bin/git-credential-netrc \
                   --set PERL5LIB   "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
@@ -185,6 +186,16 @@ stdenv.mkDerivation {
                   --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
       wrapProgram $out/libexec/git-core/git-cvsexportcommit \
                   --set GITPERLLIB "$out/${perlPackages.perl.libPrefix}:${perlPackages.makePerlPath perlLibs}"
+
+      # gzip (and optionally bzip2, xz, zip) are runtime dependencies for
+      # gitweb.cgi, need to patch so that it's found
+      sed -i -e "s|'compressor' => \['gzip'|'compressor' => ['${gzip}/bin/gzip'|" \
+          $gitweb/gitweb.cgi
+      # Give access to CGI.pm and friends (was removed from perl core in 5.22)
+      for p in ${stdenv.lib.concatStringsSep " " gitwebPerlLibs}; do
+          sed -i -e "/use CGI /i use lib \"$p/${perlPackages.perl.libPrefix}\";" \
+              "$gitweb/gitweb.cgi"
+      done
     ''
 
    + (if svnSupport then ''

--- a/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, git, fetchFromGitHub
+{ stdenv, buildEnv, git, fetchFromGitHub
 , gitwebTheme ? false }:
 
 let
@@ -6,19 +6,20 @@ let
     owner = "kogakure";
     repo = "gitweb-theme";
     rev = "049b88e664a359f8ec25dc6f531b7e2aa60dd1a2";
-    sha256 = "0wksqma41z36dbv6w6iplkjfdm0ha3njp222fakyh4lismajr71p";
+    extraPostFetch = ''
+      mkdir -p "$TMPDIR/gitwebTheme"
+      mv "$out"/* "$TMPDIR/gitwebTheme/"
+      mkdir "$out/static"
+      mv "$TMPDIR/gitwebTheme"/* "$out/static/"
+    '';
+    sha256 = "17hypq6jvhy6zhh26lp3nyi52npfd5wy5752k6sq0shk4na2acqi";
   };
-in stdenv.mkDerivation {
+in buildEnv {
   name = "gitweb-${stdenv.lib.getVersion git}";
 
-  src = git.gitweb;
-
-  installPhase = ''
-      mkdir $out
-      mv * $out
-
-      ${stdenv.lib.optionalString gitwebTheme "cp ${gitwebThemeSrc}/* $out/static"}
-  '';
+  ignoreCollisions = true;
+  paths = stdenv.lib.optional gitwebTheme "${gitwebThemeSrc}"
+       ++ [ "${git}/share/gitweb" ];
 
   meta = git.meta // {
     maintainers = with stdenv.lib.maintainers; [ gnidorah ];


### PR DESCRIPTION
###### Motivation for this change

Git’s build system does two things with the `gitwebdir` variable:

1. Puts gitweb there
2. Embeds this path into `git-instaweb`

Before this change `git-instaweb` wouldn’t work as it was looking for gitweb in git’s `share` directory, but it was moved away into a separate output by the nix expression.

This PR sets the `gitwebdir` variable in the Makefile and points it to the `gitweb` output. As a result, a path to this output is now embedded into `git-instaweb`, which will affect the closure size, but, AFAIU, only if `perlSupport` is enabled, so this is probably not a problem? I also had to move the fixups from the `gitweb` expression to `git` itself to make sure that `gitweb.cgi` that is referenced from `git-instaweb` is functional.

Fixes #53491.

@gnidorah @peti @the-kenny @wmertens


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

* I always interrupted the build of `git` as its tests take too long, but I am relatively confident that it works as its tests were running successfully for quite a while.
* `git instaweb` now works
* I have not tried to build `gitweb` (as `git` never finished building), but I don’t think this change could break something in it.