### PR TITLE
qtstyleplugin-kvantum: 0.10.6 -> 0.10.8, touchup

### DIFF
--- a/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
+++ b/pkgs/development/libraries/qtstyleplugin-kvantum/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchFromGitHub, qmake, qtbase, qtsvg, qtx11extras, libX11, libXext, qttools }:
 
 stdenv.mkDerivation rec {
-  name = "qtstyleplugin-kvantum-${version}";
-  version = "0.10.6";
+  pname = "qtstyleplugin-kvantum";
+  version = "0.10.8";
 
   src = fetchFromGitHub {
     owner = "tsujan";
     repo = "Kvantum";
-    rev = "a6daa1a6df3c5d4abc7ea39ef7028ddea2addbf6";
-    sha256 = "1zns4x95h0ydiwx8yw0bmyg4lc2sy7annmdrg66sx753x3177zxp";
+    rev = "V${version}";
+    sha256 = "0w4iqpkagrwvhahdl280ni06b7x1i621n3z740g84ysp2n3dv09l";
   };
 
   nativeBuildInputs = [ qmake qttools ];
   buildInputs = [ qtbase qtsvg qtx11extras libX11 libXext  ];
 
-  postUnpack = "sourceRoot=\${sourceRoot}/Kvantum";
+  sourceRoot = "source/Kvantum";
 
   postPatch = ''
     # Fix plugin dir


### PR DESCRIPTION
https://github.com/tsujan/Kvantum/releases/tag/V0.10.8
https://github.com/tsujan/Kvantum/releases/tag/V0.10.7


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---