### PR TITLE
chicken: fix egg installation by preserving compiled libdir

### DIFF
--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
 
   setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;
 
-  buildFlags = "PLATFORM=${platform} PREFIX=$(out) VARDIR=$(out)/var/lib";
-  installFlags = "PLATFORM=${platform} PREFIX=$(out) VARDIR=$(out)/var/lib";
+  buildFlags = "PLATFORM=${platform} PREFIX=$(out)";
+  installFlags = "PLATFORM=${platform} PREFIX=$(out)";
 
   buildInputs = [
     makeWrapper
@@ -37,10 +37,6 @@ stdenv.mkDerivation {
       wrapProgram $f \
         --prefix PATH : ${stdenv.cc}/bin
     done
-
-    mv $out/var/lib/chicken $out/lib
-    rmdir $out/var/lib
-    rmdir $out/var
   '';
 
   # TODO: Assert csi -R files -p '(pathname-file (repository-path))' == binaryVersion

--- a/pkgs/development/compilers/chicken/5/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/5/eggDerivation.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation ({
     for f in $out/bin/*
     do
       wrapProgram $f \
-        --prefix CHICKEN_REPOSITORY_PATH : "$out/lib/chicken/${toString chicken.binaryVersion}/:$CHICKEN_REPOSITORY_PATH" \
-        --prefix CHICKEN_INCLUDE_PATH : "$CHICKEN_INCLUDE_PATH:$out/share/" \
-        --prefix PATH : "$out/bin:${chicken}/bin:$CHICKEN_REPOSITORY_PATH"
+        --prefix CHICKEN_REPOSITORY_PATH : "$out/lib/chicken/${toString chicken.binaryVersion}:$CHICKEN_REPOSITORY_PATH" \
+        --prefix CHICKEN_INCLUDE_PATH : "$out/share:$CHICKEN_INCLUDE_PATH" \
+        --prefix PATH : "$out/bin:${chicken}/bin"
     done
 
     runHook postInstall

--- a/pkgs/development/compilers/chicken/5/setup-hook.sh
+++ b/pkgs/development/compilers/chicken/5/setup-hook.sh
@@ -1,6 +1,6 @@
 addChickenRepositoryPath() {
-    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_PATH "$1/lib/chicken/9/"
-    addToSearchPathWithCustomDelimiter : CHICKEN_INCLUDE_PATH "$1/share/"
+    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_PATH "$1/lib/chicken/9"
+    addToSearchPathWithCustomDelimiter : CHICKEN_INCLUDE_PATH "$1/share"
 }
 
 addEnvHooks "$targetOffset" addChickenRepositoryPath


### PR DESCRIPTION
Setting just `PREFIX` is enough to put libraries in `$out/lib` when building CHICKEN, whereas setting `VARDIR` and then moving files from `/var` to `/lib` breaks egg installation because the library installation path ends up differing from the library search path.

This patch also removes `CHICKEN_REPOSITORY_PATH` from `PATH` since it contains libraries, not executables, and removes unnecessary trailing slashes on search paths.

All of this applies only to installation of eggs using the tools in the `chicken` package. Eggs installed via `eggDerivation` are unaffected.

###### Motivation for this change

The `chicken-install` program fails for the reason above. Here are the current settings:

```
Installation prefix:             /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0
Extension installation location: /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0/var/lib/chicken/9
Extension path:                  /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0/lib/chicken/9
```

Here is an example installation failure. This installs the extension `srfi-13`, which depends on `srfi-14`. The latter is installed successfully (because it has no dependencies), but the former fails since the dependency is not available:

```
[nix-shell:~]$ chicken-install srfi-13
building srfi-14
   /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0/bin/csc -host -D compiling-extension -J -s -setup-mode -I /home/evhan/.chicken-install/cache/srfi-14 -C -I/home/evhan/.chicken-install/cache/srfi-14 -O3 -d0 srfi-14.scm -o /home/evhan/.chicken-install/cache/srfi-14/srfi-14.so
   /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0/bin/csc -setup-mode -static -I /home/evhan/.chicken-install/cache/srfi-14 -emit-link-file /home/evhan/.chicken-install/cache/srfi-14/srfi-14.link -host -D compiling-extension -c -unit srfi-14 -D compiling-static-extension -C -I/home/evhan/.chicken-install/cache/srfi-14 -O3 -d0 srfi-14.scm -o /home/evhan/.chicken-install/cache/srfi-14/srfi-14.static.o
   /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0/bin/csc -setup-mode -s -host -I /home/evhan/.chicken-install/cache/srfi-14 -C -I/home/evhan/.chicken-install/cache/srfi-14 -O3 -d0 srfi-14.import.scm -o /home/evhan/.chicken-install/cache/srfi-14/srfi-14.import.so
installing srfi-14
building srfi-13
   /nix/store/h5qlx1xjcg2wavq4f60m1qdyrlrkqjrg-chicken-5.0.0/bin/csc -host -D compiling-extension -J -s -setup-mode -I /home/evhan/.chicken-install/cache/srfi-13 -C -I/home/evhan/.chicken-install/cache/srfi-13 -O3 -d0 srfi-13.scm -o /home/evhan/.chicken-install/cache/srfi-13/srfi-13.so

Syntax error (import): cannot import from undefined module

        srfi-14

Error: shell command terminated with nonzero exit code
```

Note that `nox-review` currently fails for this PR due to the problem fixed by #53854. When this commit applied after that one, it passes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

