### PR TITLE
gnuradio-osmosdr: 0.1.4 -> 4d83c60, Added support for Soapysdr

### DIFF
--- a/pkgs/applications/misc/gnuradio/osmosdr.nix
+++ b/pkgs/applications/misc/gnuradio/osmosdr.nix
@@ -1,24 +1,33 @@
-{ stdenv, fetchgit, cmake, pkgconfig, boost, gnuradio, rtl-sdr, uhd
-, makeWrapper, hackrf, airspy
+{ stdenv, fetchgit, cmake, pkgconfig, makeWrapper
+, boost
 , pythonSupport ? true, python, swig
+, airspy
+, gnuradio
+, hackrf
+, libbladeRF
+, rtl-sdr
+, soapysdr-with-plugins
+, uhd
 }:
 
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
   name = "gnuradio-osmosdr-${version}";
-  version = "0.1.4";
+  version = "2018-08-15";
 
   src = fetchgit {
     url = "git://git.osmocom.org/gr-osmosdr";
-    rev = "refs/tags/v${version}";
-    sha256 = "0vyzr4fhkblf2v3d7m0ch5hws4c493jw3ydl4y6b2dfbfzchhsz8";
+    rev = "4d83c6067f059b0c5015c3f59f8117bbd361e877";
+    sha256 = "1d5nb47506qry52bg4cn02d3l4lwxwz44g2fz1ph0q93c7892j60";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    cmake boost gnuradio rtl-sdr uhd makeWrapper hackrf airspy
-  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+    cmake makeWrapper boost
+    airspy gnuradio hackrf libbladeRF rtl-sdr uhd
+  ] ++ stdenv.lib.optionals stdenv.isLinux [ soapysdr-with-plugins ]
+    ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do


### PR DESCRIPTION
###### Motivation for this change
I needed support for limeSDR in gnuradio and gqrx,
This can be accomplished by using limesuite via soapysdr and soapysdr via gr-osmosdr.

So this results in a rebuild of:
- `gnuradio-companion`
- `gqrx`
- `qradiolink`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

