### PR TITLE
llvm7: patch to fix PR39427

### DIFF
--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetch
+, fetchpatch
 , cmake
 , python
 , libffi
@@ -45,6 +46,14 @@ in stdenv.mkDerivation (rec {
     ++ optional enablePFM libpfm; # exegesis
 
   propagatedBuildInputs = [ ncurses zlib ];
+
+  patches = [
+    # https://bugs.llvm.org/show_bug.cgi?id=39427
+    (fetchpatch {
+      url = "https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/raw/5a7d283d4e00bc4822c7b0226e593c344c8f6050/debian/patches/pr39427-misscompile.diff";
+      sha256 = "03mpydsaw0xvcp7kb4sgjzcl5v22620r5z78kv3mz5wp7sn76fg5";
+    })
+  ];
 
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \


### PR DESCRIPTION
###### Motivation for this change

See linked issue for discussion,
but key bits:

* rustc breaks without this
* fix changes ABI, may become 7.1.0

My "day-job" project broke with LLVM 7
until I found my way to this, d'oh!

I don't think we need to worry about
ABI the same way the folks on the issue do.

(and aligning with GCC ABI is much more important
than ABI-compat with previous LLVM major)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

BTW debugging this is kinda neat in a painful way,
as the value --without any writes or instructions--
appears to corrupt itself when passed as an argument.
(it doesn't change but your debugger might say it does!)