### PR TITLE
home-assistant: 0.84.6 -> 0.85.0

### DIFF
--- a/pkgs/development/python-modules/netdisco/default.nix
+++ b/pkgs/development/python-modules/netdisco/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "netdisco";
-  version = "2.2.0";
+  version = "2.3.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b5e810721a266660f7f90fc43f12c4635ec95c3db87d9e30ca408bb922cb1007";
+    sha256 = "2571fc094f3bf8c60be211e90474515f565f3ef1c92e857176daab8577493a3b";
   };
 
   propagatedBuildInputs = [ requests zeroconf netifaces ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,10 +2,13 @@
 # Do not edit!
 
 {
-  version = "0.84.6";
+  version = "0.85.0";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
+    "air_quality" = ps: with ps; [  ];
+    "air_quality.demo" = ps: with ps; [  ];
+    "air_quality.opensensemap" = ps: with ps; [  ];
     "alarm_control_panel" = ps: with ps; [  ];
     "alarm_control_panel.abode" = ps: with ps; [  ];
     "alarm_control_panel.alarmdecoder" = ps: with ps; [  ];
@@ -25,6 +28,7 @@
     "alarm_control_panel.manual" = ps: with ps; [  ];
     "alarm_control_panel.manual_mqtt" = ps: with ps; [ paho-mqtt ];
     "alarm_control_panel.mqtt" = ps: with ps; [ paho-mqtt ];
+    "alarm_control_panel.ness_alarm" = ps: with ps; [  ];
     "alarm_control_panel.nx584" = ps: with ps; [  ];
     "alarm_control_panel.satel_integra" = ps: with ps; [  ];
     "alarm_control_panel.simplisafe" = ps: with ps; [  ];
@@ -36,6 +40,7 @@
     "alarmdecoder" = ps: with ps; [  ];
     "alert" = ps: with ps; [  ];
     "alexa" = ps: with ps; [ aiohttp-cors ];
+    "alexa.auth" = ps: with ps; [  ];
     "alexa.const" = ps: with ps; [  ];
     "alexa.flash_briefings" = ps: with ps; [  ];
     "alexa.intent" = ps: with ps; [  ];
@@ -95,6 +100,7 @@
     "binary_sensor.eight_sleep" = ps: with ps; [  ];
     "binary_sensor.enocean" = ps: with ps; [  ];
     "binary_sensor.envisalink" = ps: with ps; [  ];
+    "binary_sensor.esphome" = ps: with ps; [  ];
     "binary_sensor.ffmpeg_motion" = ps: with ps; [ ha-ffmpeg ];
     "binary_sensor.ffmpeg_noise" = ps: with ps; [ ha-ffmpeg ];
     "binary_sensor.fibaro" = ps: with ps; [  ];
@@ -106,7 +112,7 @@
     "binary_sensor.homematic" = ps: with ps; [ pyhomematic ];
     "binary_sensor.homematicip_cloud" = ps: with ps; [  ];
     "binary_sensor.hydrawise" = ps: with ps; [  ];
-    "binary_sensor.ihc" = ps: with ps; [  ];
+    "binary_sensor.ihc" = ps: with ps; [ defusedxml ];
     "binary_sensor.insteon" = ps: with ps; [  ];
     "binary_sensor.iss" = ps: with ps; [  ];
     "binary_sensor.isy994" = ps: with ps; [  ];
@@ -120,6 +126,7 @@
     "binary_sensor.mychevy" = ps: with ps; [  ];
     "binary_sensor.mysensors" = ps: with ps; [  ];
     "binary_sensor.mystrom" = ps: with ps; [ aiohttp-cors ];
+    "binary_sensor.ness_alarm" = ps: with ps; [  ];
     "binary_sensor.nest" = ps: with ps; [  ];
     "binary_sensor.netatmo" = ps: with ps; [  ];
     "binary_sensor.nx584" = ps: with ps; [  ];
@@ -251,7 +258,7 @@
     "climate.radiotherm" = ps: with ps; [  ];
     "climate.sensibo" = ps: with ps; [  ];
     "climate.spider" = ps: with ps; [  ];
-    "climate.tado" = ps: with ps; [ pytado ];
+    "climate.tado" = ps: with ps; [  ];
     "climate.tesla" = ps: with ps; [  ];
     "climate.toon" = ps: with ps; [  ];
     "climate.touchline" = ps: with ps; [  ];
@@ -296,6 +303,7 @@
     "cover.command_line" = ps: with ps; [  ];
     "cover.deconz" = ps: with ps; [  ];
     "cover.demo" = ps: with ps; [  ];
+    "cover.esphome" = ps: with ps; [  ];
     "cover.fibaro" = ps: with ps; [  ];
     "cover.garadget" = ps: with ps; [  ];
     "cover.gogogate2" = ps: with ps; [  ];
@@ -325,6 +333,8 @@
     "cover.xiaomi_aqara" = ps: with ps; [  ];
     "cover.zwave" = ps: with ps; [  ];
     "daikin" = ps: with ps; [  ];
+    "daikin.config_flow" = ps: with ps; [  ];
+    "daikin.const" = ps: with ps; [  ];
     "datadog" = ps: with ps; [ datadog ];
     "deconz" = ps: with ps; [  ];
     "deconz.config_flow" = ps: with ps; [  ];
@@ -375,7 +385,7 @@
     "device_tracker.sky_hub" = ps: with ps; [  ];
     "device_tracker.snmp" = ps: with ps; [ pysnmp ];
     "device_tracker.swisscom" = ps: with ps; [  ];
-    "device_tracker.tado" = ps: with ps; [ pytado ];
+    "device_tracker.tado" = ps: with ps; [  ];
     "device_tracker.tesla" = ps: with ps; [  ];
     "device_tracker.thomson" = ps: with ps; [  ];
     "device_tracker.tile" = ps: with ps; [  ];
@@ -411,12 +421,15 @@
     "emulated_hue.upnp" = ps: with ps; [  ];
     "enocean" = ps: with ps; [  ];
     "envisalink" = ps: with ps; [  ];
+    "esphome" = ps: with ps; [  ];
+    "esphome.config_flow" = ps: with ps; [  ];
     "eufy" = ps: with ps; [  ];
     "evohome" = ps: with ps; [  ];
     "fan" = ps: with ps; [  ];
     "fan.comfoconnect" = ps: with ps; [  ];
     "fan.demo" = ps: with ps; [  ];
     "fan.dyson" = ps: with ps; [  ];
+    "fan.esphome" = ps: with ps; [  ];
     "fan.insteon" = ps: with ps; [  ];
     "fan.isy994" = ps: with ps; [  ];
     "fan.mqtt" = ps: with ps; [ paho-mqtt ];
@@ -432,6 +445,7 @@
     "fibaro" = ps: with ps; [  ];
     "folder_watcher" = ps: with ps; [ watchdog ];
     "foursquare" = ps: with ps; [ aiohttp-cors ];
+    "freebox" = ps: with ps; [  ];
     "freedns" = ps: with ps; [  ];
     "fritzbox" = ps: with ps; [  ];
     "frontend" = ps: with ps; [ aiohttp-cors ];
@@ -482,6 +496,7 @@
     "homematicip_cloud.device" = ps: with ps; [  ];
     "homematicip_cloud.errors" = ps: with ps; [  ];
     "homematicip_cloud.hap" = ps: with ps; [  ];
+    "homeworks" = ps: with ps; [  ];
     "http" = ps: with ps; [ aiohttp-cors ];
     "http.auth" = ps: with ps; [  ];
     "http.ban" = ps: with ps; [  ];
@@ -498,8 +513,9 @@
     "hue.const" = ps: with ps; [  ];
     "hue.errors" = ps: with ps; [  ];
     "hydrawise" = ps: with ps; [  ];
+    "idteck_prox" = ps: with ps; [  ];
     "ifttt" = ps: with ps; [ aiohttp-cors pyfttt ];
-    "ihc" = ps: with ps; [  ];
+    "ihc" = ps: with ps; [ defusedxml ];
     "ihc.const" = ps: with ps; [  ];
     "ihc.ihcdevice" = ps: with ps; [  ];
     "image_processing" = ps: with ps; [ aiohttp-cors ];
@@ -536,6 +552,7 @@
     "knx" = ps: with ps; [  ];
     "konnected" = ps: with ps; [ aiohttp-cors netdisco ];
     "lametric" = ps: with ps; [  ];
+    "lcn" = ps: with ps; [  ];
     "lifx" = ps: with ps; [  ];
     "light" = ps: with ps; [  ];
     "light.abode" = ps: with ps; [  ];
@@ -549,6 +566,7 @@
     "light.demo" = ps: with ps; [  ];
     "light.elkm1" = ps: with ps; [  ];
     "light.enocean" = ps: with ps; [  ];
+    "light.esphome" = ps: with ps; [  ];
     "light.eufy" = ps: with ps; [  ];
     "light.fibaro" = ps: with ps; [  ];
     "light.flux_led" = ps: with ps; [  ];
@@ -559,13 +577,15 @@
     "light.homekit_controller" = ps: with ps; [  ];
     "light.homematic" = ps: with ps; [ pyhomematic ];
     "light.homematicip_cloud" = ps: with ps; [  ];
+    "light.homeworks" = ps: with ps; [  ];
     "light.hue" = ps: with ps; [ aiohue ];
     "light.hyperion" = ps: with ps; [  ];
     "light.iglo" = ps: with ps; [  ];
-    "light.ihc" = ps: with ps; [  ];
+    "light.ihc" = ps: with ps; [ defusedxml ];
     "light.insteon" = ps: with ps; [  ];
     "light.isy994" = ps: with ps; [  ];
     "light.knx" = ps: with ps; [  ];
+    "light.lcn" = ps: with ps; [  ];
     "light.lifx" = ps: with ps; [  ];
     "light.lifx_legacy" = ps: with ps; [  ];
     "light.lightwave" = ps: with ps; [  ];
@@ -583,6 +603,7 @@
     "light.opple" = ps: with ps; [  ];
     "light.osramlightify" = ps: with ps; [  ];
     "light.piglow" = ps: with ps; [  ];
+    "light.plum_lightpad" = ps: with ps; [  ];
     "light.qwikswitch" = ps: with ps; [  ];
     "light.rflink" = ps: with ps; [  ];
     "light.rfxtrx" = ps: with ps; [  ];
@@ -679,6 +700,7 @@
     "media_player.frontier_silicon" = ps: with ps; [  ];
     "media_player.gpmdp" = ps: with ps; [ websocket_client ];
     "media_player.gstreamer" = ps: with ps; [  ];
+    "media_player.harman_kardon_avr" = ps: with ps; [  ];
     "media_player.hdmi_cec" = ps: with ps; [  ];
     "media_player.horizon" = ps: with ps; [  ];
     "media_player.itunes" = ps: with ps; [  ];
@@ -742,8 +764,10 @@
     "mysensors.gateway" = ps: with ps; [  ];
     "mysensors.handler" = ps: with ps; [  ];
     "mysensors.helpers" = ps: with ps; [  ];
-    "namecheapdns" = ps: with ps; [  ];
+    "mythicbeastsdns" = ps: with ps; [  ];
+    "namecheapdns" = ps: with ps; [ defusedxml ];
     "neato" = ps: with ps; [ pybotvac ];
+    "ness_alarm" = ps: with ps; [  ];
     "nest" = ps: with ps; [  ];
     "nest.config_flow" = ps: with ps; [  ];
     "nest.const" = ps: with ps; [  ];
@@ -829,6 +853,7 @@
     "persistent_notification" = ps: with ps; [  ];
     "pilight" = ps: with ps; [  ];
     "plant" = ps: with ps; [  ];
+    "plum_lightpad" = ps: with ps; [  ];
     "point" = ps: with ps; [ aiohttp-cors ];
     "point.config_flow" = ps: with ps; [  ];
     "point.const" = ps: with ps; [  ];
@@ -875,6 +900,7 @@
     "scene.knx" = ps: with ps; [  ];
     "scene.lifx_cloud" = ps: with ps; [  ];
     "scene.litejet" = ps: with ps; [  ];
+    "scene.lutron" = ps: with ps; [  ];
     "scene.lutron_caseta" = ps: with ps; [  ];
     "scene.tahoma" = ps: with ps; [  ];
     "scene.tuya" = ps: with ps; [  ];
@@ -887,9 +913,11 @@
     "sensor" = ps: with ps; [  ];
     "sensor.abode" = ps: with ps; [  ];
     "sensor.ads" = ps: with ps; [  ];
+    "sensor.aftership" = ps: with ps; [  ];
     "sensor.airvisual" = ps: with ps; [ pyairvisual ];
     "sensor.alarmdecoder" = ps: with ps; [  ];
     "sensor.alpha_vantage" = ps: with ps; [  ];
+    "sensor.ambient_station" = ps: with ps; [  ];
     "sensor.amcrest" = ps: with ps; [ ha-ffmpeg ];
     "sensor.android_ip_webcam" = ps: with ps; [  ];
     "sensor.apcupsd" = ps: with ps; [  ];
@@ -912,6 +940,7 @@
     "sensor.bmw_connected_drive" = ps: with ps; [  ];
     "sensor.bom" = ps: with ps; [  ];
     "sensor.broadlink" = ps: with ps; [ broadlink ];
+    "sensor.brottsplatskartan" = ps: with ps; [  ];
     "sensor.buienradar" = ps: with ps; [  ];
     "sensor.canary" = ps: with ps; [  ];
     "sensor.cert_expiry" = ps: with ps; [  ];
@@ -956,6 +985,7 @@
     "sensor.entur_public_transport" = ps: with ps; [  ];
     "sensor.envirophat" = ps: with ps; [  ];
     "sensor.envisalink" = ps: with ps; [  ];
+    "sensor.esphome" = ps: with ps; [  ];
     "sensor.etherscan" = ps: with ps; [  ];
     "sensor.fail2ban" = ps: with ps; [  ];
     "sensor.fastdotcom" = ps: with ps; [  ];
@@ -965,12 +995,13 @@
     "sensor.file" = ps: with ps; [  ];
     "sensor.filesize" = ps: with ps; [  ];
     "sensor.filter" = ps: with ps; [  ];
-    "sensor.fints" = ps: with ps; [  ];
+    "sensor.fints" = ps: with ps; [ fints ];
     "sensor.fitbit" = ps: with ps; [ aiohttp-cors ];
     "sensor.fixer" = ps: with ps; [  ];
     "sensor.flunearyou" = ps: with ps; [  ];
     "sensor.folder" = ps: with ps; [  ];
     "sensor.foobot" = ps: with ps; [  ];
+    "sensor.freebox" = ps: with ps; [  ];
     "sensor.fritzbox_callmonitor" = ps: with ps; [ fritzconnection ];
     "sensor.fritzbox_netmonitor" = ps: with ps; [ fritzconnection ];
     "sensor.gearbest" = ps: with ps; [  ];
@@ -984,6 +1015,7 @@
     "sensor.gpsd" = ps: with ps; [  ];
     "sensor.greeneye_monitor" = ps: with ps; [  ];
     "sensor.gtfs" = ps: with ps; [  ];
+    "sensor.gtt" = ps: with ps; [  ];
     "sensor.habitica" = ps: with ps; [  ];
     "sensor.haveibeenpwned" = ps: with ps; [  ];
     "sensor.hddtemp" = ps: with ps; [  ];
@@ -996,7 +1028,7 @@
     "sensor.huawei_lte" = ps: with ps; [  ];
     "sensor.hydrawise" = ps: with ps; [  ];
     "sensor.hydroquebec" = ps: with ps; [  ];
-    "sensor.ihc" = ps: with ps; [  ];
+    "sensor.ihc" = ps: with ps; [ defusedxml ];
     "sensor.imap" = ps: with ps; [ aioimaplib ];
     "sensor.imap_email_content" = ps: with ps; [  ];
     "sensor.influxdb" = ps: with ps; [ influxdb ];
@@ -1005,6 +1037,7 @@
     "sensor.iota" = ps: with ps; [  ];
     "sensor.iperf3" = ps: with ps; [  ];
     "sensor.irish_rail_transport" = ps: with ps; [  ];
+    "sensor.islamic_prayer_times" = ps: with ps; [  ];
     "sensor.isy994" = ps: with ps; [  ];
     "sensor.jewish_calendar" = ps: with ps; [  ];
     "sensor.juicenet" = ps: with ps; [  ];
@@ -1047,12 +1080,13 @@
     "sensor.netdata" = ps: with ps; [  ];
     "sensor.netgear_lte" = ps: with ps; [  ];
     "sensor.neurio_energy" = ps: with ps; [  ];
+    "sensor.nmbs" = ps: with ps; [  ];
     "sensor.noaa_tides" = ps: with ps; [  ];
     "sensor.nsw_fuel_station" = ps: with ps; [  ];
     "sensor.nut" = ps: with ps; [  ];
     "sensor.nzbget" = ps: with ps; [  ];
     "sensor.octoprint" = ps: with ps; [  ];
-    "sensor.ohmconnect" = ps: with ps; [  ];
+    "sensor.ohmconnect" = ps: with ps; [ defusedxml ];
     "sensor.onewire" = ps: with ps; [  ];
     "sensor.openevse" = ps: with ps; [  ];
     "sensor.openexchangerates" = ps: with ps; [  ];
@@ -1069,6 +1103,7 @@
     "sensor.point" = ps: with ps; [  ];
     "sensor.pollen" = ps: with ps; [ numpy ];
     "sensor.postnl" = ps: with ps; [  ];
+    "sensor.prezzibenzina" = ps: with ps; [  ];
     "sensor.pushbullet" = ps: with ps; [ pushbullet ];
     "sensor.pvoutput" = ps: with ps; [  ];
     "sensor.pyload" = ps: with ps; [  ];
@@ -1108,6 +1143,7 @@
     "sensor.snmp" = ps: with ps; [ pysnmp ];
     "sensor.sochain" = ps: with ps; [  ];
     "sensor.socialblade" = ps: with ps; [  ];
+    "sensor.solaredge" = ps: with ps; [  ];
     "sensor.sonarr" = ps: with ps; [  ];
     "sensor.speedtest" = ps: with ps; [ speedtest-cli ];
     "sensor.spotcrime" = ps: with ps; [  ];
@@ -1124,7 +1160,7 @@
     "sensor.synologydsm" = ps: with ps; [  ];
     "sensor.systemmonitor" = ps: with ps; [ psutil ];
     "sensor.sytadin" = ps: with ps; [ beautifulsoup4 ];
-    "sensor.tado" = ps: with ps; [ pytado ];
+    "sensor.tado" = ps: with ps; [  ];
     "sensor.tahoma" = ps: with ps; [  ];
     "sensor.tank_utility" = ps: with ps; [  ];
     "sensor.tautulli" = ps: with ps; [  ];
@@ -1233,6 +1269,7 @@
     "switch.edp_redy" = ps: with ps; [  ];
     "switch.elkm1" = ps: with ps; [  ];
     "switch.enocean" = ps: with ps; [  ];
+    "switch.esphome" = ps: with ps; [  ];
     "switch.eufy" = ps: with ps; [  ];
     "switch.fibaro" = ps: with ps; [  ];
     "switch.flux" = ps: with ps; [  ];
@@ -1248,7 +1285,7 @@
     "switch.homematicip_cloud" = ps: with ps; [  ];
     "switch.hook" = ps: with ps; [  ];
     "switch.hydrawise" = ps: with ps; [  ];
-    "switch.ihc" = ps: with ps; [  ];
+    "switch.ihc" = ps: with ps; [ defusedxml ];
     "switch.insteon" = ps: with ps; [  ];
     "switch.isy994" = ps: with ps; [  ];
     "switch.kankun" = ps: with ps; [  ];
@@ -1258,6 +1295,7 @@
     "switch.linode" = ps: with ps; [ linode-api ];
     "switch.litejet" = ps: with ps; [  ];
     "switch.lupusec" = ps: with ps; [  ];
+    "switch.lutron" = ps: with ps; [  ];
     "switch.lutron_caseta" = ps: with ps; [  ];
     "switch.mfi" = ps: with ps; [  ];
     "switch.mochad" = ps: with ps; [  ];
@@ -1268,6 +1306,7 @@
     "switch.neato" = ps: with ps; [ pybotvac ];
     "switch.netio" = ps: with ps; [ aiohttp-cors ];
     "switch.orvibo" = ps: with ps; [  ];
+    "switch.pencom" = ps: with ps; [  ];
     "switch.pilight" = ps: with ps; [  ];
     "switch.pulseaudio_loopback" = ps: with ps; [  ];
     "switch.qwikswitch" = ps: with ps; [  ];
@@ -1276,6 +1315,7 @@
     "switch.raincloud" = ps: with ps; [  ];
     "switch.rainmachine" = ps: with ps; [  ];
     "switch.raspihats" = ps: with ps; [  ];
+    "switch.raspyrfm" = ps: with ps; [  ];
     "switch.recswitch" = ps: with ps; [  ];
     "switch.rest" = ps: with ps; [  ];
     "switch.rflink" = ps: with ps; [  ];
@@ -1321,13 +1361,14 @@
     "switch.zoneminder" = ps: with ps; [  ];
     "switch.zwave" = ps: with ps; [  ];
     "system_log" = ps: with ps; [ aiohttp-cors ];
-    "tado" = ps: with ps; [ pytado ];
+    "tado" = ps: with ps; [  ];
     "tahoma" = ps: with ps; [  ];
     "telegram_bot" = ps: with ps; [ python-telegram-bot ];
     "telegram_bot.broadcast" = ps: with ps; [  ];
     "telegram_bot.polling" = ps: with ps; [  ];
     "telegram_bot.webhooks" = ps: with ps; [ aiohttp-cors ];
     "tellduslive" = ps: with ps; [  ];
+    "tellduslive.config_flow" = ps: with ps; [  ];
     "tellduslive.const" = ps: with ps; [  ];
     "tellduslive.entry" = ps: with ps; [  ];
     "tellstick" = ps: with ps; [  ];
@@ -1360,7 +1401,6 @@
     "upcloud" = ps: with ps; [  ];
     "updater" = ps: with ps; [ distro ];
     "upnp" = ps: with ps; [  ];
-    "upnp.config_flow" = ps: with ps; [  ];
     "upnp.const" = ps: with ps; [  ];
     "upnp.device" = ps: with ps; [  ];
     "usps" = ps: with ps; [  ];
@@ -1421,6 +1461,7 @@
     "zha.config_flow" = ps: with ps; [  ];
     "zha.const" = ps: with ps; [  ];
     "zha.entities" = ps: with ps; [  ];
+    "zha.event" = ps: with ps; [  ];
     "zha.helpers" = ps: with ps; [  ];
     "zigbee" = ps: with ps; [  ];
     "zone" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -18,8 +18,8 @@ let
 
   defaultOverrides = [
     # Override the version of some packages pinned in Home Assistant's setup.py
-    (mkOverride "aiohttp" "3.4.4"
-      "51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db3475fa")
+    (mkOverride "aiohttp" "3.5.1"
+      "c115744b2a0bf666fd8cde52a6d3e9319ffeb486009579743f5adfdcf0bf0773")
     (mkOverride "astral" "1.7.1"
       "88086fd2006c946567285286464b2da3294a3b0cbba4410b7008ec2458f82a07")
     (mkOverride "async-timeout" "3.0.1"
@@ -34,10 +34,12 @@ let
       "8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6")
     (mkOverride "cryptography_vectors" "2.3.1" # required by cryptography==2.3.1
       "bf4d9b61dce69c49e830950aa36fad194706463b0b6dfe81425b9e0bc6644d46")
-    (mkOverride "requests" "2.20.1"
-      "ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263")
-    (mkOverride "ruamel_yaml" "0.15.80"
-      "4f203351575dba0829c7b1e5d376d08cf5f58e4a2b844e8ce552b3e41cd414e6")
+    (mkOverride "python-slugify" "1.2.6"
+      "7723daf30996db26573176bddcdf5fcb98f66dc70df05c9cb29f2c79b8193245")
+    (mkOverride "requests" "2.21.0"
+      "502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e")
+    (mkOverride "ruamel_yaml" "0.15.81"
+      "6cbe7273a2e7667cd2ca7b12bec1c715a8259ad80f09c6f12c378f664d29fa5e")
     (mkOverride "voluptuous" "0.11.5"
       "567a56286ef82a9d7ae0628c5842f65f516abcb496e74f3f59f1d7b28df314ef")
     (mkOverride "voluptuous-serialize" "2.0.0"
@@ -85,7 +87,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.84.6";
+  hassVersion = "0.85.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -100,12 +102,13 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "142hxsvhb9lh77h54975vkvl1fx5lslrydq1vbqyy51dy85ms8lc";
+    sha256 = "10lpah90ia2ycw22s65kqxd2az7l69n9hs1i4lvx1179ncvnfq9r";
   };
 
   propagatedBuildInputs = [
     # From setup.py
-    aiohttp astral async-timeout attrs bcrypt certifi jinja2 pyjwt cryptography pip pytz pyyaml requests ruamel_yaml voluptuous voluptuous-serialize
+    aiohttp astral async-timeout attrs bcrypt certifi jinja2 pyjwt cryptography pip
+    python-slugify pytz pyyaml requests ruamel_yaml voluptuous voluptuous-serialize
     # From http, frontend and recorder components and auth.mfa_modules.totp
     sqlalchemy aiohttp-cors hass-frontend pyotp pyqrcode
   ] ++ componentBuildInputs ++ extraBuildInputs;

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20181211.2";
+  version = "20190109.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "75dd525922efc1f9a6a4a42c720764a539b18636769e2febc33bb68967c7ebff";
+    sha256 = "d4e0241feca3779af67efe906be31ba3fac76e8fb3e46d8416f349f5ec3009a6";
   };
 
   propagatedBuildInputs = [ user-agents ];

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ aiohttp astral async-timeout attrs certifi jinja2 pyjwt cryptography pip pytz pyyaml requests ruamel_yaml voluptuous ])"
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ aiohttp astral async-timeout attrs certifi jinja2 pyjwt cryptography pip pytz pyyaml requests ruamel_yaml voluptuous python-slugify ])"
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each component has an associated .py file,


### PR DESCRIPTION
###### Motivation for this change
https://www.home-assistant.io/blog/2019/01/09/release-85/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg 