### PR TITLE
google-music-scripts: init at 3.0.0

### DIFF
--- a/pkgs/development/python-modules/audio-metadata/default.nix
+++ b/pkgs/development/python-modules/audio-metadata/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, attrs
+, bidict
+, bitstruct
+, more-itertools
+, pprintpp
+}:
+
+buildPythonPackage rec {
+  pname = "audio-metadata";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1jd0wzhh9as2qyiwggqmvsbsm5nlb73qnxix2mcar53cddvwrvj7";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    bidict
+    bitstruct
+    more-itertools
+    pprintpp
+  ];
+
+  # No tests
+  doCheck = false;
+
+  disabled = pythonOlder "3.6";
+
+  meta = with lib; {
+    homepage = https://github.com/thebigmunch/audio-metadata;
+    description = "A library for reading and, in the future, writing metadata from audio files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/bidict/default.nix
+++ b/pkgs/development/python-modules/bidict/default.nix
@@ -1,0 +1,42 @@
+{ lib, buildPythonPackage, fetchPypi
+, setuptools_scm
+, sphinx
+, hypothesis
+, py
+, pytest
+, pytest-benchmark
+, sortedcollections
+, sortedcontainers
+}:
+
+buildPythonPackage rec {
+  pname = "bidict";
+  version = "0.17.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1icj0fnfx47n6i33pj5gfrmd1rzpvah1jihhdhqiqx2cy9rs6x4c";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ sphinx ];
+
+  checkInputs = [
+    hypothesis
+    py
+    pytest
+    pytest-benchmark
+    sortedcollections
+    sortedcontainers
+  ];
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/jab/bidict;
+    description = "Efficient, Pythonic bidirectional map data structures and related functionality";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/bitstruct/default.nix
+++ b/pkgs/development/python-modules/bitstruct/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "bitstruct";
+  version = "6.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1znqgy2ikdqn6n6mv1ccfbl0q7x65bh3i9ph0yjl4rihwvxyg9fg";
+  };
+
+  meta = with lib; {
+    homepage = https://github.com/eerimoq/bitstruct;
+    description = "Python bit pack/unpack package";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/click-default-group/default.nix
+++ b/pkgs/development/python-modules/click-default-group/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub, click, pytest }:
+
+buildPythonPackage rec {
+  pname = "click-default-group";
+  version = "1.2";
+
+  # No tests in Pypi tarball
+  src = fetchFromGitHub {
+    owner = "click-contrib";
+    repo = "click-default-group";
+    rev = "v${version}";
+    sha256 = "0lm2k4jvy4ilvv91niawklfnp5mp7wa8c1bicsqdfzrxmw7jliwp";
+  };
+
+  propagatedBuildInputs = [ click ];
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    homepage = https://github.com/click-contrib/click-default-group;
+    description = "Group to invoke a command without explicit subcommand name";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/google-music-proto/default.nix
+++ b/pkgs/development/python-modules/google-music-proto/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, attrs
+, audio-metadata
+, marshmallow
+, pendulum
+, protobuf
+}:
+
+buildPythonPackage rec {
+  pname = "google-music-proto";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "008nap32hcrlnkkqkf462vwnm6xzrn6fj71lbryfmrakad7rz7bc";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    audio-metadata
+    marshmallow
+    pendulum
+    protobuf
+  ];
+
+  # No tests
+  doCheck = false;
+
+  disabled = pythonOlder "3.6";
+
+  meta = with lib; {
+    homepage = https://github.com/thebigmunch/google-music-proto;
+    description = "Sans-I/O wrapper of Google Music API calls";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/google-music-utils/default.nix
+++ b/pkgs/development/python-modules/google-music-utils/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, audio-metadata, multidict, wrapt
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "google-music-utils";
+  version = "2.0.0";
+
+  # Pypi tarball doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "thebigmunch";
+    repo = "google-music-utils";
+    rev = version;
+    sha256 = "0i5zcr1ypnxizi41s3lrplz9m9rmb56s5iihjx61kbybxcq2b6gk";
+  };
+
+  propagatedBuildInputs = [
+    audio-metadata multidict wrapt
+  ];
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  disabled = pythonOlder "3.6";
+
+  meta = with lib; {
+    homepage = https://github.com/thebigmunch/google-music-utils;
+    description = "A set of utility functionality for google-music and related projects";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/google-music/default.nix
+++ b/pkgs/development/python-modules/google-music/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, appdirs
+, audio-metadata
+, google-music-proto
+, protobuf
+, requests_oauthlib
+, tenacity
+}:
+
+buildPythonPackage rec {
+  pname = "google-music";
+  version = "3.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13i9nd62wqfg0f5r7ykr15q83397vdpw0js50fy5nbgs33sbf6b7";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    audio-metadata
+    google-music-proto
+    protobuf
+    requests_oauthlib
+    tenacity
+  ];
+
+  # No tests
+  doCheck = false;
+
+  disabled = pythonOlder "3.6";
+
+  meta = with lib; {
+    homepage = https://github.com/thebigmunch/google-music;
+    description = "A Google Music API wrapper";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/logzero/default.nix
+++ b/pkgs/development/python-modules/logzero/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "logzero";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hli2wgwxxackrk1ybmlpdd0rzms6blm11zzwlvrzykd8cp1xyil";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/metachris/logzero;
+    description = "Robust and effective logging for Python 2 and 3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/pprintpp/default.nix
+++ b/pkgs/development/python-modules/pprintpp/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchpatch, buildPythonPackage, fetchPypi, python, nose, parameterized }:
+
+buildPythonPackage rec {
+  pname = "pprintpp";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00v4pkyiqc0y9qjnp3br58a4k5zwqdrjjxbcsv39vx67w84630pa";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/wolever/pprintpp/commit/873217674cc824b4c1cfdad4867c560c60e8d806.patch";
+      sha256 = "0rqxzxawr83215s84mfzh1gnjwjm2xv399ywwcl4q7h395av5vb3";
+    })
+  ];
+
+  checkInputs = [ nose parameterized ];
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/wolever/pprintpp;
+    description = "A drop-in replacement for pprint that's actually pretty";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/development/python-modules/tenacity/default.nix
+++ b/pkgs/development/python-modules/tenacity/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, pbr, six, futures, monotonic
+, pytest, sphinx, tornado
+}:
+
+buildPythonPackage rec {
+  pname = "tenacity";
+  version = "5.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rjbj9wks7b7n75mbm01y0g2ngyai8yi05ck9gicmcdyix7vw42c";
+  };
+
+  nativeBuildInputs = [ pbr ];
+  propagatedBuildInputs = [ six ]
+    ++ lib.optionals isPy27 [ futures monotonic ];
+
+  checkInputs = [ pytest sphinx tornado ];
+  checkPhase = (if isPy27 then ''
+    pytest --ignore='tenacity/tests/test_asyncio.py'
+  '' else ''
+    pytest
+  '') + ''
+    sphinx-build -a -E -W -b doctest doc/source doc/build
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/jd/tenacity;
+    description = "Retrying library for Python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/tools/audio/google-music-scripts/default.nix
+++ b/pkgs/tools/audio/google-music-scripts/default.nix
@@ -1,0 +1,32 @@
+{ lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "google-music-scripts";
+  version = "3.0.0";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "12risivi11z3shrgs1kpi7x6lvk113cbp3dnczw9mmqhb4mmwviy";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    appdirs
+    audio-metadata
+    click
+    click-default-group
+    google-music
+    google-music-utils
+    logzero
+    tomlkit
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/thebigmunch/google-music-scripts;
+    description = "A CLI utility for interacting with Google Music";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3045,6 +3045,8 @@ in
 
   google-compute-engine-oslogin = callPackage ../tools/virtualization/google-compute-engine-oslogin { };
 
+  google-music-scripts = callPackage ../tools/audio/google-music-scripts { };
+
   gource = callPackage ../applications/version-management/gource { };
 
   govc = callPackage ../tools/virtualization/govc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -428,6 +428,8 @@ in {
 
   logster = callPackage ../development/python-modules/logster { };
 
+  logzero = callPackage ../development/python-modules/logzero { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   manhole = callPackage ../development/python-modules/manhole { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -510,6 +510,8 @@ in {
 
   poetry = callPackage ../development/python-modules/poetry { };
 
+  pprintpp = callPackage ../development/python-modules/pprintpp { };
+
   progress = callPackage ../development/python-modules/progress { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -998,6 +998,8 @@ in {
 
   bibtexparser = callPackage ../development/python-modules/bibtexparser { };
 
+  bidict = callPackage ../development/python-modules/bidict { };
+
   binwalk = callPackage ../development/python-modules/binwalk { };
 
   binwalk-full = appendToName "full" (self.binwalk.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -772,6 +772,8 @@ in {
 
   sniffio = callPackage ../development/python-modules/sniffio { };
 
+  tenacity = callPackage ../development/python-modules/tenacity { };
+
   tokenserver = callPackage ../development/python-modules/tokenserver {};
 
   toml = callPackage ../development/python-modules/toml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1008,6 +1008,8 @@ in {
 
   bitmath = callPackage ../development/python-modules/bitmath { };
 
+  bitstruct = callPackage ../development/python-modules/bitstruct { };
+
   caldavclientlibrary-asynk = callPackage ../development/python-modules/caldavclientlibrary-asynk { };
 
   biopython = callPackage ../development/python-modules/biopython { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1254,6 +1254,8 @@ in {
 
   click-completion = callPackage ../development/python-modules/click-completion {};
 
+  click-default-group = callPackage ../development/python-modules/click-default-group { };
+
   click-didyoumean = callPackage ../development/python-modules/click-didyoumean {};
 
   click-log = callPackage ../development/python-modules/click-log {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1793,6 +1793,8 @@ in {
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 
+  google-music-proto = callPackage ../development/python-modules/google-music-proto { };
+
   gpapi = callPackage ../development/python-modules/gpapi { };
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1797,6 +1797,8 @@ in {
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 
+  google-music = callPackage ../development/python-modules/google-music { };
+
   google-music-proto = callPackage ../development/python-modules/google-music-proto { };
 
   google-music-utils = callPackage ../development/python-modules/google-music-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1799,6 +1799,8 @@ in {
 
   google-music-proto = callPackage ../development/python-modules/google-music-proto { };
 
+  google-music-utils = callPackage ../development/python-modules/google-music-utils { };
+
   gpapi = callPackage ../development/python-modules/gpapi { };
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -935,6 +935,8 @@ in {
 
   atsim_potentials = callPackage ../development/python-modules/atsim_potentials { };
 
+  audio-metadata = callPackage ../development/python-modules/audio-metadata { };
+
   audioread = callPackage ../development/python-modules/audioread { };
 
   audiotools = callPackage ../development/python-modules/audiotools { };


### PR DESCRIPTION
###### Motivation for this change

Add `google-music-scripts`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

