### PR TITLE
nats-streaming-server: 0.11.0 -> 0.11.2

### DIFF
--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -4,7 +4,7 @@ with lib;
 
 buildGoPackage rec {
   name = "nats-streaming-server-${version}";
-  version = "0.11.0";
+  version = "0.11.2";
   rev = "v${version}";
 
   goPackagePath = "github.com/nats-io/nats-streaming-server";
@@ -13,7 +13,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "nats-io";
     repo = "nats-streaming-server";
-	sha256 = "0skkx3f7dpbf6nqpsbsk8ssn8hl55s9k76a5y5ksyqar5bdxvds5";
+    sha256 = "1jd9c5yw3xxp5hln1g8w48l4cslhxbv0k2af47g6pya09kwknqkq";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update to 0.11.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

