### PR TITLE
ugarit: fix build by using chicken-4.x

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6502,9 +6502,13 @@ in
 
   xxkb = callPackage ../applications/misc/xxkb { };
 
-  ugarit = callPackage ../tools/backup/ugarit { };
+  ugarit = callPackage ../tools/backup/ugarit {
+    inherit (chickenPackages_4) eggDerivation fetchegg;
+  };
 
-  ugarit-manifest-maker = callPackage ../tools/backup/ugarit-manifest-maker { };
+  ugarit-manifest-maker = callPackage ../tools/backup/ugarit-manifest-maker {
+    inherit (chickenPackages_4) eggDerivation fetchegg;
+  };
 
   unar = callPackage ../tools/archivers/unar { stdenv = clangStdenv; };
 


### PR DESCRIPTION
Ugarit only works with CHICKEN 4, not CHICKEN 5 (which is the version in nixpkgs since 69ef070296e), so use the egg tools from chicken-4 for ugarit and ugarit-manifest-maker.

###### Motivation for this change

The `ugarit` and `ugarit-manifest-maker` packages are broken since they're building with the wrong version of the CHICKEN compiler and libraries.

###### Things done

Pass the CHICKEN 4 versions of `eggDerivation` and `fetchegg` to those two packages explicitly so that they build and install with the right compiler/runtime/dependency sources.

Store size check isn't really applicable since the build was broken before, but here's the after:

```
/nix/store/v35vaww3312p6i5zgrdmn77hx2xaspsi-chicken-ugarit-2.0    243735720
/nix/store/hh96kdqy99w80j1x0vq62vd8glbkmgi8-chicken-ugarit-manifest-maker-0.1     241374104
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

