### PR TITLE
haskell.buildStackProject: use setup hook

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -1,6 +1,5 @@
-{ stdenv, ghc, pkgconfig, glibcLocales, cacert, stack }@depArgs:
-
-with stdenv.lib;
+{ stdenv, ghc, pkgconfig, glibcLocales
+, cacert, stack, makeSetupHook, lib }@depArgs:
 
 { buildInputs ? []
 , extraArgs ? []
@@ -10,34 +9,27 @@ with stdenv.lib;
 , ...
 }@args:
 
-let stackCmd = "stack --internal-re-exec-version=${stack.version}";
+let
 
-    # Add all dependencies in buildInputs including propagated ones to
-    # STACK_IN_NIX_EXTRA_ARGS.
-    addStackArgsHook = ''
-for pkg in ''${pkgsHostHost[@]} ''${pkgsHostBuild[@]} ''${pkgsHostTarget[@]}
-do
-  [ -d "$pkg/lib" ] && \
-    export STACK_IN_NIX_EXTRA_ARGS+=" --extra-lib-dirs=$pkg/lib"
-  [ -d "$pkg/include" ] && \
-    export STACK_IN_NIX_EXTRA_ARGS+=" --extra-include-dirs=$pkg/include"
-done
-    '';
+  stackCmd = "stack --internal-re-exec-version=${stack.version}";
+
+  # Add all dependencies in buildInputs including propagated ones to
+  # STACK_IN_NIX_EXTRA_ARGS.
+  stackHook = makeSetupHook {} ./stack-hook.sh;
+
 in stdenv.mkDerivation (args // {
 
-  buildInputs =
-    buildInputs ++
-    optional (stdenv.hostPlatform.libc == "glibc") glibcLocales ++
-    [ ghc pkgconfig stack ];
+  buildInputs = buildInputs
+    ++ lib.optional (stdenv.hostPlatform.libc == "glibc") glibcLocales;
 
-  STACK_PLATFORM_VARIANT="nix";
-  STACK_IN_NIX_SHELL=1;
+  nativeBuildInputs = [ ghc pkgconfig stack stackHook ];
+
+  STACK_PLATFORM_VARIANT = "nix";
+  STACK_IN_NIX_SHELL = 1;
   STACK_IN_NIX_EXTRA_ARGS = extraArgs;
-  shellHook = addStackArgsHook + args.shellHook or "";
-
 
   # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.
-  LD_LIBRARY_PATH = makeLibraryPath (LD_LIBRARY_PATH ++ buildInputs);
+  LD_LIBRARY_PATH = lib.makeLibraryPath (LD_LIBRARY_PATH ++ buildInputs);
                     # ^^^ Internally uses `getOutput "lib"` (equiv. to getLib)
 
   # Non-NixOS git needs cert
@@ -48,18 +40,33 @@ in stdenv.mkDerivation (args // {
 
   preferLocalBuild = true;
 
-  configurePhase = args.configurePhase or ''
+  preConfigure = ''
     export STACK_ROOT=$NIX_BUILD_TOP/.stack
-    ${addStackArgsHook}
   '';
 
-  buildPhase = args.buildPhase or "${stackCmd} build";
+  buildPhase = args.buildPhase or ''
+    runHook preBuild
 
-  checkPhase = args.checkPhase or "${stackCmd} test";
+    ${stackCmd} build
+
+    runHook postBuild
+  '';
+
+  checkPhase = args.checkPhase or ''
+    runHook preCheck
+
+    ${stackCmd} test
+
+    runHook postCheck
+  '';
 
   doCheck = args.doCheck or true;
 
   installPhase = args.installPhase or ''
+    runHook preInstall
+
     ${stackCmd} --local-bin-path=$out/bin build --copy-bins
+
+    runHook postInstall
   '';
 })

--- a/pkgs/development/haskell-modules/stack-hook.sh
+++ b/pkgs/development/haskell-modules/stack-hook.sh
@@ -1,0 +1,11 @@
+addStackArgs () {
+  if [ -d "$1/lib" ] && [[ "$STACK_IN_NIX_EXTRA_ARGS" != *"--extra-lib-dirs=$1/lib"* ]]; then
+    STACK_IN_NIX_EXTRA_ARGS+=" --extra-lib-dirs=$1/lib"
+  fi
+
+  if [ -d "$1/include" ] && [[ "$STACK_IN_NIX_EXTRA_ARGS" != *"--extra-include-dirs=$1/include"* ]]; then
+    STACK_IN_NIX_EXTRA_ARGS+=" --extra-include-dirs=$1/include"
+  fi
+}
+
+addEnvHooks "$hostOffset" addStackArgs


### PR DESCRIPTION
This makes things easier and hopefully fixes the arg too long issue.

Fixes #49206.

Also reworks a few things in generic-stack-builder.nix.