### PR TITLE
tinyscheme: init at 1.41

### DIFF
--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "tinyscheme-${version}";
+  version = "1.41";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/tinyscheme/${name}.tar.gz";
+    sha256 = "168rk4zrlhsknbvldq2jsgabpwlqkx6la44gkqmijmf7jhs11h7a";
+  };
+
+  patchPhase = ''
+    substituteInPlace scheme.c --replace "init.scm" "$out/lib/init.scm"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    cp init.scm $out/lib
+    cp scheme $out/bin/tinyscheme
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Lightweight Scheme implementation";
+    longDescription = ''
+      TinyScheme is a lightweight Scheme interpreter that implements as large a
+      subset of R5RS as was possible without getting very large and complicated.
+    '';
+    homepage = http://tinyscheme.sourceforge.net/;
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.ebzzry ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7566,6 +7566,8 @@ in
 
   tinycc = callPackage ../development/compilers/tinycc { };
 
+  tinyscheme = callPackage ../development/interpreters/tinyscheme { };
+
   inherit (ocaml-ng.ocamlPackages_4_02) trv;
 
   bupc = callPackage ../development/compilers/bupc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

