### PR TITLE
(ruby-modules/gem): (refactor)

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -144,6 +144,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
       echo "gem package built: $gempkg"
     elif [[ "$type" == "git" ]]; then
       git init
+      # remove variations to improve the likelihood of a bit-reproducible output
       rm -rf .git/logs/ .git/hooks/ .git/index .git/FETCH_HEAD .git/ORIG_HEAD .git/refs/remotes/origin/HEAD .git/config
       # support `git ls-files`
       git add .

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -143,7 +143,6 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
 
       echo "gem package built: $gempkg"
     elif [[ "$type" == "git" ]]; then
-      ls .git | head -n 10
       git init
       git config user.email nixbld@localhost.none
       git config user.name Nix

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -63,7 +63,6 @@ let
     else if type == "git" then
       fetchgit {
         inherit (attrs.source) url rev sha256 fetchSubmodules;
-        leaveDotGit = true;
       }
     else if type == "url" then
       fetchurl attrs.source
@@ -94,6 +93,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
   name = attrs.name or "${namePrefix}${gemName}-${version}";
 
   inherit src;
+
 
   unpackPhase = attrs.unpackPhase or ''
     runHook preUnpack
@@ -142,6 +142,13 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
       gempkg=$(echo "$output" | grep -oP 'File: \K(.*)')
 
       echo "gem package built: $gempkg"
+    elif [[ "$type" == "git" ]]; then
+      ls .git | head -n 10
+      git init
+      git config user.email nixbld@localhost.none
+      git config user.name Nix
+      git add .
+      git commit -m "Nixpkgs setup for rubygems" || true
     fi
 
     runHook postBuild

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -144,8 +144,8 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
       echo "gem package built: $gempkg"
     elif [[ "$type" == "git" ]]; then
       git init
-      git add .
       rm -rf .git/logs/ .git/hooks/ .git/index .git/FETCH_HEAD .git/ORIG_HEAD .git/refs/remotes/origin/HEAD .git/config
+      git add .
     fi
 
     runHook postBuild

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -145,6 +145,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     elif [[ "$type" == "git" ]]; then
       git init
       rm -rf .git/logs/ .git/hooks/ .git/index .git/FETCH_HEAD .git/ORIG_HEAD .git/refs/remotes/origin/HEAD .git/config
+      # support `git ls-files`
       git add .
     fi
 

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -144,10 +144,8 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
       echo "gem package built: $gempkg"
     elif [[ "$type" == "git" ]]; then
       git init
-      git config user.email nixbld@localhost.none
-      git config user.name Nix
       git add .
-      git commit -m "Nixpkgs setup for rubygems" || true
+      rm -rf .git/logs/ .git/hooks/ .git/index .git/FETCH_HEAD .git/ORIG_HEAD .git/refs/remotes/origin/HEAD .git/config
     fi
 
     runHook postBuild


### PR DESCRIPTION
###### Motivation for this change

Rubygems with a `git` source use `leaveDotGit` across the board. The upshot is that many unrelated changes to the upstream git repo (even on a gem that is referred to by `ref`) will change the fixed output digest and fail builds.

###### Things done

This PR removes `leaveDotGit` and replaces it with a series of git commands to recreate the git repo locally during build. The reason for this is that many gems use some variation of `git ls-files` rather than specifically enumerating their manifests. This is plainly wrong, but that battle is well lost.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have used this branch to build a relatively complicated gemset.nix that includes git gems. Attempts to use `nox-review` exhausted the disk on my laptop.
