### PR TITLE
nexus: 3.14.0-04 -> 3.15.0-01

### DIFF
--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, makeWrapper, jre, gawk }:
+{ stdenv, fetchurl, makeWrapper, jre_headless, gawk }:
 
 stdenv.mkDerivation rec {
   name = "nexus-${version}";
-  version = "3.14.0-04";
+  version = "3.15.0-01";
 
   src = fetchurl {
     url = "https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-${version}-unix.tar.gz";
-    sha256 = "1ql707672xhybmfajjmli9w0wcf1f26skq8i5kqirms2364wg35f";
+    sha256 = "0akizdljcjl1nh25k01wxvp5wp4i2jphsj0hh5rqbd0fk1pjivkv";
   };
 
   sourceRoot = name;
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     rm -fv $out/bin/nexus.bat
 
     wrapProgram $out/bin/nexus \
-      --set JAVA_HOME ${jre} \
+      --set JAVA_HOME ${jre_headless} \
       --set ALTERNATIVE_NAME "nexus" \
       --prefix PATH "${stdenv.lib.makeBinPath [ gawk ]}"
 


### PR DESCRIPTION
###### Motivation for this change

Update Nexus to the latest available version. I also changed `jre` to `jre_headless`, since the graphical part is not needed by the application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

// cc @aespinosa @ironpinguin @aflatter @ma27
