### PR TITLE
pythonPackages.mbed-ls: init at 1.6.2

### DIFF
--- a/pkgs/development/python-modules/mbed-ls/default.nix
+++ b/pkgs/development/python-modules/mbed-ls/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi, appdirs, fasteners, prettytable, pytest, mock }:
+
+buildPythonPackage rec {
+  pname = "mbed-ls";
+  version = "1.6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nyb3cw4851cs8201q2fkna0z565j7169vj7wm2c88c8fm6qd21i";
+  };
+
+  checkInputs = [
+    mock
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    appdirs
+    fasteners
+    prettytable
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+
+    # this test requires test_data, which is not present in Pypi
+    rm test/platform_detection.py
+  '';
+
+  meta = with lib; {
+    description = "A Python module that detects and lists mbed-enabled devices connected to the host computer";
+    homepage = https://github.com/ARMmbed/mbed-os-tools;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/development/python-modules/mbed-ls/default.nix
+++ b/pkgs/development/python-modules/mbed-ls/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "mbed-ls";
-  version = "1.6.2";
+  version = "1.7.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0nyb3cw4851cs8201q2fkna0z565j7169vj7wm2c88c8fm6qd21i";
+    sha256 = "0nm4h0d4ijf0vzl10msqg0d3djirsys3j6fl3yda1n9fix3gyrbg";
   };
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3727,6 +3727,8 @@ in {
 
   maya = callPackage ../development/python-modules/maya { };
 
+  mbed-ls = callPackage ../development/python-modules/mbed-ls { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mechanize = callPackage ../development/python-modules/mechanize { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

