### PR TITLE
dmd: 2.083.1 -> 2.084.0, dub: 1.12.1 -> 1.13.0, dtools: 2.083.1 -> 2.084.0, Literate: 2018-12-23 -> 2019-01-08

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchFromGitHub
 , makeWrapper, unzip, which
-, curl, tzdata, gdb, darwin
+, curl, tzdata, gdb, darwin, git
 , callPackage, targetPackages, ldc
-, version ? "2.083.1"
-, dmdSha256 ? "0b52yq7slgbrawb22kib9bk2x9xjiy6axwz1317fck5axl093d90"
-, druntimeSha256 ? "1hm9p59ih21yv8x7cqjhkyy94677q4f8wk9fs9i1rybx8x19njyn"
-, phobosSha256 ? "1zmz0f1wj0dgxy2cy63ljjc1sl2sgb7ij8bamlxw9nxrchwi3l43"
+, version ? "2.084.0"
+, dmdSha256 ? "1v61spdamncl8c1bzjc19b03p4jl0ih5zq9b7cqsy9ix7qaxmikf"
+, druntimeSha256 ? "0vp414j6s11l9s54v81np49mv60ywmd7nnk41idkbwrq0nz4sfrq"
+, phobosSha256 ? "1wp7z1x299b0w9ny1ah2wrfhrs05vc4bk51csgw9774l3dqcnv53"
 }:
 
 let
@@ -42,50 +42,22 @@ let
 
     sourceRoot = ".";
 
+    # https://issues.dlang.org/show_bug.cgi?id=19553
+    hardeningDisable = [ "fortify" ];
+
     postUnpack = ''
         patchShebangs .
-
-        # Remove cppa test for now because it doesn't work.
-        rm dmd/test/runnable/cppa.d
-        rm dmd/test/runnable/extra-files/cppb.cpp
-    ''
-
-    + stdenv.lib.optionalString (stdenv.hostPlatform.isDarwin) ''
-        rm dmd/test/runnable/test16096.sh
-    '';
-
-    # Compile with PIC to prevent colliding modules with binutils 2.28.
-    # https://issues.dlang.org/show_bug.cgi?id=17375
-    usePIC = "-fPIC";
-
-    phobosPatches = ''
-        # Ugly hack so the dlopen call has a chance to succeed.
-        # https://issues.dlang.org/show_bug.cgi?id=15391
-        substituteInPlace phobos/std/net/curl.d \
-            --replace libcurl.so ${curl.out}/lib/libcurl.so
-
-        # phobos uses curl, so we need to patch the path to the lib.
-        substituteInPlace phobos/posix.mak \
-            --replace "-soname=libcurl.so.4" "-soname=${curl.out}/lib/libcurl.so.4"
-
     '';
 
     postPatch = ''
-        substituteInPlace druntime/test/common.mak \
-            --replace "DFLAGS:=" "DFLAGS:=${usePIC} "
+        substituteInPlace dmd/test/compilable/extra-files/ddocYear.html \
+            --replace "2018" "__YEAR__"
 
-        substituteInPlace dmd/src/posix.mak \
-            --replace "DFLAGS :=" "DFLAGS += -link-defaultlib-shared=false"
-    ''
-
-    + phobosPatches
-
-    + stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
-        substituteInPlace dmd/posix.mak \
-            --replace MACOSX_DEPLOYMENT_TARGET MACOSX_DEPLOYMENT_TARGET_
+        substituteInPlace dmd/test/runnable/test16096.sh \
+            --replace "{EXT}" "{EXE}"
     '';
 
-    nativeBuildInputs = [ ldc makeWrapper unzip which gdb ]
+    nativeBuildInputs = [ ldc makeWrapper unzip which gdb git ]
 
     ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
       Foundation
@@ -109,7 +81,8 @@ let
         make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd}
         cd ../phobos
         echo ${tzdata}/share/zoneinfo/ > TZDatabaseDirFile
-        make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd} DFLAGS="-version=TZDatabaseDir -J$(pwd)"
+        echo ${curl.out}/lib/libcurl.so > LibcurlPathFile
+        make -j$NIX_BUILD_CORES -f posix.mak BUILD=release ENABLE_RELEASE=1 PIC=1 INSTALL_DIR=$out DMD=${pathToDmd} DFLAGS="-version=TZDatabaseDir -version=LibcurlPath -J$(pwd)"
         cd ..
     '';
 
@@ -119,7 +92,7 @@ let
 
     checkPhase = ''
         cd dmd
-        make -j$NIX_BUILD_CORES -C test -f Makefile PIC=1 DMD=${pathToDmd} BUILD=release SHARED=0 SHELL=$SHELL
+        make -j$NIX_BUILD_CORES -C test -f Makefile PIC=1 CC=$CXX DMD=${pathToDmd} BUILD=release SHARED=0 SHELL=$SHELL
         cd ../druntime
         make -j$NIX_BUILD_CORES -f posix.mak unittest PIC=1 DMD=${pathToDmd} BUILD=release
         cd ..
@@ -194,15 +167,14 @@ let
 
       sourceRoot = ".";
 
-      postPatch = dmdBuild.phobosPatches;
-
       nativeBuildInputs = dmdBuild.nativeBuildInputs;
       buildInputs = dmdBuild.buildInputs;
 
       buildPhase = ''
           cd phobos
           echo ${tzdata}/share/zoneinfo/ > TZDatabaseDirFile
-          make -j$NIX_BUILD_CORES -f posix.mak unittest BUILD=release ENABLE_RELEASE=1 PIC=1 DMD=${dmdBuild}/bin/dmd DFLAGS="-version=TZDatabaseDir -J$(pwd)"
+          echo ${curl.out}/lib/libcurl.so > LibcurlPathFile
+          make -j$NIX_BUILD_CORES -f posix.mak unittest BUILD=release ENABLE_RELEASE=1 PIC=1 DMD=${dmdBuild}/bin/dmd DFLAGS="-version=TZDatabaseDir -version=LibcurlPath -J$(pwd)"
       '';
 
       installPhase = ''

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -4,7 +4,7 @@ let
 
   dubBuild = stdenv.mkDerivation rec {
     name = "dubBuild-${version}";
-    version = "1.12.1";
+    version = "1.13.0";
 
     enableParallelBuilding = true;
 
@@ -12,7 +12,7 @@ let
       owner = "dlang";
       repo = "dub";
       rev = "v${version}";
-      sha256 = "0q4968vxgfxhq6ywhdvj6sqddwf7aadqmmpfqc6nl65r7jyga52a";
+      sha256 = "1wd5pdnbaafj33bbg188w0iz28ps4cyjangb12g2s9dyic29zjqv";
     };
 
     postUnpack = ''

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "dtools-${version}";
-  version = "2.083.1";
+  version = "2.084.0";
 
   srcs = [
     (fetchFromGitHub {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "0b52yq7slgbrawb22kib9bk2x9xjiy6axwz1317fck5axl093d90";
+      sha256 = "1v61spdamncl8c1bzjc19b03p4jl0ih5zq9b7cqsy9ix7qaxmikf";
       name = "dmd";
     })
     (fetchFromGitHub {

--- a/pkgs/development/tools/literate-programming/Literate/default.nix
+++ b/pkgs/development/tools/literate-programming/Literate/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, dmd, dub }:
 
 stdenv.mkDerivation {
-  name = "Literate-2018-12-23";
+  name = "Literate-2019-01-08";
 
   src = fetchgit {
     url = "https://github.com/zyedidia/Literate.git";
-    rev = "99a0b7dd1ac451c2386094be06364df9386c3862";
-    sha256 = "0jvciajr33iz049m0yal41mz9p8nxmwkpq2mrfhg1ysx2zv3q3pm";
+    rev = "e20c5c86713701d4d17fd2881779d758a27a3e5a";
+    sha256 = "1pr7iipcnp6jxi13341p5b3szdrvs7aixpfbwifj6lgbb45vg9sm";
   };
 
   buildInputs = [ dmd dub ];


### PR DESCRIPTION
###### Motivation for this change

Version updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

