### PR TITLE
mingw: use current package set for headers

### DIFF
--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -21,6 +21,6 @@ in stdenv.mkDerivation {
   patches = [ ./osvi.patch ];
 
   meta = {
-    platforms = stdenv.lib.platforms.windows;
+    platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6790,7 +6790,7 @@ in
   # built with, and use, that cross-compiled libc.
   gccCrossStageStatic = assert stdenv.targetPlatform != stdenv.hostPlatform; let
     libcCross1 =
-      if stdenv.targetPlatform.libc == "msvcrt" then targetPackages.windows.mingw_w64_headers
+      if stdenv.targetPlatform.libc == "msvcrt" then windows.mingw_w64_headers
       else if stdenv.targetPlatform.libc == "libSystem" then darwin.xcode
       else null;
     binutils1 = wrapBintoolsWith {


### PR DESCRIPTION
gccCrossStageStatic should not need targetPackages.

Fixes #53587.
