### PR TITLE
asciinema: 2.0.1 -> 2.0.2

### DIFF
--- a/pkgs/tools/misc/asciinema/default.nix
+++ b/pkgs/tools/misc/asciinema/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "asciinema";
-  version = "2.0.1";
+  version = "2.0.2";
 
   buildInputs = with python3Packages; [ nose ];
   propagatedBuildInputs = with python3Packages; [ requests ];
@@ -11,13 +11,8 @@ python3Packages.buildPythonApplication rec {
     owner = "asciinema";
     repo = "asciinema";
     rev = "v${version}";
-    sha256 = "09m9agkslrbm36y8pjqhg5nmyz9hppjyhafhzpglnadhfgwqzznr";
+    sha256 = "1a2pysxnp6icyd08mgf66xr6f6j0irnfxdpf3fmzcz31ix7l9kc4";
   };
-
-  patchPhase = ''
-    # disable one test which is failing with -> OSError: out of pty devices
-    rm tests/pty_recorder_test.py
-  '';
 
   checkInputs = [ glibcLocales ];
 

--- a/pkgs/tools/misc/asciinema/default.nix
+++ b/pkgs/tools/misc/asciinema/default.nix
@@ -4,7 +4,6 @@ python3Packages.buildPythonApplication rec {
   pname = "asciinema";
   version = "2.0.2";
 
-  buildInputs = with python3Packages; [ nose ];
   propagatedBuildInputs = with python3Packages; [ requests ];
 
   src = fetchFromGitHub {
@@ -14,7 +13,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1a2pysxnp6icyd08mgf66xr6f6j0irnfxdpf3fmzcz31ix7l9kc4";
   };
 
-  checkInputs = [ glibcLocales ];
+  checkInputs = [ glibcLocales python3Packages.nose ];
 
   checkPhase = ''
     LC_ALL=en_US.UTF-8 nosetests

--- a/pkgs/tools/misc/asciinema/default.nix
+++ b/pkgs/tools/misc/asciinema/default.nix
@@ -4,8 +4,6 @@ python3Packages.buildPythonApplication rec {
   pname = "asciinema";
   version = "2.0.2";
 
-  propagatedBuildInputs = with python3Packages; [ requests ];
-
   src = fetchFromGitHub {
     owner = "asciinema";
     repo = "asciinema";


### PR DESCRIPTION
https://github.com/asciinema/asciinema/blob/v2.0.2/CHANGELOG.md#202-2019-01-12


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---