### PR TITLE
vmware-horizon-client: init at 4.10.0-11053294

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -674,6 +674,11 @@
     github = "bstrik";
     name = "Berno Strik";
   };
+  buckley310 = {
+    email = "sean.bck@gmail.com";
+    github = "buckley310";
+    name = "Sean Buckley";
+  };
   buffet = {
     email = "niclas@countingsort.com";
     github = "buffet";

--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildFHSUserEnv, fetchurl, makeDesktopItem, libxslt, atk
 , fontconfig, freetype, gdk_pixbuf, glib, gtk2, libudev0-shim, libxml2
 , pango, pixman, libX11, libXext, libXinerama, libXrandr , libXrender
-, libXtst, libXcursor, libXi, libxkbfile , libXScrnSaver, zlib
+, libXtst, libXcursor, libXi, libxkbfile , libXScrnSaver, zlib, liberation_ttf
 }:
 
 let
@@ -87,6 +87,7 @@ in buildFHSUserEnv {
         libxml2
         pango
         pixman
+        liberation_ttf
         libX11
         libXext
         libXinerama

--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, stdenv, buildFHSUserEnv, fetchurl, makeDesktopItem }:
+{ stdenv, buildFHSUserEnv, fetchurl, makeDesktopItem, libxslt, atk
+, fontconfig, freetype, gdk_pixbuf, glib, gtk2, libudev0-shim, libxml2
+, pango, pixman, libX11, libXext, libXinerama, libXrandr , libXrender
+, libXtst, libXcursor, libXi, libxkbfile , libXScrnSaver, zlib
+}:
+
 let
     version = "4.10.0-11053294";
 
@@ -20,7 +25,7 @@ let
         name = "vmwareHorizonClientFiles";
         inherit version;
         src = vmwareBundle;
-        buildInputs = [ vmwareBundleUnpacker pkgs.libxslt ];
+        buildInputs = [ vmwareBundleUnpacker libxslt ];
         unpackPhase = ''
             echo '
                 ebegin(){
@@ -70,7 +75,7 @@ let
 
 in buildFHSUserEnv {
     name = "vmware-horizon-client";
-    targetPkgs = pkgs: with pkgs; [
+    targetPkgs = pkgs: [
         vmwareHorizonClientFiles
         atk
         fontconfig
@@ -82,16 +87,16 @@ in buildFHSUserEnv {
         libxml2
         pango
         pixman
-        xorg.libX11
-        xorg.libXext
-        xorg.libXinerama
-        xorg.libXrandr
-        xorg.libXrender
-        xorg.libXtst
-        xorg.libXcursor
-        xorg.libXi
-        xorg.libxkbfile
-        xorg.libXScrnSaver
+        libX11
+        libXext
+        libXinerama
+        libXrandr
+        libXrender
+        libXtst
+        libXcursor
+        libXi
+        libxkbfile
+        libXScrnSaver
         zlib
     ];
     runScript = ''${vmwareHorizonClientFiles}/bin/vmware-view_wrapper'';

--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -13,7 +13,7 @@ let
     };
 
     vmwareBundleUnpacker = fetchurl {
-        url = https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/eclass/vmware-bundle.eclass;
+        url = https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/eclass/vmware-bundle.eclass?revision=1.2;
         sha256 = "d8794c22229afdeb698dae5908b7b2b3880e075b19be38e0b296bb28f4555163";
     };
 

--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -1,0 +1,111 @@
+{ pkgs, stdenv, buildFHSUserEnv, fetchurl, makeDesktopItem }:
+let
+    version = "4.10.0-11053294";
+
+    vmwareBundle64 = fetchurl {
+        url = https://download3.vmware.com/software/view/viewclients/CART19FQ4/VMware-Horizon-Client-4.10.0-11053294.x64.bundle;
+        sha256 = "21617d8223aad7d282967b07dbf09ec5d5dd389d706063c0b791b20bdfe425bb";
+    };
+
+    vmwareBundleUnpacker = fetchurl {
+        url = https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/eclass/vmware-bundle.eclass;
+        sha256 = "d8794c22229afdeb698dae5908b7b2b3880e075b19be38e0b296bb28f4555163";
+    };
+
+    vmwareBundle =
+        if stdenv.hostPlatform.system == "x86_64-linux" then vmwareBundle64
+        else throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+    vmwareHorizonClientFiles = stdenv.mkDerivation {
+        name = "vmwareHorizonClientFiles";
+        inherit version;
+        src = vmwareBundle;
+        buildInputs = [ vmwareBundleUnpacker pkgs.libxslt ];
+        unpackPhase = ''
+            echo '
+                ebegin(){
+                    echo "$1"
+                }
+                eend(){
+                    echo OK
+                }
+                source "${vmwareBundleUnpacker}"
+                export T="$PWD"
+                vmware-bundle_extract-bundle-component "$src" vmware-horizon-client "./ext-client"
+                vmware-bundle_extract-bundle-component "$src" vmware-horizon-pcoip "./ext-pcoip"
+            ' >./extractor.sh
+            bash ./extractor.sh # this script seems to require being run from disk
+        '';
+        installPhase = ''
+            mkdir "$out"
+
+            cp -a ext-client/bin "$out/"
+            cp -a ext-client/lib "$out/"
+            cp -a ext-client/share "$out/"
+            cp -a ext-pcoip/pcoip/bin "$out/"
+            cp -a ext-pcoip/pcoip/lib "$out/"
+
+            cat <<EOF >"$out/bin/vmware-view_wrapper"
+            #!/bin/sh
+            export ROLLBACK_VMWAREVIEW="1"
+            export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$out/lib/vmware/view/crtbora:$out/lib/vmware"
+            exec "$out/bin/vmware-view"
+            EOF
+
+            (
+                find "$out" -type f | grep '\.so'
+                find "$out/bin" -type f
+                find "$out/lib/vmware/view/bin" -type f
+            ) | xargs chmod +x
+        '';
+    };
+
+    desktopItem = makeDesktopItem {
+        name = "vmware-horizon-client";
+        exec = "vmware-horizon-client";
+        icon = "${vmwareHorizonClientFiles}/share/icons/vmware-view.png";
+        desktopName = "VMware Horizon Client";
+        genericName = "VMware Horizon Client";
+    };
+
+in buildFHSUserEnv {
+    name = "vmware-horizon-client";
+    targetPkgs = pkgs: with pkgs; [
+        vmwareHorizonClientFiles
+        atk
+        fontconfig
+        freetype
+        gdk_pixbuf
+        glib
+        gtk2
+        libudev0-shim
+        libxml2
+        pango
+        pixman
+        xorg.libX11
+        xorg.libXext
+        xorg.libXinerama
+        xorg.libXrandr
+        xorg.libXrender
+        xorg.libXtst
+        xorg.libXcursor
+        xorg.libXi
+        xorg.libxkbfile
+        xorg.libXScrnSaver
+        zlib
+    ];
+    runScript = ''${vmwareHorizonClientFiles}/bin/vmware-view_wrapper'';
+
+    extraInstallCommands = ''
+        mkdir -p "$out/share/applications"
+        cp "${desktopItem}"/share/applications/* $out/share/applications/
+    '';
+
+    meta = {
+        license = stdenv.lib.licenses.unfree;
+        homepage = https://www.vmware.com/go/viewclients;
+        description = "Allows you to connect to your VMware Horizon virtual desktop";
+        platforms = stdenv.lib.platforms.linux;
+        maintainers = [ stdenv.lib.maintainers.buckley310 ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19875,6 +19875,8 @@ in
 
   vmpk = callPackage ../applications/audio/vmpk { };
 
+  vmware-horizon-client = callPackage ../applications/networking/remote/vmware-horizon-client { };
+
   vnstat = callPackage ../applications/networking/vnstat { };
 
   vocal = callPackage ../applications/audio/vocal { };


### PR DESCRIPTION
First package, I hope I got everything right :)

###### Motivation for this change
Add a package for VMware's remote desktop client
https://www.vmware.com/go/viewclients

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

