### PR TITLE
WIP: Sign systemd boot EFI images for secure booting.

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -116,7 +116,6 @@ def write_secureboot_entry(profile, generation, machine_id):
     if profile:
         entry_file = "@efiSysMountPoint@/loader/entries/nixos-%s-generation-%d.conf" % (profile, generation)
         efi_file_relative = "EFI/nixos/nixos-%s-generation-%d.efi" % (profile, generation)
-        efi_file = "@efiSysMountPoint@/%s" % (efi_file_relative)
     else:
         entry_file = "@efiSysMountPoint@/loader/entries/nixos-generation-%d.conf" % (generation)
         efi_file_relative = "EFI/nixos/nixos-generation-%d.efi" % (generation)

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -169,7 +169,6 @@ def write_secureboot_entry(profile, generation, machine_id):
 
         os.rename(entry_tmp, entry_file)
         os.unlink(tmp_path)
-        os.unlink(kernel_param_file)
 
 def sign_path(src, output):
     subprocess.check_call([

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -141,7 +141,7 @@ def write_secureboot_entry(profile, generation, machine_id):
         kernel_params = "systemConfig=%s init=%s/init " % (generation_dir, generation_dir)
         with open("%s/kernel-params" % (generation_dir)) as params_file:
             kernel_params = kernel_params + params_file.read()
-        kernel_param_file = "%s.kernel_params.tmp" % (efi_file)
+        kernel_param_file = "%s/kernel_params" % tmpdir
         with open(kernel_param_file, 'w') as f:
             f.write(kernel_params)
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -7,13 +7,11 @@ import errno
 import subprocess
 import glob
 import tempfile
-import errno
 import warnings
 import ctypes
 libc = ctypes.CDLL("libc.so.6")
 import re
 import datetime
-import glob
 import os.path
 
 def copy_if_not_exists(source, dest):
@@ -46,7 +44,7 @@ def write_loader_conf(profile, generation):
             f.write("default nixos-%s-generation-%d\n" % (profile, generation))
         else:
             f.write("default nixos-generation-%d\n" % (generation))
-        if not @editor@:
+        if "@editor@" != "1":
             f.write("editor 0\n");
         f.write("console-mode @consoleMode@\n");
     os.rename("@efiSysMountPoint@/loader/loader.conf.tmp", "@efiSysMountPoint@/loader/loader.conf")

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -168,7 +168,6 @@ def write_secureboot_entry(profile, generation, machine_id):
                 fp.write("machine-id %s\n" % machine_id)
 
         os.rename(entry_tmp, entry_file)
-        os.unlink(tmp_path)
 
 def sign_path(src, output):
     subprocess.check_call([

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -136,7 +136,7 @@ def write_secureboot_entry(profile, generation, machine_id):
             initrd = profile_path(profile, generation, "initrd"),
 
         generation_dir = os.readlink(system_dir(profile, generation))
-        tmp_path = "%s.tmp" % (efi_file)
+        tmp_path = "%s/efistub" % (tmpdir)
 
         kernel_params = "systemConfig=%s init=%s/init " % (generation_dir, generation_dir)
         with open("%s/kernel-params" % (generation_dir)) as params_file:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -119,7 +119,7 @@ def write_secureboot_entry(profile, generation, machine_id):
     else:
         entry_file = "@efiSysMountPoint@/loader/entries/nixos-generation-%d.conf" % (generation)
         efi_file_relative = "EFI/nixos/nixos-generation-%d.efi" % (generation)
-        efi_file = "@efiSysMountPoint@/%s" % (efi_file_relative)
+    efi_file = "@efiSysMountPoint@/%s" % (efi_file_relative)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         append_initrd_secrets = profile_path(profile, generation, "append-initrd-secrets")


### PR DESCRIPTION
with efitools (`nix-shell -p efitools`)

and running with openssl in the shell environment:

    $ cd /home/grahamc/projects/grahamc/secure-boot
    $ uuidgen --random > GUID.txt
    $ openssl req -newkey rsa:4096 -nodes -keyout PK.key -new -x509 -sha256 -days 3650 -subj "/CN=my Platform Key/" -out PK.crt
    $ openssl x509 -outform DER -in PK.crt -out PK.cer
    $ cert-to-efi-sig-list -g "$(< GUID.txt)" PK.crt PK.esl
    $ sign-efi-sig-list -g "$(< GUID.txt)" -k PK.key -c PK.crt PK PK.esl PK.auth
    $ sign-efi-sig-list -g "$(< GUID.txt)" -c PK.crt -k PK.key PK /dev/null rm_PK.auth

    $ openssl req -newkey rsa:4096 -nodes -keyout KEK.key -new -x509 -sha256 -days 3650 -subj "/CN=my Key Exchange Key/" -out KEK.crt
    $ openssl x509 -outform DER -in KEK.crt -out KEK.cer
    $ cert-to-efi-sig-list -g "$(< GUID.txt)" KEK.crt KEK.esl
    $ sign-efi-sig-list -g "$(< GUID.txt)" -k PK.key -c PK.crt KEK KEK.esl KEK.auth

    $ openssl req -newkey rsa:4096 -nodes -keyout db.key -new -x509 -sha256 -days 3650 -subj "/CN=my Signature Database key/" -out db.crt
    $ openssl x509 -outform DER -in db.crt -out db.cer
    $ cert-to-efi-sig-list -g "$(< GUID.txt)" db.crt db.esl
    $ sign-efi-sig-list -g "$(< GUID.txt)" -k KEK.key -c KEK.crt db db.esl db.auth

and then loading the .auth files in my UEFI firmware, then setting in
my configuration.nix:

    boot = {
      loader = {
        systemd-boot = {
          enable = true;
          signed = true;
          signing-key = "/home/grahamc/projects/grahamc/secure-boot/db.key";
          signing-certificate = "/home/grahamc/projects/grahamc/secure-boot/db.crt";
        };
      };
    };

and running `nixos-rebuild boot` I was able to secure-boot my laptop.

Note: this code signs EVERY boot entry for NixOS, and the BOOT files
from systemd (even if they're already tampered with! since this code
doesn't replace it.) AND does not allow a graceful key phase out. If
the key is replaced in gen2, gen1's boot EFI is deleted and replaced
with a new version.

Also note this only works on x86-64 due to the assumptions in the
builder.py.

**Finally, you can have much fewer generations: each generation on my
laptop takes 20MB in /boot.**

Info taken from:

 - https://wiki.archlinux.org/index.php/Secure_Boot#Using_your_own_keys
 - https://systemd.io/BOOT_LOADER_SPECIFICATION#type-2-efi-unified-kernel-images
 - https://www.freedesktop.org/software/systemd/man/os-release.html
