### PR TITLE
python3.pkgs.graph-tool: fix with python3.7

### DIFF
--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -3,6 +3,8 @@
 , gobject-introspection, pygobject3, gtk3, matplotlib, ncurses
 , buildPythonPackage
 , fetchpatch
+, pythonAtLeast
+, lib
 }:
 
 buildPythonPackage rec {
@@ -29,7 +31,14 @@ buildPythonPackage rec {
       url = "https://git.skewed.de/count0/graph-tool/commit/aa39e4a6b42d43fac30c841d176c75aff92cc01a.patch";
       sha256 = "1578inb4jqwq2fhhwscn5z95nzmaxvmvk30nzs5wirr26iznap4m";
     })
-  ];
+  ] ++ (lib.optionals (pythonAtLeast "3.7") [
+    # # python 3.7 compatibility (`async` is now reserved)
+    (fetchpatch {
+      name = "async-reserved.patch";
+      url = "https://git.skewed.de/count0/graph-tool/commit/0407f41a35b6be7c670927fb5dc578cbd0e88be4.patch";
+      sha256 = "1fklznhmfvbb3ykwzyf8p2hiczby6y7r0xnkkjl2jkxlvr24000q";
+    })
+  ]);
 
   configureFlags = [
     "--with-python-module-path=$(out)/${python.sitePackages}"


### PR DESCRIPTION
###### Motivation for this change

"async" is now reserved, there is an upstream fix but no release yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

