### PR TITLE
termbox: fix build

### DIFF
--- a/pkgs/development/libraries/termbox/default.nix
+++ b/pkgs/development/libraries/termbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3, wafHook }:
+{ stdenv, fetchFromGitHub, python3, wafHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "termbox-${version}";
@@ -9,7 +9,18 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "08yqxzb8fny8806p7x8a6f3phhlbfqdd7dhkv25calswj7w1ssvs";
   };
+
+  # patch which updates the `waf` version used to build
+  # to make the package buildable on Python 3.7
+  patches = [
+    (fetchpatch {
+      url = https://github.com/nsf/termbox/commit/6fe63ac3ad63dc2c3ac45b770541cc8b7a1d2db7.patch;
+      sha256 = "1s5747v51sdwvpsg6k9y1j60yn9f63qnylkgy8zrsifjzzd5fzl6";
+    })
+  ];
+
   nativeBuildInputs = [ python3 wafHook ];
+
   meta = with stdenv.lib; {
     description = "Library for writing text-based user interfaces";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

Applies a patch which fixes the `waf` build on Python 3.7.
See also https://hydra.nixos.org/build/86295267

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

