### PR TITLE
tilix: 1.8.5 -> 1.8.9

### DIFF
--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -1,33 +1,33 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, dmd, gnome3, dbus
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, dmd, gnome3, dbus
 , gsettings-desktop-schemas, desktop-file-utils, gettext, gtkd, libsecret
-, perlPackages, wrapGAppsHook, xdg_utils }:
+, appstream-glib, libunwind, perlPackages, wrapGAppsHook, xdg_utils }:
 
 stdenv.mkDerivation rec {
   name = "tilix-${version}";
-  version = "1.8.5";
+  version = "1.8.9";
 
   src = fetchFromGitHub {
     owner = "gnunn1";
     repo = "tilix";
     rev = "${version}";
-    sha256 = "1ixhkssz0xn3x75n2iw6gd3hka6bgmgwfgbvblbjhhx8gcpbw3s7";
+    sha256 = "1l1ib3g01mxiywbwjxc2522qgjy3ymjzy8bxl42k0hprpp95rw9d";
   };
 
   nativeBuildInputs = [
-    autoreconfHook dmd desktop-file-utils perlPackages.Po4a pkgconfig xdg_utils
-    wrapGAppsHook
+    meson ninja dmd desktop-file-utils perlPackages.Po4a pkgconfig xdg_utils
+    appstream-glib wrapGAppsHook
   ];
-  buildInputs = [ gnome3.dconf gettext gsettings-desktop-schemas gtkd dbus libsecret ];
+  buildInputs = [ gnome3.dconf gettext gsettings-desktop-schemas gtkd dbus libsecret libunwind ];
 
-  preBuild = ''
-    makeFlagsArray=(
-      DCFLAGS='-O -inline -release -version=StdLoggerDisableTrace'
-    )
+  # Don't use dub to fetch and build dependencies
+  patches = [ ./no-dub.patch ];
+
+  postPatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
   '';
 
   postInstall = with gnome3; ''
-    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
-
     wrapProgram $out/bin/tilix \
       --prefix LD_LIBRARY_PATH ":" "${libsecret}/lib"
   '';
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Tiling terminal emulator following the Gnome Human Interface Guidelines.";
+    description = "Tiling terminal emulator following the Gnome Human Interface Guidelines";
     homepage = https://gnunn1.github.io/tilix-web;
     license = licenses.mpl20;
     maintainers = with maintainers; [ midchildan ];

--- a/pkgs/applications/misc/tilix/no-dub.patch
+++ b/pkgs/applications/misc/tilix/no-dub.patch
@@ -1,0 +1,26 @@
+diff --git a/meson.build b/meson.build
+index feff315..cb92631 100644
+--- a/meson.build
++++ b/meson.build
+@@ -93,12 +93,8 @@ source_root = meson.source_root()
+ sources_dir = include_directories('source/')
+ 
+ # Dependencies
+-# Note relying on dub to fetch and build dependencies before running meson build is temporary due to a bug in Meson 0.48
+-# gtkd_dep = dependency('gtkd-3', version: '>= 3.8.5')
+-# vted_dep = dependency('vted-3', version: '>= 3.8.5')
+-
+-gtkd_dep = dependency('gtk-d:gtkd', version: '>=3.8.5', method: 'dub')
+-vted_dep = dependency('gtk-d:vte', version: '>=3.8.5', method: 'dub')
++gtkd_dep = dependency('gtkd-3', version: '>= 3.8.5')
++vted_dep = dependency('vted-3', version: '>= 3.8.5')
+ xlib_dep = dependency('x11')
+ libunwind_dep = dependency('libunwind')
+ msgfmt = find_program('msgfmt')
+@@ -130,4 +126,4 @@ executable('tilix',
+ #)
+ #test('tilix_test', tilix_test_exe)
+ 
+-meson.add_install_script('meson_post_install.py')
+\ No newline at end of file
++meson.add_install_script('meson_post_install.py')

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gtkd-${version}";
-  version = "3.8.4";
+  version = "3.8.5";
 
   src = fetchzip {
     url = "https://gtkd.org/Downloads/sources/GtkD-${version}.zip";
-    sha256 = "0q2kf1jwr89i8ajjzyf3b4bbla33djvnwrvljq17y206q7qknfyz";
+    sha256 = "12n2njsaplra7x15nqwrj2hrf8a27pfjj2mck4mkzxv03qk6mqky";
     stripRoot = false;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update `tilix` to its latest version and build with meson. This required me to also bump `gtkd`.

This currently fails pretty early with
```
data/meson.build:99:0: ERROR:  Output file name must not contain a subdirectory.
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

