### PR TITLE
osquery: fix build

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
     pkgconfig cmake pythonPackages.python pythonPackages.jinja2 doxygen fpm
   ];
 
+  NIX_LDFLAGS = [
+    "-lcrypto"
+  ];
+
   buildInputs = let
     gflags' = google-gflags.overrideAttrs (old: {
       cmakeFlags = stdenv.lib.filter (f: isNull (builtins.match ".*STATIC.*" f)) old.cmakeFlags;


### PR DESCRIPTION
###### Motivation for this change

It seems as without the appropriate linker flag `-lcrypto` the
`libcrypto.sh` can't be found by `ld` which broke one of the linker
processes during compilation.

See also https://hydra.nixos.org/build/87208819

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

