### PR TITLE
exfat-nofuse: fix build for 4.18

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -28,16 +28,12 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    # fix compile-errors in 4.18
+    # fix compile-errors in 4.18 and 4.20
+    # ref: https://github.com/dorimanx/exfat-nofuse/pull/137
     (fetchpatch {
-      url = https://aur.archlinux.org/cgit/aur.git/plain/4.18.patch?h=exfat-dkms-git;
-      sha256 = "18l5h631w8yja7m2kkcf9h335pvlxms23ls539i81nf6xd6yvd78";
+      url = https://github.com/dorimanx/exfat-nofuse/compare/01c30ad52625a7261e1b0d874553b6ca7af25966...f93a47e6414d567a1e7f6ab7f34b015b20f9a050.patch ;
+      sha256 = "0w57pi9h6dwjxfgc3zpwy6sr4zw42hn1zj72f7wgfpqrx6d8xkh5";
     } )
-    # fix compile-errors in 4.20
-    (fetchpatch {
-      url = https://aur.archlinux.org/cgit/aur.git/plain/4.20.patch?h=exfat-dkms-git;
-      sha256 = "05l5x5yvd4vlvnr1bjl751gzcylvm3g9551fqdx7lqphhyiyv3bc";
-    })
   ];
 
   meta = {


### PR DESCRIPTION


###### Motivation for this change

additionally to fixing the build for linux 4.18 we use the PR 137 instead of the patch files from AUR.
This avoids changes in source files and pins the patch to exactly what we want
It also removes one fetchpatch call.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

