### PR TITLE
pythonPackages.munkres: 1.0.6 -> 1.0.12

### DIFF
--- a/pkgs/development/python-modules/munkres/default.nix
+++ b/pkgs/development/python-modules/munkres/default.nix
@@ -1,19 +1,24 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, nose
 }:
 
 buildPythonPackage rec {
   pname = "munkres";
-  version = "1.0.6";
+  version = "1.0.12";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "c78f803b9b776bfb20a25c9c7bb44adbf0f9202c2024d51aa5969d21e560208d";
+  # No sdist for 1.0.12, see https://github.com/bmc/munkres/issues/25
+  src = fetchFromGitHub {
+    owner = "bmc";
+    repo = pname;
+    rev = "release-${version}";
+    sha256 = "0m3rkn0z3ialndxmyg26xn081znna34i5maa1i4nkhy6nf0ixdjm";
   };
 
-  # error: invalid command 'test'
-  doCheck = false;
+  checkInputs = [ nose ];
+
+  checkPhase = "nosetests";
 
   meta = with stdenv.lib; {
     homepage = http://bmc.github.com/munkres/;


### PR DESCRIPTION
###### Motivation for this change

* fixes
* re-enable tests
* fetch from github, no sdist on pypi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---