### PR TITLE
Support PowerPC in llvm

### DIFF
--- a/pkgs/development/compilers/llvm/common.nix
+++ b/pkgs/development/compilers/llvm/common.nix
@@ -12,6 +12,8 @@ rec {
       "ARM"
     else if platform.parsed.cpu.family == "mips" then
       "Mips"
+    else if platform.parsed.cpu.family == "power" then
+      "PowerPC"
     else
       throw "Unsupported system";
 


### PR DESCRIPTION
###### Motivation for this change
llvm refuses to build on ppc64 for no apparent reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

