### PR TITLE
pythonPackages.grandalf: init at 0.6

### DIFF
--- a/pkgs/development/python-modules/grandalf/default.nix
+++ b/pkgs/development/python-modules/grandalf/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyparsing
+, future
+, pytest
+, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "grandalf";
+  version = "0.6";
+
+  # fetch from github to acquire tests
+  src = fetchFromGitHub {
+    owner = "bdcht";
+    repo = "grandalf";
+    rev = "v${version}";
+    sha256 = "1f1l288sqna0bca7dwwvyw7wzg9b2613g6vc0g0vfngm7k75b2jg";
+  };
+
+  propagatedBuildInputs = [
+    pyparsing
+    future
+  ];
+
+  checkInputs = [ pytest pytestrunner ];
+
+  patches = [ ./no-setup-requires-pytestrunner.patch ];
+
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with lib; {
+    description = "A python package made for experimentations with graphs and drawing algorithms";
+    homepage = https://github.com/bdcht/grandalf;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/development/python-modules/grandalf/no-setup-requires-pytestrunner.patch
+++ b/pkgs/development/python-modules/grandalf/no-setup-requires-pytestrunner.patch
@@ -1,0 +1,15 @@
+diff --git a/setup.py b/setup.py
+index 0470622..d574ceb 100755
+--- a/setup.py
++++ b/setup.py
+@@ -75,8 +75,8 @@ setup(
+     # your project is installed. For an analysis of "install_requires" vs pip's
+     # requirements files see:
+     # https://packaging.python.org/en/latest/requirements.html
+-    setup_requires=['pytest-runner',],
+-    tests_require=['pytest',],
++    setup_requires=[],
++    tests_require=['pytest','pytest-runner',],
+ 
+     install_requires=['pyparsing','future'],
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -378,6 +378,8 @@ in {
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };
 
+  grandalf = callPackage ../development/python-modules/grandalf { };
+
   gsd = callPackage ../development/python-modules/gsd { };
 
   gssapi = callPackage ../development/python-modules/gssapi { };


### PR DESCRIPTION
###### Motivation for this change

Required for https://github.com/NixOS/nixpkgs/issues/49438. This library deals with graphs.

This package has tests, however the tests are not part of the source distribution, so we just need the test dependencies to satisfy the `setup.py` but we cannot run any tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

