### PR TITLE
nicotineplus: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23,7 +23,7 @@
     github = "1000101";
     name = "Jan Hrnko";
   };
-  "6AA4FD" = {
+  6AA4FD = {
     email = "6AA4FD@airmail.cc";
     github = "6AA4FD";
     name = "Quinn";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23,7 +23,7 @@
     github = "1000101";
     name = "Jan Hrnko";
   };
-  6AA4FD = {
+  "6AA4FD" = {
     email = "6AA4FD@airmail.cc";
     github = "6AA4FD";
     name = "Quinn";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23,6 +23,11 @@
     github = "1000101";
     name = "Jan Hrnko";
   };
+  "6AA4FD" = {
+    email = "6AA4FD@airmail.cc";
+    github = "6AA4FD";
+    name = "Quinn";
+  };
   a1russell = {
     email = "adamlr6+pub@gmail.com";
     github = "a1russell";

--- a/pkgs/applications/networking/p2p/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/p2p/nicotine-plus/default.nix
@@ -6,8 +6,8 @@ python2Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "Nicotine-Plus";
-    repo = "nicotine-plus";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "11j2qm67sszfqq730czsr2zmpgkghsb50556ax1vlpm7rw3gm33c";
   };
 

--- a/pkgs/applications/networking/p2p/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/p2p/nicotine-plus/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  pname = "nicotineplus";
+  pname = "nicotine-plus";
   version = "1.4.1";
-  src = fetchurl {
-    url = "https://github.com/Nicotine-Plus/nicotine-plus/archive/1.4.1.tar.gz";
-    sha256 = "1mmpjwa4c78b8325kxc8z629fa23653cr459dywlw7lqdlcyyf0v";
+
+  src = fetchFromGitHub {
+    owner = "Nicotine-Plus";
+    repo = "nicotine-plus";
+    rev = "${version}";
+    sha256 = "11j2qm67sszfqq730czsr2zmpgkghsb50556ax1vlpm7rw3gm33c";
   };
 
   propagatedBuildInputs = with python2Packages; [ pygobject2 pygtk mutagen ];
@@ -14,9 +17,8 @@ python2Packages.buildPythonApplication rec {
     description = "Python Soulseek Client";
     homepage = http://www.nicotine-plus.org/;
     downloadPage = https://github.com/Nicotine-Plus/nicotine-plus/releases;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ "6AA4FD" ];
-    platforms = platforms.all;
     longDescription = ''
     Nicotine+ is an updated fork of the popular Nicotine client for Soulseek,
     a peer to peer file sharing network generally used for music.

--- a/pkgs/applications/networking/p2p/nicotine-plus/default.nix
+++ b/pkgs/applications/networking/p2p/nicotine-plus/default.nix
@@ -20,8 +20,8 @@ python2Packages.buildPythonApplication rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ "6AA4FD" ];
     longDescription = ''
-    Nicotine+ is an updated fork of the popular Nicotine client for Soulseek,
-    a peer to peer file sharing network generally used for music.
+      Nicotine+ is an updated fork of the popular Nicotine client for Soulseek,
+      a peer to peer file sharing network generally used for music.
     '';
   };
 }

--- a/pkgs/applications/networking/p2p/nicotineplus/default.nix
+++ b/pkgs/applications/networking/p2p/nicotineplus/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  pname = "nicotineplus";
+  version = "1.4.1";
+  src = fetchurl {
+    url = "https://github.com/Nicotine-Plus/nicotine-plus/archive/1.4.1.tar.gz";
+    sha256 = "1mmpjwa4c78b8325kxc8z629fa23653cr459dywlw7lqdlcyyf0v";
+  };
+
+  propagatedBuildInputs = with python2Packages; [ pygobject2 pygtk mutagen ];
+
+  meta = with stdenv.lib; {
+    description = "Python Soulseek Client";
+    homepage = http://www.nicotine-plus.org/;
+    downloadPage = https://github.com/Nicotine-Plus/nicotine-plus/releases;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ 6AA4FD ];
+    platforms = platforms.all;
+    longDescription = ''
+    Nicotine+ is an updated fork of the popular Nicotine client for Soulseek,
+    a peer to peer file sharing network generally used for music.
+    '';
+  };
+}

--- a/pkgs/applications/networking/p2p/nicotineplus/default.nix
+++ b/pkgs/applications/networking/p2p/nicotineplus/default.nix
@@ -15,7 +15,7 @@ python2Packages.buildPythonApplication rec {
     homepage = http://www.nicotine-plus.org/;
     downloadPage = https://github.com/Nicotine-Plus/nicotine-plus/releases;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ 6AA4FD ];
+    maintainers = with maintainers; [ "6AA4FD" ];
     platforms = platforms.all;
     longDescription = ''
     Nicotine+ is an updated fork of the popular Nicotine client for Soulseek,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18298,7 +18298,7 @@ in
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
-  nicotineplus = callPackage ../applications/networking/p2p/nicotineplus { };
+  nicotine-plus = callPackage ../applications/networking/p2p/nicotine-plus { };
 
   ympd = callPackage ../applications/audio/ympd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18298,6 +18298,8 @@ in
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
+  nicotineplus = callPackage ../applications/networking/p2p/nicotineplus { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   nload = callPackage ../applications/networking/nload { };


### PR DESCRIPTION
Added myself (6AA4FD) to maintainer list

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

