### PR TITLE
mediathekview: 9 -> 13.2.1

### DIFF
--- a/pkgs/applications/video/mediathekview/default.nix
+++ b/pkgs/applications/video/mediathekview/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, jre, unzip }:
+{ stdenv, fetchurl, oraclejre, gnutar }:
 
 stdenv.mkDerivation {
-  name = "mediathekview-9";
+  name = "mediathekview-13.2.1";
   src = fetchurl {
-    url = "mirror://sourceforge/zdfmediathk/MediathekView_9.zip";
-    sha256 = "1wff0igr33z9p1mjw7yvb6658smdwnp22dv8klz0y8qg116wx7a4";
+    url = "https://github.com/mediathekview/MediathekView/releases/download/13.2.1/MediathekView-13.2.1.tar.gz";
+    sha256 = "11wg6klviig0h7pprfaygamsgqr7drqra2s4yxgfak6665033l2a";
   };
   unpackPhase = "true";
 
-  buildInputs = [ unzip ];
+  buildInputs = [ gnutar ];
   
   # Could use some more love
   # Maybe we can also preconfigure locations for vlc and the others.
@@ -16,10 +16,10 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     mkdir -p $out/opt/mediathekview
     cd $out/opt/mediathekview
-    unzip $src
+    tar xf $src --strip 1
     find . -iname '*.exe' -delete
-    sed -i -e 's, java, ${jre}/bin/java,' MediathekView__Linux.sh
-    ln -s $out/opt/mediathekview/MediathekView__Linux.sh $out/bin/mediathekview
+    sed -i -e 's, java, ${oraclejre}/bin/java,' MediathekView.sh
+    ln -s $out/opt/mediathekview/MediathekView.sh $out/bin/mediathekview
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Mediathekview has been out of date for a while. The project has its own website now https://mediathekview.de/ (warning its in german). This is my first contribution to nixpkgs so I appologize for any inconvenience in advance. I also know that this is a litte bit of a niche thing. 

###### Things done
Upgrade is from version 9 to 13.2.1. I also took the liberty to switch us to tar, since both releases are available. Further I specified oraclejre, instead of jre to avoid issues.
I kept the maintainer as is.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ x ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

