### PR TITLE
z-lua: init at 1.7.0

### DIFF
--- a/pkgs/tools/misc/z-lua/default.nix
+++ b/pkgs/tools/misc/z-lua/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, lua }:
+
+stdenv.mkDerivation rec {
+  pname = "z-lua";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "skywind3000";
+    repo = "z.lua";
+    rev = "v${version}";
+    sha256 = "1f8iafv81xsypa78prazq6k2xz8az09kjhl97vn330drxkcpj7i7";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [ lua ];
+
+  installPhase = ''
+    install -Dm755 z.lua $out/bin/z
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/skywind3000/z.lua;
+    description = "A new cd command that helps you navigate faster by learning your habits";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2582,6 +2582,8 @@ in
 
   wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
 
+  z-lua = callPackage ../tools/misc/z-lua { };
+
   zabbix-cli = callPackage ../tools/misc/zabbix-cli { };
 
   zzuf = callPackage ../tools/security/zzuf { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

