### PR TITLE
source-serif-pro: 1.017 -> 2.010, sync w/source-sans-pro expression

### DIFF
--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -18,7 +18,7 @@ in fetchzip {
     description = "A set of monospaced OpenType fonts designed for coding environments";
     maintainers = with stdenv.lib.maintainers; [ relrod ];
     platforms = with stdenv.lib.platforms; all;
-    homepage = https://blog.typekit.com/2012/09/24/source-code-pro/;
+    homepage = https://adobe-fonts.github.io/source-code-pro/;
     license = stdenv.lib.licenses.ofl;
   };
 }

--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -15,7 +15,7 @@ fetchzip {
   sha256 = "1n7z9xpxls74xxjsa61df1ln86y063m07w1f4sbxpjaa0frim4pp";
 
   meta = with stdenv.lib; {
-    homepage = https://sourceforge.net/adobe/sourcesans;
+    homepage = https://adobe-fonts.github.io/source-sans-pro/;
     description = "A set of OpenType fonts designed by Adobe for UIs";
     license = licenses.ofl;
     platforms = platforms.all;

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,18 +1,20 @@
 { stdenv, fetchzip }:
 
 let
-  version = "1.017";
+  version = "2.010";
 in fetchzip {
   name = "source-serif-pro-${version}";
 
-  url = "https://github.com/adobe-fonts/source-serif-pro/archive/${version}R.zip";
+  url = "https://github.com/adobe-fonts/source-serif-pro/releases/download/${version}R-ro%2F1.010R-it/source-serif-pro-${version}R-ro-1.010R-it.zip";
 
   postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
   '';
 
-  sha256 = "04447fbj7lwr2qmmvy7d7624qdh4in7hp627nsc8vbpxmb7bbmn1";
+  sha256 = "1a3lmqk7hyxpfkb30s9z73lhs823dmq6xr5llp9w23g6bh332x2h";
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/adobe/sourceserifpro;

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -17,7 +17,7 @@ in fetchzip {
   sha256 = "1a3lmqk7hyxpfkb30s9z73lhs823dmq6xr5llp9w23g6bh332x2h";
 
   meta = with stdenv.lib; {
-    homepage = https://sourceforge.net/adobe/sourceserifpro;
+    homepage = https://adobe-fonts.github.io/source-serif-pro/;
     description = "A set of OpenType fonts to complement Source Sans Pro";
     license = licenses.ofl;
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Now installs font in various formats, not only OTF,
since that's what we do with source-sans-pro.

If this needs to be changed, we should fix that as well.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---