### PR TITLE
pythonPackages.xml2rfc: fix build

### DIFF
--- a/pkgs/development/python-modules/google-i18n-address/default.nix
+++ b/pkgs/development/python-modules/google-i18n-address/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage, fetchPypi, lib, requests, pytest, pytestcov, mock }:
+
+buildPythonPackage rec {
+  pname = "google-i18n-address";
+  version = "2.3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0f1j1lp9bmllkzhciw0lxi7ipm8w461n0p97mz9714br0cs9glm1";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ pytest pytestcov mock ];
+
+  meta = with lib; {
+    description = "Google's i18n address data packaged for Python";
+    homepage = https://pypi.org/project/google-i18n-address/;
+    maintainers = with maintainers; [ ma27 ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/xml2rfc/default.nix
+++ b/pkgs/development/python-modules/xml2rfc/default.nix
@@ -1,4 +1,6 @@
-{ lib, fetchPypi, buildPythonPackage, intervaltree, pyflakes, requests, lxml }:
+{ lib, fetchPypi, buildPythonPackage, intervaltree, pyflakes, requests, lxml, google-i18n-address
+, pycountry, html5lib, six
+}:
 
 buildPythonPackage rec {
   pname = "xml2rfc";
@@ -9,7 +11,20 @@ buildPythonPackage rec {
     sha256 = "64609a2194d18c03e2348f1ea2fb97208b3455dfb76a16900143813aa61b6d3c";
   };
 
-  propagatedBuildInputs = [ intervaltree pyflakes requests lxml ];
+  propagatedBuildInputs = [
+    intervaltree
+    pyflakes
+    requests
+    lxml
+    google-i18n-address
+    pycountry
+    html5lib
+    six
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with lib; {
     description = "Tool generating IETF RFCs and drafts from XML sources";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2621,6 +2621,8 @@ in {
 
   google_cloud_websecurityscanner = callPackage ../development/python-modules/google_cloud_websecurityscanner { };
 
+  google-i18n-address = callPackage ../development/python-modules/google-i18n-address { };
+
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
   gpgme = toPythonModule (pkgs.gpgme.override {


### PR DESCRIPTION
###### Motivation for this change

Fixes the broken `xml2rfc` package by adding several python libraries to the build inputs list. The dependency `google-i18n-address` had to be packaged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

