### PR TITLE
tahoe-lafs: 1.12.1 -> 1.13.0

### DIFF
--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -6,13 +6,13 @@
 # some loss of functionality because of it.
 
 pythonPackages.buildPythonApplication rec {
-  version = "1.12.1";
+  version = "1.13.0";
   name = "tahoe-lafs-${version}";
   namePrefix = "";
 
   src = fetchurl {
     url = "https://tahoe-lafs.org/downloads/tahoe-lafs-${version}.tar.bz2";
-    sha256 = "0x9f1kjym1188fp6l5sqy0zz8mdb4xw861bni2ccv26q482ynbks";
+    sha256 = "11pfz9yyy6qkkyi0kskxlbn2drfppx6yawqyv4kpkrkj4q7x5m42";
   };
 
   outputs = [ "out" "doc" "info" ];
@@ -56,8 +56,10 @@ pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     twisted foolscap nevow simplejson zfec pycryptopp darcsver
     setuptoolsTrial setuptoolsDarcs pycrypto pyasn1 zope_interface
-    service-identity pyyaml
+    service-identity pyyaml magic-wormhole treq
   ];
+
+  checkInputs = with pythonPackages; [ hypothesis ];
 
   # Install the documentation.
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

I've never used tahoe-lafs before, 1.13 is apparently needed for wormhole invitiations.
I bumped version and hash, and then added packages until the tests passed, but I don't
know if any changes to the `pre*/post*` are  needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @exarkun  @MostAwesomeDude 