### PR TITLE
[18.09] dub: Fix package build

### DIFF
--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -24,6 +24,15 @@ let
     postPatch = ''
         substituteInPlace test/fetchzip.sh \
             --replace "dub remove" "\"${dubvar}\" remove"
+
+        substituteInPlace test/interactive-remove.sh \
+            --replace "0.9.20" "1.9.0"
+
+        substituteInPlace test/interactive-remove.sh \
+            --replace "0.9.21" "1.10.0"
+
+        substituteInPlace test/interactive-remove.sh \
+            --replace "select.*0\.9\.20.*0\.9\.21.*" "select.*1\.9\.0.*1\.10\.0.*"
     '';
 
     nativeBuildInputs = [ dmd libevent rsync ];


### PR DESCRIPTION
###### Motivation for this change

Resolves: #53031

The interactive-remove.sh test of dub doesn't work anymore because the dub registry doesn't support the versions in the test anymore.
This commit fixes the test and so fixes the package build in release-18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

