### PR TITLE
go: patch missing mimetype database

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
 , perl, which, pkgconfig, patch, procps, pcre, cacert, llvm, Security, Foundation
+, mailcap
 , buildPackages, targetPackages }:
 
 let
@@ -55,6 +56,10 @@ stdenv.mkDerivation rec {
     # and thus it is not corrected by patchShebangs.
     substituteInPlace misc/cgo/testcarchive/carchive_test.go \
       --replace '#!/usr/bin/env bash' '#!${stdenv.shell}'
+
+    # Patch the mimetype database location which is missing on NixOS.
+    substituteInPlace src/mime/type_unix.go \
+      --replace '/etc/mime.types' '${mailcap}/etc/mime.types'
 
     # Disabling the 'os/http/net' tests (they want files not available in
     # chroot builds)


### PR DESCRIPTION
###### Motivation for this change
Close #53550 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox))
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [ ] Tested compilation of all pkgs that depend on this change (only go-ipfs, too many)
- [x] Tested execution of all binary files (go-ipfs)
- [x] Determined the impact on package closure size (negligible)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

