### PR TITLE
add various programming fonts (migrating from dtzWill's NUR repo)

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "agave-${version}";
+  version = "008";
+
+  src = fetchurl {
+    url = "https://github.com/agarick/agave/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "0g50mqpffn4dq761vibaf8dwfkbcl5da1cc89qz6pq35ircipbns";
+  };
+
+  sourceRoot = ".";
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    description = "truetype monospaced typeface designed for X environments";
+    homepage = https://b.agaric.net/page/agave;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/data/fonts/ankacoder/condensed.nix
+++ b/pkgs/data/fonts/ankacoder/condensed.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip }:
+
+let version = "1.100"; in
+fetchzip rec {
+  name = "ankacoder-condensed-${version}";
+  url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoderCondensed.${version}.zip";
+
+  postFetch = ''
+    unzip $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  sha256 = "0i80zpr2y9368rg2i6x8jv0g7d03kdyr5h7w9yz7pjd7i9xd8439";
+
+  meta = with stdenv.lib; {
+    description = "Anka/Coder Condensed font";
+    homepage = https://code.google.com/archive/p/anka-coder-fonts;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/data/fonts/ankacoder/default.nix
+++ b/pkgs/data/fonts/ankacoder/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip }:
+
+let version = "1.100"; in
+fetchzip rec {
+  name = "ankacoder-${version}";
+  url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
+
+  postFetch = ''
+    unzip $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  sha256 = "1jqx9micfmiarqh9xp330gl96v3vxbwzz9cmg2vi845n9md4im85";
+
+  meta = with stdenv.lib; {
+    description = "Anka/Coder fonts";
+    homepage = https://code.google.com/archive/p/anka-coder-fonts;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/data/fonts/cherry/default.nix
+++ b/pkgs/data/fonts/cherry/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, bdftopcf }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "cherry";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "turquoise-hexagon";
+    repo = pname;
+    rev = version;
+    sha256 = "1sfajzndv78v8hb156876i2rw3zw8xys6qi8zr4yi0isgsqj5yx5";
+  };
+
+  nativeBuildInputs = [ bdftopcf ];
+
+  buildPhase = ''
+    patchShebangs make.sh
+    ./make.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/misc
+    cp *.pcf $out/share/fonts/misc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "cherry font";
+    homepage = https://github.com/turquoise-hexagon/cherry;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/data/fonts/hermit/default.nix
+++ b/pkgs/data/fonts/hermit/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "hermit";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "https://pcaro.es/d/otf-${pname}-${version}.tar.gz";
+    sha256 = "09rmy3sbf1j1hr8zidighjgqc8kp0wsra115y27vrnlf10ml6jy0";
+  };
+
+  sourceRoot = ".";
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/share/fonts/opentype
+    cp *.otf $out/share/fonts/opentype/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "monospace font designed to be clear, pragmatic and very readable";
+    homepage = https://pcaro.es/p/hermit;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/data/fonts/luculent/default.nix
+++ b/pkgs/data/fonts/luculent/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchzip }:
+
+let version = "2.0.0"; in
+fetchzip rec {
+  name = "luculent-${version}";
+  url =  http://www.eastfarthing.com/luculent/luculent.tar.xz;
+
+  postFetch = ''
+    tar -xJf $downloadedFile --strip-components=1
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+
+  sha256 = "1m3g64galwna1xjxb1fczmfplm6c1fn3ra1ln7f0vkm0ah5m4lbv";
+
+  meta = with lib; {
+    description = "luculent font";
+    homepage = http://www.eastfarthing.com/luculent/;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15373,6 +15373,8 @@ in
 
   adapta-backgrounds = callPackage ../data/misc/adapta-backgrounds { };
 
+  agave = callPackage ../data/fonts/agave { };
+
   aileron = callPackage ../data/fonts/aileron { };
 
   andagii = callPackage ../data/fonts/andagii { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15570,6 +15570,8 @@ in
 
   hanazono = callPackage ../data/fonts/hanazono { };
 
+  hermit = callPackage ../data/fonts/hermit { };
+
   hyperscrypt-font = callPackage ../data/fonts/hyperscrypt { };
 
   ia-writer-duospace = callPackage ../data/fonts/ia-writer-duospace { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15383,6 +15383,9 @@ in
 
   android-udev-rules = callPackage ../os-specific/linux/android-udev-rules { };
 
+  ankacoder = callPackage ../data/fonts/ankacoder { };
+  ankacoder-condensed = callPackage ../data/fonts/ankacoder/condensed.nix { };
+
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
   ant-theme = callPackage ../data/themes/ant-theme { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15422,6 +15422,8 @@ in
 
   charis-sil = callPackage ../data/fonts/charis-sil { };
 
+  cherry = callPackage ../data/fonts/cherry { };
+
   comfortaa = callPackage ../data/fonts/comfortaa {};
 
   comic-neue = callPackage ../data/fonts/comic-neue { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15646,6 +15646,8 @@ in
   # lohit-fonts.kashmiri lohit-fonts.konkani lohit-fonts.maithili lohit-fonts.sindhi
   lohit-fonts = recurseIntoAttrs ( callPackages ../data/fonts/lohit-fonts { } );
 
+  luculent = callPackage ../data/fonts/luculent { };
+
   maia-icon-theme = callPackage ../data/icons/maia-icon-theme { };
 
   mailcap = callPackage ../data/misc/mailcap { };


### PR DESCRIPTION
###### Motivation for this change

Actually, 'hermit' just had a big release today! \o/
(version prior was in 2014)

* agave
* anka/coder
* cherry
* hermit
* luculent

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---