### PR TITLE
fff: init at 1.5

### DIFF
--- a/pkgs/applications/misc/fff/default.nix
+++ b/pkgs/applications/misc/fff/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, makeWrapper, xdg_utils, file, coreutils }:
+
+stdenv.mkDerivation rec {
+  name = "fff";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "dylanaraps";
+    repo = name;
+    rev = version;
+    sha256 = "0jvv9mwj0qw3rmg1f17wbvx9fl5kxzmkp6j1113l3a6w1na83js0";
+  };
+
+  pathAdd = stdenv.lib.makeSearchPath "bin" [ xdg_utils file coreutils ];
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -D fff "$out/bin/fff"
+    install -D README.md "$out/share/doc/fff/README.md"
+    install -D fff.1 "$out/share/man/man1/fff.1"
+    wrapProgram $out/bin/fff --prefix PATH : ${pathAdd}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fucking Fast File-Manager";
+    homepage = https://github.com/dylanaraps/fff;
+    license = licenses.mit;
+    maintainers = [ maintainers.tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16986,6 +16986,8 @@ in
 
   fetchmail = callPackage ../applications/misc/fetchmail { };
 
+  fff = callPackage ../applications/misc/fff { };
+
   fig2dev = callPackage ../applications/graphics/fig2dev { };
 
   FIL-plugins = callPackage ../applications/audio/FIL-plugins { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

