### PR TITLE
pythonPackages.zfec: patch out argparse dependency

### DIFF
--- a/pkgs/development/python-modules/zfec/default.nix
+++ b/pkgs/development/python-modules/zfec/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , setuptoolsDarcs
 , pyutil
-, argparse
 , isPyPy
 }:
 
@@ -18,7 +17,12 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ setuptoolsDarcs ];
-  propagatedBuildInputs = [ pyutil argparse ];
+  propagatedBuildInputs = [ pyutil ];
+
+  # argparse is in the stdlib but zfec doesn't know that.
+  postPatch = ''
+    sed -i -e '/argparse/d' setup.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://allmydata.org/trac/zfec;


### PR DESCRIPTION
Since `argparse` stopped doing anything a while ago, we'll just patch it out of setup.py and nobody will notice.

###### Motivation for this change

Fixes Tahoe-LAFS client `tahoelafs`. This is likely the only user of zfec.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

