### PR TITLE
docker-sync: init at 0.5.9

### DIFF
--- a/pkgs/tools/misc/docker-sync/Gemfile
+++ b/pkgs/tools/misc/docker-sync/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+  gem 'docker-sync'
+end

--- a/pkgs/tools/misc/docker-sync/Gemfile.lock
+++ b/pkgs/tools/misc/docker-sync/Gemfile.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backticks (1.0.2)
+    daemons (1.3.1)
+    docker-compose (1.1.10)
+      backticks (~> 1.0)
+    docker-sync (0.5.9)
+      daemons (~> 1.2, >= 1.2.3)
+      docker-compose (~> 1.1, >= 1.1.7)
+      dotenv (~> 2.1, >= 2.1.1)
+      gem_update_checker (~> 0.2.0, >= 0.2.0)
+      os
+      terminal-notifier (= 2.0.0)
+      thor (~> 0.20, >= 0.20.0)
+    dotenv (2.6.0)
+    gem_update_checker (0.2.0)
+    os (1.0.0)
+    terminal-notifier (2.0.0)
+    thor (0.20.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docker-sync!
+
+BUNDLED WITH
+   1.16.2

--- a/pkgs/tools/misc/docker-sync/default.nix
+++ b/pkgs/tools/misc/docker-sync/default.nix
@@ -1,0 +1,18 @@
+{ lib, ruby, bundlerApp }:
+
+bundlerApp {
+  pname = "docker-sync";
+  gemdir = ./.;
+
+  inherit ruby;
+
+  exes = ["docker-sync"];
+
+  meta = with lib; {
+    description = "Run your application at full speed while syncing your code for development";
+    homepage = http://docker-sync.io;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.manveru ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/docker-sync/gemset.nix
+++ b/pkgs/tools/misc/docker-sync/gemset.nix
@@ -1,0 +1,76 @@
+{
+  backticks = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vr28l9vckavnrb9pnqrhcmnk3wsvvpas8jjh165w2rzv3sdkws5";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  daemons = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l5gai3vd4g7aqff0k1mp41j9zcsvm2rbwmqn115a325k9r7pf4w";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  docker-compose = {
+    dependencies = ["backticks"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "00v3y182rmpq34dl91iprvhc50vw8hysy2h7iy3ihmmm9pgg71gc";
+      type = "gem";
+    };
+    version = "1.1.10";
+  };
+  docker-sync = {
+    dependencies = ["daemons" "docker-compose" "dotenv" "gem_update_checker" "os" "terminal-notifier" "thor"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vrlcggj7k8w30b76f23p64yx4wg7p7mq9lp6lsnh2ysq9n3cjqg";
+      type = "gem";
+    };
+    version = "0.5.9";
+  };
+  dotenv = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rgl2kqhnxqbjvi9brbvb52iaq1z8yi0pl0bawk4fm6kl9igxr8f";
+      type = "gem";
+    };
+    version = "2.6.0";
+  };
+  gem_update_checker = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ckbz4q3q59kkv138n0cmsyida0wg45pwscxzf5vshxcrxhmq3x7";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  os = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1s401gvhqgs2r8hh43ia205mxsy1wc0ib4k76wzkdpspfcnfr1rk";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  terminal-notifier = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1slc0y8pjpw30hy21v8ypafi8r7z9jlj4bjbgz03b65b28i2n3bs";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  thor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yhrnp9x8qcy5vc7g438amd5j9sw83ih7c30dr6g6slgw9zj3g29";
+      type = "gem";
+    };
+    version = "0.20.3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -159,6 +159,8 @@ in
 
   docker-ls = callPackage ../tools/misc/docker-ls { };
 
+  docker-sync = callPackage ../tools/misc/docker-sync { };
+
   dotfiles = callPackage ../applications/misc/dotfiles { };
 
   dotnetenv = callPackage ../build-support/dotnetenv {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

