### PR TITLE
gnuradio-osmosdr: 1.1.4 -> unstable-2018-06-26

### DIFF
--- a/pkgs/applications/misc/gnuradio/osmosdr.nix
+++ b/pkgs/applications/misc/gnuradio/osmosdr.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchgit, cmake, pkgconfig, boost, gnuradio, rtl-sdr, uhd
-, makeWrapper, hackrf, airspy
+, makeWrapper, hackrf, airspy, libbladeRF
 , pythonSupport ? true, python, swig
 }:
 
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
-  name = "gnuradio-osmosdr-${version}";
-  version = "0.1.4";
+  name = "gnuradio-osmosdr-unstable-2018-06-26";
+# version = "0.1.4";
 
   src = fetchgit {
     url = "git://git.osmocom.org/gr-osmosdr";
-    rev = "refs/tags/v${version}";
-    sha256 = "0vyzr4fhkblf2v3d7m0ch5hws4c493jw3ydl4y6b2dfbfzchhsz8";
+    rev = "4d83c6067f059b0c5015c3f59f8117bbd361e877";
+    sha256 = "1d5nb47506qry52bg4cn02d3l4lwxwz44g2fz1ph0q93c7892j60";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    cmake boost gnuradio rtl-sdr uhd makeWrapper hackrf airspy
+    cmake boost gnuradio rtl-sdr uhd makeWrapper hackrf airspy libbladeRF
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change
Osmosdr development has been going on without any releases. Specifically, compatibility fixes due to recent changes in libbladeRF and other dependencies have been made. This PR updates osmosdr to the latest available in git version as well as adds bladeRF support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

