### PR TITLE
calibre: cssutils -> css-parser

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     poppler_utils libpng imagemagick libjpeg
     fontconfig podofo qtbase chmlib icu sqlite libusb1 libmtp xdg_utils wrapGAppsHook
   ] ++ (with python2Packages; [
-    apsw cssselect cssutils dateutil dnspython html5-parser lxml mechanize netifaces pillow
+    apsw cssselect css-parser dateutil dnspython html5-parser lxml mechanize netifaces pillow
     python pyqt5_with_qtwebkit sip
     regex msgpack
     # the following are distributed with calibre, but we use upstream instead

--- a/pkgs/development/python-modules/css-parser/default.nix
+++ b/pkgs/development/python-modules/css-parser/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "css-parser";
+  version = "1.0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c7ab355512ae51334ba6791a7e4d553f87bef17ba2026f1cc9bf3b17a7779d44";
+  };
+
+  # Test suite not included in tarball yet
+  # See https://github.com/ebook-utils/css-parser/pull/2
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A CSS Cascading Style Sheets library for Python";
+    homepage = https://github.com/ebook-utils/css-parser;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ jethro ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1519,6 +1519,8 @@ in {
 
   cssutils = callPackage ../development/python-modules/cssutils { };
 
+  css-parser = callPackage ../development/python-modules/css-parser { };
+
   darcsver = callPackage ../development/python-modules/darcsver { };
 
   dask = callPackage ../development/python-modules/dask { };


### PR DESCRIPTION
###### Motivation for this change

Updates an altered calibre dependency. Calibre now fails with:

```
ImportError: No module named css_parser.css
```

because of a recent change https://github.com/kovidgoyal/calibre/commit/dd7d8ea3c4f47e315623d882d6b68339da959ab9

This also introduces a new package css-parser, which calibre uses.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

