### PR TITLE
python3.pkgs.tinycss: fix build

### DIFF
--- a/pkgs/development/python-modules/tinycss/default.nix
+++ b/pkgs/development/python-modules/tinycss/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , pytest
 , python
+, cython
 , cssutils
 , isPyPy
 }:
@@ -18,6 +19,17 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ cssutils ];
+  nativeBuildInputs = [
+    cython
+  ];
+
+  preBuild = ''
+    # Force cython to re-generate this file. If it is present, cython will
+    # think it is "up to date" even though it was generated with an older,
+    # incompatible version of cython. See
+    # https://github.com/Kozea/tinycss/issues/17.
+    rm tinycss/speedups.c
+  '';
 
   checkPhase = ''
     py.test $out/${python.sitePackages}


### PR DESCRIPTION
###### Motivation for this change

The build was broken by the python 3.7 switch, which caused an
incompatible change in the way cython generates files:

https://github.com/Kozea/tinycss/issues/17

This is solved by removing the pre-generated file and re-generating it
at build time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

