### PR TITLE
ccls: init at 0.20181225.7

### DIFF
--- a/pkgs/development/tools/misc/ccls/default.nix
+++ b/pkgs/development/tools/misc/ccls/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, cmake, llvmPackages, rapidjson }:
+
+stdenv.mkDerivation rec {
+  name    = "ccls-${version}";
+  version = "0.20181225.7";
+
+  src = fetchFromGitHub {
+    owner = "MaskRay";
+    repo = "ccls";
+    rev = version;
+    sha256 = "1qgb2nk4nsgbx4qwymwlzi202daskk536a5l877fsp878jpp61cm";
+  };
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = with llvmPackages; [ clang-unwrapped llvm rapidjson ];
+
+  cmakeFlags = [ "-DSYSTEM_CLANG=ON" ];
+
+  shell = stdenv.shell;
+  postFixup = ''
+    # We need to tell ccls where to find the standard library headers.
+
+    standard_library_includes="\\\"-isystem\\\", \\\"${stdenv.lib.getDev stdenv.cc.libc}/include\\\""
+    standard_library_includes+=", \\\"-isystem\\\", \\\"${llvmPackages.libcxx}/include/c++/v1\\\""
+    export standard_library_includes
+
+    wrapped=".ccls-wrapped"
+    export wrapped
+
+    mv $out/bin/ccls $out/bin/$wrapped
+    substituteAll ${./wrapper} $out/bin/ccls
+    chmod --reference=$out/bin/$wrapped $out/bin/ccls
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A c/c++ language server powered by clang";
+    homepage    = https://github.com/MaskRay/ccls;
+    license     = licenses.asl20;
+    platforms   = platforms.linux;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/tools/misc/ccls/wrapper
+++ b/pkgs/development/tools/misc/ccls/wrapper
@@ -1,0 +1,12 @@
+#! @shell@ -e
+
+initString="--init={\"clang\":{\"extraArgs\": [@standard_library_includes@"
+
+if [ "${NIX_CFLAGS_COMPILE}" != "" ]; then
+  read -a cflags_array <<< ${NIX_CFLAGS_COMPILE}
+  initString+=$(printf ', \"%s\"' "${cflags_array[@]}")
+fi
+
+initString+="]}}"
+
+exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "${extraFlagsArray[@]}" "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8492,7 +8492,11 @@ in
   cpplint = callPackage ../development/tools/analysis/cpplint { };
 
   cquery = callPackage ../development/tools/misc/cquery {
-    llvmPackages = llvmPackages_7;
+    llvmPackages = llvmPackages_latest;
+  };
+
+  ccls = callPackage ../development/tools/misc/ccls {
+    llvmPackages = llvmPackages_latest;
   };
 
   credstash = with python3Packages; toPythonApplication credstash;


### PR DESCRIPTION
- tested with [emacs](https://dl.thalheim.io/kdh-PwxzlwGKTEl1_NpTzg/2019-01-13-190156_1920x1080_scrot.png) and vim on nix and systemd.
- wrapped to pick up our cc wrapper environment -> works perfectly in nix-shell

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

