### PR TITLE
nixos-rebuild: allow to override builders

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -326,7 +326,7 @@ $ ./result/bin/run-*-vm
      </term>
      <listitem>
        <para>
-         Allow to specify remote builders ad-hoc for building the new system.
+         Allow ad-hoc remote builders for building the new system.
          This requires the user executing <command>nixos-rebuild</command> (usually
          root) to be configured as a trusted user in the Nix daemon. This can be
          achived by using the <literal>nix.trustedUsers</literal> NixOS option.

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -329,7 +329,7 @@ $ ./result/bin/run-*-vm
          Allow ad-hoc remote builders for building the new system.
          This requires the user executing <command>nixos-rebuild</command> (usually
          root) to be configured as a trusted user in the Nix daemon. This can be
-         achived by using the <literal>nix.trustedUsers</literal> NixOS option.
+         achieved by using the <literal>nix.trustedUsers</literal> NixOS option.
          Examples values for that option are described in the
          <literal>Remote builds chapter<literal> in the Nix manual,
          (i.e. <command>--builders "ssh://bigbrother x86_64-linux"</command>).

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -13,35 +13,35 @@
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>
-   <command>nixos-rebuild</command><group choice='req'> 
+   <command>nixos-rebuild</command><group choice='req'>
    <arg choice='plain'>
     <option>switch</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>boot</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>test</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>build</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>dry-build</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>dry-activate</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>build-vm</option>
    </arg>
-    
+
    <arg choice='plain'>
     <option>build-vm-with-bootloader</option>
    </arg>
@@ -50,29 +50,33 @@
    <arg>
     <option>--upgrade</option>
    </arg>
-    
+
    <arg>
     <option>--install-bootloader</option>
    </arg>
-    
+
    <arg>
     <option>--no-build-nix</option>
    </arg>
-    
+
    <arg>
     <option>--fast</option>
    </arg>
-    
+
    <arg>
     <option>--rollback</option>
    </arg>
+   <arg>
+     <option>--builders</option>
+     <replaceable>builder-spec</replaceable>
+   </arg>
    <sbr />
    <arg>
-    <group choice='req'> 
+    <group choice='req'>
     <arg choice='plain'>
      <option>--profile-name</option>
     </arg>
-     
+
     <arg choice='plain'>
      <option>-p</option>
     </arg>
@@ -314,6 +318,27 @@ $ ./result/bin/run-*-vm
       <filename>/nix/var/nix/profiles/system</filename>.)
      </para>
     </listitem>
+   </varlistentry>
+   <varlistentry>
+     <term>
+       <option>--builders</option>
+       <replaceable>builder-spec</replaceable>
+     </term>
+     <listitem>
+       <para>
+         Allow to specify remote builders ad-hoc for building the new system.
+         This requires the user executing <command>nixos-rebuild</command> (usually
+         root) to be configured as a trusted user in the Nix daemon. This can be
+         achived by using the <literal>nix.trustedUsers</literal> NixOS option.
+         Examples values for that option are described in the
+         <literal>Remote builds chapter<literal> in the Nix manual,
+         (i.e. <command>--builders "ssh://bigbrother x86_64-linux"</command>).
+         By specifying an empty string existing builders specified in
+         <filename>/etc/nix/machines</filename> can be ignored:
+         <command>--builders ""</command> for example when they are not
+         reachable due to network connectivity.
+       </para>
+     </listitem>
    </varlistentry>
    <varlistentry>
     <term>

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -53,11 +53,11 @@ while [ "$#" -gt 0 ]; do
         repair=1
         extraBuildFlags+=("$i")
         ;;
-      --max-jobs|-j|--cores|-I)
+      --max-jobs|-j|--cores|-I|--builders)
         j="$1"; shift 1
         extraBuildFlags+=("$i" "$j")
         ;;
-      --show-trace|--no-build-hook|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair|--no-build-output|-Q|-j*)
+      --show-trace|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair|--no-build-output|-Q|-j*)
         extraBuildFlags+=("$i")
         ;;
       --option)


### PR DESCRIPTION
Since nix 2.0 the no-build-hook option was replaced by the builders options
that allows to override remote builders ad-hoc.
Since it is useful to disable remote builders updating nixos without network,
this commit reintroduces the option.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

