### PR TITLE
bear: fix wrapper detection patch by checking result of find_executable

### DIFF
--- a/pkgs/development/tools/build-managers/bear/ignore_wrapper.patch
+++ b/pkgs/development/tools/build-managers/bear/ignore_wrapper.patch
@@ -1,6 +1,6 @@
---- Bear-2.3.11-src/bear/main.py.in	1970-01-01 01:00:01.000000000 +0100
-+++ Bear-2.3.11-src-patch/bear/main.py.in	1970-01-01 01:00:01.000000000 +0100
-@@ -49,6 +49,7 @@
+--- a/bear/main.py.in
++++ b/bear/main.py.in
+@@ -49,6 +49,7 @@ import tempfile
  import shutil
  import contextlib
  import logging
@@ -8,16 +8,20 @@
  
  # Map of ignored compiler option for the creation of a compilation database.
  # This map is used in _split_command method, which classifies the parameters
-@@ -540,7 +541,11 @@
-                 any(pattern.match(cmd) for pattern in COMPILER_PATTERNS_CXX)
+@@ -569,7 +570,15 @@ class Compilation:
+                 (compiler, language, rest of the command) otherwise """
  
          if command:  # not empty list will allow to index '0' and '1:'
 -            executable = os.path.basename(command[0])  # type: str
-+            absolute_executable = os.path.realpath(find_executable(command[0]))
-+            if 'wrapper' in absolute_executable:
-+                return None
-+
-+            executable = os.path.basename(absolute_executable) # type: str
++            executable_file = find_executable(command[0])
++            if executable_file:
++                absolute_executable = os.path.realpath(executable_file)
++                # Ignore Nix wrappers.
++                if 'wrapper' in absolute_executable:
++                    return None
++                executable = os.path.basename(absolute_executable)
++            else:
++                executable = os.path.basename(command[0])
              parameters = command[1:]  # type: List[str]
              # 'wrapper' 'parameters' and
              # 'wrapper' 'compiler' 'parameters' are valid.


### PR DESCRIPTION
###### Motivation for this change

With the wrapper detection patch, if a build invokes an executable that cannot be found in PATH by `find_executable`, bear will fail with an `AttributeError` in `os.path.realpath`.

This can happen if the build invokes some project-local tool or command, like `./build-something`.

Instead of calling using the result of `find_executable` directly, first check whether the executable was found and fall back to original Bear behavior if it was not.

The problem can be easily reproduced like this, for example:

```bash
cd /tmp \
    && mkdir -p test \
    && echo -e 'all:\n\t./command' > test/Makefile \
    && echo '#!/bin/sh\necho hello' > test/command \
    && chmod +x test/command \
    && bear make -C test
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

