### PR TITLE
pulumi: 0.16.7 -> 0.16.11, patchelf on linux

### DIFF
--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, autoPatchelfHook }:
+
+with lib;
 
 let
 
@@ -27,7 +29,9 @@ in stdenv.mkDerivation rec {
     cp * $out/bin/
   '';
 
-  meta = with stdenv.lib; {
+  buildInputs = optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  meta = {
     homepage = https://pulumi.io/;
     description = "Pulumi is a cloud development platform that makes creating cloud programs easy and productive";
     license = with licenses; [ asl20 ];

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -2,17 +2,17 @@
 
 let
 
-  version = "0.16.7";
+  version = "0.16.11";
 
   # switch the dropdown to “manual” on https://pulumi.io/quickstart/install.html # TODO: update script
   pulumiArchPackage = {
     "x86_64-linux" = {
       url = "https://get.pulumi.com/releases/sdk/pulumi-v${version}-linux-x64.tar.gz";
-      sha256 = "1l1cn8pk05vl7vpmhny9rlz1hj0iqclqjj1r2q12qip7f4qkgsfw";
+      sha256 = "176nwqp1dd8vdpl4qajaq2w458f8pgavwvwd93lgnccqw3cznv75";
     };
     "x86_64-darwin" = {
       url = "https://get.pulumi.com/releases/sdk/pulumi-v${version}-darwin-x64.tar.gz";
-      sha256 = "0p07jvgy0xl524fgb5d9wijxa91isv4h4mcn9qghycqj90yqnjhx";
+      sha256 = "1mkz9bkkvpvbpzfnvwpx4892zd05bvjz5rbfwhwzm3wzfcjjs16i";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

- New 0.16.11 version is avalible
- Binaries on linux need fixed `ld-linux-x86-64.so.2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

