### PR TITLE
fmt: 5.2.1 -> 5.3.0

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,22 +1,15 @@
 { stdenv, fetchFromGitHub, fetchpatch, cmake, enableShared ? true }:
 
 stdenv.mkDerivation rec {
-  version = "5.2.1";
+  version = "5.3.0";
   name = "fmt-${version}";
 
   src = fetchFromGitHub {
     owner = "fmtlib";
     repo = "fmt";
     rev = "${version}";
-    sha256 = "1cd8yq8va457iir1hlf17ksx11fx2hlb8i4jml8gj1875pizm0pk";
+    sha256 = "1hl9s69a5ql5nckc0ifh2fzlgsgv1wsn6yhqkpnrhasqkhj0hgv4";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/fmtlib/fmt/commit/9d0c9c4bb145a286f725cd38c90331eee7addc7f.patch";
-      sha256 = "1gy93mb1s1mq746kxj4c564k2mppqp5khqdfa6im88rv29cvrl4y";
-    })
-  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION

###### Motivation for this change
There's a new version of `fmt` tagged. We can drop the extra patch.

Note: I haven't gone out of my way to test any downstream packages other than in so much as it's used in sway/wlroots apps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

