### PR TITLE
python.pkgs.entrypoints: 0.2.3 -> 0.3

### DIFF
--- a/pkgs/development/python-modules/entrypoints/default.nix
+++ b/pkgs/development/python-modules/entrypoints/default.nix
@@ -4,31 +4,23 @@
 , configparser
 , pytest
 , isPy3k
-, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "entrypoints";
-  version = "0.2.3";
+  version = "0.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d2d587dde06f99545fb13a383d2cd336a8ff1f359c5839ce3a64c917d10c029f";
+    sha256 = "0lc4si3xb7hza424414rdqdc3vng3kcrph8jbvjqb32spqddf3f7";
   };
 
   checkInputs = [ pytest ];
 
   propagatedBuildInputs = lib.optional (!isPy3k) configparser;
 
-  checkPhase = let
-    # On python2 with pytest 3.9.2 (not with pytest 3.7.4) the test_bad
-    # test fails. It tests that a warning (exectly one) is thrown on a "bad"
-    # path. The pytest upgrade added some warning, resulting in two warnings
-    # being thrown.
-    # upstream: https://github.com/takluyver/entrypoints/issues/23
-    pyTestArgs = if isPy27 then "-k 'not test_bad'" else "";
-  in ''
-    py.test ${pyTestArgs} tests
+  checkPhase = ''
+    py.test tests
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

The upstream issue requiring one test to be disabled was fixed:
https://github.com/takluyver/entrypoints/issues/23

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

