### PR TITLE
pythonPackages.jq: init at 0.1.6

### DIFF
--- a/pkgs/development/python-modules/jq/default.nix
+++ b/pkgs/development/python-modules/jq/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, fetchPypi, lib, cython, jq }:
+
+buildPythonPackage rec {
+  pname = "jq";
+  version = "0.1.6";
+
+  srcs = fetchPypi {
+    inherit pname version;
+    sha256 = "34bdf9f9e49e522e1790afc03f3584c6b57329215ea0567fb2157867d6d6f602";
+  };
+  patches = [ ./jq-py-setup.patch ];
+
+  nativeBuildInputs = [ cython ];
+
+  preBuild = ''
+    cython jq.pyx
+  '';
+
+  buildInputs = [ jq ];
+
+  meta = {
+    description = "Python bindings for jq, the flexible JSON processor";
+    homepage = "https://github.com/mwilliamson/jq.py";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ benley ];
+  };
+}

--- a/pkgs/development/python-modules/jq/jq-py-setup.patch
+++ b/pkgs/development/python-modules/jq/jq-py-setup.patch
@@ -1,0 +1,130 @@
+From 3f369cf8b9f7134d0792f6b141d39b5342a8274f Mon Sep 17 00:00:00 2001
+From: Benjamin Staffin <benley@gmail.com>
+Date: Mon, 14 Jan 2019 17:27:06 -0500
+Subject: [PATCH] Vastly simplify setup.py for distro compatibility
+
+---
+ setup.py | 81 +-------------------------------------------------------
+ 1 file changed, 1 insertion(+), 80 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 77933f2..2b71e25 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,10 +1,6 @@
+ #!/usr/bin/env python
+ 
+ import os
+-import platform
+-import subprocess
+-import tarfile
+-import shutil
+ 
+ try:
+     import sysconfig
+@@ -14,88 +10,15 @@ except ImportError:
+ 
+ from setuptools import setup
+ from distutils.extension import Extension
+-from distutils.command.build_ext import build_ext
+-
+-try:
+-    from urllib import urlretrieve
+-except ImportError:
+-    from urllib.request import urlretrieve
+-
+-def path_in_dir(relative_path):
+-    return os.path.abspath(os.path.join(os.path.dirname(__file__), relative_path))
+ 
+ def read(fname):
+     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+ 
+ 
+-jq_lib_tarball_path = path_in_dir("_jq-lib-1.5.tar.gz")
+-jq_lib_dir = path_in_dir("jq-jq-1.5")
+-
+-oniguruma_lib_tarball_path = path_in_dir("_onig-5.9.6.tar.gz")
+-oniguruma_lib_build_dir = path_in_dir("onig-5.9.6")
+-oniguruma_lib_install_dir = path_in_dir("onig-install-5.9.6")
+-
+-class jq_build_ext(build_ext):
+-    def run(self):
+-        self._build_oniguruma()
+-        self._build_libjq()
+-        build_ext.run(self)
+-    
+-    def _build_oniguruma(self):
+-        self._build_lib(
+-            source_url="https://github.com/kkos/oniguruma/releases/download/v5.9.6/onig-5.9.6.tar.gz",
+-            tarball_path=oniguruma_lib_tarball_path,
+-            lib_dir=oniguruma_lib_build_dir,
+-            commands=[
+-                ["./configure", "CFLAGS=-fPIC", "--prefix=" + oniguruma_lib_install_dir],
+-                ["make"],
+-                ["make", "install"],
+-            ])
+-        
+-    
+-    def _build_libjq(self):
+-        self._build_lib(
+-            source_url="https://github.com/stedolan/jq/archive/jq-1.5.tar.gz",
+-            tarball_path=jq_lib_tarball_path,
+-            lib_dir=jq_lib_dir,
+-            commands=[
+-                ["autoreconf", "-i"],
+-                ["./configure", "CFLAGS=-fPIC", "--disable-maintainer-mode", "--with-oniguruma=" + oniguruma_lib_install_dir],
+-                ["make"],
+-            ])
+-        
+-    def _build_lib(self, source_url, tarball_path, lib_dir, commands):
+-        self._download_tarball(source_url, tarball_path)
+-
+-        macosx_deployment_target = sysconfig.get_config_var("MACOSX_DEPLOYMENT_TARGET")
+-        if macosx_deployment_target:
+-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = macosx_deployment_target
+-
+-        def run_command(args):
+-            print("Executing: %s" % ' '.join(args))
+-            subprocess.check_call(args, cwd=lib_dir)
+-            
+-        for command in commands:
+-            run_command(command)
+-    
+-    def _download_tarball(self, source_url, tarball_path):
+-        if os.path.exists(tarball_path):
+-            os.unlink(tarball_path)
+-        urlretrieve(source_url, tarball_path)
+-        
+-        if os.path.exists(jq_lib_dir):
+-            shutil.rmtree(jq_lib_dir)
+-        tarfile.open(tarball_path, "r:gz").extractall(path_in_dir("."))
+-
+-
+ jq_extension = Extension(
+     "jq",
+     sources=["jq.c"],
+-    include_dirs=[jq_lib_dir],
+-    extra_objects=[
+-        os.path.join(jq_lib_dir, ".libs/libjq.a"),
+-        os.path.join(oniguruma_lib_install_dir, "lib/libonig.a"),
+-    ],
++    libraries=["jq"],
+ )
+ 
+ setup(
+@@ -107,7 +30,6 @@ setup(
+     url='http://github.com/mwilliamson/jq.py',
+     license='BSD 2-Clause',
+     ext_modules = [jq_extension],
+-    cmdclass={"build_ext": jq_build_ext},
+     classifiers=[
+         'Development Status :: 4 - Beta',
+         'Intended Audience :: Developers',
+@@ -123,4 +45,3 @@ setup(
+         'Programming Language :: Python :: 3.5',
+     ],
+ )
+-
+-- 
+2.19.2
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2794,6 +2794,10 @@ in {
     inherit (self) systemd pytest;
   };
 
+  jq = callPackage ../development/python-modules/jq {
+    inherit (pkgs) jq;
+  };
+
   jsondate = callPackage ../development/python-modules/jsondate { };
 
   jsondiff = callPackage ../development/python-modules/jsondiff { };


### PR DESCRIPTION
###### Motivation for this change
Python bindings for jq.  This requires patching setup.py to avoid it doing nasty things, so it makes sense to include in nixpkgs so others don't need to figure it out again.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

