### PR TITLE
smpeg: fix build by linking against libX11 explicitly

### DIFF
--- a/pkgs/development/libraries/smpeg/default.nix
+++ b/pkgs/development/libraries/smpeg/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
       --prefix PKG_CONFIG_PATH ":" "${SDL.dev}/lib/pkgconfig"
   '';
 
+  NIX_LDFLAGS = [ "-lX11" ];
+
   meta = {
     homepage = http://icculus.org/smpeg/;
     description = "MPEG decoding library";


### PR DESCRIPTION
Error:

/nix/store/anvi6cx0rcj9xn48af849qnr590avyn3-binutils-2.30/bin/ld: gtv.o: undefined reference to symbol 'XMoveWindow'
/nix/store/ps571bzx27x5imzifw4wiah32mpqpgva-libX11-1.6.7/lib/libX11.so.6: error adding symbols: DSO missing from command line


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---