### PR TITLE
attr: fix issues with 2.4.48

### DIFF
--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gettext ];
 
+  patches = [
+    # fix fakechroot: https://github.com/dex4er/fakechroot/issues/57
+    (fetchurl {
+      url = "https://git.savannah.nongnu.org/cgit/attr.git/patch/?id=14adc898a36948267bfe5c63b399996879e94c98";
+      sha256 = "0gja54fz79a9ma6b4mprnjxq77l5yg2z9xknlwhmkcrfnam02qxp";
+    })
+  ];
+
   postPatch = ''
     for script in install-sh include/install-sh; do
       patchShebangs $script


### PR DESCRIPTION
###### Motivation for this change

Shim to sys/xattr.h and add upstream patch to fix issues with fakechroot.

resolves #53716

Similar to fedora and gentoo:

- https://src.fedoraproject.org/rpms/attr/blob/7244374ddecc5a63e336b6d3a96021c9fa14f4dd/f/attr.spec#_89
- https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-apps/attr/attr-2.4.48-r3.ebuild?id=077738eb8a9905827e615ddb1ac2e788337b1291#n75

cc @pbogdan hopefully just symlinking like this should work?

###### Things done

Built bcachefs-tools (without https://github.com/NixOS/nixpkgs/pull/53919 which fixes it independently) and things seemed to work.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

