### PR TITLE
libnetfilter_acct: init at 1.0.3

### DIFF
--- a/pkgs/development/libraries/libnetfilter_acct/default.nix
+++ b/pkgs/development/libraries/libnetfilter_acct/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgconfig, libmnl }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.3";
+  name = "libnetfilter_acct-${version}";
+
+  src = fetchurl {
+    url = "https://www.netfilter.org/projects/libnetfilter_acct/files/${name}.tar.bz2";
+    sha256 = "06lsjndgfjsgfjr43px2n2wk3nr7whz6r405mks3887y7vpwwl22";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libmnl ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.netfilter.org/projects/libnetfilter_acct/;
+    description = "Userspace library providing interface to extended accounting infrastructure.";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11213,6 +11213,8 @@ in
 
   libnet = callPackage ../development/libraries/libnet { };
 
+  libnetfilter_acct = callPackage ../development/libraries/libnetfilter_acct { };
+
   libnetfilter_conntrack = callPackage ../development/libraries/libnetfilter_conntrack { };
 
   libnetfilter_cthelper = callPackage ../development/libraries/libnetfilter_cthelper { };


### PR DESCRIPTION
###### Motivation for this change

I was working towards getting ulogd in, and this is one of the missing dependencies

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).