### PR TITLE
scribusUnstable: fix build failure from poppler bump

### DIFF
--- a/pkgs/applications/office/scribus/poppler-0.73.0.patch
+++ b/pkgs/applications/office/scribus/poppler-0.73.0.patch
@@ -1,0 +1,12 @@
+diff --git a/scribus/plugins/import/pdf/slaoutput.h b/scribus/plugins/import/pdf/slaoutput.h
+--- a/scribus/plugins/import/pdf/slaoutput.h
++++ b/scribus/plugins/import/pdf/slaoutput.h
+@@ -28,7 +28,7 @@ for which a new license (GPL+exception) is in place.
+ #include "selection.h"
+ #include "vgradient.h"
+ 
+-#include <poppler/goo/gtypes.h>
++#include <poppler/goo/gfile.h>
+ #include <poppler/Object.h>
+ #include <poppler/OutputDev.h>
+ #include <poppler/Gfx.h>

--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "18xqhxjm8dl4w3izg7202i8vicfggkcvi0p9ii28k43b5ps1akg1";
   };
 
+  patches = [ ./poppler-0.73.0.patch ];
+
   enableParallelBuilding = true;
 
   buildInputs = [

--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -4,16 +4,16 @@ podofo, poppler, poppler_data, python2, harfbuzz, qtimageformats, qttools }:
 
 let
   pythonEnv = python2.withPackages(ps: [ps.tkinter ps.pillow]);
-  revision = "22730";
+  revision = "22805";
 in 
 stdenv.mkDerivation rec {
   name = "scribus-unstable-${version}";
-  version = "2018-10-13";
+  version = "2019-01-14";
 
   src = fetchsvn {
     url = "svn://scribus.net/trunk/Scribus";
     rev = revision;
-    sha256 = "1nlg4qva0fach8fi07r1pakjjlijishpwzlgpnxyaz7r31yjaw63";
+    sha256 = "18xqhxjm8dl4w3izg7202i8vicfggkcvi0p9ii28k43b5ps1akg1";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Poppler was upgraded in https://github.com/NixOS/nixpkgs/commit/7757e43fcb15f3b3e21187787edaad54614ec7e6 and therefore `scribusUnstable` broke, as [poppler/goo/gtypes.h was moved into poppler/goo/gfile.h](https://gitlab.freedesktop.org/poppler/poppler/commit/ef3ef702bc3dc845731e43215400448c5324efd4).

The patch is intended to be broght upstream and then can be reverted.

###### Motivation for this change

Fixes #53943.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

