### PR TITLE
ocamlPackages.ocp-indent: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -6,13 +6,23 @@ in
 
 assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
 
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
+    version = "1.0.3";
+    sha256 = "0g3w4hvc1cx9x2yp5aqn6m2rl8lf9x1dn754hfq8m1sc1102lxna";
+  } else {
+    version = "1.0.2";
+    sha256 = "18jqphjiifljlh9jg8zpl6310p3iwyaqphdkmf89acyaix0s4kj1";
+  }
+; in
+
 stdenv.mkDerivation rec {
-  name = "ocaml-${pname}-${version}";
-  version = "1.0.3";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  inherit (param) version;
 
   src = fetchurl {
     url = "http://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
-    sha256 = "0g3w4hvc1cx9x2yp5aqn6m2rl8lf9x1dn754hfq8m1sc1102lxna";
+    inherit (param) sha256;
   };
 
   nativeBuildInputs = [ ocamlbuild topkg ];

--- a/pkgs/development/tools/ocaml/ocp-indent/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-indent/default.nix
@@ -1,31 +1,22 @@
-{ stdenv, fetchzip, ocaml, findlib, dune, ocp-build, cmdliner }:
+{ lib, fetchzip, buildDunePackage, cmdliner }:
 
-let inherit (stdenv.lib) getVersion versionAtLeast; in
-
-assert versionAtLeast (getVersion ocaml) "3.12.1";
-assert versionAtLeast (getVersion cmdliner) "1.0.0";
-assert versionAtLeast (getVersion ocp-build) "1.99.6-beta";
-
-stdenv.mkDerivation rec {
-
-  name = "ocaml${ocaml.version}-ocp-indent-${version}";
-  version = "1.6.1";
+buildDunePackage rec {
+  version = "1.7.0";
+  pname = "ocp-indent";
 
   src = fetchzip {
     url = "https://github.com/OCamlPro/ocp-indent/archive/${version}.tar.gz";
-    sha256 = "0rcaa11mjqka032g94wgw9llqpflyk3ywr3lr6jyxbh1rjvnipnw";
+    sha256 = "006x3fsd61vxnxj4chlakyk3b2s10pb0bdl46g0ghf3j8h33x7hc";
   };
 
-  nativeBuildInputs = [ ocp-build ];
-  buildInputs = [ ocaml findlib cmdliner ];
+  minimumOCamlVersion = "4.02";
 
-  inherit (dune) installPhase;
+  buildInputs = [ cmdliner ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://typerex.ocamlpro.com/ocp-indent.html;
     description = "A customizable tool to indent OCaml code";
     license = licenses.gpl3;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.jirkamarsik ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version 1.6.1 does not seem to build with upcoming version of dune.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

