### PR TITLE
cups: use v2.2.6 on darwin

### DIFF
--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -10,13 +10,17 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "cups-${version}";
-  version = "2.2.10";
+
+  # After 2.2.6, CUPS requires headers only available in macOS 10.12+
+  version = if stdenv.isDarwin then "2.2.6" else "2.2.10";
 
   passthru = { inherit version; };
 
   src = fetchurl {
     url = "https://github.com/apple/cups/releases/download/v${version}/cups-${version}-source.tar.gz";
-    sha256 = "1fq52aw1mini3ld2czv5gg37wbbvh4n7yc7wzzxvbs3zpfrv5j3p";
+    sha256 = if version == "2.2.6"
+             then "16qn41b84xz6khrr2pa2wdwlqxr29rrrkjfi618gbgdkq9w5ff20"
+             else "1fq52aw1mini3ld2czv5gg37wbbvh4n7yc7wzzxvbs3zpfrv5j3p";
   };
 
   outputs = [ "out" "lib" "dev" "man" ];


### PR DESCRIPTION
This is the last version known to build. Normally I would not like using an old version. But, I can't figure out any other way to fix this besides using 2.2.6.

Fixes #53609.
