### PR TITLE
lego: 1.2.1 -> 2.0.1

### DIFF
--- a/pkgs/tools/admin/lego/default.nix
+++ b/pkgs/tools/admin/lego/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   name = "lego-${version}";
-  version = "1.2.1";
+  version = "2.0.1";
   rev = "v${version}";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "xenolf";
     repo = "lego";
-    sha256 = "1b2cv78v54afflz3gfyidkwzq7r2h5j45rmz0ybps03pr0hs4gk3";
+    sha256 = "17q5j2zxc2c0xw8pfhnls67dmwrkicjmd2jdyim3fhi5cgxl9h93";
   };
 
   goPackagePath = "github.com/xenolf/lego";


### PR DESCRIPTION
###### Motivation for this change
Update to version 2.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

