### PR TITLE
pythonPackages.poetry: init at 0.12.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1953,6 +1953,11 @@
     github = "jakelogemann";
     name = "Jake Logemann";
   };
+  jakewaksbaum = {
+    email = "jake.waksbaum@gmail.com";
+    github = "jbaum98";
+    name = "Jake Waksbaum";
+  };
   jammerful = {
     email = "jammerful@gmail.com";
     github = "jammerful";

--- a/pkgs/development/python-modules/cachy/default.nix
+++ b/pkgs/development/python-modules/cachy/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi
+, redis
+, memcached
+, msgpack-python
+}:
+
+buildPythonPackage rec {
+  pname = "cachy";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0v6mjyhgx6j7ya20bk69cr3gdzdkdf6psay0h090rscclgji65dp";
+  };
+
+  propagatedBuildInputs = [
+    redis
+    memcached
+    msgpack-python
+  ];
+
+  # The Pypi tarball doesn't include tests, and the GitHub source isn't
+  # buildable until we bootstrap poetry, see
+  # https://github.com/NixOS/nixpkgs/pull/53599#discussion_r245855665
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/sdispater/cachy;
+    description = "Cachy provides a simple yet effective caching library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/cleo/default.nix
+++ b/pkgs/development/python-modules/cleo/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchPypi
+, pylev, pastel, clikit }:
+
+buildPythonPackage rec {
+  pname = "cleo";
+  version = "0.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "091nzpfp5incd2fzqych78rvyx4i3djr50cnizbjzr3dc7g00l3s";
+  };
+
+  propagatedBuildInputs = [
+    pylev
+    pastel
+    clikit
+  ];
+
+  # The Pypi tarball doesn't include tests, and the GitHub source isn't
+  # buildable until we bootstrap poetry, see
+  # https://github.com/NixOS/nixpkgs/pull/53599#discussion_r245855665
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/sdispater/cleo;
+    description = "Allows you to create beautiful and testable command-line interfaces";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/clikit/default.nix
+++ b/pkgs/development/python-modules/clikit/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchPypi
+, isPy27, isPy34
+, pylev, pastel, typing, enum34 }:
+
+buildPythonPackage rec {
+  pname = "clikit";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zr1s0xhk62p9a6zcp5whvsb27lddyk8gx03k9l8q18jp7y3igbv";
+  };
+
+  propagatedBuildInputs = [
+    pylev pastel
+  ] ++ lib.optional (isPy27 || isPy34) typing
+    ++ lib.optional isPy27 enum34;
+
+  # The Pypi tarball doesn't include tests, and the GitHub source isn't
+  # buildable until we bootstrap poetry, see
+  # https://github.com/NixOS/nixpkgs/pull/53599#discussion_r245855665
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/sdispater/clikit;
+    description = "A group of utilities to build beautiful and testable command line interfaces";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/pastel/default.nix
+++ b/pkgs/development/python-modules/pastel/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, pytest }:
+
+buildPythonPackage rec {
+  pname = "pastel";
+  version = "0.1.0";
+
+  # No tests in PyPi tarball
+  src = fetchFromGitHub {
+    owner = "sdispater";
+    repo = "pastel";
+    rev = version;
+    sha256 = "1b4ag7jr7j0sxly5g29imdq8g0d4ixhbck55dblr45mlsidydx0s";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest tests -sq
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/sdispater/pastel;
+    description = "Bring colors to your terminal";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -1,0 +1,76 @@
+{ lib, buildPythonPackage, fetchPypi, callPackage
+, isPy27, isPy34
+, cleo
+, requests
+, cachy
+, requests-toolbelt
+, pyrsistent
+, pyparsing
+, cachecontrol
+, pkginfo
+, html5lib
+, shellingham
+, tomlkit
+, typing
+, pathlib2
+, virtualenv
+, functools32
+, pytest
+}:
+
+let
+  cleo6 = cleo.overrideAttrs (oldAttrs: rec {
+    version = "0.6.8";
+    src = fetchPypi {
+      inherit (oldAttrs) pname;
+      inherit version;
+      sha256 = "06zp695hq835rkaq6irr1ds1dp2qfzyf32v60vxpd8rcnxv319l5";
+    };
+  });
+
+  jsonschema3 = callPackage ./jsonschema.nix { };
+
+in buildPythonPackage rec {
+  pname = "poetry";
+  version = "0.12.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00npb0jlimnk4r01zkhfmns4843j1hfhd388s326da5pd8n0dq7l";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace "3.0a3" "3.0.0a3"
+    substituteInPlace setup.py --replace "3.0a3" "3.0.0a3"
+  '';
+
+  propagatedBuildInputs = [
+    cleo6
+    requests
+    cachy
+    requests-toolbelt
+    jsonschema3
+    pyrsistent
+    pyparsing
+    cachecontrol
+    pkginfo
+    html5lib
+    shellingham
+    tomlkit
+  ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 ]
+    ++ lib.optionals isPy27 [ virtualenv functools32 ];
+
+  # No tests in Pypi tarball
+  doCheck = false;
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/sdispater/poetry;
+    description = "Python dependency management and packaging made easy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/poetry/jsonschema.nix
+++ b/pkgs/development/python-modules/poetry/jsonschema.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, callPackage
+, attrs
+, pyrsistent
+, six
+, functools32
+, lockfile
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "jsonschema";
+  version = "3.0.0a3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pkhsq91rhk6384p0jxjkhc9yml2ya2l0mysyq78sb4981h45n6z";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [
+    attrs
+    pyrsistent
+    six
+    lockfile
+  ] ++ lib.optional isPy27 functools32;
+
+  # tests for latest version rely on custom version of betterpaths that is
+  # difficult to deal with and isn't used on master
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/Julian/jsonschema;
+    description = "An implementation of JSON Schema validation for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/pylev/default.nix
+++ b/pkgs/development/python-modules/pylev/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "pylev";
+  version = "1.3.0";
+
+  # No tests in PyPi tarball
+  src = fetchFromGitHub {
+    owner = "toastdriven";
+    repo = "pylev";
+    # Can't use a tag because it's missing
+    # https://github.com/toastdriven/pylev/issues/10
+    # rev = "v${version};
+    rev = "72e3d490515c3188e2acac9c15ea1b466f9ff938";
+    sha256 = "18dg1rfnqgfl6x4vafiq4la9d7f65xak19gcvngslq0bm1z6hyd8";
+  };
+
+  meta = with lib; {
+    homepage = https://github.com/toastdriven/pylev;
+    description = "A pure Python Levenshtein implementation that's not freaking GPL'd";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/pyrsistent/default.nix
+++ b/pkgs/development/python-modules/pyrsistent/default.nix
@@ -4,6 +4,7 @@
 , six
 , pytest
 , hypothesis
+, pytestrunner
 }:
 
 buildPythonPackage rec {
@@ -16,11 +17,11 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six ];
-  buildInputs = [ pytest hypothesis ];
 
-  checkPhase = ''
-    py.test
-  '';
+  checkInputs = [ pytestrunner pytest hypothesis ];
+
+  # pytestrunner is only needed to run tests
+  patches = [ ./no-setup-requires-pytestrunner.patch ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/tobgu/pyrsistent/;

--- a/pkgs/development/python-modules/pyrsistent/no-setup-requires-pytestrunner.patch
+++ b/pkgs/development/python-modules/pyrsistent/no-setup-requires-pytestrunner.patch
@@ -1,0 +1,15 @@
+diff --git a/setup.py b/setup.py
+index 90a39a5..7bf444f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -77,9 +77,8 @@ setup(
+         'Programming Language :: Python :: Implementation :: PyPy',
+     ],
+     test_suite='tests',
+-    tests_require=['pytest','hypothesis'],
++    tests_require=['pytest-runner', 'pytest','hypothesis'],
+     scripts=[],
+-    setup_requires=['pytest-runner'],
+     ext_modules=extensions,
+     cmdclass={'build_ext': custom_build_ext},
+     install_requires=['six'],

--- a/pkgs/development/python-modules/tomlkit/default.nix
+++ b/pkgs/development/python-modules/tomlkit/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, isPy34
+, enum34, functools32, typing
+}:
+
+buildPythonPackage rec {
+  pname = "tomlkit";
+  version = "0.5.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hjfzlb6y694pkadygcaq1n63di97pxgq2zpc74in1axc5166l6n";
+  };
+
+  propagatedBuildInputs =
+    lib.optionals isPy27 [ enum34 functools32 ]
+    ++ lib.optional (isPy27 || isPy34) typing;
+
+  # The Pypi tarball doesn't include tests, and the GitHub source isn't
+  # buildable until we bootstrap poetry, see
+  # https://github.com/NixOS/nixpkgs/pull/53599#discussion_r245855665
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/sdispater/tomlkit;
+    description = "Style-preserving TOML library for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -290,6 +290,8 @@ in {
 
   chalice = callPackage ../development/python-modules/chalice { };
 
+  cleo = callPackage ../development/python-modules/cleo { };
+
   clikit = callPackage ../development/python-modules/clikit { };
 
   clustershell = callPackage ../development/python-modules/clustershell { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -290,6 +290,8 @@ in {
 
   chalice = callPackage ../development/python-modules/chalice { };
 
+  clikit = callPackage ../development/python-modules/clikit { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cozy = callPackage ../development/python-modules/cozy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -512,6 +512,8 @@ in {
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  poetry = callPackage ../development/python-modules/poetry { };
+
   progress = callPackage ../development/python-modules/progress { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -488,6 +488,8 @@ in {
 
   palettable = callPackage ../development/python-modules/palettable { };
 
+  pastel = callPackage ../development/python-modules/pastel { };
+
   pathlib = callPackage ../development/python-modules/pathlib { };
 
   pdf2image = callPackage ../development/python-modules/pdf2image { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -774,6 +774,8 @@ in {
 
   toml = callPackage ../development/python-modules/toml { };
 
+  tomlkit = callPackage ../development/python-modules/tomlkit { };
+
   unifi = callPackage ../development/python-modules/unifi { };
 
   vidstab = callPackage ../development/python-modules/vidstab { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -286,6 +286,8 @@ in {
 
   cachecontrol = callPackage ../development/python-modules/cachecontrol { };
 
+  cachy = callPackage ../development/python-modules/cachy { };
+
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
   chalice = callPackage ../development/python-modules/chalice { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -595,6 +595,8 @@ in {
 
   pykeepass = callPackage ../development/python-modules/pykeepass { };
 
+  pylev = callPackage ../development/python-modules/pylev { };
+
   pymatgen = callPackage ../development/python-modules/pymatgen { };
 
   pymatgen-lammps = callPackage ../development/python-modules/pymatgen-lammps { };


### PR DESCRIPTION
###### Motivation for this change

Add the `poetry` package and its dependencies.

Closes #53132.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

