### PR TITLE
emacsPackages.emacsql-sqlite: build sqlite binary

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -147,6 +147,32 @@ let
     };
   };
 
+  emacsql-sqlite = melpaBuild rec {
+    pname = "emacsql-sqlite";
+    ename = "emacsql-sqlite";
+    version = "20180128.1252";
+    src = fetchFromGitHub {
+      owner = "skeeto";
+      repo = "emacsql";
+      rev = "62d39157370219a1680265fa593f90ccd51457da";
+      sha256 = "0ghl3g8n8wlw8rnmgbivlrm99wcwn93bv8flyalzs0z9j7p7fdq9";
+    };
+    recipe = fetchurl {
+      url = "https://raw.githubusercontent.com/milkypostman/melpa/3cfa28c7314fa57fa9a3aaaadf9ef83f8ae541a9/recipes/emacsql-sqlite";
+      sha256 = "1y81nabzzb9f7b8azb9giy23ckywcbrrg4b88gw5qyjizbb3h70x";
+      name = "recipe";
+    };
+    preBuild = ''
+      cd sqlite
+      make
+    '';
+    packageRequires = [ emacs emacsql ];
+    meta = {
+      homepage = "https://melpa.org/#/emacsql-sqlite";
+      license = lib.licenses.free;
+    };
+  };
+
   elpy = melpaBuild rec {
     pname   = "elpy";
     version = external.elpy.version;


### PR DESCRIPTION
###### Motivation for this change
The default emacssql-sqlite expression does not build the sqlite binary, required in the package.

This override builds the binary, fixing #53853 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

