### PR TITLE
Pb cli and capture initialization

### DIFF
--- a/pkgs/tools/misc/capture/0001-eval-fix.patch
+++ b/pkgs/tools/misc/capture/0001-eval-fix.patch
@@ -1,0 +1,10 @@
+diff --git a/src/capture.sh b/src/capture.sh
+index a32b018..82d1f15 100755
+--- a/src/capture.sh
++++ b/src/capture.sh
+@@ -103,4 +103,4 @@ capture () {
+ 
+ 
+ # remove this line if you want to source this file instead
+-eval " ${0##*/}" "$@"
++capture "$@"

--- a/pkgs/tools/misc/capture/0002-sane-defaults.patch
+++ b/pkgs/tools/misc/capture/0002-sane-defaults.patch
@@ -1,0 +1,22 @@
+diff --git a/src/capture.sh b/src/capture.sh
+index a32b018..42f3936 100755
+--- a/src/capture.sh
++++ b/src/capture.sh
+@@ -9,7 +9,7 @@ set -e
+ #
+ 
+ scale="-1:-1"
+-fps="15"
++fps="30"
+ raw_video="-vf fps=$fps -c:v utvideo -f nut"
+ raw_video_container=".nut"
+ 
+@@ -18,7 +18,7 @@ raw_video_container=".nut"
+ # https://stackoverflow.com/questions/41372045/vp9-encoding-limited-to-4-threads
+ webm_video="-pix_fmt yuv420p -c:v libvpx-vp9 -crf 25 -b:v 0 -f webm -tile-columns 6 -frame-parallel 1 -threads 8"
+ 
+-tmpdir="/var/tmp"
++tmpdir="/tmp"
+ 
+ 
+ # capture_raw ./foo.nut

--- a/pkgs/tools/misc/capture/default.nix
+++ b/pkgs/tools/misc/capture/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, pkgs, slop, ffmpeg, fetchFromGitHub, makeWrapper}:
+
+stdenv.mkDerivation rec {
+  name = "capture-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "buhman";
+    repo = "capture";
+    rev  = "4be986f17462b8d520559429c74da6bf3a436259";
+    sha256 = "172y06vs993x5v78zwl81xma1gkvjq1ad9rvmf3a217fyxsz4nhh";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  patches = [ ./0001-eval-fix.patch ./0002-sane-defaults.patch ];
+
+  installPhase = ''
+    install -Dm755 src/capture.sh $out/bin/capture
+
+    patchShebangs $out/bin/capture
+    wrapProgram $out/bin/capture \
+      --prefix PATH : '${stdenv.lib.makeBinPath [ slop ffmpeg ]}'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A no bullshit screen capture tool";
+    homepage = "https://github.com/buhman/capture";
+    maintainers = [ maintainers.ar1a ];
+  };
+}

--- a/pkgs/tools/misc/pb_cli/0001-eval-fix.patch
+++ b/pkgs/tools/misc/pb_cli/0001-eval-fix.patch
@@ -1,0 +1,10 @@
+diff --git a/src/pb.sh b/src/pb.sh
+index be1e472..eb9e6f9 100755
+--- a/src/pb.sh
++++ b/src/pb.sh
+@@ -61,4 +61,4 @@ pb () {
+   esac
+ }
+
+-eval " ${0##*/}" "$@"
++pb "$@"

--- a/pkgs/tools/misc/pb_cli/default.nix
+++ b/pkgs/tools/misc/pb_cli/default.nix
@@ -1,0 +1,40 @@
+{ screenshots ? true, video ? false, clipboard ? true
+, stdenv, pkgs, jq, curl, fetchFromGitHub, makeWrapper, maim ? null, xclip ? null, capture ? null }:
+
+assert screenshots -> maim != null;
+assert video -> capture != null;
+assert clipboard -> xclip != null;
+
+stdenv.mkDerivation rec {
+  name = "pb_cli-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "ptpb";
+    repo = "pb_cli";
+    rev  = "5242382b3d6b5c0ddaf6e4843a69746b40866e57";
+    sha256 = "0543x3377apinhxnsfq82zlp5sm8g1bf6hmsvvcwra5rsshv2ybk";
+  };
+
+  patches = [ ./0001-eval-fix.patch ];
+
+  buildInputs = [ makeWrapper ];
+
+  liveDeps = [ jq curl ] ++ stdenv.lib.optional screenshots maim
+                         ++ stdenv.lib.optional video capture
+                         ++ stdenv.lib.optional clipboard xclip;
+
+  installPhase = ''
+    install -Dm755 src/pb.sh $out/bin/pb
+
+    patchShebangs $out/bin/pb
+    wrapProgram $out/bin/pb \
+      --prefix PATH : '${stdenv.lib.makeBinPath liveDeps}'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A no bullshit ptpb client";
+    homepage = "https://github.com/ptpb/pb_cli";
+    maintainers = [ maintainers.ar1a ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18713,6 +18713,8 @@ in
 
   pb_cli = callPackage ../tools/misc/pb_cli {};
 
+  capture = callPackage ../tools/misc/capture {};
+
   pbrt = callPackage ../applications/graphics/pbrt { };
 
   pcsxr = callPackage ../misc/emulators/pcsxr {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18711,6 +18711,8 @@ in
 
   packet = callPackage ../development/tools/packet { };
 
+  pb_cli = callPackage ../tools/misc/pb_cli {};
+
   pbrt = callPackage ../applications/graphics/pbrt { };
 
   pcsxr = callPackage ../misc/emulators/pcsxr {


### PR DESCRIPTION
###### Motivation for this change
pb is a fantastic pastebin service with a nice client, and it optionally depends on capture, which is a fantastic screen cap tool that uses ffmpeg. I use both of these at least every week and thought it'd be a nice addition.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

