### PR TITLE
Use a deterministic seed for kernel RANDSTRUCT, and re-enable in hardened kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -125,6 +125,11 @@ ${optionalString (versionAtLeast version "4.20") ''
   GCC_PLUGIN_STACKLEAK y # A port of the PaX stackleak plugin
 ''}
 
+${optionalString (versionAtLeast version "4.13") ''
+  GCC_PLUGIN_RANDSTRUCT y # A port of the PaX randstruct plugin
+  GCC_PLUGIN_RANDSTRUCT_PERFORMANCE y
+''}
+
 # Disable various dangerous settings
 ACPI_CUSTOM_METHOD n # Allows writing directly to physical memory
 PROC_KCORE n # Exposes kernel text image layout

--- a/pkgs/os-specific/linux/kernel/randstruct-provide-seed.patch
+++ b/pkgs/os-specific/linux/kernel/randstruct-provide-seed.patch
@@ -1,0 +1,12 @@
+diff -ru a/scripts/gcc-plugins/gen-random-seed.sh b/scripts/gcc-plugins/gen-random-seed.sh
+--- a/scripts/gcc-plugins/gen-random-seed.sh	2019-01-11 11:50:29.228258920 +0100
++++ b/scripts/gcc-plugins/gen-random-seed.sh	2019-01-11 12:18:33.555902720 +0100
+@@ -2,7 +2,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ 
+ if [ ! -f "$1" ]; then
+-	SEED=`od -A n -t x8 -N 32 /dev/urandom | tr -d ' \n'`
++	SEED="NIXOS_RANDSTRUCT_SEED"
+ 	echo "const char *randstruct_seed = \"$SEED\";" > "$1"
+ 	HASH=`echo -n "$SEED" | sha256sum | cut -d" " -f1 | tr -d ' \n'`
+ 	echo "#define RANDSTRUCT_HASHED_SEED \"$HASH\"" > "$2"


### PR DESCRIPTION
###### Motivation for this change
First step in addressing #53592. Does not allow users to configure their own seed just yet, but fixes the incompatibility issue with out-of-tree modules.

I think I'll attempt to contribute something upstream that adds an environment variable for users to inject a non-random RANDSTRUCT seed. I've looked through a few distros and everyone does it differently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

