### PR TITLE
linux_rpi: allow modDirVersion override

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -26,7 +26,7 @@ lib.overrideDerivation (buildLinux (args // rec {
   } // (args.features or {});
 
   extraMeta.hydraPlatforms = [ "aarch64-linux" ];
-})) (oldAttrs: {
+} // (args.argsOverride or {}))) (oldAttrs: {
   postConfigure = ''
     # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.
     sed -i $buildRoot/.config -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'


### PR DESCRIPTION
###### Motivation for this change
I like having a consistent kernel version while `overrideDerivation` doesn't seem to override `modDirVersion`.

4.19.14 boots on raspberry pi 3 b+.

```nix
    kernelPackages = pkgs.linuxPackagesFor (pkgs.linux_rpi.override {
      argsOverride = rec {
        version = "${modDirVersion}-20190109";
        modDirVersion = "4.19.14";

        src = pkgs.fetchFromGitHub {
          owner = "raspberrypi";
          repo = "linux";
          rev = "7e312d57b01683ee93699fdac1121d5cc62fb211";
          sha256 = "0wci548pwkcjd7zjm17m3d8lcvk0m5x8p90sd516mpl06ghyf9iy";
        };
      };
    });
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

