### PR TITLE
parity: 2.1.10 -> 2.2.7

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.2.6";
-  sha256      = "1zbkbj8njawqsqfd5bp64p1wm6paa7y3nkdxggj6ap6dbg6549v0";
-  cargoSha256 = "1izwqg87qxhmmkd49m0k09i7r05sfcb18m5jbpvggjzp57ips09r";
+  version     = "2.3.0";
+  sha256      = "0v79nz19riaga6iwj6m59fq8adm5llrkq61xizriz30rw8rkk04z";
+  cargoSha256 = "01vdrfqh2nlghbgnbb7qmrazsjmynrb9542qrgchxq589wasb4j2";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.2.5";
-  sha256      = "0q9vgwc0jlja73r4na7yil624iagq1607ac47wh8a7xgfjmjjai1";
-  cargoSha256 = "0ibdmyh1jvfq51vhwn4riyhilqwhf71hjd4vyj525smn95p75b14";
+  version     = "2.2.6";
+  sha256      = "1zbkbj8njawqsqfd5bp64p1wm6paa7y3nkdxggj6ap6dbg6549v0";
+  cargoSha256 = "1izwqg87qxhmmkd49m0k09i7r05sfcb18m5jbpvggjzp57ips09r";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.1.10";
-  sha256      = "1l4yl8i24q8v4hzljzai37f587x8m3cz3byzifhvq3bjky7p8h80";
-  cargoSha256 = "04pni9cmz8nhlqznwafz9d81006808kh24aqnb8rjdcr84d11zis";
+  version     = "2.1.11";
+  sha256      = "0s0vig9pcz9iw774drfanb6hwnx97wm5fgn4hf5pydwb4jws1qrf";
+  cargoSha256 = "1nx6aiq4888d75xfzx9q7ih5jgidjaq1i63bvvgxqyldxq0hjrma";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.1.11";
-  sha256      = "0s0vig9pcz9iw774drfanb6hwnx97wm5fgn4hf5pydwb4jws1qrf";
-  cargoSha256 = "1nx6aiq4888d75xfzx9q7ih5jgidjaq1i63bvvgxqyldxq0hjrma";
+  version     = "2.2.7";
+  sha256      = "0bxq4z84vsb8hmbscr41xiw11m9xg6if231v76c2dmkbyqgpqy8p";
+  cargoSha256 = "1izwqg87qxhmmkd49m0k09i7r05sfcb18m5jbpvggjzp57ips09r";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/paritytech/parity-ethereum/releases/tag/v2.3.0
* https://github.com/paritytech/parity-ethereum/releases/tag/v2.2.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

