### PR TITLE
acts: init at 1.3

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -190,6 +190,7 @@
   ./services/audio/snapserver.nix
   ./services/audio/squeezelite.nix
   ./services/audio/ympd.nix
+  ./services/backup/acts.nix
   ./services/backup/automysqlbackup.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix

--- a/nixos/modules/services/backup/acts.nix
+++ b/nixos/modules/services/backup/acts.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.acts;
+  pkg = pkgs.acts;
+  user = "acts";
+  group = "acts";
+
+  inherit (lib) mkEnableOption mkIf mkOption types;
+in
+  {
+    # interface
+    options = {
+      services.acts = {
+        enable = mkEnableOption "acts";
+
+        calendar = mkOption {
+          type = types.str;
+          default = "daily";
+          description = ''
+            Configures when to run the backups using systemd.time syntax
+          '';
+        };
+      };
+    };
+
+    # implementation
+    config = {
+      systemd.services.acts = {
+        description= "acts tarsnap backup service";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pkg}/bin/acts";
+        };
+      };
+
+      systemd.timers.acts = {
+        description = "acts timer";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = cfg.calendar;
+          Persistent = "true";
+        };
+      };
+    };
+  }

--- a/nixos/modules/services/backup/acts.nix
+++ b/nixos/modules/services/backup/acts.nix
@@ -2,17 +2,78 @@
 
 let
   cfg = config.services.acts;
+  cfgFile = pkgs.writeText "acts.conf" ''
+    #!/bin/sh
+    backuptargets="${concatStringsSep " " cfg.backupTargets}"
+
+    # tarsnap
+    # What command to call for 'tarsnap'.
+    # Default: tarsnap
+    tarsnap="nice -n19 ionice -c3 tarsnap"
+
+    # tarsnapbackupoptions
+    # What options to use when backing up.
+    # e.g.: --one-file-system --humanize-numbers
+    # Note: this variable will be expanded by /bin/sh.
+    # Default: unset
+    tarsnapbackupoptions="--one-file-system --humanize-numbers"
+
+    # verbose
+    # Log verbosity. Output is written to stderr.
+    # -1 silent. 0=normal. 1=verbose. 2=debug.
+    # Default: 0
+    verbose=1
+
+    # hostname
+    # The machine name prefixed to created archives.
+    # Default: $(hostname -s)
+    #hostname=$(hostname)
+
+    # uselocaltime
+    # Use local time instead of UTC for the archive date and timestamps.
+    # Default: 0 (i.e. use UTC)
+    #uselocaltime=1
+
+    # prebackupscript
+    # This script is run before backups are created. Make sure it's executable.
+    # Default: unset
+    #prebackupscript=/root/acts-pre.sh
+
+    # postbackupscript
+    # This script is run after acts is otherwise finished. Make sure it's executable.
+    # Default: unset
+    #postbackupscript=/root/acts-post.sh
+
+    # syslog
+    # If set, log output will be written to syslog with the given facility.
+    # eg, user, local0, ...
+    # Default: unset
+    #syslog=user
+
+    # lockfile
+    # Where acts should write its lockfile.
+    # Default: /var/run/acts
+    #lockfile=/tmp/acts
+  '';
   pkg = pkgs.acts;
   user = "acts";
   group = "acts";
 
-  inherit (lib) mkEnableOption mkIf mkOption types;
+  inherit (lib) concatStringsSep mkEnableOption mkIf mkOption types;
 in
   {
     # interface
     options = {
       services.acts = {
         enable = mkEnableOption "acts";
+
+        backupTargets = mkOption {
+          type = types.listOf types.str;
+          example = [ "var" "etc" "home" "root" ];
+          description = ''
+            Space-separated list of directories to backup, relative to /.
+          '';
+        };
 
         calendar = mkOption {
           type = types.str;
@@ -25,12 +86,12 @@ in
     };
 
     # implementation
-    config = {
+    config = mkIf cfg.enable {
       systemd.services.acts = {
         description= "acts tarsnap backup service";
         serviceConfig = {
           Type = "simple";
-          ExecStart = "${pkg}/bin/acts";
+          ExecStart = "${pkg}/bin/acts ${cfgFile}";
         };
       };
 

--- a/pkgs/tools/backup/acts/default.nix
+++ b/pkgs/tools/backup/acts/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "acts";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner   = "alexjurkiewicz";
+    repo    = "acts";
+    rev     = version;
+    sha256  = "1gmhnksbmbn0icp7vqvzkh4i5hbar0k1l144j48rrsw8035sin6a";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/{bin,etc}
+
+    mv acts $out/bin
+    mv acts.conf.sample $out/etc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Another Calendar-based Tarsnap Script";
+    homepage = "https://github.com/alexjurkiewicz/acts";
+    license = licenses.publicDomain;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.asymmetric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -449,6 +449,8 @@ in
 
   actkbd = callPackage ../tools/system/actkbd { };
 
+  acts = callPackage ../tools/backup/acts { };
+
   adafruit-ampy = callPackage ../tools/misc/adafruit-ampy { };
 
   adlplug = callPackage ../applications/audio/adlplug { };


### PR DESCRIPTION
###### Motivation for this change

An alternative to [tarsnapper](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/tarsnapper/default.nix) and the [NixOS module](ithttps://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/tarsnapper/default.nix).

It uses [logger](https://linux.die.net/man/1/logger), does it mean I need to be declared a runtime dependency to `utilLinuxMinimal`, or is it somehow already included on all Linux builds?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

