### PR TITLE
ispc: 1.9.2 -> 1.10.0

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -3,7 +3,7 @@ testedTargets ? ["sse2" "host"] # the default test target is sse4, but that is n
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.2";
+  version = "1.10.0";
   rev = "v${version}";
 
   inherit testedTargets;
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "ispc";
     repo = "ispc";
     inherit rev;
-    sha256 = "0zaw7mwvly1csbdcbz9j8ry89n0r1fag1m1f579l4mgg1x6ksqry";
+    sha256 = "1x07n2gaff3v32yvddrb659mx5gg12bnbsqbyfimp396wn04w60b";
   };
 
   # there are missing dependencies in the Makefile, causing sporadic build failures
@@ -32,14 +32,7 @@ stdenv.mkDerivation rec {
     llvmPackages.clang-unwrapped # we need to link against libclang, so we need the unwrapped
   ];
 
-  patches = [
-    (fetchpatch {
-      url = https://github.com/ispc/ispc/commit/d504641f5af9d5992e7c8f0ed42c1063a39ede5b.patch;
-      sha256 = "192q3gyvam79469bmlwf0jpfi2y4f8hl2vgcvjngsqhvscwira0s";
-    })
-  ];
-
-  postPatch = "sed -i -e 's/\\/bin\\///g' -e 's/-lcurses/-lncurses/g' Makefile";
+  postPatch = "sed -i -e 's,/bin/,,g' -e 's/-lcurses/-lncurses/g' Makefile";
 
   # TODO: this correctly catches errors early, but also some things that are just weird and don't seem to be real
   # errors


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---