### PR TITLE
culmus: add .otf, .pfa and .afm files

### DIFF
--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -9,11 +9,16 @@ in fetchzip {
 
   postFetch = ''
     tar -xzvf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/{truetype,type1}
+    cp -v *.pfa $out/share/fonts/type1/
+    cp -v *.afm $out/share/fonts/type1/
+    cp -v fonts.scale-type1 $out/share/fonts/type1/fonts.scale
     cp -v *.ttf $out/share/fonts/truetype/
+    cp -v *.otf $out/share/fonts/truetype/
+    cp -v fonts.scale-ttf $out/share/fonts/truetype/fonts.scale
   '';
 
-  sha256 = "1jxg2wf4kwasp5cia00nki2lrcdnhsyh4yy7d05l0a9bim5hq2lr";
+  sha256 = "1lvwv15lpk4cqarh2ncl83c43fmqxnzqaqzfm251zkx6svi1l0is";
 
   meta = {
     description = "Culmus Hebrew fonts";

--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -3,17 +3,24 @@
 let
   version = "0.133";
 in fetchzip {
-  name = "culmus-${version}";
+  name = "culmus-${version}-1";
 
   url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
 
   postFetch = ''
     tar -xzvf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/{truetype,type1}
+    cp -v *.pfa $out/share/fonts/type1/
+    cp -v *.afm $out/share/fonts/type1/
+    cp -v fonts.scale-type1 $out/share/fonts/type1/fonts.scale
     cp -v *.ttf $out/share/fonts/truetype/
+    cp -v *.otf $out/share/fonts/truetype/
+    cp -v fonts.scale-ttf $out/share/fonts/truetype/fonts.scale
+    mkdir -p $out/etc/fonts/conf.d
+    cp -v culmus.conf $out/etc/fonts/conf.d/39-culmus.conf
   '';
 
-  sha256 = "1jxg2wf4kwasp5cia00nki2lrcdnhsyh4yy7d05l0a9bim5hq2lr";
+  sha256 = "1lvwv15lpk4cqarh2ncl83c43fmqxnzqaqzfm251zkx6svi1l0is";
 
   meta = {
     description = "Culmus Hebrew fonts";

--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -2,12 +2,15 @@
 
 let
   version = "0.133";
-in fetchzip {
+in stdenv.mkDerivation {
   name = "culmus-${version}";
 
-  url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
-
-  postFetch = ''
+  src = fetchzip {
+    url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
+    sha256 = "c0c6873742d07544f6bacf2ad52eb9cb392974d56427938dc1dfbc8399c64d05";
+  }
+  
+  installPhase = ''
     tar -xzvf $downloadedFile --strip-components=1
     mkdir -p $out/share/fonts/{truetype,type1}
     cp -v *.pfa $out/share/fonts/type1/
@@ -18,7 +21,7 @@ in fetchzip {
     cp -v fonts.scale-ttf $out/share/fonts/truetype/fonts.scale
   '';
 
-  sha256 = "1lvwv15lpk4cqarh2ncl83c43fmqxnzqaqzfm251zkx6svi1l0is";
+  
 
   meta = {
     description = "Culmus Hebrew fonts";


### PR DESCRIPTION
###### Motivation for this change

DavidCLM changed from ttf to otf with the change from 0.130 to 0.133, otf files was not handled.

###### Things done

Used the font successfully on NixOS

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

