### PR TITLE
clightning: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/applications/altcoins/clightning.nix
+++ b/pkgs/applications/altcoins/clightning.nix
@@ -1,17 +1,22 @@
 { stdenv, python3, pkgconfig, which, libtool, autoconf, automake,
-  autogen, sqlite, gmp, zlib, fetchFromGitHub, fetchpatch }:
+  autogen, sqlite, gmp, zlib, fetchzip }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "clightning-${version}";
-  version = "0.6.2";
+  version = "0.6.3";
 
-  src = fetchFromGitHub {
-    fetchSubmodules = true;
-    owner = "ElementsProject";
-    repo = "lightning";
-    rev = "v${version}";
-    sha256 = "18yns0yyf7kc4p4n1crxdqh37j9faxkx216nh2ip7cxj4x8bf9gx";
+  src = fetchzip {
+    #
+    # NOTE 0.6.3 release zip was bugged, this zip is a fix provided by the team
+    # https://github.com/ElementsProject/lightning/issues/2254#issuecomment-453791475
+    #
+    # replace url with:
+    #   https://github.com/ElementsProject/lightning/releases/download/v${version}/clightning-v${version}.zip
+    # for future relases
+    #
+    url = "https://github.com/ElementsProject/lightning/files/2752675/clightning-v0.6.3.zip";
+    sha256 = "0k5pwimwn69pcakiq4a7qnjyf4i8w1jlacwrjazm1sfivr6nfiv6";
   };
 
   enableParallelBuilding = true;
@@ -19,20 +24,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf autogen automake libtool pkgconfig which ];
   buildInputs = [ sqlite gmp zlib python3 ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  makeFlags = [ "prefix=$(out) VERSION=v${version}" ];
 
   configurePhase = ''
     ./configure --prefix=$out --disable-developer --disable-valgrind
   '';
-
-  # NOTE: remove me in 0.6.3
-  patches = [
-    (fetchpatch {
-      name = "clightning_0_6_2-compile-error.patch";
-      url = https://patch-diff.githubusercontent.com/raw/ElementsProject/lightning/pull/2070.patch;
-      sha256 = "1576fqik5zcpz5zsvp2ks939bgiz0jc22yf24iv61000dd5j6na9";
-    })
-  ];
 
   postPatch = ''
     echo "" > tools/refresh-submodules.sh


### PR DESCRIPTION
Added
-----

- JSON API: New command `check` checks the validity of a JSON API call without running it.
- JSON API: `getinfo` now returns `num_peers` `num_pending_channels`,
  `num_active_channels` and `num_inactive_channels` fields.
- JSON API: use `\n\n` to terminate responses, for simplified parsing (pylightning now relies on this)
- JSON API: `fundchannel` now includes an `announce` option, when false it will keep channel private. Defaults to true.
- JSON API: `listpeers`'s `channels` now includes a `private` flag to indicate if channel is announced or not.
- Plugins: Added plugins to `lightningd`, including option passthrough and JSON-RPC passthrough.

Changed
-------

- JSON API: `pay` and `decodepay` accept and ignore `lightning:` prefixes.
- pylightning: Allow either keyword arguments or positional arguments.
- JSON-RPC: messages are now separated by 2 consecutive newlines.
- JSON-RPC: `jsonrpc`:`2.0` now included in json-rpc command calls. complies with spec.

Deprecated
----------

Note: You should always set `allow-deprecated-apis=false` to test for
changes.

- pylightning: Support for pre-2-newline JSON-RPC (<= 0.6.2 lightningd) is deprecated.

Removed
-------

- option_data_loss_protect is now only offered if EXPERIMENTAL_FEATURES is enabled, since it seems incompatible with lnd and has known bugs.

Fixed
-----

- JSON API: uppercase invoices now parsed correctly (broken in 0.6.2).
- JSON API: commands are once again read even if one hasn't responded yet (broken in 0.6.2).
- Protocol: allow lnd to send `update_fee` before `funding_locked`.
- Protocol: fix limit on how much funder can send (fee was 1000x too small)
- Protocol: don't send invalid onion errors if peer says onion was bad.
- Protocol: don't crash when peer sends a 0-block-expiry HTLC.
- pylightning: handle multiple simultanous RPC replies reliably.

Signed-off-by: William Casarin <jb55@jb55.com>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

