### PR TITLE
hexyl: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/tools/misc/hexyl/default.nix
+++ b/pkgs/tools/misc/hexyl/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   name    = "hexyl-${version}";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
     repo   = "hexyl";
     rev    = "v${version}";
-    sha256 = "138w6czi62dpw6gcd3yqpk7lns7m89kwbgm1d1i5lnzsqck3wb4s";
+    sha256 = "1q4klph45a7zjzwajrccb51yc3k1p16mjlnqislpm43h653f728q";
   };
 
-  cargoSha256 = "01m8n7yl3yqr8kj0dl1wfaz724da17hs3sb1fbncv64l6qpvdka1";
+  cargoSha256 = "17mp6amib58akh175qprqsz3qkffgdacfm3dhkbysiqmw5m2p2p7";
 
   meta = with stdenv.lib; {
     description = "A command-line hex viewer";
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage    = https://github.com/sharkdp/hexyl;
     license     = with licenses; [ asl20 /* or */ mit ];
-    maintainers = [];
+    maintainers = with maintainers; [ dywedir ];
     platforms   = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
https://github.com/sharkdp/hexyl/releases/tag/v0.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @kballard
