### PR TITLE
shaderc: git-2018-06-01 -> 2018.0

### DIFF
--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -57,5 +57,6 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "A collection of tools, libraries and tests for shader compilation.";
+    license = [ licenses.asl20 ];
   };
 }

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -42,13 +42,15 @@ in stdenv.mkDerivation rec {
     ln -s ${spirv-headers} third_party/spirv-tools/external/spirv-headers
   '';
 
-  buildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python ];
 
   postInstall = ''
     moveToOutput "lib/*.a" $static
   '';
 
   preConfigure = ''cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_BINDIR=$bin/bin"'';
+
+  enableParallelBuilding = true;
 
   cmakeFlags = [ "-DSHADERC_SKIP_TESTS=ON" ];
 

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -27,6 +27,8 @@ in stdenv.mkDerivation rec {
   name = "shaderc-git-${version}";
   version = "2018-06-01";
 
+  outputs = [ "out" "lib" "bin" "dev" "static" ];
+
   src = fetchFromGitHub {
     owner = "google";
     repo = "shaderc";
@@ -41,7 +43,12 @@ in stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ cmake python ];
-  enableParallelBuilding = true;
+
+  postInstall = ''
+    moveToOutput "lib/*.a" $static
+  '';
+
+  preConfigure = ''cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_BINDIR=$bin/bin"'';
 
   cmakeFlags = [ "-DSHADERC_SKIP_TESTS=ON" ];
 

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -8,32 +8,32 @@ let
   glslang = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "32d3ec319909fcad0b2b308fe1635198773e8316";
-    sha256 = "1kmgjv5kbrjy6azpgwnjcn3cj8vg5i8hnyk3m969sc0gq2j1rbjj";
+    rev = "712cd6618df2c77e126d68042ad7a81a69ee4a6f";
+    sha256 = "0wncdj6q1hn40lc7cnz97mx5qjvb8p13mhxilnncgcmf0crsvblz";
   };
   spirv-tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "fe2fbee294a8ad4434f828a8b4d99eafe9aac88c";
-    sha256 = "03rq4ypwqnz34n8ip85n95a3b9rxb34j26azzm3b3invaqchv19x";
+    rev = "df5bd2d05ac1fd3ec3024439f885ec21cc949b22";
+    sha256 = "0l8ds4nn2qcfi8535ai8891i3547x35hscs2jxwwq6qjgw1sgkax";
   };
   spirv-headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "3ce3e49d73b8abbf2ffe33f829f941fb2a40f552";
-    sha256 = "0yk4bzqifdqpmdxkhvrxbdqhf5ngkga0ig1yyz7khr7rklqfz7wp";
+    rev = "79b6681aadcb53c27d1052e5f8a0e82a981dbf2f";
+    sha256 = "0flng2rdmc4ndq3j71h6wk1ibcjvhjrg2rzd6rv445vcsf0jh2pj";
   };
 in stdenv.mkDerivation rec {
-  name = "shaderc-git-${version}";
-  version = "2018-06-01";
+  name = "shaderc-${version}";
+  version = "2018.0";
 
   outputs = [ "out" "lib" "bin" "dev" "static" ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "shaderc";
-    rev = "be8e0879750303a1de09385465d6b20ecb8b380d";
-    sha256 = "16p25ry2i4zrj00zihfpf210f8xd7g398ffbw25igvi9mbn4nbfd";
+    rev = "v${version}";
+    sha256 = "0qigmj0riw43pgjn5f6kpvk72fajssz1lc2aiqib5qvmj9rqq3hl";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change
This started out as just an attempt at closure size reduction for https://github.com/NixOS/nixpkgs/pull/54290.
It turns out there is quite a lot we can do to achieve that.

With this PR the vulkan-enabled `mpv` closure is reduced by ~48M.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Ralith 