### PR TITLE
mdl: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/misc/mdl/.bundle/config
+++ b/pkgs/development/tools/misc/mdl/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_CACHE_ALL: "true"

--- a/pkgs/development/tools/misc/mdl/Gemfile
+++ b/pkgs/development/tools/misc/mdl/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "mdl"

--- a/pkgs/development/tools/misc/mdl/Gemfile.lock
+++ b/pkgs/development/tools/misc/mdl/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    kramdown (1.17.0)
+    mdl (0.5.0)
+      kramdown (~> 1.12, >= 1.12.0)
+      mixlib-cli (~> 1.7, >= 1.7.0)
+      mixlib-config (~> 2.2, >= 2.2.1)
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.18)
+      tomlrb
+    tomlrb (1.2.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mdl
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/development/tools/misc/mdl/default.nix
+++ b/pkgs/development/tools/misc/mdl/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerEnv, ruby }:
+
+bundlerEnv {
+  inherit ruby;
+  pname = "mdl";
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "A tool to check markdown files and flag style issues";
+    homepage = https://github.com/markdownlint/markdownlint;
+    license = licenses.mit;
+    maintainers = with maintainers; [ gerschtli ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/misc/mdl/gemset.nix
+++ b/pkgs/development/tools/misc/mdl/gemset.nix
@@ -1,0 +1,44 @@
+{
+  kramdown = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1c4jmrh5ig8iv1rw81s4mw4xsp4v97hvf8zkigv4hn5h542qjq";
+      type = "gem";
+    };
+    version = "1.17.0";
+  };
+  mdl = {
+    dependencies = ["kramdown" "mixlib-cli" "mixlib-config"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "047hp8z1ma630wp38bm1giklkf385rp6wly8aidn825q831w2g4i";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+  mixlib-cli = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0647msh7kp7lzyf6m72g6snpirvhimjm22qb8xgv9pdhbcrmcccp";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
+  mixlib-config = {
+    dependencies = ["tomlrb"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1gm6yj9cbbgsl9x4xqxga0vz5w0ksq2jnq1wj8hvgm5c4wfcrswb";
+      type = "gem";
+    };
+    version = "2.2.18";
+  };
+  tomlrb = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0g28ssfal6vry3cmhy509ba3vi5d5aggz1gnffnvvmc8ml8vkpiv";
+      type = "gem";
+    };
+    version = "1.2.8";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8870,6 +8870,8 @@ in
 
   mbed-cli = callPackage ../development/tools/mbed-cli { };
 
+  mdl = callPackage ../development/tools/misc/mdl { };
+
   minify = callPackage ../development/web/minify { };
 
   minizinc = callPackage ../development/tools/minizinc { };


### PR DESCRIPTION
###### Motivation for this change

Add mdl at 0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

