### PR TITLE
ocrad: 0.26 -> 0.27

### DIFF
--- a/pkgs/applications/graphics/ocrad/default.nix
+++ b/pkgs/applications/graphics/ocrad/default.nix
@@ -1,14 +1,16 @@
 { fetchurl, stdenv, lzip, texinfo }:
 
 stdenv.mkDerivation rec {
-  name = "ocrad-0.26";
+  pname = "ocrad";
+  version = "0.27";
 
   src = fetchurl {
-    url = "mirror://gnu/ocrad/${name}.tar.lz";
-    sha256 = "0g4fq7maybdnd1471kd05a3f5sb7spa3d26k706rk85sd5wd70y3";
+    url = "mirror://gnu/ocrad/${pname}-${version}.tar.lz";
+    sha256 = "0divffvcaim89g4pvqs8kslbcxi475bcl3b4ynphf284k9zfdgx9";
   };
 
-  buildInputs = [ lzip texinfo ];
+  nativeBuildInputs = [ lzip /* unpack */ ];
+  buildInputs = [ texinfo ];
 
   doCheck = true;
 


### PR DESCRIPTION
https://lists.gnu.org/archive/html/bug-ocrad/2019-01/msg00000.html


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---