### PR TITLE
pythonPackages.pyvcd: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3930,6 +3930,11 @@
     github = "sauyon";
     name = "Sauyon Lee";
   };
+  sb0 = {
+    email = "sb@m-labs.hk";
+    github = "sbourdeauducq";
+    name = "Sébastien Bourdeauducq";
+  };
   sboosali = {
     email = "SamBoosalis@gmail.com";
     github = "sboosali";

--- a/pkgs/development/python-modules/pyvcd/default.nix
+++ b/pkgs/development/python-modules/pyvcd/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, six
+, pytest }:
+
+buildPythonPackage rec {
+  version = "0.1.4";
+  pname = "pyvcd";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dv9wac5y5z9j54ypyc59csxdiy9ybpphw9ipxp1k8nfg65q9jxx";
+  };
+
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "Python package for writing Value Change Dump (VCD) files";
+    homepage = https://github.com/SanDisk-Open-Source/pyvcd;
+    license = licenses.mit;
+    maintainers = [ maintainers.sb0 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -698,6 +698,8 @@ in {
 
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });
 
+  pyvcd = callPackage ../development/python-modules/pyvcd { };
+
   pyvoro = callPackage ../development/python-modules/pyvoro { };
 
   relatorio = callPackage ../development/python-modules/relatorio { };


### PR DESCRIPTION
###### Motivation for this change
Add the pyvcd Python package required by some electronic design automation tools.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS) - Can't figure it out. Works fine with ``nix-shell --pure``.
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- N/A Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size: < 1MB
- N/A Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

