### PR TITLE
[WIP] Build nixpkgs with gcc 8 by default

### DIFF
--- a/pkgs/applications/graphics/gnuclad/default.nix
+++ b/pkgs/applications/graphics/gnuclad/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ka2kscpjff7gflsargv3r9fdaxhkf3nym9mfaln3pnq6q7fwdki";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=catch-value" ];
+
   nativeBuildInputs = [ pkgconfig ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/graphics/imgcat/default.nix
+++ b/pkgs/applications/graphics/imgcat/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation rec {
   name = "imgcat-${version}";
   version = "2.3.0";
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=class-memaccess" ];
+
   buildInputs = [ autoconf automake libtool ncurses ];
 
   preConfigure = ''

--- a/pkgs/applications/misc/getxbook/default.nix
+++ b/pkgs/applications/misc/getxbook/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ihwrx4gspj8l7fc8vxch6dpjrw1lvv9z3c19f0wxnmnxhv1cjvs";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" ];
+
   buildInputs = [ openssl ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
+++ b/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
   ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type";
+
   meta = with stdenv.lib; {
     homepage = http://www.netsurf-browser.org/;
     description = "String internment library for netsurf browser";

--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -61,6 +61,9 @@ in stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     pythonProtobuf
   ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-overflow -Wno-error=class-memaccess";
+
   preConfigure = ''
     # https://issues.apache.org/jira/browse/MESOS-6616
     configureFlagsArray+=(

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/telegram-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/telegram-purple/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchgit, pkgconfig, pidgin, libwebp, libgcrypt, gettext } :
 
 let
-  version = "1.3.0";
+  version = "1.3.1";
 in
 stdenv.mkDerivation rec {
   name = "telegram-purple-${version}";
 
   src = fetchgit {
     url = "https://github.com/majn/telegram-purple";
-    rev = "0340e4f14b2480782db4e5b9242103810227c522";
-    sha256 = "1xb7hrgisbpx00dsrm5yz934bdd7nfzicd7k855iynk3hjzqj7k5";
+    rev = "v${version}";
+    sha256 = "0p93jpjpx7hszwffzgixw04zkrpsiyzz4za3gfr4j07krc4771fp";
   };
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=cast-function-type" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ pidgin libwebp libgcrypt gettext ];

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-cli/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     rev = "6547c0b21b977b327b3c5e8142963f4bc246187a";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=cast-function-type" ];
+
   buildInputs = [
     libconfig libevent openssl readline zlib
     lua5_2 python pkgconfig jansson

--- a/pkgs/applications/networking/irc/bip/default.nix
+++ b/pkgs/applications/networking/irc/bip/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-result" "-Wno-error=duplicate-decl-specifier" ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-result" "-Wno-error=duplicate-decl-specifier" "-Wno-error=format-truncation" ];
 
   meta = {
     description = "An IRC proxy (bouncer)";

--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, itk, vtk }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, itk, vtk }:
 
 stdenv.mkDerivation rec {
   _name    = "ANTs";
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
     rev    = "37ad4e20be3a5ecd26c2e4e41b49e778a0246c3d";
     sha256 = "1hrdwv3m9xh3yf7l0rm2ggxc2xzckfb8srs88g485ibfszx7i03q";
   };
+
+  patches = [
+    # Fix build with gcc8
+    (fetchpatch {
+      url = "https://github.com/ANTsX/ANTs/commit/89af9b2694715bf8204993e032fa132f80cf37bd.patch";
+      sha256 = "1glkrwa1jmxxbmzihycxr576azjqby31jwpj165qc54c91pn0ams";
+    })
+  ];
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ itk vtk ];

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, bash, cmake
+{ stdenv, lib, fetchgit, bash, cmake, pkgconfig
 , opencv, gtest, openblas, liblapack, perl
 , cudaSupport ? false, cudatoolkit, nvidia_x11
 , cudnnSupport ? false, cudnn
@@ -16,14 +16,14 @@ stdenv.mkDerivation rec {
     sha256 = "06vk4q7bh17sjhnr72bzmggcqlp2injnsah5yflklg360p7vpijj";
   };
 
-  nativeBuildInputs = [ cmake perl ];
+  nativeBuildInputs = [ cmake perl pkgconfig ];
 
   buildInputs = [ opencv gtest openblas liblapack ]
               ++ lib.optionals cudaSupport [ cudatoolkit nvidia_x11 ]
               ++ lib.optional cudnnSupport cudnn;
 
-  cmakeFlags =
-    (if cudaSupport then [
+  cmakeFlags = [ "-DBLAS=open" "-DUSE_MKLDNN=0" ]
+    ++ (if cudaSupport then [
       "-DCUDA_ARCH_NAME=All"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
     ] else [ "-DUSE_CUDA=OFF" ])

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, bash, cmake
+{ stdenv, lib, fetchgit, bash, cmake
 , opencv, gtest, openblas, liblapack, perl
 , cudaSupport ? false, cudatoolkit, nvidia_x11
 , cudnnSupport ? false, cudnn
@@ -8,14 +8,12 @@ assert cudnnSupport -> cudaSupport;
 
 stdenv.mkDerivation rec {
   name = "mxnet-${version}";
-  version = "1.2.1";
+  version = "1.3.1";
 
-  # Fetching from git does not work at the time (1.2.1) due to an
-  # incorrect hash in one of the submodules. The provided tarballs
-  # contain all necessary sources.
-  src = fetchurl {
-    url = "https://github.com/apache/incubator-mxnet/releases/download/${version}/apache-mxnet-src-${version}-incubating.tar.gz";
-    sha256 = "053zbdgs4j8l79ipdz461zc7wyfbfcflmi5bw7lj2q08zm1glnb2";
+  src = fetchgit {
+    url = "https://github.com/apache/incubator-mxnet";
+    rev = "1.3.1";
+    sha256 = "06vk4q7bh17sjhnr72bzmggcqlp2injnsah5yflklg360p7vpijj";
   };
 
   nativeBuildInputs = [ cmake perl ];
@@ -43,6 +41,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rm "$out"/lib/*.a
   '';
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, cmake, fetchFromGitHub, emscriptenRev ? null }:
+{ stdenv, cmake, fetchFromGitHub, python3, emscriptenRev ? null }:
 
 let
-  defaultVersion = "45";
+  defaultVersion = "63";
 
   # Map from git revs to SHA256 hashes
   sha256s = {
-    "version_45" = "1wgzfzjjzkiaz0rf2lnwrcvlcsjvjhyvbyh58jxhqq43vi34zyjc";
-    "1.37.36" = "1wgzfzjjzkiaz0rf2lnwrcvlcsjvjhyvbyh58jxhqq43vi34zyjc";
+    "version_63" = "0qd6kxiaqrwm4hsxvx4z6nv20z4arnfr1ks4zjavnw0nzn1n6m3s";
+    "1.38.22" = "0qnkwyb9ylpk24gl5rdj526601z0p9wclg8rdx7b2bl1cydfa8sf";
   };
 in
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake python3 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/WebAssembly/binaryen;

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
+
   /*
   ** We patch out a very annoying 'feature' in ./configure, which
   ** tries to use 'git' to update submodules.

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -33,6 +33,7 @@ edk2 = stdenv.mkDerivation {
   buildInputs = [ libuuid pythonEnv ];
 
   makeFlags = "-C BaseTools";
+  NIX_CFLAGS_COMPILE = "-Wno-return-type -Wno-error=stringop-truncation";
 
   hardeningDisable = [ "format" "fortify" ];
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten";
-    sha256 = "02p0cp86vd1mydlpq544xbydggpnrq9dhbxx7h08j235frjm5cdc";
+    sha256 = "1z3mn9y3ila75yf2a111jqrhcb84cyp7wipyab5vc2yqp20ckjg1";
     inherit rev;
   };
 

--- a/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp";
-    sha256 = "04j698gmp686b5lricjakm5hyh2z2kh28m1ffkghmkyz4zkzmx98";
+    sha256 = "0dqy3g5khkvhfp8c8mxw28xrayzjm41dmvajjfyb98fj10jqjzhi";
     inherit rev;
   };
 
   srcFL = fetchFromGitHub {
     owner = "kripken";
     repo = "emscripten-fastcomp-clang";
-    sha256 = "1ici51mmpgg80xk3y8f376nbbfak6rz27qdy98l8lxkrymklp5g5";
+    sha256 = "0hgag7dc0mk25nh8h8ji3vmq4g77r724xnsnjcvx0mvky2b0r3sc";
     inherit rev;
   };
 

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     sha256 = "15dx1b71xv7b265gqk9nv02pirggpw7d83apikhrza2qkj64ydd0";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
+
   # perl is used for testing go vet
   nativeBuildInputs = [ perl which pkgconfig patch procps ];
   buildInputs = [ cacert pcre ]

--- a/pkgs/development/compilers/iasl/default.nix
+++ b/pkgs/development/compilers/iasl/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "iasl-${version}";
-  version = "20181213";
+  version = "20190108";
 
   src = fetchurl {
     url = "https://acpica.org/sites/acpica/files/acpica-unix-${version}.tar.gz";
-    sha256 = "1vgqlv9pvxc52faxixpgz7hi1awqmj88bw5vqn3bldf6fmkh147w";
+    sha256 = "0bqhr3ndchvfhxb31147z8gd81dysyz5dwkvmp56832d0js2564q";
   };
 
   NIX_CFLAGS_COMPILE = "-O3";

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetch
+, fetchpatch
 , cmake
 , python
 , libffi
@@ -40,6 +41,13 @@ in stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  patches = [
+    (fetchpatch {
+      url = "https://bugzilla.redhat.com/attachment.cgi?id=1389687";
+      name = "llvm-gcc8-type-mismatch.patch";
+      sha256 = "0ga2123aclq3x9w72d0rm0az12m8c1i4r1106vh701hf4cghgbch";
+    })
+  ];
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir)" \

--- a/pkgs/development/interpreters/gnu-apl/default.nix
+++ b/pkgs/development/interpreters/gnu-apl/default.nix
@@ -11,9 +11,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ readline gettext ncurses ];
 
-  # Needed with GCC 7
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isGNU "-Wno-error=int-in-bool-context"
-    + stdenv.lib.optionalString stdenv.cc.isClang "-Wno-error=null-dereference";
+  # Needed with GCC 8
+  NIX_CFLAGS_COMPILE = with stdenv.lib; (optionals stdenv.cc.isGNU [
+    "-Wno-error=int-in-bool-context"
+    "-Wno-error=class-memaccess"
+    "-Wno-error=restrict"
+    "-Wno-error=format-truncation"
+   ]) ++ optional stdenv.cc.isClang "-Wno-error=null-dereference";
 
   patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/LApack.cc --replace "malloc.h" "malloc/malloc.h"

--- a/pkgs/development/libraries/agg/default.nix
+++ b/pkgs/development/libraries/agg/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ autoconf automake libtool freetype SDL libX11 ];
 
+  postPatch = ''
+    substituteInPlace include/agg_renderer_outline_aa.h \
+      --replace 'line_profile_aa& profile() {' 'const line_profile_aa& profile() {'
+  '';
+
   # fix build with new automake, from Gentoo ebuild
   preConfigure = ''
     sed -i '/^AM_C_PROTOTYPES/d' configure.in

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -18,7 +18,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=deprecated-declarations"
+    "-Wno-error=format-truncation"
+    "-Wno-error=cast-function-type"
+  ];
 
   propagatedBuildInputs = [ antlr3_4 libantlr3c polarssl bctoolbox ];
 
@@ -26,7 +30,8 @@ stdenv.mkDerivation rec {
     "--with-polarssl=${polarssl}"
   ];
 
-  enableParallelBuilding = true;
+  # Fails to build with lots of parallel jobs
+  enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
     homepage = http://www.linphone.org/index.php/eng;

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ bctoolbox sqlite ];
   nativeBuildInputs = [ cmake ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type";
+
   meta = with stdenv.lib; {
     description = "BZRTP is an opensource implementation of ZRTP keys exchange protocol";
     homepage = https://github.com/BelledonneCommunications/bzrtp;

--- a/pkgs/development/libraries/cpp-gsl/default.nix
+++ b/pkgs/development/libraries/cpp-gsl/default.nix
@@ -1,18 +1,21 @@
 { stdenv, fetchFromGitHub, cmake, catch }:
 
 stdenv.mkDerivation rec {
-  pname = "GSL-unstable";
-  version = "2017-02-15";
+  pname = "GSL";
+  version = "2.0.0";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "GSL";
-    rev = "c87c123d1b3e64ae2cf725584f0c004da4d90f1c";
-    sha256 = "0h8py468bvxnydkjs352d7a9s8hk0ihc7msjkcnzj2d7nzp5nsc1";
+    rev = "v${version}";
+    sha256 = "1kxfca9ik934nkzyn34ingkyvwpc09li81cg1yc6vqcrdw51l4ri";
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error=sign-conversion";
+  postPatch = ''
+    sed -i 's/-Wno-unknown-attributes/-Wno-error=catch-value/' tests/CMakeLists.txt
+  '';
   nativeBuildInputs = [ cmake catch ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/cpp-hocon/default.nix
+++ b/pkgs/development/libraries/cpp-hocon/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     owner = "puppetlabs";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=catch-value" ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost curl leatherman ];

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -40,6 +40,8 @@ callPackage ./common.nix { inherit stdenv; } {
     #      limit rebuilds by only disabling pie w/musl
       ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "pie";
 
+    NIX_CFLAGS_COMPILE = if withGd then "-Wno-error=stringop-truncation" else null;
+
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for
     # any program we run, because the gcc will have been placed at a new
     # store path than that determined when built (as a source for the

--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     owner = "puppetlabs";
   };
 
-  buildInputs = [ boost cmake curl ruby ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=ignored-qualifiers" "-Wno-error=class-memaccess" "-Wno-error=catch-value" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost curl ruby ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = [
     "-Wno-error=implicit-fallthrough"
     "-Wno-error=nonnull"
+    "-Wno-error=tautological-compare"
+    "-Wno-error=class-memaccess"
+    "-Wno-error=parentheses"
   ];
 
   buildInputs = [ cmake ];

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1z1cb35griqzvshqdv5ck98dy0sgpsswn7fgiy7lbzi34sma8dg2";
   };
 
+  patches = [ ./fix-gcc8-build.patch ];
+
   preConfigure =
     '' echo "patching installation directory in \`extractor.c'..."
        sed -i "src/main/extractor.c" \

--- a/pkgs/development/libraries/libextractor/fix-gcc8-build.patch
+++ b/pkgs/development/libraries/libextractor/fix-gcc8-build.patch
@@ -1,0 +1,16 @@
+diff --git a/src/plugins/ole2_extractor.c b/src/plugins/ole2_extractor.c
+index 072ffc5..a105840 100644
+--- a/src/plugins/ole2_extractor.c
++++ b/src/plugins/ole2_extractor.c
+@@ -345,9 +345,8 @@ process_star_office (GsfInput *src,
+     gsf_input_read (src, size, (unsigned char*) buf);
+     if ( (buf[0] != 0x0F) ||
+ 	 (buf[1] != 0x0) ||
+-	 (0 != strncmp (&buf[2],
+-			"SfxDocumentInfo",
+-			strlen ("SfxDocumentInfo"))) ||
++	 (0 != strcmp (&buf[2],
++			"SfxDocumentInfo")) ||
+ 	 (buf[0x11] != 0x0B) ||
+ 	 (buf[0x13] != 0x00) || /* pw protected! */
+ 	 (buf[0x12] != 0x00) )

--- a/pkgs/development/libraries/libfaketime/default.nix
+++ b/pkgs/development/libraries/libfaketime/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     makeFlagsArray+=(PREFIX="$out" LIBDIRNAME=/lib)
   '';
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type -Wno-error=format-truncation";
+
   checkInputs = [ perl ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -27,7 +27,8 @@ in stdenv.mkDerivation rec {
     "-UDEFAULT_EGL_VENDOR_CONFIG_DIRS"
     # FHS paths are added so that non-NixOS applications can find vendor files.
     "-DDEFAULT_EGL_VENDOR_CONFIG_DIRS=\"${driverLink}/share/glvnd/egl_vendor.d:/etc/glvnd/egl_vendor.d:/usr/share/glvnd/egl_vendor.d\""
-  ] ++ lib.optional stdenv.cc.isClang "-Wno-error";
+    "-Wno-error"
+  ];
 
   # Indirectly: https://bugs.freedesktop.org/show_bug.cgi?id=35268
   configureFlags  = stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-tls";

--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fedora-fixes.patch ];
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=array-bounds" ];
+
   doCheck = false; # fails
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/liboping/default.nix
+++ b/pkgs/development/libraries/liboping/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1n2wkmvw6n80ybdwkjq8ka43z2x8mvxq49byv61b52iyz69slf7b";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" ];
+
   buildInputs = [ ncurses perl ];
 
   configureFlags = stdenv.lib.optional (perl == null) "--with-perl-bindings=no";

--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -2,17 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "libwhereami-${version}";
-  version = "0.2.0";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
-    sha256 = "10phq4a11m8ly6b4dc2yg3dnjzg8ad5wnjv0ilvwylnw32800pxr";
+    sha256 = "084n153jaq8fmhjififk0xlx1d1i3lclnw2j3ly8bixvc392vzly";
     rev = version;
     repo = "libwhereami";
     owner = "puppetlabs";
   };
 
-  # post gcc7, upstream bug: https://tickets.puppetlabs.com/browse/FACT-1828
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated";
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=catch-value" ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -53,7 +53,12 @@ stdenv.mkDerivation rec {
     "--enable-sage"
   ];
 
-  patches = stdenv.lib.optionals withSage [
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/linbox-team/linbox/commit/56be8673613fff87fb2329f71bceb0c793c00b82.patch";
+      sha256 = "0lwxaxgvs17f81qnjgd03cy5lxqgpz7vap6p19dk197kmwll75ha";
+    })
+  ] ++ stdenv.lib.optionals withSage [
     # https://trac.sagemath.org/ticket/24214#comment:39
     # Will be resolved by
     # https://github.com/linbox-team/linbox/issues/69

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -34,8 +34,12 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  NIX_CFLAGS_COMPILE = " -DGIT_VERSION=\"v2.14.0\" -Wno-error=deprecated-declarations ";
-  NIX_LDFLAGS = " -lXext -lssl ";
+  NIX_CFLAGS_COMPILE = [
+    "-DGIT_VERSION=\"v2.14.0\""
+    "-Wno-error=deprecated-declarations"
+    "-Wno-error=cast-function-type"
+  ];
+  NIX_LDFLAGS = "-lXext -lssl";
 
   meta = with stdenv.lib; {
     description = "A powerful and lightweight streaming engine specialized for voice/video telephony applications";

--- a/pkgs/development/libraries/mps/default.nix
+++ b/pkgs/development/libraries/mps/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [
     "-Wno-implicit-fallthrough"
     "-Wno-error=clobbered"
+    "-Wno-error=cast-function-type"
   ];
 
 

--- a/pkgs/development/libraries/science/benchmark/papi/default.nix
+++ b/pkgs/development/libraries/science/benchmark/papi/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "13mngf9kl0y2wfxqvkad0smdaag7k8fvw82b4312gx62nwhc1i6r";
   };
 
-  buildInputs = [ stdenv ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" ];
 
   preConfigure = ''
     cd src

--- a/pkgs/development/libraries/smpeg/default.nix
+++ b/pkgs/development/libraries/smpeg/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./format.patch
     ./gcc6.patch
+    ./libx11.patch
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/smpeg/libx11.patch
+++ b/pkgs/development/libraries/smpeg/libx11.patch
@@ -1,0 +1,25 @@
+Index: smpeg-0.4.5+cvs20030824/Makefile.am
+===================================================================
+--- smpeg-0.4.5+cvs20030824.orig/Makefile.am
++++ smpeg-0.4.5+cvs20030824/Makefile.am
+@@ -74,7 +74,7 @@
+ 
+ # Sources for gtv
+ gtv_SOURCES = gtv.c gtv.h
+-gtv_LDADD = @GTK_LIBS@ libsmpeg.la
++gtv_LDADD = @GTK_LIBS@ @X11_LIBS@ libsmpeg.la
+ 
+ # Sources for glmovie
+ glmovie_SOURCES = glmovie-tile.c glmovie.c glmovie.h
+Index: smpeg-0.4.5+cvs20030824/configure.in
+===================================================================
+--- smpeg-0.4.5+cvs20030824.orig/configure.in
++++ smpeg-0.4.5+cvs20030824/configure.in
+@@ -215,6 +215,7 @@
+         CFLAGS="$CFLAGS $GTK_CFLAGS"
+     fi
+     AC_SUBST(GTK_LIBS)
++    PKG_CHECK_MODULES([X11], [x11])
+ fi
+ AM_CONDITIONAL(HAVE_GTK, test x$have_gtk = xyes)
+ 

--- a/pkgs/development/libraries/uri/default.nix
+++ b/pkgs/development/libraries/uri/default.nix
@@ -1,14 +1,17 @@
 { stdenv, fetchFromGitHub, cmake, doxygen }:
 
-stdenv.mkDerivation {
-  name = "uri-2017-07-16";
+stdenv.mkDerivation rec {
+  name = "uri-${version}";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "cpp-netlib";
     repo = "uri";
-    rev = "ac30f19cc7a4745667a8ebd3eac68d5e70b9a4a6";
-    sha256 = "0ys295ij071rilwkk3xq1p3sdzgb0gyybvd3f0cahh67kh8hyk6n";
+    rev = "v${version}";
+    sha256 = "148361pixrm94q6v04k13s1msa04bx9yc3djb0lxpa7dlw19vhcd";
   };
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=parentheses" ];
 
   nativeBuildInputs = [ cmake doxygen ];
 

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -8,8 +8,8 @@ with stdenv.lib;
 
 let
   os = stdenv.lib.optionalString;
-  majorVersion = "7.0";
-  minorVersion = "0";
+  majorVersion = "7.1";
+  minorVersion = "1";
   version = "${majorVersion}.${minorVersion}";
 in
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   name = "vtk-${os (qtLib != null) "qvtk-"}${version}";
   src = fetchurl {
     url = "${meta.homepage}files/release/${majorVersion}/VTK-${version}.tar.gz";
-    sha256 = "1hrjxkcvs3ap0bdhk90vymz5pgvxmg7q6sz8ab3wsyddbshr1abq";
+    sha256 = "0nm7xwwj7rnsxjdv2ssviys8nhci4n9iiiqm2y14s520hl2dsp1d";
   };
 
   buildInputs =

--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "05xympbns32aalgcfcpxwfd7bvg343f16xpg6jv5s335ski3cjy2";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=class-memaccess" ];
+
   patches = [ ./makefile.patch ];
 
   buildInputs = [ mcpp bzip2 expat openssl db5 ]

--- a/pkgs/development/libraries/zookeeper_mt/default.nix
+++ b/pkgs/development/libraries/zookeeper_mt/default.nix
@@ -1,20 +1,21 @@
 { stdenv, zookeeper, bash }:
 
 stdenv.mkDerivation rec {
-   name = "zookeeper_mt-${stdenv.lib.getVersion zookeeper}";
-   
-   src = zookeeper.src;
-   
-   setSourceRoot = "export sourceRoot=${zookeeper.name}/src/c";
+  name = "zookeeper_mt-${stdenv.lib.getVersion zookeeper}";
 
-   buildInputs = [ zookeeper bash ];
+  src = zookeeper.src;
 
-   meta = with stdenv.lib; {
-   	homepage = http://zookeeper.apache.org;
-   	description = "Apache Zookeeper";
-   	license = licenses.asl20;
-   	maintainers = [ maintainers.boothead ];	
-   	platforms = platforms.unix;	
-   };
+  setSourceRoot = "export sourceRoot=${zookeeper.name}/src/c";
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=format-overflow" ];
+
+  buildInputs = [ zookeeper bash ];
+
+  meta = with stdenv.lib; {
+    homepage = http://zookeeper.apache.org;
+    description = "Apache Zookeeper";
+    license = licenses.asl20;
+    maintainers = [ maintainers.boothead ];
+    platforms = platforms.unix;
+  };
 }
-

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -183,7 +183,19 @@ in
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ openssl ];
     hardeningDisable = [ "format" ];
-    NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-overflow" "-Wno-error=implicit-fallthrough" ];
+    NIX_CFLAGS_COMPILE = [
+      "-Wno-error=stringop-overflow"
+      "-Wno-error=implicit-fallthrough"
+      "-Wno-error=sizeof-pointer-memaccess"
+      "-Wno-error=cast-function-type"
+      "-Wno-error=class-memaccess"
+      "-Wno-error=ignored-qualifiers"
+    ];
+    dontBuild = false;
+    postPatch = ''
+      substituteInPlace Makefile \
+        --replace '-Wno-invalid-source-encoding' ""
+    '';
   };
 
   hitimes = attrs: {

--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     "-Wno-implicit-fallthrough"
     "-Wno-format-truncation"
     "-Wno-format-overflow"
+    "-Wno-error=tautological-compare"
   ];
 
   postInstall = ''

--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
     "MAN3DIR=$(man)/share/man/man3"
     "MAN5DIR=$(man)/share/man/man5"
     "MAN8DIR=$(man)/share/man/man8"
+    "PYTHONLIBDIR=$(py)/${python.sitePackages}"
     "SBINDIR=$(bin)/sbin"
     "SHLIBDIR=$(out)/lib"
 
@@ -42,10 +43,6 @@ stdenv.mkDerivation rec {
   ];
 
   installTargets = [ "install" ] ++ optional enablePython "install-pywrap";
-
-  postInstall = ''
-    moveToOutput "${python.sitePackages}" "$py"
-  '';
 
   meta = removeAttrs libsepol.meta ["outputsToInstall"] // {
     description = "SELinux core library";

--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -9,14 +9,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libselinux-${version}";
-  version = "2.7";
+  version = "2.8";
   inherit (libsepol) se_release se_url;
 
   outputs = [ "bin" "out" "dev" "man" "py" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libselinux-${version}.tar.gz";
-    sha256 = "0mwcq78v6ngbq06xmb9dvilpg0jnl2vs9fgrpakhmmiskdvc1znh";
+    sha256 = "1qc7c6lzvhs9sdgqalg1rxni3a88d989hgrw5f8i1kj3fvn9dnri";
   };
 
   nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python ];
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     "MAN3DIR=$(man)/share/man/man3"
     "MAN5DIR=$(man)/share/man/man5"
     "MAN8DIR=$(man)/share/man/man8"
-    "PYSITEDIR=$(py)/${python.sitePackages}"
     "SBINDIR=$(bin)/sbin"
     "SHLIBDIR=$(out)/lib"
 
@@ -43,6 +42,10 @@ stdenv.mkDerivation rec {
   ];
 
   installTargets = [ "install" ] ++ optional enablePython "install-pywrap";
+
+  postInstall = ''
+    moveToOutput "${python.sitePackages}" "$py"
+  '';
 
   meta = removeAttrs libsepol.meta ["outputsToInstall"] // {
     description = "SELinux core library";

--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "libsepol-${version}";
-  version = "2.7";
-  se_release = "20170804";
+  version = "2.8";
+  se_release = "20180524";
   se_url = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libsepol-${version}.tar.gz";
-    sha256 = "1rzr90d3f1g5wy1b8sh6fgnqb9migys2zgpjmpakn6lhxkc3p7fn";
+    sha256 = "1mi4kpx7b94wjphv8k2fz5b8rd7mllvq1k4ssjxg1gjjhdm93mis";
   };
 
   nativeBuildInputs = [ flex ];

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "mmc-utils-${version}";
-  version = "2018-03-27";
+  version = "2018-12-14";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils.git";
-    rev = "b4fe0c8c0e57a74c01755fa9362703b60d7ee49d";
-    sha256 = "01llwan5j40mv5p867f31lm87qh0hcyhy892say60y5pxc0mzpyn";
+    rev = "aef913e31b659462fe6b9320d241676cba97f67b";
+    sha256 = "1mak9rqjp6yvqk2h5hfil5a9gfx138h62n3cryckfbhr6fmaylm7";
   };
 
   makeFlags = "CC=${stdenv.cc.targetPrefix}cc";

--- a/pkgs/os-specific/linux/setools/default.nix
+++ b/pkgs/os-specific/linux/setools/default.nix
@@ -8,18 +8,18 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "setools";
-  version = "2017-11-10";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
-    owner = "TresysTechnology";
+    owner = "SELinuxProject";
     repo = pname;
-    rev = "a1aa0f33f5c428d3f9fe82960ed5de36f38047f7";
-    sha256 = "0iyj35fff93cprjkzbkg9dn5xz8dg5h2kjx3476fl625nxxskndn";
+    rev = version;
+    sha256 = "1bjwcvr6rjx79cdcvaxn68bdrnl4f2a8gnnqsngdxhkhwpddksjy";
   };
 
   nativeBuildInputs = [ bison flex ];
   buildInputs = [ libsepol swig ];
-  propagatedBuildInputs = [ enum34 libselinux networkx ]
+  propagatedBuildInputs = [ enum34 libselinux networkx cython ]
     ++ optionals withGraphics [ pyqt5 ];
 
   checkInputs = [ tox checkpolicy ];
@@ -34,8 +34,8 @@ buildPythonApplication rec {
   '';
 
   meta = {
-    description = "SELinux Tools";
-    homepage = https://github.com/TresysTechnology/setools/wiki;
+    description = "SELinux Policy Analysis Tools";
+    homepage = https://github.com/SELinuxProject/setools;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/trinity/default.nix
+++ b/pkgs/os-specific/linux/trinity/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "trinity-${version}";
-  version = "1.8-git-2018-06-08";
+  version = "1.8-git-2018-09-21";
 
   src = fetchFromGitHub {
     owner = "kernelslacker";
     repo = "trinity";
-    rev = "1b2d43cb383cef86a05acb2df046ce5e9b17a7fe";
-    sha256 = "0dsq10vmd6ii1dnpaqhizk9p8mbd6mwgpmi13b11dxwxpcvbhlar";
+    rev = "9f6f9f916da3b42cef2e7c30101ff4b0397df736";
+    sha256 = "09bjclgr31dhdqhyig84263q9l59x1q3ppa89sxbmg0yn6ixrc9h";
   };
 
   # Fails on 32-bit otherwise
-  NIX_CFLAGS_COMPILE = [
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionals stdenv.targetPlatform.is32bit [
     "-Wno-error=int-to-pointer-cast"
     "-Wno-error=pointer-to-int-cast"
     "-Wno-error=incompatible-pointer-types"

--- a/pkgs/servers/amqp/qpid-cpp/default.nix
+++ b/pkgs/servers/amqp/qpid-cpp/default.nix
@@ -38,6 +38,8 @@ let
       "-Wno-error=int-in-bool-context"
       "-Wno-error=maybe-uninitialized"
       "-Wno-error=unused-function"
+      "-Wno-error=ignored-qualifiers"
+      "-Wno-error=catch-value"
     ];
   };
 

--- a/pkgs/servers/dict/libmaa.nix
+++ b/pkgs/servers/dict/libmaa.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ libtool ];
   # configureFlags = [ "--datadir=/var/run/current-system/share/dictd" ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
+
   meta = with stdenv.lib; {
     description = "Dict protocol server and client";
     maintainers = [ ];

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -58,7 +58,10 @@ stdenv.mkDerivation {
     ++ optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;
 
-  NIX_CFLAGS_COMPILE = [ "-I${libxml2.dev}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
+  NIX_CFLAGS_COMPILE = [
+    "-I${libxml2.dev}/include/libxml2"
+    "-Wno-error=implicit-fallthrough"
+  ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
 
   configurePlatforms = [];
 

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [
     "-I${libxml2.dev}/include/libxml2"
     "-Wno-error=implicit-fallthrough"
+    "-Wno-error=cast-function-type"
   ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
 
   preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);

--- a/pkgs/servers/mail/postfix/pfixtools.nix
+++ b/pkgs/servers/mail/postfix/pfixtools.nix
@@ -41,7 +41,10 @@ stdenv.mkDerivation {
                       --replace /bin/bash ${bash}/bin/bash;
   '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=nonnull-compare";
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=unused-result" "-Wno-error=nonnull-compare"
+    "-Wno-error=format-truncation"
+  ];
 
   makeFlags = "DESTDIR=$(out) prefix=";
 

--- a/pkgs/servers/nosql/aerospike/default.nix
+++ b/pkgs/servers/nosql/aerospike/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool ];
   buildInputs = [ openssl zlib ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-truncation";
+
   preBuild = ''
     patchShebangs build/gen_version
     substituteInPlace build/gen_version --replace 'git describe' 'echo ${version}'

--- a/pkgs/tools/filesystems/blobfuse/default.nix
+++ b/pkgs/tools/filesystems/blobfuse/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qh04z1fsj1l6l12sz9yl2sy9hwlrnzac54hwrr7wvsgv90n9gbp";
   };
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=catch-value" ];
+
   buildInputs = [ curl gnutls libgcrypt libuuid fuse ];
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/tools/filesystems/darling-dmg/default.nix
+++ b/pkgs/tools/filesystems/darling-dmg/default.nix
@@ -1,24 +1,18 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, fuse, zlib, bzip2, openssl, libxml2, icu } :
+{ stdenv, fetchFromGitHub, cmake, fuse, zlib, bzip2, openssl, libxml2, icu } :
 
 stdenv.mkDerivation rec {
   name = "darling-dmg-${version}";
-  version = "1.0.4";
+  version = "1.0.4+git20180914";
 
   src = fetchFromGitHub {
     owner = "darlinghq";
     repo = "darling-dmg";
-    rev = "v${version}";
-    sha256 = "0x285p16zfnp0p6injw1frc8krif748sfgxhdd7gb75kz0dfbkrk";
+    rev = "97a92a6930e43cdbc9dedaee62716e3223deb027";
+    sha256 = "1bngr4827qnl4s2f7z39wjp13nfm3zzzykjshb43wvjz536bnqdj";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/darlinghq/darling-dmg/commit/cbb0092264b5c5cf3e92d6c2de23f02d859ebf44.patch";
-    sha256 = "05fhgn5c09f1rva6bvbq16nhlkblrhscbf69k04ajwdh7y98sw39";
-     })
-  ];
-
-  buildInputs = [ cmake fuse openssl zlib bzip2 libxml2 icu ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ fuse openssl zlib bzip2 libxml2 icu ];
 
   meta = {
     homepage = http://www.darlinghq.org/;

--- a/pkgs/tools/networking/altermime/default.nix
+++ b/pkgs/tools/networking/altermime/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     "-Wno-error=format-truncation"
     "-Wno-error=pointer-compare"
     "-Wno-error=memset-elt-size"
+    "-Wno-error=restrict"
   ];
 
   postPatch = ''

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
   ] ++ stdenv.lib.optionals (openldap != null) [ "--with-ldap" "--with-ldapcrypto" ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=pointer-compare" ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=pointer-compare" "-Wno-error=format-truncation" ];
 
   installFlags = [ "DESTDIR=\${out}" ];
 

--- a/pkgs/tools/package-management/xbps/default.nix
+++ b/pkgs/tools/package-management/xbps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, which, zlib, openssl, libarchive }:
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, which, zlib, openssl, libarchive }:
 
 stdenv.mkDerivation rec {
   name = "xbps-${version}";
@@ -15,7 +15,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib openssl libarchive ];
 
-  patches = [ ./cert-paths.patch ];
+  patches = [
+    ./cert-paths.patch
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/void-linux/xbps/pull/38.patch";
+      sha256 = "050a9chw0cxy67nm2phz67mgndarrxrv50d54m3l1s5sx83axww3";
+    })
+  ];
 
   postPatch = ''
     # fix unprefixed ranlib (needed on cross)

--- a/pkgs/tools/security/chaps/default.nix
+++ b/pkgs/tools/security/chaps/default.nix
@@ -31,8 +31,12 @@ stdenv.mkDerivation rec {
     sha256 = "0chk6pnn365d5kcz6vfqx1d0383ksk97icc0lzg0vvb0kvyj0ff1";
   };
 
-  # readdir_r(3) is deprecated in glibc >= 2.24
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  NIX_CFLAGS_COMPILE = [
+    # readdir_r(3) is deprecated in glibc >= 2.24
+    "-Wno-error=deprecated-declarations"
+    # gcc8 catching polymorphic type error
+    "-Wno-error=catch-value"
+  ];
 
   patches = [ ./fix_absolute_path.patch  ./fix_environment_variables.patch  ./fix_scons.patch  ./insert_prefetches.patch ];
 

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "puppetlabs";
   };
 
-  CXXFLAGS = "-fpermissive";
+  CXXFLAGS = "-fpermissive -Wno-error=catch-value";
   NIX_LDFLAGS = "-lblkid";
 
   cmakeFlags = [ "-DFACTER_RUBY=${ruby}/lib/libruby.so" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2462,7 +2462,7 @@ in
 
   cholmod-extra = callPackage ../development/libraries/science/math/cholmod-extra { };
 
-  emscriptenVersion = "1.37.36";
+  emscriptenVersion = "1.38.22";
 
   emscripten = callPackage ../development/compilers/emscripten { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6752,8 +6752,8 @@ in
   gerbil = callPackage ../development/compilers/gerbil { stdenv = gccStdenv; };
   gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { stdenv = gccStdenv; };
 
-  gccFun = callPackage ../development/compilers/gcc/7;
-  gcc = gcc7;
+  gccFun = callPackage ../development/compilers/gcc/8;
+  gcc = gcc8;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6969,6 +6969,14 @@ in
     profiledCompiler = false;
   });
 
+  gfortran8 = wrapCC (gcc8.cc.override {
+    name = "gfortran";
+    langFortran = true;
+    langCC = false;
+    langC = false;
+    profiledCompiler = false;
+  });
+
   gcj = gcj6;
   gcj6 = wrapCC (gcc6.cc.override {
     name = "gcj";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22025,6 +22025,7 @@ in
     cudaSupport = config.cudaSupport or false;
     cudnnSupport = cudaSupport;
     inherit (linuxPackages) nvidia_x11;
+    opencv = opencv3;
   };
 
   wxmaxima = callPackage ../applications/science/math/wxmaxima { wxGTK = wxGTK30; };


### PR DESCRIPTION
This PR bumps gcc used in `stdenv` to version 8. The main motivation for this is the ability to add `-fstack-clash-protection` to our default hardening flags (#53753). This will be done in a separate PR.

I anticipate quite a few of broken packages because there are some new checks, i.e. for array bounds and format truncation.

There is also an old `gcc8` branch which I noticed just now thanks to @Synthetica9. I'll cherry-pick changes from there.

Hydra Job: https://hydra.nixos.org/jobset/nixpkgs/gcc8
Newly failing builds with gcc8: https://hydra.nixos.org/eval/1500732?compare=staging-next

**Current state:** Most packages seem to build. `clang` segfaults currently. `gcc` fails on Darwin.