### PR TITLE
boehm-gc: fix cross build of dependent packages

### DIFF
--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -35,7 +35,12 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--enable-cplusplus" ]
     ++ lib.optional enableLargeConfig "--enable-large-config"
-    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
+    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static"
+    # Configure script can't detect whether C11 atomic intrinsics are available
+    # when cross-compiling, so it links to libatomic_ops, which has to be
+    # propagated to all dependencies. To avoid this, assume that the intrinsics
+    # are available.
+    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--with-libatomic-ops=none";
 
   doCheck = true; # not cross;
 


### PR DESCRIPTION
`boehm-gc` tries to detect whether the compiler supports C11 atomic intrinsics, and if not, it links to `libatomic_ops` to provide equivalent functionality. This check requires running a program on the host architecture, so it cannot be done when cross-compiling. In that case, the configure script assumes the intrinsics are not available and links to `libatomic_ops`. This is not new behavior, but the upgrade to 8.0.2 includes https://github.com/ivmai/bdwgc/commit/02a44ee1df8176c72e75fd706d1a8f063d3196d5, which requires that if `boehm-gc` links to `libatomic_ops`, all packages that depend on `boehm-gc` must also link to `libatomic_ops`. This broke cross-compiled `guile`, `nix` and probably anything else that depends on `boehm-gc`.

One solution is to make `libatomic_ops` a `propagatedBuildInput`, but this is not really a great solution because most of the time `libatomic_ops` is not really needed. On `x86_64-linux`, `armv6l-linux`, `armv7l-linux` and `aarch64-linux`, native builds of `boehm-gc` do not link to `libatomic_ops` and therefore it shouldn't be needed when cross-compiling to those platforms. I do not know of any supported architectures that do not have C11 atomic intrinsics, except that `armv6l-linux` requires `libatomic` (different from `libatomic_ops`)  to support certain intrinsics. AFAICT, `libatomic` is not needed for `boehm-gc`.

Alternatively (and what this PR does), we can just unconditionally disable `libatomic_ops` when cross-compiling. This could possibly "break" (it would already be broken because of the missing dep) a platform I have not tested, but seems cleaner than propagating `libatomic_ops`.

Note that this problem is not specific to cross-compiling, any platform that actually needs `libatomic_ops` will be broken natively right now because of the missing propagation. We should actually remove `libatomic_ops` as a build input altogether, since it can't work correctly unless it is propagated. The only reason I didn't do that in this PR is that it would cause a mass rebuild.

I also removed the `dontStrip` line, which I believe is a relic from the past.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

