### PR TITLE
pkgconf: 1.5.4 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pkgconf-1.5.4";
+  name = "pkgconf-1.6.0";
 
   src = fetchurl {
     url = "https://distfiles.dereferenced.org/pkgconf/${name}.tar.xz";
-    sha256 = "0r26qmij9lxpz183na3dxj6lamcma94cjhasy19fya44w2j68n4w";
+    sha256 = "1rgcw7lbmxv45y4ybnlh1wzhd1d15d2616499ajjnrvnnnms6db1";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://git.dereferenced.org/pkgconf/pkgconf/src/tag/pkgconf-1.6.0/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---