### PR TITLE
pythonPackages.pycairo: 1.16.3 -> 1.18.0

### DIFF
--- a/pkgs/development/python-modules/pycairo/default.nix
+++ b/pkgs/development/python-modules/pycairo/default.nix
@@ -1,35 +1,39 @@
-{ lib, fetchFromGitHub, python, buildPythonPackage, pytest, pkgconfig, cairo, xlibsWrapper, isPyPy }:
+{ lib, fetchFromGitHub, meson, ninja, buildPythonPackage, pytest, pkgconfig, cairo, xlibsWrapper, isPy33, isPy3k }:
 
 buildPythonPackage rec {
   pname = "pycairo";
-  version = "1.16.3";
+  version = "1.18.0";
 
-  disabled = isPyPy;
+  format = "other";
+
+  disabled = isPy33;
 
   src = fetchFromGitHub {
     owner = "pygobject";
     repo = "pycairo";
     rev = "v${version}";
-    sha256 = "0clk6wrfls3fa1xrn844762qfaw6gs4ivwkrfysidbzmlbxhpngl";
+    sha256 = "0k266cf477j74v7mv0d4jxaq3wx8b7qa85qgh68cn094gzaasqd9";
   };
 
-  # We need to create the pkgconfig file but it cannot be installed as a wheel since wheels
-  # are supposed to be relocatable and do not support --prefix option
-  buildPhase = ''
-    ${python.interpreter} setup.py build
-  '';
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
 
-  installPhase = ''
-    ${python.interpreter} setup.py install --skip-build --prefix="$out" --optimize=1
-  '';
+  buildInputs = [
+    cairo
+    xlibsWrapper
+  ];
 
-  checkPhase = ''
-    ${python.interpreter} setup.py test
-  '';
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ python cairo xlibsWrapper ];
   checkInputs = [ pytest ];
 
-  meta.platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  mesonFlags = [ "-Dpython=${if isPy3k then "python3" else "python"}" ];
+
+  meta = with lib; {
+    description = "Python 2/3 bindings for cairo";
+    homepage = https://pycairo.readthedocs.io/;
+    license = with licenses; [ lgpl2 mpl11 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
 }


### PR DESCRIPTION
Changelog: https://pycairo.readthedocs.io/en/latest/changelog.html

###### Motivation for this change
They switched to meson, this expression looks a lot cleaner because of it.
Though I wonder if this will build for pypy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

