### PR TITLE
osxfuse: init at 3.8.3

### DIFF
--- a/pkgs/os-specific/darwin/osxfuse/default.nix
+++ b/pkgs/os-specific/darwin/osxfuse/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, runCommand, fetchFromGitHub, autoreconfHook }:
+
+let
+  version = "3.8.3";
+
+  headers = runCommand "osxfuse-common-${version}" {
+    src = fetchFromGitHub {
+      owner = "osxfuse";
+      repo = "osxfuse";
+      rev = "osxfuse-${version}";
+      sha256 = "13lmg41zcyiajh8m42w7szkbg2is4551ryx2ia2mmzvvd23pag0z";
+    };
+  } ''
+    mkdir -p $out/include
+    cp --target-directory=$out/include $src/common/*.h
+  '';
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  pname = "osxfuse";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "osxfuse";
+    repo = "fuse";
+    rev = "1a1977a"; # Submodule reference from osxfuse/osxfuse at tag osxfuse-${version}
+    sha256 = "101fw8j40ylfbbrjycnwr5qp422agyf9sfbczyb9w5ivrkds3rfw";
+  };
+
+  postPatch = ''
+    touch config.rpath
+  '';
+
+  postInstall = ''
+    ln -s osxfuse.pc $out/lib/pkgconfig/fuse.pc
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ headers ];
+
+  meta = with stdenv.lib; {
+    homepage = https://osxfuse.github.io;
+    description = "C-based FUSE for macOS SDK";
+    platforms = platforms.darwin;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14518,6 +14518,8 @@ in
 
   openisns = callPackage ../os-specific/linux/open-isns { };
 
+  osxfuse = callPackage ../os-specific/darwin/osxfuse { };
+
   powerstat = callPackage ../os-specific/linux/powerstat { };
 
   smemstat = callPackage ../os-specific/linux/smemstat { };


### PR DESCRIPTION
###### Motivation for this change

This is the user land side of the [osxfuse][] project. Assuming the kernel extension is installed, this is sufficient to run at least encfs, and version 2 of sshfs (not presently in nixpkgs).

[osxfuse]: https://osxfuse.github.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---