### PR TITLE
[PoC] fetchurl: use Software Heritage as a content addressable mirror

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -69,7 +69,8 @@ tryHashedMirrors() {
     fi
 
     for mirror in $hashedMirrors; do
-        url="$mirror/$outputHashAlgo/$outputHash"
+        outputHash_base16="$(nix-hash --to-base16 --type "$outputHashAlgo" "$outputHash")"
+        url="$(echo -n "$mirror" | sed -e "s/@outputHashAlgo@/$outputHashAlgo/g" -e "s/@outputHash@/$outputHash/g" -e "s/@outputHash_base16@/$outputHash_base16/g")"
         if "${curl[@]}" --retry 0 --connect-timeout "${NIX_CONNECT_TIMEOUT:-15}" \
             --fail --silent --show-error --head "$url" \
             --write-out "%{http_code}" --output /dev/null > code 2> log; then

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -33,6 +33,8 @@ tryDownload() {
 
     success=
 
+    if echo "$url" | grep -v softwareheritage; then break; fi
+
     # if we get error code 18, resume partial download
     while [ $curlexit -eq 18 ]; do
        # keep this inside an if statement, since on failure it doesn't abort the script
@@ -79,6 +81,7 @@ tryHashedMirrors() {
     fi
 
     for mirror in $hashedMirrors; do
+        echo $outputHash
         # TODO: handle other hash types
         outputHash_base16="$outputHash"
         if [ "$outputHashAlgo" == "sha256" ] && [ "$(echo -n $outputHash | wc -m)" -ne 64 ]; then

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -79,8 +79,11 @@ tryHashedMirrors() {
     fi
 
     for mirror in $hashedMirrors; do
-        # TODO: detect hash format
-        outputHash_base16="$(base32to16 "$outputHash")"
+        # TODO: handle other hash types
+        outputHash_base16="$outputHash"
+        if [ "$outputHashAlgo" == "sha256" ] && [ "$(echo -n $outputHash | wc -m)" -ne 64 ]; then
+            outputHash_base16="$(base32to16 "$outputHash")"
+        fi
         url="$(echo -n "$mirror" | sed -e "s/@outputHashAlgo@/$outputHashAlgo/g" -e "s/@outputHash@/$outputHash/g" -e "s/@outputHash_base16@/$outputHash_base16/g")"
         if "${curl[@]}" --retry 0 --connect-timeout "${NIX_CONNECT_TIMEOUT:-15}" \
             --fail --silent --show-error --head "$url" \

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -2,6 +2,9 @@
 
 let
 
+  # needed for nix-hash
+  inherit (import (builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/18.09.tar.gz) {}) nix;
+
   mirrors = import ./mirrors.nix;
 
   # Write the list of mirrors to a file that we can reuse between
@@ -123,7 +126,7 @@ stdenvNoCC.mkDerivation {
 
   builder = ./builder.sh;
 
-  nativeBuildInputs = [ curl ];
+  nativeBuildInputs = [ curl nix ];
 
   urls = urls_;
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -2,9 +2,6 @@
 
 let
 
-  # needed for nix-hash
-  inherit (import (builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/18.09.tar.gz) {}) nix;
-
   mirrors = import ./mirrors.nix;
 
   # Write the list of mirrors to a file that we can reuse between
@@ -126,7 +123,7 @@ stdenvNoCC.mkDerivation {
 
   builder = ./builder.sh;
 
-  nativeBuildInputs = [ curl nix ];
+  nativeBuildInputs = [ curl ];
 
   urls = urls_;
 

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -2,7 +2,10 @@
 
   # Content-addressable Nix mirrors.
   hashedMirrors = [
-    "http://tarballs.nixos.org"
+    "http://tarballs.nixos.org/@outputHashAlgo@/@outputHash@"
+
+    # sha1 and sha256 can work
+    "https://archive.softwareheritage.org/api/1/content/@outputHashAlgo@:@outputHash_base16@/raw/"
   ];
 
   # Mirrors for mirror://site/filename URIs, where "site" is


### PR DESCRIPTION
This is a proof of concept implementation of the idea from #53653.

Can be tested like this:
```nix
with import ./. {};

fetchurl {
  # simulate a dead URL (we never packaged version 1.2.9)
  url = "gopher://example.com/not_a_thing/zlib-1.2.9";

  # base32 hash as commonly used in nixpkgs
  sha256 = "08dabvnaqis3jlhyzwvh0dmz4lsq5zsmdbyjjm4fgl8yycp31avk";
}
```

```
trying https://archive.softwareheritage.org/api/1/content/sha256:73ab302ef31ed1e74895d2af56f52f5853f26b0370f3ef21954347acec5eaa21/raw/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  593k  100  593k    0     0   144k      0  0:00:04  0:00:04 --:--:--  144k
/nix/store/3ynhg01hji29wsv1g177f5sqyx6zfr91-zlib-1.2.9
```

~~To make this really work we would need to figure out how to convert hashes without "nix-hash".~~ Also this would require some kind of negotiation with Software Heritage, and, perhaps, we would need to set up some kind of caching proxy.

Obviously, do not merge this.