### PR TITLE
esphome: init at 1.10.1

### DIFF
--- a/pkgs/servers/home-assistant/dont-import-platformio-esptool.patch
+++ b/pkgs/servers/home-assistant/dont-import-platformio-esptool.patch
@@ -1,0 +1,119 @@
+diff --git a/esphomeyaml/__main__.py b/esphomeyaml/__main__.py
+index 26f42c1..529d2e0 100644
+--- a/esphomeyaml/__main__.py
++++ b/esphomeyaml/__main__.py
+@@ -167,13 +167,10 @@ def compile_program(args, config):
+ 
+ 
+ def upload_using_esptool(config, port):
+-    import esptool
+-
+     path = os.path.join(CORE.build_path, '.pioenvs', CORE.name, 'firmware.bin')
+-    cmd = ['esptool.py', '--before', 'default_reset', '--after', 'hard_reset',
++    cmd = ['@esptool@/bin/esptool.py', '--before', 'default_reset', '--after', 'hard_reset',
+            '--chip', 'esp8266', '--port', port, 'write_flash', '0x0', path]
+-    # pylint: disable=protected-access
+-    return run_external_command(esptool._main, *cmd)
++    return run_external_command(*cmd)
+ 
+ 
+ def upload_program(config, args, host):
+diff --git a/esphomeyaml/platformio_api.py b/esphomeyaml/platformio_api.py
+index df29491..f991701 100644
+--- a/esphomeyaml/platformio_api.py
++++ b/esphomeyaml/platformio_api.py
+@@ -13,12 +13,9 @@ _LOGGER = logging.getLogger(__name__)
+ 
+ 
+ def run_platformio_cli(*args, **kwargs):
+-    import platformio.__main__
+-
+     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
+-    cmd = ['platformio'] + list(args)
+-    return run_external_command(platformio.__main__.main,
+-                                *cmd, **kwargs)
++    cmd = ['@platformio@/bin/platformio'] + list(args)
++    return run_external_command(*cmd, **kwargs)
+ 
+ 
+ def run_platformio_cli_run(config, verbose, *args, **kwargs):
+diff --git a/esphomeyaml/util.py b/esphomeyaml/util.py
+index eebb4b7..9e9e58f 100644
+--- a/esphomeyaml/util.py
++++ b/esphomeyaml/util.py
+@@ -4,6 +4,7 @@ import io
+ import logging
+ import re
+ import sys
++import subprocess
+ 
+ _LOGGER = logging.getLogger(__name__)
+ 
+@@ -79,42 +80,25 @@ class RedirectText(object):
+         return True
+ 
+ 
+-def run_external_command(func, *cmd, **kwargs):
+-    def mock_exit(return_code):
+-        raise SystemExit(return_code)
+-
+-    orig_argv = sys.argv
+-    orig_exit = sys.exit  # mock sys.exit
++def run_external_command(*cmd, **kwargs):
+     full_cmd = u' '.join(shlex_quote(x) for x in cmd)
+     _LOGGER.info(u"Running:  %s", full_cmd)
+ 
+-    orig_stdout = sys.stdout
+-    sys.stdout = RedirectText(sys.stdout)
+-    orig_stderr = sys.stderr
+-    sys.stderr = RedirectText(sys.stderr)
+-
+     capture_stdout = kwargs.get('capture_stdout', False)
+     if capture_stdout:
+-        cap_stdout = sys.stdout = io.BytesIO()
++        cap_stdout = io.BytesIO()
++    else:
++        cap_stdout = sys.stdout
+ 
+     try:
+-        sys.argv = list(cmd)
+-        sys.exit = mock_exit
+-        return func() or 0
+-    except KeyboardInterrupt:
+-        return 1
+-    except SystemExit as err:
+-        return err.args[0]
++        completed_process = subprocess.run(cmd,
++                                           stdout=RedirectText(cap_stdout),
++                                           stderr=RedirectText(sys.stderr))
++        return completed_process.returncode
+     except Exception as err:  # pylint: disable=broad-except
+         _LOGGER.error(u"Running command failed: %s", err)
+         _LOGGER.error(u"Please try running %s locally.", full_cmd)
+     finally:
+-        sys.argv = orig_argv
+-        sys.exit = orig_exit
+-
+-        sys.stdout = orig_stdout
+-        sys.stderr = orig_stderr
+-
+         if capture_stdout:
+             # pylint: disable=lost-exception
+             return cap_stdout.getvalue()
+diff --git a/setup.py b/setup.py
+index 78a5378..8ce80de 100755
+--- a/setup.py
++++ b/setup.py
+@@ -23,12 +23,10 @@ DOWNLOAD_URL = '{}/archive/{}.zip'.format(GITHUB_URL, const.__version__)
+ 
+ REQUIRES = [
+     'voluptuous>=0.11.1',
+-    'platformio>=3.5.3',
+     'pyyaml>=3.12',
+     'paho-mqtt>=1.3.1',
+     'colorlog>=3.1.2',
+     'tornado>=5.0.0',
+-    'esptool>=2.3.1',
+     'typing>=3.0.0',
+     'protobuf>=3.4',
+     'tzlocal>=1.4',

--- a/pkgs/servers/home-assistant/esphome.nix
+++ b/pkgs/servers/home-assistant/esphome.nix
@@ -1,0 +1,43 @@
+{ lib, python3, fetchpatch, substituteAll, platformio, esptool }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "esphomeyaml";
+  version = "1.10.1";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "426cd545b4e9505ce5b4f5c63d2d54cb038f93fe3ba9d4d56b6b6431b222485d";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./dont-import-platformio-esptool.patch;
+      inherit platformio esptool;
+    })
+  ];
+
+  postPatch = ''
+     # typing is part of the standard library since Python 3.5
+     substituteInPlace setup.py --replace "'typing>=3.0.0'," ""
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    voluptuous pyyaml paho-mqtt colorlog
+    tornado protobuf tzlocal pyserial
+  ];
+
+  checkPhase = ''
+    $out/bin/esphomeyaml tests/test1.yaml compile
+    $out/bin/esphomeyaml tests/test2.yaml compile
+  '';
+
+  # Platformio will try to access the network
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Make creating custom firmwares for ESP32/ESP8266 super easy";
+    homepage = https://esphomelib.com/esphomeyaml;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1378,6 +1378,8 @@ in
 
   eschalot = callPackage ../tools/security/eschalot { };
 
+  esphome = callPackage ../servers/home-assistant/esphome.nix { };
+
   esptool = callPackage ../tools/misc/esptool { };
 
   esptool-ck = callPackage ../tools/misc/esptool-ck { };


### PR DESCRIPTION
###### Motivation for this change
I have not tested this with real hardware yet. This is just a PoC for how to patch esphomeyaml not to import platformio and esptool. See #38571.

Should I put esphomeyaml in `pkgs/development/arduino` instead?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg @FRidh 