### PR TITLE
libsvg: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2303,6 +2303,11 @@
     github = "kirelagin";
     name = "Kirill Elagin";
   };
+  kisonecat = {
+    email = "kisonecat@gmail.com";
+    github = "kisonecat";
+    name = "Jim Fowler";
+  };
   kkallio = {
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";

--- a/pkgs/development/libraries/libsvg/default.nix
+++ b/pkgs/development/libraries/libsvg/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, libpng, libjpeg, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "libsvg-${version}";
+  version = "0.1.4";
+
+  buildInputs = [ pkgconfig libpng libjpeg libxml2 ]; 
+
+  src = fetchurl {
+      url = "http://cairographics.org/snapshots/libsvg-0.1.4.tar.gz";
+      sha256 = "13xw0ka1wpzlpdzvds555rzwsf0g9pk1ns9q4fqp4sk75qlzjfsc";
+  };
+ 
+  meta = with stdenv.lib; {    
+    description = "A library for parsing SVG files";
+    homepage = http://cairographics.org/;
+    license = with licenses; [ lgpl2Plus mpl10 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ kisonecat ];
+  };
+}

--- a/pkgs/development/libraries/libsvg/default.nix
+++ b/pkgs/development/libraries/libsvg/default.nix
@@ -4,13 +4,20 @@ stdenv.mkDerivation rec {
   name = "libsvg-${version}";
   version = "0.1.4";
 
-  buildInputs = [ pkgconfig libpng libjpeg libxml2 ]; 
+  buildInputs = [ pkgconfig libxml2 libpng libjpeg ];
 
   src = fetchurl {
       url = "http://cairographics.org/snapshots/libsvg-0.1.4.tar.gz";
       sha256 = "13xw0ka1wpzlpdzvds555rzwsf0g9pk1ns9q4fqp4sk75qlzjfsc";
   };
- 
+
+  # The function png_set_gray_1_2_4_to_8() was removed. It has been
+  # deprecated since libpng-1.0.18 and 1.2.9, when it was replaced
+  # with png_set_expand_gray_1_2_4_to_8()
+  patchPhase = ''
+    substituteInPlace src/svg_image.c --replace "png_set_gray_1_2_4_to_8" "png_set_expand_gray_1_2_4_to_8"
+  '';
+
   meta = with stdenv.lib; {    
     description = "A library for parsing SVG files";
     homepage = http://cairographics.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11357,6 +11357,8 @@ in
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  libsvg = callPackage ../development/libraries/libsvg { };
+      
   libsvm = callPackage ../development/libraries/libsvm { };
 
   libtar = callPackage ../development/libraries/libtar { };


### PR DESCRIPTION
###### Motivation for this change

Support for libsvg with patch to handle nixpkgs' newer libpng

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

