### PR TITLE
litecli: init at 1.0.0

### DIFF
--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -1,0 +1,37 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "litecli";
+  version = "1.0.0";
+
+  # Python 2 won't have prompt_toolkit 2.x.x
+  # See: https://github.com/NixOS/nixpkgs/blob/f49e2ad3657dede09dc998a4a98fd5033fb52243/pkgs/top-level/python-packages.nix#L3408
+  disabled = python3Packages.isPy27;
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0s5a6r5q09144cc5169snwis5i2jrh3z2g4mw9wi2fsjxyhgpwq5";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    cli-helpers
+    click
+    configobj
+    prompt_toolkit
+    pygments
+    sqlparse
+  ];
+
+  #Checks are failing due to missing TTY, which won't exist.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Command-line interface for SQLite";
+    longDescription = ''
+      A command-line client for SQLite databases that has auto-completion and syntax highlighting.
+    '';
+    homepage = https://litecli.com;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -13,6 +13,12 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0s5a6r5q09144cc5169snwis5i2jrh3z2g4mw9wi2fsjxyhgpwq5";
   };
 
+  # fixes tests https://github.com/dbcli/litecli/pull/53
+  postPatch = ''
+    substituteInPlace litecli/main.py \
+      --replace 'except FileNotFoundError:' 'except (FileNotFoundError, OSError):'
+  '';
+
   propagatedBuildInputs = with python3Packages; [
     cli-helpers
     click
@@ -22,8 +28,16 @@ python3Packages.buildPythonApplication rec {
     sqlparse
   ];
 
-  #Checks are failing due to missing TTY, which won't exist.
-  doCheck = false;
+  checkInputs = with python3Packages; [
+    pytest
+    mock
+  ];
+
+  preCheck = ''
+    export XDG_CONFIG_HOME=$TMP
+    # add missing file
+    echo "litecli is awesome!" > tests/test.txt
+  '';
 
   meta = with lib; {
     description = "Command-line interface for SQLite";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8817,6 +8817,8 @@ in
 
   lit = callPackage ../development/tools/misc/lit { };
 
+  litecli = callPackage ../development/tools/database/litecli {};
+
   lsof = callPackage ../development/tools/misc/lsof { };
 
   ltrace = callPackage ../development/tools/misc/ltrace { };


### PR DESCRIPTION
###### Motivation for this change
Wanted to use the tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

