### PR TITLE
[Help needed] energyplus: init at 9.0.1

### DIFF
--- a/pkgs/applications/science/misc/energyplus/default.nix
+++ b/pkgs/applications/science/misc/energyplus/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
 
-  name = "energyplus";
+  pname = "energyplus";
   version = "9.0.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/science/misc/energyplus/default.nix
+++ b/pkgs/applications/science/misc/energyplus/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, python }:
+
+stdenv.mkDerivation rec {
+
+  name = "energyplus";
+  version = "9.0.1";
+
+  src = fetchFromGitHub {
+    owner = "NREL";
+    repo = "EnergyPlus";
+    rev = "v${version}";
+    sha256 = "1578iv879dsyjssq0slfmyk1a3dpsg8xswrskwin7n6l0iasy1hc";
+  };
+
+  buildInputs = [ cmake python ];
+
+  # cmakeFlags = [
+  #   "-DBUILD_FORTRAN=ON"
+  # ];
+
+  meta = with stdenv.lib; {
+    description = "A whole building energy simulation program";
+    homepage = https://energyplus.net/;
+    maintainers = with maintainers; [ jluttine ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2516,6 +2516,8 @@ in
     tinyxml2 = tinyxml-2;
   };
 
+  energyplus = callPackage ../applications/science/misc/energyplus { };
+
   enscript = callPackage ../tools/text/enscript { };
 
   entr = callPackage ../tools/misc/entr { };


### PR DESCRIPTION
###### Motivation for this change

Add EnergyPlus https://energyplus.net/

This is work in progress, I opened this pull request already now so that I could perhaps get some help.

I can build the package like this:
```
nix-build '<nixpkgs>' -A energyplus
```

But when I try to run the compiled binary, I get:

```
$ result/energyplus
result/energyplus: symbol lookup error: /nix/store/vdj3wf599ry7ls6ghlh1mfss56vv31pm-energyplus/libenergyplusapi.so.9.0.1: undefined symbol: XXX
```

I have no idea what is this symbol `XXX`, why it's missing and how to make it available.. Any ideas how to fix this?

Here are the official build instructions: https://github.com/NREL/EnergyPlus/wiki/BuildingEnergyPlus

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

