### PR TITLE
maintainer-list: countingsort -> buffet

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -669,6 +669,11 @@
     github = "bstrik";
     name = "Berno Strik";
   };
+  buffet = {
+    email = "niclas@countingsort.com";
+    github = "buffet";
+    name = "Niclas Meyer";
+  };
   bugworm = {
     email = "bugworm@zoho.com";
     github = "bugworm";
@@ -926,11 +931,6 @@
     email = "couchemar@yandex.ru";
     github = "couchemar";
     name = "Andrey Pavlov";
-  };
-  countingsort = {
-    email = "niclas@countingsort.com";
-    github = "countingsort";
-    name = "Niclas Meyer";
   };
   cpages = {
     email = "page@ruiec.cat";

--- a/pkgs/tools/package-management/bunny/default.nix
+++ b/pkgs/tools/package-management/bunny/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://gitlab.com/tim241/bunny;
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ countingsort ];
+    maintainers = with maintainers; [ buffet ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I changed my GitHub name a while ago, don't think it actually matters, since the email is still correct, but who knows.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

