### PR TITLE
gem-config: support rbnacl v6.0.0

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -297,13 +297,16 @@ in
     buildInputs = [ rainbow_rake ];
   };
 
-  rbnacl = spec: {
-    postInstall = ''
-    sed -i $(cat $out/nix-support/gem-meta/install-path)/lib/rbnacl.rb -e "2a \
-    RBNACL_LIBSODIUM_GEM_LIB_PATH = '${libsodium.out}/lib/libsodium${stdenv.hostPlatform.extensions.sharedLibrary}'
-    "
-    '';
-  };
+  rbnacl = spec:
+    if lib.versionOlder spec.version "6.0.0" then {
+      postInstall = ''
+        sed -i $(cat $out/nix-support/gem-meta/install-path)/lib/rbnacl.rb -e "2a \
+        RBNACL_LIBSODIUM_GEM_LIB_PATH = '${libsodium.out}/lib/libsodium${stdenv.hostPlatform.extensions.sharedLibrary}'
+        "
+      '';
+    } else {
+      buildInputs = [ libsodium ];
+    };
 
   re2 = attrs: {
     buildInputs = [ re2 ];


### PR DESCRIPTION
###### Motivation for this change

With the v6.0.0 release of the `rbnacl` gem, it does not longer depend on `rbnacl-libsodium` gem (which is now deprecated ([1])) to package the `libsodium` library and should use the one provided by the distribution; it raises an error if `rbnacl-libsodium` is detected ([2]). Unfortunately, default gem config patches `rbnacl` unconditionally ([3]), which means that newer versions of `rbnacl` fail at startup.

[1]: https://github.com/crypto-rb/rbnacl-libsodium/issues/29
[2]: https://github.com/crypto-rb/rbnacl/blob/c176fc0bd8be74cf62c93a4b122e220ce4895348/lib/rbnacl.rb#L4-L8
[3]: https://github.com/NixOS/nixpkgs/blob/9fd099a6ae1690909ebf40145e4cdabd67179676/pkgs/development/ruby-modules/gem-config/default.nix#L300-L306

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

