### PR TITLE
fetchArchive: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,6 +71,7 @@ let
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
       getLib getDev chooseDevOutputs zipWithNames zip;
+    inherit (filesystem) stripRoot;
     inherit (lists) singleton foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -1,4 +1,9 @@
 { lib }:
+
+let
+  inherit (builtins) attrNames head readDir;
+in
+
 { # haskellPathsInDir : Path -> Map String Path
   # A map of all haskell packages defined in the given path,
   # identified by having a cabal file with the same name as the
@@ -42,4 +47,15 @@
               type = (builtins.readDir parent).${base} or null;
           in file == /. || type == "directory";
     in go (if isDir then file else parent);
+
+  /* Given a dir, return absolute path to its first child as a string.
+
+     Example:
+       stripRoot (runCommand "dir" {} ''
+         mkdir -p $out/a
+         touch $out/a/b
+       '')
+       => "/nix/store/alnqnc3hfhnk72cjhs1xz7xkwgl6k6xz-dir/a"
+  */
+  stripRoot = dir: dir + "/" + head (attrNames (readDir dir));
 }

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -1,99 +1,34 @@
-{ stdenv, fetchurl, dpkg, lib, glib, dbus, makeWrapper, gnome2, gnome3, gtk3, atk, cairo, pango
-, gdk_pixbuf, freetype, fontconfig, nspr, nss, xorg, alsaLib, cups, expat, udev, wrapGAppsHook }:
+{ stdenv, fetchArchive, makeWrapper, electron_3, dpkg }:
 
 stdenv.mkDerivation rec {
   name = "typora-${version}";
-  version = "0.9.53";
+  version = "0.9.62";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
-        sha256 = "02k6x30l4mbjragqbq5rn663xbw3h4bxzgppfxqf5lwydswldklb";
-      }
-    else
-      fetchurl {
-        url = "https://www.typora.io/linux/typora_${version}_i386.deb";
-        sha256 = "1wyq1ri0wwdy7slbd9dwyrdynsaa644x44c815jl787sg4nhas6y";
-      }
-    ;
+  nativeBuildInputs = [ makeWrapper ];
 
-    rpath = stdenv.lib.makeLibraryPath [
-      alsaLib
-      gnome2.GConf
-      gdk_pixbuf
-      pango
-      gnome3.defaultIconTheme
-      expat
-      gtk3
-      atk
-      nspr
-      nss
-      stdenv.cc.cc
-      glib
-      cairo
-      cups
-      dbus
-      udev
-      fontconfig
-      freetype
-      xorg.libX11
-      xorg.libXi
-      xorg.libXext
-      xorg.libXtst
-      xorg.libXfixes
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXrender
-      xorg.libXrandr
-      xorg.libXcomposite
-      xorg.libxcb
-      xorg.libXScrnSaver
-  ];
+  src = fetchArchive {
+    url = "https://typora.io/linux/typora_${version}_amd64.deb";
+    hash = "sha512-/Ck03Rs53vzqj9AQaVq5CBxW9kcc5kPxmNFqbXTa66J6OLT+Kr+Ey5YcE8EL3uoDfW2SNfgOjJLsXzSLQhWiMQ==";
+    inputs = [ dpkg ];
+  };
 
-  nativeBuildInputs = [ wrapGAppsHook ];
-
-  dontWrapGApps = true;
-
-  buildInputs = [ dpkg makeWrapper ];
-
-  unpackPhase = "true";
   installPhase = ''
-    mkdir -p $out
-    dpkg -x $src $out
-    mv $out/usr/bin $out
-    mv $out/usr/share $out
-    rm $out/bin/typora
-    rmdir $out/usr
+    mkdir -p $out/bin
 
-    # Otherwise it looks "suspicious"
-    chmod -R g-w $out
-  '';
+    mv usr/share/typora/resources/app $out
 
-  postFixup = ''
-     patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/share/typora:${rpath}" "$out/share/typora/Typora"
-
-    makeWrapper $out/share/typora/Typora $out/bin/typora
-
-    wrapProgram $out/bin/typora \
-      "''${gappsWrapperArgs[@]}" \
-      --suffix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-      --prefix XDG_DATA_DIRS : "${gnome3.defaultIconTheme}/share"
-
-    # Fix the desktop link
-    substituteInPlace $out/share/applications/typora.desktop \
-      --replace /usr/bin/ $out/bin/ \
-      --replace /usr/share/ $out/share/
-
+    makeWrapper ${electron_3}/bin/electron $out/bin/typora \
+      --add-flags $out/app
   '';
 
   meta = with stdenv.lib; {
     description = "A minimal Markdown reading & writing app";
     homepage = https://typora.io;
     license = licenses.unfree;
-    maintainers = with maintainers; [ jensbin ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [
+      jensbin
+      yegortimoshenko
+    ];
+    inherit (electron_3.meta) platforms;
   };
 }

--- a/pkgs/build-support/fetch-archive/default.nix
+++ b/pkgs/build-support/fetch-archive/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }: { url, hash, inputs }:
+
+(fetchurl {
+  inherit url;
+
+  name = "source";
+  outputHash = hash;
+
+  downloadToTemp = true;
+  recursiveHash = true;
+
+  postFetch = ''
+    mkdir "$out"
+    cd "$out"
+
+    in="$TMPDIR/${baseNameOf url}"
+    mv "$downloadedFile" "$in"
+    unpackFile "$in"
+
+    chmod -R ugo-w "$out"
+  '';
+}).overrideAttrs (super: {
+  nativeBuildInputs = super.nativeBuildInputs ++ inputs;
+})

--- a/pkgs/build-support/fetch-archive/default.nix
+++ b/pkgs/build-support/fetch-archive/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }: { url, hash, inputs }:
+{ stdenv, fetchurl }: { url, hash, inputs ? [] }:
 
 (fetchurl {
   inherit url;

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -102,13 +102,14 @@ let
   hash_ =
     if md5 != "" then throw "fetchurl does not support md5 anymore, please use sha256 or sha512"
     else if (outputHash != "" && outputHashAlgo != "") then { inherit outputHashAlgo outputHash; }
+    else if (outputHash != "") then { inherit outputHash; }
     else if sha512 != "" then { outputHashAlgo = "sha512"; outputHash = sha512; }
     else if sha256 != "" then { outputHashAlgo = "sha256"; outputHash = sha256; }
     else if sha1   != "" then { outputHashAlgo = "sha1";   outputHash = sha1; }
     else throw "fetchurl requires a hash for fixed-output derivation: ${lib.concatStringsSep ", " urls_}";
 in
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (hash_ // {
   name =
     if showURLs then "urls"
     else if name != "" then name
@@ -123,9 +124,6 @@ stdenvNoCC.mkDerivation {
   # If set, prefer the content-addressable mirrors
   # (http://tarballs.nixos.org) over the original URLs.
   preferHashedMirrors = true;
-
-  # New-style output content requirements.
-  inherit (hash_) outputHashAlgo outputHash;
 
   outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 
@@ -146,4 +144,4 @@ stdenvNoCC.mkDerivation {
 
   inherit meta;
   inherit passthru;
-}
+})

--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0w8vhvwnhvwq3k3cw9d1jiy61v4r81wv6q5rkliq2nq6z0naxwpq";
   };
 
+  setupHook = ./setup-hook.sh;
+
   configureFlags = [
     "--disable-dselect"
     "--with-admindir=/var/lib/dpkg"

--- a/pkgs/tools/package-management/dpkg/setup-hook.sh
+++ b/pkgs/tools/package-management/dpkg/setup-hook.sh
@@ -1,0 +1,5 @@
+unpackCmdHooks+=(_tryDpkgDeb)
+_tryDpkgDeb() {
+    if ! [[ "$curSrc" =~ \.deb$ ]]; then return 1; fi
+    dpkg-deb -x $curSrc .
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -217,6 +217,36 @@ in
 
   mht2htm = callPackage ../tools/misc/mht2htm { };
 
+  /* Fetches and unpacks an archive using one of tools specified in `inputs`.
+
+     Hash is computed from archive contents, instead of archive itself. This 
+     means that archive metadata and compression algorithm do not matter as
+     long as archive contents stay the same.
+
+     All `inputs` should have a `setupHook` that appends to `unpackCmdHooks`.
+     For example, see `pkgs/tools/archivers/unzip/setup-hook.sh`.
+
+     Takes an SRI hash, available in Nix 2.2: https://git.io/fhnKx
+
+     Example:
+       fetchArchive {
+         url = https://github.com/NixOS/nix/archive/2.2.1.tar.gz;
+         hash = "sha512-U8y9gVgvjowXZ/lTp7fxqRrWFbxZwrbS4LY95XduiM2plvhQ37rJ5TACo/PHStCILSvhzHG19UBZ1bWP62jEgQ==";
+         inputs = [];
+       }
+
+       fetchArchive {
+         url = https://github.com/NixOS/nix/archive/2.2.1.zip;
+         hash = "sha512-U8y9gVgvjowXZ/lTp7fxqRrWFbxZwrbS4LY95XduiM2plvhQ37rJ5TACo/PHStCILSvhzHG19UBZ1bWP62jEgQ==";
+         inputs = [ unzip ];
+       }
+
+       fetchArchive {
+         url = https://deb.debian.org/debian/pool/main/a/apt/apt_1.4.8_arm64.deb;
+         hash = "sha512-/6NY2ZhfJIKA6Qzg5vBxVaG9qfR7TqF/kK2ntzwMGXGpg2ycopjUAtxLqqRsM87OZQsYS7hklQhHcvx/NVz3dQ==";
+         inputs = [ dpkg ];
+       }
+  */
   fetchArchive = callPackage ../build-support/fetch-archive { };
 
   fetchpatch = callPackage ../build-support/fetchpatch { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -217,6 +217,8 @@ in
 
   mht2htm = callPackage ../tools/misc/mht2htm { };
 
+  fetchArchive = callPackage ../build-support/fetch-archive { };
+
   fetchpatch = callPackage ../build-support/fetchpatch { };
 
   fetchs3 = callPackage ../build-support/fetchs3 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -232,7 +232,6 @@ in
        fetchArchive {
          url = https://github.com/NixOS/nix/archive/2.2.1.tar.gz;
          hash = "sha512-U8y9gVgvjowXZ/lTp7fxqRrWFbxZwrbS4LY95XduiM2plvhQ37rJ5TACo/PHStCILSvhzHG19UBZ1bWP62jEgQ==";
-         inputs = [];
        }
 
        fetchArchive {


### PR DESCRIPTION
###### Motivation for this change

Even though `fetchzip` uses stdenv's `unpackFile` to unpack `.{tar{,.*},zip}` files, it doesn't expose any convenient way to extend it to handle anything other than that.

Additionally, `fetchzip`'s `stripRoot` goes beyond ignoring archive metadata/algorithm non-determinism and affects actual archive contents.

This is an attempt at a more explicit API that only fetches, then unpacks with one of `inputs`. It uses SRI hashes added in Nix 2.2 to avoid [code churn](https://github.com/NixOS/nixpkgs/blob/f44012ba10537e1a2a94b2be443a86e4dd0ad38f/pkgs/build-support/fetchurl/default.nix#L102-L108) that happens to algorithm-specific arg attrs as hash algorithms change.

`stripRoot` is implemented a la carte as a function that takes a directory and returns its first child.

Short list of changes:

- add `unpackCmd` hook to `dpkg`
- add SRI hash support to `fetchurl`
- add `fetchArchive` + docs
- showcase `fetchArchive` on `typora` derivation
- add `lib.stripRoot` + docs

Fetch examples:

```nix
fetchArchive {
  url = https://github.com/NixOS/nix/archive/2.2.1.tar.gz;
  hash = "sha512-U8y9gVgvjowXZ/lTp7fxqRrWFbxZwrbS4LY95XduiM2plvhQ37rJ5TACo/PHStCILSvhzHG19UBZ1bWP62jEgQ==";
}

fetchArchive {
  url = https://github.com/NixOS/nix/archive/2.2.1.zip;
  hash = "sha512-U8y9gVgvjowXZ/lTp7fxqRrWFbxZwrbS4LY95XduiM2plvhQ37rJ5TACo/PHStCILSvhzHG19UBZ1bWP62jEgQ==";
  inputs = [ unzip ];
}

fetchArchive {
  url = https://deb.debian.org/debian/pool/main/a/apt/apt_1.4.8_arm64.deb;
  hash = "sha512-/6NY2ZhfJIKA6Qzg5vBxVaG9qfR7TqF/kK2ntzwMGXGpg2ycopjUAtxLqqRsM87OZQsYS7hklQhHcvx/NVz3dQ==";
  inputs = [ dpkg ];
}
```

Derivation override example:

```nix
nixUnstable.overrideAttrs (super: {
  src = lib.stripRoot (fetchArchive {
    url = https://github.com/NixOS/nix/archive/2.2.1.tar.gz;
    hash = "sha512-U8y9gVgvjowXZ/lTp7fxqRrWFbxZwrbS4LY95XduiM2plvhQ37rJ5TACo/PHStCILSvhzHG19UBZ1bWP62jEgQ==";
  });
})
```

Maybe this should better be called `fetchThenUnpack`. Also, instead of `lib.stripRoot`, stdenv can be tweaked into supporting non-stripped sources.

cc @grahamc, @LnL7, @oxij, @zimbatm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---