### PR TITLE
saleae-logic: 1.2.10 -> 1.2.28

### DIFF
--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -9,7 +9,7 @@
 { stdenv, fetchurl, unzip, glib, libSM, libICE, gtk2, libXext, libXft
 , fontconfig, libXrender, libXfixes, libX11, libXi, libXrandr, libXcursor
 , freetype, libXinerama, libxcb, zlib, pciutils
-, makeDesktopItem, xkeyboardconfig, runtimeShell
+, makeDesktopItem, xkeyboardconfig, dbus, runtimeShell, libGL
 }:
 
 let
@@ -17,30 +17,23 @@ let
   libPath = stdenv.lib.makeLibraryPath [
     glib libSM libICE gtk2 libXext libXft fontconfig libXrender libXfixes libX11
     libXi libXrandr libXcursor freetype libXinerama libxcb zlib stdenv.cc.cc.lib
+    dbus libGL
   ];
 
 in
 
+assert stdenv.hostPlatform.system == "x86_64-linux";
+
 stdenv.mkDerivation rec {
   pname = "saleae-logic";
-  version = "1.2.10";
+  version = "1.2.28";
   name = "${pname}-${version}";
 
-  src =
-    if stdenv.hostPlatform.system == "i686-linux" then
-      fetchurl {
-        name = "saleae-logic-${version}-32bit.zip";
-        url = "http://downloads.saleae.com/logic/${version}/Logic%20${version}%20(32-bit).zip";
-        sha256 = "1dyrj07cgj2fvwi1sk97vady9ri8f8n7mxy9zyzmw9isngs7bmll";
-      }
-    else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        name = "saleae-logic-${version}-64bit.zip";
-        url = "http://downloads.saleae.com/logic/${version}/Logic%20${version}%20(64-bit).zip";
-        sha256 = "1skx2pfnic7pyss7c69qb7kg2xvflpxf112xkf9awk516dw1w4h7";
-      }
-    else
-      throw "Saleae Logic software requires i686-linux or x86_64-linux";
+  src = fetchurl {
+    name = "saleae-logic-${version}-64bit.zip";
+    url = "http://downloads.saleae.com/logic/${version}/Logic%20${version}%20(64-bit).zip";
+    sha256 = "0apq8hmn39k0ads4xy8iyy9rp8bvia60mh7a944rk1gjpqv227g5";
+  };
 
   desktopItem = makeDesktopItem {
     name = "saleae-logic";
@@ -61,7 +54,15 @@ stdenv.mkDerivation rec {
 
     # Patch it
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/Logic"
-    patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$out/Logic"
+    for bin in "$out/Logic"              \
+               "$out/libQt5Widgets.so.5" \
+               "$out/libQt5Gui.so.5"     \
+               "$out/libQt5Core.so.5"    \
+               "$out/libQt5Network.so.5" ; do
+        patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64:${libPath}:\$ORIGIN/Analyzers:\$ORIGIN" "$bin"
+    done
+
+    patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:${stdenv.cc.cc.lib}/lib64:${libPath}:\$ORIGIN/../" "$out/platforms/libqxcb.so"
 
     # Build the LD_PRELOAD library that makes Logic work from a read-only directory
     mkdir -p "$out/lib"
@@ -91,7 +92,7 @@ stdenv.mkDerivation rec {
     description = "Software for Saleae logic analyzers";
     homepage = http://www.saleae.com/;
     license = licenses.unfree;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The older 1.2.10 version does not support new Saleae devices well, like Saleae Logic Pro 16.

###### Things done

i686 platform was removed because Saleae stopped providing 32-bit
builds since 1.2.11.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

