### PR TITLE
display-managers: use xsession from nix-profile

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -109,9 +109,8 @@ let
       ${config.systemd.package}/bin/systemctl --user start graphical-session.target
 
       # Allow the user to setup a custom session type.
-      if test -x ~/.xsession; then
-          exec ~/.xsession
-      fi
+      test -x ~/.nix-profile/bin/xsession && exec ~/.nix-profile/bin/xsession
+      test -x ~/.xsession && exec ~/.xsession
 
       if test "$1"; then
           # Run the supplied session command. Remove any double quotes with eval.


### PR DESCRIPTION
###### Motivation for this change
This allows more declarative config of the user environment independent of the system config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

