### PR TITLE
pythonPackages.pyment: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/pyment/default.nix
+++ b/pkgs/development/python-modules/pyment/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pyment";
+  version = "0.3.3";
+
+  src = fetchPypi {
+    pname = "Pyment";
+    inherit version;
+    sha256 = "951a4c52d6791ccec55bc739811169eed69917d3874f5fe722866623a697f39d";
+  };
+
+  # Tests are not included in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/dadadel/pyment;
+    description = "Create, update or convert docstrings in existing Python files, managing several styles";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jethro ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3608,6 +3608,8 @@ in {
 
   pygpgme = callPackage ../development/python-modules/pygpgme { };
 
+  pyment = callPackage ../development/python-modules/pyment { };
+
   pylint = if isPy3k then callPackage ../development/python-modules/pylint { }
            else callPackage ../development/python-modules/pylint/1.9.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
init new package pyment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

