### PR TITLE
python37Packages.cryptography{,_vectors}: 2.3.1 -> 2.4.2

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -23,11 +23,11 @@
 buildPythonPackage rec {
   # also bump cryptography_vectors
   pname = "cryptography";
-  version = "2.3.1";
+  version = "2.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6";
+    sha256 = "1pc60dksi9w9mshl6cvn7gdjazbp3pmydy3qp9wgy5wzd8n0b9h5";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/cryptography_vectors/default.nix
+++ b/pkgs/development/python-modules/cryptography_vectors/default.nix
@@ -5,11 +5,11 @@
 buildPythonPackage rec {
   # also bump cryptography
   pname = "cryptography_vectors";
-  version = "2.3.1";
+  version = "2.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bf4d9b61dce69c49e830950aa36fad194706463b0b6dfe81425b9e0bc6644d46";
+    sha256 = "013qx2hz0jv79yzfzpn0r2kk33i5qy3sdnzgwiv5779d18snblwi";
   };
 
   # No tests included


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

