### PR TITLE
glib.setupHook: fix gsettings-schemas location

### DIFF
--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -15,9 +15,9 @@ preInstallPhases+=" glibPreInstallPhase"
 
 glibPreFixupPhase() {
     # Move gschemas in case the install flag didn't help
-    if [ -d "${!outputLib}/share/glib-2.0/schemas" ]; then
+    if [ -d "$prefix/share/glib-2.0/schemas" ]; then
         mkdir -p "${!outputLib}/share/gsettings-schemas/$name/glib-2.0"
-        mv "${!outputLib}/share/glib-2.0/schemas" "${!outputLib}/share/gsettings-schemas/$name/glib-2.0/"
+        mv "$prefix/share/glib-2.0/schemas" "${!outputLib}/share/gsettings-schemas/$name/glib-2.0/"
     fi
 
     addToSearchPath GSETTINGS_SCHEMAS_PATH "${!outputLib}/share/gsettings-schemas/$name"


### PR DESCRIPTION
###### Motivation for this change
GLib setup hook expects GSettings schemas to be installed in `${!outputLib}` and tries to move them to `gsettings-schemas/$name` subdirectory to prevent conflicts. But the schemas will only end up in the library output when the build system recognizes `makeFlags` set by the setup hook, and in that case the move is not necessary, since the flag already includes the subdirectory.

Normally, this is not an issue, since most packages relying on GSettings schemas either still use Autotools with `gsettings.m4`, or do not have a lib output set. But with the promulgation of multiple outputs in Nixpkgs and more and more projects switching to Meson, the issue will become increasingly common.

We first noticed this problem with nm-applet.

Closes https://github.com/NixOS/nixpkgs/issues/45043

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested building nm-applet and checked that the file is moved correctly and that path in the wrapper points to the correct output.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @worldofpeace @hedning 