### PR TITLE
gem-config: add digest-sha3

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -94,6 +94,10 @@ in
     '';
   };
 
+  digest-sha3 = attrs: {
+    hardeningDisable = [ "format" ];
+  };
+
   ethon = attrs: {
     dontBuild = false;
     postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

`digest-sha3` is a C-extension gem which fails to build on Nix because it uses non-literals as format strings which is forbidden by the default Nix hardening settings. There is a pull request to fix that ([1]), but the gem seems to be abandoned.

[1]: https://github.com/phusion/digest-sha3-ruby/pull/8

###### Things done

This PR disables the "format" hardening for `digest-sha3`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Original thread: https://discourse.nixos.org/t/solved-hardeningdisable-and-bundlerenv/1765

