### PR TITLE
sage: fix transient ecl error

### DIFF
--- a/pkgs/applications/science/math/sage/patches/fix-ecl-race.patch
+++ b/pkgs/applications/science/math/sage/patches/fix-ecl-race.patch
@@ -1,0 +1,19 @@
+diff --git a/src/sage/doctest/forker.py b/src/sage/doctest/forker.py
+index 02e18e67e7..2ebf6eb35f 100644
+--- a/src/sage/doctest/forker.py
++++ b/src/sage/doctest/forker.py
+@@ -1075,6 +1075,14 @@ class SageDocTestRunner(doctest.DocTestRunner, object):
+             sage: set(ex2.predecessors) == set([ex0,ex1])
+             True
+         """
++
++        # Fix ECL dir race conditions by using a separate dir for each process
++        # (https://trac.sagemath.org/ticket/26968)
++        os.environ['MAXIMA_USERDIR'] = "{}/sage-maxima-{}".format(
++            tempfile.gettempdir(),
++            os.getpid()
++        )
++
+         if isinstance(globs, RecordingDict):
+             globs.start()
+         example.sequence_number = len(self.history)

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -46,6 +46,9 @@ stdenv.mkDerivation rec {
     # tests) are also run. That is necessary to test dochtml individually. See
     # https://trac.sagemath.org/ticket/26110 for an upstream discussion.
     ./patches/Only-test-py2-py3-optional-tests-when-all-of-sage-is.patch
+
+    # Fixes a potential race condition which can lead to transient doctest failures.
+    ./patches/fix-ecl-race.patch
   ];
 
   # Patches needed because of package updates. We could just pin the versions of


### PR DESCRIPTION

###### Motivation for this change

Sometimes the doctests fail because ecl races to create a directory.
This should fix that by making sure each process has its own directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

