### PR TITLE
openblas: 0.3.4 -> 0.3.5, rework a bit

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -72,24 +72,15 @@ let
 in
 stdenv.mkDerivation rec {
   name = "openblas-${version}";
-  version = "0.3.4";
+  version = "0.3.5";
   src = fetchFromGitHub {
     owner = "xianyi";
     repo = "OpenBLAS";
     rev = "v${version}";
-    sha256 = "1jdq4msfyg13pdmwwfqpixf4fshss68qzls820lmn0i6y7h4aix3";
+    sha256 = "0hwfplr6ciqjvfqkya5vz92z2rx8bhdg5mkh923z246ylhs6d94k";
   };
 
   inherit blas64;
-
-  patches = [
-    # Fixes build on x86_64-darwin. See:
-    # https://github.com/xianyi/OpenBLAS/issues/1926
-    (fetchpatch {
-      url = https://github.com/xianyi/OpenBLAS/commit/701ea88347461e4c5d896765438dc870281b3834.patch;
-      sha256 = "18rcfgkjsijl9d2510jn961wqvz7zdlz2fgy1yjmax29kvv8fqd9";
-    })
-  ];
 
   # Some hardening features are disabled due to sporadic failures in
   # OpenBLAS-based programs. The problem may not be with OpenBLAS itself, but

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -115,18 +115,17 @@ stdenv.mkDerivation rec {
     coreutils
   ];
 
-  makeFlags =
-    [
-      "FC=${stdenv.cc.targetPrefix}gfortran"
-      "CC=${stdenv.cc.targetPrefix}cc"
-      ''PREFIX="''$(out)"''
-      "NUM_THREADS=64"
-      "INTERFACE64=${toString (if blas64 then true else false)}"
-      "NO_STATIC=1"
-    ]
-    ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "musl") "NO_AFFINITY=1"
-    ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "NO_BINARY_MODE=1" "HOSTCC=cc" "CROSS=1" ]
-    ++ mapAttrsToList (var: val: "${var}=${toString val}") config;
+  makeFlags = mapAttrsToList (var: val: "${var}=${toString val}") (config // {
+    FC = "${stdenv.cc.targetPrefix}gfortran";
+    CC = "${stdenv.cc.targetPrefix}cc";
+    PREFIX = placeholder "out";
+    NUM_THREADS = 64;
+    INTERFACE64 = blas64;
+    NO_STATIC = true;
+    CROSS = stdenv.hostPlatform != stdenv.buildPlatform;
+    HOSTCC = "${buildPackages.stdenv.cc.targetPrefix}cc";
+    NO_BINARY_MODE = stdenv.hostPlatform != stdenv.buildPlatform;
+  });
 
   doCheck = true;
   checkTarget = "tests";

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -117,8 +117,8 @@ stdenv.mkDerivation rec {
 
   makeFlags =
     [
-      "FC=${optionalString (stdenv.hostPlatform != stdenv.buildPlatform) stdenv.cc.targetPrefix}gfortran"
-      "CC=${optionalString (stdenv.hostPlatform != stdenv.buildPlatform) stdenv.cc.targetPrefix}cc"
+      "FC=${stdenv.cc.targetPrefix}gfortran"
+      "CC=${stdenv.cc.targetPrefix}cc"
       ''PREFIX="''$(out)"''
       "NUM_THREADS=64"
       "INTERFACE64=${if blas64 then "1" else "0"}"
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "NO_BINARY_MODE=1" "HOSTCC=cc" "CROSS=1" ]
     ++ mapAttrsToList (var: val: var + "=" + val) config;
 
-  doCheck = stdenv.hostPlatform != stdenv.buildPlatform;
+  doCheck = true;
   checkTarget = "tests";
 
   postInstall = ''

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -14,46 +14,46 @@ let
   # To add support for a new platform, add an element to this set.
   configs = {
     armv6l-linux = {
-      BINARY = "32";
+      BINARY = 32;
       TARGET = "ARMV6";
-      DYNAMIC_ARCH = "0";
-      USE_OPENMP = "1";
+      DYNAMIC_ARCH = false;
+      USE_OPENMP = true;
     };
 
     armv7l-linux = {
-      BINARY = "32";
+      BINARY = 32;
       TARGET = "ARMV7";
-      DYNAMIC_ARCH = "0";
-      USE_OPENMP = "1";
+      DYNAMIC_ARCH = false;
+      USE_OPENMP = true;
     };
 
     aarch64-linux = {
-      BINARY = "64";
+      BINARY = 64;
       TARGET = "ARMV8";
-      DYNAMIC_ARCH = "1";
-      USE_OPENMP = "1";
+      DYNAMIC_ARCH = true;
+      USE_OPENMP = true;
     };
 
     i686-linux = {
-      BINARY = "32";
+      BINARY = 32;
       TARGET = "P2";
-      DYNAMIC_ARCH = "1";
-      USE_OPENMP = "1";
+      DYNAMIC_ARCH = true;
+      USE_OPENMP = true;
     };
 
     x86_64-darwin = {
-      BINARY = "64";
+      BINARY = 64;
       TARGET = "ATHLON";
-      DYNAMIC_ARCH = "1";
-      USE_OPENMP = "0";
+      DYNAMIC_ARCH = true;
+      USE_OPENMP = false;
       MACOSX_DEPLOYMENT_TARGET = "10.7";
     };
 
     x86_64-linux = {
-      BINARY = "64";
+      BINARY = 64;
       TARGET = "ATHLON";
-      DYNAMIC_ARCH = "1";
-      USE_OPENMP = "1";
+      DYNAMIC_ARCH = true;
+      USE_OPENMP = true;
     };
   };
 in
@@ -121,12 +121,12 @@ stdenv.mkDerivation rec {
       "CC=${stdenv.cc.targetPrefix}cc"
       ''PREFIX="''$(out)"''
       "NUM_THREADS=64"
-      "INTERFACE64=${if blas64 then "1" else "0"}"
+      "INTERFACE64=${toString (if blas64 then true else false)}"
       "NO_STATIC=1"
     ]
     ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "musl") "NO_AFFINITY=1"
     ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "NO_BINARY_MODE=1" "HOSTCC=cc" "CROSS=1" ]
-    ++ mapAttrsToList (var: val: var + "=" + val) config;
+    ++ mapAttrsToList (var: val: "${var}=${toString val}") config;
 
   doCheck = true;
   checkTarget = "tests";


### PR DESCRIPTION
* prefer attributes
* let nix string-ify for us
* bools become the same 1/0, FWIW, in case that matters


###### Motivation for this change

https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---