### PR TITLE
mbed-cli: init at 1.8.3

### DIFF
--- a/pkgs/development/tools/mbed-cli/default.nix
+++ b/pkgs/development/tools/mbed-cli/default.nix
@@ -1,0 +1,23 @@
+{ lib, python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "mbed-cli";
+  version = "1.8.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04vn2v0d7y3vmm8cswzvn2z85balgp3095n5flvgf3r60fdlhlmp";
+  };
+
+  doCheck = false; # no tests available in Pypi
+
+  meta = with lib; {
+    homepage = https://github.com/ARMmbed/mbed-cli;
+    description = "Arm Mbed Command Line Interface";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8842,6 +8842,8 @@ in
 
   mage = callPackage ../development/tools/build-managers/mage { };
 
+  mbed-cli = callPackage ../development/tools/mbed-cli { };
+
   minify = callPackage ../development/web/minify { };
 
   minizinc = callPackage ../development/tools/minizinc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

