### PR TITLE
openconnect: 7.08 -> 8.02

### DIFF
--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -3,22 +3,17 @@
 assert (openssl != null) == (gnutls == null);
 
 stdenv.mkDerivation rec {
-  name = "openconnect-7.08";
+  pname = "openconnect";
+  version = "8.02";
 
   src = fetchurl {
     urls = [
-      "ftp://ftp.infradead.org/pub/openconnect/${name}.tar.gz"
+      "ftp://ftp.infradead.org/pub/openconnect/${pname}-${version}.tar.gz"
     ];
-    sha256 = "00wacb79l2c45f94gxs63b9z25wlciarasvjrb8jb8566wgyqi0w";
+    sha256 = "04p0vzc1791h68hd9803wsyb64zrwm8qpdqx0szhj9pig71g5a0w";
   };
 
   outputs = [ "out" "dev" ];
-
-  preConfigure = ''
-      export PKG_CONFIG=${pkgconfig}/bin/pkg-config
-      export LIBXML2_CFLAGS="-I ${libxml2.dev}/include/libxml2"
-      export LIBXML2_LIBS="-L${libxml2.out}/lib -lxml2"
-    '';
 
   configureFlags = [
     "--with-vpnc-script=${vpnc}/etc/vpnc/vpnc-script"


### PR DESCRIPTION
###### Motivation for this change

Been using 8.01 for a while and so far so good, FWIW :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---