### PR TITLE
alsaLib: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,20 +1,15 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-lib-1.1.7";
+  name = "alsa-lib-1.1.8";
 
   src = fetchurl {
     url = "mirror://alsa/lib/${name}.tar.bz2";
-    sha256 = "02fw7dw202mjid49w9ki3dsfcyvid5fj488561bdzcm3haw00q4x";
+    sha256 = "1pxf0zkmps03l3zzd0fr828xhkg6a8hxljmbxzc2cyj2ls9kmp1w";
   };
 
   patches = [
     ./alsa-plugin-conf-multilib.patch
-    (fetchpatch { # pcm interval fix needed for some programs with broken audio, remove when bumping version
-      name = "pcm-interval-fix.patch";
-      url = "http://git.alsa-project.org/?p=alsa-lib.git;a=commitdiff_plain;h=b420056604f06117c967b65d43d01536c5ffcbc9";
-      sha256 = "1vjfslzsypd6w15zvvrpdk825hm5j0gz16gw7kj290pkbsdgd435";
-    })
   ];
 
   # Fix pcm.h file in order to prevent some compilation bugs


### PR DESCRIPTION
also remove a patch that is now obsolete. Still rebuilding on my machine, but the release only contains bugfixes

EDIT: Actually the part about it being only bug fixes isn't true. See the changelog at 
https://www.alsa-project.org/main/index.php/Changes_v1.1.7_v1.1.8

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

