### PR TITLE
Bump django-contrib, django-hijack, django-hijack-admin

### DIFF
--- a/pkgs/development/python-modules/django-hijack-admin/default.nix
+++ b/pkgs/development/python-modules/django-hijack-admin/default.nix
@@ -17,13 +17,21 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
+
+    # we have to do a little bit of tinkering to convince the tests to run against the installed package, not the
+    # source directory
+    mkdir testbase
+    pushd testbase
+    mv ../runtests.py .
     ${python.interpreter} runtests.py hijack_admin
+    popd
+
     runHook postCheck
   '';
 
   meta = with stdenv.lib; {
     description = "Admin integration for django-hijack";
-    homepage = https://github.com/arteria/django-hijack;
+    homepage = https://github.com/arteria/django-hijack-admin;
     license = licenses.mit;
     maintainers = with maintainers; [ lsix ];
   };

--- a/pkgs/development/python-modules/django-hijack-admin/default.nix
+++ b/pkgs/development/python-modules/django-hijack-admin/default.nix
@@ -2,14 +2,14 @@
   django_hijack, django_nose }:
 buildPythonPackage rec {
   pname = "django-hijack-admin";
-  version = "2.1.5";
+  version = "2.1.10";
 
   # the pypi packages don't include everything required for the tests
   src = fetchFromGitHub {
     owner = "arteria";
     repo = "django-hijack-admin";
     rev = "v${version}";
-    sha256 = "02j75blvkjiz5mv5wc4jxl27rgmjsrl6l67a3p8342jwazzsm6jg";
+    sha256 = "0m98lchp2y43886n67j4s7miyd50pg2r5r966vjnxmd7nx7qkihf";
   };
 
   checkInputs = [ django_nose ];

--- a/pkgs/development/python-modules/django-hijack/default.nix
+++ b/pkgs/development/python-modules/django-hijack/default.nix
@@ -3,15 +3,14 @@
 }:
 buildPythonPackage rec {
   pname = "django-hijack";
-  version = "2.1.9";
-  name = pname + "-" + version;
+  version = "2.1.10";
 
   # the pypi packages don't include everything required for the tests
   src = fetchFromGitHub {
     owner = "arteria";
     repo = "django-hijack";
     rev = "v${version}";
-    sha256 = "109xi93xj37ycdsvainybhg89pcb5sawv6w80px4r6fjvaq4732c";
+    sha256 = "01fwkjdzvw0yx2spwi7zc1yy64ndq1y72bfmk7kxnq5x803m2ak6";
   };
 
   checkInputs = [ django_nose ];
@@ -24,7 +23,7 @@ buildPythonPackage rec {
     # source directory
     mkdir testbase
     pushd testbase
-    cp ../runtests.py .
+    mv ../runtests.py .
     ${python.interpreter} runtests.py hijack
     popd
 


### PR DESCRIPTION
###### Motivation for this change
Fairly straightforward bumps except for a couple of changes to the `checkPhase`s that were needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

