### PR TITLE
GHC 8.6 fixes and bound relaxation

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1193,4 +1193,16 @@ self: super: {
   hlint = super.hlint.overrideScope (self: super: { haskell-src-exts = self.haskell-src-exts_1_21_0; });
   hoogle = super.hoogle.overrideScope (self: super: { haskell-src-exts = self.haskell-src-exts_1_21_0; });
 
+  # jailbreak tasty < 1.2: https://github.com/phadej/tdigest/issues/30
+  tdigest = doJailbreak super.tdigest; # until tdigest > 0.2.1
+
+  # These patches contain fixes for 8.6 that should be safe for
+  # earlier versions, but we need the relaxed version bounds in GHC
+  # 8.4 builds. beam needs to release a round of updates that relax
+  # bounds and include the 8.6 fixes:
+  # https://github.com/tathougies/beam/issues/315
+  beam-core = appendPatch super.beam-core ./patches/beam-core-fix-ghc-8.6.x-build.patch;
+  beam-migrate = appendPatch super.beam-migrate ./patches/beam-migrate-fix-ghc-8.6.x-build.patch;
+  beam-postgres = appendPatch super.beam-postgres ./patches/beam-postgres-fix-ghc-8.6.x-build.patch;
+  beam-sqlite = appendPatch super.beam-sqlite ./patches/beam-sqlite-fix-ghc-8.6.x-build.patch;
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -942,7 +942,12 @@ self: super: {
   # aarch64 and armv7l fixes.
   happy = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.happy else super.happy; # Similar to https://ghc.haskell.org/trac/ghc/ticket/13062
   hashable = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.hashable else super.hashable; # https://github.com/tibbe/hashable/issues/95
-  servant-docs = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontCheck super.servant-docs else super.servant-docs;
+  servant-docs =
+    let
+      f = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64)
+          then dontCheck
+          else pkgs.lib.id;
+    in doJailbreak (f super.servant-docs); # jailbreak tasty < 1.2 until servant-docs > 0.11.3 is on hackage.
   swagger2 = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontHaddock (dontCheck super.swagger2) else super.swagger2;
 
   # requires a release including https://github.com/haskell-servant/servant-swagger/commit/249530d9f85fe76dfb18b100542f75a27e6a3079

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1198,7 +1198,7 @@ self: super: {
   hlint = super.hlint.overrideScope (self: super: { haskell-src-exts = self.haskell-src-exts_1_21_0; });
   hoogle = super.hoogle.overrideScope (self: super: { haskell-src-exts = self.haskell-src-exts_1_21_0; });
 
-  # jailbreak tasty < 1.2: https://github.com/phadej/tdigest/issues/30
+  # Jailbreak tasty < 1.2: https://github.com/phadej/tdigest/issues/30
   tdigest = doJailbreak super.tdigest; # until tdigest > 0.2.1
 
   # These patches contain fixes for 8.6 that should be safe for

--- a/pkgs/development/haskell-modules/patches/beam-core-fix-ghc-8.6.x-build.patch
+++ b/pkgs/development/haskell-modules/patches/beam-core-fix-ghc-8.6.x-build.patch
@@ -1,0 +1,72 @@
+diff --git a/beam-core/Database/Beam/Backend/SQL.hs b/beam-core/Database/Beam/Backend/SQL.hs
+index e2cd37d0..6f9db126 100644
+--- a/Database/Beam/Backend/SQL.hs
++++ b/Database/Beam/Backend/SQL.hs
+@@ -10,6 +10,7 @@
+ import Database.Beam.Backend.Types
+ 
+ import Control.Monad.IO.Class
++import Control.Monad.Fail (MonadFail)
+ 
+ -- * MonadBeam class
+ 
+@@ -29,7 +30,7 @@
+ --   strategies. More complicated strategies (for example, Postgres's @COPY@)
+ --   are supported in individual backends. See the documentation of those
+ --   backends for more details.
+-class (BeamBackend be, Monad m, MonadIO m, Sql92SanityCheck syntax) =>
++class (BeamBackend be, Monad m, MonadIO m, MonadFail m, Sql92SanityCheck syntax) =>
+   MonadBeam syntax be handle m | m -> syntax be handle where
+ 
+   {-# MINIMAL withDatabaseDebug, runReturningMany #-}
+diff --git a/Database/Beam/Backend/SQL/Builder.hs b/Database/Beam/Backend/SQL/Builder.hs
+index 9e734036..e9849912 100644
+--- a/Database/Beam/Backend/SQL/Builder.hs
++++ b/Database/Beam/Backend/SQL/Builder.hs
+@@ -33,6 +33,7 @@
+ import           Data.Hashable
+ import           Data.Int
+ import           Data.String
++import qualified Control.Monad.Fail as Fail
+ #if !MIN_VERSION_base(4, 11, 0)
+ import           Data.Semigroup
+ #endif
+@@ -507,8 +508,10 @@
+   type BackendFromField SqlSyntaxBackend = Trivial
+ 
+ newtype SqlSyntaxM a = SqlSyntaxM (IO a)
+-  deriving (Applicative, Functor, Monad, MonadIO)
++  deriving (Applicative, Functor, Monad, MonadIO, Fail.MonadFail)
+ 
+ instance MonadBeam SqlSyntaxBuilder SqlSyntaxBackend SqlSyntaxBackend SqlSyntaxM where
+-  withDatabaseDebug _ _ _ = fail "absurd"
+-  runReturningMany _ _ = fail "absurd"
++  withDatabaseDebug _ _ _ = Fail.fail "absurd"
++  runReturningMany _ _ = Fail.fail "absurd"
++
++
+diff --git a/Database/Beam/Schema/Lenses.hs b/Database/Beam/Schema/Lenses.hs
+index b21dddb6..5df0654c 100644
+--- a/Database/Beam/Schema/Lenses.hs
++++ b/Database/Beam/Schema/Lenses.hs
+@@ -1,4 +1,5 @@
+ {-# LANGUAGE PolyKinds #-}
++{-# LANGUAGE UndecidableInstances #-}
+ module Database.Beam.Schema.Lenses
+     ( tableLenses
+     , TableLens(..)
+diff --git a/beam-core.cabal b/beam-core.cabal
+index 4bf4ffd9..251d4d85 100644
+--- a/beam-core.cabal
++++ b/beam-core.cabal
+@@ -64,8 +64,8 @@
+                        time         >=1.6     && <1.10,
+                        hashable     >=1.1     && <1.3,
+                        network-uri  >=2.6     && <2.7,
+-                       containers   >=0.5     && <0.6,
+-                       vector-sized >=0.5     && <1.1,
++                       containers   >=0.5     && <0.7,
++                       vector-sized >=0.5     && <1.3,
+                        tagged       >=0.8     && <0.9
+   Default-language:    Haskell2010
+   default-extensions:  ScopedTypeVariables, OverloadedStrings, GADTs, RecursiveDo, FlexibleInstances, FlexibleContexts, TypeFamilies,

--- a/pkgs/development/haskell-modules/patches/beam-migrate-fix-ghc-8.6.x-build.patch
+++ b/pkgs/development/haskell-modules/patches/beam-migrate-fix-ghc-8.6.x-build.patch
@@ -1,0 +1,29 @@
+diff --git a/Database/Beam/Migrate/Generics/Types.hs b/Database/Beam/Migrate/Generics/Types.hs
+index 553e208b..0cf9b2c8 100644
+--- a/Database/Beam/Migrate/Generics/Types.hs
++++ b/Database/Beam/Migrate/Generics/Types.hs
+@@ -1,3 +1,5 @@
++{-# LANGUAGE UndecidableInstances #-}
++
+ module Database.Beam.Migrate.Generics.Types where
+ 
+ import           Database.Beam.Migrate.Types
+diff --git a/beam-migrate.cabal b/beam-migrate.cabal
+index f53b280d..9cf3722c 100644
+--- a/beam-migrate.cabal
++++ b/beam-migrate.cabal
+@@ -69,13 +69,12 @@ library
+                        mtl                  >=2.2     && <2.3,
+                        scientific           >=0.3     && <0.4,
+                        vector               >=0.11    && <0.13,
+-                       containers           >=0.5     && <0.6,
+                        unordered-containers >=0.2     && <0.3,
+                        hashable             >=1.2     && <1.3,
+                        parallel             >=3.2     && <3.3,
+                        deepseq              >=1.4     && <1.5,
+                        ghc-prim             >=0.5     && <0.6,
+-                       containers           >=0.5     && <0.6,
++                       containers           >=0.5     && <0.7,
+                        haskell-src-exts     >=1.18    && <1.21,
+                        pretty               >=1.1     && <1.2,
+                        dependent-map        >=0.2     && <0.3,

--- a/pkgs/development/haskell-modules/patches/beam-postgres-fix-ghc-8.6.x-build.patch
+++ b/pkgs/development/haskell-modules/patches/beam-postgres-fix-ghc-8.6.x-build.patch
@@ -1,0 +1,45 @@
+diff --git a/Database/Beam/Postgres/Connection.hs b/Database/Beam/Postgres/Connection.hs
+index 433f55b9..5836c53d 100644
+--- a/Database/Beam/Postgres/Connection.hs
++++ b/Database/Beam/Postgres/Connection.hs
+@@ -52,6 +52,8 @@ import qualified Database.PostgreSQL.Simple.Types as Pg (Null(..), Query(..))
+ 
+ import           Control.Monad.Reader
+ import           Control.Monad.State
++import           Control.Monad.Fail (MonadFail)
++import qualified Control.Monad.Fail as Fail
+ 
+ import           Data.ByteString (ByteString)
+ import           Data.ByteString.Builder (toLazyByteString, byteString)
+@@ -302,6 +304,9 @@ deriving instance Functor PgF
+ newtype Pg a = Pg { runPg :: F PgF a }
+     deriving (Monad, Applicative, Functor, MonadFree PgF)
+ 
++instance MonadFail Pg where
++    fail e = fail $ "Internal Error with: " <> show e
++
+ instance MonadIO Pg where
+     liftIO x = liftF (PgLiftIO x id)
+ 
+diff --git a/beam-postgres.cabal b/beam-postgres.cabal
+index e14b84f5..d29a5b67 100644
+--- a/beam-postgres.cabal
++++ b/beam-postgres.cabal
+@@ -31,7 +31,7 @@ library
+                       beam-migrate         >=0.3  && <0.4,
+ 
+                       postgresql-libpq     >=0.8  && <0.10,
+-                      postgresql-simple    >=0.5  && <0.6,
++                      postgresql-simple    >=0.5  && <0.7,
+ 
+                       text                 >=1.0  && <1.3,
+                       bytestring           >=0.10 && <0.11,
+@@ -38,7 +38,7 @@ library
+ 
+                       hashable             >=1.1  && <1.3,
+                       lifted-base          >=0.2  && <0.3,
+-                      free                 >=4.12 && <5.1,
++                      free                 >=4.12 && <5.2,
+                       time                 >=1.6  && <1.10,
+                       monad-control        >=1.0  && <1.1,
+                       mtl                  >=2.1  && <2.3,

--- a/pkgs/development/haskell-modules/patches/beam-sqlite-fix-ghc-8.6.x-build.patch
+++ b/pkgs/development/haskell-modules/patches/beam-sqlite-fix-ghc-8.6.x-build.patch
@@ -1,0 +1,21 @@
+diff --git a/Database/Beam/Sqlite/Connection.hs b/Database/Beam/Sqlite/Connection.hs
+index f034b272..4e459ea3 100644
+--- a/Database/Beam/Sqlite/Connection.hs
++++ b/Database/Beam/Sqlite/Connection.hs
+@@ -37,6 +37,7 @@ import           Database.SQLite.Simple.Types (Null)
+ 
+ import           Control.Exception (bracket_, onException, mask)
+ import           Control.Monad (forM_, replicateM_)
++import           Control.Monad.Fail (MonadFail)
+ import           Control.Monad.Free.Church
+ import           Control.Monad.IO.Class (MonadIO(..))
+ import           Control.Monad.Identity (Identity)
+@@ -143,7 +144,7 @@ newtype SqliteM a
+   { runSqliteM :: ReaderT (String -> IO (), Connection) IO a
+     -- ^ Run an IO action with access to a SQLite connection and a debug logging
+     -- function, called or each query submitted on the connection.
+-  } deriving (Monad, Functor, Applicative, MonadIO)
++  } deriving (Monad, Functor, Applicative, MonadIO, MonadFail)
+ 
+ newtype BeamSqliteParams = BeamSqliteParams [SQLData]
+ instance ToRow BeamSqliteParams where


### PR DESCRIPTION
###### Motivation for this change

A haskell project I am working on cannot enter a nix-shell from nixpkgs master. This fixes some of the problems. Some problems are due to ghc 8.6 (e.g., the MonadFail fixes for beam) but some are due to version bounds that have become too tight.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

