### PR TITLE
gcc-arm-embedded: fix MANPATH

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -r * $out
+    ln -s $out/share/doc/gcc-arm-none-eabi/man $out/man
   '';
 
   dontPatchELF = true;

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -r * $out
+    ln -s $out/share/doc/gcc-arm-none-eabi/man $out/man
   '';
 
   dontPatchELF = true;

--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -pv $out
     cp -r ./* $out
+    ln -s $out/share/doc/gcc-arm-none-eabi/man $out/man
 
     for f in $(find $out); do
       if [ -f "$f" ] && patchelf "$f" 2> /dev/null; then


### PR DESCRIPTION
###### Motivation for this change
Fix isssue #54291

###### Things done
Add symlink to fix MANPATH 

- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

