### PR TITLE
qtxmlpatterns: fix dependency with qtdeclarative

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -1,10 +1,10 @@
-{ qtModule, lib, python2, qtbase, qtsvg, qtxmlpatterns }:
+{ qtModule, lib, python2, qtbase, qtsvg }:
 
 with lib;
 
 qtModule {
   name = "qtdeclarative";
-  qtInputs = [ qtbase qtsvg qtxmlpatterns ];
+  qtInputs = [ qtbase qtsvg ];
   nativeBuildInputs = [ python2 ];
   outputs = [ "out" "dev" "bin" ];
   preConfigure = ''

--- a/pkgs/development/libraries/qt-5/modules/qtxmlpatterns.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtxmlpatterns.nix
@@ -1,7 +1,7 @@
-{ qtModule, qtbase }:
+{ qtModule, qtbase, qtdeclarative }:
 
 qtModule {
   name = "qtxmlpatterns";
-  qtInputs = [ qtbase ];
+  qtInputs = [ qtbase qtdeclarative ];
   devTools = [ "bin/xmlpatterns" "bin/xmlpatternsvalidator" ];
 }


### PR DESCRIPTION
In Qt-5.12, the order of the dependency between these two packages
flipped.

A symptom of the problem is an error like, `module
"QtQuick.XmlListModel" is not installed`.

The upstream changes that this reflects are in qtxmlpatterns
<https://github.com/qt/qtxmlpatterns/commit/8c6e24329ecd65f364654b1ca2b6a273f0826a8b>
and qtdeclarative <https://github.com/qt/qtdeclarative/commit/0477a057fd02050fd330760bf046f5e0e91a9331>

###### Motivation for this change
I encountered this error in the KDE Plasma Weather Widget which stopped functioning after I updated, but I believe it occurs anywhere the XmlListModel module is used in QML.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

