### PR TITLE
pythonPackages.pythonparser: init at 1.3

### DIFF
--- a/pkgs/development/python-modules/pythonparser/default.nix
+++ b/pkgs/development/python-modules/pythonparser/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, regex
+}:
+
+buildPythonPackage rec {
+  pname = "pythonparser";
+  version = "1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qby6w2pcfwxi4w62rly08d9wj32amf6m7rmbrqw0xz6mirq7rrp";
+  };
+
+  # test_parser tearDownModule writes to non-existent directory
+  # It generates a grammar coverage report in ./doc, which exists in git, but
+  # not in the pypi package. We do not make use of the report.
+  # Remove the report call to be able to run tests successfully.
+  patches = [
+    ./no_test_parser_teardown.patch
+  ];
+
+  propagatedBuildInputs = [
+    regex
+  ];
+
+  meta = {
+    description = "A Python parser intended for use in tooling";
+    homepage = https://m-labs.hk/pythonparser;
+    downloadPage = https://github.com/m-labs/pythonparser;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ clacke ];
+  };
+}

--- a/pkgs/development/python-modules/pythonparser/default.nix
+++ b/pkgs/development/python-modules/pythonparser/default.nix
@@ -2,12 +2,23 @@
 , buildPythonPackage
 , fetchPypi
 , python
+, pythonAtLeast
 , regex
 }:
 
 buildPythonPackage rec {
   pname = "pythonparser";
   version = "1.3";
+
+  # Under 3.7 a couple of tests fail with:
+  #   NotImplementedError: pythonparser.lexer.Lexer cannot lex Python (3, 7)
+  # Disable for Python 3.7 and above.
+
+  # According to https://github.com/m-labs/pythonparser/issues/20 3.6 support
+  # is incomplete, but it does build and test, and can be run under 3.6 to
+  # parse 3.5-compatible source.
+
+  disabled = pythonAtLeast "3.7";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pythonparser/no_test_parser_teardown.patch
+++ b/pkgs/development/python-modules/pythonparser/no_test_parser_teardown.patch
@@ -1,0 +1,14 @@
+diff --git a/pythonparser/test/test_parser.py b/pythonparser/test/test_parser.py
+index ff02f0d..b8af242 100644
+--- a/pythonparser/test/test_parser.py
++++ b/pythonparser/test/test_parser.py
+@@ -12,9 +12,6 @@ UnicodeOnly = test_utils.UnicodeOnly
+ if sys.version_info >= (3,):
+     def unicode(x): return x
+ 
+-def tearDownModule():
+-    coverage.report(parser)
+-
+ class ParserTestCase(unittest.TestCase):
+ 
+     maxDiff = None

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -714,6 +714,8 @@ in {
 
   python-utils = callPackage ../development/python-modules/python-utils { };
 
+  pythonparser = callPackage ../development/python-modules/pythonparser { };
+
   pytimeparse =  callPackage ../development/python-modules/pytimeparse { };
 
   PyWebDAV = callPackage ../development/python-modules/pywebdav { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

