### PR TITLE
 flashplayer: 32.0.0.101 -> 32.0.0.114 

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -100,11 +100,11 @@ let
 
   flash = stdenv.mkDerivation rec {
     name = "flashplayer-ppapi-${version}";
-    version = "32.0.0.101";
+    version = "32.0.0.114";
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "1bmmjraqzdz03jzbgs1l932gka1zhiyiis06r4yi4f93mdy31w72";
+      sha256 = "11b47w14hgvp7lpis39a9vkncla7lvqrgc717v4mwj6p741z7v78";
       stripRoot = false;
     };
 

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/default.nix
@@ -74,7 +74,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "flashplayer-${version}";
-  version = "32.0.0.101";
+  version = "32.0.0.114";
 
   src = fetchurl {
     url =
@@ -85,14 +85,14 @@ stdenv.mkDerivation rec {
     sha256 =
       if debug then
         if arch == "x86_64" then
-          "0383r5pl1jrspy06mpxq50kkip5q5v052kz9aymk4qylgy1dwpn2"
+          "199dd2fkjfcavfzfd2d38y21155yxvj9yl838i8y63v9i5j5nhfj"
         else
-          "1vx2map0wlj6bj8dqyxxaymmz9awjjfhi6097knpmqp6j8dj7l5g"
+          "1b7g92ywwxrzfdj8acqx2r8k19y84ci2nhwwghjc7276q95gpzj8"
       else
         if arch == "x86_64" then
-          "003mr9mqkg0agj3zlmci5a1m3lnhj27mnvqswjaffdg5rlihvxyi"
+          "17nzchmacyqnb184d23caz52w7sy5sr7d081iwc46wic0px78m3m"
         else
-          "1smmdsnnlsssakzqas5268svyv3rk717zr7kwpkj4rd5d1pqwcps";
+          "16slvhyqq0i7rlh2s5kpy78whkh57r129kva14wradx9yv8bqr7h";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation rec {
   name = "flashplayer-standalone-${version}";
-  version = "32.0.0.101";
+  version = "32.0.0.114";
 
   src = fetchurl {
     url =
@@ -60,9 +60,9 @@ stdenv.mkDerivation rec {
         "https://fpdownload.macromedia.com/pub/flashplayer/updaters/32/flash_player_sa_linux.x86_64.tar.gz";
     sha256 =
       if debug then
-        "1i59vfhxrlksxwmr3kj3dfbasfjgnx9aimmv400z07fw3zmdrbpw"
+        "0wlzqdnl8lhbc428gcahld842bhia4aygy1k5vyyg27fwmskxhy7"
       else
-        "0fz9zhp0qn9xda5pg37dfnvx04n8d7156h1qayf2l3la94apsacq";
+        "01a1dwrgw7lc098vp4ifkf5bj2qvv0pmdyibjhzzrx3387d1pd2l";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix
@@ -99,5 +99,7 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.unfree;
     maintainers = [];
     platforms = [ "x86_64-linux" ];
+    # Application crashed with an unhandled SIGSEGV
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Low priority security update
- Other performance fix

https://helpx.adobe.com/flash-player/release-note/fp_32_air_32_release_notes.html
https://helpx.adobe.com/security/products/flash-player/apsb19-01.html

flashplayer-standalone crashes with `Application crashed with an unhandled SIGSEGV`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

