### PR TITLE
coreutils: fix tests failing on f2fs

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -26,8 +26,9 @@ stdenv.mkDerivation rec {
   patches = optional stdenv.hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch;
 
   postPatch = ''
-    # The test tends to fail on btrfs and maybe other unusual filesystems.
+    # The test tends to fail on btrfs,f2fs and maybe other unusual filesystems.
     sed '2i echo Skipping dd sparse test && exit 0' -i ./tests/dd/sparse.sh
+    sed '2i echo Skipping du threshold test && exit 0' -i ./tests/du/threshold.sh
     sed '2i echo Skipping cp sparse test && exit 0' -i ./tests/cp/sparse.sh
     sed '2i echo Skipping rm deep-2 test && exit 0' -i ./tests/rm/deep-2.sh
     sed '2i echo Skipping du long-from-unreadable test && exit 0' -i ./tests/du/long-from-unreadable.sh


### PR DESCRIPTION
###### Motivation for this change

```nixos-rebuild switch``` fails on F2FS based install.

```
============================================================================
Testsuite summary for GNU coreutils 8.29
============================================================================
# TOTAL: 603
# PASS:  464
# SKIP:  138
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See ./tests/test-suite.log
Please report to bug-coreutils@gnu.org
============================================================================
```
The culprit is "du threshold test" in ```tests/du/threshold.sh```

###### Things done

Removed failing test, as originally suggested in the comments:
https://github.com/NixOS/nixpkgs/blob/31712afa7b08a46c8e393a1b63c9fbae576762e6/pkgs/tools/misc/coreutils/default.nix#L26
---

