### PR TITLE
metasploit: 4.16.1 -> 5.0.1

### DIFF
--- a/pkgs/tools/security/metasploit/Gemfile
+++ b/pkgs/tools/security/metasploit/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/5.0.1"
+gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "bf949b7fd2a705a74ca02f66792f80ab41b4c81a"

--- a/pkgs/tools/security/metasploit/Gemfile
+++ b/pkgs/tools/security/metasploit/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/4.16.1"
+gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/5.0.1"

--- a/pkgs/tools/security/metasploit/Gemfile.lock
+++ b/pkgs/tools/security/metasploit/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rapid7/metasploit-framework
-  revision: 1442130a2717aabf75750f4f2412a416481e2154
-  ref: refs/tags/5.0.1
+  revision: bf949b7fd2a705a74ca02f66792f80ab41b4c81a
+  ref: bf949b7fd2a705a74ca02f66792f80ab41b4c81a
   specs:
     metasploit-framework (5.0.1)
       actionpack (~> 4.2.6)
@@ -113,7 +113,7 @@ GEM
     arel (6.0.4)
     arel-helpers (2.8.0)
       activerecord (>= 3.1.0, < 6)
-    backports (3.11.4)
+    backports (3.12.0)
     bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.0)
     bindata (2.4.4)
@@ -136,7 +136,7 @@ GEM
       eventmachine (>= 1.0.0.beta.4)
     erubis (2.7.0)
     eventmachine (1.2.7)
-    faker (1.9.1)
+    faker (1.9.3)
       i18n (>= 0.7)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -147,7 +147,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jsobfu (0.4.2)
       rkelly-remix
-    json (2.1.0)
+    json (2.2.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -156,12 +156,12 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (3.0.2)
+    metasploit-credential (3.0.3)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 3.0.0)
       net-ssh
-      pg (~> 0.15)
+      pg
       railties
       rex-socket
       rubyntlm
@@ -171,13 +171,13 @@ GEM
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
     metasploit-payloads (1.3.58)
-    metasploit_data_models (3.0.4)
+    metasploit_data_models (3.0.5)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
       metasploit-concern
       metasploit-model
-      pg (= 0.20.0)
+      pg
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
@@ -234,7 +234,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
     rb-readline (0.5.5)
-    recog (2.1.45)
+    recog (2.2.0)
       nokogiri
     redcarpet (3.4.0)
     rex-arch (0.1.13)
@@ -273,7 +273,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.15)
+    rex-socket (0.1.17)
       rex-core
     rex-sslscan (0.1.5)
       rex-core
@@ -284,7 +284,7 @@ GEM
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)
-    ruby-macho (2.1.0)
+    ruby-macho (2.2.0)
     ruby-rc4 (0.1.5)
     ruby_smb (1.0.5)
       bindata
@@ -299,8 +299,8 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    sqlite3 (1.3.13)
-    sshkey (1.9.0)
+    sqlite3 (1.4.0)
+    sshkey (2.0.0)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)

--- a/pkgs/tools/security/metasploit/Gemfile.lock
+++ b/pkgs/tools/security/metasploit/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/rapid7/metasploit-framework
-  revision: dbec1c2d2ae4bd77276cbfb3c6ee2902048b9453
-  ref: refs/tags/4.16.1
+  revision: 1442130a2717aabf75750f4f2412a416481e2154
+  ref: refs/tags/5.0.1
   specs:
-    metasploit-framework (4.16.1)
+    metasploit-framework (5.0.1)
       actionpack (~> 4.2.6)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -11,7 +11,11 @@ GIT
       bcrypt
       bcrypt_pbkdf
       bit-struct
+      concurrent-ruby (= 1.0.5)
       dnsruby
+      ed25519
+      em-http-request
+      faker
       filesize
       jsobfu
       json
@@ -19,9 +23,10 @@ GIT
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.1)
+      metasploit-payloads (= 1.3.58)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.2.0)
+      metasploit_payloads-mettle (= 0.5.1)
+      mqtt
       msgpack
       nessus_rest
       net-ssh
@@ -38,8 +43,6 @@ GIT
       pg (= 0.20.0)
       railties
       rb-readline
-      rbnacl (< 5.0.0)
-      rbnacl-libsodium
       recog
       redcarpet
       rex-arch
@@ -51,7 +54,7 @@ GIT
       rex-mime
       rex-nop
       rex-ole
-      rex-powershell (< 0.1.73)
+      rex-powershell
       rex-random_identifier
       rex-registry
       rex-rop_builder
@@ -60,14 +63,17 @@ GIT
       rex-struct2
       rex-text
       rex-zip
-      robots
+      ruby-macho
       ruby_smb
       rubyntlm
       rubyzip
+      sinatra
       sqlite3
       sshkey
+      thin
       tzinfo
       tzinfo-data
+      warden
       windows_error
       xdr
       xmlrpc
@@ -75,67 +81,87 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (1.0.2)
-    actionpack (4.2.9)
-      actionview (= 4.2.9)
-      activesupport (= 4.2.9)
+    Ascii85 (1.0.3)
+    actionpack (4.2.11)
+      actionview (= 4.2.11)
+      activesupport (= 4.2.11)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.9)
-      activesupport (= 4.2.9)
+    actionview (4.2.11)
+      activesupport (= 4.2.11)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activemodel (4.2.9)
-      activesupport (= 4.2.9)
+    activemodel (4.2.11)
+      activesupport (= 4.2.11)
       builder (~> 3.1)
-    activerecord (4.2.9)
-      activemodel (= 4.2.9)
-      activesupport (= 4.2.9)
+    activerecord (4.2.11)
+      activemodel (= 4.2.11)
+      activesupport (= 4.2.11)
       arel (~> 6.0)
-    activesupport (4.2.9)
+    activesupport (4.2.11)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
     arel (6.0.4)
-    arel-helpers (2.4.0)
+    arel-helpers (2.8.0)
       activerecord (>= 3.1.0, < 6)
-    backports (3.8.0)
-    bcrypt (3.1.11)
+    backports (3.11.4)
+    bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.0)
-    bindata (2.4.0)
+    bindata (2.4.4)
     bit-struct (0.16)
     builder (3.2.3)
-    dnsruby (1.60.2)
+    concurrent-ruby (1.0.5)
+    cookiejar (0.3.3)
+    crass (1.0.4)
+    daemons (1.3.1)
+    dnsruby (1.61.2)
+      addressable (~> 2.5)
+    ed25519 (1.2.4)
+    em-http-request (1.1.5)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.2)
+      eventmachine (>= 1.0.0.beta.4)
     erubis (2.7.0)
-    faraday (0.13.1)
+    eventmachine (1.2.7)
+    faker (1.9.1)
+      i18n (>= 0.7)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
-    filesize (0.1.1)
+    filesize (0.2.0)
     hashery (2.1.2)
-    i18n (0.8.6)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     jsobfu (0.4.2)
       rkelly-remix
     json (2.1.0)
-    loofah (2.0.3)
+    loofah (2.2.3)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     metasm (1.0.3)
     metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.12)
+    metasploit-credential (3.0.2)
       metasploit-concern
       metasploit-model
-      metasploit_data_models
-      pg
+      metasploit_data_models (>= 3.0.0)
+      net-ssh
+      pg (~> 0.15)
       railties
       rex-socket
       rubyntlm
@@ -144,37 +170,38 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.1)
-    metasploit_data_models (2.0.15)
+    metasploit-payloads (1.3.58)
+    metasploit_data_models (3.0.4)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
       metasploit-concern
       metasploit-model
-      pg
+      pg (= 0.20.0)
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.2.0)
-    mini_portile2 (2.2.0)
-    minitest (5.10.3)
-    msgpack (1.1.0)
+    metasploit_payloads-mettle (0.5.1)
+    mini_portile2 (2.4.0)
+    minitest (5.11.3)
+    mqtt (0.5.0)
+    msgpack (1.2.6)
     multipart-post (2.0.0)
     nessus_rest (0.1.6)
-    net-ssh (4.1.0)
-    network_interface (0.0.1)
-    nexpose (6.1.1)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
-    octokit (4.7.0)
+    net-ssh (5.1.0)
+    network_interface (0.0.2)
+    nexpose (7.2.1)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    openssl-ccm (1.2.1)
+    openssl-ccm (1.2.2)
     openvas-omp (0.0.4)
     packetfu (1.1.13)
       pcaprub
     patch_finder (1.0.2)
-    pcaprub (0.12.4)
-    pdf-reader (2.0.0)
+    pcaprub (0.13.0)
+    pdf-reader (2.2.0)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
@@ -182,50 +209,48 @@ GEM
       ttfunk
     pg (0.20.0)
     pg_array_parser (0.0.9)
-    postgres_ext (3.0.0)
-      activerecord (>= 4.0.0)
+    postgres_ext (3.0.1)
+      activerecord (~> 4.0)
       arel (>= 4.0.1)
       pg_array_parser (~> 0.0.9)
-    public_suffix (2.0.5)
+    public_suffix (3.0.3)
     rack (1.6.11)
+    rack-protection (1.5.5)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.8)
-      activesupport (>= 4.2.0.beta, < 5.0)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
-    railties (4.2.9)
-      actionpack (= 4.2.9)
-      activesupport (= 4.2.9)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
+    railties (4.2.11)
+      actionpack (= 4.2.11)
+      activesupport (= 4.2.11)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.0.0)
+    rake (12.3.2)
     rb-readline (0.5.5)
-    rbnacl (4.0.2)
-      ffi
-    rbnacl-libsodium (1.0.13)
-      rbnacl (>= 3.0.1)
-    recog (2.1.12)
+    recog (2.1.45)
       nokogiri
     redcarpet (3.4.0)
-    rex-arch (0.1.11)
+    rex-arch (0.1.13)
       rex-text
-    rex-bin_tools (0.1.4)
+    rex-bin_tools (0.1.6)
       metasm
       rex-arch
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.12)
+    rex-core (0.1.13)
     rex-encoder (0.1.4)
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.14)
+    rex-exploitation (0.1.20)
       jsobfu
       metasm
       rex-arch
@@ -238,47 +263,58 @@ GEM
       rex-arch
     rex-ole (0.1.6)
       rex-text
-    rex-powershell (0.1.72)
+    rex-powershell (0.1.79)
       rex-random_identifier
       rex-text
-    rex-random_identifier (0.1.2)
+    rex-random_identifier (0.1.4)
       rex-text
     rex-registry (0.1.3)
     rex-rop_builder (0.1.3)
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.8)
+    rex-socket (0.1.15)
       rex-core
     rex-sslscan (0.1.5)
       rex-core
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.15)
+    rex-text (0.2.21)
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)
-    robots (0.10.1)
+    ruby-macho (2.1.0)
     ruby-rc4 (0.1.5)
-    ruby_smb (0.0.18)
+    ruby_smb (1.0.5)
       bindata
       rubyntlm
       windows_error
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sqlite3 (1.3.13)
     sshkey (1.9.0)
-    thor (0.20.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    thor (0.20.3)
     thread_safe (0.3.6)
+    tilt (2.0.9)
     ttfunk (1.5.1)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2017.2)
+    tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
+    warden (1.2.7)
+      rack (>= 1.0)
     windows_error (0.1.2)
     xdr (2.0.0)
       activemodel (>= 4.2.7)
@@ -292,4 +328,4 @@ DEPENDENCIES
   metasploit-framework!
 
 BUNDLED WITH
-   1.16.4
+   1.16.3

--- a/pkgs/tools/security/metasploit/default.nix
+++ b/pkgs/tools/security/metasploit/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, makeWrapper, ruby, bundlerEnv }:
 
 # Maintainer notes for updating:
-# 1. increment version number in expression and in Gemfile
+# 1. update version number and revision in expression and in Gemfile
 # 2. run $ nix-prefetch-git --url https://github.com/rapid7/metasploit-framework.git --rev [version]
 #    in metasploit in nixpkgs, and copy the resulting hash to default.nix
 # 3. run $ nix-shell --command "bundler install && bundix"
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rapid7";
     repo = "metasploit-framework";
-    rev = version;
+    rev = "bf949b7fd2a705a74ca02f66792f80ab41b4c81a";
     sha256 = "1pqh1ya3c3l0jmqzbglyigag1g29yvqp9i8lzlgvcr8wvdf356bv";
   };
 

--- a/pkgs/tools/security/metasploit/default.nix
+++ b/pkgs/tools/security/metasploit/default.nix
@@ -17,13 +17,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "metasploit-framework-${version}";
-  version = "4.16.1";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "rapid7";
     repo = "metasploit-framework";
     rev = version;
-    sha256 = "1vilyy0dqzp8kbbpvs2zrv2ac7s39w2vv7mrbzgcjgh2bj7c6bg1";
+    sha256 = "1pqh1ya3c3l0jmqzbglyigag1g29yvqp9i8lzlgvcr8wvdf356bv";
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/metasploit/default.nix
+++ b/pkgs/tools/security/metasploit/default.nix
@@ -2,12 +2,11 @@
 
 # Maintainer notes for updating:
 # 1. increment version number in expression and in Gemfile
-# 2. run $ nix-shell --command "bundler install && bundix"
+# 2. run $ nix-prefetch-git --url https://github.com/rapid7/metasploit-framework.git --rev [version]
+#    in metasploit in nixpkgs, and copy the resulting hash to default.nix
+# 3. run $ nix-shell --command "bundler install && bundix"
 #    in metasploit in nixpkgs
-# 3. run $ sed -i '/[ ]*dependencies =/d' gemset.nix
 # 4. run $ nix-build -A metasploit ../../../../
-# 5. update sha256sum in expression
-# 6. run step 3 again
 
 let
   env = bundlerEnv {

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -89,10 +89,10 @@
   backports = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hshjxww2h7s0dk57njrygq4zpp0nlqrjfya7zwm27iq3rhc3y8g";
+      sha256 = "0ba6n9l4kki56s2cszarps14zp2wlhw7nfawb8qwsxy3a57v4mw4";
       type = "gem";
     };
-    version = "3.11.4";
+    version = "3.12.0";
   };
   bcrypt = {
     source = {
@@ -221,10 +221,10 @@
     dependencies = ["i18n"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01q7wrk5bl0c0qrvg2my3kl0mbfnj1jpd89mqm3fzy4ggbkdhh7i";
+      sha256 = "1vslyqmk9gjvp1ahyfqmwy1jcyv75rp88hxwpy7cdk2lpdb1jp3l";
       type = "gem";
     };
-    version = "1.9.1";
+    version = "1.9.3";
   };
   faraday = {
     dependencies = ["multipart-post"];
@@ -280,10 +280,10 @@
   json = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      sha256 = "0sx97bm9by389rbzv8r1f43h06xcz8vwi3h5jv074gvparql7lcx";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.0";
   };
   loofah = {
     dependencies = ["crass" "nokogiri"];
@@ -315,17 +315,17 @@
     dependencies = ["metasploit-concern" "metasploit-model" "metasploit_data_models" "net-ssh" "pg" "railties" "rex-socket" "rubyntlm" "rubyzip"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0liyc1yppsjjn63713n2z7hsi1lvqcamp0xny0ax9d4rksn56w92";
+      sha256 = "0m6j149x502p00y2jzra65281dhhw3m8a41pwfn1sk9wv7aiclvl";
       type = "gem";
     };
-    version = "3.0.2";
+    version = "3.0.3";
   };
   metasploit-framework = {
     dependencies = ["actionpack" "activerecord" "activesupport" "backports" "bcrypt" "bcrypt_pbkdf" "bit-struct" "concurrent-ruby" "dnsruby" "ed25519" "em-http-request" "faker" "filesize" "jsobfu" "json" "metasm" "metasploit-concern" "metasploit-credential" "metasploit-model" "metasploit-payloads" "metasploit_data_models" "metasploit_payloads-mettle" "mqtt" "msgpack" "nessus_rest" "net-ssh" "network_interface" "nexpose" "nokogiri" "octokit" "openssl-ccm" "openvas-omp" "packetfu" "patch_finder" "pcaprub" "pdf-reader" "pg" "railties" "rb-readline" "recog" "redcarpet" "rex-arch" "rex-bin_tools" "rex-core" "rex-encoder" "rex-exploitation" "rex-java" "rex-mime" "rex-nop" "rex-ole" "rex-powershell" "rex-random_identifier" "rex-registry" "rex-rop_builder" "rex-socket" "rex-sslscan" "rex-struct2" "rex-text" "rex-zip" "ruby-macho" "ruby_smb" "rubyntlm" "rubyzip" "sinatra" "sqlite3" "sshkey" "thin" "tzinfo" "tzinfo-data" "warden" "windows_error" "xdr" "xmlrpc"];
     source = {
       fetchSubmodules = false;
-      rev = "1442130a2717aabf75750f4f2412a416481e2154";
-      sha256 = "0f8kvf5wn16jir9nka1v2jbh2znf7yjg7z7znw026rkwnc52ff82";
+      rev = "bf949b7fd2a705a74ca02f66792f80ab41b4c81a";
+      sha256 = "0p5mfrlbl62vi0yf4a4kc0q4nq5ag9kz94jwa1lqqcb1rw7474gk";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };
@@ -352,10 +352,10 @@
     dependencies = ["activerecord" "activesupport" "arel-helpers" "metasploit-concern" "metasploit-model" "pg" "postgres_ext" "railties" "recog"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0n600ywghnc3d4kamfg33v6kmc6mfaqi0hp1c69p4x0pwr6p76xd";
+      sha256 = "0v01cvan15z91sr2k785va7mbjgv4z60gzwgfrbszbmy5j6y44wi";
       type = "gem";
     };
-    version = "3.0.4";
+    version = "3.0.5";
   };
   metasploit_payloads-mettle = {
     source = {
@@ -620,10 +620,10 @@
     dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "143b0zg2xx4jaympqzqz55r45vgs5k59ymm4rgk8ckxirvsz0cq4";
+      sha256 = "1zj401gv5ihdvfgk9mkl2jmhyps61y5pf0i37fpimpy9fjgp9gdf";
       type = "gem";
     };
-    version = "2.1.45";
+    version = "2.2.0";
   };
   redcarpet = {
     source = {
@@ -751,10 +751,10 @@
     dependencies = ["rex-core"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0zvvw9wbxppz2s6mmw57xjqvj7wbmfq88d8v8xm4v78cdkgxqzmg";
+      sha256 = "136szyv31fcdzmcgs44vg009k3ssyawkqppkhm3xyv2ivpp1mlgv";
       type = "gem";
     };
-    version = "0.1.15";
+    version = "0.1.17";
   };
   rex-sslscan = {
     dependencies = ["rex-core" "rex-socket" "rex-text"];
@@ -801,10 +801,10 @@
   ruby-macho = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1lkarnkjssp1nas941vq1dbv20xa31pnwh1db7l1qdhk23g0a7yw";
+      sha256 = "1k5vvk9d13pixhbram6fs74ibgmr2dngv7bks13npcjb42q275if";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.0";
   };
   ruby-rc4 = {
     source = {
@@ -860,18 +860,18 @@
   sqlite3 = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01ifzp8nwzqppda419c9wcvr8n82ysmisrs0hph9pdmv1lpa4f5i";
+      sha256 = "0pmgpqx2sg8pms54rk7kjjy8jwsw21g1f7mb02fggbdcqy8jk3fx";
       type = "gem";
     };
-    version = "1.3.13";
+    version = "1.4.0";
   };
   sshkey = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0g02lh50jd5z4l9bp7xirnfn3n1dh9lr06dv3xh0kr3yhsny059h";
+      sha256 = "03bkn55qsng484iqwz2lmm6rkimj01vsvhwk661s3lnmpkl65lbp";
       type = "gem";
     };
-    version = "1.9.0";
+    version = "2.0.0";
   };
   thin = {
     dependencies = ["daemons" "eventmachine" "rack"];

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -325,7 +325,7 @@
     source = {
       fetchSubmodules = false;
       rev = "bf949b7fd2a705a74ca02f66792f80ab41b4c81a";
-      sha256 = "0p5mfrlbl62vi0yf4a4kc0q4nq5ag9kz94jwa1lqqcb1rw7474gk";
+      sha256 = "0shlc8yq8kfpwa6mk9ns87irl72hgfkgs1qhm34vyak3x99jxc5a";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -1,5 +1,6 @@
 {
   actionpack = {
+    dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "13xkil3y7gjj0m4ky14asi4m08x69wwv63wfn0h95wli4x8h8w7r";
@@ -8,6 +9,7 @@
     version = "4.2.11";
   };
   actionview = {
+    dependencies = ["activesupport" "builder" "erubis" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "09vwq0xgxxhssxxh8fa7l2pv6a56smw3v6gvb9l1mycmf8vprd4b";
@@ -16,6 +18,7 @@
     version = "4.2.11";
   };
   activemodel = {
+    dependencies = ["activesupport" "builder"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "11aqvabf5c1pgb404f5bqp1i7mxkyhzmwk6y8zm5w6rf4nq095mq";
@@ -24,6 +27,7 @@
     version = "4.2.11";
   };
   activerecord = {
+    dependencies = ["activemodel" "activesupport" "arel"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1sw0m19cnasbr4cabvc302hjddc3s6fja3fr0gbj9h2n8b3633i5";
@@ -32,6 +36,7 @@
     version = "4.2.11";
   };
   activesupport = {
+    dependencies = ["i18n" "minitest" "thread_safe" "tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0pqr25wmhvvlg8av7bi5p5c7r5464clhhhhv45j63bh7xw4ad6n4";
@@ -40,6 +45,7 @@
     version = "4.2.11";
   };
   addressable = {
+    dependencies = ["public_suffix"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0viqszpkggqi8hq87pqp0xykhvz60g99nwmkwsb0v45kc2liwxvk";
@@ -64,6 +70,7 @@
     version = "6.0.4";
   };
   arel-helpers = {
+    dependencies = ["activerecord"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0qj4iljnsyp2ljdcw4ihi2lsj752h4xn3qw7qk6q7q5i5n0syfk3";
@@ -160,6 +167,7 @@
     version = "1.3.1";
   };
   dnsruby = {
+    dependencies = ["addressable"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "04sxvjif1pxmlf02mj3hkdb209pq18fv9sr2p0mxwi0dpifk6f3x";
@@ -176,6 +184,7 @@
     version = "1.2.4";
   };
   em-http-request = {
+    dependencies = ["addressable" "cookiejar" "em-socksify" "eventmachine" "http_parser.rb"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "13rxmbi0fv91n4sg300v3i9iiwd0jxv0i6xd0sp81dx3jlx7kasx";
@@ -184,6 +193,7 @@
     version = "1.1.5";
   };
   em-socksify = {
+    dependencies = ["eventmachine"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0rk43ywaanfrd8180d98287xv2pxyl7llj291cwy87g1s735d5nk";
@@ -208,6 +218,7 @@
     version = "1.2.7";
   };
   faker = {
+    dependencies = ["i18n"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "01q7wrk5bl0c0qrvg2my3kl0mbfnj1jpd89mqm3fzy4ggbkdhh7i";
@@ -216,6 +227,7 @@
     version = "1.9.1";
   };
   faraday = {
+    dependencies = ["multipart-post"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0s72m05jvzc1pd6cw1i289chas399q0a14xrwg4rvkdwy7bgzrh0";
@@ -248,6 +260,7 @@
     version = "0.6.0";
   };
   i18n = {
+    dependencies = ["concurrent-ruby"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "038qvz7kd3cfxk8bvagqhakx68pfbnmghpdkx7573wbf0maqp9a3";
@@ -256,6 +269,7 @@
     version = "0.9.5";
   };
   jsobfu = {
+    dependencies = ["rkelly-remix"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1hchns89cfj0gggm2zbr7ghb630imxm2x2d21ffx2jlasn9xbkyk";
@@ -272,6 +286,7 @@
     version = "2.1.0";
   };
   loofah = {
+    dependencies = ["crass" "nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1ccsid33xjajd0im2xv941aywi58z7ihwkvaf1w2bv89vn5bhsjg";
@@ -288,6 +303,7 @@
     version = "1.0.3";
   };
   metasploit-concern = {
+    dependencies = ["activemodel" "activesupport" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0v9lm225fhzhnbjcc0vwb38ybikxwzlv8116rrrkndzs8qy79297";
@@ -296,6 +312,7 @@
     version = "2.0.5";
   };
   metasploit-credential = {
+    dependencies = ["metasploit-concern" "metasploit-model" "metasploit_data_models" "net-ssh" "pg" "railties" "rex-socket" "rubyntlm" "rubyzip"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0liyc1yppsjjn63713n2z7hsi1lvqcamp0xny0ax9d4rksn56w92";
@@ -304,16 +321,18 @@
     version = "3.0.2";
   };
   metasploit-framework = {
+    dependencies = ["actionpack" "activerecord" "activesupport" "backports" "bcrypt" "bcrypt_pbkdf" "bit-struct" "concurrent-ruby" "dnsruby" "ed25519" "em-http-request" "faker" "filesize" "jsobfu" "json" "metasm" "metasploit-concern" "metasploit-credential" "metasploit-model" "metasploit-payloads" "metasploit_data_models" "metasploit_payloads-mettle" "mqtt" "msgpack" "nessus_rest" "net-ssh" "network_interface" "nexpose" "nokogiri" "octokit" "openssl-ccm" "openvas-omp" "packetfu" "patch_finder" "pcaprub" "pdf-reader" "pg" "railties" "rb-readline" "recog" "redcarpet" "rex-arch" "rex-bin_tools" "rex-core" "rex-encoder" "rex-exploitation" "rex-java" "rex-mime" "rex-nop" "rex-ole" "rex-powershell" "rex-random_identifier" "rex-registry" "rex-rop_builder" "rex-socket" "rex-sslscan" "rex-struct2" "rex-text" "rex-zip" "ruby-macho" "ruby_smb" "rubyntlm" "rubyzip" "sinatra" "sqlite3" "sshkey" "thin" "tzinfo" "tzinfo-data" "warden" "windows_error" "xdr" "xmlrpc"];
     source = {
       fetchSubmodules = false;
       rev = "1442130a2717aabf75750f4f2412a416481e2154";
-      sha256 = "0qg96g04ksgj27fz2fiv5n2nv4fik3qzpmkzdrf4k5bxw194q4ns";
+      sha256 = "0f8kvf5wn16jir9nka1v2jbh2znf7yjg7z7znw026rkwnc52ff82";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };
     version = "5.0.1";
   };
   metasploit-model = {
+    dependencies = ["activemodel" "activesupport" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "05pnai1cv00xw87rrz38dz4s3ss45s90290d0knsy1mq6rp8yvmw";
@@ -330,6 +349,7 @@
     version = "1.3.58";
   };
   metasploit_data_models = {
+    dependencies = ["activerecord" "activesupport" "arel-helpers" "metasploit-concern" "metasploit-model" "pg" "postgres_ext" "railties" "recog"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0n600ywghnc3d4kamfg33v6kmc6mfaqi0hp1c69p4x0pwr6p76xd";
@@ -418,6 +438,7 @@
     version = "7.2.1";
   };
   nokogiri = {
+    dependencies = ["mini_portile2"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "09zll7c6j7xr6wyvh5mm5ncj6pkryp70ybcsxdbw1nyphx5dh184";
@@ -426,6 +447,7 @@
     version = "1.10.1";
   };
   octokit = {
+    dependencies = ["sawyer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1yh0yzzqg575ix3y2l2261b9ag82gv2v4f1wczdhcmfbxcz755x6";
@@ -450,6 +472,7 @@
     version = "0.0.4";
   };
   packetfu = {
+    dependencies = ["pcaprub"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "16ppq9wfxq4x2hss61l5brs3s6fmi8gb50mnp1nnnzb1asq4g8ll";
@@ -474,6 +497,7 @@
     version = "0.13.0";
   };
   pdf-reader = {
+    dependencies = ["Ascii85" "afm" "hashery" "ruby-rc4" "ttfunk"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0aas2f5clgwpgryywrh4gihdi10afx3kbyfs1n31cinri02psd43";
@@ -498,6 +522,7 @@
     version = "0.0.9";
   };
   postgres_ext = {
+    dependencies = ["activerecord" "arel" "pg_array_parser"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0ni1ajzxvc17ba4rgl27cd3645ddbpqpfckv7m08sfgk015hh7dq";
@@ -522,6 +547,7 @@
     version = "1.6.11";
   };
   rack-protection = {
+    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0my0wlw4a5l3hs79jkx2xzv7djhajgf8d28k8ai1ddlnxxb0v7ss";
@@ -530,6 +556,7 @@
     version = "1.5.5";
   };
   rack-test = {
+    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
@@ -538,6 +565,7 @@
     version = "0.6.3";
   };
   rails-deprecated_sanitizer = {
+    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0qxymchzdxww8bjsxj05kbf86hsmrjx40r41ksj0xsixr2gmhbbj";
@@ -546,6 +574,7 @@
     version = "1.0.3";
   };
   rails-dom-testing = {
+    dependencies = ["activesupport" "nokogiri" "rails-deprecated_sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0wssfqpn00byhvp2372p99mphkcj8qx6pf6646avwr9ifvq0q1x6";
@@ -554,6 +583,7 @@
     version = "1.0.9";
   };
   rails-html-sanitizer = {
+    dependencies = ["loofah"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1gv7vr5d9g2xmgpjfq4nxsqr70r9pr042r9ycqqnfvw5cz9c7jwr";
@@ -562,6 +592,7 @@
     version = "1.0.4";
   };
   railties = {
+    dependencies = ["actionpack" "activesupport" "rake" "thor"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "09x32zkxs0vfi4y0bjrqd61821kx2azwhdxvk2ygqj4yvxfh11i1";
@@ -586,6 +617,7 @@
     version = "0.5.5";
   };
   recog = {
+    dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "143b0zg2xx4jaympqzqz55r45vgs5k59ymm4rgk8ckxirvsz0cq4";
@@ -602,6 +634,7 @@
     version = "3.4.0";
   };
   rex-arch = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0cvdy2ysiphdig258lkicbxqq2y47bkl69kgj4kkj8w338rb5kwa";
@@ -610,6 +643,7 @@
     version = "0.1.13";
   };
   rex-bin_tools = {
+    dependencies = ["metasm" "rex-arch" "rex-core" "rex-struct2" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "19q4cj7cis29k3zx9j2gp4h3ib0zig2fa4rs56c1gjr32f192zzk";
@@ -626,6 +660,7 @@
     version = "0.1.13";
   };
   rex-encoder = {
+    dependencies = ["metasm" "rex-arch" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1zm5jdxgyyp8pkfqwin34izpxdrmglx6vmk20ifnvcsm55c9m70z";
@@ -634,6 +669,7 @@
     version = "0.1.4";
   };
   rex-exploitation = {
+    dependencies = ["jsobfu" "metasm" "rex-arch" "rex-encoder" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0gzmxi4v5q44f12mfqaz223w9vnndjqraabrkgdm8w2i76v0sw9z";
@@ -650,6 +686,7 @@
     version = "0.1.5";
   };
   rex-mime = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "15a14kz429h7pn81ysa6av3qijxjmxagjff6dyss5v394fxzxf4a";
@@ -658,6 +695,7 @@
     version = "0.1.5";
   };
   rex-nop = {
+    dependencies = ["rex-arch"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0aigf9qsqsmiraa6zvfy1a7cyvf7zc3iyhzxi6fjv5sb8f64d6ny";
@@ -666,6 +704,7 @@
     version = "0.1.1";
   };
   rex-ole = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1pnzbqfnvbs0vc0z0ryszk3fxhgxrjd6gzwqa937rhlphwp5jpww";
@@ -674,6 +713,7 @@
     version = "0.1.6";
   };
   rex-powershell = {
+    dependencies = ["rex-random_identifier" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1z2im5sfkbacvnr3xr1niavk7q6in8zgh2m9wsf0mkhmv96bv4bv";
@@ -682,6 +722,7 @@
     version = "0.1.79";
   };
   rex-random_identifier = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0fg94sczff5c2rlvqqgw2dndlqyzjil5rjk3p9f46ss2hc8zxlbk";
@@ -698,6 +739,7 @@
     version = "0.1.3";
   };
   rex-rop_builder = {
+    dependencies = ["metasm" "rex-core" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0xjd3d6wnbq4ym0d0m268md8fb16f2hbwrahvxnl14q63fj9i3wy";
@@ -706,6 +748,7 @@
     version = "0.1.3";
   };
   rex-socket = {
+    dependencies = ["rex-core"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0zvvw9wbxppz2s6mmw57xjqvj7wbmfq88d8v8xm4v78cdkgxqzmg";
@@ -714,6 +757,7 @@
     version = "0.1.15";
   };
   rex-sslscan = {
+    dependencies = ["rex-core" "rex-socket" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "06gbx45q653ajcx099p0yxdqqxazfznbrqshd4nwiwg1p498lmyx";
@@ -738,6 +782,7 @@
     version = "0.2.21";
   };
   rex-zip = {
+    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1mbfryyhcw47i7jb8cs8vilbyqgyiyjkfl1ngl6wdbf7d87dwdw7";
@@ -770,6 +815,7 @@
     version = "0.1.5";
   };
   ruby_smb = {
+    dependencies = ["bindata" "rubyntlm" "windows_error"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0kx0q0wqfzgiccjqin2mp04bdk5jyyz4fnm78m1d5p3d9zqvi6v1";
@@ -794,6 +840,7 @@
     version = "1.2.2";
   };
   sawyer = {
+    dependencies = ["addressable" "faraday"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0sv1463r7bqzvx4drqdmd36m7rrv6sf1v3c6vswpnq3k6vdw2dvd";
@@ -802,6 +849,7 @@
     version = "0.8.1";
   };
   sinatra = {
+    dependencies = ["rack" "rack-protection" "tilt"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0byxzl7rx3ki0xd7aiv1x8mbah7hzd8f81l65nq8857kmgzj1jqq";
@@ -826,6 +874,7 @@
     version = "1.9.0";
   };
   thin = {
+    dependencies = ["daemons" "eventmachine" "rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0nagbf9pwy1vg09k6j4xqhbjjzrg5dwzvkn4ffvlj76fsn6vv61f";
@@ -866,6 +915,7 @@
     version = "1.5.1";
   };
   tzinfo = {
+    dependencies = ["thread_safe"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1fjx9j327xpkkdlxwmkl3a8wqj7i4l4jwlrv3z13mg95z9wl253z";
@@ -874,6 +924,7 @@
     version = "1.2.5";
   };
   tzinfo-data = {
+    dependencies = ["tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1jzl5cv7b5h24lh8s42s3j1ls0p27b5wmc4zdjs2j7hajgbdp19q";
@@ -882,6 +933,7 @@
     version = "1.2018.9";
   };
   warden = {
+    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0va966lhpylcwbqb9n151kkihx30agh0a57mwjwdxyanll4s1q12";
@@ -898,6 +950,7 @@
     version = "0.1.2";
   };
   xdr = {
+    dependencies = ["activemodel" "activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0c5cp1k4ij3xq1q6fb0f6xv5b65wy18y7bhwvsdx8wd0zyg3x96m";

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -1,57 +1,51 @@
 {
   actionpack = {
-    dependencies = ["actionview" "activesupport" "rack" "rack-test" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kgrq74gp2czzxr0f2sqrc98llz03lgq498300z2z5n4khgznwc4";
+      sha256 = "13xkil3y7gjj0m4ky14asi4m08x69wwv63wfn0h95wli4x8h8w7r";
       type = "gem";
     };
-    version = "4.2.9";
+    version = "4.2.11";
   };
   actionview = {
-    dependencies = ["activesupport" "builder" "erubis" "rails-dom-testing" "rails-html-sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04kgp4gmahw31miz8xdq1pns14qmvvzd14fgfv7fg9klkw3bxyyp";
+      sha256 = "09vwq0xgxxhssxxh8fa7l2pv6a56smw3v6gvb9l1mycmf8vprd4b";
       type = "gem";
     };
-    version = "4.2.9";
+    version = "4.2.11";
   };
   activemodel = {
-    dependencies = ["activesupport" "builder"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1qxmivny0ka5s3iyap08sn9bp2bd9wrhqp2njfw26hr9wsjk5kfv";
+      sha256 = "11aqvabf5c1pgb404f5bqp1i7mxkyhzmwk6y8zm5w6rf4nq095mq";
       type = "gem";
     };
-    version = "4.2.9";
+    version = "4.2.11";
   };
   activerecord = {
-    dependencies = ["activemodel" "activesupport" "arel"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "18i790dfhi4ndypd1pj9pv08knpxr2sayvvwfq7axj5jfwgpmrqb";
+      sha256 = "1sw0m19cnasbr4cabvc302hjddc3s6fja3fr0gbj9h2n8b3633i5";
       type = "gem";
     };
-    version = "4.2.9";
+    version = "4.2.11";
   };
   activesupport = {
-    dependencies = ["i18n" "minitest" "thread_safe" "tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1d0a362p3m2m2kljichar2pwq0qm4vblc3njy1rdzm09ckzd45sp";
+      sha256 = "0pqr25wmhvvlg8av7bi5p5c7r5464clhhhhv45j63bh7xw4ad6n4";
       type = "gem";
     };
-    version = "4.2.9";
+    version = "4.2.11";
   };
   addressable = {
-    dependencies = ["public_suffix"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1i8q32a4gr0zghxylpyy7jfqwxvwrivsxflg9mks6kx92frh75mh";
+      sha256 = "0viqszpkggqi8hq87pqp0xykhvz60g99nwmkwsb0v45kc2liwxvk";
       type = "gem";
     };
-    version = "2.5.1";
+    version = "2.5.2";
   };
   afm = {
     source = {
@@ -70,37 +64,36 @@
     version = "6.0.4";
   };
   arel-helpers = {
-    dependencies = ["activerecord"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1sx4qbzhld3a99175p2krz3hv1npc42rv3sd8x4awzkgplg3zy9c";
+      sha256 = "0qj4iljnsyp2ljdcw4ihi2lsj752h4xn3qw7qk6q7q5i5n0syfk3";
       type = "gem";
     };
-    version = "2.4.0";
+    version = "2.8.0";
   };
   Ascii85 = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0j95sbxd18kc8rhcnvl1w37kflqpax1r12h1x47gh4xxn3mz4m7q";
+      sha256 = "0658m37jjjn6drzqg1gk4p6c205mgp7g1jh2d00n4ngghgmz5qvs";
       type = "gem";
     };
-    version = "1.0.2";
+    version = "1.0.3";
   };
   backports = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17pcz0z6jms5jydr1r95kf1bpk3ms618hgr26c62h34icy9i1dpm";
+      sha256 = "1hshjxww2h7s0dk57njrygq4zpp0nlqrjfya7zwm27iq3rhc3y8g";
       type = "gem";
     };
-    version = "3.8.0";
+    version = "3.11.4";
   };
   bcrypt = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1d254sdhdj6mzak3fb5x3jam8b94pvl1srladvs53j05a89j5z50";
+      sha256 = "0ysblqxkclmnhrd0kmb5mr8p38mbar633gdsb14b7dhkhgawgzfy";
       type = "gem";
     };
-    version = "3.1.11";
+    version = "3.1.12";
   };
   bcrypt_pbkdf = {
     source = {
@@ -113,10 +106,10 @@
   bindata = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "10sii2chgnkp2jw830sbr2wb20p8p1wcwrl9jhadkw94f505qcyg";
+      sha256 = "0kz42nvxnk1j9cj0i8lcnhprcgdqsqska92g6l19ziadydfk2gqy";
       type = "gem";
     };
-    version = "2.4.0";
+    version = "2.4.4";
   };
   bit-struct = {
     source = {
@@ -134,13 +127,69 @@
     };
     version = "3.2.3";
   };
+  concurrent-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "183lszf5gx84kcpb779v6a2y0mx9sssy8dgppng1z9a505nj1qcf";
+      type = "gem";
+    };
+    version = "1.0.5";
+  };
+  cookiejar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0q0kmbks9l3hl0wdq744hzy97ssq9dvlzywyqv9k9y1p3qc9va2a";
+      type = "gem";
+    };
+    version = "0.3.3";
+  };
+  crass = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bpxzy6gjw9ggjynlxschbfsgmx8lv3zw1azkjvnb8b9i895dqfi";
+      type = "gem";
+    };
+    version = "1.0.4";
+  };
+  daemons = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l5gai3vd4g7aqff0k1mp41j9zcsvm2rbwmqn115a325k9r7pf4w";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
   dnsruby = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0qfvpkka69f8vnmda3zhkr54fjpf7pwgmbx0gcsxg3jd6c7sjs1d";
+      sha256 = "04sxvjif1pxmlf02mj3hkdb209pq18fv9sr2p0mxwi0dpifk6f3x";
       type = "gem";
     };
-    version = "1.60.2";
+    version = "1.61.2";
+  };
+  ed25519 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1f5kr8za7hvla38fc0n9jiv55iq62k5bzclsa5kdb14l3r4w6qnw";
+      type = "gem";
+    };
+    version = "1.2.4";
+  };
+  em-http-request = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13rxmbi0fv91n4sg300v3i9iiwd0jxv0i6xd0sp81dx3jlx7kasx";
+      type = "gem";
+    };
+    version = "1.1.5";
+  };
+  em-socksify = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rk43ywaanfrd8180d98287xv2pxyl7llj291cwy87g1s735d5nk";
+      type = "gem";
+    };
+    version = "0.3.2";
   };
   erubis = {
     source = {
@@ -150,30 +199,37 @@
     };
     version = "2.7.0";
   };
-  faraday = {
-    dependencies = ["multipart-post"];
+  eventmachine = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1gyqsj7vlqynwvivf9485zwmcj04v1z7gq362z0b8zw2zf4ag0hw";
+      sha256 = "0wh9aqb0skz80fhfn66lbpr4f86ya2z5rx6gm5xlfhd05bj1ch4r";
       type = "gem";
     };
-    version = "0.13.1";
+    version = "1.2.7";
   };
-  ffi = {
+  faker = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "034f52xf7zcqgbvwbl20jwdyjwznvqnwpbaps9nk18v9lgb1dpx0";
+      sha256 = "01q7wrk5bl0c0qrvg2my3kl0mbfnj1jpd89mqm3fzy4ggbkdhh7i";
       type = "gem";
     };
-    version = "1.9.18";
+    version = "1.9.1";
+  };
+  faraday = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0s72m05jvzc1pd6cw1i289chas399q0a14xrwg4rvkdwy7bgzrh0";
+      type = "gem";
+    };
+    version = "0.15.4";
   };
   filesize = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "061qmg82mm9xnmnq3b7gbi24g28xk62w0b0nw86gybd07m1jn989";
+      sha256 = "17p7rf1x7h3ivaznb4n4kmxnnzj25zaviryqgn2n12v2kmibhp8g";
       type = "gem";
     };
-    version = "0.1.1";
+    version = "0.2.0";
   };
   hashery = {
     source = {
@@ -183,16 +239,23 @@
     };
     version = "2.1.2";
   };
+  "http_parser.rb" = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15nidriy0v5yqfjsgsra51wmknxci2n2grliz78sf9pga3n0l7gi";
+      type = "gem";
+    };
+    version = "0.6.0";
+  };
   i18n = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1i3aqvzfsj786kwjj70jsjpxm6ffw5pwhalzr2abjfv2bdc7k9kw";
+      sha256 = "038qvz7kd3cfxk8bvagqhakx68pfbnmghpdkx7573wbf0maqp9a3";
       type = "gem";
     };
-    version = "0.8.6";
+    version = "0.9.5";
   };
   jsobfu = {
-    dependencies = ["rkelly-remix"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1hchns89cfj0gggm2zbr7ghb630imxm2x2d21ffx2jlasn9xbkyk";
@@ -209,13 +272,12 @@
     version = "2.1.0";
   };
   loofah = {
-    dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "109ps521p0sr3kgc460d58b4pr1z4mqggan2jbsf0aajy9s6xis8";
+      sha256 = "1ccsid33xjajd0im2xv941aywi58z7ihwkvaf1w2bv89vn5bhsjg";
       type = "gem";
     };
-    version = "2.0.3";
+    version = "2.2.3";
   };
   metasm = {
     source = {
@@ -226,7 +288,6 @@
     version = "1.0.3";
   };
   metasploit-concern = {
-    dependencies = ["activemodel" "activesupport" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0v9lm225fhzhnbjcc0vwb38ybikxwzlv8116rrrkndzs8qy79297";
@@ -235,27 +296,24 @@
     version = "2.0.5";
   };
   metasploit-credential = {
-    dependencies = ["metasploit-concern" "metasploit-model" "metasploit_data_models" "pg" "railties" "rex-socket" "rubyntlm" "rubyzip"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1flahrcl5hf4bncqs40mry6pkffvmir85kqzkad22x3dh6crw50i";
+      sha256 = "0liyc1yppsjjn63713n2z7hsi1lvqcamp0xny0ax9d4rksn56w92";
       type = "gem";
     };
-    version = "2.0.12";
+    version = "3.0.2";
   };
   metasploit-framework = {
-    dependencies = ["actionpack" "activerecord" "activesupport" "backports" "bcrypt" "bcrypt_pbkdf" "bit-struct" "dnsruby" "filesize" "jsobfu" "json" "metasm" "metasploit-concern" "metasploit-credential" "metasploit-model" "metasploit-payloads" "metasploit_data_models" "metasploit_payloads-mettle" "msgpack" "nessus_rest" "net-ssh" "network_interface" "nexpose" "nokogiri" "octokit" "openssl-ccm" "openvas-omp" "packetfu" "patch_finder" "pcaprub" "pdf-reader" "pg" "railties" "rb-readline" "rbnacl" "rbnacl-libsodium" "recog" "redcarpet" "rex-arch" "rex-bin_tools" "rex-core" "rex-encoder" "rex-exploitation" "rex-java" "rex-mime" "rex-nop" "rex-ole" "rex-powershell" "rex-random_identifier" "rex-registry" "rex-rop_builder" "rex-socket" "rex-sslscan" "rex-struct2" "rex-text" "rex-zip" "robots" "ruby_smb" "rubyntlm" "rubyzip" "sqlite3" "sshkey" "tzinfo" "tzinfo-data" "windows_error" "xdr" "xmlrpc"];
     source = {
       fetchSubmodules = false;
-      rev = "dbec1c2d2ae4bd77276cbfb3c6ee2902048b9453";
-      sha256 = "06a2dc64wl8w02zimf44hch4cap7ckw42kg1x01lmcwaa8d5q09w";
+      rev = "1442130a2717aabf75750f4f2412a416481e2154";
+      sha256 = "0qg96g04ksgj27fz2fiv5n2nv4fik3qzpmkzdrf4k5bxw194q4ns";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };
-    version = "4.16.1";
+    version = "5.0.1";
   };
   metasploit-model = {
-    dependencies = ["activemodel" "activesupport" "railties"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "05pnai1cv00xw87rrz38dz4s3ss45s90290d0knsy1mq6rp8yvmw";
@@ -266,51 +324,58 @@
   metasploit-payloads = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0icha08z4c5rnyp66xcyn9c8lbv43gx7hgs9rsm3539gj8c40znx";
+      sha256 = "15kkw1nkd2xaly4nnipr45dkjlz673f30kj73jrakimf5v8iqn1m";
       type = "gem";
     };
-    version = "1.3.1";
+    version = "1.3.58";
   };
   metasploit_data_models = {
-    dependencies = ["activerecord" "activesupport" "arel-helpers" "metasploit-concern" "metasploit-model" "pg" "postgres_ext" "railties" "recog"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0j3ijxn6n3ack9572a74cwknijymy41c8rx34njyhg25lx4hbvah";
+      sha256 = "0n600ywghnc3d4kamfg33v6kmc6mfaqi0hp1c69p4x0pwr6p76xd";
       type = "gem";
     };
-    version = "2.0.15";
+    version = "3.0.4";
   };
   metasploit_payloads-mettle = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1y2nfzgs17pq3xvlw14jgjcksr4h8p4miypxk9a87l1h7xv7dcgn";
+      sha256 = "1d0m2vw9xh0227rp36gyyj6kffhy1h3c0hl8cifyr3d0b42yr28j";
       type = "gem";
     };
-    version = "0.2.0";
+    version = "0.5.1";
   };
   mini_portile2 = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0g5bpgy08q0nc0anisg3yvwc1gc3inl854fcrg48wvg7glqd6dpm";
+      sha256 = "15zplpfw3knqifj9bpf604rb3wc1vhq6363pd6lvhayng8wql5vy";
       type = "gem";
     };
-    version = "2.2.0";
+    version = "2.4.0";
   };
   minitest = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "05521clw19lrksqgvg2kmm025pvdhdaniix52vmbychrn2jm7kz2";
+      sha256 = "0icglrhghgwdlnzzp4jf76b0mbc71s80njn5afyfjn4wqji8mqbq";
       type = "gem";
     };
-    version = "5.10.3";
+    version = "5.11.3";
+  };
+  mqtt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0d1khsry5mf63y03r6v91f4vrbn88277ksv7d69z3xmqs9sgpri9";
+      type = "gem";
+    };
+    version = "0.5.0";
   };
   msgpack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ck7w17d6b4jbb8inh1q57bghi9cjkiaxql1d3glmj1yavbpmlh7";
+      sha256 = "0031gd2mjyba6jb7m97sqa149zjkr0vzn2s2gpb3m9nb67gqkm13";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.2.6";
   };
   multipart-post = {
     source = {
@@ -331,52 +396,50 @@
   net-ssh = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "013p5jb4wy0cq7x7036piw2a3s1i9p752ki1srx2m289mpz4ml3q";
+      sha256 = "0jglf8rxvlw6is5019r6kwsdhw38zm3z39jbghdbj449r6h7h77n";
       type = "gem";
     };
-    version = "4.1.0";
+    version = "5.1.0";
   };
   network_interface = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ir4c1vbz1y0gxyih024262i7ig1nji1lkylcrn9pjzx3798p97a";
+      sha256 = "1xh4knfq77ii4pjzsd2z1p3nd6nrcdjhb2vi5gw36jqj43ffw0zp";
       type = "gem";
     };
-    version = "0.0.1";
+    version = "0.0.2";
   };
   nexpose = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jnyvj09z8r3chhj930fdnashbfcfv0vw2drjvsrcnm7firdhdzb";
+      sha256 = "0i108glkklwgjxhfhnlqf4b16plqf9b84qpfz0pnl2pbnal5af8m";
       type = "gem";
     };
-    version = "6.1.1";
+    version = "7.2.1";
   };
   nokogiri = {
-    dependencies = ["mini_portile2"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1nffsyx1xjg6v5n9rrbi8y1arrcx2i5f21cp6clgh9iwiqkr7rnn";
+      sha256 = "09zll7c6j7xr6wyvh5mm5ncj6pkryp70ybcsxdbw1nyphx5dh184";
       type = "gem";
     };
-    version = "1.8.0";
+    version = "1.10.1";
   };
   octokit = {
-    dependencies = ["sawyer"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0h6cm7bi0y7ysjgwws3paaipqdld6c0m0niazrjahhpz88qqq1g4";
+      sha256 = "1yh0yzzqg575ix3y2l2261b9ag82gv2v4f1wczdhcmfbxcz755x6";
       type = "gem";
     };
-    version = "4.7.0";
+    version = "4.13.0";
   };
   openssl-ccm = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "18h5lxv0zh4j2f0wnhdmfz63x02vbzbq2k1clz6kzr0q83h8kj9c";
+      sha256 = "0gxwxk657jya2s5m8cpckvgy5m7qx0hzfp8xvc0hg2wf1lg5gwp0";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.2.2";
   };
   openvas-omp = {
     source = {
@@ -387,7 +450,6 @@
     version = "0.0.4";
   };
   packetfu = {
-    dependencies = ["pcaprub"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "16ppq9wfxq4x2hss61l5brs3s6fmi8gb50mnp1nnnzb1asq4g8ll";
@@ -406,19 +468,18 @@
   pcaprub = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0pl4lqy7308185pfv0197n8b4v20fhd0zb3wlpz284rk8ssclkvz";
+      sha256 = "0h4iarqdych6v4jm5s0ywkc01qspadz8sf6qn7pkqmszq4iqv67q";
       type = "gem";
     };
-    version = "0.12.4";
+    version = "0.13.0";
   };
   pdf-reader = {
-    dependencies = ["Ascii85" "afm" "hashery" "ruby-rc4" "ttfunk"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0nlammdpjy3padmzxhsql7mw31jyqp88n6bdffiarv5kzl4s3y7p";
+      sha256 = "0aas2f5clgwpgryywrh4gihdi10afx3kbyfs1n31cinri02psd43";
       type = "gem";
     };
-    version = "2.0.0";
+    version = "2.2.0";
   };
   pg = {
     source = {
@@ -437,21 +498,20 @@
     version = "0.0.9";
   };
   postgres_ext = {
-    dependencies = ["activerecord" "arel" "pg_array_parser"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1lbp1qf5s1addhznm7d4bzks9adh7jpilgcsr8k7mbd0a1ailcgc";
+      sha256 = "0ni1ajzxvc17ba4rgl27cd3645ddbpqpfckv7m08sfgk015hh7dq";
       type = "gem";
     };
-    version = "3.0.0";
+    version = "3.0.1";
   };
   public_suffix = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "040jf98jpp6w140ghkhw2hvc1qx41zvywx5gj7r2ylr1148qnj7q";
+      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
       type = "gem";
     };
-    version = "2.0.5";
+    version = "3.0.3";
   };
   rack = {
     source = {
@@ -461,8 +521,15 @@
     };
     version = "1.6.11";
   };
+  rack-protection = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0my0wlw4a5l3hs79jkx2xzv7djhajgf8d28k8ai1ddlnxxb0v7ss";
+      type = "gem";
+    };
+    version = "1.5.5";
+  };
   rack-test = {
-    dependencies = ["rack"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
@@ -471,7 +538,6 @@
     version = "0.6.3";
   };
   rails-deprecated_sanitizer = {
-    dependencies = ["activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0qxymchzdxww8bjsxj05kbf86hsmrjx40r41ksj0xsixr2gmhbbj";
@@ -480,39 +546,36 @@
     version = "1.0.3";
   };
   rails-dom-testing = {
-    dependencies = ["activesupport" "nokogiri" "rails-deprecated_sanitizer"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ny7mbjxhq20rzg4pivvyvk14irmc7cn20kxfk3vc0z2r2c49p8r";
+      sha256 = "0wssfqpn00byhvp2372p99mphkcj8qx6pf6646avwr9ifvq0q1x6";
       type = "gem";
     };
-    version = "1.0.8";
+    version = "1.0.9";
   };
   rails-html-sanitizer = {
-    dependencies = ["loofah"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "138fd86kv073zqfx0xifm646w6bgw2lr8snk16lknrrfrss8xnm7";
+      sha256 = "1gv7vr5d9g2xmgpjfq4nxsqr70r9pr042r9ycqqnfvw5cz9c7jwr";
       type = "gem";
     };
-    version = "1.0.3";
+    version = "1.0.4";
   };
   railties = {
-    dependencies = ["actionpack" "activesupport" "rake" "thor"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1g5jnk1zllm2fr06lixq7gv8l2cwqc99akv7886gz6lshijpfyxd";
+      sha256 = "09x32zkxs0vfi4y0bjrqd61821kx2azwhdxvk2ygqj4yvxfh11i1";
       type = "gem";
     };
-    version = "4.2.9";
+    version = "4.2.11";
   };
   rake = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01j8fc9bqjnrsxbppncai05h43315vmz9fwg28qdsgcjw9ck1d7n";
+      sha256 = "1sy5a7nh6xjdc9yhcw31jji7ssrf9v5806hn95gbrzr998a2ydjn";
       type = "gem";
     };
-    version = "12.0.0";
+    version = "12.3.2";
   };
   rb-readline = {
     source = {
@@ -522,32 +585,13 @@
     };
     version = "0.5.5";
   };
-  rbnacl = {
-    dependencies = ["ffi"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "08dkigw8wdx53hviw1zqrs7rcrzqcwh9jd3dvwr72013z9fmyp48";
-      type = "gem";
-    };
-    version = "4.0.2";
-  };
-  rbnacl-libsodium = {
-    dependencies = ["rbnacl"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1323fli41m01af13xz5xvabsjnz09si1b9l4qd2p802kq0dr61gd";
-      type = "gem";
-    };
-    version = "1.0.13";
-  };
   recog = {
-    dependencies = ["nokogiri"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0h023ykrrra74bpbibkyg083kafaswvraw4naw9p1ghcjzn9ggj3";
+      sha256 = "143b0zg2xx4jaympqzqz55r45vgs5k59ymm4rgk8ckxirvsz0cq4";
       type = "gem";
     };
-    version = "2.1.12";
+    version = "2.1.45";
   };
   redcarpet = {
     source = {
@@ -558,33 +602,30 @@
     version = "3.4.0";
   };
   rex-arch = {
-    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1izzalmjwdyib8y0xlgys8qb60di6xyjk485ylgh14p47wkyc6yp";
+      sha256 = "0cvdy2ysiphdig258lkicbxqq2y47bkl69kgj4kkj8w338rb5kwa";
       type = "gem";
     };
-    version = "0.1.11";
+    version = "0.1.13";
   };
   rex-bin_tools = {
-    dependencies = ["metasm" "rex-arch" "rex-core" "rex-struct2" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01hi1cjr68adp47nxbjfprvn0r3b72r4ib82x9j33bf2pny6nvaw";
+      sha256 = "19q4cj7cis29k3zx9j2gp4h3ib0zig2fa4rs56c1gjr32f192zzk";
       type = "gem";
     };
-    version = "0.1.4";
+    version = "0.1.6";
   };
   rex-core = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "16dwf4pw7bpx8xvlv241imxvwhvjfv0cw9kl7ipsv40yazy5lzpk";
+      sha256 = "1b9pf7f8m2zjck65dpp8h8v4n0a05kfas6cn9adv0w8d9z58aqvv";
       type = "gem";
     };
-    version = "0.1.12";
+    version = "0.1.13";
   };
   rex-encoder = {
-    dependencies = ["metasm" "rex-arch" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1zm5jdxgyyp8pkfqwin34izpxdrmglx6vmk20ifnvcsm55c9m70z";
@@ -593,13 +634,12 @@
     version = "0.1.4";
   };
   rex-exploitation = {
-    dependencies = ["jsobfu" "metasm" "rex-arch" "rex-encoder" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0gbj28jqaaldpk4qzysgcl6m0wcqx3gcldarqdk55p5z9zasrk19";
+      sha256 = "0gzmxi4v5q44f12mfqaz223w9vnndjqraabrkgdm8w2i76v0sw9z";
       type = "gem";
     };
-    version = "0.1.14";
+    version = "0.1.20";
   };
   rex-java = {
     source = {
@@ -610,7 +650,6 @@
     version = "0.1.5";
   };
   rex-mime = {
-    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "15a14kz429h7pn81ysa6av3qijxjmxagjff6dyss5v394fxzxf4a";
@@ -619,7 +658,6 @@
     version = "0.1.5";
   };
   rex-nop = {
-    dependencies = ["rex-arch"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0aigf9qsqsmiraa6zvfy1a7cyvf7zc3iyhzxi6fjv5sb8f64d6ny";
@@ -628,7 +666,6 @@
     version = "0.1.1";
   };
   rex-ole = {
-    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1pnzbqfnvbs0vc0z0ryszk3fxhgxrjd6gzwqa937rhlphwp5jpww";
@@ -637,22 +674,20 @@
     version = "0.1.6";
   };
   rex-powershell = {
-    dependencies = ["rex-random_identifier" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0nl60fdd1rlckk95d3s3y873w84vb0sgwvwxdzv414qxz8icpjnm";
+      sha256 = "1z2im5sfkbacvnr3xr1niavk7q6in8zgh2m9wsf0mkhmv96bv4bv";
       type = "gem";
     };
-    version = "0.1.72";
+    version = "0.1.79";
   };
   rex-random_identifier = {
-    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0cksrljaw61mdjvbmj9vqqhd8nra7jv466w5nim47n73rj72jc19";
+      sha256 = "0fg94sczff5c2rlvqqgw2dndlqyzjil5rjk3p9f46ss2hc8zxlbk";
       type = "gem";
     };
-    version = "0.1.2";
+    version = "0.1.4";
   };
   rex-registry = {
     source = {
@@ -663,7 +698,6 @@
     version = "0.1.3";
   };
   rex-rop_builder = {
-    dependencies = ["metasm" "rex-core" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0xjd3d6wnbq4ym0d0m268md8fb16f2hbwrahvxnl14q63fj9i3wy";
@@ -672,16 +706,14 @@
     version = "0.1.3";
   };
   rex-socket = {
-    dependencies = ["rex-core"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0bkr64qrfy2mcv6cpp2z2rn9npgn9s0yyagzjh7kawbm80ldwf2h";
+      sha256 = "0zvvw9wbxppz2s6mmw57xjqvj7wbmfq88d8v8xm4v78cdkgxqzmg";
       type = "gem";
     };
-    version = "0.1.8";
+    version = "0.1.15";
   };
   rex-sslscan = {
-    dependencies = ["rex-core" "rex-socket" "rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "06gbx45q653ajcx099p0yxdqqxazfznbrqshd4nwiwg1p498lmyx";
@@ -700,13 +732,12 @@
   rex-text = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "024miva867h4wv4y1lnxxrw2d7p51va32ismxqf3fsz4s9cqc88m";
+      sha256 = "1w2ndcxkbn6f43504l5wss2j8q1s38vi2d7iml37cdvy1gwrczm8";
       type = "gem";
     };
-    version = "0.2.15";
+    version = "0.2.21";
   };
   rex-zip = {
-    dependencies = ["rex-text"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1mbfryyhcw47i7jb8cs8vilbyqgyiyjkfl1ngl6wdbf7d87dwdw7";
@@ -722,13 +753,13 @@
     };
     version = "0.0.7";
   };
-  robots = {
+  ruby-macho = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "141gvihcr2c0dpzl3dqyh8kqc9121prfdql2iamaaw0mf9qs3njs";
+      sha256 = "1lkarnkjssp1nas941vq1dbv20xa31pnwh1db7l1qdhk23g0a7yw";
       type = "gem";
     };
-    version = "0.10.1";
+    version = "2.1.0";
   };
   ruby-rc4 = {
     source = {
@@ -739,13 +770,12 @@
     version = "0.1.5";
   };
   ruby_smb = {
-    dependencies = ["bindata" "rubyntlm" "windows_error"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1jby5wlppxhc2jlqldic05aqd5l57171lsxqv86702grk665n612";
+      sha256 = "0kx0q0wqfzgiccjqin2mp04bdk5jyyz4fnm78m1d5p3d9zqvi6v1";
       type = "gem";
     };
-    version = "0.0.18";
+    version = "1.0.5";
   };
   rubyntlm = {
     source = {
@@ -758,19 +788,26 @@
   rubyzip = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "06js4gznzgh8ac2ldvmjcmg9v1vg9llm357yckkpylaj6z456zqz";
+      sha256 = "1n1lb2sdwh9h27y244hxzg1lrxxg2m53pk1vq7p33bna003qkyrj";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.2.2";
   };
   sawyer = {
-    dependencies = ["addressable" "faraday"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0sv1463r7bqzvx4drqdmd36m7rrv6sf1v3c6vswpnq3k6vdw2dvd";
       type = "gem";
     };
     version = "0.8.1";
+  };
+  sinatra = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0byxzl7rx3ki0xd7aiv1x8mbah7hzd8f81l65nq8857kmgzj1jqq";
+      type = "gem";
+    };
+    version = "1.4.8";
   };
   sqlite3 = {
     source = {
@@ -788,13 +825,21 @@
     };
     version = "1.9.0";
   };
+  thin = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nagbf9pwy1vg09k6j4xqhbjjzrg5dwzvkn4ffvlj76fsn6vv61f";
+      type = "gem";
+    };
+    version = "1.7.2";
+  };
   thor = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0nmqpyj642sk4g16nkbq6pj856adpv91lp4krwhqkh2iw63aszdl";
+      sha256 = "1yhrnp9x8qcy5vc7g438amd5j9sw83ih7c30dr6g6slgw9zj3g29";
       type = "gem";
     };
-    version = "0.20.0";
+    version = "0.20.3";
   };
   thread_safe = {
     source = {
@@ -803,6 +848,14 @@
       type = "gem";
     };
     version = "0.3.6";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ca4k0clwf0rkvy7726x4nxpjxkpv67w043i39saxgldxd97zmwz";
+      type = "gem";
+    };
+    version = "2.0.9";
   };
   ttfunk = {
     source = {
@@ -813,22 +866,28 @@
     version = "1.5.1";
   };
   tzinfo = {
-    dependencies = ["thread_safe"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "05r81lk7q7275rdq7xipfm0yxgqyd2ggh73xpc98ypngcclqcscl";
+      sha256 = "1fjx9j327xpkkdlxwmkl3a8wqj7i4l4jwlrv3z13mg95z9wl253z";
       type = "gem";
     };
-    version = "1.2.3";
+    version = "1.2.5";
   };
   tzinfo-data = {
-    dependencies = ["tzinfo"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1n83rmy476d4qmzq74qx0j7lbcpskbvrj1bmy3np4d5pydyw2yky";
+      sha256 = "1jzl5cv7b5h24lh8s42s3j1ls0p27b5wmc4zdjs2j7hajgbdp19q";
       type = "gem";
     };
-    version = "1.2017.2";
+    version = "1.2018.9";
+  };
+  warden = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0va966lhpylcwbqb9n151kkihx30agh0a57mwjwdxyanll4s1q12";
+      type = "gem";
+    };
+    version = "1.2.7";
   };
   windows_error = {
     source = {
@@ -839,7 +898,6 @@
     version = "0.1.2";
   };
   xdr = {
-    dependencies = ["activemodel" "activesupport"];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0c5cp1k4ij3xq1q6fb0f6xv5b65wy18y7bhwvsdx8wd0zyg3x96m";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

