### PR TITLE
moolticute: init at 0.30.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2508,6 +2508,11 @@
     github = "kirelagin";
     name = "Kirill Elagin";
   };
+  kirikaza = {
+    email = "k@kirikaza.ru";
+    github = "kirikaza";
+    name = "Kirill Kazakov";
+  };
   kisonecat = {
     email = "kisonecat@gmail.com";
     github = "kisonecat";

--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl
+, libusb1, pkgconfig, qmake, qtbase, qttools, qtwebsockets
+}:
+
+stdenv.mkDerivation rec {
+  name = "moolticute-${version}";
+  version = "0.30.8";
+
+  src = fetchurl {
+    url = "https://github.com/mooltipass/moolticute/archive/v${version}.tar.gz";
+    sha256 = "1qi18r2v0mpw1y007vjgzhiia89fpgsbg2wirxgngl21yxdns1pf";
+  };
+
+  preConfigure = "mkdir -p build && cd build";
+  nativeBuildInputs = [ pkgconfig qmake qttools ];
+  qmakeFlags = [ "../Moolticute.pro" ];
+
+  outputs = [ "out" "udev" ];
+  preInstall = ''
+    mkdir -p $udev/lib/udev/rules.d
+    sed -n '/^ \+cat > "$tmpfile" <<- EOF$/,/^EOF$/p' ../data/moolticute.sh |
+        sed '1d;$d' > $udev/lib/udev/rules.d/50-mooltipass.rules
+ '';
+  
+  buildInputs = [ libusb1 qtbase qtwebsockets ];
+
+  meta = with stdenv.lib; {
+    description = "GUI app and daemon to work with Mooltipass device via USB";
+    longDescription = ''
+      To install udev rules, add `services.udev.packages == [ moolticute.udev ]`
+      into `nixos/configuration.nix`.
+    '';
+    homepage = https://github.com/mooltipass/moolticute;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.kirikaza ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18687,6 +18687,8 @@ in
 
   inherit (ocaml-ng.ocamlPackages_4_01_0) monotoneViz;
 
+  moolticute = libsForQt5.callPackage ../applications/misc/moolticute { };
+
   moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };
 
   mop = callPackage ../applications/misc/mop { };


### PR DESCRIPTION
###### Motivation for this change
I need Moolticute (https://github.com/mooltipass/moolticute/) on my laptop since I have Mooltipass device. I hope there are other people with Mooltipass and NixOS -- and they could use it :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS  _(there is an official dmg for macOS)_
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` _(no more packages depend on this change)_
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested udev rules and communication with Mooltipass device (saving and loading secrets)
---

