### PR TITLE
[Help needed] traccar: init at 4.2

### DIFF
--- a/pkgs/servers/traccar/default.nix
+++ b/pkgs/servers/traccar/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, maven  }:
+
+stdenv.mkDerivation rec {
+
+  pname = "traccar";
+  version = "4.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "traccar";
+    rev = "v${version}";
+    sha256 = "1xqnqz53h5yw5l1qc2mi35pnwihjfwpfccy86wl6jphl968w1czn";
+    fetchSubmodules = true;
+  };
+
+  # How to build with Maven????
+  #
+  # Build instructions:
+  # https://www.traccar.org/build/
+
+  buildInputs = [ maven ];
+
+  buildPhase = ''
+    mvn package
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Modern GPS tracking platform";
+    homepage = https://www.traccar.org/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jluttine ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14119,6 +14119,8 @@ in
 
   shaarli-material = callPackage ../servers/web-apps/shaarli/material-theme.nix { };
 
+  traccar = callPackage ../servers/traccar { };
+
   matomo = callPackage ../servers/web-apps/matomo { };
 
   axis2 = callPackage ../servers/http/tomcat/axis2 { };

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -312,4 +312,7 @@ in {
 
   inherit (callPackage ../development/java-modules/xml-apis { inherit fetchMaven; })
     xmlApis_1_3_03;
+
+  inherit (callPackage ../development/java-modules/traccar { inherit mavenbuild fetchMaven; })
+    traccar_4_2;
 }


### PR DESCRIPTION
###### Motivation for this change

Package for Traccar: https://www.traccar.org/

After this works, I'd like to add a traccar service to NixOS.

This is still work in progress, and any help would be greatly appreciated. I have no idea how to build with Maven on NixOS.. This is the build failure I'm now getting:

```
$ nix-build '<nixpkgs>' -A traccar
these derivations will be built:
  /nix/store/vng60wpg616h5mpkwyzn4aq5z94rfawz-traccar-4.2.drv
building '/nix/store/vng60wpg616h5mpkwyzn4aq5z94rfawz-traccar-4.2.drv'...
unpacking sources
unpacking source archive /nix/store/2bj2wyj2lsc8cmh8hgwk9v37d6fwz7ma-source
source root is source
patching sources
configuring
no configure script, doing nothing
building
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------< org.traccar:traccar >-------------------------
[INFO] Building traccar 4.2-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-enforcer-plugin/1.4.1/maven-enforcer-plugin-1.4.1.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.377 s
[INFO] Finished at: 2019-01-19T11:07:48Z
[INFO] ------------------------------------------------------------------------
[ERROR] Plugin org.apache.maven.plugins:maven-enforcer-plugin:1.4.1 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.maven.plugins:maven-enforcer-plugin:jar:1.4.1: Could not transfer artifact org.apache.maven.plugins:maven-enforcer-plugin:pom:1.4.1 from/to central (https://repo.maven.apache.org/maven2): repo.maven.apache.org: Name or service not known: Unknown host repo.maven.apache.org: Name or service not known -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
builder for '/nix/store/vng60wpg616h5mpkwyzn4aq5z94rfawz-traccar-4.2.drv' failed with exit code 1
error: build of '/nix/store/vng60wpg616h5mpkwyzn4aq5z94rfawz-traccar-4.2.drv' failed
```

Official build instructions: https://www.traccar.org/build/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

