### PR TITLE
python.pkgs.glances: add graph support

### DIFF
--- a/pkgs/development/python-modules/glances/default.nix
+++ b/pkgs/development/python-modules/glances/default.nix
@@ -2,7 +2,11 @@
 , psutil, setuptools, bottle, batinfo, pysnmp
 , hddtemp
 , unittest2
+# disabled by default since it triples the closure size (100MB -> 300MB)
+, graphSupport ? false, pygal ? null
 }:
+
+assert graphSupport -> pygal != null;
 
 buildPythonPackage rec {
   name = "glances-${version}";
@@ -22,7 +26,16 @@ buildPythonPackage rec {
   doCheck = true;
 
   buildInputs = [ unittest2 ];
-  propagatedBuildInputs = [ psutil setuptools bottle batinfo pysnmp hddtemp ];
+  propagatedBuildInputs = [
+    psutil
+    setuptools
+    bottle
+    batinfo
+    pysnmp
+    hddtemp
+  ] ++ (lib.optionals graphSupport [
+    pygal
+  ]);
 
   preConfigure = ''
     sed -i 's/data_files\.append((conf_path/data_files.append(("etc\/glances"/' setup.py;


### PR DESCRIPTION
###### Motivation for this change

Makes it possible to generate system monitoring graphs. As mentioned in the inline commit, enabling this by default would lead to a significant closure size incerase:

```
with graph: /nix/store/37wp9rz60sk3cv6hvq282hhgnl89yf73-python3.7-glances-3.0.2       348 277 920
w/o  graph: /nix/store/5m50ba3qlfb2bra5jj098hy4y1pmdqk5-python3.7-glances-3.0.2       128 647 560
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

