### PR TITLE
yubioath-desktop: Fix the desktop icon

### DIFF
--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -27,7 +27,7 @@ python27Packages.buildPythonApplication rec {
       cp resources/yubioath*.{icns,ico,png,xpm} $out/share/yubioath/icons
       substituteInPlace $out/share/applications/yubioath.desktop \
         --replace 'Exec=yubioath-gui' "Exec=$out/bin/yubioath-gui" \
-        --replace 'Icon=yubioath' "Icon=$out/share/yubioath/icons"
+        --replace 'Icon=yubioath' "Icon=$out/share/yubioath/icons/yubioath-desktop.png"
 
     '';
 


### PR DESCRIPTION
###### Motivation for this change

`yubioath-desktop` did not have an icon in the applications menu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

