### PR TITLE
xkbmon: 0.2 -> 0.3

### DIFF
--- a/pkgs/applications/misc/xkbmon/default.nix
+++ b/pkgs/applications/misc/xkbmon/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "xkbmon-${version}";
-  version = "0.2";
+  version = "0.3";
 
   src = fetchFromGitHub {
     owner = "xkbmon";
     repo = "xkbmon";
     rev = version;
-    sha256 = "1x2xwak0yp0xkl63jzz3k1pf074mh9yxgppwwm96ms3zaslq44yp";
+    sha256 = "03v8f6fijgwagjphyj8w7lgh5hlc8jk0j2n45n7fm0xwy82cxxx9";
   };
 
   buildInputs = [ libX11 ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.3](https://github.com/xkbmon/xkbmon/releases/tag/0.3)

https://github.com/xkbmon/xkbmon/compare/0.2..0.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).