### PR TITLE
pythonPackages.nanotime: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/nanotime/default.nix
+++ b/pkgs/development/python-modules/nanotime/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "nanotime";
+  version = "0.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c7cc231fc5f6db401b448d7ab51c96d0a4733f4b69fabe569a576f89ffdf966b";
+  };
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  # tests currently fail
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Provides a time object that keeps time as the number of nanoseconds since the UNIX epoch";
+    homepage = https://github.com/jbenet/nanotime/tree/master/python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5181,6 +5181,8 @@ in {
 
   nanoleaf = callPackage ../development/python-modules/nanoleaf { };
 
+  nanotime = callPackage ../development/python-modules/nanotime { };
+
   importlib-metadata = callPackage ../development/python-modules/importlib-metadata {};
 
   importlib-resources = callPackage ../development/python-modules/importlib-resources {};


### PR DESCRIPTION
###### Motivation for this change

Added nanotime package for measuring nanotime in Python.

https://github.com/NixOS/nixpkgs/issues/49438

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

