### PR TITLE
gtk3: fix segfaults when opening dialogs

### DIFF
--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -35,10 +35,15 @@ stdenv.mkDerivation rec {
       url = "https://bug757142.bugzilla-attachments.gnome.org/attachment.cgi?id=344123";
       sha256 = "0g6fhqcv8spfy3mfmxpyji93k8d4p4q4fz1v9a1c1cgcwkz41d7p";
     })
-    # https://gitlab.gnome.org/GNOME/gtk/issues/1521
+    # 3.24.2: https://gitlab.gnome.org/GNOME/gtk/issues/1521
     (fetchpatch {
       url = https://gitlab.gnome.org/GNOME/gtk/commit/2905fc861acda3d134a198e56ef2f6c962ad3061.patch;
       sha256 = "0y8ljny59kgdhrcfpimi2r082bax60d5kflw1qj9k1mnzjcvjjwl";
+    })
+    # 3.24.2: https://gitlab.gnome.org/GNOME/gtk/issues/1523
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gtk/commit/e3a1593a0984cc0156ec1892a46af8f256a64878.patch;
+      sha256 = "0akvp1r8xlzf5amk9gmk7b5sabr1wbmg3ak15rppsid7nf9f5dqf";
     })
   ];
 


### PR DESCRIPTION
Apply upstream fix.

closes https://github.com/NixOS/nixpkgs/issues/53697

