### PR TITLE
overlays: (partially) recursive merge

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -33,7 +33,7 @@ with pkgs;
         isPyPy = interpreter == "pypy";
 
         buildEnv = callPackage ./wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
-        withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages;};
+        withPackages = import ./with-packages.nix { inherit buildEnv; pythonPackages = self.pkgs; };
         pkgs = pythonPackages;
         interpreter = "${self}/bin/${executable}";
         inherit executable implementation libPrefix pythonVersion sitePackages;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7996,8 +7996,11 @@ in
   python37Full = python37.override{x11Support=true;};
 
   # pythonPackages further below, but assigned here because they need to be in sync
+  _merge_pythonPackages = true;
   pythonPackages = python.pkgs;
+  _merge_python2Packages = true;
   python2Packages = python2.pkgs;
+  _merge_python3Packages = true;
   python3Packages = python3.pkgs;
 
   pythonInterpreters = callPackage ./../development/interpreters/python {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20,7 +20,7 @@ let
 let
   inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy3k isPyPy pythonAtLeast pythonOlder;
 
-  callPackage = pkgs.newScope self;
+  callPackage = pkgs.newScope (self // python.pkgs);
 
   namePrefix = python.libPrefix + "-";
 


### PR DESCRIPTION
###### Motivation for this change

One of the problems newcomers face when working with overlays is
non-expected behavior of overriding packages in package sets. Let's take,
for example, Python. Here's an overlay:

```
self: super: {
    pythonPackages.my-new-package = super.callPackages ./xxx { };
}
```

Big supprise is that `pythonPackages` set is now empty!

```
$ nix-build -E '(with import ./. { overlays = [
    (self: super: {
        pythonPackages.my-new-package = self.pythonPackages.pip;
    })
]; }; pythonPackages.ipython)'

error: attribute 'ipython' missing, at (string):5:7
```

It is not empty, but contains only one package. That's because attribute
sets are not merged recursively (like NixOS modules do), but are replaced
on each `extends`. Recursive merge is tricky, because it has to force
evaluation in lot of places and breaks the knot.

But we can do poor-man recursive merge "whitelist". Say, when overlay
contains attribute `_merge_pythonPackages = true;`, then we can merge it
recursively:

```
$ nix-build -E '(with import ./. { overlays = [
    (self: super: {
        _merge_pythonPackages = true;
        pythonPackages.my-new-package = self.pythonPackages.pip;
    })
]; }; pythonPackages.ipython)'

/nix/store/k4wf0244qq8xcml85n45sdwalizy0i6k-python2.7-ipython-5.8.0
```

We can also support this attribute in left-hand side overlay (for
example, `all-packages.nix`):

```
  ...
  _merge_pythonPackages = true;
  pythonPackages = python.pkgs;
  _merge_python2Packages = true;
  python2Packages = python2.pkgs;
  _merge_python3Packages = true;
  python3Packages = python3.pkgs;
  ...
```

So we get merge behavior by default for `pythonPackages`. We can also
disable merging in our overlay if desired:
```
$ nix-build -E '(with import ./. { overlays = [
    (self: super: {
        _merge_pythonPackages = false;
        pythonPackages = self.python3Packages;
    })
]; }; pythonPackages.ipython)'

/nix/store/0yx0q6v6nisx4fq1vj8x2vc51n7aj5pz-python3.7-ipython-7.1.1
```

cc @nbp @Ericson2314 

###### Things done

[x] my system evaluates
