### PR TITLE
zotero: 5.0.35.1 -> 5.0.60

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, buildFHSUserEnv, makeDesktopItem, runCommand, bash, wrapGAppsHook, gsettings-desktop-schemas, gtk3, gnome3 }:
 
 let
-version = "5.0.35.1";
+version = "5.0.60";
 meta = with stdenv.lib; {
   homepage = https://www.zotero.org;
   description = "Collect, organize, cite, and share your research sources";
@@ -15,7 +15,7 @@ zoteroSrc = stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.zotero.org/client/release/${version}/Zotero-${version}_linux-x86_64.tar.bz2";
-    sha256 = "0d2imvp84svllrnja1dl4nldp634z632g5xkm2q9v7j3dwbzw1hw";
+    sha256 = "0753xk95shhxma4dvdxrj2q6y81z8lianxg7jnab9m17fb67jy2d";
   };
 
   buildInputs= [ wrapGAppsHook gsettings-desktop-schemas gtk3 gnome3.adwaita-icon-theme gnome3.dconf ];
@@ -32,7 +32,7 @@ zoteroSrc = stdenv.mkDerivation rec {
 fhsEnv = buildFHSUserEnv {
   name = "zotero-fhs-env";
   targetPkgs = pkgs: with pkgs; with xorg; [
-    gtk3 dbus-glib
+    gtk3 dbus-glib glib
     libXt nss
     libX11
   ];


### PR DESCRIPTION
Needs glib to run now, add.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---