### PR TITLE
gap: install libgap, add packageSet option

### DIFF
--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -107,7 +107,16 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  installPhase = ''
+  installTargets = [
+    "install-libgap"
+    "install-headers"
+  ];
+
+  # full `make install` is not yet implemented, just for libgap and headers
+  postInstall = ''
+    # Install config.h, which is not currently handled by `make install-headers`
+    cp gen/config.h "$out/include/gap"
+
     mkdir -p "$out/bin" "$out/share/gap/"
 
     mkdir -p "$out/share/gap"

--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -129,6 +129,7 @@ stdenv.mkDerivation rec {
     [
       raskin
       chrisjefferson
+      timokau
     ];
     platforms = platforms.all;
     # keeping all packages increases the package size considerably, wchich

--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -5,11 +5,60 @@
 , makeWrapper
 , m4
 , gmp
-# don't remove any packages -- results in a ~1.3G size increase
-# see https://github.com/NixOS/nixpkgs/pull/38754 for a discussion
-, keepAllPackages ? true
+# one of
+# - "minimal" (~400M):
+#     Install the bare minimum of packages required by gap to start.
+#     This is likely to break a lot of stuff. Do not expect upstream support with
+#     this configuration.
+# - "standard" (~700M):
+#     Install the "standard packages" which gap autoloads by default. These
+#     packages are effectively considered a part of gap.
+# - "full" (~1.7G):
+#     Install all available packages. This takes a lot of space.
+, packageSet ? "standard"
+# Kept for backwards compatibility. Overrides packageSet to "full".
+, keepAllPackages ? false
 }:
+let
+  # packages absolutely required for gap to start
+  # `*` represents the version where applicable
+  requiredPackages = [
+    "GAPDoc-*"
+    "primgrp-*"
+    "SmallGrp-*"
+    "transgrp"
+  ];
+  # packages autoloaded by default if available
+  autoloadedPackages = [
+    "atlasrep"
+    "autpgrp-*"
+    "alnuth-*"
+    "crisp-*"
+    "ctbllib"
+    "FactInt-*"
+    "fga"
+    "irredsol-*"
+    "laguna-*"
+    "polenta-*"
+    "polycyclic-*"
+    "resclasses-*"
+    "sophus-*"
+    "tomlib-*"
+  ];
+  standardPackages = requiredPackages ++ autoloadedPackages;
+  keepAll = keepAllPackages || (packageSet == "full");
+  packagesToKeep = requiredPackages ++ lib.optionals (packageSet == "standard") autoloadedPackages;
 
+  # Generate bash script that removes all packages from the `pkg` subdirectory
+  # that are not on the whitelist. The whitelist consists of strings expected by
+  # `find`'s `-name`.
+  removeNonWhitelistedPkgs = whitelist: ''
+    find pkg -type d -maxdepth 1 -mindepth 1 \
+  '' + (lib.concatStringsSep "\n" (map (str: "-not -name '${str}' \\") whitelist)) + ''
+    -exec echo "Removing package {}" \; \
+    -exec rm -r '{}' \;
+  '';
+in
 stdenv.mkDerivation rec {
   pname = "gap";
   # https://www.gap-system.org/Releases/
@@ -21,14 +70,8 @@ stdenv.mkDerivation rec {
   };
 
   # remove all non-essential packages (which take up a lot of space)
-  preConfigure = ''
+  preConfigure = lib.optionalString (!keepAll) (removeNonWhitelistedPkgs packagesToKeep) + ''
     patchShebangs .
-  '' + lib.optionalString (!keepAllPackages) ''
-    find pkg -type d -maxdepth 1 -mindepth 1 \
-       -not -name 'GAPDoc-*' \
-       -not -name 'autpgrp*' \
-       -exec echo "Removing package {}" \; \
-       -exec rm -r {} \;
   '';
 
   configureFlags = [ "--with-gmp=system" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22003,7 +22003,9 @@ in
 
   gap = callPackage ../applications/science/math/gap { };
 
-  gap-minimal = lowPrio (gap.override { keepAllPackages = false; });
+  gap-minimal = lowPrio (gap.override { packageSet = "minimal"; });
+
+  gap-full = lowPrio (gap.override { packageSet = "full"; });
 
   geogebra = callPackage ../applications/science/math/geogebra { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10806,17 +10806,31 @@ in
 
   libgadu = callPackage ../development/libraries/libgadu { };
 
+  # Deprecated since gap itself now ships with a library component. This is
+  # still necessary for sage 8.5 but will be removed once we switch to sage
+  # 8.6.
   gap-libgap-compatible = let
     version = "4r8p6";
     pkgVer = "2016_11_12-14_25";
   in
-    (gap.override { keepAllPackages = false; }).overrideAttrs (oldAttrs: {
+    (gap.override { packageSet = "minimal"; }).overrideAttrs (oldAttrs: {
       name = "libgap-${oldAttrs.pname}-${version}";
       inherit version;
       src = fetchurl {
         url = "https://www.gap-system.org/pub/gap/gap48/tar.bz2/gap${version}_${pkgVer}.tar.bz2";
         sha256 = "19n2p1mdg33s2x9rs51iak7rgndc1cwr56jyqnah0g1ydgg1yh6b";
       };
+      # libgap targets not yet available for 4r8p6
+      installPhase = ''
+        mkdir -p "$out/bin" "$out/share/gap/"
+
+        mkdir -p "$out/share/gap"
+        echo "Copying files to target directory"
+        cp -ar . "$out/share/gap/build-dir"
+
+        makeWrapper "$out/share/gap/build-dir/bin/gap.sh" "$out/bin/gap" \
+          --set GAP_DIR $out/share/gap/build-dir
+      '';
       patches = [
         # don't install any packages by default (needed for interop with libgap, probably obsolete  with 4r10
         (fetchpatch {


### PR DESCRIPTION
3 Commits:

###### add timokau as maintainer

So that I'll be notified on changes which likely impact sage.

###### install libgap

There are some starts of a `make install`, but nothing complete yet.
Upstream now ships a `libgap` as a replacement of the custom one used by
sagemath.

###### add packageSet option

Two reasons for this:

- more fine-grained space/functionality tradeoff

- preparation for the sage 8.6 update, which finally doesn't need a
  downgraded gap anymore but does break when unexpected (non-standard)
  packages are installed. Details: 0ttps://trac.sagemath.org/ticket/26983

The proper way to deal with gap packages would be to create a package
set, package each one individually and have something like gap
equivalent of `python.withPackages`. I am not willing to do that
however.

Previous discussion about package sets here: https://github.com/NixOS/nixpkgs/pull/38754

CC @7c6f434c @ChrisJefferson 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

