### PR TITLE
oraclejdk: 8.191 -> 8.201; no longer depend on requireFile

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -1,15 +1,15 @@
 { productVersion
 , patchVersion
-, downloadUrl
+, buildVersion
 , sha256
 , jceName
-, jceDownloadUrl
+, releaseToken
 , sha256JCE
 }:
 
 { swingSupport ? true
 , stdenv
-, requireFile
+, fetchurl
 , makeWrapper
 , unzip
 , file
@@ -17,6 +17,7 @@
 , installjdk ? true
 , pluginSupport ? true
 , installjce ? false
+, licenseAccepted ? false
 , glib
 , libxml2
 , libav_0_8
@@ -36,6 +37,13 @@
 
 assert swingSupport -> xorg != null;
 
+if !licenseAccepted then throw ''
+    You must accept the Oracle Binary Code License Agreement for Java SE at
+    https://www.oracle.com/technetwork/java/javase/terms/license/index.html
+    by setting nixpkgs config option 'oraclejdk.accept_license = true;'
+  ''
+else assert licenseAccepted;
+
 let
 
   /**
@@ -50,10 +58,10 @@ let
 
   jce =
     if installjce then
-      requireFile {
-        name = jceName;
-        url = jceDownloadUrl;
+      fetchurl {
+        url = "http://download.oracle.com/otn-pub/java/jce/${productVersion}/${jceName}";
         sha256 = sha256JCE;
+        curlOpts = "-b oraclelicense=a";
       }
     else
       "";
@@ -67,19 +75,23 @@ let
 
 in
 
+assert sha256 ? ${stdenv.hostPlatform.system};
+
 let result = stdenv.mkDerivation rec {
   name =
     if installjdk then "oraclejdk-${productVersion}u${patchVersion}" else "oraclejre-${productVersion}u${patchVersion}";
 
-  src = requireFile {
-    name = {
-      i686-linux    = "jdk-${productVersion}u${patchVersion}-linux-i586.tar.gz";
-      x86_64-linux  = "jdk-${productVersion}u${patchVersion}-linux-x64.tar.gz";
-      armv7l-linux  = "jdk-${productVersion}u${patchVersion}-linux-arm32-vfp-hflt.tar.gz";
-      aarch64-linux = "jdk-${productVersion}u${patchVersion}-linux-arm64-vfp-hflt.tar.gz";
+  src = let
+    platformName = {
+      i686-linux    = "linux-i586";
+      x86_64-linux  = "linux-x64";
+      armv7l-linux  = "linux-arm32-vfp-hflt";
+      aarch64-linux = "linux-arm64-vfp-hflt";
     }.${stdenv.hostPlatform.system};
-    url = downloadUrl;
-    sha256 = sha256.${stdenv.hostPlatform.system};
+  in fetchurl {
+   url = "http://download.oracle.com/otn-pub/java/jdk/${productVersion}u${patchVersion}-b${buildVersion}/${releaseToken}/jdk-${productVersion}u${patchVersion}-${platformName}.tar.gz";
+   curlOpts = "-b oraclelicense=a";
+   sha256 = sha256.${stdenv.hostPlatform.system};
   };
 
   nativeBuildInputs = [ file ]

--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,12 +1,14 @@
+# http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
+# jce download url: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "191";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "1dmnv3x28l0rdi92gpmcp38gpy3lf4pl441bijvjhi7j97kk60v4";
-  sha256.x86_64-linux = "0r8dvb0hahfybvf9wiv7904rn22n93bfc9x6pgypynj0w83rbhjk";
-  sha256.armv7l-linux = "0wgdr9ainzc2yc5qp6ncflnsdygpgrmv2af522djkc83skp5g70v";
-  sha256.aarch64-linux = "1rgwf0i9ikcjqbxkvr4x94y62m1kklfdhgqscxil479d5mg6akqz";
+  patchVersion = "201";
+  buildVersion = "09";
+  sha256.i686-linux = "1f9n93zmkggchaxkchp4bqasvxznn96zjci34f52h7v392jkzqac";
+  sha256.x86_64-linux = "0w730v2q0iaxf2lprabwmy7129byrs0hhdbwas575p1xmk00qw6b";
+  sha256.armv7l-linux = "0p82d2vah63a6r2rip9v17lbjam39kgqp0584q3cnljgr5p9gyhz";
+  sha256.aarch64-linux = "1qm4b3aj5wi0hp9q6gy1da4bz5k9ky4shgiqa4zxrib4kjp9yf0k";
+  releaseToken = "42970487e3af4f5aa5bca3f542482c60";
   jceName = "jce_policy-8.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,12 +1,14 @@
+# http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
+# jce download url: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "191";
-  downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "1dmnv3x28l0rdi92gpmcp38gpy3lf4pl441bijvjhi7j97kk60v4";
-  sha256.x86_64-linux = "0r8dvb0hahfybvf9wiv7904rn22n93bfc9x6pgypynj0w83rbhjk";
-  sha256.armv7l-linux = "0wgdr9ainzc2yc5qp6ncflnsdygpgrmv2af522djkc83skp5g70v";
-  sha256.aarch64-linux = "1rgwf0i9ikcjqbxkvr4x94y62m1kklfdhgqscxil479d5mg6akqz";
+  patchVersion = "201";
+  buildVersion = "09";
+  sha256.i686-linux = "1f9n93zmkggchaxkchp4bqasvxznn96zjci34f52h7v392jkzqac";
+  sha256.x86_64-linux = "0w730v2q0iaxf2lprabwmy7129byrs0hhdbwas575p1xmk00qw6b";
+  sha256.armv7l-linux = "0p82d2vah63a6r2rip9v17lbjam39kgqp0584q3cnljgr5p9gyhz";
+  sha256.aarch64-linux = "1qm4b3aj5wi0hp9q6gy1da4bz5k9ky4shgiqa4zxrib4kjp9yf0k";
+  releaseToken = "42970487e3af4f5aa5bca3f542482c60";
   jceName = "jce_policy-8.zip";
-  jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7224,11 +7224,17 @@ in
 
   oraclejdk8distro = installjdk: pluginSupport:
     (if pluginSupport then appendToName "with-plugin" else x: x)
-      (callPackage ../development/compilers/oraclejdk/jdk8cpu-linux.nix { inherit installjdk pluginSupport; });
+      (callPackage ../development/compilers/oraclejdk/jdk8cpu-linux.nix {
+        inherit installjdk pluginSupport;
+        licenseAccepted = config.oraclejdk.accept_license or false;
+      });
 
   oraclejdk8psu_distro = installjdk: pluginSupport:
     (if pluginSupport then appendToName "with-plugin" else x: x)
-      (callPackage ../development/compilers/oraclejdk/jdk8psu-linux.nix { inherit installjdk pluginSupport; });
+      (callPackage ../development/compilers/oraclejdk/jdk8psu-linux.nix {
+        inherit installjdk pluginSupport;
+        licenseAccepted = config.oraclejdk.accept_license or false;
+      });
 
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 


### PR DESCRIPTION


###### Motivation for this change

No longer use requireFile and accept the license via nixpkgs option

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

