### PR TITLE
python.pkgs.r2pipe: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/r2pipe/default.nix
+++ b/pkgs/development/python-modules/r2pipe/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, python
+, buildPythonPackage
+, fetchPypi
+, radare2
+, coreutils
+}:
+
+buildPythonPackage rec {
+  pname = "r2pipe";
+  version = "1.2.0";
+
+  postPatch = let
+    r2lib = "${lib.getOutput "lib" radare2}/lib";
+    libr_core = "${r2lib}/libr_core${stdenv.hostPlatform.extensions.sharedLibrary}";
+  in
+  ''
+    # Fix find_library, can be removed after
+    # https://github.com/NixOS/nixpkgs/issues/7307 is resolved.
+    substituteInPlace r2pipe/native.py --replace "find_library('r_core')" "'${libr_core}'"
+
+    # Fix the default r2 executable
+    substituteInPlace r2pipe/open_sync.py --replace "r2e = 'radare2'" "r2e = '${radare2}/bin/radare2'"
+    substituteInPlace r2pipe/open_base.py --replace 'which("radare2")' "'${radare2}/bin/radare2'"
+  '';
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qs3xqmi9alahsgr8akzw06ia4c3554dz8pran1h7z5llk262nj4";
+  };
+
+  # Tiny sanity check to make sure r2pipe finds radare2 (since r2pipe doesn't
+  # provide its own tests):
+  # Analyze ls with the fastest analysis and do nothing with the result.
+  postCheck = ''
+    ${python.interpreter} <<EOF
+    import r2pipe
+    r2 = r2pipe.open('${coreutils}/bin/ls')
+    r2.cmd('a')
+    r2.quit()
+    EOF
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Interact with radare2";
+    homepage = https://github.com/radare/radare2-r2pipe;
+    license = licenses.mit;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2094,6 +2094,8 @@ in {
 
   svg-path = callPackage ../development/python-modules/svg-path { };
 
+  r2pipe = callPackage ../development/python-modules/r2pipe { };
+
   regex = callPackage ../development/python-modules/regex { };
 
   ratelimiter = callPackage ../development/python-modules/ratelimiter { };


### PR DESCRIPTION
###### Motivation for this change

Init r2pipe which can be used to script the popular radare2 reverse-engineering framework.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

