### PR TITLE
pythonPackages.pytest-rerunfailures: 4.2 -> 5.0

### DIFF
--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -2,24 +2,23 @@
 
 buildPythonPackage rec {
   pname = "pytest-rerunfailures";
-  version = "4.2";
+  version = "6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "97216f8a549f74da3cc786236d9093fbd43150a6fbe533ba622cb311f7431774";
+    sha256 = "978349ae00687504fd0f9d0970c37199ccd89cbdb0cb8c4ed7ee417ede582b40";
   };
 
   checkInputs = [ mock ];
 
   propagatedBuildInputs = [ pytest ];
 
-  # disable tests that fail with pytest 3.7.4
   checkPhase = ''
-    py.test test_pytest_rerunfailures.py -k 'not test_reruns_with_delay'
+    py.test test_pytest_rerunfailures.py
   '';
 
   meta = with stdenv.lib; {
-    description = "pytest plugin to re-run tests to eliminate flaky failures.";
+    description = "pytest plugin to re-run tests to eliminate flaky failures";
     homepage = https://github.com/pytest-dev/pytest-rerunfailures;
     license = licenses.mpl20;
     maintainers = with maintainers; [ jgeerds ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

