### PR TITLE
SRT support for gstreamer

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -9,6 +9,7 @@
 , libwebp, xvidcore, gnutls, mjpegtools
 , libGLU_combined, libintl, libgme
 , openssl, x265, libxml2
+, srt
 }:
 
 assert faacSupport -> faac != null;
@@ -74,6 +75,7 @@ stdenv.mkDerivation rec {
     libwebp xvidcore gnutls libGLU_combined
     libgme openssl x265 libxml2
     libintl
+    srt
   ]
     ++ optional faacSupport faac
     ++ optional stdenv.isLinux wayland

--- a/pkgs/development/libraries/srt/default.nix
+++ b/pkgs/development/libraries/srt/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, openssl
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "srt";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Haivision";
+    repo = "srt";
+    rev = "v${version}";
+    sha256 = "0cv73j9c8024p6pg16c4hiryiv4jpgrfj2xhfdaprsikmkdnygmz";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    # TODO Remove this when https://github.com/Haivision/srt/issues/538 is fixed and available to nixpkgs
+    # Workaround for the fact that srt incorrectly disables GNUInstallDirs when LIBDIR is specified,
+    # see https://github.com/NixOS/nixpkgs/pull/54463#discussion_r249878330
+    "-UCMAKE_INSTALL_LIBDIR"
+  ];
+
+  meta = {
+    description = "Secure, Reliable, Transport";
+    homepage    = https://www.srtalliance.org;
+    license     = licenses.mpl20;
+    maintainers = with maintainers; [ nh2 ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12658,6 +12658,8 @@ in
 
   srm = callPackage ../tools/security/srm { };
 
+  srt = callPackage ../development/libraries/srt { };
+
   srtp = callPackage ../development/libraries/srtp {
     libpcap = if stdenv.isLinux then libpcap else null;
   };


### PR DESCRIPTION
##### Motivation for this change

SRT support for gstreamer. See:

* https://github.com/Haivision/srt
* https://www.collabora.com/news-and-blog/blog/2018/02/16/srt-in-gstreamer/

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - See https://github.com/NixOS/nixpkgs/pull/54380#issuecomment-455939517
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---