### PR TITLE
pax: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2312,7 +2312,11 @@
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";
   };
-
+  klntsky = {
+    email = "klntsky@gmail.com";
+    name = "Vladimir Kalnitsky";
+    github = "8084";
+  };
   kmeakin = {
     email = "karlwfmeakin@gmail.com";
     name = "Karl Meakin";

--- a/pkgs/development/tools/pax-rs/default.nix
+++ b/pkgs/development/tools/pax-rs/default.nix
@@ -2,7 +2,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "pax-${version}";
+  name = "pax-rs-${version}";
   version = "0.4.0";
 
   meta = with stdenv.lib; {
@@ -30,7 +30,7 @@ buildRustPackage rec {
         sha256 = "0ff1b64b99cbca1cc2ceabcd2e4f7bc3411e3a2a9fbb9db2204d9240fe38ddeb";
       };
     in
-    runCommand "pax-src" {} ''
+    runCommand "pax-rs-src" {} ''
       cp -R ${source} $out
       chmod +w $out
       cp ${cargo-lock} $out/Cargo.lock

--- a/pkgs/development/tools/pax/default.nix
+++ b/pkgs/development/tools/pax/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, fetchurl, rustPlatform, runCommand } :
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "pax-${version}";
+  version = "0.4.0";
+
+  meta = with stdenv.lib; {
+    description = "The fastest JavaScript bundler in the galaxy.";
+    longDescription = ''
+      The fastest JavaScript bundler in the galaxy. Fully supports ECMAScript module syntax (import/export) in addition to CommonJS require(<string>).
+    '';
+    homepage = https://github.com/nathan/pax;
+    license = licenses.mit;
+    maintainers = [ maintainers.klntsky ];
+    platforms = platforms.all;
+  };
+
+  src =
+    let
+      source = fetchFromGitHub {
+        owner = "nathan";
+        repo = "pax";
+        rev = "pax-v${version}";
+        sha256 = "1l2xpgsms0bfc0i3l0hyw4dbp6d4qdxa9vxyp704p27vvn4ndhv2";
+      };
+
+      cargo-lock = fetchurl {
+        url = "https://gist.github.com/8084/c7863424d7df0c379782015f6bb3b399/raw/1cf7481e33984fd1510dc77ed677606d08fa8eb6/Cargo.lock";
+        sha256 = "0ff1b64b99cbca1cc2ceabcd2e4f7bc3411e3a2a9fbb9db2204d9240fe38ddeb";
+      };
+    in
+    runCommand "pax-src" {} ''
+      cp -R ${source} $out
+      chmod +w $out
+      cp ${cargo-lock} $out/Cargo.lock
+    '';
+
+  cargoSha256 = "0sdk090sp89vgwz5a71f481a5sk13kcqb29cx1dslfq59sp4j6y7";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8929,6 +8929,8 @@ in
 
   patchelfUnstable = lowPrio (callPackage ../development/tools/misc/patchelf/unstable.nix { });
 
+  pax = callPackage ../development/tools/pax { };
+
   peg = callPackage ../development/tools/parsing/peg { };
 
   pgcli = callPackage ../development/tools/database/pgcli {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6529,9 +6529,9 @@ in
   fish-foreign-env = callPackage ../shells/fish/fish-foreign-env { };
 
   ion = callPackage ../shells/ion { };
-  
+
   ksh = callPackage ../shells/ksh { };
-  
+
   mksh = callPackage ../shells/mksh { };
 
   oh = callPackage ../shells/oh { };
@@ -8929,7 +8929,7 @@ in
 
   patchelfUnstable = lowPrio (callPackage ../development/tools/misc/patchelf/unstable.nix { });
 
-  pax = callPackage ../development/tools/pax { };
+  pax-rs = callPackage ../development/tools/pax-rs { };
 
   peg = callPackage ../development/tools/parsing/peg { };
 


### PR DESCRIPTION
###### Motivation for this change

Pax is a JS bundler, see https://pax.js.org/

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not sure if including `Cargo.lock` through Github Gists is a good idea, but it is done the same way at [cargo-fuzz](https://github.com/NixOS/nixpkgs/blob/92a047a6c4d46a222e9c323ea85882d0a7a13af8/pkgs/development/tools/rust/cargo-fuzz/default.nix).