### PR TITLE
networkmanager: leave thunderbolt rule alone, it's builtin

### DIFF
--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -22,17 +22,6 @@
 +PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @coreutils@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
---- a/data/90-nm-thunderbolt.rules
-+++ b/data/90-nm-thunderbolt.rules
-@@ -5,7 +5,7 @@
- 
- # Load he thunderbolt-net driver if we a device of type thunderbolt_xdomain
- # is added.
--SUBSYSTEM=="thunderbolt", ENV{DEVTYPE}=="thunderbolt_xdomain", RUN{builtin}+="kmod load thunderbolt-net"
-+SUBSYSTEM=="thunderbolt", ENV{DEVTYPE}=="thunderbolt_xdomain", RUN{builtin}+="@kmod@/bin/kmod load thunderbolt-net"
- 
- # For all thunderbolt network devices, we want to enable link-local configuration
- SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="thunderbolt-net", ENV{NM_AUTO_DEFAULT_LINK_LOCAL_ONLY}="1"
 --- a/data/NetworkManager.service.in
 +++ b/data/NetworkManager.service.in
 @@ -8,7 +8,7 @@


### PR DESCRIPTION
###### Motivation for this change

As-is I'm seeing errors in log an invalid rule:

```
Jan 09 11:05:24 dtznix systemd-udevd[556]: Invalid rule /nix/store/fcqa36rd10d5rjcbv7xbwmzrvdi6wd90-udev-rules/90-nm-thunderbolt.rules:8: RUN{builtin}: '/nix/store/h6m6nj56v9q4jqhc8vqhqy27qzhkgprs-kmod-25/bin/kmod load thunderbolt-net' unknown
```

However with this change (using stock upstream version of this file),
the error is gone-- presumably `kmod` is how to specify the builtin?

Grep'ing (ripgrep anyway) for other uses of `builtin` in my system's
udev rules suggests there are no other instances where absolute path
is given and just the tool name in the handful of cases it IS used.
YMMV, of course.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---