### PR TITLE
darktable: 2.4.4 -> 2.6.0

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -3,16 +3,16 @@
 , ilmbase, gtk3, intltool, lcms2, lensfun, libX11, libexif, libgphoto2, libjpeg
 , libpng, librsvg, libtiff, openexr, osm-gps-map, pkgconfig, sqlite, libxslt
 , openjpeg, lua, pugixml, colord, colord-gtk, libwebp, libsecret, gnome3
-, ocl-icd, pcre, gtk-mac-integration
+, ocl-icd, pcre, gtk-mac-integration, isocodes
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.4";
+  version = "2.6.0";
   name = "darktable-${version}";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "0kdhmiw4wxk2w9v2hms9yk8nl4ymdshnqyj0l07nivzzr6w20hwn";
+    sha256 = "0y04cx0a0rwdclmn16f5y0z2vnm7yxly291gzjgdhcn59a77sga8";
   };
 
   nativeBuildInputs = [ cmake ninja llvm pkgconfig intltool perl desktop-file-utils wrapGAppsHook ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     cairo curl exiv2 glib gtk3 ilmbase lcms2 lensfun libexif
     libgphoto2 libjpeg libpng librsvg libtiff openexr sqlite libxslt
     libsoup graphicsmagick json-glib openjpeg lua pugixml
-    libwebp libsecret gnome3.adwaita-icon-theme osm-gps-map pcre
+    libwebp libsecret gnome3.adwaita-icon-theme osm-gps-map pcre isocodes
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     colord colord-gtk libX11 ocl-icd
   ] ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration;


### PR DESCRIPTION
###### Motivation for this change

Update. Note however that upstream recommends to additionally pass `-DRAWSPEED_ENABLE_LTO=ON` to enable partial LTO which did not build for me and needs some more work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @goibhniu @rickynils @flosse @mrVanDalo
