### PR TITLE
marvin: init at 19.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1586,6 +1586,11 @@
     email = "eocallaghan@alterapraxis.com";
     name = "Edward O'Callaghan";
   };
+  fusion809 = {
+    email = "brentonhorne77@gmail.com";
+    github = "fusion809";
+    name = "Brenton Horne";
+  };
   fuuzetsu = {
     email = "fuuzetsu@fuuzetsu.co.uk";
     github = "fuuzetsu";

--- a/pkgs/applications/science/chemistry/marvin/LicenseManager.desktop
+++ b/pkgs/applications/science/chemistry/marvin/LicenseManager.desktop
@@ -1,0 +1,9 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Type=Application
+Name=ChemAxon License Manager
+Exec=@out@/bin/LicenseManager
+Icon=LicenseManager
+Categories=Education;Science;Chemistry;
+StartupWMClass=com-install4j-runtime-launcher-UnixLauncher
+Comment=License manager for ChemAxon software like MarvinSketch

--- a/pkgs/applications/science/chemistry/marvin/MarvinSketch.desktop
+++ b/pkgs/applications/science/chemistry/marvin/MarvinSketch.desktop
@@ -1,0 +1,10 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Type=Application
+Name=MarvinSketch
+Exec=@out@/bin/msketch %f
+Icon=MarvinSketch
+MimeType=text/xml;text/plain;chemical/x-cml;chemical/x-mdl-molfile;chemical/x-mdl-sdfile;chemical/x-mol2;chemical/x-pdb;chemical/x-xyz;chemical/x-mdl-rdfile;chemical/x-mdl-rxnfile;chemical/x-inchi;
+Categories=Education;Science;Chemistry;
+StartupWMClass=com-install4j-runtime-launcher-UnixLauncher
+Comment=Molecular modelling, analysis and structure drawing program

--- a/pkgs/applications/science/chemistry/marvin/MarvinView.desktop
+++ b/pkgs/applications/science/chemistry/marvin/MarvinView.desktop
@@ -1,0 +1,10 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Type=Application
+Name=MarvinView
+Exec=@out@/bin/mview %f
+Icon=MarvinView
+Comment=Molecule viewing program
+MimeType=text/xml;text/plain;chemical/x-cml;chemical/x-mdl-molfile;chemical/x-mdl-sdfile;chemical/x-mol2;chemical/x-pdb;chemical/x-xyz;chemical/x-mdl-rdfile;chemical/x-mdl-rxnfile;chemical/x-inchi;
+Categories=Education;Science;Chemistry;
+StartupWMClass=com-install4j-runtime-launcher-UnixLauncher

--- a/pkgs/applications/science/chemistry/marvin/default.nix
+++ b/pkgs/applications/science/chemistry/marvin/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, dpkg, makeWrapper, coreutils, gawk, gnugrep, gnused, jre }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "marvin";
+  version = "19.1.0";
+
+  src = fetchurl {
+    name = "marvin-${version}.deb";
+    url = "http://dl.chemaxon.com/marvin/${version}/marvin_linux_${versions.majorMinor version}.deb";
+    sha256 = "1ccsimfvms5q4prjyk6sg5hsc3hkcjjfq3gl7jjm8dgd2173zzyc";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src opt
+  '';
+
+  installPhase = ''
+    wrapBin() {
+      makeWrapper $1 $out/bin/$(basename $1) \
+        --set INSTALL4J_JAVA_HOME "${jre}" \
+        --prefix PATH : ${makeBinPath [ coreutils gawk gnugrep gnused ]}
+    }
+    cp -r opt $out
+    mkdir -p $out/bin $out/share/pixmaps $out/share/applications
+    for name in LicenseManager MarvinSketch MarvinView; do
+      wrapBin $out/opt/chemaxon/marvinsuite/$name
+      ln -s {$out/opt/chemaxon/marvinsuite/.install4j,$out/share/pixmaps}/$name.png
+    done
+    for name in cxcalc cxtrain evaluate molconvert mview msketch; do
+      wrapBin $out/opt/chemaxon/marvinsuite/bin/$name
+    done
+    ${concatStrings (map (name: ''
+      substitute ${./. + "/${name}.desktop"} $out/share/applications/${name}.desktop --subst-var out
+    '') [ "LicenseManager" "MarvinSketch" "MarvinView" ])}
+  '';
+
+  meta = {
+    description = "A chemical modelling, analysis and structure drawing program";
+    homepage = https://chemaxon.com/products/marvin;
+    maintainers = with maintainers; [ fusion809 ];
+    license = licenses.unfree;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21395,6 +21395,8 @@ in
 
   jmol = callPackage ../applications/science/chemistry/jmol { };
 
+  marvin = callPackage ../applications/science/chemistry/marvin { };
+
   molden = callPackage ../applications/science/chemistry/molden { };
 
   octopus = callPackage ../applications/science/chemistry/octopus { openblas=openblasCompat; };


### PR DESCRIPTION
###### Motivation for this change
The Marvin Suite is one of the finest skeletal structure drawing programs that is available free of cost to the end user. There are some features one must pay for, but most of them are advanced features that many users, like myself, don't really care about. Here's a screenshot showing it running, opened to a molecule of clozapine:

![screenshot_20190112_220048](https://user-images.githubusercontent.com/4717341/51072949-93701a80-16b5-11e9-8841-1ea678fbe4da.png)

. I have added myself to the maintainers list, as this package, of course, needs a maintainer. 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Area that could do with some improvement
[Line 9 of the default.nix](https://github.com/fusion809/nixpkgs/blob/3f51913ca67eba6216d8458126cb2aafd0d0105c/pkgs/applications/science/chemistry/marvin/default.nix#L9) file could do with some improvement. Namely, if anyone knows a way I could let the nix file determine the version 19.1 from the full version 19.1.0, and use it in the URL, it'd be much appreciated :). I've tried using `${version%.?}` and sadly, it merely caused Nix to give the error message:

```bash
error: syntax error, unexpected $undefined, expecting '}', at /home/fusion809/GitHub/mine/packaging/nixpkgs/pkgs/applications/science/chemistry/marvin/default.nix:9:77
```