### PR TITLE
ant-theme: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/data/themes/ant-theme/default.nix
+++ b/pkgs/data/themes/ant-theme/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ant-theme";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "https://github.com/EliverLara/Ant/releases/download/v${version}/Ant.tar";
-    sha256 = "15751pnb94g2wi6y932l3d7ksaz18402zbzp3l7ryy0lqwjnqvkj";
+    sha256 = "1r795v96ywzcb4dq08q2fdbmfia32g36cc512mhy41s8fb1a47dz";
   };
 
   propagatedUserEnvPkgs = [
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "1fzy7bq5v9fzjpfxplvk0nwjgamcva83462gkz01lhr1mipb92h1";
+  outputHash = "1gpacrmi5y87shp39jgy78n0ca2xdpvbqfh0mgldlxx99ca9rvvy";
 
   meta = with stdenv.lib; {
     description = "A flat and light theme with a modern look";


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.3.0](https://github.com/EliverLara/Ant/releases/tag/v1.3.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).