### PR TITLE
neovim-qt: add desktop file to wrapper

### DIFF
--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -58,6 +58,10 @@ in
     '' else ''
       makeWrapper '${unwrapped}/bin/nvim-qt' "$out/bin/nvim-qt" \
         --prefix PATH : "${neovim}/bin"
+
+      # link .desktop file
+      mkdir -p "$out/share"
+      ln -s '${unwrapped}/share/applications' "$out/share/applications"
     '';
 
     preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

My recent change in #53447 caused neovim-qt to no longer be recognized
as a desktop application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

