### PR TITLE
pythonPackages: sphinxcontrib-wavedrom: init at 2.0.0, wavedrom: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -892,6 +892,11 @@
     github = "cko";
     name = "Christine Koppelt";
   };
+  clacke = {
+    email = "claes.wallin@greatsinodevelopment.com";
+    github = "clacke";
+    name = "Claes Wallin";
+  };
   cleverca22 = {
     email = "cleverca22@gmail.com";
     github = "cleverca22";

--- a/pkgs/development/python-modules/sphinxcontrib-wavedrom/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-wavedrom/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cairosvg
+, python
+, sphinx
+, wavedrom
+, xcffib
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-wavedrom";
+  version = "2.0.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nk36zqq5ipxqx9izz2iazb3iraasanv3nm05bjr21gw42zgkz22";
+  };
+
+  propagatedBuildInputs = [
+    cairosvg
+    sphinx
+    wavedrom
+    xcffib
+  ];
+
+  meta = {
+    description = "A sphinx extension that allows generating wavedrom diagrams based on their textual representation";
+    homepage = https://github.com/bavovanachte/sphinx-wavedrom;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ clacke ];
+  };
+}

--- a/pkgs/development/python-modules/wavedrom/default.nix
+++ b/pkgs/development/python-modules/wavedrom/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, freefont_ttf
+, glibcLocales
+, librsvg
+, makeFontsConf
+, python
+, attrdict
+, setuptools_scm
+, svgwrite
+}:
+
+buildPythonPackage rec {
+  pname = "wavedrom";
+  version = "0.1";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "006w683zlmmwcw5xz1n5dwg34ims5jg3gl2700ql4wr0myjz6710";
+  };
+  LC_ALL = "en_US.UTF-8";
+
+  checkInputs = [
+    glibcLocales
+    librsvg
+  ];
+
+  propagatedBuildInputs = [
+    attrdict
+    setuptools_scm
+    svgwrite
+  ];
+
+  FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+
+  postPatch = "patchShebangs .";
+
+  checkPhase = ''
+    (cd test && PATH=$out/bin:$PATH ./test.sh)
+  '';
+
+  meta = {
+    description = "WaveDrom compatible python command line";
+    homepage = https://github.com/K4zuki/wavedrompy;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ clacke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4503,6 +4503,8 @@ in {
 
   vultr = callPackage ../development/python-modules/vultr { };
 
+  wavedrom = callPackage ../development/python-modules/wavedrom { };
+
   waitress = callPackage ../development/python-modules/waitress { };
 
   waitress-django = callPackage ../development/python-modules/waitress-django { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4052,6 +4052,8 @@ in {
 
   sphinx = callPackage ../development/python-modules/sphinx { };
 
+  sphinxcontrib-wavedrom = callPackage ../development/python-modules/sphinxcontrib-wavedrom { };
+
   sphinxcontrib-websupport = callPackage ../development/python-modules/sphinxcontrib-websupport { };
 
   hieroglyph = callPackage ../development/python-modules/hieroglyph { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

