### PR TITLE
oci-image-tool: init at 1.0.0-rc1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3235,6 +3235,11 @@
     github = "nyarly";
     name = "Judson Lester";
   };
+  nzhang-zh = {
+    email = "n.zhang.hp.au@gmail.com";
+    github = "nzhang-zh";
+    name = "Ning Zhang";
+  };
   obadz = {
     email = "obadz-nixos@obadz.com";
     github = "obadz";

--- a/pkgs/tools/misc/oci-image-tool/default.nix
+++ b/pkgs/tools/misc/oci-image-tool/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "oci-image-tool-${version}";
+  version = "1.0.0-rc1";
+
+  goPackagePath = "github.com/opencontainers/image-tools";
+  subPackages = [ "cmd/oci-image-tool" ];
+
+  src = fetchFromGitHub {
+    owner = "opencontainers";
+    repo = "image-tools";
+    rev = "v${version}";
+    sha256 = "0c4n69smqlkf0r6khy9gbg5f810qh9g8jqsl9kibb0dyswizr14r";
+  };
+
+  meta = {
+    description = "A collection of tools for working with the OCI image format specification";
+    homepage = https://github.com/opencontainers/image-tools;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nzhang-zh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4562,6 +4562,8 @@ in
 
   obexd = callPackage ../tools/bluetooth/obexd { };
 
+  oci-image-tool = callPackage ../tools/misc/oci-image-tool { };
+
   ocproxy = callPackage ../tools/networking/ocproxy { };
 
   ocserv = callPackage ../tools/networking/ocserv { };


### PR DESCRIPTION
###### Motivation for this change
Using this to validate and unpack OCI images.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

