### PR TITLE
mailutils: use system-sendmail instead of sendmailPath

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -387,6 +387,14 @@
     root CA (for example Let's Encrypt).
    </para>
   </listitem>
+   <listitem>
+    <para>
+     <literal>mailutils</literal> now works by default when
+     <literal>sendmail</literal> is not in a setuid wrapper. As a consequence,
+     the <literal>sendmailPath</literal> argument, having lost its main use, has
+     been removed.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, autoreconfHook, dejagnu, gettext, pkgconfig
 , gdbm, pam, readline, ncurses, gnutls, guile, texinfo, gnum4, sasl, fribidi, nettools
-, python, gss, mysql, sendmailPath ? "/run/wrappers/bin/sendmail" }:
+, python, gss, mysql, system-sendmail }:
 
 stdenv.mkDerivation rec {
   name = "${project}-${version}";
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     "--with-gssapi"
     "--with-gsasl"
     "--with-mysql"
-    "--with-path-sendmail=${sendmailPath}"
+    "--with-path-sendmail=${system-sendmail}/bin/sendmail"
   ];
 
   readmsg-tests = let


### PR DESCRIPTION
system-sendmail allows all sendmail's to be auto-detected, including on
non-NixOS systems. This is, to me, a better UX than having to manually
override the sendmailPath argument.

In exchange, it is a breach of retro-compatibility. Given right now I
can't see any uses for sendmailPath other than what is supported by
system-sendmail, I didn't keep it, but it'd be possible to allow
sendmailPath to override the choice of sendmail from system-sendmail.

Fixes https://github.com/NixOS/nixpkgs/issues/40871

Built on NixOS.

cc @orivej @vrthra 