### PR TITLE
nicotine-plus: init at 1.4.1

### DIFF
--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -1,13 +1,6 @@
-{ stdenv, fetchFromGitHub, python27Packages, lib
-, geoip
-# Nicotine+ supports a country code blocker. This requires a (GPL'ed) library called GeoIP.
-, enableGeoIP ? true
-}:
-
-assert enableGeoIP -> python27Packages.GeoIP != null;
+{ stdenv, fetchFromGitHub, python27Packages, lib, geoip }:
 
 with stdenv.lib;
-with lists;
 
 python27Packages.buildPythonApplication rec {
   pname = "nicotine-plus";
@@ -24,10 +17,8 @@ python27Packages.buildPythonApplication rec {
     miniupnpc
     mutagen
     notify
-    ] ++ optional enableGeoIP
-     (GeoIP.overrideAttrs (_: {
-       propagatedBuildInputs = [geoip];
-     }));
+    (GeoIP.override { inherit geoip; })
+  ];
 
   # Insert real docs directory.
   # os.getcwd() is not needed

--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchFromGitHub, python27Packages, lib, geoip }:
+{ stdenv, fetchFromGitHub, python27Packages, geoip }:
 
 with stdenv.lib;
 
 python27Packages.buildPythonApplication rec {
   pname = "nicotine-plus";
   version = "1.4.1";
+
   src = fetchFromGitHub {
     owner = "Nicotine-Plus";
     repo = "nicotine-plus";

--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -35,7 +35,17 @@ python27Packages.buildPythonApplication rec {
          }));
      }));
 
-  postFixup = "mv $out/bin/nicotine $out/bin/nicotine-plus";
+  # Insert real docs directory.
+  # os.getcwd() is not needed
+  patchPhase = ''
+    sed -e 's|paths.append(os.getcwd())|paths.append("'"$out"/doc'")|' -i ./pynicotine/gtkgui/frame.py
+  '';
+
+  postFixup = ''
+    mkdir -p $out/doc/
+    mv ./doc/NicotinePlusGuide $out/doc/
+    mv $out/bin/nicotine $out/bin/nicotine-plus
+  '';
 
   meta = {
     description = "A graphical client for the SoulSeek peer-to-peer system";
@@ -45,8 +55,3 @@ python27Packages.buildPythonApplication rec {
     platforms = platforms.unix;
   };
 }
-
-# Known problems:
-#
-# - Offline guide does not work because of hardcoded path.
-#   see pynicotine/gtkgui/frame.py

--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, fetchFromGitHub, python27Packages }:
+{ stdenv, fetchFromGitHub, python27Packages, lib
+, geoip ? null
+, geolite-legacy ? null
+
+# Nicotine+ supports a country code blocker. This requires a (GPL'ed) library called GeoIP.
+, enableGeoIP ? true
+}:
+
+assert enableGeoIP -> python27Packages.GeoIP != null;
+assert enableGeoIP -> geoip                  != null;
+assert enableGeoIP -> geolite-legacy         != null;
 
 with stdenv.lib;
 
@@ -12,16 +22,23 @@ python27Packages.buildPythonApplication rec {
     sha256 = "11j2qm67sszfqq730czsr2zmpgkghsb50556ax1vlpm7rw3gm33c";
   };
 
-  # TODO: include GeoIP as an optional dependency
   propagatedBuildInputs = with python27Packages; [
     pygtk
     miniupnpc
     mutagen
     notify
-  ];
+  ] ++ lib.lists.optional enableGeoIP
+     (GeoIP.overrideAttrs (_: {
+       propagatedBuildInputs = lib.lists.singleton
+         (geoip.override  (_: {
+           geoipDatabase = geolite-legacy;
+         }));
+     }));
+
+  postFixup = "mv $out/bin/nicotine $out/bin/nicotine-plus";
 
   meta = {
-    description = "A graphical client for the SoulSeek peer-to-peer system ";
+    description = "A graphical client for the SoulSeek peer-to-peer system";
     homepage = https://www.nicotine-plus.org;
     license = licenses.gpl3;
     maintainers = with maintainers; [ klntsky ];

--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -42,6 +42,11 @@ python27Packages.buildPythonApplication rec {
     homepage = https://www.nicotine-plus.org;
     license = licenses.gpl3;
     maintainers = with maintainers; [ klntsky ];
-    platforms = platforms.all;
+    platforms = platforms.unix;
   };
 }
+
+# Known problems:
+#
+# - Offline guide does not work because of hardcoded path.
+#   see pynicotine/gtkgui/frame.py

--- a/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/soulseek/nicotine-plus/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, python27Packages }:
+
+with stdenv.lib;
+
+python27Packages.buildPythonApplication rec {
+  pname = "nicotine-plus";
+  version = "1.4.1";
+  src = fetchFromGitHub {
+    owner = "Nicotine-Plus";
+    repo = "nicotine-plus";
+    rev = "4e057d64184885c63488d4213ade3233bd33e67b";
+    sha256 = "11j2qm67sszfqq730czsr2zmpgkghsb50556ax1vlpm7rw3gm33c";
+  };
+
+  # TODO: include GeoIP as an optional dependency
+  propagatedBuildInputs = with python27Packages; [
+    pygtk
+    miniupnpc
+    mutagen
+    notify
+  ];
+
+  meta = {
+    description = "A graphical client for the SoulSeek peer-to-peer system ";
+    homepage = https://www.nicotine-plus.org;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ klntsky ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18403,7 +18403,9 @@ in
 
   natron = callPackage ../applications/video/natron { };
 
-  nicotine-plus = callPackage ../applications/networking/soulseek/nicotine-plus { };
+  nicotine-plus = callPackage ../applications/networking/soulseek/nicotine-plus {
+    geoip = geoipWithDatabase;
+  };
 
   notion = callPackage ../applications/window-managers/notion { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6529,9 +6529,9 @@ in
   fish-foreign-env = callPackage ../shells/fish/fish-foreign-env { };
 
   ion = callPackage ../shells/ion { };
-  
+
   ksh = callPackage ../shells/ksh { };
-  
+
   mksh = callPackage ../shells/mksh { };
 
   oh = callPackage ../shells/oh { };
@@ -18402,6 +18402,8 @@ in
   neomutt = callPackage ../applications/networking/mailreaders/neomutt { };
 
   natron = callPackage ../applications/video/natron { };
+
+  nicotine-plus = callPackage ../applications/networking/soulseek/nicotine-plus { };
 
   notion = callPackage ../applications/window-managers/notion { };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/Nicotine-Plus/nicotine-plus
Would be nice to have it.

Also, maybe it's a good idea to pin dependencies to specific versions?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

