### PR TITLE
vscode-extensions.ms-python.python: Fix packaging.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3978,6 +3978,11 @@
     github = "sdll";
     name = "Sasha Illarionov";
   };
+  sdorminey = {
+    email = "amabel.dorminey@gmail.com";
+    github = "sdorminey";
+    name = "Star Dorminey";
+  };
   SeanZicari = {
     email = "sean.zicari@gmail.com";
     github = "SeanZicari";

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -1,5 +1,11 @@
-{ lib, vscode-utils
-
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, makeWrapper
+, icu
+, openssl
+, vscode-utils
 , pythonUseFixed ? false, python  # When `true`, the python default setting will be fixed to specified.
                                   # Use version from `PATH` for default setting otherwise.
                                   # Defaults to `false` as we expect it to be project specific most of the time.
@@ -14,6 +20,40 @@ assert ctagsUseFixed -> null != ctags;
 let
   pythonDefaultsTo = if pythonUseFixed then "${python}/bin/python" else "python";
   ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
+
+  # The arch tag comes from 'PlatformName' defined here:
+  # https://github.com/Microsoft/vscode-python/blob/master/src/client/activation/types.ts
+  archTag =
+    if stdenv.isLinux && stdenv.isx86_64 then "linux-x64"
+    else if stdenv.isDarwin then "osx-x64"
+    else throw "Only x86_64 Linux and Darwin are supported.";
+
+  extractNuGet = { name, version, src, ... }:
+    stdenv.mkDerivation {
+      inherit name version src;
+
+      buildInputs = [ unzip ];
+      dontBuild = true;
+      unpackPhase = "unzip $src";
+      installPhase = ''
+        mkdir -p "$out"
+        chmod -R +w .
+        find . -mindepth 1 -maxdepth 1 | xargs cp -a -t "$out"
+      '';
+    };
+
+  languageServer = extractNuGet rec {
+    name="Python-Language-Server";
+    version = "0.1.75";
+    src = fetchurl {
+      url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${archTag}.${version}.nupkg";
+      sha256 = "c15937eb9e81538971794bced4d58041381d26724dc05a72b76bd7c25db5ebd5";
+    };
+  };
+
+  libPath = lib.makeLibraryPath [
+    stdenv.cc.cc.lib  # libstdc++.so.6
+  ];
 in
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -23,6 +63,25 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2018.12.1";
     sha256 = "1cf3yll2hfililcwq6avscgi35caccv8m8fdsvzqdfrggn5h41h4";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ languageServer icu openssl ];
+  dontPatchELF = true;
+
+  buildPhase = ''
+    mkdir -p "languageServer.${languageServer.version}"
+    cp -R --no-preserve=ownership ${languageServer}/* "languageServer.${languageServer.version}"
+    chmod -R +wx "languageServer.${languageServer.version}"
+
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      "languageServer.${languageServer.version}/Microsoft.Python.LanguageServer"
+  '';
+
+  fixupPhase = ''
+    wrapProgram `find $out -name Microsoft.Python.LanguageServer` --prefix LD_LIBRARY_PATH ":" ${icu}/lib:${openssl.out}/lib
+  '';
 
   postPatch = ''
     # Patch `packages.json` so that nix's *python* is used as default value for `python.pythonPath`.
@@ -34,8 +93,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
       --replace "\"default\": \"ctags\"" "\"default\": \"${ctagsDefaultsTo}\""
   '';
 
-    meta = with lib; {
-      license = licenses.mit;
-      maintainers = [ maintainers.jraygauthier ];
-    };
+  meta = with lib; {
+    license = licenses.mit;
+    maintainers = [ maintainers.jraygauthier maintainers.sdorminey ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Previously, this extension used the JEDI backend for understanding
Python. Recently, Microsoft switched to using their Python Language
Server (https://github.com/Microsoft/python-language-server). The
extension attempts to download the latest version into the extension
folder, which failed for obvious reasons.

This change packages the language server into the extension, and
performs the necessary fixups and wrapping to make the dotnet binary
run.

Tested on Linux x86_64, but it should work on Darwin too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) `Before: 2794344 After: 2869216`
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

