### PR TITLE
ibus-engines.mozc: 2.20.2673.102 -> 2.23.2815.102

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -10,7 +10,7 @@ let
   };
 in clangStdenv.mkDerivation rec {
   name = "ibus-mozc-${version}";
-  version = "2.20.2673.102";
+  version = "2.23.2815.102";
 
   meta = with clangStdenv.lib; {
     isIbusEngine = true;
@@ -27,8 +27,8 @@ in clangStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "google";
     repo   = "mozc";
-    rev    = "280e38fe3d9db4df52f0713acf2ca65898cd697a";
-    sha256 = "0s599f817gjgqynm4n1yll1ipd25ai2c55y8k6wvhg9s7qaxnyhs";
+    rev    = "afb03ddfe72dde4cf2409863a3bfea160f7a66d8";
+    sha256 = "0w2dy2j9x5nc7x3g95j17r3m60vbfyn5j617h7js9xryv33yzpgx";
   };
 
   postUnpack = ''


### PR DESCRIPTION
###### Motivation for this change

Version bump. Includes some dictionary updates.

https://github.com/google/mozc/compare/280e38fe3d9db4df52f0713acf2ca65898cd697a...afb03ddfe72dde4cf2409863a3bfea160f7a66d8

cc maintainers @gebner @ericsagnes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested that Hiragana input works.  Mozc Settings also seem to work as before.

Note that I had to kill the lingering previous-version `mozc_server` because it stayed around after `nixos-rebuild switch`.