### PR TITLE
nginx: expose list of additional modules

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -87,6 +87,8 @@ stdenv.mkDerivation {
     mv $out/sbin $out/bin
   '';
 
+  passthru.modules = modules;
+
   meta = {
     description = "A reverse proxy and lightweight webserver";
     homepage    = http://nginx.org;


### PR DESCRIPTION
###### Motivation for this change

Currently, it seems there is no easy way to override package to add
modules. For example, if we want to add the `ipscrub` module, we can
do:

    pkgs.nginxStable.override {
      modules = [ pkgs.nginxModules.ipscrub ];
    };

But, then, we loose `rtmp`, `dav` and `moreheaders` which are defined
in `all-packages.nix`. With this modification, we can now do:

    pkgs.nginxStable.override {
      modules = pkg.nginxStable.passthru.modules ++ [ pkgs.nginxModules.ipscrub ];
    };

I have been suggested this on IRC by @cleverca22. He told me to put that in `meta`, but I didn't find another example of use of passthru in meta while there are several examples of using passthru outside of meta. Tested through `nix repl` with:

```
:l <nixpkgs>
myNginx = pkgs.nginxStable.override { modules = pkgs.nginxStable.passthru.modules ++ [ pkgs.nginxModules.ipscrub ]; }
:b myNginx
```

Then `/nix/store/.../bin/nginx -V` shows:

```
nginx version: nginx/1.14.2
built by gcc 7.4.0 (GCC)
built with OpenSSL 1.0.2q  20 Nov 2018
TLS SNI support enabled
configure arguments: --prefix=/nix/store/11pr5fhax5gfslhirlcr6zvylk5090wy-nginx-1.14.2 --with-http_ssl_module --with-http_v2_module --with-http_realip_module --with-http_addition_module --with-http_xslt_module --with-http_geoip_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_auth_request_module --with-http_random_index_module --with-http_secure_link_module --with-http_degradation_module --with-http_stub_status_module --with-threads --with-pcre-jit --with-stream --with-stream_geoip_module --with-stream_realip_module --with-stream_ssl_module --with-stream_ssl_preread_module --with-http_image_filter_module --with-file-aio --add-module=/nix/store/4w2zbpv9ihl36kbpp6w5d1x33gp5ivfh-source --add-module=/nix/store/c1d0qwva4ncx3473pl336q3fbjs5qslr-source --add-module=/nix/store/jsqrk045m09i136mgcfjfai8i05nq14c-source --add-module=/nix/store/14a8h4xrv62l0b7njnq1jgka7ci6biv6-source/ipscrub
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

