### PR TITLE
ocamlPackages.alcotest: 0.8.2 -> 0.8.5

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchzip, ocaml, findlib, ocamlbuild, topkg, dune
-, cmdliner, astring, fmt, result
+, cmdliner, astring, fmt, result, uuidm
 }:
 
 let param =
   if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
-    version = "0.8.2";
-    sha256 = "1zpg079v89mz2dpnh59f9hk5r03wl26skfn43llrv3kg24abjfpf";
+    version = "0.8.5";
+    sha256 = "1mhckvdcxkikbzgvy24kjz4265l15b86a6swz7m3ynbgvqdcfzqn";
     buildInputs = [ dune ];
+    propagatedBuildInputs = [ uuidm ];
     buildPhase = "dune build -p alcotest";
     inherit (dune) installPhase;
   } else {
@@ -28,7 +29,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ] ++ param.buildInputs;
 
-  propagatedBuildInputs = [ cmdliner astring fmt result ];
+  propagatedBuildInputs = [ cmdliner astring fmt result ]
+  ++ (param.propagatedBuildInputs or []);
 
   createFindlibDestdir = true;
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

