### PR TITLE
pythonPackages.qrcode: 6.0 -> 6.1

### DIFF
--- a/pkgs/development/python-modules/qrcode/default.nix
+++ b/pkgs/development/python-modules/qrcode/default.nix
@@ -10,16 +10,15 @@
 
 buildPythonPackage rec {
   pname = "qrcode";
-  version = "6.0";
+  version = "6.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "037b0db4c93f44586e37f84c3da3f763874fcac85b2974a69a98e399ac78e1bf";
+    sha256 = "505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369";
   };
 
   propagatedBuildInputs = [ six pillow pymaging_png ];
   checkInputs = [ mock ];
-  doCheck = isPy27; # https://github.com/lincolnloop/python-qrcode/issues/163
 
   meta = with stdenv.lib; {
     description = "Quick Response code generation for Python";


### PR DESCRIPTION
###### Motivation for this change

This update fixes checks with python 3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

