### PR TITLE
thrift: fix build

### DIFF
--- a/pkgs/development/python-modules/pycassa/default.nix
+++ b/pkgs/development/python-modules/pycassa/default.nix
@@ -1,5 +1,18 @@
 { stdenv, buildPythonPackage, fetchPypi, thrift, isPy3k }:
 
+let
+
+  thrift' = thrift.overridePythonAttrs (old: rec {
+    version = "0.9.3";
+    src= fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "0zl7cgckqy9j5vq8wyfzw82q1blkdpsblnmhv8c6ffcxs4xkvg6z";
+    };
+  });
+
+in
+
 buildPythonPackage rec {
   pname = "pycassa";
   version = "1.11.2";
@@ -15,7 +28,7 @@ buildPythonPackage rec {
   # running
   doCheck = false;
 
-  propagatedBuildInputs = [ thrift ];
+  propagatedBuildInputs = [ thrift' ];
 
   meta = {
     description = "A python client library for Apache Cassandra";

--- a/pkgs/development/python-modules/thrift/default.nix
+++ b/pkgs/development/python-modules/thrift/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, six
 }:
 
 buildPythonPackage rec {
@@ -11,6 +12,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "7d59ac4fdcb2c58037ebd4a9da5f9a49e3e034bf75b3f26d9fe48ba3d8806e6b";
   };
+
+  propagatedBuildInputs = [ six ];
 
   # No tests. Breaks when not disabling.
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Fixes the build of `thrift` (and `pycassa`) by specifying proper constraints and adding missing dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

