### PR TITLE
searx: 0.14.0 -> 0.15.0 [backport]

### DIFF
--- a/pkgs/development/python-modules/plone-testing/default.nix
+++ b/pkgs/development/python-modules/plone-testing/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, six
 , zope_testing
 , setuptools
 }:
@@ -14,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "8aa7c45237b883ea1d1c28fb465322f69310b084b9f9b6a79af64401b649dc4c";
   };
 
-  propagatedBuildInputs = [ setuptools zope_testing ];
+  propagatedBuildInputs = [ six setuptools zope_testing ];
 
   # Huge amount of testing dependencies (including Zope2)
   doCheck = false;

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -4,26 +4,31 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "searx";
-  version = "0.14.0";
+  version = "0.15.0";
 
   # Can not use PyPI because certain test files are missing.
   src = fetchFromGitHub {
     owner = "asciimoo";
     repo = "searx";
     rev = "v${version}";
-    sha256 = "046xg6xcs1mxgahz7kwf3fsmwd99q3hhms6pdjlvyczidlfhpmxl";
+    sha256 = "05si0fn57z1g80l6003cs0ypag2m6zyi3dgsi06pvjp066xbrjvd";
   };
 
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace 'certifi==2017.11.5' 'certifi' \
-      --replace 'flask==0.12.2' 'flask==0.12.*' \
+      --replace 'flask==1.0.2' 'flask==1.0.*' \
       --replace 'flask-babel==0.11.2' 'flask-babel==0.11.*' \
-      --replace 'lxml==4.1.1' 'lxml==4.1.*' \
-      --replace 'idna==2.5' 'idna' \
+      --replace 'lxml==4.2.3' 'lxml==4.2.*' \
+      --replace 'idna==2.7' 'idna' \
       --replace 'pygments==2.1.3' 'pygments>=2.1,<3.0' \
-      --replace 'pyopenssl==17.4.0' 'pyopenssl' \
-      --replace 'python-dateutil==2.6.1' 'python-dateutil==2.6.*'
+      --replace 'pyopenssl==18.0.0' 'pyopenssl' \
+      --replace 'python-dateutil==2.7.3' 'python-dateutil==2.7.*'
+    substituteInPlace requirements-dev.txt \
+      --replace 'plone.testing==5.0.0' 'plone.testing' \
+      --replace 'pep8==1.7.1' 'pep8==1.7.*' \
+      --replace 'splinter==0.7.5' 'splinter' \
+      --replace 'selenium==3.5.0' 'selenium'
   '';
 
   propagatedBuildInputs = [
@@ -33,7 +38,8 @@ buildPythonApplication rec {
   ];
 
   checkInputs = [
-    splinter mock plone-testing robotsuite unittest2 selenium
+    Babel mock nose2 covCore pep8 plone-testing splinter
+    unittest2 zope_testrunner selenium
   ];
 
   preCheck = ''

--- a/pkgs/servers/web-apps/searx/default.nix
+++ b/pkgs/servers/web-apps/searx/default.nix
@@ -29,6 +29,12 @@ buildPythonApplication rec {
       --replace 'pep8==1.7.1' 'pep8==1.7.*' \
       --replace 'splinter==0.7.5' 'splinter' \
       --replace 'selenium==3.5.0' 'selenium'
+
+    # fix decoding when loading the README
+    substituteInPlace setup.py --replace \
+      'open(os.path.join(os.path.dirname(__file__), *rnames)).read()' \
+      'open(os.path.join(os.path.dirname(__file__), *rnames),
+            encoding="utf-8").read()'
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
This update has fixes for currently broken search engines.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not sure why the decode error occurs in 18.09 but not in master, was this fixed tree-wide recently?