### PR TITLE
xsuspender: init at 1.1

### DIFF
--- a/pkgs/applications/misc/xsuspender/default.nix
+++ b/pkgs/applications/misc/xsuspender/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, cmake, makeWrapper, pkgconfig
+, glib, libwnck3, procps }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "xsuspender-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "kernc";
+    repo = "xsuspender";
+    rev = version;
+    sha256 = "03lbga68dxg89d227sdwk1f5xj4r1pmj0qh2kasi2cqh8ll7qv4b";
+  };
+
+  outputs = [ "out" "man" "doc" ];
+
+  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
+  buildInputs = [ glib libwnck3 ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/xsuspender \
+      --prefix PATH : "${makeBinPath [ procps ]}"
+  '';
+
+  meta = {
+    description = "Auto-suspend inactive X11 applications.";
+    homepage = "https://kernc.github.io/xsuspender/";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20305,6 +20305,8 @@ in
     inherit (gnome2) libglade;
   };
 
+  xsuspender = callPackage ../applications/misc/xsuspender {  };
+
   xss-lock = callPackage ../misc/screensavers/xss-lock { };
 
   xloadimage = callPackage ../tools/X11/xloadimage { };


### PR DESCRIPTION
###### Motivation for this change

This PR packages `xsuspender` app, that suspends X applications whether they are focused or not.

More info about this awesome tool: https://kernc.github.io/xsuspender/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

