### PR TITLE
hexyl: init at 0.3.0

### DIFF
--- a/pkgs/tools/misc/hexyl/default.nix
+++ b/pkgs/tools/misc/hexyl/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name    = "hexyl-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner  = "sharkdp";
+    repo   = "hexyl";
+    rev    = "v${version}";
+    sha256 = "138w6czi62dpw6gcd3yqpk7lns7m89kwbgm1d1i5lnzsqck3wb4s";
+  };
+
+  cargoSha256 = "01m8n7yl3yqr8kj0dl1wfaz724da17hs3sb1fbncv64l6qpvdka1";
+
+  meta = with stdenv.lib; {
+    description = "A command-line hex viewer";
+    longDescription = ''
+      `hexyl` is a simple hex viewer for the terminal. It uses a colored
+      output to distinguish different categories of bytes (NULL bytes,
+      printable ASCII characters, ASCII whitespace characters, other ASCII
+      characters and non-ASCII).
+    '';
+    homepage    = https://github.com/sharkdp/hexyl;
+    license     = with licenses; [ asl20 /* or */ mit ];
+    maintainers = [];
+    platforms   = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1498,6 +1498,8 @@ in
 
   hexio = callPackage ../development/tools/hexio { };
 
+  hexyl = callPackage ../tools/misc/hexyl { };
+
   hid-listen = callPackage ../tools/misc/hid-listen { };
 
   home-manager = callPackage ../tools/package-management/home-manager {};


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I left the maintainers empty as I don't particularly want to be on the hook for keeping this up-to-date. I'm hoping @dywedir will consent to maintain it as they already maintain the similar `fd` and `bat` packages by the same author.