### PR TITLE
tt-rss-plugin-ff-instagram: Init at git-2019-01-10

### DIFF
--- a/pkgs/servers/tt-rss/plugin-ff-instagram/default.nix
+++ b/pkgs/servers/tt-rss/plugin-ff-instagram/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
+  name = "tt-rss-plugin-ff-instagram-${version}";
+  version = "git-2019-01-10"; # No release, see https://github.com/wltb/ff_instagram/issues/6
+
+  src = fetchFromGitHub {
+    owner = "wltb";
+    repo = "ff_instagram";
+    rev = "0366ffb18c4d490c8fbfba2f5f3367a5af23cfe8";
+    sha256 = "0vvzl6wi6jmrqknsfddvckjgsgfizz1d923d1nyrpzjfn6bda1vk";
+  };
+
+  installPhase = ''
+    mkdir -p $out/ff_instagram
+
+    cp *.php $out/ff_instagram
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Plugin for Tiny Tiny RSS that allows to fetch posts from Instagram user sites";
+    longDescription = ''
+      Plugin for Tiny Tiny RSS that allows to fetch posts from Instagram user sites.
+
+      The name of the plugin in TT-RSS is 'ff_instagram'.
+    '';
+    license = licenses.agpl3;
+    homepage = "https://github.com/wltb/ff_instagram";
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14126,6 +14126,7 @@ in
   torque = callPackage ../servers/computing/torque { };
 
   tt-rss = callPackage ../servers/tt-rss { };
+  tt-rss-plugin-ff-instagram = callPackage ../servers/tt-rss/plugin-ff-instagram { };
   tt-rss-plugin-tumblr-gdpr = callPackage ../servers/tt-rss/plugin-tumblr-gdpr { };
   tt-rss-theme-feedly = callPackage ../servers/tt-rss/theme-feedly { };
 


### PR DESCRIPTION
###### Motivation for this change

I'd like to view Instagram feeds in tt-rss.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

