### PR TITLE
python.pkgs.pygal: fix build

### DIFF
--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -5,6 +5,7 @@
 , flask
 , pyquery
 , pytest
+, pytestrunner
 , cairosvg
 , tinycss
 , cssselect
@@ -22,7 +23,24 @@ buildPythonPackage rec {
     sha256 = "9204f05380b02a8a32f9bf99d310b51aa2a932cba5b369f7a4dc3705f0a4ce83";
   };
 
-  buildInputs = [ flask pyquery pytest ];
+  buildInputs = [
+    flask
+    pyquery
+
+    # Should be a check input, but upstream lists it under "setup_requires".
+    # https://github.com/Kozea/pygal/issues/430
+    pytestrunner
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  preCheck = ''
+    # necessary on darwin to pass the testsuite
+    export LANG=en_US.UTF-8
+  '';
+
   propagatedBuildInputs = [ cairosvg tinycss cssselect ]
     ++ stdenv.lib.optionals (!isPyPy) [ lxml ];
 


### PR DESCRIPTION
###### Motivation for this change

Missing build input.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

