### PR TITLE
yubioath-desktop: 3.1.0 -> 4.3.4; yubikey-manager: 1.0.1 -> 2.0.0

### DIFF
--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -45,11 +45,12 @@ stdenv.mkDerivation rec {
         --replace 'Exec=yubioath-desktop' "Exec=$out/bin/yubioath-desktop" \
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Yubikey Desktop Authenticator";
 
     homepage = https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/;
 
     license = stdenv.lib.licenses.gpl3;
+    maintainers = with maintainers; [ mic92 ];
   };
 }

--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -1,41 +1,55 @@
-{ stdenv, fetchurl,  python27Packages, pcsclite, yubikey-personalization }:
+{ stdenv, fetchurl, fetchFromGitHub
+, qmake, qtbase, qtquickcontrols, qtsvg
+, python3, pyotherside, ncurses
+, pcsclite, yubikey-personalization
+, yubikey-manager, makeWrapper }:
 
-python27Packages.buildPythonApplication rec {
-    namePrefix = "";
-    name = "yubioath-desktop-${version}";
-    version = "3.1.0";
+stdenv.mkDerivation rec {
+  pname = "yubioath-desktop";
+  version = "4.3.4";
 
-    src = fetchurl {
-      url = "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-${version}.tar.gz";
-      sha256 = "0jfvllgh88g2vwd8sg6willlnn2hq05nd9d3xmv98lhl7gyy1akw";
-    };
+  src = fetchurl {
+    url = "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-${version}.tar.gz";
+    sha256 = "0hb7j71032sigs8zd5r8yr0m59sjkb24vhs2l4jarpvj8q7hv30d";
+  };
 
-    doCheck = false;
+  doCheck = false;
 
-    buildInputs = [ stdenv ];
+  buildInputs = [ stdenv qtbase qtquickcontrols pyotherside python3 ];
 
-    propagatedBuildInputs = [ python27Packages.pycrypto python27Packages.click python27Packages.pyscard python27Packages.pyside ];
+  nativeBuildInputs = [ qmake makeWrapper python3.pkgs.wrapPython ];
 
-    # Need LD_PRELOAD for libykpers as the Nix cpython disables ctypes.cdll.LoadLibrary
-    # support that the yubicommon library uses to load libykpers
-    makeWrapperArgs = ''--prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib pcsclite}/lib:${yubikey-personalization}/lib" --prefix LD_PRELOAD : "${yubikey-personalization}/lib/libykpers-1.so"'';
+  postPatch = ''
+    substituteInPlace deployment.pri \
+      --replace '/usr/bin' "$out/bin"
+  '';
 
-    postInstall = ''
+  pythonPath = [ yubikey-manager ];
+
+  # Need LD_PRELOAD for libykpers as the Nix cpython disables ctypes.cdll.LoadLibrary
+  # support that the yubicommon library uses to load libykpers
+
+  postInstall = ''
+    buildPythonPath "$out $pythonPath"
+    wrapProgram $out/bin/yubioath-desktop \
+      --prefix PYTHONPATH : "$program_PYTHONPATH" \
+      --prefix LD_PRELOAD : "${yubikey-personalization}/lib/libykpers-1.so" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib pcsclite}/lib:${yubikey-personalization}/lib"
+
       mkdir -p $out/share/applications
-      cp resources/yubioath.desktop $out/share/applications/yubioath.desktop
+      cp resources/yubioath-desktop.desktop \
+        $out/share/applications/yubioath-desktop.desktop
       mkdir -p $out/share/yubioath/icons
-      cp resources/yubioath*.{icns,ico,png,xpm} $out/share/yubioath/icons
-      substituteInPlace $out/share/applications/yubioath.desktop \
-        --replace 'Exec=yubioath-gui' "Exec=$out/bin/yubioath-gui" \
-        --replace 'Icon=yubioath' "Icon=$out/share/yubioath/icons"
+      cp resources/icons/*.{icns,ico,png,xpm} $out/share/yubioath/icons
+      substituteInPlace $out/share/applications/yubioath-desktop.desktop \
+        --replace 'Exec=yubioath-desktop' "Exec=$out/bin/yubioath-desktop" \
+  '';
 
-    '';
+  meta = {
+    description = "Yubikey Desktop Authenticator";
 
-    meta = {
-      description = "Yubikey Desktop Authenticator";
+    homepage = https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/;
 
-      homepage = https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/;
-
-      license = stdenv.lib.licenses.gpl3;
-    };
+    license = stdenv.lib.licenses.gpl3;
+  };
 }

--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub
+, python3, qmake, qtbase, qtquickcontrols, qtsvg, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "pyotherside";
+  version = "1.5.3";
+
+  src = fetchFromGitHub {
+    owner = "thp";
+    repo = "pyotherside";
+    rev = version;
+    sha256 = "1xaw1aarj8gpgpm4z3lk8klbssadrsf3xdyzqx10zcwy16amka7k";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [
+    python3 qtbase qtquickcontrols qtsvg ncurses
+  ];
+
+  patches = [ ./qml-path.patch ];
+  installTargets = [ "sub-src-install_subtargets" ];
+
+  meta = with stdenv.lib; {
+    description = "Asynchronous Python 3 Bindings for Qt 5";
+    homepage = https://thp.io/2011/pyotherside/;
+    license = licenses.isc;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/libraries/pyotherside/qml-path.patch
+++ b/pkgs/development/libraries/pyotherside/qml-path.patch
@@ -1,0 +1,12 @@
+diff -Naur --strip-trailing-cr source.org/src/src.pro source/src/src.pro
+--- source.org/src/src.pro	1970-01-01 01:00:01.000000000 +0100
++++ source/src/src.pro	2019-01-17 19:14:46.256821852 +0000
+@@ -10,7 +10,7 @@
+ CONFIG += qt plugin
+ QT += qml quick svg
+ 
+-target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH
++target.path = $$NIX_OUTPUT_QML/$$PLUGIN_IMPORT_PATH
+ INSTALLS += target
+ 
+ qmldir.files += $$_PRO_FILE_PWD_/qmldir $$_PRO_FILE_PWD_/pyotherside.qmltypes

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -43,6 +43,6 @@ python3Packages.buildPythonPackage rec {
 
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ benley ];
+    maintainers = with maintainers; [ benley mic92 ];
   };
 }

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -1,17 +1,16 @@
-{ pythonPackages, fetchurl, lib,
+{ python3Packages, fetchurl, lib,
   yubikey-personalization, libu2f-host, libusb1 }:
 
-pythonPackages.buildPythonPackage rec {
-  name = "yubikey-manager-1.0.1";
+python3Packages.buildPythonPackage rec {
+  name = "yubikey-manager-2.0.0";
 
   srcs = fetchurl {
     url = "https://developers.yubico.com/yubikey-manager/Releases/${name}.tar.gz";
-    sha256 = "0i7w1f89hqlw7g800fjhbb6yvq9wjmj5d7w7p6v8bkyvk645v48z";
+    sha256 = "1x36pyg9g3by2pa11j6d73d79sdlb7qy98lwwn05f43fjm74qnz9";
   };
 
   propagatedBuildInputs =
-    with pythonPackages;
-    lib.optional (!pythonPackages.pythonAtLeast "3.4") enum34 ++ [
+    with python3Packages; [
       click
       cryptography
       pyscard

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12118,6 +12118,8 @@ in
     qtxmlpatterns = qt59.qtxmlpatterns;
   };
 
+  pyotherside = libsForQt5.callPackage ../development/libraries/pyotherside {};
+
   re2 = callPackage ../development/libraries/re2 { };
 
   qbs = libsForQt5.callPackage ../development/tools/build-managers/qbs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13137,7 +13137,7 @@ in
 
   yojimbo = callPackage ../development/libraries/yojimbo { };
 
-  yubioath-desktop = callPackage ../applications/misc/yubioath-desktop { };
+  yubioath-desktop = libsForQt5.callPackage ../applications/misc/yubioath-desktop { };
 
   yubico-piv-tool = callPackage ../tools/misc/yubico-piv-tool { };
 


### PR DESCRIPTION
###### Motivation for this change

yubioath-desktop did not work for me before this upgrade.
I also documented the steps needed in the wiki: https://nixos.wiki/wiki/Yubikey
I tested both the CCID mode and the OTP mode.

cc @bjornfor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---