### PR TITLE
ncurses: 6.1-20181027 -> 6.1-20190112

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -13,7 +13,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "6.1-20181027";
+  version = "6.1-20190112";
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   src = fetchurl {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       "https://invisible-mirror.net/archives/ncurses/current/ncurses-${version}.tgz"
       "ftp://ftp.invisible-island.net/ncurses/current/ncurses-${version}.tgz"
     ];
-    sha256 = "1xn6wpi22jc61158w4ifq6s1fvilhmsy1in2srn3plk8pm0d4902";
+    sha256 = "10s9r1lci2zym401ddw4w9cb3jmgprjnzpzr08djl3mmr0vpqnx2";
   };
 
   patches = lib.optional (!stdenv.cc.isClang) ./clang.patch;


### PR DESCRIPTION
v6.1-20181027 url is 404.

###### Motivation for this change
The url for https://invisible-mirror.net/archives/ncurses/current/ncurses-6.1-20181027.tgz produces 404 and this particular version is now available only as a patchset from https://invisible-mirror.net/archives/ncurses/6.1/ncurses-6.1-20181027.patch.gz

Unless there is a hard requirement for 20181027, here's an update to current latest 6.1-20190112

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
in reference to my borked attempt #53942 