### PR TITLE
xdg-desktop-portal-kde: fix missing dependencies

### DIFF
--- a/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
+++ b/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
@@ -1,13 +1,15 @@
 {
   mkDerivation,
   extra-cmake-modules, gettext, kdoctools, python,
-  kcoreaddons, knotifications, kwayland, kwidgetsaddons
+  kcoreaddons, knotifications, kwayland, kwidgetsaddons,
+  cups, pcre, pipewire
 }:
 
 mkDerivation {
   name = "xdg-desktop-portal-kde";
   nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
   buildInputs = [
+    cups pcre pipewire
     kcoreaddons knotifications kwayland kwidgetsaddons
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

It didn't build due to missing dependencies. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

