### PR TITLE
libhandy: 0.0.6 -> 0.0.7

### DIFF
--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -2,11 +2,12 @@
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43
 , gtk3, gnome3
 , dbus, xvfb_run, libxml2
+, hicolor-icon-theme
 }:
 
 let
   pname = "libhandy";
-  version = "0.0.6";
+  version = "0.0.7";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
@@ -18,7 +19,7 @@ in stdenv.mkDerivation rec {
     owner = "Librem5";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0gmqsxkpi288qjfdczfrbvjqyy9sbn3gligqwgqj27ask95zl1q5";
+    sha256 = "1k9v6q2dz9x8lfcyzmsksrkq6md7m9jdkjlfan7nqlcj3mqhd7m9";
   };
 
   nativeBuildInputs = [
@@ -26,10 +27,12 @@ in stdenv.mkDerivation rec {
     gtk-doc docbook_xsl docbook_xml_dtd_43
   ];
   buildInputs = [ gnome3.gnome-desktop gtk3 gnome3.glade libxml2 ];
-  checkInputs = [ dbus xvfb_run ];
+  checkInputs = [ dbus xvfb_run hicolor-icon-theme ];
 
   mesonFlags = [
     "-Dgtk_doc=true"
+    "-Dglade_catalog=enabled"
+    "-Dintrospection=enabled"
   ];
 
   PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";


### PR DESCRIPTION
* fix tests by providing hicolor

* enable glade catalog and introspection features explicitly
  (this is no longer the default or something)

###### Motivation for this change

https://bytesgnomeschozo.blogspot.com/2019/01/my-name-is-handy-lib-handy.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---