### PR TITLE
transifex-client: init at 0.13.5

### DIFF
--- a/pkgs/tools/text/transifex-client/default.nix
+++ b/pkgs/tools/text/transifex-client/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildPythonApplication, fetchPypi
+, python-slugify, requests, urllib3 }:
+
+buildPythonApplication rec {
+  pname = "transifex-client";
+  version = "0.13.5";
+
+  propagatedBuildInputs = [
+    urllib3 requests python-slugify
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00igk35nyzqp1slj7lbhiv4lc42k87ix43ipx2zcrsjf6xxv6l7v";
+  };
+
+  prePatch = ''
+    substituteInPlace requirements.txt --replace "urllib3<1.24" "urllib3<2.0"
+  '';
+
+  # Requires external resources
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://www.transifex.com/;
+    license = licenses.gpl2;
+    description = "Transifex translation service client";
+    maintainers = [ maintainers.etu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5868,6 +5868,8 @@ in
 
   tracefilesim = callPackage ../development/tools/analysis/garcosim/tracefilesim { };
 
+  transifex-client = python3.pkgs.callPackage ../tools/text/transifex-client { };
+
   translate-shell = callPackage ../applications/misc/translate-shell { };
 
   transporter = callPackage ../applications/networking/transporter { };


### PR DESCRIPTION
###### Motivation for this change
Util used to manage translations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

