### PR TITLE
ktouch backport: init at 18.08.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3636,6 +3636,10 @@
     github = "fkz";
     name = "Fabian Schmitthenner";
   };
+  schmittlauch = {
+    email = "t.schmittlauch+nixos@orlives.de";
+    github = "schmittlauch";
+  };
   schneefux = {
     email = "schneefux+nixos_pkg@schneefux.xyz";
     github = "schneefux";

--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -250,7 +250,7 @@ sub connect {
         $self->start;
 
         local $SIG{ALRM} = sub { die "timed out waiting for the VM to connect\n"; };
-        alarm 300;
+        alarm 600;
         readline $self->{socket} or die "the VM quit before connecting\n";
         alarm 0;
 

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -12,9 +12,9 @@ let
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    "i686-linux" = "1xadkgqfwsl53blm2f0kdvczwmag47585dswa1hpafzc8i86009b";
-    "x86_64-linux" = "0h77kc6z9c5bkkb8svjxjabnbbv0lb835kzd1c2yypamkhag9j4a";
-    "x86_64-darwin" = "1f8grgav5capd2mm1nx0416na8c6qjh91680cfvf1jh4pjihs6g4";
+    "i686-linux" = "1g73fay6fxlqhalkqq5m6rjbp68k9npk0rrxrkhdj8mw0cz74dpm";
+    "x86_64-linux" = "0mil8n5i2ajdyrgq862wq59ajy2122rvvn7m7mxq4ab92sk26rix";
+    "x86_64-darwin" = "07r52scs1sgafzxqal39r8vf9p9qqvwwx8f6z09gqcf6clr6k48q";
   }.${stdenv.hostPlatform.system};
 
   archive_fmt = if stdenv.hostPlatform.system == "x86_64-darwin" then "zip" else "tar.gz";
@@ -31,7 +31,7 @@ let
 in
   stdenv.mkDerivation rec {
     name = "vscode-${version}";
-    version = "1.30.1";
+    version = "1.30.2";
 
     src = fetchurl {
       name = "VSCode_${version}_${plat}.${archive_fmt}";

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -139,6 +139,7 @@ let
       kruler = callPackage ./kruler.nix {};
       ksystemlog = callPackage ./ksystemlog.nix {};
       ktnef = callPackage ./ktnef.nix {};
+      ktouch = callPackage ./ktouch.nix {};
       kwalletmanager = callPackage ./kwalletmanager.nix {};
       libgravatar = callPackage ./libgravatar.nix {};
       libkcddb = callPackage ./libkcddb.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -93,6 +93,7 @@ let
       kcalc = callPackage ./kcalc.nix {};
       kcalcore = callPackage ./kcalcore.nix {};
       kcalutils = callPackage ./kcalutils.nix {};
+      kcharselect = callPackage ./kcharselect.nix {};
       kcolorchooser = callPackage ./kcolorchooser.nix {};
       kcontacts = callPackage ./kcontacts.nix {};
       kdav = callPackage ./kdav.nix {};

--- a/pkgs/applications/kde/kcharselect.nix
+++ b/pkgs/applications/kde/kcharselect.nix
@@ -1,0 +1,19 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules, kdoctools,
+  kbookmarks, kconfig, kconfigwidgets, kcrash, kcoreaddons, ki18n, kwidgetsaddons, kxmlgui
+}:
+
+mkDerivation {
+  name = "kcharselect";
+  meta = {
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.schmittlauch ];
+    description = "A tool to select special characters from all installed fonts and copy them into the clipboard";
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kbookmarks kconfig kconfigwidgets kcoreaddons kcrash ki18n kwidgetsaddons kxmlgui
+  ];
+  enableParallelBuilding = true;
+}

--- a/pkgs/applications/kde/ktouch.nix
+++ b/pkgs/applications/kde/ktouch.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, lib
+, extra-cmake-modules, kdoctools
+, kconfig, kconfigwidgets, kcoreaddons, kdeclarative, ki18n
+, kitemviews, kcmutils, kio, knewstuff, ktexteditor, kwidgetsaddons
+, kwindowsystem, kxmlgui, qtscript, qtdeclarative, kqtquickcharts
+, qtx11extras, qtgraphicaleffects, xorg
+}:
+
+
+  mkDerivation {
+    name = "ktouch";
+    meta = {
+      license = lib.licenses.gpl2;
+      maintainers = [ lib.maintainers.schmittlauch ];
+      description = "A touch typing tutor from the KDE software collection";
+    };
+    nativeBuildInputs = [ extra-cmake-modules kdoctools qtdeclarative ];
+    buildInputs = [
+      kconfig kconfigwidgets kcoreaddons kdeclarative ki18n
+      kitemviews kcmutils kio knewstuff ktexteditor kwidgetsaddons
+      kwindowsystem kxmlgui qtscript qtdeclarative kqtquickcharts
+      qtx11extras qtgraphicaleffects xorg.libxkbfile xorg.libxcb
+    ];
+
+    enableParallelBuilding = true;
+}

--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, ncurses, glib, openssl, perl, libintl }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.1";
+  version = "1.1.2";
   name = "irssi-${version}";
 
   src = fetchurl {
     url = "https://github.com/irssi/irssi/releases/download/${version}/${name}.tar.gz";
-    sha256 = "09a9p1yfg0m3w7n2a4axvn8874002ly8x0b543sxihzqk29radpa";
+    sha256 = "0jbhd4aad3bn61svnb2rwa4dwj8qyrb2dmzribi2hfn1f719wzfv";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/qt-5/5.11/qtdeclarative.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtdeclarative.patch
@@ -18,6 +18,19 @@ index 005db4248..685c5b1b2 100644
      // env import paths
      if (Q_UNLIKELY(!qEnvironmentVariableIsEmpty("QML2_IMPORT_PATH"))) {
          const QString envImportPath = qEnvironmentVariable("QML2_IMPORT_PATH");
+diff --git a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake
+index 56cb3fb55..74509d601 100644
+--- a/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake
++++ b/tools/qmlcachegen/Qt5QuickCompilerConfig.cmake
+@@ -17,7 +17,7 @@ function(QTQUICK_COMPILER_ADD_RESOURCES outfiles)
+ 
+     find_package(Qt5 COMPONENTS Qml Core)
+ 
+-    set(compiler_path "${_qt5Core_install_prefix}/bin/qmlcachegen")
++    set(compiler_path "qmlcachegen")
+ 
+     get_target_property(rcc_path ${Qt5Core_RCC_EXECUTABLE} IMPORTED_LOCATION)
+ 
 diff --git a/tools/qmlcachegen/qmlcache.prf b/tools/qmlcachegen/qmlcache.prf
 index 537eaf62e..e21de58f6 100644
 --- a/tools/qmlcachegen/qmlcache.prf

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nextcloud-${version}";
-  version = "15.0.0";
+  version = "15.0.2";
 
   src = fetchurl {
     url = "https://download.nextcloud.com/server/releases/${name}.tar.bz2";
-    sha256 = "0y7bk1588n5rmmranmmrkajh50074460hr4v052ahg9mf60wbc2v";
+    sha256 = "1shgr81hhxr2k45hqlx06qhyayhbqdi0ndvpcyzdv54rwcrwrx61";
   };
 
   installPhase = ''

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -19,11 +19,11 @@ buildPythonPackage rec {
   # The websites youtube-dl deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2019.01.02";
+  version = "2019.01.10";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0iw8cfzghhkx2q7m3rwnhm3xyyh88qd2553fb287shkxyg9kz96b";
+    sha256 = "07r1y06697vhbkbf8pix4cnybaqmlf1wb2df5glj2xv8nl6f51gd";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -19,11 +19,11 @@ buildPythonPackage rec {
   # The websites youtube-dl deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2018.12.17";
+  version = "2019.01.02";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1nd4zr3wd35vldm775m9wcgbzma2013yyj134lcz19ipjs38isrk";
+    sha256 = "0iw8cfzghhkx2q7m3rwnhm3xyyh88qd2553fb287shkxyg9kz96b";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -14,11 +14,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "tor-0.3.4.9";
+  name = "tor-0.3.4.10";
 
   src = fetchurl {
     url = "https://dist.torproject.org/${name}.tar.gz";
-    sha256 = "0jhnvnp08hsfrzgsvg5xnfxyaw3nzgg9h24cwbwnz6iby20i05qs";
+    sha256 = "12i51i6swkdpnbcpa6f1csc00q177sbjnw2x31j53glxshmwpv5d";
   };
 
   outputs = [ "out" "geoip" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17232,9 +17232,9 @@ with pkgs;
 
   inherit (kdeApplications)
     akonadi akregator ark dolphin dragon ffmpegthumbs filelight gwenview k3b
-    kaddressbook kate kcachegrind kcalc kcolorchooser kcontacts kdenlive kdf kdialog keditbookmarks
-    kget kgpg khelpcenter kig kleopatra kmail kmix kolourpaint kompare konsole kpkpass kitinerary
-    kontact korganizer krdc krfb ksystemlog kwalletmanager marble minuet okular spectacle;
+    kaddressbook kate kcachegrind kcalc kcharselect kcolorchooser kcontacts kdenlive kdf kdialog
+    keditbookmarks kget kgpg khelpcenter kig kleopatra kmail kmix kolourpaint kompare konsole
+    kpkpass kitinerary kontact korganizer krdc krfb ksystemlog kwalletmanager marble minuet okular spectacle;
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17237,7 +17237,7 @@ with pkgs;
     akonadi akregator ark dolphin dragon ffmpegthumbs filelight gwenview k3b
     kaddressbook kate kcachegrind kcalc kcolorchooser kcontacts kdenlive kdf kdialog keditbookmarks
     kget kgpg khelpcenter kig kleopatra kmail kmix kolourpaint kompare konsole kpkpass kitinerary
-    kontact korganizer krdc krfb ksystemlog kwalletmanager marble minuet okular spectacle;
+    kontact korganizer krdc krfb ksystemlog ktouch kwalletmanager marble minuet okular spectacle;
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 


### PR DESCRIPTION
###### Motivation for this change

backport of #53859
changes to qtdeclarative cause a lot of rebuilds, so this needs to go to staging.
Needs to be installed into a profile to work (Qt impurities)

merged release-18.09 in here because of maintainership files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

