### PR TITLE
kubectl: reduce closure size

### DIFF
--- a/pkgs/applications/networking/cluster/kubectl/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, kubernetes }:
+
+stdenv.mkDerivation {
+  name = "kubectl-${kubernetes.version}";
+
+  # kubectl is currently part of the main distribution but will eventially be
+  # split out (see homepage)
+  src = kubernetes;
+
+  outputs = [ "out" "man" ];
+
+  doBuild = false;
+
+  installPhase = ''
+    mkdir -p \
+      "$out/bin" \
+      "$out/share/bash-completion/completions" \
+      "$out/share/zsh/site-functions" \
+      "$man/share/man/man1"
+
+    cp bin/kubectl $out/bin/kubectl
+
+    cp "${kubernetes.man}/share/man/man1"/kubectl* "$man/share/man/man1"
+
+    $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
+    $out/bin/kubectl completion zsh > $out/share/zsh/site-functions/_kubectl
+  '';
+
+  meta = kubernetes.meta // {
+    description = "Kubernetes CLI";
+    homepage = "https://github.com/kubernetes/kubectl";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17916,11 +17916,9 @@ in
 
   kubeval = callPackage ../applications/networking/cluster/kubeval { };
 
-  kubernetes = callPackage ../applications/networking/cluster/kubernetes {  };
+  kubernetes = callPackage ../applications/networking/cluster/kubernetes { };
 
-  kubectl = (kubernetes.override { components = [ "cmd/kubectl" ]; }).overrideAttrs(oldAttrs: {
-    name = "kubectl-${oldAttrs.version}";
-  });
+  kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
   kubernetes-helm = callPackage ../applications/networking/cluster/helm { };
 


### PR DESCRIPTION
before: 482M
after: 38M

###### Motivation for this change

the closure size is too big

maintainers: @johanot @offlinehacker 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

