### PR TITLE
libmediaart: turn off broken tests until fixed

### DIFF
--- a/pkgs/development/libraries/libmediaart/default.nix
+++ b/pkgs/development/libraries/libmediaart/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkgconfig vala gtk-doc docbook_xsl docbook_xml_dtd_412 gobject-introspection ];
   buildInputs = [ glib gdk_pixbuf ];
 
-  doCheck = true;
+  # FIXME: Turn on again when https://github.com/NixOS/nixpkgs/issues/53701
+  # is fixed on master.
+  doCheck = false;
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
###### Motivation for this change

Turn off the tests until glib is through staging: #53714.

https://github.com/NixOS/nixpkgs/issues/53701#issuecomment-452908686