### PR TITLE
cpupower: add bash_completion_dir (linux 5.0-rc1)

### DIFF
--- a/pkgs/os-specific/linux/cpupower/default.nix
+++ b/pkgs/os-specific/linux/cpupower/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation {
     "localedir=$(out)/share/locale"
     "docdir=$(out)/share/doc/cpupower"
     "confdir=$(out)/etc"
+    "bash_completion_dir=$(out)/share/bash-completion/completions"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

linux_testing fails to build

https://github.com/torvalds/linux/commit/901d32bc69f3423ad53947b992f973123faf2622

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---