### PR TITLE
ocamlPackages.lablgtk: make glade support optional

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview }:
+{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, gtksourceview
+, gladeSupport ? !stdenv.isDarwin
+, libglade ? null
+, libgnomecanvas ? null
+}:
 
 let param =
   let check = stdenv.lib.versionAtLeast ocaml.version; in
@@ -22,7 +26,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocaml findlib gtk2 libgnomecanvas libglade gtksourceview ];
+  buildInputs = [ ocaml findlib gtk2 gtksourceview ]
+  ++ stdenv.lib.optionals gladeSupport [ libglade libgnomecanvas ];
 
   configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
   buildFlags = "world";


### PR DESCRIPTION
###### Motivation for this change

`gnome2.libglade` has been broken on darwin for a while (e.g., https://hydra.nixos.org/build/85407675).

Disabling `Glade` and `GnomeCanvas` (which also depends on `libglade`) support breaks `monotoneViz`, and the GUI of `frama-c`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

