### PR TITLE
rxvt_unicode: fix build

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -47,11 +47,11 @@ stdenv.mkDerivation (rec {
       configureFlags="--with-terminfo=$terminfo/share/terminfo --enable-256-color ${if perlSupport then "--enable-perl" else "--disable-perl"} ${if unicode3Support then "--enable-unicode3" else "--disable-unicode3"}";
       export TERMINFO=$terminfo/share/terminfo # without this the terminfo won't be compiled by tic, see man tic
       NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${freetype.dev}/include/freetype2"
-      NIX_LDFLAGS="$NIX_LDFLAGS -lfontconfig -lXrender "
+      NIX_LDFLAGS="$NIX_LDFLAGS -lfontconfig -lXrender -lpthread "
     ''
     # make urxvt find its perl file lib/perl5/site_perl is added to PERL5LIB automatically
     + stdenv.lib.optionalString perlSupport ''
-      mkdir -p $(dirname ${perl.libPrefix})
+      mkdir -p $out/$(dirname ${perl.libPrefix})
       ln -s $out/lib/urxvt $out/${perl.libPrefix}
     '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix build following changes in https://github.com/NixOS/nixpkgs/pull/52100 and https://github.com/NixOS/nixpkgs/pull/51770

/cc @volth for the Perl changes

I don't (knowingly) use any Perl functionality of urxvt ATM so can't verify this actually works for anything provided by the Perl modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

