### PR TITLE
Keybase 2.13.1

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub, cf-private
+{ stdenv, lib, buildGoPackage, fetchurl, cf-private
 , AVFoundation, AudioToolbox, ImageIO, CoreMedia
 , Foundation, CoreGraphics, MediaToolbox
 }:
@@ -12,11 +12,9 @@ buildGoPackage rec {
 
   dontRenameImports = true;
 
-  src = fetchFromGitHub {
-    owner  = "keybase";
-    repo   = "client";
-    rev    = "v${version}";
-    sha256 = "13mkbr99k3i03vp28ab5y0h5fa1pfnbfjqq2fhh4j87d5h74ld13";
+  src = fetchurl {
+    url = "https://github.com/keybase/client/archive/v${version}.tar.gz";
+    sha256 = "0avq87y7cs3jipl444ssz1zd5jygpks20hls0fkqxxaikkpdsy4v";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -5,7 +5,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "2.11.0";
+  version = "2.13.1";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner  = "keybase";
     repo   = "client";
     rev    = "v${version}";
-    sha256 = "1mj78cs6j0f1f86c71j4gdphas75j3rfaqygpy87dc40kc2yj0gd";
+    sha256 = "13mkbr99k3i03vp28ab5y0h5fa1pfnbfjqq2fhh4j87d5h74ld13";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -3,16 +3,16 @@
 , libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook }:
 
 let
-  versionSuffix = "20190104191034.69b3ee25b7";
+  versionSuffix = "20190115203650.eec94506e4";
 in
 
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "2.13.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "2.13.1"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "5b188185dc6d594cd18876a2c955bb6481598c206f048cfd80ac2e7e8022241e";
+    sha256 = "01663jknr8s4sp51mclw9llhx07ww6yh22apawxikvpwmw9yg2qr";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This change updates the keybase clients to version 2.13.1

This update introduces a Stellar (XLM) wallet built-in to the GUI client.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
~- [] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - /nix/store/crmrla0ldzwq9xxi7sk95mpyq20n3xc2-keybase-gui-2.13.0    514194056
  - /nix/store/agy45qxjhd1599rvw04j0lf068y9cbqw-keybase-gui-2.13.1    602877480
  - /nix/store/7f052pbid2v2sr0wkpi1x8fpjxyiavmk-keybase-2.11.0-bin     83144176
  - /nix/store/95kli1cw668417w6ff4mck35jgr6dx23-keybase-2.13.1-bin     84715536

~- [ ] Assured whether relevant documentation is up to date~
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

