### PR TITLE
pythonPackages.cython: 0.29.1 -> 0.29.2

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -26,11 +26,11 @@ let
 
 in buildPythonPackage rec {
   pname = "Cython";
-  version = "0.29.1";
+  version = "0.29.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "15zv9c4ami9hzya28wz1shqljbbk5sxdvqbjxqnf15ssk137daqq";
+    sha256 = "07plsfqyd53chf4yv74cd49sgqciiwbvalp4zavsp5cak7zqgh9a";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

We ("we", probably our fearless python maintainer is what I mean) looked
into 0.29.2 earlier -- I have dangling git commits indicating as much...
but can't find discussion so submitting anyway.

Apologies if not useful or if I'm blind :P.

https://github.com/cython/cython/blob/0.29.2/CHANGES.rst

numpy 1.16.0 mentions needing cython >= 0.29.2, FWIW (#53976)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---