### PR TITLE
pythonPackages.PyChromecast: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/pychromecast/default.nix
+++ b/pkgs/development/python-modules/pychromecast/default.nix
@@ -1,19 +1,20 @@
-{ lib, fetchurl, buildPythonPackage, requests, six, zeroconf, protobuf, casttube }:
+{ lib, fetchPypi, buildPythonPackage, requests, zeroconf, protobuf, casttube, isPy3k }:
 
 buildPythonPackage rec {
   pname = "PyChromecast";
-  version = "2.3.0";
-  name = pname + "-" + version;
+  version = "2.4.0";
 
-  src = fetchurl {
-    url    = "mirror://pypi/p/pychromecast/${name}.tar.gz";
-    sha256 = "f385168e34d2ef47f976c8e41bad2f58f5ca004634c0ccb1a12623d8beb2fa38";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0q012ghssk2xhm17v28sc2lv62vk7wd5p7zzdbgxk6kywfx8yvm2";
   };
 
-  propagatedBuildInputs = [ requests six zeroconf protobuf casttube ];
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [ requests zeroconf protobuf casttube ];
 
   meta = with lib; {
-    description = "Library for Python 2 and 3 to communicate with the Google Chromecast";
+    description = "Library for Python 3.4+ to communicate with the Google Chromecast";
     homepage    = https://github.com/balloob/pychromecast;
     license     = licenses.mit;
     maintainers = with maintainers; [ abbradar ];


### PR DESCRIPTION
also py2 support was dropped in 2.0 (apparently)


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---