### PR TITLE
nvidia_x11: 410.78 -> 410.93

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -19,10 +19,10 @@ rec {
   stable = if stdenv.hostPlatform.system != "x86_64-linux"
     then legacy_390
     else generic {
-      version = "410.78";
-      sha256_64bit = "1ciabnmvh95gsfiaakq158x2yws3m9zxvnxws3p32lz9riblpdjx";
-      settingsSha256 = "1677g7rcjbcs5fja1s4p0syhhz46g9x2qqzyn3wwwrjsj7rwaz77";
-      persistencedSha256 = "01kvd3zp056i4n8vazj7gx1xw0h4yjdlpazmspnsmwg24ijb82x4";
+      version = "410.93";
+      sha256_64bit = "0q913rr0j24h50a17isi1j0amg8fl3xa15rrz3lq1ijxw8mybgik";
+      settingsSha256 = "0xg0rrapa8wj46jkwflcgv04ib789bj00d48chr3sy65djrciskn";
+      persistencedSha256 = "138w8xbmw64frdg3ncyq36qa43dyfq1hrccd3qp2zvklcr8cdy2v";
     };
 
   # No active beta right now


### PR DESCRIPTION
###### Motivation for this change
this updated is needed for the driver to be build with the new linux kernel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

