### PR TITLE
python3Packages.pika-pool: fix build

### DIFF
--- a/pkgs/development/python-modules/pika-pool/default.nix
+++ b/pkgs/development/python-modules/pika-pool/default.nix
@@ -11,6 +11,10 @@ buildPythonPackage rec {
     sha256 = "f3985888cc2788cdbd293a68a8b5702a9c955db6f7b8b551aeac91e7f32da397";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "pika >=0.9,<0.11" "pika"
+  '';
+
   # Tests require database connections
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

Loosen version constraint to allow current `pika` as well (currently
0.12). See also https://hydra.nixos.org/build/86116480

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

