### PR TITLE
Flexget 2.17.20: add transmissionrpc as dependency

### DIFF
--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -54,7 +54,7 @@ buildPythonApplication rec {
     flask_login flask-cors
     pyparsing zxcvbn-python future
     # Optional requirements
-    deluge-client
+    deluge-client transmissionrpc
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   meta = with lib; {

--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -54,7 +54,9 @@ buildPythonApplication rec {
     flask_login flask-cors
     pyparsing zxcvbn-python future
     # Optional requirements
-    deluge-client transmissionrpc
+    deluge-client
+    # Plugins
+    transmissionrpc
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   meta = with lib; {


### PR DESCRIPTION


###### Motivation for this change
Some entries from propagatedBuildInputs were removed from the latest flexget upgrade.  One such removed dependency is transmissionrpc, which is needed for flexget to communicate with transmission client.  The one and only change of this pull request is to add back transmissionrpc to propagatedBuildInputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

