### PR TITLE
discord: 0.0.5 -> 0.0.8 [backport to release-18.09]

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
         patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
                  $out/opt/discord/Discord
 
-        paxmark m $out/opt/discord/Discord
-
         wrapProgram $out/opt/discord/Discord --prefix LD_LIBRARY_PATH : ${libPath}
 
         ln -s $out/opt/discord/Discord $out/bin/

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,26 +1,26 @@
 { stdenv, fetchurl, makeDesktopItem, makeWrapper
-, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf
-, glib, gnome2, gtk2, libnotify, libX11, libXcomposite, libXcursor, libXdamage
+, alsaLib, atk, at-spi2-atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf
+, glib, gtk3, libnotify, libX11, libXcomposite, libXcursor, libXdamage, libuuid
 , libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, libxcb
 , pango, systemd, libXScrnSaver, libcxx, libpulseaudio }:
 
 stdenv.mkDerivation rec {
 
     pname = "discord";
-    version = "0.0.5";
+    version = "0.0.7";
     name = "${pname}-${version}";
 
     src = fetchurl {
         url = "https://cdn.discordapp.com/apps/linux/${version}/${pname}-${version}.tar.gz";
-        sha256 = "067gb72qsxrzfma04njkbqbmsvwnnyhw4k9igg5769jkxay68i1g";
+        sha256 = "1jjlwbx80vwhc8il48lb4sqzdb8zdwg28d8vnxsvhcqylfhwf8d8";
     };
 
     nativeBuildInputs = [ makeWrapper ];
 
     libPath = stdenv.lib.makeLibraryPath [
         libcxx systemd libpulseaudio
-        stdenv.cc.cc alsaLib atk cairo cups dbus expat fontconfig freetype
-        gdk_pixbuf glib gnome2.GConf gtk2 libnotify libX11 libXcomposite
+        stdenv.cc.cc alsaLib atk at-spi2-atk cairo cups dbus expat fontconfig freetype
+        gdk_pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
         libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
         libXtst nspr nss libxcb pango systemd libXScrnSaver
      ];
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
         mkdir -p $out/{bin,opt/discord,share/pixmaps}
         mv * $out/opt/discord
 
+        chmod +x $out/opt/discord/Discord
         patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
                  $out/opt/discord/Discord
 

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -7,12 +7,12 @@
 stdenv.mkDerivation rec {
 
     pname = "discord";
-    version = "0.0.7";
+    version = "0.0.8";
     name = "${pname}-${version}";
 
     src = fetchurl {
         url = "https://cdn.discordapp.com/apps/linux/${version}/${pname}-${version}.tar.gz";
-        sha256 = "1jjlwbx80vwhc8il48lb4sqzdb8zdwg28d8vnxsvhcqylfhwf8d8";
+        sha256 = "1p786ma54baljs0bw8nl9sr37ypbpjblcndxsw4djgyxkd9ii16r";
     };
 
     nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeDesktopItem, makeWrapper
+{ stdenv, fetchurl, makeDesktopItem, wrapGAppsHook
 , alsaLib, atk, at-spi2-atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf
 , glib, gtk3, libnotify, libX11, libXcomposite, libXcursor, libXdamage, libuuid
 , libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, libxcb
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
         sha256 = "1p786ma54baljs0bw8nl9sr37ypbpjblcndxsw4djgyxkd9ii16r";
     };
 
-    nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ wrapGAppsHook ];
+
+    dontWrapGApps = true;
 
     libPath = stdenv.lib.makeLibraryPath [
         libcxx systemd libpulseaudio
@@ -33,7 +35,10 @@ stdenv.mkDerivation rec {
         patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
                  $out/opt/discord/Discord
 
-        wrapProgram $out/opt/discord/Discord --prefix LD_LIBRARY_PATH : ${libPath}
+        wrapProgram $out/opt/discord/Discord \
+          "''${gappsWrapperArgs[@]}" \
+          --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+          --prefix LD_LIBRARY_PATH : ${libPath}
 
         ln -s $out/opt/discord/Discord $out/bin/
         ln -s $out/opt/discord/discord.png $out/share/pixmaps


### PR DESCRIPTION
discord now depends on gtk3 instead of gtk2. Unfortunately there is no public changelog to the Linux client specifically, so other changes are unknown.

###### Motivation for this change
Fixes #54003

Older versions of Discord become unusable every update that comes out, so it'd be nice to make sure our stable NixOS users don't lose the ability to use it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

