### PR TITLE
Update noweb (and icon-lang)

### DIFF
--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -1,19 +1,24 @@
-{ stdenv, fetchFromGitHub, libX11, libXt }:
+{ stdenv, fetchFromGitHub, libX11, libXt , withGraphics ? true }:
 
 stdenv.mkDerivation rec {
   name = "icon-lang-${version}";
   version = "9.5.1";
   src = fetchFromGitHub {
-    rev = "39d7438e8d23ccfe20c0af8bbbf61e34d9c715e9";
     owner = "gtownsend";
     repo = "icon";
+    rev = "rel${builtins.replaceStrings ["."] [""] version}";
     sha256 = "1gkvj678ldlr1m5kjhx6zpmq11nls8kxa7pyy64whgakfzrypynw";
   };
-  buildInputs = [ libX11 libXt ];
 
-  configurePhase = ''
-    make X-Configure name=linux
-  '';
+  buildInputs = stdenv.lib.optionals withGraphics [ libX11 libXt ];
+
+  configurePhase =
+    let
+      _name = if stdenv.isDarwin then "macintosh" else "linux";
+    in
+    ''
+      make ${stdenv.lib.optionalString withGraphics "X-"}Configure name=${_name}
+    '';
 
   installPhase = ''
     make Install dest=$out
@@ -21,8 +26,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = ''A very high level general-purpose programming language'';
-    maintainers = with maintainers; [ vrthra ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ vrthra yurrriq ];
+    platforms = with platforms; linux ++ darwin;
     license = licenses.publicDomain;
     homepage = https://www.cs.arizona.edu/icon/;
   };

--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -1,29 +1,75 @@
-{stdenv, fetchurl, gawk}:
+{ stdenv, fetchFromGitHub, gawk, groff, icon-lang ? null }:
 
-stdenv.mkDerivation {
-  name = "noweb-2.11b";
-  src = fetchurl {
-    urls = [ "http://ftp.de.debian.org/debian/pool/main/n/noweb/noweb_2.11b.orig.tar.gz"
-             "ftp://www.eecs.harvard.edu/pub/nr/noweb.tgz"
-          ];
-    sha256 = "10hdd6mrk26kyh4bnng4ah5h1pnanhsrhqa7qwqy6dyv3rng44y9";
+let noweb = stdenv.mkDerivation rec {
+  pname = "noweb";
+  version = "2.12";
+
+  src = fetchFromGitHub {
+    owner = "nrnrnr";
+    repo = "noweb";
+    rev = "v${builtins.replaceStrings ["."] ["_"] version}";
+    sha256 = "1160i2ghgzqvnb44kgwd6s3p4jnk9668rmc15jlcwl7pdf3xqm95";
   };
-  preBuild = ''
-    mkdir -p $out/lib/noweb
-    cd src
-    makeFlags="BIN=$out/bin LIB=$out/lib/noweb MAN=$out/share/man TEXINPUTS=$out/share/texmf/tex/latex"
-  '';
-  preInstall=''mkdir -p $out/share/texmf/tex/latex'';
-  postInstall= ''
-    substituteInPlace $out/bin/cpif --replace "PATH=/bin:/usr/bin" ""
-    for f in $out/bin/{noweb,nountangle,noroots,noroff,noindex} \
-             $out/lib/noweb/{toroff,btdefn,totex,noidx,unmarkup,toascii,tohtml,emptydefn}; do
-      substituteInPlace $f --replace "nawk" "${gawk}/bin/awk"
-    done
-  '';
+
   patches = [ ./no-FAQ.patch ];
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  nativeBuildInputs = [ groff ] ++ stdenv.lib.optionals (!isNull icon-lang) [ icon-lang ];
+
+  preBuild = ''
+    mkdir -p "$out/lib/noweb"
+    cd src
+  '';
+
+  makeFlags = stdenv.lib.optionals (!isNull icon-lang) [
+    "LIBSRC=icon"
+    "ICONC=icont"
+  ];
+
+  installFlags = [
+    "BIN=$(out)/bin"
+    "ELISP=$(out)/share/emacs/site-lisp"
+    "LIB=$(out)/lib/noweb"
+    "MAN=$(out)/share/man"
+    "TEXINPUTS=$(tex)/tex/latex/noweb"
+  ];
+
+  preInstall = ''
+    mkdir -p "$tex/tex/latex/noweb"
+  '';
+
+  installTargets = "install-code install-tex install-elisp";
+
+  postInstall = ''
+    substituteInPlace "$out/bin/cpif" --replace "PATH=/bin:/usr/bin" ""
+
+    for f in $out/bin/no{index,roff,roots,untangle,web} \
+             $out/lib/noweb/to{ascii,html,roff,tex} \
+             $out/lib/noweb/{bt,empty}defn \
+             $out/lib/noweb/{noidx,unmarkup}; do
+        # NOTE: substituteInPlace breaks Icon binaries, so make sure the script
+        #       uses (n)awk before calling.
+        if grep -q nawk "$f"; then
+            substituteInPlace "$f" --replace "nawk" "${gawk}/bin/awk"
+        fi
+    done
+
+    # HACK: This is ugly, but functional.
+    PATH=$out/bin:$PATH make -BC xdoc
+    make $installFlags install-man
+
+    ln -s "$tex" "$out/share/texmf"
+  '';
+
+  outputs = [ "out" "tex" ];
+
+  tlType = "run";
+  passthru.pkgs = [ noweb.tex ];
+
+  meta = with stdenv.lib; {
+    description = "A simple, extensible literate-programming tool";
+    homepage = https://www.cs.tufts.edu/~nr/noweb;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ yurrriq ];
+    platforms = with platforms; linux ++ darwin;
   };
-}
+}; in noweb

--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -23,6 +23,8 @@ let noweb = stdenv.mkDerivation rec {
   makeFlags = stdenv.lib.optionals (!isNull icon-lang) [
     "LIBSRC=icon"
     "ICONC=icont"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "CC=clang"
   ];
 
   installFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9684,7 +9684,9 @@ in
     gconf = pkgs.gnome2.GConf;
   };
 
-  noweb = callPackage ../development/tools/literate-programming/noweb { };
+  noweb = noweb_icon;
+  noweb_awk = noweb_icon.override { icon-lang = null; };
+  noweb_icon = callPackage ../development/tools/literate-programming/noweb { };
   nuweb = callPackage ../development/tools/literate-programming/nuweb { tex = texlive.combined.scheme-small; };
 
   nrfutil = callPackage ../development/tools/misc/nrfutil { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9684,9 +9684,9 @@ in
     gconf = pkgs.gnome2.GConf;
   };
 
-  noweb = noweb_icon;
-  noweb_awk = noweb_icon.override { icon-lang = null; };
-  noweb_icon = callPackage ../development/tools/literate-programming/noweb { };
+  # NOTE: Override and set icon-lang = null to use Awk instead of Icon.
+  noweb = callPackage ../development/tools/literate-programming/noweb { };
+
   nuweb = callPackage ../development/tools/literate-programming/nuweb { tex = texlive.combined.scheme-small; };
 
   nrfutil = callPackage ../development/tools/misc/nrfutil { };


### PR DESCRIPTION
###### Motivation for this change

As per [`src/INSTALL`](https://github.com/nrnrnr/noweb/blob/v2_12/src/INSTALL):

> Crucial parts of noweb are written in both Icon and Awk.  You can use
either Icon or Awk, but Icon is better

Most notable (to me, anyway) are the performance increase and the autodefs.

###### Things done

- Update icon-lang
    - Add Darwin support
        - set `name` appropriately in `configurePhase`
        - `meta.platforms`: `linux` -> `linux ++ darwin`
    - Add me as maintainer
    - Support nongraphical build (via `withGraphics=false`)
        - Use the right configure target
        - Don't depend on `libX{11,t}`
- Update noweb
    - `fetchurl` -> `fetchFromGitHub`
    - Update version: 2.11b -> 2.12
    - Configure for use as TeX Live package
    - Tweak quotes and whitespace for safety/consistency/readability
    - Flesh out `meta`
    - Install noweb-mode to `$out/share/emacs/site-lisp`
    - Provide `noweb_awk` and `noweb_icon`, where `noweb` is the latter

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).