### PR TITLE
Python dugong 3.5 -> 3.7.4

### DIFF
--- a/pkgs/development/python-modules/dugong/default.nix
+++ b/pkgs/development/python-modules/dugong/default.nix
@@ -2,12 +2,13 @@
 
 buildPythonPackage rec {
   pname = "dugong";
-  version = "3.5";
+  version = "3.7.4";
 
   disabled = pythonOlder "3.3"; # Library does not support versions older than 3.3
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0y0rdxbiwm03zv6vpvapqilrird3h8ijz7xmb0j7ds5j4p6q3g24";
+    extension = "tar.bz2";
+    sha256 = "1fb9kwib6jsd09bxiz70av6g0blscygkx7xzaz1b7ibd28ms77zd";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The version of the dugong library was very outdated, causing bugs in another package update. (latest s3ql).

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

