### PR TITLE
springLobby: Fix TLS problems on map downloads

### DIFF
--- a/pkgs/games/spring/fix-certs.patch
+++ b/pkgs/games/spring/fix-certs.patch
@@ -1,0 +1,11 @@
+--- a/src/downloader/lib/src/Downloader/CurlWrapper.cpp
++++ b/src/downloader/lib/src/Downloader/CurlWrapper.cpp
+@@ -108,7 +108,6 @@
+ 		if (res != CURLE_OK) {
+ 			LOG_WARN("Error setting CURLOPT_CAPATH: %d", res);
+ 		}
+-		return;
+ 	}
+ 
+ 	const std::string cafile = GetCAFilePath();
+

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
   ];
 
-  patches = [ ./revert_58b423e.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
+  patches = [ ./revert_58b423e.patch ./fix-certs.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Experiencing TLS problems when downloading maps and games through springlobby. Although springlobby downloads a ca-bundle, it will prefer `/etc/ssl/certs` but expects a set of hashed names inside, which seams not to be the case on my NixOS systems. With this patch, springlobby will  use the custom ca-bundle, even if `/etc/ssl/certs` is present.

cc mainainers @Phreedom  @qknight  @domenkozar  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

