### PR TITLE
Adding ksh

### DIFF
--- a/pkgs/shells/ksh/default.nix
+++ b/pkgs/shells/ksh/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, meson, ninja, fetchFromGitHub, gcc-unwrapped, which, python }:
+
+with import <nixpkgs> {}; 
+
+stdenv.mkDerivation rec {
+  name = "ksh-${version}";
+  version = "93v";
+
+  src = fetchFromGitHub {
+    owner  = "att";
+    repo   = "ast";
+    rev    = "b8d88244ae87857e7bbd6da230ffbbc51165df70";
+    sha256 = "12kf14n8vz36hnsy3wp6lnyv1841p7hcq25y1d78w532dil69lx9";
+  };
+
+  nativeBuildInputs = [ meson ninja which python ];
+
+  meta = with stdenv.lib; {
+    description = "KornShell Command And Programming Language";
+    longDescription = ''
+      The KornShell language was designed and developed by David G. Korn at
+      AT&T Bell Laboratories. It is an interactive command language that
+      provides access to the UNIX system and to many other systems, on the
+      many different computers and workstations on which it is implemented. 
+    '';
+    homepage = http://www.kornshell.com/i;
+    license = licenses.cpl10;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+  };
+
+  passthru = {
+    shellPath = "/bin/ksh";
+  };
+}

--- a/pkgs/shells/ksh/default.nix
+++ b/pkgs/shells/ksh/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, fetchFromGitHub, gcc-unwrapped, which, python }:
-
-with import <nixpkgs> {}; 
+{ stdenv, meson, ninja, fetchFromGitHub, which, python }:
 
 stdenv.mkDerivation rec {
   name = "ksh-${version}";
@@ -23,7 +21,7 @@ stdenv.mkDerivation rec {
       provides access to the UNIX system and to many other systems, on the
       many different computers and workstations on which it is implemented. 
     '';
-    homepage = http://www.kornshell.com/i;
+    homepage = https://github.com/att/ast;
     license = licenses.cpl10;
     maintainers = with maintainers; [ ];
     platforms = platforms.all;
@@ -33,3 +31,4 @@ stdenv.mkDerivation rec {
     shellPath = "/bin/ksh";
   };
 }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6521,7 +6521,9 @@ in
   fish-foreign-env = callPackage ../shells/fish/fish-foreign-env { };
 
   ion = callPackage ../shells/ion { };
-
+  
+  ksh = callPackage ../shells/ksh { };
+  
   mksh = callPackage ../shells/mksh { };
 
   oh = callPackage ../shells/oh { };


### PR DESCRIPTION
###### Motivation for this change
There is no ksh, which needed for some commercial software, so I want to add it to the repository.  I believe someone will need it too some day.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [+] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [+] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

