### PR TITLE
bftools: init at 5.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4356,6 +4356,11 @@
     github = "tazjin";
     name = "Vincent Ambo";
   };
+  tbenst = {
+    email = "nix@tylerbenster.com";
+    github = "tbenst";
+    name = "Tyler Benster";
+  };
   teh = {
     email = "tehunger@gmail.com";
     github = "teh";

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeWrapper, fetchurl, unzip, openjdk }:
+{ stdenv, lib, makeWrapper, fetchurl, unzip, jre }:
 
 stdenv.mkDerivation rec {
   name = "bftools-${version}";
@@ -11,13 +11,12 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp $(find ./* -maxdepth 1 ! -path "*.bat") $out/
+    cp $(find ./* -maxdepth 1 ! -path "*.bat") $out/bin
   '';
 
   postFixup = ''
-    for script in "$out"/bin/*; do
-      wrapProgram "$script" --prefix PATH : "${lib.makeBinPath [ openjdk ]}"
-    done
+    chmod +x $out/bin/bf.sh
+    wrapProgram $out/bin/bf.sh --prefix PATH : "${lib.makeBinPath [ jre ]}"
   '';
 
   buildInputs = [ unzip ];

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -10,12 +10,15 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/bin
+    find . -maxdepth 1 -perm -111 -type f -not -name "*.sh" \
+      -exec install -vD {} "$out"/bin/{} \;
+
     mkdir $out/libexec
     mkdir -p $out/share/java
-    cp $(find . -maxdepth 1 -perm -111 -type f) $out/bin
+
     cp ./*.sh $out/libexec
     cp ./*.jar $out/share/java
+
     for file in $out/bin/*; do
       substituteInPlace $file --replace "\$BF_DIR" $out/libexec
     done
@@ -23,8 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    chmod +x $out/bin/bf.sh
-    wrapProgram $out/bin/bf.sh --prefix PATH : "${lib.makeBinPath [ jre ]}"
+    wrapProgram $out/libexec/bf.sh --prefix PATH : "${lib.makeBinPath [ jre ]}"
   '';
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -11,7 +11,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp $(find ./* -maxdepth 1 ! -path "*.bat") $out/bin
+    mkdir $out/libexec
+    mkdir -p $out/share/java
+    cp $(find . -maxdepth 1 -perm -111 -type f) $out/bin
+    cp ./*.sh $out/libexec
+    cp ./*.jar $out/share/java
+    for file in $out/bin/*; do
+      substituteInPlace $file --replace "\$BF_DIR" $out/libexec
+    done
+    substituteInPlace $out/libexec/bf.sh --replace "\$BF_JAR_DIR" $out/share/java
   '';
 
   postFixup = ''

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included";
     license = licenses.gpl3;
-    meta.platforms = platforms.all;
+    platforms = platforms.all;
     homepage = https://www.openmicroscopy.org/bio-formats/;
     maintainers = [ maintainers.tbenst ];
   };

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, lib, makeWrapper, fetchurl, unzip, jre }:
+{ stdenv, lib, makeWrapper, fetchzip, jre }:
 
 stdenv.mkDerivation rec {
   name = "bftools-${version}";
   version = "5.9.2";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "http://downloads.openmicroscopy.org/bio-formats/${version}/artifacts/bftools.zip";
-    sha256 = "02x8p07z7js41kgiblkr9k8v9v4ka8rm7pg3f1vy9s5p6hmpfvnx";
+    sha256 = "08lmbg3kfxh17q6548il0i2h3f9a6ch8r0r067p14dajhzfpjyqj";
   };
 
   installPhase = ''
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/bf.sh
     wrapProgram $out/bin/bf.sh --prefix PATH : "${lib.makeBinPath [ jre ]}"
   '';
-
-  buildInputs = [ unzip ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included";
-    license = licenses.gpl3;
+    license = licenses.gpl2;
     platforms = platforms.all;
     homepage = https://www.openmicroscopy.org/bio-formats/;
     maintainers = [ maintainers.tbenst ];

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, pkgs, fetchurl, unzip, openjdk }:
+{ stdenv, lib, makeWrapper, fetchurl, unzip, openjdk }:
 
 stdenv.mkDerivation rec {
   name = "bftools-${version}";
@@ -11,25 +11,23 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ./* $out/
-    for script in $(find . -maxdepth 1 -perm -111 -type f); do
-      ln -s $out/$script $out/bin/$script
-    done
+    cp $(find ./* -maxdepth 1 ! -path "*.bat") $out/
   '';
 
   postFixup = ''
-        for script in "$out"/bin/*; do
-          wrapProgram "$script" --prefix PATH : "${lib.makeBinPath [ openjdk ]}"
-        done
-      '';
+    for script in "$out"/bin/*; do
+      wrapProgram "$script" --prefix PATH : "${lib.makeBinPath [ openjdk ]}"
+    done
+  '';
 
-  buildInputs = [ unzip pkgs.makeWrapper ];
+  buildInputs = [ unzip ];
 
-  # phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+  nativeBuildInputs = [ makeWrapper ];
 
   meta = with stdenv.lib; {
-    description = "A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included.";
+    description = "A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included";
     license = licenses.gpl3;
+    meta.platforms = platforms.all;
     homepage = https://www.openmicroscopy.org/bio-formats/;
     maintainers = [ maintainers.tbenst ];
   };

--- a/pkgs/applications/science/biology/bftools/default.nix
+++ b/pkgs/applications/science/biology/bftools/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, pkgs, fetchurl, unzip, openjdk }:
+
+stdenv.mkDerivation rec {
+  name = "bftools-${version}";
+  version = "5.9.2";
+
+  src = fetchurl {
+    url = "http://downloads.openmicroscopy.org/bio-formats/${version}/artifacts/bftools.zip";
+    sha256 = "02x8p07z7js41kgiblkr9k8v9v4ka8rm7pg3f1vy9s5p6hmpfvnx";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./* $out/
+    for script in $(find . -maxdepth 1 -perm -111 -type f); do
+      ln -s $out/$script $out/bin/$script
+    done
+  '';
+
+  postFixup = ''
+        for script in "$out"/bin/*; do
+          wrapProgram "$script" --prefix PATH : "${lib.makeBinPath [ openjdk ]}"
+        done
+      '';
+
+  buildInputs = [ unzip pkgs.makeWrapper ];
+
+  # phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  meta = with stdenv.lib; {
+    description = "A bundle of scripts for using Bio-Formats on the command line with bioformats_package.jar already included.";
+    license = licenses.gpl3;
+    homepage = https://www.openmicroscopy.org/bio-formats/;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -964,6 +964,8 @@ in
 
   bfr = callPackage ../tools/misc/bfr { };
 
+  bftools = callPackage ../applications/science/biology/bftools { };
+
   bibtool = callPackage ../tools/misc/bibtool { };
 
   bibutils = callPackage ../tools/misc/bibutils { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -964,8 +964,6 @@ in
 
   bfr = callPackage ../tools/misc/bfr { };
 
-  bftools = callPackage ../applications/science/biology/bftools { };
-
   bibtool = callPackage ../tools/misc/bibtool { };
 
   bibutils = callPackage ../tools/misc/bibutils { };
@@ -21423,6 +21421,8 @@ in
   bedtools = callPackage ../applications/science/biology/bedtools { };
 
   bcftools = callPackage ../applications/science/biology/bcftools { };
+
+  bftools = callPackage ../applications/science/biology/bftools { };
 
   conglomerate = callPackage ../applications/science/biology/conglomerate { };
 


### PR DESCRIPTION
###### Motivation for this change
This package is useful for microscopy. First pull request here so feedback most welcome!

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested bfconvert, which is the only tool I use, and this worked properly for converting a .oir file to a .ome.btf. The other executables display "--help" properly but were not otherwise tested.

---

