### PR TITLE
nixos/nixpkgs: virtualbox docs update

### DIFF
--- a/nixos/doc/manual/installation/installing-virtualbox-guest.xml
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.xml
@@ -77,7 +77,10 @@
   Shared folders can be given a name and a path in the host system in the
   VirtualBox settings (Machine / Settings / Shared Folders, then click on the
   "Add" icon). Add the following to the
-  <literal>/etc/nixos/configuration.nix</literal> to auto-mount them:
+  <literal>/etc/nixos/configuration.nix</literal> to auto-mount them. If you 
+   do not add <literal>"nofail"</literal>, the system will no boot properly. 
+   The same goes for disabling <literal>rngd</literal> which is normally used 
+   to get randomness but this does not work in virtual machines.
  </para>
 
 <programlisting>

--- a/nixos/doc/manual/installation/installing-virtualbox-guest.xml
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.xml
@@ -86,12 +86,13 @@
 <programlisting>
 { config, pkgs, ...} :
 {
+  security.rngd.enable = false; // otherwise vm will not boot
   ...
 
   fileSystems."/virtualboxshare" = {
     fsType = "vboxsf";
     device = "nameofthesharedfolder";
-    options = [ "rw" ];
+    options = [ "rw" "nofail" ];
   };
 }
 </programlisting>


### PR DESCRIPTION
###### Motivation for this change
When using the virtualbox instructions, i discovered them to be lacking.

###### Things done

- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- Added info about disabling rngd and failing shared folder blocking boot.

