### PR TITLE
pythonPackages.sphinx-argparse: init at 0.2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -867,6 +867,11 @@
     github = "cko";
     name = "Christine Koppelt";
   };
+  clacke = {
+    email = "claes.wallin@greatsinodevelopment.com";
+    github = "clacke";
+    name = "Claes Wallin";
+  };
   cleverca22 = {
     email = "cleverca22@gmail.com";
     github = "cleverca22";

--- a/pkgs/development/python-modules/sphinx-argparse/default.nix
+++ b/pkgs/development/python-modules/sphinx-argparse/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-argparse";
+  version = "0.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05wc8f5hb3jsg2vh2jf7jsyan8d4i09ifrz2c8fp6f7x1zw9iav0";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = "py.test";
+
+  propagatedBuildInputs = [
+    sphinx
+  ];
+
+  meta = {
+    description = "A sphinx extension that automatically documents argparse commands and options";
+    homepage = https://github.com/ribozz/sphinx-argparse;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ clacke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4018,6 +4018,8 @@ in {
 
   sphinx = callPackage ../development/python-modules/sphinx { };
 
+  sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
+
   sphinxcontrib-websupport = callPackage ../development/python-modules/sphinxcontrib-websupport { };
 
   hieroglyph = callPackage ../development/python-modules/hieroglyph { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

