### PR TITLE
[WIP] github-desktop: add GitHub Desktop to NixOS

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1650,6 +1650,11 @@
     github = "Gerschtli";
     name = "Tobias Happ";
   };
+  ghuntley = {
+    email = "ghuntley@ghuntley.com";
+    github = "ghuntley";
+    name = "Geoffrey Huntley";
+  };
   gilligan = {
     email = "tobias.pflug@gmail.com";
     github = "gilligan";

--- a/pkgs/applications/version-management/github-desktop/default.nix
+++ b/pkgs/applications/version-management/github-desktop/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, autoPatchelfHook, alsaLib, atk, cairo, cups, dbus, dpkg
+, expat, fontconfig, freetype, fetchurl, gnome3, gdk_pixbuf
+, glib, gtk2, gtk3, libpulseaudio, makeWrapper, nspr, nss, pango
+, udev, xorg
+}:
+
+let
+  version = "1.6.0";
+
+  deps = [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gnome3.GConf
+    gdk_pixbuf
+    glib
+    gtk2
+    gtk3
+    libpulseaudio
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    udev
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXtst
+  ];
+
+in
+
+stdenv.mkDerivation {
+  name = "github-desktop-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/shiftkey/desktop/releases/download/release-${version}-linux1/GitHubDesktop-linux-${version}-linux1.deb";
+    sha256 = "08wi0y98smi1p9cmjifkj5ivswbqk2b3wm9jwy7b00djqc9lxgc8";
+  };
+
+  dontBuild = true;
+  buildInputs = [ dpkg ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+ 
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./opt/GitHub\ Desktop $out
+  '';
+
+  runtimeDependencies = [
+    gnome3.gtk
+  ];
+
+  meta = {
+    description = "Desktop client for GitHub";
+    homepage = "https://github.com/desktop/desktop/issues/1525";
+    license = stdenv.lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ stdenv.lib.maintainers.ghuntley ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2885,6 +2885,8 @@ in
 
   ggobi = callPackage ../tools/graphics/ggobi { };
 
+  github-desktop = callPackage ../applications/version-management/github-desktop { };
+
   gibo = callPackage ../tools/misc/gibo { };
 
   gifsicle = callPackage ../tools/graphics/gifsicle { };


### PR DESCRIPTION
###### Motivation for this change

Howdy folks,

This is a work in progress and I'm opening it early for feedback. **It is not ready for merging.** Whilst the expression builds successfully the application does not load yet. If anyone has some spare cycles to help out that would be k-rad. The upstream repository we are building from is https://github.com/shiftkey/desktop

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

