### PR TITLE
[backport] rambox: update electron to 3.x

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,6 +1,6 @@
 { stdenv, newScope, makeWrapper
 , wrapGAppsHook, gnome3, glib
-, electron, xdg_utils, makeDesktopItem
+, electron_3, xdg_utils, makeDesktopItem
 , auth0ClientID ? "0spuNKfIGeLAQ_Iki9t3fGxbfJl3k8SU"
 , auth0Domain ? "nixpkgs.auth0.com" }:
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
   '';
 
   postFixup = ''
-    makeWrapper ${electron}/bin/electron $out/bin/rambox \
+    makeWrapper ${electron_3}/bin/electron $out/bin/rambox \
       --add-flags "${rambox-bare} --without-update" \
       "''${gappsWrapperArgs[@]}" \
       --prefix PATH : ${xdg_utils}/bin

--- a/pkgs/development/tools/electron/3.x.nix
+++ b/pkgs/development/tools/electron/3.x.nix
@@ -27,11 +27,11 @@ let
       };
       armv7l-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-armv7l.zip";
-        sha256 = "1ayfcy7jm7mymmbdq08id9wpjj6cja2cyix1sw2r3m8gpn4l6ih2";
+        sha256 = "04yj58v1sqnw64csazpfcchv2498ppxs2izadpnirawk09azl3bl";
       };
       aarch64-linux = fetchurl {
         url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-arm64.zip";
-        sha256 = "18cqg9zb98c0rfrdg7ri26dvhjwrwzj41jn8dfra9131xc84nl3i";
+        sha256 = "0cjf4i24qpgkmzb4nm89kgl07bwrncpz66xs5jjvi94pmr6wx6jm";
       };
     }.${stdenv.hostPlatform.system} or throwSystem;
 

--- a/pkgs/development/tools/electron/3.x.nix
+++ b/pkgs/development/tools/electron/3.x.nix
@@ -1,0 +1,77 @@
+{ stdenv, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv, gtk2, at-spi2-atk }:
+
+let
+  version = "3.1.0";
+  name = "electron-${version}";
+
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  meta = with stdenv.lib; {
+    description = "Cross platform desktop application shell";
+    homepage = https://github.com/electron/electron;
+    license = licenses.mit;
+    maintainers = with maintainers; [ travisbhartwell manveru ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" "i686-linux" "armv7l-linux" "aarch64-linux" ];
+  };
+
+  linux = {
+    inherit name version meta;
+    src = {
+      i686-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-ia32.zip";
+        sha256 = "09llladfj8l1vnk8fl8ad66qq4czr755fhrp5ciivpbh38zi6d3d";
+      };
+      x86_64-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-x64.zip";
+        sha256 = "0g0af1z598f8k2i5sbkzpbga49hbgzl98qgk1n4iagk08iivyfwy";
+      };
+      armv7l-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-armv7l.zip";
+        sha256 = "1ayfcy7jm7mymmbdq08id9wpjj6cja2cyix1sw2r3m8gpn4l6ih2";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-linux-arm64.zip";
+        sha256 = "18cqg9zb98c0rfrdg7ri26dvhjwrwzj41jn8dfra9131xc84nl3i";
+      };
+    }.${stdenv.hostPlatform.system} or throwSystem;
+
+    buildInputs = [ unzip makeWrapper ];
+
+    buildCommand = ''
+      mkdir -p $out/lib/electron $out/bin
+      unzip -d $out/lib/electron $src
+      ln -s $out/lib/electron/electron $out/bin
+
+      fixupPhase
+
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${atomEnv.libPath}:${gtk2}/lib:${at-spi2-atk}/lib:$out/lib/electron" \
+        $out/lib/electron/electron
+
+      wrapProgram $out/lib/electron/electron \
+        --prefix LD_PRELOAD : ${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1
+    '';
+  };
+
+  darwin = {
+    inherit name version meta;
+
+    src = fetchurl {
+      url = "https://github.com/electron/electron/releases/download/v${version}/electron-v${version}-darwin-x64.zip";
+      sha256 = "1cd1ashrcbdjlrr6yijyh2ppk8x8jdw5cm9qnx4lzk7sj9lwjbgb";
+    };
+
+    buildInputs = [ unzip ];
+
+    buildCommand = ''
+      mkdir -p $out/Applications
+      unzip $src
+      mv Electron.app $out/Applications
+      mkdir -p $out/bin
+      ln -s $out/Applications/Electron.app/Contents/MacOs/Electron $out/bin/electron
+    '';
+  };
+in
+
+  stdenv.mkDerivation (if stdenv.isDarwin then darwin else linux)

--- a/pkgs/development/tools/electron/print-hashes.sh
+++ b/pkgs/development/tools/electron/print-hashes.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "$0: version" >&2
+    exit 1
+fi
+
+
+VERSION=$1
+
+declare -A SYSTEMS HASHES
+SYSTEMS=(
+    [i686-linux]=linux-ia32
+    [x86_64-linux]=linux-x64
+    [armv7l-linux]=linux-armv7l
+    [aarch64-linux]=linux-arm64
+    [x86_64-darwin]=darwin-x64
+)
+
+for S in "${!SYSTEMS[@]}"; do
+  HASHES["$S"]=$(nix-prefetch-url "https://github.com/electron/electron/releases/download/v${VERSION}/electron-v${VERSION}-${SYSTEMS[$S]}.zip")
+done
+
+for S in "${!HASHES[@]}"; do
+    echo "$S"
+    echo "sha256 = \"${HASHES[$S]}\";"
+done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7994,6 +7994,8 @@ with pkgs;
 
   electron = callPackage ../development/tools/electron { };
 
+  electron_3 = callPackage ../development/tools/electron/3.x.nix { };
+
   autobuild = callPackage ../development/tools/misc/autobuild { };
 
   autoconf = callPackage ../development/tools/misc/autoconf { };


### PR DESCRIPTION
###### Motivation for this change

security security.
@mrVanDalo for testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

