### PR TITLE
source-sans-pro: 2.040 -> 2.045

### DIFF
--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchzip }:
 
 fetchzip {
-  name = "source-sans-pro-2.040";
+  name = "source-sans-pro-2.045";
 
-  url = "https://github.com/adobe-fonts/source-sans-pro/releases/download/2.040R-ro%2F1.090R-it/source-sans-pro-2.040R-ro-1.090R-it.zip";
+  url = https://github.com/adobe-fonts/source-sans-pro/releases/download/2.045R-ro%2F1.095R-it/source-sans-pro-2.045R-ro-1.095R-it.zip;
 
   postFetch = ''
-    mkdir -p $out/share/fonts/opentype $out/share/fonts/truetype $out/share/fonts/variable
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
     unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
     unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
     unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
   '';
 
-  sha256 = "1n7z9xpxls74xxjsa61df1ln86y063m07w1f4sbxpjaa0frim4pp";
+  sha256 = "0xjdp226ybdcfylbpfsdgnz2bf4pj4qv1wfs6fv22hjxlzqfixf3";
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/adobe/sourcesans;


### PR DESCRIPTION
https://github.com/adobe-fonts/source-sans-pro/releases/tag/2.045R-ro%2F1.095R-it


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---