### PR TITLE
electrum: 3.2.3 -> 3.2.4

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -14,11 +14,11 @@ in
 
 python3Packages.buildPythonApplication rec {
   name = "electrum-${version}";
-  version = "3.2.3";
+  version = "3.2.4";
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "139kzapas1l61w1in9f7c6ybricid4fzryfnvsrfhpaqh83ydn2c";
+    sha256 = "0nwipn1alk3r54zpsv2bdwsqxw4f08bxnfmygnwakfkiaifmmhxg";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change

**This is an security update. Please add the relevant tag if you can. :)**

From the release notes https://github.com/spesmilo/electrum/blob/3.2.x/RELEASE-NOTES:

`backport anti-phishing measures from master`

Also see the backported version to the stable nixpkgs branch in PR #54253

While there is a newer version available, it needs more work to package. In the meantime I think it would be a good idea to atleast to merge this PR, esp. for stable nixpkgs.

cc @ehmry @joachifm @np

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

