### PR TITLE
udocker: change homepage to documentation on gitbooks.io

### DIFF
--- a/pkgs/tools/virtualization/udocker/default.nix
+++ b/pkgs/tools/virtualization/udocker/default.nix
@@ -28,7 +28,7 @@ buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "basic user tool to execute simple docker containers in user space without root privileges";
-    homepage = https://www.gitbook.com/book/indigo-dc/udocker;
+    homepage = https://indigo-dc.gitbooks.io/udocker;
     license = licenses.asl20;
     maintainers = [ maintainers.bzizou ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

[That view](https://indigo-dc.gitbooks.io/udocker), other than the currently used [gitbook.com one](https://www.gitbook.com/book/indigo-dc/udocker), is available to readers who are not logged into GitBook, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

