### PR TITLE
pythonPackages.m2crypto: fix build with libressl

### DIFF
--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, fetchpatch
 , buildPythonPackage
 , fetchPypi
 , swig2
@@ -16,6 +17,14 @@ buildPythonPackage rec {
     sha256 = "a1b2751cdadc6afac3df8a5799676b7b7c67a6ad144bb62d38563062e7cd3fc6";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/void-linux/void-packages/raw/7946d12eb3d815e5ecd4578f1a6133d948694370/srcpkgs/python-M2Crypto/patches/libressl.patch";
+      sha256 = "0z5qnkndg6ma5f5qqrid5m95i9kybsr000v3fdy1ab562kf65a27";
+    })
+  ];
+  patchFlags = "-p0";
+
   buildInputs = [ swig2 openssl ];
 
   propagatedBuildInputs = [ typing ];
@@ -30,6 +39,7 @@ buildPythonPackage rec {
     description = "A Python crypto and SSL toolkit";
     homepage = http://chandlerproject.org/Projects/MeTooCrypto;
     license = licenses.mit;
+    maintainers = with maintainers; [ andrew-d ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
Fix build with libressl, since it does not include some of the OpenSSL APIs.
Fixes #53529

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @qolii 