### PR TITLE
shmig: 2017-07-24 -> 1.0.0

### DIFF
--- a/pkgs/development/tools/database/shmig/default.nix
+++ b/pkgs/development/tools/database/shmig/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchFromGitHub
-, withMySQL ? false, withPSQL ? false, withSQLite ? false
-, mysql, postgresql, sqlite, gawk, which
+, withMySQL ? true, withPSQL ? false, withSQLite ? false
+, mysql, postgresql, sqlite, gawk
 , lib
 }:
 
-stdenv.mkDerivation {
-  name = "shmig-2017-07-24";
+stdenv.mkDerivation rec {
+  name = "shmig-${version}";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "mbucc";
     repo = "shmig";
-    rev = "aff54e03d13f8f95b422cf898505490a56152a4a";
-    sha256 = "08q94dka5yqkzkis3w7j1q8kc7d3kk7mb2drx8ms59jcqvp847j3";
+    rev = "v${version}";
+    sha256 = "15ry1d51d6dlzzzhck2x57wrq48vs4n9pp20bv2sz6nk92fva5l5";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -23,8 +24,7 @@ stdenv.mkDerivation {
       --replace "\`which mysql\`" "${lib.optionalString withMySQL "${mysql.client}/bin/mysql"}" \
       --replace "\`which psql\`" "${lib.optionalString withPSQL "${postgresql}/bin/psql"}" \
       --replace "\`which sqlite3\`" "${lib.optionalString withSQLite "${sqlite}/bin/sqlite3"}" \
-      --replace "awk" "${gawk}/bin/awk" \
-      --replace "which" "${which}/bin/which"
+      --replace "awk" "${gawk}/bin/awk"
   '';
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

Update to the latest revision, don't replace `which` anymore as all
`which` references are eliminated previously, enable support for at
least one database type (otherwise this scrpit is unusable and needs to
be built manually with support for on of these packages).

Tested functionality with a simple SQLite database.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

