### PR TITLE
Update seafile-shared hash

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "Desktop client for Seafile, the Next-generation Open Source Cloud Storage";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/libsearpc/default.nix
+++ b/pkgs/development/libraries/libsearpc/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     description = "A simple and easy-to-use C language RPC framework (including both server side & client side) based on GObject System";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "haiwen";
     repo = "seafile";
     rev = "v${version}";
-    sha256 = "18gnri8zpgaxcfg08lwzlrkc4zmqszdjg930vy4q8ixggh6jywjf";
+    sha256 = "1bl22dmbl9gbavwxqbxfzq838k7aiv8ihgyr8famj9954xy7b7qn";
   };
 
   nativeBuildInputs = [ pkgconfig which autoreconfHook vala intltool ];


### PR DESCRIPTION
###### Motivation for this change

`seafile-client` does not build successfully because of a hash mismatch in `seafile-shared`. The old hash appears to point to commit `b7f2be78c1d979ff1242c3b65b41228e31427843` rather than `ea8f5e2b45612d77fee9934f942d1d7d55560dad`, which is the commit that the `v6.2.10` tag currently references.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

