### PR TITLE
xrdp: 0.9.7 -> 0.9.9

### DIFF
--- a/pkgs/applications/networking/remote/xrdp/default.nix
+++ b/pkgs/applications/networking/remote/xrdp/default.nix
@@ -3,13 +3,13 @@
 let
   xorgxrdp = stdenv.mkDerivation rec {
     name = "xorgxrdp-${version}";
-    version = "0.2.7";
+    version = "0.2.9";
 
     src = fetchFromGitHub {
       owner = "neutrinolabs";
       repo = "xorgxrdp";
       rev = "v${version}";
-      sha256 = "15idwgcjgwa9in8y1bblpj67y7w0bfngc2sa0hd9hn0dinrlifrk";
+      sha256 = "1bhp5x47hajhinvglmc4vxxnpjvfjm6369njb3ghqfr7c5xypvzr";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf automake which libtool nasm ];
@@ -34,15 +34,15 @@ let
   };
 
   xrdp = stdenv.mkDerivation rec {
-    version = "0.9.7";
+    version = "0.9.9";
     name = "xrdp-${version}";
 
     src = fetchFromGitHub {
       owner = "volth";
       repo = "xrdp";
-      rev = "refs/heads/runtime-cfg-path-${version}";  # Fixes https://github.com/neutrinolabs/xrdp/issues/609; not a patch on top of the official repo because "xorgxrdp.configureFlags" above includes "xrdp.src" which must be patched already
+      rev = "refs/tags/runtime-cfg-path-${version}";  # Fixes https://github.com/neutrinolabs/xrdp/issues/609; not a patch on top of the official repo because "xorgxrdp.configureFlags" above includes "xrdp.src" which must be patched already
       fetchSubmodules = true;
-      sha256 = "1dw2zl9zh6win1q0kxj08n9fawpcrs1krjh5978wp0jmq8sdbn7k";
+      sha256 = "0ynj6pml4f38y8571ryhifza57wfqg4frdrjcwzw3fmryiznfm1z";
     };
 
     nativeBuildInputs = [ pkgconfig autoconf automake which libtool nasm ];


### PR DESCRIPTION
###### Motivation for this change

Version update

[Changelog](https://github.com/neutrinolabs/xrdp/compare/v0.9.7..v0.9.9#diff-8312ad0561ef661716b48d09478362f3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

