### PR TITLE
DMD to provide libphobos2.so.x.y

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -121,8 +121,6 @@ let
         cd ..
     '';
 
-    extension = if stdenv.hostPlatform.isDarwin then "a" else "{a,so}";
-    
     dontStrip = true;
 
     installPhase = ''
@@ -143,7 +141,7 @@ let
 
         cd ../phobos
         mkdir $out/lib
-        cp generated/${osname}/release/${bits}/libphobos2.${extension} $out/lib
+        cp generated/${osname}/release/${bits}/libphobos2.* $out/lib
 
         cp -r std $out/include/d2
         cp -r etc $out/include/d2


### PR DESCRIPTION
###### Motivation for this change
Fixes #53885.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

