### PR TITLE
exfat-nofuse: unbreak for 4.18 and 4.20

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, kernel }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel }:
 
 
 # Upstream build for kernel 4.1 is broken, 3.12 and below seems to be working
@@ -27,12 +27,24 @@ stdenv.mkDerivation rec {
     install -m644 -b -D exfat.ko $out/lib/modules/${kernel.modDirVersion}/kernel/fs/exfat/exfat.ko
   '';
 
+  patches = [
+    # fix compile-errors in 4.18
+    (fetchpatch {
+      url = https://aur.archlinux.org/cgit/aur.git/plain/4.18.patch?h=exfat-dkms-git;
+      sha256 = "18l5h631w8yja7m2kkcf9h335pvlxms23ls539i81nf6xd6yvd78";
+    } )
+    # fix compile-errors in 4.20
+    (fetchpatch {
+      url = https://aur.archlinux.org/cgit/aur.git/plain/4.20.patch?h=exfat-dkms-git;
+      sha256 = "05l5x5yvd4vlvnr1bjl751gzcylvm3g9551fqdx7lqphhyiyv3bc";
+    })
+  ];
+
   meta = {
     description = "exfat kernel module";
     homepage = https://github.com/dorimanx/exfat-nofuse;
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ makefu ];
     platforms = lib.platforms.linux;
-    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

fix `exfat-nofuse` for `linuxPackages_latest`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

