### PR TITLE
darwin: basic_cmds was installing binaries in the wrong path

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/basic_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/basic_cmds/default.nix
@@ -15,7 +15,7 @@ appleDerivation rec {
   installPhase = ''
     for f in Products/Release/*; do
       if [ -f $f ]; then
-        install -D $f $out/usr/bin/$(basename $f)
+        install -D $f $out/bin/$(basename $f)
       fi
     done
 


### PR DESCRIPTION
###### Motivation for this change

Installing unixtools.write failed because files were copied from $out/bin and basic_cmds was installing in $out/usr/bin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

