### PR TITLE
gstreamer-1.16.0

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -49,7 +49,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gst-plugins-bad-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Bad Plugins";
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-bad/${name}.tar.xz";
-    sha256 = "0dpky8a0pbwwkc5r8hawi5yizdqk65j9liwvhxkjwbnpv53n5y10";
+    sha256 = "019b0yqjrcg6jmfd4cc336h1bz5p4wxl58yz1c4sdb96avirs4r2";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -1,10 +1,40 @@
 { stdenv, fetchurl, fetchpatch, meson, ninja, gettext
+, config
 , pkgconfig, python3, gst-plugins-base, orc
+, gobject-introspection
 , faacSupport ? false, faac ? null
 , faad2, libass, libkate, libmms, librdf, ladspaH
 , libnice, webrtc-audio-processing, lilv, lv2, serd, sord, sratom
 , libbs2b, libmodplug, mpeg2dec
 , openjpeg, libopus, librsvg
+, bluez
+, chromaprint
+, curl
+, directfb
+, fdk_aac
+, flite
+, libaom
+, libdc1394
+, libde265
+, libdrm
+, libdvdnav
+, libdvdread
+, libgudev
+, libofa
+, libsndfile
+, libusb1
+, neon
+, openal
+, opencv3
+, openexr
+, openh264
+, pango
+, sbc
+, soundtouch
+, spandsp
+, srtp
+, zbar
+, wayland-protocols
 , wildmidi, fluidsynth, libvdpau, wayland
 , libwebp, xvidcore, gnutls, mjpegtools
 , libGLU_combined, libintl, libgme
@@ -15,11 +45,11 @@
 assert faacSupport -> faac != null;
 
 let
-  inherit (stdenv.lib) optional;
+  inherit (stdenv.lib) optional optionals;
 in
 stdenv.mkDerivation rec {
   name = "gst-plugins-bad-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Bad Plugins";
@@ -40,27 +70,22 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    (fetchpatch {
-        url = "https://bug794856.bugzilla-attachments.gnome.org/attachment.cgi?id=370409";
-        sha256 = "0hy0rcn35alq65yqwri4fqjz2hf3nyyg5c7rnndk51msmqjxpprk";
-    })
     ./fix_pkgconfig_includedir.patch
-    # Enable bs2b compilation
-    # https://bugzilla.gnome.org/show_bug.cgi?id=794346
-    (fetchurl {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=369724;
-      sha256 = "1716mp0h2866ab33w607isvfhv1zwyj71qb4jrkx5v0h276v1pwr";
-    })
   ];
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-bad/${name}.tar.xz";
-    sha256 = "1r8dma3x127rbx42yab7kwq7q1bhkmvz2ykn0rnqnzl95q74w2wi";
+    sha256 = "0dpky8a0pbwwkc5r8hawi5yizdqk65j9liwvhxkjwbnpv53n5y10";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig python3 gettext ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig python3 gettext gobject-introspection
+  ]
+  ++ optionals stdenv.isLinux [
+    wayland-protocols
+  ];
 
   buildInputs = [
     gst-plugins-base orc
@@ -71,6 +96,33 @@ stdenv.mkDerivation rec {
     lilv lv2 serd sord sratom # lv2 plug-in
     libmodplug mpeg2dec
     openjpeg libopus librsvg
+    bluez
+    chromaprint
+    curl.dev
+    directfb
+    fdk_aac
+    flite
+    libaom
+    libdc1394
+    libde265
+    libdrm
+    libdvdnav
+    libdvdread
+    libgudev
+    libofa
+    libsndfile
+    libusb1
+    neon
+    openal
+    opencv3
+    openexr
+    openh264
+    pango
+    sbc
+    soundtouch
+    spandsp
+    srtp
+    zbar
     fluidsynth libvdpau
     libwebp xvidcore gnutls libGLU_combined
     libgme openssl x265 libxml2
@@ -84,6 +136,48 @@ stdenv.mkDerivation rec {
     ++ optional (!stdenv.isDarwin) wildmidi
     # TODO: mjpegtools uint64_t is not compatible with guint64 on Darwin
     ++ optional (!stdenv.isDarwin) mjpegtools;
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+
+    "-Ddts=disabled" # required `libdca` library not packaged in nixpkgs as of writing, and marked as "BIG FAT WARNING: libdca is still in early development"
+    "-Dfaac=${if faacSupport then "enabled" else "disabled"}"
+    "-Dgsm=disabled" # as of writing, with `gsm` in `buildInputs` we get "GSM plugin is enabled: found libgsm but no headers"; gsm packaging problem?
+    "-Diqa=disabled" # required `dssim` library not packaging in nixpkgs as of writing
+    "-Dmsdk=disabled" # not packaged in nixpkgs as of writing / no Windows support
+    # As of writing, with `libmpcdec` in `buildInputs` we get
+    #   "Could not find libmpcdec header files, but Musepack was enabled via options"
+    # This is likely because nixpkgs has the header in libmpc/mpcdec.h
+    # instead of mpc/mpcdec.h, like Arch does. The situation is not trivial.
+    # There are apparently 2 things called `libmpcdec` from the same author:
+    #   * http://svn.musepack.net/libmpcdec/trunk/src/
+    #   * http://svn.musepack.net/libmpc/trunk/include/mpc/
+    # Fixing it likely requires to first figure out with upstream which one
+    # is needed, and then patching upstream to find it (though it probably
+    # already works on Arch?).
+    "-Dmusepack=disabled"
+    "-Dopenmpt=disabled" # `libopenmpt` not packaged in nixpkgs as of writing
+    "-Dopenni2=disabled" # not packaged in nixpkgs as of writing
+    "-Dopensles=disabled" # not packaged in nixpkgs as of writing
+    "-Drtmp=disabled" # `librtmp` not packaged in nixpkgs as of writing
+    "-Dsctp=disabled" # required `usrsctp` library not packaged in nixpkgs as of writing
+    "-Dteletext=disabled" # required `zvbi` library not packaged in nixpkgs as of writing
+    "-Dtinyalsa=disabled" # not packaged in nixpkgs as of writing
+    "-Dvoaacenc=disabled" # required `vo-aacenc` library not packaged in nixpkgs as of writing
+    "-Dvoamrwbenc=disabled" # required `vo-amrwbenc` library not packaged in nixpkgs as of writing
+    "-Dvulkan=disabled" # Linux-only, and we haven't figured out yet which of the vulkan nixpkgs it needs
+    "-Dwasapi=disabled" # not packaged in nixpkgs as of writing / no Windows support
+    "-Dwpe=disabled" # required `wpe-webkit` library not packaged in nixpkgs as of writing
+
+    # Requires CUDA and we haven't figured out how to make Meson find CUDA yet;
+    # it probably searches via pkgconfig, for which we have no .pc files,
+    # see https://github.com/NixOS/nixpkgs/issues/54395
+    "-Dnvdec=disabled"
+    "-Dnvenc=disabled"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -13,6 +13,7 @@
 , directfb
 , fdk_aac
 , flite
+, gsm
 , libaom
 , libdc1394
 , libde265
@@ -71,6 +72,16 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix_pkgconfig_includedir.patch
+    # Remove when https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/merge_requests/312 is merged and available to us
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/commit/99790eaad9083cce5ab2b1646489e1a1c0faad1e.patch";
+      sha256 = "11bqy4sl05qq5mj4bx5s09rq106s3j0vnpjl4np058im32j69lr3";
+    })
+    # Remove when https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/merge_requests/312 is merged and available to us
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/commit/1872da81c48d3a719bd39955fd97deac7d037d74.patch";
+      sha256 = "11zwrr5ggflmvr0qfssj7dmhgd3ybiadmy79b4zh24022zgw3xpz";
+    })
   ];
 
   src = fetchurl {
@@ -102,6 +113,7 @@ stdenv.mkDerivation rec {
     directfb
     fdk_aac
     flite
+    gsm
     libaom
     libdc1394
     libde265
@@ -145,7 +157,6 @@ stdenv.mkDerivation rec {
 
     "-Ddts=disabled" # required `libdca` library not packaged in nixpkgs as of writing, and marked as "BIG FAT WARNING: libdca is still in early development"
     "-Dfaac=${if faacSupport then "enabled" else "disabled"}"
-    "-Dgsm=disabled" # as of writing, with `gsm` in `buildInputs` we get "GSM plugin is enabled: found libgsm but no headers"; gsm packaging problem?
     "-Diqa=disabled" # required `dssim` library not packaging in nixpkgs as of writing
     "-Dmsdk=disabled" # not packaged in nixpkgs as of writing / no Windows support
     # As of writing, with `libmpcdec` in `buildInputs` we get

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -30,6 +30,7 @@
 , openexr
 , openh264
 , pango
+, rtmpdump
 , sbc
 , soundtouch
 , spandsp
@@ -129,6 +130,7 @@ stdenv.mkDerivation rec {
     opencv3
     openexr
     openh264
+    rtmpdump
     pango
     sbc
     soundtouch
@@ -173,7 +175,6 @@ stdenv.mkDerivation rec {
     "-Dopenmpt=disabled" # `libopenmpt` not packaged in nixpkgs as of writing
     "-Dopenni2=disabled" # not packaged in nixpkgs as of writing
     "-Dopensles=disabled" # not packaged in nixpkgs as of writing
-    "-Drtmp=disabled" # `librtmp` not packaged in nixpkgs as of writing
     "-Dsctp=disabled" # required `usrsctp` library not packaged in nixpkgs as of writing
     "-Dteletext=disabled" # required `zvbi` library not packaged in nixpkgs as of writing
     "-Dtinyalsa=disabled" # not packaged in nixpkgs as of writing

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -2,6 +2,11 @@
 , pkgconfig, meson, ninja, gettext, gobject-introspection
 , python3, gstreamer, orc, pango, libtheora
 , libintl, libopus
+, isocodes
+, libjpeg
+, libvisual
+, tremor # provides 'virbisidec'
+, gtk-doc, docbook_xsl, docbook_xml_dtd_412
 , enableX11 ? stdenv.isLinux, libXv
 , enableWayland ? stdenv.isLinux, wayland
 , enableAlsa ? stdenv.isLinux, alsaLib
@@ -10,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-base-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = with lib; {
     description = "Base plugins and helper libraries";
@@ -22,28 +27,48 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-base/${name}.tar.xz";
-    sha256 = "0qbllw4kphchwhy4p7ivdysigx69i97gyw6q0rvkx1j81r4kjqfa";
+    sha256 = "0qvyx9gs7z2ryhdxxzynn9r1gphfk4xfkhd6dma02sbda9c5jckf";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig python3 gettext gobject-introspection ]
-
+  nativeBuildInputs = [
+    pkgconfig python3 gettext gobject-introspection
+    gtk-doc
+    # Without these, enabling the 'gtk_doc' gives us `FAILED: meson-install`
+    docbook_xsl docbook_xml_dtd_412
+  ]
   # Broken meson with Darwin. Should hopefully be fixed soon. Tracking
   # in https://bugzilla.gnome.org/show_bug.cgi?id=781148.
   ++ lib.optionals (!stdenv.isDarwin) [ meson ninja ];
 
+  # On Darwin, we currently use autoconf, on all other systems Meson
+  # TODO Switch to Meson on Darwin as well
+
   # TODO How to pass these to Meson?
-  configureFlags = [
+  configureFlags = lib.optionals stdenv.isDarwin [
     "--enable-x11=${if enableX11 then "yes" else "no"}"
     "--enable-wayland=${if enableWayland then "yes" else "no"}"
     "--enable-cocoa=${if enableCocoa then "yes" else "no"}"
   ]
-
   # Introspection fails on my MacBook currently
   ++ lib.optional stdenv.isDarwin "--disable-introspection";
 
-  buildInputs = [ orc libtheora libintl libopus ]
+  mesonFlags = lib.optionals (!stdenv.isDarwin) [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+    "-Dgl-graphene=disabled" # not packaged in nixpkgs as of writing
+    # See https://github.com/GStreamer/gst-plugins-base/blob/d64a4b7a69c3462851ff4dcfa97cc6f94cd64aef/meson_options.txt#L15 for a list of choices
+    "-Dgl_winsys=[${lib.concatStringsSep "," (lib.optional enableX11 "x11" ++ lib.optional enableWayland "wayland" ++ lib.optional enableCocoa "cocoa")}]"
+  ]
+  ++ lib.optional (!enableX11) "-Dx11=disabled"
+  # TODO How to disable Wayland?
+  ++ lib.optional (!enableAlsa) "-Dalsa=disabled"
+  ++ lib.optional (!enableCdparanoia) "-Dcdparanoia=disabled"
+  ;
+
+  buildInputs = [ orc libtheora libintl libopus isocodes libjpeg libvisual tremor ]
     ++ lib.optional enableAlsa alsaLib
     ++ lib.optionals enableX11 [ libXv pango ]
     ++ lib.optional enableWayland wayland
@@ -61,10 +86,6 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails, wants DRI access for OpenGL
 
   patches = [
-    (fetchpatch {
-        url = "https://bug794856.bugzilla-attachments.gnome.org/attachment.cgi?id=370414";
-        sha256 = "07x43xis0sr0hfchf36ap0cibx0lkfpqyszb3r3w9dzz301fk04z";
-    })
     ./fix_pkgconfig_includedir.patch
   ];
 }

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-base-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = with lib; {
     description = "Base plugins and helper libraries";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-base/${name}.tar.xz";
-    sha256 = "0qvyx9gs7z2ryhdxxzynn9r1gphfk4xfkhd6dma02sbda9c5jckf";
+    sha256 = "1bmmdwbyy89ayb85xc48y217f6wdmpz96f30zm6v53z2a5xsm4s0";
   };
 
   outputs = [ "out" "dev" ];
@@ -61,6 +61,13 @@ stdenv.mkDerivation rec {
     "-Dgl-graphene=disabled" # not packaged in nixpkgs as of writing
     # See https://github.com/GStreamer/gst-plugins-base/blob/d64a4b7a69c3462851ff4dcfa97cc6f94cd64aef/meson_options.txt#L15 for a list of choices
     "-Dgl_winsys=[${lib.concatStringsSep "," (lib.optional enableX11 "x11" ++ lib.optional enableWayland "wayland" ++ lib.optional enableCocoa "cocoa")}]"
+    # We must currently disable gtk_doc API docs generation,
+    # because it is not compatible with some features being disabled.
+    # See for example
+    #     https://gitlab.gnome.org/GNOME/gnome-build-meta/issues/38
+    # for it failing because some Wayland symbols are missing.
+    # This problem appeared between 1.15.1 and 1.16.0.
+    "-Dgtk_doc=disabled"
   ]
   ++ lib.optional (!enableX11) "-Dx11=disabled"
   # TODO How to disable Wayland?

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   name = "gstreamer-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = with lib ;{
     description = "Open source multimedia framework";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer/${name}.tar.xz";
-    sha256 = "05ri9y37qkgvkb2xjywf32c3k9479b0af0m6cjigx04pgwsf42kq";
+    sha256 = "003wy1p1in85p9sr5jsyhbnwqaiwz069flwkhyx7qhxy31qjz3hf";
   };
 
   patches = [
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     # Enables all features, so that we know when new dependencies are necessary.
     "-Dauto_features=enabled"
+    "-Ddbghelp=disabled" # not needed as we already provide libunwind and libdw, and dbghelp is a fallback to those
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
   ];
 
@@ -60,9 +61,17 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  preConfigure= ''
-    patchShebangs .
-  '';
+  preConfigure=
+    # These files are not executable upstream, so we need to
+    # make them executable for `patchShebangs` to pick them up.
+    # Can be removed when this is merged and available:
+    #     https://gitlab.freedesktop.org/gstreamer/gstreamer/merge_requests/141
+    ''
+      chmod +x gst/parse/get_flex_version.py
+    '' +
+    ''
+      patchShebangs .
+    '';
 
   preFixup = ''
     moveToOutput "share/bash-completion" "$dev"

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -13,7 +13,7 @@ rec {
 
   gst-plugins-ugly = callPackage ./ugly { inherit gst-plugins-base; };
 
-  gst-rtsp-server = callPackage ./rtsp-server { inherit gst-plugins-base; };
+  gst-rtsp-server = callPackage ./rtsp-server { inherit gst-plugins-base gst-plugins-bad; };
 
   gst-libav = callPackage ./libav { inherit gst-plugins-base; };
 

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   name = "gstreamer-editing-services-${version}";
-  version = "1.14.4";
+  version = "1.16.0";
 
   meta = with stdenv.lib; {
     description = "Library for creation of audio/video non-linear editors";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer-editing-services/${name}.tar.xz";
-    sha256 = "0pxk65jib3mqszjkyvlzklwia4kbdj6j2b6jw1d502b06mdx5lak";
+    sha256 = "1las94jkx83sxmzi5w6b0xm89dqqwzpdsb6h9w9ixndhnbpzm8w2";
   };
 
   outputs = [ "out" "dev" ];
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gst-plugins-base libxml2 ];
 
   patches = [
-    (fetchpatch {
-        url = "https://bug794856.bugzilla-attachments.gnome.org/attachment.cgi?id=370413";
-        sha256 = "1xcgbs18g6n5p7z7kqj7ffakwmkxq7ijajyvhyl7p3zvqll9dc7x";
-    })
     ./fix_pkgconfig_includedir.patch
   ];
 

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -6,6 +6,9 @@
 , libsoup, libpulseaudio, libintl
 , darwin, lame, mpg123, twolame
 , gtkSupport ? false, gtk3 ? null
+# As of writing, jack2 incurs a Qt dependency (big!) via `ffado`.
+# In the fuure we should probably split `ffado`.
+, enableJack ? false
 , libXdamage
 , libXext
 , libXfixes
@@ -23,7 +26,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gst-plugins-good-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Good Plugins";
@@ -40,7 +43,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-good/${name}.tar.xz";
-    sha256 = "15f6klr7wg6jlcyx0qspi13s8wmc9fij1bx1bbvy90a9a72v97rb";
+    sha256 = "1zdhif1mhf0ihkjpjyrh65g2iz2cawkjjb3h5w8h9ml06grxwjk5";
   };
 
   outputs = [ "out" "dev" ];
@@ -56,19 +59,20 @@ stdenv.mkDerivation rec {
     libdv libvpx speex flac taglib
     cairo gdk_pixbuf aalib libcaca
     libsoup libshout lame mpg123 twolame libintl
-    # TODO: Remove the comments once https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/commit/e234932dc703e51a0e1aa3b9c408f12758b12335
-    # is merged and available in nixpkgs.
-    libXdamage # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
-    libXext # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
-    libXfixes # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
+    libXdamage
+    libXext
+    libXfixes
     ncurses
-    xorg.libXfixes # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
-    xorg.libXdamage # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
+    xorg.libXfixes
+    xorg.libXdamage
     wavpack
   ]
   ++ optional gtkSupport gtk3 # for gtksink
   ++ optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ]
-  ++ optionals stdenv.isLinux [ libv4l libpulseaudio libavc1394 libiec61883 libgudev jack2 ];
+  ++ optionals stdenv.isLinux [ libv4l libpulseaudio libavc1394 libiec61883 libgudev jack2 ]
+  ++ optionals (stdenv.isLinux && enableJack) [
+    jack2
+  ];
 
   mesonFlags = [
     # Enables all features, so that we know when new dependencies are necessary.
@@ -77,7 +81,7 @@ stdenv.mkDerivation rec {
     "-Dqt5=disabled" # not clear as of writing how to correctly pass in the required qt5 deps
   ]
   ++ optional (!gtkSupport) "-Dgtk3=disabled"
-  ++ optionals (!stdenv.isLinux) [
+  ++ optionals (!stdenv.isLinux || !enableJack) [
     "-Djack=disabled" # unclear whether Jack works on Darwin
   ]
   ++ optionals (!stdenv.isLinux) [

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -10,6 +10,10 @@
 , libXext
 , libXfixes
 , ncurses
+, xorg
+, libgudev
+, wavpack
+, jack2
 }:
 
 assert gtkSupport -> gtk3 != null;
@@ -19,7 +23,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gst-plugins-good-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Good Plugins";
@@ -36,7 +40,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-good/${name}.tar.xz";
-    sha256 = "0y89qynb4b6fry3h43z1r99qslmi3m8xhlq0i5baq2nbc0r5b2sz";
+    sha256 = "15f6klr7wg6jlcyx0qspi13s8wmc9fij1bx1bbvy90a9a72v97rb";
   };
 
   outputs = [ "out" "dev" ];
@@ -58,10 +62,27 @@ stdenv.mkDerivation rec {
     libXext # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
     libXfixes # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
     ncurses
+    xorg.libXfixes # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
+    xorg.libXdamage # present feature but undeclared in meson_options.txt, see https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/issues/553
+    wavpack
   ]
   ++ optional gtkSupport gtk3 # for gtksink
   ++ optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Cocoa ]
-  ++ optionals stdenv.isLinux [ libv4l libpulseaudio libavc1394 libiec61883 ];
+  ++ optionals stdenv.isLinux [ libv4l libpulseaudio libavc1394 libiec61883 libgudev jack2 ];
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+    "-Dqt5=disabled" # not clear as of writing how to correctly pass in the required qt5 deps
+  ]
+  ++ optional (!gtkSupport) "-Dgtk3=disabled"
+  ++ optionals (!stdenv.isLinux) [
+    "-Djack=disabled" # unclear whether Jack works on Darwin
+  ]
+  ++ optionals (!stdenv.isLinux) [
+    "-Dv4l2-gudev=disabled"
+  ];
 
   # fails 1 tests with "Unexpected critical/warning: g_object_set_is_valid_property: object class 'GstRtpStorage' has no property named ''"
   doCheck = false;

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -10,7 +10,7 @@ assert withSystemLibav -> libav != null;
 
 stdenv.mkDerivation rec {
   name = "gst-libav-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = {
     homepage = https://gstreamer.freedesktop.org;
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-libav/${name}.tar.xz";
-    sha256 = "0hq5y8zg6a3fliwip7k85hg6s6amsmbqgrjl6axzrr3y6akcvslk";
+    sha256 = "16ixqpfrr7plaaz14n3vagr2q5xbfkv7gpmcsyndrkx98f813b6z";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -10,7 +10,7 @@ assert withSystemLibav -> libav != null;
 
 stdenv.mkDerivation rec {
   name = "gst-libav-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = {
     homepage = https://gstreamer.freedesktop.org;
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-libav/${name}.tar.xz";
-    sha256 = "1nk5g24z2xx5kaw5cg8dv8skdc516inahmkymcz8bxqxj28qbmyz";
+    sha256 = "0hq5y8zg6a3fliwip7k85hg6s6amsmbqgrjl6axzrr3y6akcvslk";
   };
 
   outputs = [ "out" "dev" ];
@@ -34,4 +34,10 @@ stdenv.mkDerivation rec {
     [ gst-plugins-base orc bzip2 ]
     ++ optional withSystemLibav libav
     ;
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+  ];
+
 }

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   name = "gst-rtsp-server-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = with stdenv.lib; {
     description = "Gstreamer RTSP server";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-rtsp-server/${name}.tar.xz";
-    sha256 = "0d0jaf7ir40dxpxs41wyb7m7riyl7wsqcb5qvd4vhwpz0dwxhpvl";
+    sha256 = "069zy159izy50blci9fli1i2r8jh91qkmgrz1n0xqciy3bn9x3hr";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -1,10 +1,12 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig
-, gst-plugins-base, gettext, gobject-introspection
+, gettext, gobject-introspection
+, gst-plugins-base
+, gst-plugins-bad
 }:
 
 stdenv.mkDerivation rec {
   name = "gst-rtsp-server-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = with stdenv.lib; {
     description = "Gstreamer RTSP server";
@@ -19,12 +21,18 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-rtsp-server/${name}.tar.xz";
-    sha256 = "1wc4d0y57hpfvv9sykjg8mxj86dw60mf696fbqbiqq6dzlmcw3ix";
+    sha256 = "0d0jaf7ir40dxpxs41wyb7m7riyl7wsqcb5qvd4vhwpz0dwxhpvl";
   };
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ meson ninja gettext gobject-introspection pkgconfig ];
 
-  buildInputs = [ gst-plugins-base ];
+  buildInputs = [ gst-plugins-base gst-plugins-bad ];
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+  ];
 }

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-ugly-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = with lib; {
     description = "Gstreamer Ugly Plugins";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-ugly/${name}.tar.xz";
-    sha256 = "17p9x30ywanz1lbk061kzd8bypcv5hkin6iyaqffp8alrwiak3qp";
+    sha256 = "1hm46c1fy9vl1wfwipsj41zp79cm7in1fpmjw24j5hriy32n82g3";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -2,12 +2,13 @@
 , gst-plugins-base, orc, gettext
 , a52dec, libcdio, libdvdread
 , libmad, libmpeg2, x264, libintl, lib
+, opencore-amr
 , darwin
 }:
 
 stdenv.mkDerivation rec {
   name = "gst-plugins-ugly-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = with lib; {
     description = "Gstreamer Ugly Plugins";
@@ -25,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-ugly/${name}.tar.xz";
-    sha256 = "08vd1xgwmapnviah47zv5h2r02qdd20y4f07rvv5zhv6y4vxh0mc";
+    sha256 = "17p9x30ywanz1lbk061kzd8bypcv5hkin6iyaqffp8alrwiak3qp";
   };
 
   outputs = [ "out" "dev" ];
@@ -37,8 +38,16 @@ stdenv.mkDerivation rec {
     a52dec libcdio libdvdread
     libmad libmpeg2 x264
     libintl
+    opencore-amr
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks;
     [ IOKit CoreFoundation DiskArbitration ]);
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+    "-Dsidplay=disabled" # sidplay / sidplay/player.h isn't packaged in nixpkgs as of writing
+  ];
 
   NIX_LDFLAGS = [ "-lm" ];
 }

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gst-vaapi-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz";
-    sha256 = "18yha6119v7mwz47idv2vykzfssqfmh6hc824wqqsshwjvzdn66f";
+    sha256 = "1aazan6r6p5aabb671znjkh8kmpxkz68wvaickqwzb1bz0ijcivc";
   };
 
   outputs = [ "out" "dev" ];
@@ -26,6 +26,12 @@ stdenv.mkDerivation rec {
     export GST_PLUGIN_PATH_1_0=$out/lib/gstreamer-1.0
     mkdir -p $GST_PLUGIN_PATH_1_0
   '';
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
+  ];
 
   meta = {
     homepage = https://gstreamer.freedesktop.org;

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gst-vaapi-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz";
-    sha256 = "1aazan6r6p5aabb671znjkh8kmpxkz68wvaickqwzb1bz0ijcivc";
+    sha256 = "07qpynamiz0lniqajcaijh3n7ixs4lfk9a5mfk50sng0dricwzsf";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "gst-validate-${version}";
-  version = "1.15.1";
+  version = "1.16.0";
 
   meta = {
     description = "Integration testing infrastructure for the GStreamer framework";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-validate/${name}.tar.xz";
-    sha256 = "195hwblagfsnq1xn858al3f32jn5nynr4j5x395dpg3vl3c4k5v4";
+    sha256 = "1jfnd0g9hmdbqfxsx96yc9vpf1w6m33hqwrr6lj4i83kl54awcck";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "gst-validate-${version}";
-  version = "1.14.4";
+  version = "1.15.1";
 
   meta = {
     description = "Integration testing infrastructure for the GStreamer framework";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-validate/${name}.tar.xz";
-    sha256 = "1ismv4i7ldi04swq76pcpd5apxqd52yify5hvlyan2yw9flwrp0q";
+    sha256 = "195hwblagfsnq1xn858al3f32jn5nynr4j5x395dpg3vl3c4k5v4";
   };
 
   outputs = [ "out" "dev" ];
@@ -31,4 +31,9 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gstreamer gst-plugins-base ];
 
   enableParallelBuilding = true;
+
+  mesonFlags = [
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+  ];
 }

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -20,18 +20,20 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig python3 gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig python3 gobject-introspection
+    gtk-doc
+    # Without these, enabling the 'gtk_doc' gives us `FAILED: meson-install`
+    docbook_xsl docbook_xml_dtd_412
+  ];
   buildInputs = [ gst_all_1.gstreamer gst_all_1.gst-plugins-base gnutls ];
   propagatedBuildInputs = [ glib gupnp-igd ];
 
   mesonFlags = [
-    "-Dgupnp=enabled"
-    "-Dgstreamer=enabled"
-    "-Dignored-network-interface-prefix=enabled"
-    "-Dexamples=enabled"
-    "-Dtests=enabled"
-    "-Dgtk_doc=enabled"
-    "-Dintrospection=enabled"
+    # Enables all features, so that we know when new dependencies are necessary.
+    "-Dauto_features=enabled"
+    "-Dgtk_doc=enabled" # Disabled by default as of libnice-0.1.15
+    "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
   ];
 
   # TODO; see #53293 etc.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10663,7 +10663,7 @@ in
   gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
 
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
-    callPackage = newScope { libav = pkgs.ffmpeg; };
+    callPackage = newScope { libav = pkgs.ffmpeg_4; };
   });
 
   gstreamer = callPackage ../development/libraries/gstreamer/legacy/gstreamer { };


### PR DESCRIPTION
* [x] Based upon the (tiny) #54380; let's merge that first. (**done**)
* [x] Wait for 1.16 to be released (https://github.com/NixOS/nixpkgs/pull/54398#issuecomment-455932989)
* [x] Fix any fallout when 1.16 is released

## Motivation for this change

~The latest gstreamer version~ The current gstreamer development version, leading up to the next to-be-released 1.16 stable version. Already doing some work here so we have less work to do when 1.16 comes out.

**Edit:** This is now, and the PR has been updated.

Copying an important part of the commit message:

---

During the 1.14 -> 1.15 upgrade, lots of stuff stopped working because gstreamer changed what features are enabled by default and which ones are automatically turned on/off via pkgconfig dependency detection.

This resulted in the `gstreamer` ("core" attribute in nixpkgs) package to have only 15 of its previous 163 build targets enabled, and downstream packages breaking correspondingly.

To ease maintainability and to ensure users will find the expected features available (and when not, will see in the nix file why not), we now pass the `-Dauto_features=enabled` Meson build flag to all gstreamer builds, which sets all `auto` dependencies to `enabled`, and we explicitly disable those that we can't build .

This means in particular that `gst-plugins-bad` now has vastly more integrations (namely all for which nixpkgs has libraries available).

## @nh2's notes while working on this (for posterity)

* various meson patches: Removed: Seem no longer necessary, but I haven't checked all the details and whether the patches were fully merged or only partially.
  See e.g. https://lists.freedesktop.org/archives/gstreamer-bugs/2018-August/223857.html where they say
  > Committed without the gl part which was installed into libdir on purpose. You will have to take account of that in your packaging.
* libice: `gstreamer-check-1.0.pc` not found (and indeed it's not there)
  * fixed by `-Dcheck=enabled` meson flag, see https://github.com/GStreamer/gstreamer/blob/6ea4380230d1cca1d63196dfbd753af887b8b241/pkgconfig/meson.build#L32
* `core` configure output:
  ```diff
  -Found pkg-config: /nix/store/4iij6zf2z7gx68rx3kg28xi5rqvnfja6-pkg-config-0.29.2/bin/pkg-config (0.29.2)
  -Dependency libunwind found: YES 1.3.1
  -Found CMake: NO
  -Dependency libdw found: NO (tried pkgconfig and cmake)
  -Message: Support for backtraces is partial only.
  +Dependency libunwind skipped: feature libunwind disabled
  +Dependency libdw skipped: feature libdw disabled
  +Checking for function "backtrace" : YES
  ```
  * likely the same as before (partial support), but I improved it by adding an `elfutils` dep which provides `libdw`
* `core` configure output:
  -Build targets in project: 163
  +Build targets in project: 15
* `gst-validate` build complains that `GstPbutils-1.0.gir` couldn't be found / `GEN`'d even though it says `checking for GST_PBUTILS... yes` before
  * probably due to `core` configure output: `Program g-ir-scanner skipped: feature introspection disabled`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested via:

`NIX_PATH=nixpkgs=. nix-shell -p gst_all_1.gstreamer -p gst_all_1.gst-plugins-good -p gst_all_1.gst-plugins-base -p gst_all_1.gst-plugins-bad -p gst_all_1.gst-plugins-ugly -p gst_all_1.gst-libav -p gst_all_1.gst-rtsp-server -p gst_all_1.gst-validate -p gst_all_1.gst-vaapi`

CC @matthewbauer

## TODO

* [x] Merge #54380
* [x] Somebody should double-check whether indeed all patches removed in this PR have all their contents merged upstream, or if some were merged only partially
  * Done in https://github.com/NixOS/nixpkgs/pull/54398#issuecomment-455939823
* [x] Check that the vastly-increased `gst-plugins-bad` integrations work on Darwin, make those conditional that don't
  * See #60922
* [ ] This needs some real testing from some real NixOS users, as I haven't checked whether any of the multimedia functionality actually works (I only built it)