### PR TITLE
asciiquarium: init at 1.1

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -32,14 +32,14 @@
 , wrapGAppsHook
 }:
 let
-  version = "3.30.2";
+  version = "3.30.3";
   pname = "gnome-builder";
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "05yax7iv9g831xvw9xdc01qc0l7qpmh6rfd692x8cbg76hljxdrr";
+    sha256 = "11h6apjyah91djf77m8xkl5rvdz7mwpp3bjc4yzzs9lm3pag764r";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/asciiquarium/default.nix
+++ b/pkgs/applications/misc/asciiquarium/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, makeWrapper, perlPackages }:
+
+let version = "1.1";
+in stdenv.mkDerivation {
+  name = "asciiquarium-${version}";
+  src = fetchurl {
+    url = "https://robobunny.com/projects/asciiquarium/asciiquarium_${version}.tar.gz";
+    sha256 = "sha256:0qfkr5b7sxzi973nh0h84blz2crvmf28jkkgaj3mxrr56mhwc20v";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = "unpackPhase installPhase";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp asciiquarium $out/bin
+    chmod +x $out/bin/asciiquarium
+    wrapProgram $out/bin/asciiquarium \
+      --prefix PATH : ${perlPackages.perl}/bin/path \
+      --prefix PERL5LIB : ${perlPackages.makeFullPerlPath [ perlPackages.TermAnimation ] }
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Enjoy the mysteries of the sea from the safety of your own terminal!";
+    homepage = https://robobunny.com/projects/asciiquarium/html;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.utdemir ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -56,11 +56,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.19.0";
+  version = "1.20.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "19a585mylbwrxd2m75hgp77ys1r350xkvawq2ysp0cxzr04l46z7";
+    sha256 = "1w75g7i7hf9b3yilnd6ivhd4xgp4z000x9wnrqcba2dgbr5pz7c7";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -4,7 +4,7 @@
 
 let
   # if you bump version, update pkgs.tortoisehg too or ping maintainer
-  version = "4.8.1";
+  version = "4.8.2";
   name = "mercurial-${version}";
   inherit (python2Packages) docutils hg-git dulwich python;
 in python2Packages.buildPythonApplication {
@@ -13,7 +13,7 @@ in python2Packages.buildPythonApplication {
 
   src = fetchurl {
     url = "https://mercurial-scm.org/release/${name}.tar.gz";
-    sha256 = "08gsn0s5802bs8ks77xqg7c8dwpbsh8df47kvb1gn14ivrf5z928";
+    sha256 = "1cpx8nf6vcqz92kx6b5c4900pcay8zb89gvy8y33prh5rywjq83c";
   };
 
   inherit python; # pass it so that the same version can be used in hg2git

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -595,6 +595,8 @@ in
 
   asciinema = callPackage ../tools/misc/asciinema {};
 
+  asciiquarium = callPackage ../applications/misc/asciiquarium {};
+
   asymptote = callPackage ../tools/graphics/asymptote {
     texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super; };
     gsl = gsl_1;


### PR DESCRIPTION
###### Motivation for this change

It's a cool terminal animation. 

`asciiquarium` is a simple perl script which doesn't require anything to build, just putting `perl` and `Term::Animation` to the `PATH` looks enough.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

