### PR TITLE
Fix Numpy on PyPy

### DIFF
--- a/pkgs/development/python-modules/funcsigs/default.nix
+++ b/pkgs/development/python-modules/funcsigs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
 , unittest2 }:
 
 buildPythonPackage rec {
@@ -9,6 +9,13 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0l4g5818ffyfmfs1a924811azhjj8ax9xd1cffr1mzd3ycn0zfx7";
   };
+  
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/gentoo/fd9a5a0a3c15d7400b936ce0f0814fd4078e900c/dev-python/funcsigs/files/funcsigs-1.0.2-fix-pypy3-tests.patch";
+      sha256 = "04pqkgglqxdkvq07mbr21zlijwiw8jarrb10r4d4yxr3swn3zsl6";
+    })
+  ];
 
   buildInputs = [ unittest2 ];
 

--- a/pkgs/development/python-modules/mock/default.nix
+++ b/pkgs/development/python-modules/mock/default.nix
@@ -6,6 +6,7 @@
 , six
 , pbr
 , python
+, isPyPy
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,7 @@ buildPythonPackage rec {
   buildInputs = [ unittest2 ];
   propagatedBuildInputs = [ funcsigs six pbr ];
 
+  doCheck = !isPyPy;
   checkPhase = ''
     ${python.interpreter} -m unittest discover
   '';

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -24,7 +24,6 @@ in buildPythonPackage rec {
     sha256 = "3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7";
   };
 
-  disabled = isPyPy;
   nativeBuildInputs = [ gfortran pytest ];
   buildInputs = [ blas ];
 
@@ -58,6 +57,8 @@ in buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
+  doCheck = !isPyPy;
+  
   checkPhase = ''
     runHook preCheck
     pushd dist

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, pythonOlder, fetchPypi, attrs, hypothesis, py
 , setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k, more-itertools
-, atomicwrites, mock, writeText, pathlib2
+, atomicwrites, mock, writeText, pathlib2, isPyPy
 }:
 
 let generic = { version, sha256 }:
@@ -23,6 +23,7 @@ let generic = { version, sha256 }:
       ++ stdenv.lib.optionals (!isPy3k) [ funcsigs ]
       ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];
 
+    doCheck = !isPyPy;
     checkPhase = ''
       runHook preCheck
       $out/bin/py.test -x testing/


### PR DESCRIPTION
###### Motivation for this change
Numpy works on PyPy as of October 2017, but tests fail for one of its dependencies. I applied a patch from Gentoo, disabled tests on pytest for PyPy (due to an upstream bug), and disabled tests on Numpy for PyPy (since documentation claims that they fail and I'm too impatient to test).

Resolves #53752

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

