### PR TITLE
obs-studio: add new optional dependencies

### DIFF
--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -21,6 +21,11 @@
 , vlc
 , mbedtls
 
+, scriptingSupport ? true
+, luajit
+, swig
+, python3
+
 , alsaSupport ? false
 , alsaLib
 , pulseaudioSupport ? false
@@ -68,6 +73,7 @@ in stdenv.mkDerivation rec {
                   makeWrapper
                   mbedtls
                 ]
+                ++ optional scriptingSupport [ luajit swig python3 ]
                 ++ optional alsaSupport alsaLib
                 ++ optional pulseaudioSupport libpulseaudio;
 


### PR DESCRIPTION
###### Motivation for this change

Resolves #53779.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

