### PR TITLE
abella: 2.0.5 -> 2.0.6

### DIFF
--- a/pkgs/applications/science/logic/abella/default.nix
+++ b/pkgs/applications/science/logic/abella/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "abella-${version}";
-  version = "2.0.5";
+  version = "2.0.6";
 
   src = fetchurl {
     url = "http://abella-prover.org/distributions/${name}.tar.gz";
-    sha256 = "0bry4pj6p9y7sg79ygdksynml4rdsjhqi959vnnwwsbaysa3bci0";
+    sha256 = "164q9gngckg6q69k13lwx2pq3cnc9ckw1qi8dnpxqfjgwfqr7xyi";
   };
 
   buildInputs = [ rsync ] ++ (with ocamlPackages; [ ocaml ocamlbuild findlib ]);


### PR DESCRIPTION
###### Motivation for this change
Standard package bump. The schematic polymorphism branch has finally been merged and the changes are now included in this release! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

