### PR TITLE
pythonPackages.fuzzywuzzy: init at 0.17.0

### DIFF
--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -1,0 +1,22 @@
+{ lib , buildPythonPackage , fetchPypi, pycodestyle }:
+
+buildPythonPackage rec {
+  pname = "fuzzywuzzy";
+  version = "0.17.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qid283ysgzn3pm6pdm9dy9mghsa511dl5md80fwgq80vd3xwjbg";
+  };
+
+  propagatedBuildInputs = [
+    pycodestyle
+  ];
+
+  meta = with lib; {
+    description = "Fuzzy String Matching in Python";
+    homepage = https://github.com/seatgeek/fuzzywuzzy;
+    license = licenses.gpl20;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4665,6 +4665,8 @@ in {
 
   funcy = callPackage ../development/python-modules/funcy { };
 
+  fuzzywuzzy = callPackage ../development/python-modules/fuzzywuzzy { };
+
   vxi11 = callPackage ../development/python-modules/vxi11 { };
 
   svg2tikz = callPackage ../development/python-modules/svg2tikz { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

