### PR TITLE
vimPlugins: add pname to remaining plugins

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -19,18 +19,21 @@
 self: super: {
 
   vim2nix = buildVimPluginFrom2Nix {
-    name = "vim2nix";
+    pname = "vim2nix";
+    version = "1.0";
     src = ./vim2nix;
     dependencies = with super; [ vim-addon-manager ];
   };
 
   fzfWrapper = buildVimPluginFrom2Nix {
-    name = fzf.name;
+    pname = "fzf";
+    version = fzf.version;
     src = fzf.src;
   };
 
   skim = buildVimPluginFrom2Nix {
-    name = skim.name;
+    pname = "skim";
+    version = skim.version;
     src = skim.vim;
   };
 
@@ -54,7 +57,8 @@ self: super: {
       '';
     };
   in buildVimPluginFrom2Nix {
-    name = "LanguageClient-neovim-2018-09-07";
+    pname = "LanguageClient-neovim";
+    version = "2018-09-07";
     src = LanguageClient-neovim-src;
 
     propogatedBuildInputs = [ LanguageClient-neovim-bin ];
@@ -67,7 +71,8 @@ self: super: {
 
   # do not auto-update this one, as the name clashes with vim-snippets
   vim-docbk-snippets = buildVimPluginFrom2Nix {
-    name = "vim-docbk-snippets-2017-11-02";
+    pname = "vim-docbk-snippets";
+    version = "2017-11-02";
     src = fetchgit {
       url = "https://github.com/jhradilek/vim-snippets";
       rev = "69cce66defdf131958f152ea7a7b26c21ca9d009";


### PR DESCRIPTION
###### Motivation for this change

This makes it possible to access plugin name and version seperately (and
reliably), e.g. for accessing the plugin directory using pname.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

