### PR TITLE
aws-xray-daemon-V3.0.0 | awx-xray-daemon: init at V3.0.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -473,6 +473,7 @@
   ./services/monitoring/vnstat.nix
   ./services/monitoring/zabbix-agent.nix
   ./services/monitoring/zabbix-server.nix
+  ./services/monitoring/aws-xray-daemon.nix
   ./services/network-filesystems/beegfs.nix
   ./services/network-filesystems/cachefilesd.nix
   ./services/network-filesystems/davfs2.nix

--- a/nixos/modules/services/monitoring/aws-xray-daemon.nix
+++ b/nixos/modules/services/monitoring/aws-xray-daemon.nix
@@ -3,156 +3,47 @@
 with lib;
 
 let
-    cfg = config.services.aws-xray-daemon;
 
-    xrayConfig = {
-        TotalBufferSizeMB = cfg.TotalBufferSizeMB;
-        Concurrency = cfg.Concurrency;
-        Region = cfg.Region;
-        Endpoint = cfg.EndPoint;
-        Socket = {
-          UDPAddress = cfg.Socket.UDPAddress;
-          TCPAddress = cfg.Socket.TCPAddress;
-        };
-        Logging = {
-          LogRotation = cfg.Logging.LogRotation;
-          LogLevel = cfg.Logging.LogLevel;
-          LogPath = cfg.Logging.LogPath;
-        };
-        LocalMode = cfg.LocalMode;
-        ResourceARN = cfg.ResourceARN;
-        RoleARN = cfg.RoleARN;
-        NoVerifySSL = cfg.NoVerifySSL;
-        ProxyAddress = cfg.ProxyAddress;
-        Version = cfg.Version;
-    };
+cfg = config.services.aws-xray-daemon;
 
-    configFile = pkgs.writeText "xray.yaml" (builtins.toJSON xrayConfig);
+configFile = pkgs.writeText "xray.yaml" cfg.configs;
+
 in
 {
-    options.services.aws-xray-daemon = {
-        enable = mkOption {
-            description = "Whether to enable aws-xray-daemon service";
-            default = false;
-            type = types.bool;
-        };
-
-        package = mkOption {
-            description = "Which aws-xray-daemon package to use";
-            default = pkgs.aws-xray-daemon;
-            type = types.package;
-        };
-
-        TotalBufferSizeMB = mkOption {
-            description = "Maximum buffer size in MB (minimum 3). Choose 0 to use 1% of host memory.";
-            default = 0;
-            type = types.int;
-        };
-
-        Concurrency = mkOption {
-            description = "Maximum number of concurrent calls to AWS X-Ray to upload segment documents.";
-            default = 8;
-            type = types.int;
-        };
-
-        Region = mkOption {
-            description = "Send segments to AWS X-Ray service in a specific region.";
-            default = "";
-            type = types.str;
-        };
-
-        EndPoint = mkOption {
-            description = "Change the X-Ray service endpoint to which the daemon sends segment documents.";
-            default = "";
-            type = types.str;
-        };
-
-        Socket = {
-            UDPAddress = mkOption {
-                description = "Change the address and port on which the daemon listens for UDP packets containing segment documents.";
-                default = "127.0.0.1:2000";
-                type = types.str;
-            };
-
-            TCPAddress = mkOption {
-                description = "Change the address and port on which the daemon listens for HTTP requests to proxy to AWS X-Ray.";
-                default = "127.0.0.1:2000";
-                type = types.str;
-            };
-        };
-
-        Logging = {
-            LogRotation = mkOption {
-                description = "Whether to enable log rotation.";
-                default = true;
-                type = types.bool;
-            };
-
-            LogLevel = mkOption {
-                description = "Change the log level, from most verbose to least: dev, debug, info, warn, error, prod (default).";
-                default = "prod";
-                type = types.str;
-            };
-
-            LogPath = mkOption {
-                description = "Output logs to the specified file path.";
-                default = "";
-                type = types.str;
-            };
-        };
-
-        LocalMode = mkOption {
-            description = "Turn on local mode to skip EC2 instance metadata check.";
-            default = false;
-            type = types.bool;
-        };
-
-        ResourceARN = mkOption {
-            description = "Amazon Resource Name (ARN) of the AWS resource running the daemon.";
-            default = "";
-            type = types.str;
-        };
-
-        RoleARN = mkOption {
-            description = "Assume an IAM role to upload segments to a different account.";
-            default = "";
-            type = types.str;
-        };
-
-        NoVerifySSL = mkOption {
-            description = "Disable TLS certificate verification.";
-            default = false;
-            type = types.bool;
-        };
-
-        ProxyAddress = mkOption {
-            description = "Upload segments to AWS X-Ray through a proxy.";
-            default = "";
-            type = types.str;
-        };
-
-        Version = mkOption {
-            description = "Daemon configuration file format version.";
-            default = 2;
-            type = types.int;
-        };
+  options.services.aws-xray-daemon = {
+    enable = mkOption {
+      description = "Whether to enable aws-xray-daemon service";
+      default = false;
+      type = types.bool;
     };
 
-    config = mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
-
-        systemd.services.aws-xray-daemon = {
-            description = "aws xray daemon service";
-            wantedBy = [ "multi-user.target" ];
-            after = [ "networking.target" ];
-            serviceConfig = {
-                ExecStart = "${cfg.package.bin}/bin/daemon --config ${configFile}";
-                User = "xray";
-            };
-        };
-
-        users.users.xray = {
-          description = "xray user";
-        };
+    package = mkOption {
+      description = "Which aws-xray-daemon package to use";
+      default = pkgs.aws-xray-daemon;
+      type = types.package;
     };
+
+    configs = mkOption {
+      description = "Aws xray configurations json or yaml formatted.";
+      default = "Version: 2";
+      type = types.str;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    systemd.services.aws-xray-daemon = {
+      description = "aws xray daemon service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ];
+      serviceConfig = {
+          ExecStart = "${cfg.package.bin}/bin/daemon --config ${configFile}";
+          User = "xray";
+      };
+    };
+
+    users.users.xray = {
+      description = "xray user";
+    };
+  };
 }

--- a/nixos/modules/services/monitoring/aws-xray-daemon.nix
+++ b/nixos/modules/services/monitoring/aws-xray-daemon.nix
@@ -1,0 +1,158 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+    cfg = config.services.aws-xray-daemon;
+
+    xrayConfig = {
+        TotalBufferSizeMB = cfg.TotalBufferSizeMB;
+        Concurrency = cfg.Concurrency;
+        Region = cfg.Region;
+        Endpoint = cfg.EndPoint;
+        Socket = {
+          UDPAddress = cfg.Socket.UDPAddress;
+          TCPAddress = cfg.Socket.TCPAddress;
+        };
+        Logging = {
+          LogRotation = cfg.Logging.LogRotation;
+          LogLevel = cfg.Logging.LogLevel;
+          LogPath = cfg.Logging.LogPath;
+        };
+        LocalMode = cfg.LocalMode;
+        ResourceARN = cfg.ResourceARN;
+        RoleARN = cfg.RoleARN;
+        NoVerifySSL = cfg.NoVerifySSL;
+        ProxyAddress = cfg.ProxyAddress;
+        Version = cfg.Version;
+    };
+
+    configFile = pkgs.writeText "xray.yaml" (builtins.toJSON xrayConfig);
+in
+{
+    options.services.aws-xray-daemon = {
+        enable = mkOption {
+            description = "Whether to enable aws-xray-daemon service";
+            default = false;
+            type = types.bool;
+        };
+
+        package = mkOption {
+            description = "Which aws-xray-daemon package to use";
+            default = pkgs.aws-xray-daemon;
+            type = types.package;
+        };
+
+        TotalBufferSizeMB = mkOption {
+            description = "Maximum buffer size in MB (minimum 3). Choose 0 to use 1% of host memory.";
+            default = 0;
+            type = types.int;
+        };
+
+        Concurrency = mkOption {
+            description = "Maximum number of concurrent calls to AWS X-Ray to upload segment documents.";
+            default = 8;
+            type = types.int;
+        };
+
+        Region = mkOption {
+            description = "Send segments to AWS X-Ray service in a specific region.";
+            default = "";
+            type = types.str;
+        };
+
+        EndPoint = mkOption {
+            description = "Change the X-Ray service endpoint to which the daemon sends segment documents.";
+            default = "";
+            type = types.str;
+        };
+
+        Socket = {
+            UDPAddress = mkOption {
+                description = "Change the address and port on which the daemon listens for UDP packets containing segment documents.";
+                default = "127.0.0.1:2000";
+                type = types.str;
+            };
+
+            TCPAddress = mkOption {
+                description = "Change the address and port on which the daemon listens for HTTP requests to proxy to AWS X-Ray.";
+                default = "127.0.0.1:2000";
+                type = types.str;
+            };
+        };
+
+        Logging = {
+            LogRotation = mkOption {
+                description = "Whether to enable log rotation.";
+                default = true;
+                type = types.bool;
+            };
+
+            LogLevel = mkOption {
+                description = "Change the log level, from most verbose to least: dev, debug, info, warn, error, prod (default).";
+                default = "prod";
+                type = types.str;
+            };
+
+            LogPath = mkOption {
+                description = "Output logs to the specified file path.";
+                default = "";
+                type = types.str;
+            };
+        };
+
+        LocalMode = mkOption {
+            description = "Turn on local mode to skip EC2 instance metadata check.";
+            default = false;
+            type = types.bool;
+        };
+
+        ResourceARN = mkOption {
+            description = "Amazon Resource Name (ARN) of the AWS resource running the daemon.";
+            default = "";
+            type = types.str;
+        };
+
+        RoleARN = mkOption {
+            description = "Assume an IAM role to upload segments to a different account.";
+            default = "";
+            type = types.str;
+        };
+
+        NoVerifySSL = mkOption {
+            description = "Disable TLS certificate verification.";
+            default = false;
+            type = types.bool;
+        };
+
+        ProxyAddress = mkOption {
+            description = "Upload segments to AWS X-Ray through a proxy.";
+            default = "";
+            type = types.str;
+        };
+
+        Version = mkOption {
+            description = "Daemon configuration file format version.";
+            default = 2;
+            type = types.int;
+        };
+    };
+
+    config = mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+
+        systemd.services.aws-xray-daemon = {
+            description = "aws xray daemon service";
+            wantedBy = [ "multi-user.target" ];
+            after = [ "networking.target" ];
+            serviceConfig = {
+                ExecStart = "${cfg.package.bin}/bin/daemon --config ${configFile}";
+                User = "xray";
+            };
+        };
+
+        users.users.xray = {
+          description = "xray user";
+        };
+    };
+}

--- a/pkgs/tools/networking/aws-xray-daemon/default.nix
+++ b/pkgs/tools/networking/aws-xray-daemon/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+        name = "aws-xray-daemon-${version}";
+        version = "V3.0.0";
+
+        goPackagePath = "github.com/aws/aws-xray-daemon";
+        subPackages = [ "daemon" ];
+
+        src = fetchFromGitHub {
+            owner = "aws";
+            repo = "aws-xray-daemon";
+            rev = "${version}";
+            sha256 = "090z5q7iw6y9c0d70z29mxqw55yxxh9d8bnl6lxda72rhmdnvfcq";
+        };
+
+        goDeps = ./deps.nix;
+
+        meta = {
+            homepage = "https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html";
+            description = "aws X-RAY daemon.";
+            license = stdenv.lib.licenses.asl20;
+        };
+}

--- a/pkgs/tools/networking/aws-xray-daemon/default.nix
+++ b/pkgs/tools/networking/aws-xray-daemon/default.nix
@@ -1,24 +1,24 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-        name = "aws-xray-daemon-${version}";
-        version = "V3.0.0";
+  name = "aws-xray-daemon-${version}";
+  version = "V3.0.0";
 
-        goPackagePath = "github.com/aws/aws-xray-daemon";
-        subPackages = [ "daemon" ];
+  goPackagePath = "github.com/aws/aws-xray-daemon";
+  subPackages = [ "daemon" ];
 
-        src = fetchFromGitHub {
-            owner = "aws";
-            repo = "aws-xray-daemon";
-            rev = "${version}";
-            sha256 = "090z5q7iw6y9c0d70z29mxqw55yxxh9d8bnl6lxda72rhmdnvfcq";
-        };
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-xray-daemon";
+    rev = "${version}";
+    sha256 = "090z5q7iw6y9c0d70z29mxqw55yxxh9d8bnl6lxda72rhmdnvfcq";
+  };
 
-        goDeps = ./deps.nix;
+  goDeps = ./deps.nix;
 
-        meta = {
-            homepage = "https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html";
-            description = "aws X-RAY daemon.";
-            license = stdenv.lib.licenses.asl20;
-        };
+  meta = {
+    homepage = "https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html";
+    description = "aws X-RAY daemon.";
+    license = stdenv.lib.licenses.asl20;
+  };
 }

--- a/pkgs/tools/networking/aws-xray-daemon/deps.nix
+++ b/pkgs/tools/networking/aws-xray-daemon/deps.nix
@@ -2,145 +2,145 @@
   {
     goPackagePath = "github.com/aws/aws-sdk-go";
     fetch = {
-      type = "git";
-      url = "https://github.com/aws/aws-sdk-go";
-      rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
-      sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
+        type = "git";
+        url = "https://github.com/aws/aws-sdk-go";
+        rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
+        sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
     };
   }
   {
     goPackagePath = "github.com/cihub/seelog";
     fetch = {
-      type = "git";
-      url = "https://github.com/cihub/seelog";
-      rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
-      sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
+        type = "git";
+        url = "https://github.com/cihub/seelog";
+        rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
+        sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
     };
   }
   {
     goPackagePath = "github.com/go-ini/ini";
     fetch = {
-      type = "git";
-      url = "https://github.com/go-ini/ini";
-      rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
-      sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
+        type = "git";
+        url = "https://github.com/go-ini/ini";
+        rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
+        sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
     };
   }
   {
     goPackagePath = "github.com/go-ole/go-ole";
     fetch = {
-      type = "git";
-      url = "https://github.com/go-ole/go-ole";
-      rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
-      sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
+        type = "git";
+        url = "https://github.com/go-ole/go-ole";
+        rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
+        sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
     };
   }
   {
     goPackagePath = "github.com/golang/sys";
     fetch = {
-      type = "git";
-      url = "https://github.com/golang/sys";
-      rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-      sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+        type = "git";
+        url = "https://github.com/golang/sys";
+        rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+        sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
     };
   }
   {
     goPackagePath = "github.com/jmespath/go-jmespath";
     fetch = {
-      type = "git";
-      url = "https://github.com/jmespath/go-jmespath";
-      rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
-      sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+        type = "git";
+        url = "https://github.com/jmespath/go-jmespath";
+        rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
+        sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
     };
   }
   {
     goPackagePath = "github.com/shirou/gopsutil";
     fetch = {
-      type = "git";
-      url = "https://github.com/shirou/gopsutil";
-      rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
-      sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
+        type = "git";
+        url = "https://github.com/shirou/gopsutil";
+        rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
+        sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
     };
   }
   {
     goPackagePath = "github.com/StackExchange/wmi";
     fetch = {
-      type = "git";
-      url = "https://github.com/StackExchange/wmi";
-      rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
-      sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
+        type = "git";
+        url = "https://github.com/StackExchange/wmi";
+        rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
+        sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
     };
   }
   {
     goPackagePath = "github.com/stretchr/testify";
     fetch = {
-      type = "git";
-      url = "https://github.com/stretchr/testify";
-      rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
-      sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
+        type = "git";
+        url = "https://github.com/stretchr/testify";
+        rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
+        sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
     };
   }
   {
     goPackagePath = "golang.org/x/net";
     fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/net";
-      rev = "1e491301e022f8f977054da4c2d852decd59571f";
-      sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
+        type = "git";
+        url = "https://go.googlesource.com/net";
+        rev = "1e491301e022f8f977054da4c2d852decd59571f";
+        sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
     };
   }
   {
     goPackagePath = "golang.org/x/sys";
     fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/sys";
-      rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-      sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+        type = "git";
+        url = "https://go.googlesource.com/sys";
+        rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+        sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
     };
   }
   {
     goPackagePath = "golang.org/x/text";
     fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/text";
-      rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
-      sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
+        type = "git";
+        url = "https://go.googlesource.com/text";
+        rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
+        sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
     };
   }
   {
     goPackagePath = "gopkg.in/yaml.v2";
     fetch = {
-      type = "git";
-      url = "https://github.com/go-yaml/yaml";
-      rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
-      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+        type = "git";
+        url = "https://github.com/go-yaml/yaml";
+        rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+        sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
     };
   }
   {
     goPackagePath = "github.com/davecgh/go-spew";
     fetch = {
-      type = "git";
-      url = "https://github.com/davecgh/go-spew";
-      rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
-      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+        type = "git";
+        url = "https://github.com/davecgh/go-spew";
+        rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+        sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
     };
   }
   {
     goPackagePath = "github.com/pmezard/go-difflib";
     fetch = {
-      type = "git";
-      url = "https://github.com/pmezard/go-difflib";
-      rev = "792786c7400a136282c1664665ae0a8db921c6c2";
-      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+        type = "git";
+        url = "https://github.com/pmezard/go-difflib";
+        rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+        sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
     };
   }
   {
     goPackagePath = "github.com/stretchr/objx";
     fetch = {
-      type = "git";
-      url = "https://github.com/stretchr/objx";
-      rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
-      sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
+        type = "git";
+        url = "https://github.com/stretchr/objx";
+        rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
+        sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
     };
   }
 ]

--- a/pkgs/tools/networking/aws-xray-daemon/deps.nix
+++ b/pkgs/tools/networking/aws-xray-daemon/deps.nix
@@ -1,146 +1,146 @@
 [
-    {
-        goPackagePath = "github.com/aws/aws-sdk-go";
-        fetch = {
-            type = "git";
-            url = "https://github.com/aws/aws-sdk-go";
-            rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
-            sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
-        };
-    }
-    {
-        goPackagePath = "github.com/cihub/seelog";
-        fetch = {
-            type = "git";
-            url = "https://github.com/cihub/seelog";
-            rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
-            sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
-        };
-    }
-    {
-        goPackagePath = "github.com/go-ini/ini";
-        fetch = {
-            type = "git";
-            url = "https://github.com/go-ini/ini";
-            rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
-            sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
-        };
-    }
-    {
-        goPackagePath = "github.com/go-ole/go-ole";
-        fetch = {
-            type = "git";
-            url = "https://github.com/go-ole/go-ole";
-            rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
-            sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
-        };
-    }
-    {
-        goPackagePath = "github.com/golang/sys";
-        fetch = {
-            type = "git";
-            url = "https://github.com/golang/sys";
-            rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-            sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
-        };
-    }
-    {
-        goPackagePath = "github.com/jmespath/go-jmespath";
-        fetch = {
-            type = "git";
-            url = "https://github.com/jmespath/go-jmespath";
-            rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
-            sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
-        };
-    }
-    {
-        goPackagePath = "github.com/shirou/gopsutil";
-        fetch = {
-            type = "git";
-            url = "https://github.com/shirou/gopsutil";
-            rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
-            sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
-        };
-    }
-    {
-        goPackagePath = "github.com/StackExchange/wmi";
-        fetch = {
-            type = "git";
-            url = "https://github.com/StackExchange/wmi";
-            rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
-            sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
-        };
-    }
-    {
-        goPackagePath = "github.com/stretchr/testify";
-        fetch = {
-            type = "git";
-            url = "https://github.com/stretchr/testify";
-            rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
-            sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
-        };
-    }
-    {
-        goPackagePath = "golang.org/x/net";
-        fetch = {
-            type = "git";
-            url = "https://go.googlesource.com/net";
-            rev = "1e491301e022f8f977054da4c2d852decd59571f";
-            sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
-        };
-    }
-    {
-        goPackagePath = "golang.org/x/sys";
-        fetch = {
-            type = "git";
-            url = "https://go.googlesource.com/sys";
-            rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-            sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
-        };
-    }
-    {
-        goPackagePath = "golang.org/x/text";
-        fetch = {
-            type = "git";
-            url = "https://go.googlesource.com/text";
-            rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
-            sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
-        };
-    }
-    {
-        goPackagePath = "gopkg.in/yaml.v2";
-        fetch = {
-            type = "git";
-            url = "https://github.com/go-yaml/yaml";
-            rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
-            sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
-        };
-    }
-    {
-        goPackagePath = "github.com/davecgh/go-spew";
-        fetch = {
-            type = "git";
-            url = "https://github.com/davecgh/go-spew";
-            rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
-            sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
-        };
-    }
-    {
-        goPackagePath = "github.com/pmezard/go-difflib";
-        fetch = {
-            type = "git";
-            url = "https://github.com/pmezard/go-difflib";
-            rev = "792786c7400a136282c1664665ae0a8db921c6c2";
-            sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
-        };
-    }
-    {
-        goPackagePath = "github.com/stretchr/objx";
-        fetch = {
-            type = "git";
-            url = "https://github.com/stretchr/objx";
-            rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
-            sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
-        };
-    }
+  {
+    goPackagePath = "github.com/aws/aws-sdk-go";
+    fetch = {
+        type = "git";
+        url = "https://github.com/aws/aws-sdk-go";
+        rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
+        sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
+    };
+  }
+  {
+    goPackagePath = "github.com/cihub/seelog";
+    fetch = {
+        type = "git";
+        url = "https://github.com/cihub/seelog";
+        rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
+        sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+        type = "git";
+        url = "https://github.com/go-ini/ini";
+        rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
+        sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ole/go-ole";
+    fetch = {
+        type = "git";
+        url = "https://github.com/go-ole/go-ole";
+        rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
+        sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/sys";
+    fetch = {
+        type = "git";
+        url = "https://github.com/golang/sys";
+        rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+        sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+    };
+  }
+  {
+    goPackagePath = "github.com/jmespath/go-jmespath";
+    fetch = {
+        type = "git";
+        url = "https://github.com/jmespath/go-jmespath";
+        rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
+        sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+    };
+  }
+  {
+    goPackagePath = "github.com/shirou/gopsutil";
+    fetch = {
+        type = "git";
+        url = "https://github.com/shirou/gopsutil";
+        rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
+        sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
+    };
+  }
+  {
+    goPackagePath = "github.com/StackExchange/wmi";
+    fetch = {
+        type = "git";
+        url = "https://github.com/StackExchange/wmi";
+        rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
+        sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+        type = "git";
+        url = "https://github.com/stretchr/testify";
+        rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
+        sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/net";
+        rev = "1e491301e022f8f977054da4c2d852decd59571f";
+        sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/sys";
+        rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+        sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/text";
+        rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
+        sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+        type = "git";
+        url = "https://github.com/go-yaml/yaml";
+        rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+        sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+        type = "git";
+        url = "https://github.com/davecgh/go-spew";
+        rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+        sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+        type = "git";
+        url = "https://github.com/pmezard/go-difflib";
+        rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+        sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+        type = "git";
+        url = "https://github.com/stretchr/objx";
+        rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
+        sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
+    };
+  }
 ]

--- a/pkgs/tools/networking/aws-xray-daemon/deps.nix
+++ b/pkgs/tools/networking/aws-xray-daemon/deps.nix
@@ -2,145 +2,145 @@
   {
     goPackagePath = "github.com/aws/aws-sdk-go";
     fetch = {
-        type = "git";
-        url = "https://github.com/aws/aws-sdk-go";
-        rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
-        sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
+      sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
     };
   }
   {
     goPackagePath = "github.com/cihub/seelog";
     fetch = {
-        type = "git";
-        url = "https://github.com/cihub/seelog";
-        rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
-        sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
+      type = "git";
+      url = "https://github.com/cihub/seelog";
+      rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
+      sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
     };
   }
   {
     goPackagePath = "github.com/go-ini/ini";
     fetch = {
-        type = "git";
-        url = "https://github.com/go-ini/ini";
-        rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
-        sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
+      sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
     };
   }
   {
     goPackagePath = "github.com/go-ole/go-ole";
     fetch = {
-        type = "git";
-        url = "https://github.com/go-ole/go-ole";
-        rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
-        sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
+      type = "git";
+      url = "https://github.com/go-ole/go-ole";
+      rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
+      sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
     };
   }
   {
     goPackagePath = "github.com/golang/sys";
     fetch = {
-        type = "git";
-        url = "https://github.com/golang/sys";
-        rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-        sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+      type = "git";
+      url = "https://github.com/golang/sys";
+      rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+      sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
     };
   }
   {
     goPackagePath = "github.com/jmespath/go-jmespath";
     fetch = {
-        type = "git";
-        url = "https://github.com/jmespath/go-jmespath";
-        rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
-        sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
+      sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
     };
   }
   {
     goPackagePath = "github.com/shirou/gopsutil";
     fetch = {
-        type = "git";
-        url = "https://github.com/shirou/gopsutil";
-        rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
-        sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
+      type = "git";
+      url = "https://github.com/shirou/gopsutil";
+      rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
+      sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
     };
   }
   {
     goPackagePath = "github.com/StackExchange/wmi";
     fetch = {
-        type = "git";
-        url = "https://github.com/StackExchange/wmi";
-        rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
-        sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
+      type = "git";
+      url = "https://github.com/StackExchange/wmi";
+      rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
+      sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
     };
   }
   {
     goPackagePath = "github.com/stretchr/testify";
     fetch = {
-        type = "git";
-        url = "https://github.com/stretchr/testify";
-        rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
-        sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
+      sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
     };
   }
   {
     goPackagePath = "golang.org/x/net";
     fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/net";
-        rev = "1e491301e022f8f977054da4c2d852decd59571f";
-        sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "1e491301e022f8f977054da4c2d852decd59571f";
+      sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
     };
   }
   {
     goPackagePath = "golang.org/x/sys";
     fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/sys";
-        rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-        sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+      sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
     };
   }
   {
     goPackagePath = "golang.org/x/text";
     fetch = {
-        type = "git";
-        url = "https://go.googlesource.com/text";
-        rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
-        sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
+      sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
     };
   }
   {
     goPackagePath = "gopkg.in/yaml.v2";
     fetch = {
-        type = "git";
-        url = "https://github.com/go-yaml/yaml";
-        rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
-        sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
     };
   }
   {
     goPackagePath = "github.com/davecgh/go-spew";
     fetch = {
-        type = "git";
-        url = "https://github.com/davecgh/go-spew";
-        rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
-        sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
     };
   }
   {
     goPackagePath = "github.com/pmezard/go-difflib";
     fetch = {
-        type = "git";
-        url = "https://github.com/pmezard/go-difflib";
-        rev = "792786c7400a136282c1664665ae0a8db921c6c2";
-        sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
     };
   }
   {
     goPackagePath = "github.com/stretchr/objx";
     fetch = {
-        type = "git";
-        url = "https://github.com/stretchr/objx";
-        rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
-        sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
+      sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
     };
   }
 ]

--- a/pkgs/tools/networking/aws-xray-daemon/deps.nix
+++ b/pkgs/tools/networking/aws-xray-daemon/deps.nix
@@ -1,0 +1,146 @@
+[
+    {
+        goPackagePath = "github.com/aws/aws-sdk-go";
+        fetch = {
+            type = "git";
+            url = "https://github.com/aws/aws-sdk-go";
+            rev = "47309c012812d9e9c488a54313e5cdfa7479df93";
+            sha256 = "04chrwdjpnqzm0ppfkxk9zvjc8jslwp299bdfhjxs3ggyianagxk";
+        };
+    }
+    {
+        goPackagePath = "github.com/cihub/seelog";
+        fetch = {
+            type = "git";
+            url = "https://github.com/cihub/seelog";
+            rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
+            sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
+        };
+    }
+    {
+        goPackagePath = "github.com/go-ini/ini";
+        fetch = {
+            type = "git";
+            url = "https://github.com/go-ini/ini";
+            rev = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
+            sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
+        };
+    }
+    {
+        goPackagePath = "github.com/go-ole/go-ole";
+        fetch = {
+            type = "git";
+            url = "https://github.com/go-ole/go-ole";
+            rev = "a1ec82a652ebc7e784d7df887cfb31061aeabbcc";
+            sha256 = "1lhwg5zq6g9796bdarjw8wgc7wb702szpp52yi68bpc5hlh5qlvg";
+        };
+    }
+    {
+        goPackagePath = "github.com/golang/sys";
+        fetch = {
+            type = "git";
+            url = "https://github.com/golang/sys";
+            rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+            sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+        };
+    }
+    {
+        goPackagePath = "github.com/jmespath/go-jmespath";
+        fetch = {
+            type = "git";
+            url = "https://github.com/jmespath/go-jmespath";
+            rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
+            sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+        };
+    }
+    {
+        goPackagePath = "github.com/shirou/gopsutil";
+        fetch = {
+            type = "git";
+            url = "https://github.com/shirou/gopsutil";
+            rev = "bc5d02c9acfb50d18e651edb592eee0ab048c13a";
+            sha256 = "1s6v0ksavmrsihif1dvgbhbqnvd3qbwwxc7wn6h72214vffxd2g4";
+        };
+    }
+    {
+        goPackagePath = "github.com/StackExchange/wmi";
+        fetch = {
+            type = "git";
+            url = "https://github.com/StackExchange/wmi";
+            rev = "cdffdb33acae0e14efff2628f9bae377b597840e";
+            sha256 = "1xgm9xrq42zqwn8c159baspphn6adgmvd29l8wn202c4yqrzclv6";
+        };
+    }
+    {
+        goPackagePath = "github.com/stretchr/testify";
+        fetch = {
+            type = "git";
+            url = "https://github.com/stretchr/testify";
+            rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
+            sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
+        };
+    }
+    {
+        goPackagePath = "golang.org/x/net";
+        fetch = {
+            type = "git";
+            url = "https://go.googlesource.com/net";
+            rev = "1e491301e022f8f977054da4c2d852decd59571f";
+            sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
+        };
+    }
+    {
+        goPackagePath = "golang.org/x/sys";
+        fetch = {
+            type = "git";
+            url = "https://go.googlesource.com/sys";
+            rev = "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+            sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+        };
+    }
+    {
+        goPackagePath = "golang.org/x/text";
+        fetch = {
+            type = "git";
+            url = "https://go.googlesource.com/text";
+            rev = "5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877";
+            sha256 = "03br8p1sb1ffr02l8hyrgcyib7ms0z06wy3v4r1dj2l6q4ghwzfs";
+        };
+    }
+    {
+        goPackagePath = "gopkg.in/yaml.v2";
+        fetch = {
+            type = "git";
+            url = "https://github.com/go-yaml/yaml";
+            rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+            sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+        };
+    }
+    {
+        goPackagePath = "github.com/davecgh/go-spew";
+        fetch = {
+            type = "git";
+            url = "https://github.com/davecgh/go-spew";
+            rev = "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+            sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+        };
+    }
+    {
+        goPackagePath = "github.com/pmezard/go-difflib";
+        fetch = {
+            type = "git";
+            url = "https://github.com/pmezard/go-difflib";
+            rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+            sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+        };
+    }
+    {
+        goPackagePath = "github.com/stretchr/objx";
+        fetch = {
+            type = "git";
+            url = "https://github.com/stretchr/objx";
+            rev = "0ab728f62c7f6fcd754334f7931c2dd659dce1d1";
+            sha256 = "1krrgw5474jjrd5asgdjm3dviz22pglvwbn8dzc2b6psnqnx0nj1";
+        };
+    }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -634,6 +634,8 @@ in
 
   aws-vault = callPackage ../tools/admin/aws-vault { };
 
+  aws-xray-daemon = callPackage ../tools/networking/aws-xray-daemon { };
+
   iamy = callPackage ../tools/admin/iamy { };
 
   azure-cli = nodePackages_8_x.azure-cli;


### PR DESCRIPTION
###### Motivation for this change

The AWS X-Ray daemon is a software application that listens for traffic on UDP port 2000, gathers raw segment data, and relays it to the AWS X-Ray API.

The pull request contains the xray daemon packaged next to its nixos service.
This should add support to aws xray daemon in nixos.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (ubuntu 16.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
nix path-info -rS /nix/store/gbppfb3i7xv6lp7n5ng015x09kqmldnj-aws-xray-daemon-V3.0.0-bin
/nix/store/794g4fijpi67xk9ri99f8i0hhmj49rr9-tzdata-2018g              	    2095096
/nix/store/gbppfb3i7xv6lp7n5ng015x09kqmldnj-aws-xray-daemon-V3.0.0-bin	   37261432
/nix/store/xdsjx0gba4id3yyqxv66bxnm2sqixkjj-glibc-2.27                	   25010568
/nix/store/yzfwmssgpkff21f4xcnk2m8vav6nwlah-iana-etc-20180905         	     562856
```
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
 
##### I think I'm missing the maintainer. Don't know who to set to ?
---

