### PR TITLE
elixir_1_8: 1.8.0-rc.1 -> 1.8.1

### DIFF
--- a/pkgs/development/interpreters/elixir/1.8.nix
+++ b/pkgs/development/interpreters/elixir/1.8.nix
@@ -1,7 +1,7 @@
 { mkDerivation }:
 
 mkDerivation rec {
-  version = "1.8.0-rc.1";
-  sha256 = "06k9q46cwn79ic6kw0b0mskf9rqlgm02jb8n1ajz55kmw134kq6m";
+  version = "1.8.1";
+  sha256 = "1npnrkn21kqqfqrsn06mr78jxs6n5l8c935jpxvnmj7iysp50pf9";
   minimumOTPVersion = "20";
 }


### PR DESCRIPTION
###### Motivation for this change

Elixir 1.8.0 [is out](https://elixir-lang.org/blog/2019/01/14/elixir-v1-8-0-released/). I’ve let `elixir_1_7` as the default version as Elixir 1.8.0 has not been used widely in production yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

