### PR TITLE
nanomsg-python: init at 1.0.20190114

### DIFF
--- a/pkgs/development/python-modules/nanomsg-python/default.nix
+++ b/pkgs/development/python-modules/nanomsg-python/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, nanomsg }:
+
+buildPythonPackage rec {
+  pname = "nanomsg-python";
+  version = "1.0.20190114";
+
+  src = fetchFromGitHub {
+    owner = "tonysimpson";
+    repo = "nanomsg-python";
+    rev = "3acd9160f90f91034d4a43ce603aaa19fbaf1f2e";
+    sha256 = "1qgybcpmm9xxrn39alcgdcpvwphgm1glkbnwx0ljpz4nd1jsnyrl";
+  };
+
+  propagatedBuildInputs = [ nanomsg ];
+
+  # Tests requires network connections
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Bindings for nanomsg.";
+    homepage = https://github.com/tonysimpson/nanomsg-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bgamari ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -450,6 +450,8 @@ in {
 
   mwoauth = callPackage ../development/python-modules/mwoauth { };
 
+  nanomsg-python = callPackage ../development/python-modules/nanomsg-python { inherit (pkgs) nanomsg; };
+
   nbval = callPackage ../development/python-modules/nbval { };
 
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };


### PR DESCRIPTION
###### Motivation for this change

It's a useful package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

