### PR TITLE
Grafana configuration

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -491,6 +491,13 @@
      the Redmine 3.x series.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <link linkend="opt-services.grafana.enable">Grafana module</link> now supports declarative
+     <link xlink:href="http://docs.grafana.org/administration/provisioning/">datasource and dashboard</link>
+     provisioning.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>


### PR DESCRIPTION
Provision data sources and dashboards declarativly
http://docs.grafana.org/administration/provisioning/

Example usage:
```
    provision = {
      enable = true;
      datasources = [
        {
          type = "prometheus";
          name = "prometheus";
          url = "http://localhost:9090";
        }
      ];
      dashboards = [
        {
          options.path = "/etc/nixos/grafana-dashboards";
        }
      ];
    };
```
This adds `prometheus` as datasource to grafana and a dashboard provider path "/etc/nixos/grafana-dashboards" which is scanned by grafana and dashboards are automatically added. 
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

