### PR TITLE
pgsanity: init at 0.2.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3053,6 +3053,11 @@
     github = "nadrieril";
     name = "Nadrieril Feneanar";
   };
+  nalbyuites = {
+    email = "ashijit007@gmail.com";
+    github = "nalbyuites";
+    name = "Ashijit Pramanik";
+  };
   namore = {
     email = "namor@hemio.de";
     github = "namore";

--- a/pkgs/development/python-modules/pgsanity/default.nix
+++ b/pkgs/development/python-modules/pgsanity/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, python
+, fetchPypi
+, buildPythonPackage
+, postgresql }:
+
+buildPythonPackage rec {
+  pname = "pgsanity";
+  version = "0.2.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "de0bbd6fe4f98bf5139cb5f466eac2e2abaf5a7b050b9e4867b87bf360873173";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover -s test
+  '';
+
+  propagatedBuildInputs = [ postgresql ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/markdrago/pgsanity";
+    description = "Checks the syntax of Postgresql SQL files";
+    longDescription = ''
+      PgSanity checks the syntax of Postgresql SQL files by
+      taking a file that has a list of bare SQL in it, 
+      making that file look like a C file with embedded SQL, 
+      run it through ecpg and 
+      let ecpg report on the syntax errors of the SQL.
+    '';
+    license = stdenv.lib.licenses.mit;
+    maintainers = with maintainers; [ nalbyuites ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3388,6 +3388,8 @@ in {
 
   pg8000 = callPackage ../development/python-modules/pg8000 { };
 
+  pgsanity = callPackage ../development/python-modules/pgsanity { };
+
   pgspecial = callPackage ../development/python-modules/pgspecial { };
 
   pickleshare = callPackage ../development/python-modules/pickleshare { };


### PR DESCRIPTION
###### Motivation for this change
Requested by Joachim Schiele <js@lastlog.de>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

