### PR TITLE
fff: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4286,6 +4286,11 @@
     github = "t184256";
     name = "Alexander Sosedkin";
   };
+  tadeokondrak = {
+    email = "me@tadeo.ca";
+    github = "tadeokondrak";
+    name = "Tadeo Kondrak";
+  };
   tadfisher = {
     email = "tadfisher@gmail.com";
     github = "tadfisher";

--- a/pkgs/applications/misc/fff/default.nix
+++ b/pkgs/applications/misc/fff/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper,
+  bash, xdg_utils, file, coreutils }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "fff";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "dylanaraps";
+    repo = name;
+    rev = version;
+    sha256 = "00yaxmhdyrf1pr82kiqgw2gszmwsw45pysm9vg77yppiq40flabv";
+  };
+
+  pathAdd = makeSearchPath "bin" [ xdg_utils file coreutils ];
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/man/man1,share/doc/fff}
+    mv ${name} $out/bin
+    wrapProgram $out/bin/${name} --prefix PATH : ${pathAdd}
+    mv ${name}.1 $out/share/man/man1
+    mv README.md $out/share/doc/fff
+  '';
+
+  meta = with stdenv.lib; {
+      description = "Fucking Fast File-Manager";
+      homepage = https://github.com/dylanaraps/fff;
+      license = licenses.mit;
+      maintainers = [ maintainers.tadeokondrak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9680,6 +9680,8 @@ in
 
   ffcast = callPackage ../tools/X11/ffcast { };
 
+  fff = callPackage ../applications/misc/fff { };
+
   fflas-ffpack = callPackage ../development/libraries/fflas-ffpack {
     # We need to use blas instead of openblas on darwin,
     # see https://github.com/NixOS/nixpkgs/pull/45013.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

