### PR TITLE
kitty: 0.13.1 -> 0.13.2

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -7,7 +7,7 @@
 
 with python3Packages;
 buildPythonApplication rec {
-  version = "0.13.1";
+  version = "0.13.2";
   name = "kitty-${version}";
   format = "other";
 
@@ -15,7 +15,7 @@ buildPythonApplication rec {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "1j24zjasdh48z7majfpqr71n1wn5a9688wsmmqn26v8kfb68pqs4";
+    sha256 = "1w93fq4rks6va0aapz6f6l1cn6zhchrfq8fv39xb6x0llx78dimx";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/kitty/fix-paths.patch
+++ b/pkgs/applications/misc/kitty/fix-paths.patch
@@ -6,8 +6,8 @@
      static bool done = false;
 -    static const char* libname = "libstartup-notification-1.so";
 +    static const char* libname = "@libstartup_notification@";
-     if (!done) {
-         done = true;
+     // some installs are missing the .so symlink, so try the full name
+     static const char* libname2 = "libstartup-notification-1.so.0";
 
 --- a/docs/Makefile
 +++ b/docs/Makefile


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

