### PR TITLE
pythonPackages.django_reversion: disable checks

### DIFF
--- a/pkgs/development/python-modules/django_reversion/default.nix
+++ b/pkgs/development/python-modules/django_reversion/default.nix
@@ -13,6 +13,9 @@ buildPythonPackage rec {
     sha256 = "9b8a245917e1bae131d3210c9ca7efbc066e60f32efa436e391c9803c3f4b61b";
   };
 
+  # tests assume the availability of a mysql/postgresql database
+  doCheck = false;
+
   propagatedBuildInputs = [ django ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

These weren't running properly anyway - they assume the availability of a mysql and/or postgresql database. Disabling them should stop them causing trouble. I've made a small suggestion to the author of how they could make their tests more friendly to us: https://github.com/etianen/django-reversion/issues/773

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

