### PR TITLE
clightning: 0.6.1 -> 0.6.3 (security, 18.09 backport)

### DIFF
--- a/pkgs/applications/altcoins/clightning.nix
+++ b/pkgs/applications/altcoins/clightning.nix
@@ -1,24 +1,30 @@
 { stdenv, python3, pkgconfig, which, libtool, autoconf, automake,
-  autogen, sqlite, gmp, zlib, fetchFromGitHub }:
+  autogen, sqlite, gmp, zlib, fetchzip }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "clightning-${version}";
-  version = "0.6.1";
+  version = "0.6.3";
 
-  src = fetchFromGitHub {
-    fetchSubmodules = true;
-    owner = "ElementsProject";
-    repo = "lightning";
-    rev = "v${version}";
-    sha256 = "0qx30i1c97ic4ii8bm0sk9dh76nfg4ihl9381gxjj14i4jr1q8y4";
+  src = fetchzip {
+    #
+    # NOTE 0.6.3 release zip was bugged, this zip is a fix provided by the team
+    # https://github.com/ElementsProject/lightning/issues/2254#issuecomment-453791475
+    #
+    # replace url with:
+    #   https://github.com/ElementsProject/lightning/releases/download/v${version}/clightning-v${version}.zip
+    # for future relases
+    #
+    url = "https://github.com/ElementsProject/lightning/files/2752675/clightning-v0.6.3.zip";
+    sha256 = "0k5pwimwn69pcakiq4a7qnjyf4i8w1jlacwrjazm1sfivr6nfiv6";
   };
 
   enableParallelBuilding = true;
 
-  buildInputs = [ which sqlite gmp zlib autoconf libtool automake autogen python3 pkgconfig ];
+  nativeBuildInputs = [ autoconf autogen automake libtool pkgconfig which ];
+  buildInputs = [ sqlite gmp zlib python3 ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  makeFlags = [ "prefix=$(out) VERSION=v${version}" ];
 
   configurePhase = ''
     ./configure --prefix=$out --disable-developer --disable-valgrind


### PR DESCRIPTION
Versions before 0.6.3 have a potential coin-stealing DoS vulnerability.

Please upgrade!

backported from commits:

ca67e65182290c66d0b4e784ac547119ed027265 0.6.2 -> 0.6.3
b0fbc9ed40738176b1539009bcae88f5f63b8eab split native build inputs
3c1d7118e6cf60df88a6e44509cd137c8cf6b4ac 0.6.1 -> 0.6.2

Signed-off-by: William Casarin <jb55@jb55.com>

###### Motivation for this change

Security vulnerability

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

