### PR TITLE
bazel: fix python stub paths

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, runCommand, makeWrapper
+{ stdenv, callPackage, lib, fetchurl, fetchpatch, runCommand, makeWrapper
 , jdk, zip, unzip, bash, writeCBin, coreutils
 , which, python, perl, gnused, gnugrep, findutils
 # Apple dependencies
@@ -38,6 +38,11 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux ++ platforms.darwin;
   };
 
+  # additional tests that check bazel’s functionality
+  passthru.tests = {
+    python_bin_path = callPackage ./python-bin-path-test.nix {};
+  };
+
   name = "bazel-${version}";
 
   src = fetchurl {
@@ -47,8 +52,10 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  patches =
-    lib.optional enableNixHacks ./nix-hacks.patch;
+  patches = [
+    (lib.optional enableNixHacks ./nix-hacks.patch)
+    ./python-stub-path-fix.patch
+    ];
 
   # Bazel expects several utils to be available in Bash even without PATH. Hence this hack.
 
@@ -118,6 +125,10 @@ stdenv.mkDerivation rec {
     '';
 
     genericPatches = ''
+      # Substitute python's stub shebang to plain python path. (see TODO add pr URL)
+      substituteInPlace src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt\
+          --replace "/usr/bin/env python" "${python}/bin/python" \
+          --replace "NIX_STORE_PYTHON_PATH" "${python}/bin/python" \
       # substituteInPlace is rather slow, so prefilter the files with grep
       grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
         # If you add more replacements here, you must change the grep above!
@@ -136,6 +147,7 @@ stdenv.mkDerivation rec {
       substituteInPlace tools/jdk/default_java_toolchain.bzl \
         --replace '"jvm_opts": JDK9_JVM_OPTS' \
                   '"jvm_opts": JDK8_JVM_OPTS'
+
 
       # add nix environment vars to .bazelrc
       cat >> .bazelrc <<EOF

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -1,0 +1,55 @@
+{ stdenv, lib, writeText, runCommandCC, bazel }:
+
+let
+  WORKSPACE = writeText "WORKSPACE" ''
+    workspace(name = "our_workspace")
+  '';
+
+  pythonLib = writeText "lib.py" ''
+    def foo():
+      return 43
+  '';
+
+  pythonBin = writeText "bin.py" ''
+    from lib import foo
+
+    assert foo() == 43
+  '';
+
+  pythonBUILD = writeText "BUILD" ''
+    py_library(
+      name = "lib",
+      srcs = [ "lib.py" ],
+    )
+
+    py_test(
+      name = "bin",
+      srcs = [ "bin.py" ],
+      deps = [ ":lib" ],
+    )
+  '';
+
+  runLocal = name: script: runCommandCC name { preferLocalBuild = true; } script;
+
+  workspaceDir = runLocal "our_workspace" ''
+    mkdir $out
+    cp ${WORKSPACE} $out/WORKSPACE
+    mkdir $out/python
+    cp ${pythonLib} $out/python/lib.py
+    cp ${pythonBin} $out/python/bin.py
+    cp ${pythonBUILD} $out/python/BUILD.bazel
+  '';
+
+  testBazel = runLocal "bazel-test-builtin-rules" ''
+    export HOME=$(mktemp -d)
+    cp -r ${workspaceDir}/* .
+    ${bazel}/bin/bazel --output_base=/tmp/bazel-tests/wd\
+      test \
+        --test_output=errors \
+        --host_javabase='@local_jdk//:jdk' \
+        //...
+
+    touch $out
+  '';
+
+in testBazel

--- a/pkgs/development/tools/build-managers/bazel/python-stub-path-fix.patch
+++ b/pkgs/development/tools/build-managers/bazel/python-stub-path-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+index dac21c9a83..69b11c283f 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+@@ -67,7 +67,7 @@ def FindPythonBinary(module_space):
+     return os.path.join(module_space, PYTHON_BINARY)
+   else:
+     # Case 4: Path has to be looked up in the search path.
+-    return SearchPath(PYTHON_BINARY)
++    return "NIX_STORE_PYTHON_PATH"
+ 
+ def CreatePythonPathEntries(python_imports, module_space):
+   parts = python_imports.split(':');


### PR DESCRIPTION
###### Motivation for this change

Since the [0.21 upgrade](https://github.com/NixOS/nixpkgs/commit/9e9fec640edab8b92e84b6dfd8ea01c585715cea#diff-4746b81564a01e241a84d455575437e7), the host $PATH is not forwarded anymore by default to the sandboxes in charge to realize Bazel actions. This default change broke the py_binary rule among other things.

Every python binary is wrapped in a stub in charge to setup the execution environment. Currently, this stub's shebang points to a `/usr/bin/env python` which cannot be resolved with the current $PATH. This results in breaking any build pipeline requiring the use of python at some point. On top of the incorrect shebang, the stub template is unable to find the actual python binary using SearchPath.

This PR fixes those two things by re-writing the stub template shebang to the actual python binary and by substituting the faulty default python binary lookup to the right one.

Notes:

- The patch file instead of a substitute-in-place is intentional: we probably want to build to fail if this part of the template logic changed.
- The default python path can be overridden using the --python_path bazel flag. This patch does not break this behaviour.
- A test exposing the bug is also provided. (This test has been written by @Profpatsch, thanks :) )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

