### PR TITLE
bonfire: fix build

### DIFF
--- a/pkgs/tools/misc/bonfire/default.nix
+++ b/pkgs/tools/misc/bonfire/default.nix
@@ -20,7 +20,8 @@ buildPythonApplication rec {
     # https://github.com/blue-yonder/bonfire/pull/24
     substituteInPlace requirements.txt \
       --replace "arrow>=0.5.4,<0.8" "arrow>=0.5.4" \
-      --replace "keyring>=9,<10"    "keyring>=9"
+      --replace "keyring>=9,<10"    "keyring>=9" \
+      --replace "click>=3.3,<7"     "click>=3.3"
     # pip fails when encountering the git hash for the package version
     substituteInPlace setup.py \
       --replace "version=version," "version='${version}',"


### PR DESCRIPTION
###### Motivation for this change

The build could be fixed by loosening the constraint for `click` (which
is currently at 7.0 in master). The CLI interface remains functional
with v7.

See also https://hydra.nixos.org/build/86455177


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

