### PR TITLE
icestorm: parallel builds, use pypy3

### DIFF
--- a/pkgs/development/tools/icestorm/default.nix
+++ b/pkgs/development/tools/icestorm/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ pythonPkg libftdi ];
   makeFlags = [ "PREFIX=$(out)" ];
 
+  enableParallelBuilding = true;
+
   # fix icebox_vlog chipdb path. icestorm issue:
   #   https://github.com/cliffordwolf/icestorm/issues/125
   #

--- a/pkgs/development/tools/icestorm/default.nix
+++ b/pkgs/development/tools/icestorm/default.nix
@@ -1,4 +1,13 @@
-{ stdenv, fetchFromGitHub, python3, libftdi, pkgconfig }:
+{ stdenv, fetchFromGitHub
+, pkgconfig, libftdi
+, python3, pypy3
+}:
+
+let
+  pypyCompatible = stdenv.isx86_64; /* pypy3 seems broken on i686 */
+  pythonPkg      = if pypyCompatible then pypy3 else python3;
+  pythonInterp   = if pypyCompatible then "pypy3" else "python3";
+in
 
 stdenv.mkDerivation rec {
   name = "icestorm-${version}";
@@ -12,14 +21,26 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ python3 libftdi ];
+  buildInputs = [ pythonPkg libftdi ];
   makeFlags = [ "PREFIX=$(out)" ];
 
   # fix icebox_vlog chipdb path. icestorm issue:
   #   https://github.com/cliffordwolf/icestorm/issues/125
+  #
+  # also, fix up the path to the chosen Python interpreter. for pypy-compatible
+  # platforms, it offers significant performance improvements.
   patchPhase = ''
     substituteInPlace ./icebox/icebox_vlog.py \
       --replace /usr/local/share "$out/share"
+
+    for x in icefuzz/Makefile icebox/Makefile icetime/Makefile; do
+      substituteInPlace "$x" --replace python3 "${pythonInterp}"
+    done
+
+    for x in $(find . -type f -iname '*.py'); do
+      substituteInPlace "$x" \
+        --replace '/usr/bin/env python3' '${pythonPkg}/bin/${pythonInterp}'
+    done
   '';
 
   meta = {
@@ -30,9 +51,9 @@ stdenv.mkDerivation rec {
       FPGAs and providing simple tools for analyzing and
       creating bitstream files.
     '';
-    homepage = http://www.clifford.at/icestorm/;
-    license = stdenv.lib.licenses.isc;
+    homepage    = http://www.clifford.at/icestorm/;
+    license     = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ shell thoughtpolice ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms   = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

