### PR TITLE
ktouch: init at 18.12.0

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -141,6 +141,7 @@ let
       kruler = callPackage ./kruler.nix {};
       ksystemlog = callPackage ./ksystemlog.nix {};
       ktnef = callPackage ./ktnef.nix {};
+      ktouch = callPackage ./ktouch.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};
       libgravatar = callPackage ./libgravatar.nix {};
       libkcddb = callPackage ./libkcddb.nix {};

--- a/pkgs/applications/kde/ktouch.nix
+++ b/pkgs/applications/kde/ktouch.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, lib
+, extra-cmake-modules, kdoctools
+, kconfig, kconfigwidgets, kcoreaddons, kdeclarative, ki18n
+, kitemviews, kcmutils, kio, knewstuff, ktexteditor, kwidgetsaddons
+, kwindowsystem, kxmlgui, qtscript, qtdeclarative, kqtquickcharts
+, qtx11extras, qtgraphicaleffects, xorg
+}:
+
+
+  mkDerivation {
+    name = "ktouch";
+    meta = {
+      license = lib.licenses.gpl2;
+      maintainers = [ lib.maintainers.schmittlauch ];
+      description = "A touch typing tutor from the KDE software collection";
+    };
+    nativeBuildInputs = [ extra-cmake-modules kdoctools qtdeclarative ];
+    buildInputs = [
+      kconfig kconfigwidgets kcoreaddons kdeclarative ki18n
+      kitemviews kcmutils kio knewstuff ktexteditor kwidgetsaddons
+      kwindowsystem kxmlgui qtscript qtdeclarative kqtquickcharts
+      qtx11extras qtgraphicaleffects xorg.libxkbfile xorg.libxcb
+    ];
+
+    enableParallelBuilding = true;
+}

--- a/pkgs/development/libraries/qt-5/5.11/qtdeclarative.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtdeclarative.patch
@@ -18,6 +18,19 @@ index 005db4248..685c5b1b2 100644
      // env import paths
      if (Q_UNLIKELY(!qEnvironmentVariableIsEmpty("QML2_IMPORT_PATH"))) {
          const QString envImportPath = qEnvironmentVariable("QML2_IMPORT_PATH");
+diff --git a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake
+index 56cb3fb55..74509d601 100644
+--- a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake
++++ b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake
+@@ -17,7 +17,7 @@ function(QTQUICK_COMPILER_ADD_RESOURCES outfiles)
+ 
+     find_package(Qt5 COMPONENTS Qml Core)
+ 
+-    set(compiler_path "${_qt5Core_install_prefix}/bin/qmlcachegen")
++    set(compiler_path "qmlcachegen")
+ 
+     get_target_property(rcc_path ${Qt5Core_RCC_EXECUTABLE} IMPORTED_LOCATION)
+ 
 diff --git a/tools/qmlcachegen/qmlcache.prf b/tools/qmlcachegen/qmlcache.prf
 index 537eaf62e..e21de58f6 100644
 --- a/tools/qmlcachegen/qmlcache.prf

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17811,7 +17811,7 @@ in
     akonadi akregator ark dolphin dragon ffmpegthumbs filelight gwenview k3b
     kaddressbook kate kcachegrind kcalc kcharselect kcolorchooser kcontacts kdenlive kdf kdialog
     keditbookmarks kget kgpg khelpcenter kig kleopatra kmail kmix kolourpaint kompare konsole
-    kpkpass kitinerary kontact korganizer krdc krfb ksystemlog kwalletmanager marble minuet okular spectacle;
+    kpkpass kitinerary kontact korganizer krdc krfb ksystemlog ktouch kwalletmanager marble minuet okular spectacle;
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 


### PR DESCRIPTION
###### Motivation for this change

Follow-up to #53256

A small fix for qtdeclarative was necessary to get it built (see respective commit), which causes plenty of rebuilds of dependants. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---