### PR TITLE
strongswan: fix up path for modprobe

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, substituteAll
 , pkgconfig, autoreconfHook
 , gmp, python, iptables, ldns, unbound, openssl, pcsclite
 , openresolv
 , systemd, pam
 , curl
+, kmod
 , enableTNC            ? false, trousers, sqlite, libxml2
 , enableNetworkManager ? false, networkmanager
 , libpcap
@@ -40,6 +41,10 @@ stdenv.mkDerivation rec {
     ./ext_auth-path.patch
     ./firewall_defaults.patch
     ./updown-path.patch
+    (substituteAll {
+      src = ./modprobe-path.patch;
+      inherit kmod;
+    })
   ];
 
   postPatch = ''

--- a/pkgs/tools/networking/strongswan/modprobe-path.patch
+++ b/pkgs/tools/networking/strongswan/modprobe-path.patch
@@ -1,0 +1,56 @@
+diff --git a/src/starter/klips.c b/src/starter/klips.c
+index 2216546..d626677 100644
+--- a/src/starter/klips.c
++++ b/src/starter/klips.c
+@@ -30,7 +30,7 @@ bool starter_klips_init(void)
+ 		/* ipsec module makes the pf_key proc interface visible */
+ 		if (stat(PROC_MODULES, &stb) == 0)
+ 		{
+-			ignore_result(system("modprobe -qv ipsec"));
++			ignore_result(system("@kmod@/bin/modprobe -qv ipsec"));
+ 		}
+ 
+ 		/* now test again */
+@@ -42,9 +42,9 @@ bool starter_klips_init(void)
+ 	}
+ 
+ 	/* load crypto algorithm modules */
+-	ignore_result(system("modprobe -qv ipsec_aes"));
+-	ignore_result(system("modprobe -qv ipsec_blowfish"));
+-	ignore_result(system("modprobe -qv ipsec_sha2"));
++	ignore_result(system("@kmod@/bin/modprobe -qv ipsec_aes"));
++	ignore_result(system("@kmod@/bin/modprobe -qv ipsec_blowfish"));
++	ignore_result(system("@kmod@/bin/modprobe -qv ipsec_sha2"));
+ 
+ 	DBG2(DBG_APP, "found KLIPS IPsec stack");
+ 	return TRUE;
+diff --git a/src/starter/netkey.c b/src/starter/netkey.c
+index b150d3e..0a7c2ff 100644
+--- a/src/starter/netkey.c
++++ b/src/starter/netkey.c
+@@ -30,7 +30,7 @@ bool starter_netkey_init(void)
+ 		/* af_key module makes the netkey proc interface visible */
+ 		if (stat(PROC_MODULES, &stb) == 0)
+ 		{
+-			ignore_result(system("modprobe -qv af_key"));
++			ignore_result(system("@kmod@/bin/modprobe -qv af_key"));
+ 		}
+ 
+ 		/* now test again */
+@@ -44,11 +44,11 @@ bool starter_netkey_init(void)
+ 	/* make sure that all required IPsec modules are loaded */
+ 	if (stat(PROC_MODULES, &stb) == 0)
+ 	{
+-		ignore_result(system("modprobe -qv ah4"));
+-		ignore_result(system("modprobe -qv esp4"));
+-		ignore_result(system("modprobe -qv ipcomp"));
+-		ignore_result(system("modprobe -qv xfrm4_tunnel"));
+-		ignore_result(system("modprobe -qv xfrm_user"));
++		ignore_result(system("@kmod@/bin/modprobe -qv ah4"));
++		ignore_result(system("@kmod@/bin/modprobe -qv esp4"));
++		ignore_result(system("@kmod@/bin/modprobe -qv ipcomp"));
++		ignore_result(system("@kmod@/bin/modprobe -qv xfrm4_tunnel"));
++		ignore_result(system("@kmod@/bin/modprobe -qv xfrm_user"));
+ 	}
+ 
+ 	DBG2(DBG_APP, "found netkey IPsec stack");


### PR DESCRIPTION
strongswan uses `modprobe` to load IPSec-related kernel modules.  The full path needs to be specified to `modprobe` for it to be able to be found.

###### Motivation for this change

strongswan is used by the l2tp plugin for NetworkManager, which I am using to connect to a VPN at work.

Without this change, strongswan produces the following error messages in the system log when enabling my VPN:

```
Jan 16 15:54:42 lemu8 NetworkManager[30106]: Starting strongSwan 5.7.1 IPsec [starter]...
Jan 16 15:54:42 lemu8 NetworkManager[30106]: Loading config setup
Jan 16 15:54:42 lemu8 NetworkManager[30106]: Loading conn '1c5abe1b-ebef-4658-8991-563d1d248812'
Jan 16 15:54:42 lemu8 ipsec_starter[30201]: Starting strongSwan 5.7.1 IPsec [starter]...
Jan 16 15:54:42 lemu8 ipsec_starter[30201]: Loading config setup
Jan 16 15:54:42 lemu8 ipsec_starter[30201]: Loading conn '1c5abe1b-ebef-4658-8991-563d1d248812'
Jan 16 15:54:42 lemu8 NetworkManager[30106]: sh: modprobe: command not found
Jan 16 15:54:42 lemu8 NetworkManager[30106]: sh: modprobe: command not found
Jan 16 15:54:42 lemu8 NetworkManager[30106]: sh: modprobe: command not found
Jan 16 15:54:42 lemu8 NetworkManager[30106]: sh: modprobe: command not found
Jan 16 15:54:42 lemu8 NetworkManager[30106]: sh: modprobe: command not found
Jan 16 15:54:42 lemu8 NetworkManager[30106]: found netkey IPsec stack
Jan 16 15:54:42 lemu8 ipsec_starter[30201]: found netkey IPsec stack
Jan 16 15:54:42 lemu8 ipsec_starter[30215]: Attempting to start charon...
```

The line in question is `sh: modprobe: command not found`.  Note that this doesn't appear to cause any problem, but it is nice to not get these error messages in the log.

With this PR, strongswan doesn't produce the `sh: modprobe: command not found` lines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

