### PR TITLE
alsaLib: add upstream pcm interval patch to fix audio

### DIFF
--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "alsa-lib-1.1.7";
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./alsa-plugin-conf-multilib.patch
+    (fetchpatch { # pcm interval fix needed for some programs with broken audio, remove when bumping version
+      name = "pcm-interval-fix.patch";
+      url = "http://git.alsa-project.org/?p=alsa-lib.git;a=commitdiff_plain;h=b420056604f06117c967b65d43d01536c5ffcbc9";
+      sha256 = "1vjfslzsypd6w15zvvrpdk825hm5j0gz16gw7kj290pkbsdgd435";
+    })
   ];
 
   # Fix pcm.h file in order to prevent some compilation bugs


### PR DESCRIPTION
fixes audio for Audacious, Old School Runescape (yet to be packaged, but I'm working on that!),
and a few other packages, see the following issues:

https://bugs.archlinux.org/task/60591?project=1&string=alsa-lib
https://bugzilla.redhat.com/show_bug.cgi?id=1640602
http://git.alsa-project.org/?p=alsa-lib.git;a=commitdiff;h=b420056604f06117c967b65d43d01536c5ffcbc9

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

