### PR TITLE
epson-201106w: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3221,6 +3221,11 @@
     github = "np";
     name = "Nicolas Pouillard";
   };
+  nphilou = {
+    email = "nphilou@gmail.com";
+    github = "nphilou";
+    name = "Philippe Nguyen";
+  };
   nslqqq = {
     email = "nslqqq@gmail.com";
     name = "Nikita Mikhailov";

--- a/pkgs/misc/drivers/epson-201106w/default.nix
+++ b/pkgs/misc/drivers/epson-201106w/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchurl, rpmextract, autoreconfHook, file, libjpeg, cups }:
+
+let
+  version = "1.0.1";
+  filterVersion = "1.0.0";
+in
+  stdenv.mkDerivation {
+
+    name = "epson-201106w-${version}";
+
+    src = fetchurl {
+      url = "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201106w-${version}-1lsb3.2.src.rpm";
+      sha256 = "1yig1xrh1ikblbp7sx706n5nnc237wy4mbch23ymy6akbgqg4aig";
+    };
+
+    nativeBuildInputs = [ rpmextract autoreconfHook file ];
+
+    buildInputs = [ libjpeg cups ];
+
+    unpackPhase = ''
+      rpmextract $src
+      tar -zxf epson-inkjet-printer-201106w-${version}.tar.gz
+      tar -zxf epson-inkjet-printer-filter-${filterVersion}.tar.gz
+      for ppd in epson-inkjet-printer-201106w-${version}/ppds/*; do
+        substituteInPlace $ppd --replace "/opt/epson-inkjet-printer-201106w" "$out"
+        substituteInPlace $ppd --replace "/cups/lib" "/lib/cups"
+      done
+      cd epson-inkjet-printer-filter-${filterVersion}
+    '';
+
+    preConfigure = ''
+      chmod +x configure
+      export LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+    '';
+
+    postInstall = ''
+      cd ../epson-inkjet-printer-201106w-${version}
+      cp -a lib64 resource watermark $out
+      mkdir -p $out/share/cups/model/epson-inkjet-printer-201106w
+      cp -a ppds $out/share/cups/model/epson-inkjet-printer-201106w/
+      cp -a Manual.txt $out/doc/
+      cp -a README $out/doc/README.driver
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://www.openprinting.org/driver/epson-201106w;
+      description = "Epson printer driver (BX535WD, BX630FW, BX635FWD, ME940FW, NX530, NX635, NX635, SX535WD, WorkForce 545, WorkForce 645";
+      longDescription = ''
+        This software is a filter program used with the Common UNIX Printing
+        System (CUPS) under Linux. It supplies high quality printing with
+        Seiko Epson Color Ink Jet Printers.
+        List of printers supported by this package:
+          Epson BX535WD Series
+          Epson BX630FW Series
+          Epson BX635FWD Series
+          Epson ME940FW Series
+          Epson NX530 Series
+          Epson SX535WD Series
+          Epson WorkForce 545 Series
+          Epson WorkForce 645 Series
+        To use the driver adjust your configuration.nix file:
+          services.printing = {
+            enable = true;
+            drivers = [ pkgs.epson-201106w ];
+          };
+      '';
+      license = with licenses; [ lgpl21 epson ];
+      platforms = platforms.linux;
+      maintainers = [ maintainers.nphilou ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22243,6 +22243,8 @@ in
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };
 
+  epson-201106w = callPackage ../misc/drivers/epson-201106w { };
+
   epson-workforce-635-nx625-series = callPackage ../misc/drivers/epson-workforce-635-nx625-series { };
 
   gutenprint = callPackage ../misc/drivers/gutenprint { };


### PR DESCRIPTION
###### Motivation for this change

Adding driver for my Epson SX535WD printer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

