### PR TITLE
fetchgit: use buildPackages.cacert

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -197,6 +197,7 @@ in
 
   fetchgit = callPackage ../build-support/fetchgit {
     git = buildPackages.gitMinimal;
+    cacert = buildPackages.cacert;
   };
 
   fetchgitPrivate = callPackage ../build-support/fetchgit/private.nix { };


### PR DESCRIPTION
###### Motivation for this change

```cacert``` is used in ```fetchgit``` by ```git``` in ```nativeBuildInputs```, so by ```buildPackages.git```

As a data package ```buildPackages.cacert``` suppose to be equal to ```hostPackages.cacert```.
But ```hostPackages.cacert``` causes needless build of ```hostPackages.python``` and other packages, which takes time and requires them to support cross-compilation.

I am not sure why ```fetchgit``` needs the certificates. ```fetchurl``` works well without them skipping the certificate check (and allows to download from the websites with expired certificates - anyway ```sha256``` is checked afterwards). Doesn't ```git``` have an option like ```curl```'s ```-k``` ?
