### PR TITLE
pyznap: init at 1.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3773,6 +3773,11 @@
     github = "rbasso";
     name = "Rafael Basso";
   };
+  rbrewer = {
+    email = "rwb123@gmail.com";
+    github = "rbrewer123";
+    name = "Rob Brewer";
+  };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";

--- a/pkgs/tools/backup/pyznap/default.nix
+++ b/pkgs/tools/backup/pyznap/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, paramiko
+, configparser
+}:
+
+buildPythonApplication rec {
+  pname = "pyznap";
+  version = "1.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9ac0da5d7f6461d1d6f128362786e297144b415f9e3a2f1835642ab3dda82d55";
+  };
+
+  propagatedBuildInputs = [ configparser paramiko ];
+
+  # tests aren't included in the PyPI packages
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/yboetz/pyznap";
+    description = "ZFS snapshot tool written in python";
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ rbrewer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1579,6 +1579,8 @@ in
 
   pyCA = python3Packages.callPackage ../applications/video/pyca {};
 
+  pyznap = python3Packages.callPackage ../tools/backup/pyznap {};
+
   scour = with python3Packages; toPythonApplication scour;
 
   s2png = callPackage ../tools/graphics/s2png { };


### PR DESCRIPTION
###### Motivation for this change

Add pyznap ZFS snapshot package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

