### PR TITLE
awless: 0.0.14 -> 0.1.11

### DIFF
--- a/pkgs/tools/virtualization/awless/default.nix
+++ b/pkgs/tools/virtualization/awless/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "awless-${version}";
-  version = "0.0.14";
+  version = "0.1.11";
 
   goPackagePath = "github.com/wallix/awless";
 
   src = fetchFromGitHub {
     owner  = "wallix";
     repo   = "awless";
-    rev    = version;
-    sha256 = "1syxw8d9y1b4bdb1arsx05m5mxnd0dqp3nj7fk5j1v7cnnbja3hj";
+    rev    = "v${version}";
+    sha256 = "187i21yrm10r3f5naj3jl0rmydr5dkhmdhxs90hhf8hjp59a89kg";
   };
 
   meta = with stdenv.lib; {
@@ -18,6 +18,6 @@ buildGoPackage rec {
     description = "A Mighty CLI for AWS";
     platforms = with platforms; linux ++ darwin;
     license = licenses.asl20;
-    maintainers = with maintainers; [ pradeepchhetri ];
+    maintainers = with maintainers; [ pradeepchhetri swdunlop ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update awless to 0.1.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

