### PR TITLE
ghc844: update hash for d8495549ba9d194815c2d0eaee6797fc7c00756a patch

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation (rec {
     ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch
     ++ stdenv.lib.optional (targetPlatform.isAarch32 || targetPlatform.isAarch64) (fetchpatch {
       url = "https://git.haskell.org/ghc.git/patch/d8495549ba9d194815c2d0eaee6797fc7c00756a";
-      sha256 = "1czx12qcl088vjn7mqxvyja4b2ia2n09c28br8c777fd0xk069pm";
+      sha256 = "1yjcma507c609bcim4rnxq0gaj2dg4d001jklmbpbqpzqzxkn5sz";
     });
 
   postPatch = "patchShebangs .";


### PR DESCRIPTION
###### Motivation for this change

Hash for one of GHC patches has changed, causing `nix-shell -p pkgsCross.aarch64-multiplatform.ghc` to fail with hash mismatch. Change doesn't seem to be malicious.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

