### PR TITLE
mpv: Add javascript support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, makeWrapper
 , docutils, perl, pkgconfig, python3, which, ffmpeg_4
-, freefont_ttf, freetype, libass, libpthreadstubs
+, freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , lua, luasocket, libuchardet, libiconv ? null, darwin
 
 , waylandSupport ? false
@@ -139,7 +139,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     ffmpeg_4 freetype libass libpthreadstubs
-    lua luasocket libuchardet
+    lua luasocket libuchardet mujs
   ] ++ optional alsaSupport        alsaLib
     ++ optional archiveSupport     libarchive
     ++ optional bluraySupport      libbluray

--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchgit, clang }:
+{ stdenv, fetchurl, readline }:
 
 stdenv.mkDerivation rec {
-  name = "mujs-2017-01-24";
+  name = "mujs-${version}";
+  version = "1.0.5";
 
-  src = fetchgit {
-    url = git://git.ghostscript.com/mujs.git;
-    rev  = "4006739a28367c708dea19aeb19b8a1a9326ce08";
-    sha256 = "0wvjl8lkh0ga6fkmxgjqq77yagncbv1bdy6hpnxq31x3mkwn1s51";
+  src = fetchurl {
+    url = "https://mujs.com/downloads/mujs-${version}.tar.xz";
+    sha256 = "02cqrfnww2s3ylcvqin1951f2c5nzpby8gxb207p2hbrivbg8f0l";
   };
 
-  buildInputs = [ clang ];
+  buildInputs = [ readline ];
 
   makeFlags = [ "prefix=$(out)" ];
 


### PR DESCRIPTION
###### Motivation for this change
Tested by putting `mp.msg.error("Loaded!")` in `~/.config/mpv/scripts/tst.js`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @AndersonTorres @Fuuzetsu @fpletz @xantoz