### PR TITLE
nixos/pam: add pam_nologin.so by default

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -308,6 +308,7 @@ let
           ''}
 
           # Authentication management.
+          auth requisite pam_nologin.so
           ${optionalString cfg.googleOsLoginAuthentication
               "auth [success=done perm_denied=bad default=ignore] ${pkgs.google-compute-engine-oslogin}/lib/pam_oslogin_login.so"}
           ${optionalString cfg.rootOK


### PR DESCRIPTION
###### Motivation for this change
Some NixOS services already override the default PAM config and add
pam_nologin.so. This change adds it to the default config, so that it
applies to services like sshd and login too. (It also applies to things
like sudo, which might be surprising, but I'm having a hard time
justifying "forking" the default config for sshd etc. just because of
this.)

pam_nologin.so prevents non-root user login if the file /etc/nologin or
/run/nologin exists. (The file can also contain a message that will be
shown to the user before getting access denied.)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

