### PR TITLE
qtile: 0.12.0 -> 0.13.0

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub, python27Packages, glib, cairo, pango, pkgconfig, libxcb, xcbutilcursor }:
+{ stdenv, fetchFromGitHub, python37Packages, glib, cairo, pango, pkgconfig, libxcb, xcbutilcursor }:
 
-let cairocffi-xcffib = python27Packages.cairocffi.override {
+let cairocffi-xcffib = python37Packages.cairocffi.override {
     withXcffib = true;
   };
 in
 
-python27Packages.buildPythonApplication rec {
+python37Packages.buildPythonApplication rec {
   name = "qtile-${version}";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "qtile";
     repo = "qtile";
     rev = "v${version}";
-    sha256 = "0ynmmnh12mr3gwgz0j7l2hvm8c0y5gzsw80jszdkp4s5bh1q0nrj";
+    sha256 = "1lyclnn8hs6wl4w9v5b4hh2q0pvmsn7cyibpskhbpw0cgv7bvi90";
   };
 
   patches = [
@@ -30,9 +30,9 @@ python27Packages.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libxcb cairo pango python27Packages.xcffib ];
+  buildInputs = [ glib libxcb cairo pango python37Packages.xcffib ];
 
-  pythonPath = with python27Packages; [ xcffib cairocffi-xcffib trollius ];
+  pythonPath = with python37Packages; [ xcffib cairocffi-xcffib ];
 
   postInstall = ''
     wrapProgram $out/bin/qtile \


### PR DESCRIPTION
###### Motivation for this change

qtile 0.13.0
needs Python 3 to use Clock widget:
https://github.com/qtile/qtile/issues/1258#issuecomment-451958978

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

