### PR TITLE
ocamlPackages.zarith: use buildOcaml instead of mkDerivation

### DIFF
--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gmp, perl }:
+{ stdenv, buildOcaml, fetchurl
+, ocaml, findlib, pkgconfig, perl
+, gmp
+}:
 
-assert stdenv.lib.versionAtLeast ocaml.version "3.12.1";
-
-let param =
+let source =
   if stdenv.lib.versionAtLeast ocaml.version "4.02"
   then {
     version = "1.7";
@@ -15,17 +16,19 @@ let param =
   };
 in
 
-stdenv.mkDerivation rec {
-  name = "zarith-${version}";
-  inherit (param) version;
+buildOcaml rec {
+  name = "zarith";
+  inherit (source) version;
+  src = fetchurl { inherit (source) url sha256; };
 
-  src = fetchurl {
-    inherit (param) url sha256;
-  };
+  minimumSupportedOcamlVersion = "3.12.1";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml findlib perl ];
   propagatedBuildInputs = [ gmp ];
+
+  # needed so setup-hook.sh sets CAML_LD_LIBRARY_PATH for dllzarith.so
+  hasSharedObjects = true;
 
   patchPhase = "patchShebangs ./z_pp.pl";
   configurePhase = ''


### PR DESCRIPTION
This has two main advantages:

  - By setting hasSharedObjects = true, buildOcaml will automatically
include a setup-hook.sh that sets CAML_LD_LIBRARY_PATH in dependent
expressions. This is needed to pick up dllzarith.so properly which is
shipped as party of the library.

  - We can kill the ugly assert in the expression and instead change it
to use minimumSupportedOcamlVersion.

(Note: this was reverted in b44d5136e8a8d2d407, but the change is
exactly equivalent -- I wasn't sure what impact zarith might actually
have without checking OfBorg, which I wanted to do first.)

Signed-off-by: Austin Seipp <aseipp@pobox.com>

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

