### PR TITLE
cpupower: fix w/linux 5, rework a bit

### DIFF
--- a/pkgs/os-specific/linux/cpupower/default.nix
+++ b/pkgs/os-specific/linux/cpupower/default.nix
@@ -17,16 +17,16 @@ stdenv.mkDerivation {
   makeFlags = [ "CROSS=${stdenv.cc.targetPrefix}" ];
 
   installFlags = stdenv.lib.mapAttrsToList
-    (n: v: "${n}=${placeholder "out"}/${v}") {
-    bindir = "bin";
-    sbindir = "sbin";
-    mandir = "share/man";
-    includedir = "include";
-    libdir = "lib";
-    localedir = "share/locale";
-    docdir = "share/doc/cpupower";
-    confdir = "etc";
-    bash_completion_dir = "share/bash-completion/completions";
+    (n: v: "${n}dir=${placeholder "out"}/${v}") {
+    bin = "bin";
+    sbin = "sbin";
+    man = "share/man";
+    include = "include";
+    lib = "lib";
+    locale = "share/locale";
+    doc = "share/doc/cpupower";
+    conf = "etc";
+    bash_completion_ = "share/bash-completion/completions";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/cpupower/default.nix
+++ b/pkgs/os-specific/linux/cpupower/default.nix
@@ -1,9 +1,8 @@
 { stdenv, buildPackages, kernel, pciutils, gettext }:
 
 stdenv.mkDerivation {
-  name = "cpupower-${kernel.version}";
-
-  src = kernel.src;
+  pname = "cpupower";
+  inherit (kernel) version src;
 
   nativeBuildInputs = [ gettext ];
   buildInputs = [ pciutils ];
@@ -17,16 +16,18 @@ stdenv.mkDerivation {
 
   makeFlags = [ "CROSS=${stdenv.cc.targetPrefix}" ];
 
-  installFlags = [
-    "bindir=$(out)/bin"
-    "sbindir=$(out)/sbin"
-    "mandir=$(out)/share/man"
-    "includedir=$(out)/include"
-    "libdir=$(out)/lib"
-    "localedir=$(out)/share/locale"
-    "docdir=$(out)/share/doc/cpupower"
-    "confdir=$(out)/etc"
-  ];
+  installFlags = stdenv.lib.mapAttrsToList
+    (n: v: "${n}=${placeholder "out"}/${v}") {
+    bindir = "bin";
+    sbindir = "sbin";
+    mandir = "share/man";
+    includedir = "include";
+    libdir = "lib";
+    localedir = "share/locale";
+    docdir = "share/doc/cpupower";
+    confdir = "etc";
+    bash_completion_dir = "share/bash-completion/completions";
+  };
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Primarily need to specify where to install bash completions,
or the build fails attempting to write to invalid location.

The rest is because I was going cross-eyed checking I didn't typo
one of the "dir" flags, but I can see this either way.

General trend seems to be away from "$(out)" usage here,
in favor of the placholder builtin for the
definitely-not-shell-escape-problem factor :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---