### PR TITLE
nix-prefetch: init at 0.1.0

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt
+, coreutils, gawk, gnugrep, gnused, jq, nix }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "nix-prefetch";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "msteen";
+    repo = "nix-prefetch";
+    rev = "f9507a655651b51f3a3ebacde85bb40758853615";
+    sha256 = "0ykrbvbwwpz348424yy2452idgw8dffi3klh7n85n96dfflyyd4s";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    asciidoc docbook_xml_dtd_45 docbook_xsl libxml2 libxslt
+  ];
+
+  configurePhase = ''
+    . configure.sh
+  '';
+
+  buildPhase = ''
+    a2x -f manpage doc/nix-prefetch.1.asciidoc
+  '';
+
+  installPhase = ''
+    lib=$out/lib/${pname}
+    mkdir -p $lib
+    substitute src/main.sh $lib/main.sh \
+      --subst-var-by lib $lib \
+      --subst-var-by version '${version}'
+    chmod +x $lib/main.sh
+    patchShebangs $lib/main.sh
+    cp lib/*.nix $lib/
+
+    mkdir -p $out/bin
+    makeWrapper $lib/main.sh $out/bin/${pname} \
+      --prefix PATH : '${makeBinPath [ coreutils gawk gnugrep gnused jq nix ]}'
+
+    substitute src/tests.sh $lib/tests.sh \
+      --subst-var-by bin $out/bin
+    chmod +x $lib/tests.sh
+    patchShebangs $lib/tests.sh
+
+    mkdir -p $out/share/man/man1
+    substitute doc/nix-prefetch.1 $out/share/man/man1/nix-prefetch.1 \
+      --subst-var-by version '${version}' \
+      --replace '01/01/1970' "$date"
+
+    install -D contrib/nix-prefetch-completion.bash $out/share/bash-completion/completions/nix-prefetch
+    install -D contrib/nix-prefetch-completion.zsh $out/share/zsh/site-functions/_nix_prefetch
+
+    mkdir $out/contrib
+    cp -r contrib/hello_rs $out/contrib/
+  '';
+
+  meta = {
+    description = "Prefetch any fetcher function call, e.g. package sources";
+    homepage = https://github.com/msteen/nix-prefetch;
+    license = licenses.mit;
+    maintainers = with maintainers; [ msteen ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22655,6 +22655,8 @@ in
 
   nix-pin = callPackage ../tools/package-management/nix-pin { };
 
+  nix-prefetch = callPackage ../tools/package-management/nix-prefetch { };
+
   nix-prefetch-github = callPackage ../build-support/nix-prefetch-github {};
 
   inherit (callPackages ../tools/package-management/nix-prefetch-scripts { })


### PR DESCRIPTION
###### Motivation for this change
I wanted better tooling to get the hash of the sources of a package to help with update scripts, e.g. I am using this for my not yet published update script for the OpenRA mods. The existing `nix-prefetch-url` was sufficient for this use case and I wanted to prevent the need for having to add a dummy hash yourself at first use every time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

