### PR TITLE
bazel-remote: init at 2019-01-12

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -50,6 +50,7 @@ in stdenv.mkDerivation (fBuildAttrs // {
 
       # Patching markers to make them deterministic
       sed -i 's, -\?[0-9][0-9]*$, 1,' $bazelOut/external/\@*.marker
+      sed -i '/^ENV:TMP.*/d' $bazelOut/external/\@*.marker
 
       # Remove all vcs files
       rm -rf $(find $bazelOut/external -type d -name .git)

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -1,0 +1,81 @@
+{ buildBazelPackage
+, cacert
+, fetchFromGitHub
+, fetchpatch
+, git
+, go
+, stdenv
+}:
+
+buildBazelPackage rec {
+  name = "bazel-remote-${version}";
+  version = "2019-01-12";
+
+  src = fetchFromGitHub {
+    owner = "buchgr";
+    repo = "bazel-remote";
+    rev = "3f65b6ccf69e223950c77275a743d0d3a04a8583";
+    sha256 = "0fklrlylmc55yzhm3m1f211x5gmk7hpqjb7k5kml7n3gw3npbjda";
+  };
+
+  nativeBuildInputs = [ go git ];
+
+  bazelTarget = "//:bazel-remote";
+
+  fetchAttrs = {
+    preBuild = ''
+      patchShebangs .
+
+      # tell rules_go to use the Go binary found in the PATH
+      sed -e 's:go_register_toolchains():go_register_toolchains(go_version = "host"):g' -i WORKSPACE
+
+      # update gazelle to work around https://github.com/golang/go/issues/29850
+      sed -e 's,https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz,https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz,g' -i WORKSPACE
+      sed -e 's,6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d,7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb,g' -i WORKSPACE
+
+      # tell rules_go to invoke GIT with custom CAINFO path
+      export GIT_SSL_CAINFO="${cacert}/etc/ssl/certs/ca-bundle.crt"
+    '';
+
+    preInstall = ''
+      # Remove the go_sdk (it's just a copy of the go derivation) and all
+      # references to it from the marker files. Bazel does not need to download
+      # this sdk because we have patched the WORKSPACE file to point to the one
+      # currently present in PATH. Without removing the go_sdk from the marker
+      # file, the hash of it will change anytime the Go derivation changes and
+      # that would lead to impurities in the marker files which would result in
+      # a different sha256 for the fetch phase.
+      rm -rf $bazelOut/external/{go_sdk,\@go_sdk.marker}
+      sed -e '/^FILE:@go_sdk.*/d' -i $bazelOut/external/\@*.marker
+
+      # Remove the gazelle tools, they contain go binaries that are built
+      # non-deterministically. As long as the gazelle version matches the tools
+      # should be equivalent.
+      rm -rf $bazelOut/external/{bazel_gazelle_go_repository_tools,\@bazel_gazelle_go_repository_tools.marker}
+      sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
+    '';
+
+    sha256 = "1wvyv3w5y6vj6qs6v5qyd356j1lxc3mf7n3j2pcib1bqmx3igw35";
+  };
+
+  buildAttrs = {
+    preBuild = ''
+      patchShebangs .
+
+      # tell rules_go to use the Go binary found in the PATH
+      sed -e 's:go_register_toolchains():go_register_toolchains(go_version = "host"):g' -i WORKSPACE
+    '';
+
+    installPhase = ''
+      install -Dm755 bazel-bin/*_pure_stripped/bazel-remote $out/bin/bazel-remote
+    '';
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/buchgr/bazel-remote;
+    description = "A remote HTTP/1.1 cache for Bazel.";
+    license = licenses.asl20;
+    maintainers = [ maintainers.uri-canva ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8396,6 +8396,8 @@ in
     buildBazelPackage = buildBazelPackage.override { enableNixHacks = false; };
   };
 
+  bazel-remote = callPackage ../development/tools/build-managers/bazel/bazel-remote { };
+
   bazel-watcher = callPackage ../development/tools/bazel-watcher { };
 
   buildBazelPackage = callPackage ../build-support/build-bazel-package { };


### PR DESCRIPTION
###### Motivation for this change

Adds `bazel-remote`. This the implementation for a bazel cache http backend the official docs refer to, though it's experimental: https://docs.bazel.build/versions/master/remote-caching.html#bazel-remote-cache. It's authored by a member of the Bazel team, even though it's not published under the `bazelbuild` org because it's not officially supported. There is no officially supported self-hostable caching backend though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

