### PR TITLE
[RFC] Python library wrappers

### DIFF
--- a/pkgs/development/python-modules/matplotlib/add_python_wrapper.py
+++ b/pkgs/development/python-modules/matplotlib/add_python_wrapper.py
@@ -1,0 +1,48 @@
+DOCSTRING_DELIM = '"""'
+
+def split_module_docstring(lines):
+    module_docstring = []
+    rest = []
+    if not lines[0].startswith(DOCSTRING_DELIM):
+        return ([], lines)
+
+    if '"""' in lines[0][3:]:
+        return ([lines[0]], lines[1:])
+
+    end_index = 1
+    for line in lines[1:]:
+        end_index += 1
+        if '"""' in line:
+            break
+
+    return (lines[:end_index], lines[end_index:])
+
+def inject_lines(filename, addition):
+    with open(filename, "r+") as f:
+        old = f.readlines()
+        (docstring, rest) = split_module_docstring(old)
+        f.seek(0)
+        f.write("".join(docstring + addition + rest))
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Wrap python libraries')
+    parser.add_argument('file', type=str, help='File to wrap')
+    parser.add_argument('-p', '--prefix', type=str, action='append', dest='prefixes', nargs=3, default=[])
+
+    args = parser.parse_args()
+    lines_to_add = [
+        'import os\n'
+    ]
+    for prefix in args.prefixes:
+        var_to_prefix = prefix[0]
+        sep = prefix[1]
+        value = prefix[2]
+        lines_to_add += [
+            # TODO add escaping
+            f'os.environ["{var_to_prefix}"] = "{value}{sep}" + os.environ.get("{var_to_prefix}", "")\n'
+        ]
+    inject_lines(args.file, lines_to_add)
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -2,13 +2,15 @@
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
 , enableGhostscript ? true, ghostscript ? null, gtk3
+, pango, gdk_pixbuf, atk
 , enableGtk2 ? false, pygtk ? null, gobject-introspection
-, enableGtk3 ? false, cairo
+, enableGtk3 ? true, cairo
 , enableTk ? false, tcl ? null, tk ? null, tkinter ? null, libX11 ? null
 , enableQt ? false, pyqt4
 , libcxx
 , Cocoa
 , pythonOlder
+, python3
 }:
 
 assert enableGhostscript -> ghostscript != null;
@@ -38,6 +40,13 @@ buildPythonPackage rec {
   buildInputs = [ python which sphinx stdenv ]
     ++ stdenv.lib.optional enableGhostscript ghostscript
     ++ stdenv.lib.optional stdenv.isDarwin [ Cocoa ];
+
+  preBuild = let
+    gi_typelib_path = stdenv.lib.makeSearchPath "lib/girepository-1.0" [ gtk3 pango.out gdk_pixbuf atk ];
+  in ''
+    ${python3.interpreter} ${./add_python_wrapper.py} 'lib/matplotlib/__init__.py' \
+      --prefix GI_TYPELIB_PATH : ${gi_typelib_path}
+  '';
 
   propagatedBuildInputs =
     [ cycler dateutil nose numpy pyparsing tornado freetype kiwisolver


### PR DESCRIPTION
###### Motivation for this change

Some python libraries require specific environment variables to be set. One example are those that use gtk libraries. On most other distros, those environment variables would either be set in the global environment or the dependencies would be found in standard paths. Since that is not the case for nixos, we need to hardcode those environment variables into the libraries.

We have `makeWrapper` for binaries. Here I try (purely as a proof of concept, kept as simple as possible) to add a `makePythonWrapper` function that does the same for python libraries. In particular, this would make the gtk3 matplotlib backend usable without using `nix-shell` and without manually setting environment variables.

```
python3 -c 'import matplotlib.pyplot as p; p.switch_backend("gtk3agg")'
```

Should now succeed. This works because python always executes all parent modules before importing a module. So by adding some code to the top of the topmost module (taking care to leave module docstrings in tact), we can set environment variables as soon as a module is imported.

Some next steps/improvements would be:

- factor out `makePythonWrapper`
- provide the full functionality `makeWrapper` provides
- automatically determine the right `__init__.py` to modify
- provide a GTK setup hook or maybe adapt the existing one

What do you think?

CC @jtojnar @FRidh 

(This is *not* about enabling the gtk backend in matplotlib by default, that is just for easier testing)