### PR TITLE
Install gsettings schemas

### DIFF
--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -39,7 +39,7 @@ in
 
         # symlink any schema files to the standard schema directory
         for d in $out/share/gsettings-schemas/*; do
-          # Force symlink, in case there's duplicates
+          # Force symlink, in case there are duplicates
           ln -fs $d/glib-2.0/schemas/*.xml $out/share/glib-2.0/schemas
         done
 

--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -32,6 +32,24 @@ in
     environment.etc = optionals (cfg.profiles != {})
       (mapAttrsToList mkDconfProfile cfg.profiles);
 
+    environment.extraSetup = optionalString cfg.enable ''
+      if [ -d  $out/share/gsettings-schemas/ ]; then
+        # Create the standard schemas directory
+        mkdir -p $out/share/glib-2.0/schemas
+
+        # symlink any schema files to the standard schema directory
+        for d in $out/share/gsettings-schemas/*; do
+          # Force symlink, in case there's duplicates
+          ln -fs $d/glib-2.0/schemas/*.xml $out/share/glib-2.0/schemas
+        done
+
+        # and compile them
+        if [ -w $out/share/glib-2.0/schemas ]; then
+          ${pkgs.glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+        fi
+      fi
+    '';
+
     services.dbus.packages = [ pkgs.gnome3.dconf ];
 
     environment.variables.GIO_EXTRA_MODULES = optional cfg.enable

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -128,6 +128,7 @@ in {
     services.udev.packages = [ pkgs.gnome3.gnome-settings-daemon ];
     systemd.packages = [ pkgs.gnome3.vino ];
     services.flatpak.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+    programs.dconf.enable = true;
 
     # If gnome3 is installed, build vim for gtk3 too.
     nixpkgs.config.vim.gui = "gtk3";
@@ -163,12 +164,12 @@ in {
 
     services.xserver.updateDbusEnvironment = true;
 
-    environment.variables.GIO_EXTRA_MODULES = [ "${lib.getLib pkgs.gnome3.dconf}/lib/gio/modules"
-                                                "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"
+    environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"
                                                 "${pkgs.gnome3.gvfs}/lib/gio/modules" ];
     environment.systemPackages = pkgs.gnome3.corePackages ++ cfg.sessionPath
       ++ (removePackagesByName pkgs.gnome3.optionalPackages config.environment.gnome3.excludePackages) ++ [
       pkgs.xdg-user-dirs # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
+      pkgs.gnome3.mutter # Give eg. gnome-control-center access to schema
     ];
 
     # Use the correct gnome3 packageSet


### PR DESCRIPTION
###### Motivation for this change

Provide global access to gsettings schemas of installed packages.

resolves https://github.com/NixOS/nixpkgs/issues/19590
resolves  https://github.com/NixOS/nixpkgs/issues/54082

Will also help with various plugins that's picked up from the global environment, but which doesn't expose its own gsettings schemas properly (eg. https://github.com/NixOS/nixpkgs/issues/42176)

###### Things done

Running with this on my machine right now.