### PR TITLE
pythonPackages.fs: 2.1.2 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -18,11 +18,11 @@
 
 buildPythonPackage rec {
   pname = "fs";
-  version = "2.1.2";
+  version = "2.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6f7e36b6381f353339957784a67bd9d440482b7eaeaff7b1f97249ceb7223f63";
+    sha256 = "2581685468e0e492466170235e1bcda5ed4359c69607c83935afee7d4945ad2d";
   };
 
   buildInputs = [ pkgs.glibcLocales ];


### PR DESCRIPTION
###### Motivation for this change

Noticed out-of-date, no particular reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---