### PR TITLE
 python.pkgs.recommonmark: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -1,26 +1,30 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pytest
-, sphinx
-, CommonMark_54
+, CommonMark
 , docutils
+, sphinx
 }:
 
 buildPythonPackage rec {
   pname = "recommonmark";
-  version = "0.4.0";
+  version = "0.5.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "6e29c723abcf5533842376d87c4589e62923ecb6002a8e059eb608345ddaff9d";
+  # PyPI tarball is missing some test files: https://github.com/rtfd/recommonmark/pull/128
+  src = fetchFromGitHub {
+    owner = "rtfd";
+    repo = pname;
+    rev = version;
+    sha256 = "04bjqx2hczmg7rnj2rpsjk7h24diwk83s6fhgrxk00k40w2bpz5j";
   };
 
-  checkInputs = [ pytest sphinx ];
-  propagatedBuildInputs = [ CommonMark_54 docutils ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ CommonMark docutils sphinx ];
 
-  # No tests in archive
-  doCheck = false;
+  checkPhase = ''
+    py.test
+  '';
 
   meta = {
     description = "A docutils-compatibility bridge to CommonMark";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1270,14 +1270,6 @@ in {
 
   CommonMark = callPackage ../development/python-modules/commonmark { };
 
-  CommonMark_54 = self.CommonMark.overridePythonAttrs (oldAttrs: rec {
-    version = "0.5.4";
-    src = oldAttrs.src.override {
-      inherit version;
-      sha256 = "34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5";
-    };
-  });
-
   coilmq = callPackage ../development/python-modules/coilmq { };
 
   colander = callPackage ../development/python-modules/colander { };


### PR DESCRIPTION
###### Motivation for this change
Sphinx was moved to `propagatedBuildInputs` becaused it's listed in `install_requires`: https://github.com/rtfd/recommonmark/blob/0.5.0/setup.py#L28

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh 