### PR TITLE
linuxPackages.nvidia_x11*: Add maintainer: baracoder 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -475,6 +475,11 @@
     github = "bandresen";
     name = "Benjamin Andresen";
   };
+  baracoder = {
+    email = "baracoder@googlemail.com";
+    github = "baracoder";
+    name = "Herman Fries";
+  };
   barrucadu = {
     email = "mike@barrucadu.co.uk";
     github = "barrucadu";

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -90,7 +90,7 @@ let
       description = "X.org driver and kernel module for NVIDIA graphics cards";
       license = licenses.unfreeRedistributable;
       platforms = [ "i686-linux" "x86_64-linux" ];
-      maintainers = [ ];
+      maintainers = with maintainers; [ baracoder ];
       priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
       inherit broken;
     };


### PR DESCRIPTION
###### Motivation for this change

I bought some recent nvidia hardware, so I am stuck with it for a couple
of years and because of this, I have an interest in a working nvidia driver.

See also https://github.com/NixOS/nixpkgs/commit/9ee8cf517713135cfe395a56fd59d107fda0103b and https://github.com/NixOS/nixpkgs/pull/50861#issuecomment-451744219

/cc @vcunat @eadwu @Infinisil 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

