### PR TITLE
detect-secrets: 0.11.0 -> 0.11.4

### DIFF
--- a/pkgs/development/tools/detect-secrets/default.nix
+++ b/pkgs/development/tools/detect-secrets/default.nix
@@ -2,20 +2,20 @@
 
 buildPythonApplication rec {
   pname = "detect-secrets";
-  version = "0.11.0";
+  version = "0.11.4";
 
   # PyPI tarball doesn't ship tests
   src = fetchFromGitHub {
     owner = "Yelp";
     repo = "detect-secrets";
     rev = "v${version}";
-    sha256 = "11r11q6d8aajqqnhhz4lsa93qf1x745331kl9jd3z4y4w91l4gdz";
+    sha256 = "1ydigridkjirrfhyfr8barw0yrd4hw6w0k9g7mbd0gdqng6gpmgc";
   };
 
-  propagatedBuildInputs = [ pyyaml unidiff ]
+  propagatedBuildInputs = [ pyyaml ]
     ++ lib.optionals isPy27 [ configparser enum34 future functools32 ];
 
-  checkInputs = [ mock pytest ];
+  checkInputs = [ mock pytest unidiff ];
 
   # deselect tests which require git setup
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

