### PR TITLE
void: init at 1.1.5

### DIFF
--- a/pkgs/tools/misc/void/default.nix
+++ b/pkgs/tools/misc/void/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "void-${version}";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "spacejam";
+    repo = "void";
+    rev = "${version}";
+    sha256 = "08vazw4rszqscjz988k89z28skyj3grm81bm5iwknxxagmrb20fz";
+  };
+
+  # The tests are long-running and not that useful
+  checkPhase = null;
+
+  cargoSha256 = "1rq947s82icl7gdkjynjwz426bpmd96dip2dv2y7p8rg7yz29x0m";
+
+  meta = with stdenv.lib; {
+    description = "Terminal-based personal organizer";
+    homepage = https://github.com/spacejam/void;
+    license = licenses.mit;
+    maintainers = with maintainers; [ spacekookie ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/void/default.nix
+++ b/pkgs/tools/misc/void/default.nix
@@ -12,14 +12,14 @@ rustPlatform.buildRustPackage rec {
   };
 
   # The tests are long-running and not that useful
-  checkPhase = null;
+  doCheck = false;
 
   cargoSha256 = "1rq947s82icl7gdkjynjwz426bpmd96dip2dv2y7p8rg7yz29x0m";
 
   meta = with stdenv.lib; {
     description = "Terminal-based personal organizer";
     homepage = https://github.com/spacejam/void;
-    license = licenses.mit;
+    license = licenses.gpl3;
     maintainers = with maintainers; [ spacekookie ];
     platforms = platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6012,6 +6012,8 @@ in
 
   vobsub2srt = callPackage ../tools/cd-dvd/vobsub2srt { };
 
+  void = callPackage ../tools/misc/void { };
+
   volume_key = callPackage ../development/libraries/volume-key { };
 
   vorbisgain = callPackage ../tools/misc/vorbisgain { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
