### PR TITLE
 python3.pkgs.aiohttp: 3.4.4 -> 3.5.2

### DIFF
--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -1,63 +1,54 @@
 { stable, branch, version, sha256Hash }:
 
-{ stdenv, python36Packages, fetchFromGitHub, fetchurl }:
+{ stdenv, python36, fetchFromGitHub }:
 
 let
-  pythonPackages = python36Packages;
-  async-timeout = pythonPackages.async-timeout.overrideAttrs
-    (oldAttrs:
-      rec {
-        pname = "async-timeout";
+  python = python36.override {
+    packageOverrides = self: super: {
+      async-timeout = super.async-timeout.overridePythonAttrs (oldAttrs: rec {
         version = "2.0.1";
-        src = pythonPackages.fetchPypi {
-          inherit pname version;
+        src = oldAttrs.src.override {
+          inherit version;
           sha256 = "1l3kg062m02mph6rf9rdv8r5c5n356clxa6b6mrn0i77vk9g9kq0";
         };
       });
-  aiohttp = pythonPackages.aiohttp.overrideAttrs
-    (oldAttrs:
-      rec {
-        pname = "aiohttp";
+      aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
         version = "2.3.10";
-        src = pythonPackages.fetchPypi {
-          inherit pname version;
+        src = oldAttrs.src.override {
+          inherit version;
           sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964";
         };
-        propagatedBuildInputs = [ async-timeout ]
-          ++ (with pythonPackages; [ attrs chardet multidict yarl idna-ssl ]);
+        propagatedBuildInputs = with self; [ async-timeout attrs chardet multidict yarl idna-ssl ];
+        doCheck = false;
       });
-  aiohttp-cors = pythonPackages.aiohttp-cors.overrideAttrs
-    (oldAttrs:
-      rec {
-        pname = "aiohttp-cors";
+      aiohttp-cors = super.aiohttp-cors.overridePythonAttrs (oldAttrs: rec {
         version = "0.5.3";
-        name = "${pname}-${version}";
-        src = pythonPackages.fetchPypi {
-          inherit pname version;
+        src = oldAttrs.src.override {
+          inherit version;
           sha256 = "11b51mhr7wjfiikvj3nc5s8c7miin2zdhl3yrzcga4mbpkj892in";
         };
-        propagatedBuildInputs = [ aiohttp ]
-          ++ stdenv.lib.optional
-               (pythonPackages.pythonOlder "3.5")
-               pythonPackages.typing;
+        propagatedBuildInputs = with self; [ aiohttp ]
+          ++ stdenv.lib.optional (pythonOlder "3.5") typing;
       });
-in pythonPackages.buildPythonPackage rec {
-  name = "${pname}-${version}";
+    };
+  };
+
+in python.pkgs.buildPythonPackage {
   pname = "gns3-server";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "GNS3";
-    repo = pname;
+    repo = "gns3-server";
     rev = "v${version}";
     sha256 = sha256Hash;
   };
 
-  propagatedBuildInputs = [ aiohttp-cors ]
-    ++ (with pythonPackages; [
-      yarl aiohttp multidict
-      jinja2 psutil zipstream raven jsonschema typing
-      (pythonPackages.callPackage ../../../development/python-modules/prompt_toolkit/1.nix {})
-    ]);
+  propagatedBuildInputs = with python.pkgs; [
+    aiohttp-cors yarl aiohttp multidict
+    jinja2 psutil zipstream raven jsonschema typing
+    (python.pkgs.callPackage ../../../development/python-modules/prompt_toolkit/1.nix {})
+  ];
 
   # Requires network access
   doCheck = false;
@@ -65,6 +56,7 @@ in pythonPackages.buildPythonPackage rec {
   postInstall = ''
     rm $out/bin/gns3loopback # For Windows only
   '';
+
   meta = with stdenv.lib; {
     description = "Graphical Network Simulator 3 server (${branch} release)";
     longDescription = ''

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -8,33 +8,37 @@
 , async-timeout
 , yarl
 , idna-ssl
+, typing-extensions
+, pytestrunner
 , pytest
 , gunicorn
-, pytest-mock
-, async_generator
-, pytestrunner
 , pytest-timeout
+, async_generator
+, pytest_xdist
+, pytestcov
+, pytest-mock
+, trustme
+, brotlipy
 }:
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.4.4";
+  version = "3.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1ykm6kdjkrg556j0zd7dx2l1rsrbh0d9g27ivr6dmaahz9pyrbsi";
+    sha256 = "3d851b15e615c0ad619de0990ab94c9721c335aebb58d160bf77a4af963c6b50";
   };
 
   disabled = pythonOlder "3.5";
 
-  checkInputs = [ pytest gunicorn pytest-mock async_generator pytestrunner pytest-timeout ];
+  checkInputs = [
+    pytestrunner pytest gunicorn pytest-timeout async_generator pytest_xdist
+    pytest-mock pytestcov trustme brotlipy
+  ];
 
   propagatedBuildInputs = [ attrs chardet multidict async-timeout yarl ]
-    ++ lib.optional (pythonOlder "3.7") idna-ssl;
-
-
-  # Several test failures. Need to be looked into.
-  doCheck = false;
+    ++ lib.optionals (pythonOlder "3.7") [ idna-ssl typing-extensions ];
 
   meta = with lib; {
     description = "Asynchronous HTTP Client/Server for Python and asyncio";

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -11,7 +11,8 @@ let
           sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964";
         };
         # TODO: remove after pinning aiohttp to a newer version
-        propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ self.idna-ssl ];
+        propagatedBuildInputs = with self; [ chardet multidict async-timeout yarl idna-ssl ];
+        doCheck = false;
       });
 
       yarl = super.yarl.overridePythonAttrs (oldAttrs: rec {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

