### PR TITLE
gnome3.removePackagesByName: fix filter reference

### DIFF
--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -17,7 +17,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       pkgName = drv: (builtins.parseDrvName drv.name).name;
       namesToRemove = map pkgName packagesToRemove;
     in
-      filter (x: !(builtins.elem (pkgName x) namesToRemove)) packages;
+      lib.filter (x: !(builtins.elem (pkgName x) namesToRemove)) packages;
 
   maintainers = with pkgs.lib.maintainers; [ lethalman jtojnar hedning ];
 


### PR DESCRIPTION
###### Motivation for this change

Missed lib broke hydra eval.

ref https://github.com/NixOS/nixpkgs/pull/54124/

###### Things done

Verified that gnome3 tests evaluates.