### PR TITLE
emacs: tramp: detect wrapped gvfsd-fuse daemon

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./clean-env.patch
+    ./tramp-detect-wrapped-gvfsd.patch
   ];
 
   postPatch = lib.optionalString srcRepo ''

--- a/pkgs/applications/editors/emacs/tramp-detect-wrapped-gvfsd.patch
+++ b/pkgs/applications/editors/emacs/tramp-detect-wrapped-gvfsd.patch
@@ -1,0 +1,14 @@
+diff --git a/lisp/net/tramp-gvfs.el b/lisp/net/tramp-gvfs.el
+index f370abba31..f2806263a9 100644
+--- a/lisp/net/tramp-gvfs.el
++++ b/lisp/net/tramp-gvfs.el
+@@ -164,7 +164,8 @@ tramp-gvfs-enabled
+     (and (featurep 'dbusbind)
+ 	 (tramp-compat-funcall 'dbus-get-unique-name :system)
+ 	 (tramp-compat-funcall 'dbus-get-unique-name :session)
+-	 (or (tramp-compat-process-running-p "gvfs-fuse-daemon")
++	 (or (tramp-compat-process-running-p ".gvfsd-fuse-wrapped")
++             (tramp-compat-process-running-p "gvfs-fuse-daemon")
+ 	     (tramp-compat-process-running-p "gvfsd-fuse"))))
+   "Non-nil when GVFS is available.")
+ 


### PR DESCRIPTION
###### Motivation for this change

Tramp checks for a running `gvfsd-fuse` process to figure out whether to enable gvfs-based. Its `tramp-compat-process-running-p` function uses `/proc/<pid>/comm` to check for the name of running process(es). In Nix, the gvfsd processes are launched via wrappers and the name of `gvfsd-fuse` in
`comm` in Linux is `.gvfsd-fuse-wra` (truncated to 15 characters) which means the process is not detected and `tramp-gvfs-enabled` ends up with `nil` even when gvfs is available.

This patch adds `.gvfsd-fuse-wrapped` to the list of process names to check when determining the value of `tramp-gvfs-enabled`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

