### PR TITLE
pythonPackages.asciimatics: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/asciimatics/default.nix
+++ b/pkgs/development/python-modules/asciimatics/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pyfiglet
+, pillow
+, wcwidth
+, future
+, mock
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "asciimatics";
+  version = "1.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9101b0b6885542f324980bbe13a772475cd6a12678f601228eaaea412db919ab";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    pyfiglet
+    pillow
+    wcwidth
+    future
+  ];
+
+  checkInputs = [
+    mock
+    nose
+  ];
+
+  # tests require a pty emulator
+  # which is too complicated to setup here
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Helps to create full-screen text UIs (from interactive forms to ASCII animations) on any platform";
+    homepage = https://github.com/peterbrittain/asciimatics;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -176,6 +176,8 @@ in {
 
   asana = callPackage ../development/python-modules/asana { };
 
+  asciimatics = callPackage ../development/python-modules/asciimatics { };
+
   ase = callPackage ../development/python-modules/ase { };
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };


### PR DESCRIPTION
###### Motivation for this change

Asciimatics is a package to help people create full-screen text UIs (from interactive forms to ASCII animations) on any platform.

This package only has a wheel on Pypi, and I don't understand how to execute its tests. So I don't have a specified checkPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

