### PR TITLE
oraclejdk: 8u191 -> 8u201, 8u202 [Security fixes]

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -199,4 +199,4 @@ let result = stdenv.mkDerivation rec {
     platforms = [ "i686-linux" "x86_64-linux" "armv7l-linux" "aarch64-linux" ]; # some inherit jre.meta.platforms
   };
 
-}; in result
+}; in stdenv.lib.trivial.warn "Public updates for Oracle Java SE 8 released after January 2019 will not be available for business, commercial or production use without a commercial license. See https://java.com/en/download/release_notice.jsp for more information." result

--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -6,8 +6,8 @@ import ./jdk-linux-base.nix {
   buildVersion = "09";
   sha256.i686-linux = "1f9n93zmkggchaxkchp4bqasvxznn96zjci34f52h7v392jkzqac";
   sha256.x86_64-linux = "0w730v2q0iaxf2lprabwmy7129byrs0hhdbwas575p1xmk00qw6b";
-  sha256.armv7l-linux = "0p82d2vah63a6r2rip9v17lbjam39kgqp0584q3cnljgr5p9gyhz";
-  sha256.aarch64-linux = "1qm4b3aj5wi0hp9q6gy1da4bz5k9ky4shgiqa4zxrib4kjp9yf0k";
+  sha256.armv7l-linux = "0y6bvq93lsf21v6ca536dpfhkk5ljsj7c6di0qzkban37bivj0si";
+  sha256.aarch64-linux = "1bybysgg9llqzllsmdszmmb73v5az2l1shxn6lxwv3wwiazpf47q";
   releaseToken = "42970487e3af4f5aa5bca3f542482c60";
   jceName = "jce_policy-8.zip";
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -2,12 +2,12 @@
 # jce download url: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "201";
+  patchVersion = "202";
   buildVersion = "09";
-  sha256.i686-linux = "1f9n93zmkggchaxkchp4bqasvxznn96zjci34f52h7v392jkzqac";
-  sha256.x86_64-linux = "0w730v2q0iaxf2lprabwmy7129byrs0hhdbwas575p1xmk00qw6b";
-  sha256.armv7l-linux = "0p82d2vah63a6r2rip9v17lbjam39kgqp0584q3cnljgr5p9gyhz";
-  sha256.aarch64-linux = "1qm4b3aj5wi0hp9q6gy1da4bz5k9ky4shgiqa4zxrib4kjp9yf0k";
+  sha256.i686-linux = "19np392dwdqdq39lmm10607w2h042lrm5953fnsfh1bb9jli1pgj";
+  sha256.x86_64-linux = "1q4l8pymjvsvxfwaw0rdcnhryh1la2bvg5f4d4my41ka390k4p4s";
+  sha256.armv7l-linux = "06aljl7dqmmhmp7xswgvkcgh9mam71wnqydg9yb3hkcc443cm581";
+  sha256.aarch64-linux = "12v9ndv7a2c9zqq6ai2vsgwad0lzmf4c6jxy4p9miapmhjzx5vii";
   releaseToken = "42970487e3af4f5aa5bca3f542482c60";
   jceName = "jce_policy-8.zip";
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

Security fixes and other updates.

https://www.oracle.com/technetwork/java/javase/8u201-relnotes-5209271.html
https://www.oracle.com/technetwork/java/javase/8u202-relnotes-5209339.html
https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html#AppendixJAVA

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only x86_64.

---

