### PR TITLE
asciiquarium: init at 1.1

### DIFF
--- a/pkgs/applications/misc/asciiquarium/default.nix
+++ b/pkgs/applications/misc/asciiquarium/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, makeWrapper, perlPackages }:
+
+let version = "1.1";
+in stdenv.mkDerivation {
+  name = "asciiquarium-${version}";
+  src = fetchurl {
+    url = "https://robobunny.com/projects/asciiquarium/asciiquarium_${version}.tar.gz";
+    sha256 = "0qfkr5b7sxzi973nh0h84blz2crvmf28jkkgaj3mxrr56mhwc20v";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perlPackages.perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp asciiquarium $out/bin
+    chmod +x $out/bin/asciiquarium
+    wrapProgram $out/bin/asciiquarium \
+      --set PERL5LIB ${perlPackages.makeFullPerlPath [ perlPackages.TermAnimation ] }
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Enjoy the mysteries of the sea from the safety of your own terminal!";
+    homepage = https://robobunny.com/projects/asciiquarium/html;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.utdemir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -595,6 +595,8 @@ in
 
   asciinema = callPackage ../tools/misc/asciinema {};
 
+  asciiquarium = callPackage ../applications/misc/asciiquarium {};
+
   asymptote = callPackage ../tools/graphics/asymptote {
     texLive = texlive.combine { inherit (texlive) scheme-small epsf cm-super; };
     gsl = gsl_1;


### PR DESCRIPTION
###### Motivation for this change

It's a cool terminal animation. 

`asciiquarium` is a simple perl script which doesn't require anything to build, just putting `perl` and `Term::Animation` to the `PATH` looks enough.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---