### PR TITLE
Tegola v0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1919,6 +1919,11 @@
     github = "infinisil";
     name = "Silvan Mosberger";
   };
+  ingenieroariel = {
+    email = "ariel@nunez.co";
+    github = "ingenieroariel";
+    name = "Ariel Nunez";
+  };
   ironpinguin = {
     email = "michele@catalano.de";
     github = "ironpinguin";

--- a/pkgs/servers/tegola/default.nix
+++ b/pkgs/servers/tegola/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "tegola-${version}";
@@ -7,9 +7,10 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/go-spatial/tegola";
 
-  src = fetchgit {
+  src = fetchFromGitHub {
+    owner = "go-spatial";
+    repo = "tegola";
     inherit rev;
-    url = "https://github.com/go-spatial/tegola";
     sha256 = "1f70vsrj3i1d0kg76a8s741nps71hrglgyyrz2xm6a8b31w833pi";
   };
 
@@ -20,7 +21,4 @@ buildGoPackage rec {
     platforms = platforms.unix;
     license = licenses.mit;
   };
-
 }
-
-

--- a/pkgs/servers/tegola/default.nix
+++ b/pkgs/servers/tegola/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  name = "tegola-${version}";
+  version = "0.8.1";
+  rev = "8b2675a63624ad1d69a8d2c84a6a3f3933e25ca1";
+
+  goPackagePath = "github.com/go-spatial/tegola";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/go-spatial/tegola";
+    sha256 = "1f70vsrj3i1d0kg76a8s741nps71hrglgyyrz2xm6a8b31w833pi";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://www.tegola.io/;
+    description = "Mapbox Vector Tile server";
+    maintainers = with maintainers; [ ingenieroariel ];
+    platforms = platforms.unix;
+    license = licenses.mit;
+  };
+
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6143,6 +6143,8 @@ in
 
   rcm = callPackage ../tools/misc/rcm {};
 
+  tegola = callPackage ../servers/tegola {};
+
   tftp-hpa = callPackage ../tools/networking/tftp-hpa {};
 
   tigervnc = callPackage ../tools/admin/tigervnc {


### PR DESCRIPTION
###### Motivation for this change
Tegola is a Vector Tile Server. It is used to create basemaps for Geospatial applications, for example from an OpenStreetMap dump.

Despite the pre-1.0 version, it has been used for production workloads since 2016.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

