### PR TITLE
gitAndTools.overcommit: init at 0.46.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -141,6 +141,8 @@ let
 
   lab = callPackage ./lab { };
 
+  overcommit = callPackage ./overcommit { };
+
   pre-commit = callPackage ./pre-commit { };
 
   pass-git-helper = python3Packages.callPackage ./pass-git-helper { };

--- a/pkgs/applications/version-management/git-and-tools/overcommit/Gemfile
+++ b/pkgs/applications/version-management/git-and-tools/overcommit/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'overcommit'

--- a/pkgs/applications/version-management/git-and-tools/overcommit/Gemfile.lock
+++ b/pkgs/applications/version-management/git-and-tools/overcommit/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    ffi (1.10.0)
+    iniparse (1.4.4)
+    overcommit (0.46.0)
+      childprocess (~> 0.6, >= 0.6.3)
+      iniparse (~> 1.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  overcommit
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/applications/version-management/git-and-tools/overcommit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/overcommit/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  inherit ruby;
+  pname = "overcommit";
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "A fully configurable and extendable Git hook manager";
+    homepage = https://github.com/brigade/overcommit;
+    license = with licenses; mit;
+    maintainers = with maintainers; [ gerschtli ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/overcommit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/overcommit/default.nix
@@ -1,9 +1,10 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerApp }:
 
-bundlerEnv {
-  inherit ruby;
+bundlerApp {
   pname = "overcommit";
   gemdir = ./.;
+
+  exes = [ "overcommit" ];
 
   meta = with lib; {
     description = "A fully configurable and extendable Git hook manager";

--- a/pkgs/applications/version-management/git-and-tools/overcommit/gemset.nix
+++ b/pkgs/applications/version-management/git-and-tools/overcommit/gemset.nix
@@ -1,0 +1,44 @@
+{
+  childprocess = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0a61922kmvcxyj5l70fycapr87gz1dzzlkfpq85rfqk5vdh3d28p";
+      type = "gem";
+    };
+    version = "0.9.0";
+  };
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j8pzj8raxbir5w5k6s7a042sb5k02pg0f8s4na1r5lan901j00p";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+  iniparse = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xbik6838gfh5yq9ahh1m7dzszxlk0g7x5lvhb8amk60mafkrgws";
+      type = "gem";
+    };
+    version = "1.4.4";
+  };
+  overcommit = {
+    dependencies = ["childprocess" "iniparse"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jfgpprjkq7hkyk7z0wc8difnnzmvmkin0b3bgsmnh6vvpyrz0mn";
+      type = "gem";
+    };
+    version = "0.46.0";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Init overcommit at 0.46.0.

Added `vendor` in `.gitignore` because this directory gets generated while building `gemset.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

