### PR TITLE
pg_topn: 2.2.0 -> 2.2.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_topn.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_topn.nix
@@ -1,17 +1,16 @@
-{ stdenv, fetchFromGitHub, postgresql, protobufc }:
+{ stdenv, fetchFromGitHub, postgresql }:
 
 stdenv.mkDerivation rec {
   name = "pg_topn-${version}";
-  version = "2.2.0";
+  version = "2.2.2";
 
-  nativeBuildInputs = [ protobufc ];
   buildInputs = [ postgresql ];
 
   src = fetchFromGitHub {
     owner  = "citusdata";
     repo   = "postgresql-topn";
     rev    = "refs/tags/v${version}";
-    sha256 = "1i5fn517mdvzfhlcj7fh4z0iniynanshcn7kzhsq19sgci0g31fr";
+    sha256 = "1bh28nrxj06vc2cvlsxlwrwad5ff3lfj3kr5cnnggwjk2dhwbbjm";
   };
 
   installPhase = ''
@@ -24,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Efficient querying of 'top values' for PostgreSQL";
-    homepage    = https://www.citusdata.com/;
+    homepage    = https://github.com/citusdata/postgresql-topn;
     maintainers = with maintainers; [ thoughtpolice ];
     platforms   = platforms.linux;
     license     = licenses.agpl3;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

