### PR TITLE
omping: init at 0.0.5

### DIFF
--- a/pkgs/applications/networking/omping/default.nix
+++ b/pkgs/applications/networking/omping/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  name = "omping-${version}";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner  = "troglobit";
+    repo   = "omping";
+    rev    = version;
+    sha256 = "1f0vsbnhxp7bbgdnfqshryx3nhz2sqdnxdj068s0nmzsh53ckbf7";
+  };
+
+  patches = [
+    # This can go in 0.0.6+
+    (fetchpatch {
+      url    = "https://github.com/troglobit/omping/commit/08a31ec1a6eb4e8f88c301ef679c3b6f9893f333.patch";
+      sha256 = "1xafyvd46bq53w2zvjw8bdw7vjqbrcrr21cyh6d0zfcn4gif1k0f";
+      name   = "fix_manpage_install.patch";
+    })
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Open Multicast Ping (omping) is a tool for testing IPv4/IPv6 multicast connectivity on a LAN.";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4586,6 +4586,8 @@ in
 
   ola = callPackage ../applications/misc/ola { };
 
+  omping = callPackage ../applications/networking/omping { };
+
   onioncircuits = callPackage ../tools/security/onioncircuits {
     inherit (gnome3) defaultIconTheme;
   };


### PR DESCRIPTION
###### Motivation for this change

Missing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

