### PR TITLE
allow extending PYTHONPATH for datadog-agent

### DIFF
--- a/pkgs/tools/networking/dd-agent/6.nix
+++ b/pkgs/tools/networking/dd-agent/6.nix
@@ -63,7 +63,7 @@ in buildGoPackage rec {
     cp -R $src/pkg/status/dist/templates $bin/share/datadog-agent
 
     wrapProgram "$bin/bin/agent" \
-      --set PYTHONPATH "$bin/${python.sitePackages}" \
+      --set PYTHONPATH "$bin/${python.sitePackages}:$PYTHONPATH" \
       --prefix LD_LIBRARY_PATH : ${systemd.lib}/lib
   '';
 


### PR DESCRIPTION
should be useful to allow running datadog checks that import
different python libs.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

