### PR TITLE
ffmpeg, mpv: enable hardware-accelerated decoding with CUDA

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, makeWrapper
 , docutils, perl, pkgconfig, python3, which, ffmpeg_4
 , freefont_ttf, freetype, libass, libpthreadstubs, mujs
-, lua, libuchardet, libiconv ? null, darwin
+, nv-codec-headers, lua, libuchardet, libiconv ? null, darwin
 
 , waylandSupport ? false
   , wayland           ? null
@@ -141,7 +141,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     ffmpeg_4 freetype libass libpthreadstubs
-    luaEnv libuchardet mujs
+    luaEnv libuchardet mujs nv-codec-headers
   ] ++ optional alsaSupport        alsaLib
     ++ optional archiveSupport     libarchive
     ++ optional bluraySupport      libbluray

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, perl, texinfo, yasm
 , alsaLib, bzip2, fontconfig, freetype, gnutls, libiconv, lame, libass, libogg
 , libssh, libtheora, libva, libdrm, libvorbis, libvpx, lzma, libpulseaudio, soxr
-, x264, x265, xvidcore, zlib, libopus, speex
+, x264, x265, xvidcore, zlib, libopus, speex, nv-codec-headers
 , openglSupport ? false, libGLU_combined ? null
 # Build options
 , runtimeCpuDetectBuild ? true # Detect CPU capabilities at runtime
@@ -161,7 +161,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     bzip2 fontconfig freetype gnutls libiconv lame libass libogg libssh libtheora
-    libvdpau libvorbis lzma soxr x264 x265 xvidcore zlib libopus speex
+    libvdpau libvorbis lzma soxr x264 x265 xvidcore zlib libopus speex nv-codec-headers
   ] ++ optional openglSupport libGLU_combined
     ++ optional vpxSupport libvpx
     ++ optionals (!isDarwin && !isAarch32) [ libpulseaudio ] # Need to be fixed on Darwin and ARM


### PR DESCRIPTION
###### Motivation for this change

NVIDIA users can now use `mpv --hwdec=nvdec` to play videos that the software decoders cannot keep up with.

I did not touch any configure options, so this should hopefully not cause build errors on unsupported platforms/versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested a very similar change applied to `master`, and I don't really have the build resources to test `staging` right now, so I am hoping someone can test this on `staging`.

Test with `mpv --hwdec=nvdec --msg-level=vd=debug ...` and check mpv's output to make sure it doesn't fall back to software decoding.

8K test content that plays fine at 1.0-1.7x on a 1080 Ti:

```
youtube-dl -f 272+251 'https://www.youtube.com/watch?v=5MnVakBk850'
```

Dumb problems that can occur while testing:

```
[vo/gpu/x11] X11 error: BadValue (integer parameter out of range for operation)
...
[vo/gpu] Could not create GLX context!
```

Fix: check `journalctl -b` for NVIDIA version mismatch and reboot to fix.

```
[vd] Looking at hwdec vp9-nvdec...
[vo/gpu/cuda-nvdec] cu->cuInit(0) failed -> CUDA_ERROR_UNKNOWN: unknown error
[vo/gpu/cuda-nvdec] cu->cuCtxPopCurrent(&dummy) failed -> CUDA_ERROR_NOT_INITIALIZED: initialization error
```

Fix: `modprobe nvidia-uvm` if it was previously unloaded or never loaded.
