### PR TITLE
anki: add manual output

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -5,6 +5,7 @@
 , python
 , fetchurl
 , fetchpatch
+, fetchFromGitHub
 , lame
 , mplayer
 , libpulseaudio
@@ -24,10 +25,51 @@
 # This little flag adds a huge number of dependencies, but we assume that
 # everyone wants Anki to draw plots with statistics by default.
 , plotsSupport ? true
+# manual
+, asciidoc
 }:
 
-buildPythonApplication rec {
+let
+    # when updating, also update rev-manual to a recent version of
+    # https://github.com/dae/ankidocs
+    # The manual is distributed independently of the software.
     version = "2.1.8";
+    sha256-pkg = "08wb9hwpmbq7636h7sinim33qygdwwlh3frqqh2gfgm49f46di2p";
+    rev-manual = "3a3d32dd9bfee6f5a7f5bdad2d70938874c881fa";
+    sha256-manual = "1kz9ywbb6f42krxg8c5cwpjsnzm863vnkkn07szb3m1j85c10gjy";
+
+    manual = stdenv.mkDerivation {
+      name = "anki-manual-${version}";
+      src = fetchFromGitHub {
+        owner = "dae";
+        repo = "ankidocs";
+        rev = rev-manual;
+        sha256 = sha256-manual;
+      };
+      phases = [ "unpackPhase" "patchPhase" "buildPhase" ];
+      nativeBuildInputs = [ asciidoc ];
+      patchPhase = ''
+        # rsync isnt needed
+        # WEB is the PREFIX
+        # We remove any special ankiweb output generation
+        # and rename every .mako to .html
+        sed -e 's/rsync -a/cp -a/g' \
+            -e "s|\$(WEB)/docs|$out/share/doc/anki/html|" \
+            -e '/echo asciidoc/,/mv $@.tmp $@/c \\tasciidoc -b html5 -o $@ $<' \
+            -e 's/\.mako/.html/g' \
+            -i Makefile
+        # patch absolute links to the other language manuals
+        sed -e 's|https://apps.ankiweb.net/docs/|link:./|g' \
+            -i {manual.txt,manual.*.txt}
+        # there’s an artifact in most input files
+        sed -e '/<%def.*title.*/d' \
+            -i *.txt
+        mkdir -p $out/share/doc/anki/html
+      '';
+    };
+
+in
+buildPythonApplication rec {
     name = "anki-${version}";
 
     src = fetchurl {
@@ -37,8 +79,10 @@ buildPythonApplication rec {
         # "http://ankisrs.net/download/mirror/${name}.tgz"
         # "http://ankisrs.net/download/mirror/archive/${name}.tgz"
       ];
-      sha256 = "08wb9hwpmbq7636h7sinim33qygdwwlh3frqqh2gfgm49f46di2p";
+      sha256 = sha256-pkg;
     };
+
+    outputs = [ "out" "doc" "man" ];
 
     propagatedBuildInputs = [
       pyqt5 sqlalchemy beautifulsoup4 send2trash pyaudio requests decorator
@@ -73,6 +117,11 @@ buildPythonApplication rec {
 
       # Remove QT translation files. We'll use the standard QT ones.
       rm "locale/"*.qm
+
+      # hitting F1 should open the local manual
+      substituteInPlace anki/consts.py \
+        --replace 'HELP_SITE="http://ankisrs.net/docs/manual.html"' \
+                  'HELP_SITE="${manual}/share/doc/anki/html/manual.html"'
     '';
 
     # UTF-8 locale needed for testing
@@ -89,8 +138,8 @@ buildPythonApplication rec {
 
       mkdir -p $out/bin
       mkdir -p $out/share/applications
-      mkdir -p $out/share/doc/anki
-      mkdir -p $out/share/man/man1
+      mkdir -p $doc/share/doc/anki
+      mkdir -p $man/share/man/man1
       mkdir -p $out/share/mime/packages
       mkdir -p $out/share/pixmaps
       mkdir -p $pp
@@ -103,15 +152,22 @@ buildPythonApplication rec {
       chmod 755 $out/bin/anki
 
       cp -v anki.desktop $out/share/applications/
-      cp -v README* LICENSE* $out/share/doc/anki/
-      cp -v anki.1 $out/share/man/man1/
+      cp -v README* LICENSE* $doc/share/doc/anki/
+      cp -v anki.1 $man/share/man/man1/
       cp -v anki.xml $out/share/mime/packages/
       cp -v anki.{png,xpm} $out/share/pixmaps/
       cp -rv locale $out/share/
       cp -rv anki aqt web $pp/
 
       wrapPythonPrograms
+
+      # copy the manual into $doc
+      cp -r ${manual}/share/doc/anki/html $doc/share/doc/anki
     '';
+
+    passthru = {
+      inherit manual;
+    };
 
     meta = with stdenv.lib; {
       homepage = "https://apps.ankiweb.net/";
@@ -131,6 +187,6 @@ buildPythonApplication rec {
       license = licenses.agpl3Plus;
       broken = stdenv.hostPlatform.isAarch64;
       platforms = platforms.mesaPlatforms;
-      maintainers = with maintainers; [ the-kenny ];
+      maintainers = with maintainers; [ the-kenny Profpatsch ];
     };
 }


### PR DESCRIPTION
The Anki manual is distibuted in a separate repository and has to be
patched a bit to work offline.
The in-program manual now points to our distributed offline version.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

