### PR TITLE
openssh: apply CVE-2018-20685 patch

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -41,6 +41,15 @@ stdenv.mkDerivation rec {
 
       # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
       ./dont_create_privsep_path.patch
+
+      # CVE-2018-20685, can probably be dropped with next version bump
+      # See https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
+      # for details
+      (fetchpatch {
+        name = "CVE-2018-20685.patch";
+        url = https://github.com/openssh/openssh-portable/commit/6010c0303a422a9c5fa8860c061bf7105eb7f8b2.patch;
+        sha256 = "0q27i9ymr97yb628y44qi4m11hk5qikb1ji1vhvax8hp18lwskds";
+      })
     ]
     ++ optional withGssapiPatches (assert withKerberos; gssapiPatch);
 


### PR DESCRIPTION
###### Motivation for this change

@samueldr mentioned in #nixos-security (IRC) that there exists an issue with SCP (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=919101; variant 1 from https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

