### PR TITLE
radare2: add propagated build inputs

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -75,11 +75,18 @@ let
       depsBuildBuild = [ buildPackages.stdenv.cc ];
 
       nativeBuildInputs = [ pkgconfig ];
-      buildInputs = [ file libzip xxHash readline libusb libewf perl zlib openssl libuv ]
+      buildInputs = [ file readline libusb libewf perl zlib openssl libuv ]
         ++ optional useX11 [ gtkdialog vte gtk2 ]
         ++ optional rubyBindings [ ruby ]
         ++ optional pythonBindings [ python3 ]
         ++ optional luaBindings [ lua ];
+
+      propagatedBuildInputs = [
+        # radare2 exposes r_lib which depends on these libraries
+        file # for its list of magic numbers (`libmagic`)
+        libzip
+        xxHash
+      ];
 
       meta = {
         description = "unix-like reverse engineering framework and commandline tools";


### PR DESCRIPTION
###### Motivation for this change

Fixes the cutter build which was broken when radare2 was moved away from
vendored dependencies in #51837.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

