### PR TITLE
pulseeffects: fix functionality for non-GNOME environments

### DIFF
--- a/pkgs/applications/audio/pulseeffects/default.nix
+++ b/pkgs/applications/audio/pulseeffects/default.nix
@@ -32,6 +32,7 @@
 , rubberband
 , mda_lv2
 , hicolor-icon-theme
+, gnome3
 }:
 
 let
@@ -85,6 +86,7 @@ in stdenv.mkDerivation rec {
     fftwFloat
     zita-convolver
     hicolor-icon-theme
+    gnome3.defaultIconTheme
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Until now `pkgs.pulseeffects` only worked on GNOME-like environments and didn't work in different desktop environments (in my case `i3wm` as window manager and a simple X session init script).

Icons now work and settings can be persisted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

