### PR TITLE
ec2_hibernate_linux_agent: init at 1.0.0

### DIFF
--- a/pkgs/os-specific/linux/ec2_hibernate_agent/default.nix
+++ b/pkgs/os-specific/linux/ec2_hibernate_agent/default.nix
@@ -1,0 +1,30 @@
+{ lib, python3, python3Packages, fetchFromGitHub, coreutils }:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "ec2-hibernate-linux-agent";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = pname;
+    rev = "149cb45404c0f75f5fa634fbca7289132ff423e0";
+    sha256 = "1wivhn8y2f61q297hrckbn4fj8r56agv4l7qjk5xd6szbx11z1in";
+  };
+
+  prePatch = ''
+    substituteInPlace test/hibagent_test.py \
+      --replace /usr/bin/touch ${coreutils}/bin/touch
+  '';
+
+  checkInputs = with python3Packages; [ pytest ];
+
+  meta = with lib; {
+    description = "A Hibernating Agent for Linux on Amazon EC2 ";
+    homepage = https://github.com/aws/ec2-hibernate-linux-agent;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psyanticy ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -714,6 +714,8 @@ in
   dkimpy = with pythonPackages; toPythonApplication dkimpy;
 
   dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
+ 
+  ec2_hibernate_linux_agent = callPackage ../os-specific/linux/ec2_hibernate_agent { };
 
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

