### PR TITLE
enpass: 5.6.5 -> 6.0.1

### DIFF
--- a/pkgs/tools/security/enpass/data.json
+++ b/pkgs/tools/security/enpass/data.json
@@ -1,12 +1,12 @@
 {
   "amd64": {
-    "path": "pool/main/e/enpass/enpass_5.6.5_amd64.deb", 
-    "sha256": "c7529b745aa462b56eac17af6fe88d4c1610fd2f446d222aaad9510f19212a7d", 
-    "version": "5.6.5"
+    "path": "pool/main/e/enpass/enpass_6.0.1.239_amd64.deb", 
+    "sha256": "408a2bb318564307607f13b52fec7667f425c01ac40cbe345ebfa191ab1479ba", 
+    "version": "6.0.1.239"
   }, 
   "i386": {
-    "path": "pool/main/e/enpass/enpass_5.6.5_i386.deb", 
-    "sha256": "de46e27d5552dcd9d72abac8e5c3b6161ad551ce191a2ee689c67367b63ff8f9", 
-    "version": "5.6.5"
+    "path": "pool/main/e/enpass/enpass_5.6.9_i386.deb", 
+    "sha256": "3f699ac3e2ecfd4afee1505d8d364d4f6b6b94c55ba989d0a80bd678ff66cb2c", 
+    "version": "5.6.9"
   }
 }

--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, dpkg, openssl, xorg
+{ stdenv, fetchurl, dpkg, xorg
 , glib, libGLU_combined, libpulseaudio, zlib, dbus, fontconfig, freetype
-, gtk2, pango, atk, cairo, gdk_pixbuf, jasper, xkeyboardconfig
+, gtk3, pango
 , makeWrapper , python, pythonPackages, lib
-, libredirect, lsof
+, lsof, curl, libuuid, cups, mesa_drivers
 }:
 
 let
   all_data = builtins.fromJSON (builtins.readFile ./data.json);
   system_map = {
-    i686-linux = "i386";
+    # i686-linux = "i386"; Uncomment if enpass 6 becomes available on i386
     x86_64-linux = "amd64";
   };
 
@@ -18,7 +18,7 @@ let
 
   # used of both wrappers and libpath
   libPath = lib.makeLibraryPath (with xorg; [
-    openssl
+    mesa_drivers
     libGLU_combined
     fontconfig
     freetype
@@ -29,17 +29,15 @@ let
     libXi
     libSM
     libICE
-    libXext
     libXrender
     libXScrnSaver
+    libxcb
     glib
-    gtk2
+    gtk3
     pango
-    cairo
-    atk
-    gdk_pixbuf
-    jasper
-    stdenv.cc.cc
+    curl
+    libuuid
+    cups
   ]);
   package = stdenv.mkDerivation rec {
 
@@ -63,39 +61,22 @@ let
 
     unpackPhase = "dpkg -X $src .";
     installPhase=''
-      mkdir $out
-      cp -r opt/Enpass/*  $out
+      mkdir -p $out/bin
+      cp -r opt/enpass/*  $out/bin
       cp -r usr/* $out
-      rm $out/bin/runenpass.sh
-      cp $out/bin/EnpassHelper/EnpassHelper{,.untampered}
-      cp $out/bin/EnpassHelper/EnpassNMHost{,.untampered}
 
       sed \
-        -i s@/opt/Enpass/bin/runenpass.sh@$out/bin/Enpass@ \
+        -i s@/opt/enpass/Enpass@$out/bin/Enpass@ \
         $out/share/applications/enpass.desktop
 
-      for i in $out/bin/{Enpass,EnpassHelper/{EnpassHelper,EnpassNMHost}}; do
+      for i in $out/bin/{Enpass,importer_enpass}; do
         patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $i
       done
 
-      # The helper's sha256 sum must match, hence the use of libredirect.
-      # Also, lsof must be in the path for proper operation.
+      # lsof must be in PATH for proper operation
       wrapProgram $out/bin/Enpass \
-        --set LD_LIBRARY_PATH "${libPath}:$out/lib:$out/plugins/sqldrivers" \
-        --set QT_PLUGIN_PATH "$out/plugins" \
-        --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/plugins/platforms" \
-        --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb" \
-        --set HIDE_TOOLBAR_LINE 0 \
-        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
-        --set NIX_REDIRECTS "$out/bin/EnpassHelper/EnpassHelper=$out/bin/EnpassHelper/EnpassHelper.untampered:$out/bin/EnpassHelper/EnpassNMHost=$out/bin/EnpassHelper/EnpassNMHost.untampered" \
+        --set LD_LIBRARY_PATH "${libPath}" \
         --prefix PATH : ${lsof}/bin
-
-      makeWrapper $out/bin/EnpassHelper/{EnpassNMHost,runNativeMessaging.sh} \
-        --set LD_LIBRARY_PATH "${libPath}:$out/lib:$out/plugins/sqldrivers" \
-        --set QT_PLUGIN_PATH "$out/plugins" \
-        --set QT_QPA_PLATFORM_PLUGIN_PATH "$out/plugins/platforms" \
-        --set QT_XKB_CONFIG_ROOT "${xkeyboardconfig}/share/X11/xkb" \
-        --set HIDE_TOOLBAR_LINE 0
     '';
   };
   updater = {


### PR DESCRIPTION
###### Motivation for this change
Update enpass to new version 6, which is the version expected by the recent browser plugin update. They made significant changes, including the way it communicates with the browser (ie with the new helper "importer_enpass") which explains somes of the changes of this commit. I made sure to test the following before submitting for review : reusing setup from enpass 5, syncing from scratch a password db, using it to login via browser plugin (firefox and chrome).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

