### PR TITLE
ncurses: use github mirror

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -13,15 +13,18 @@
 }:
 
 stdenv.mkDerivation rec {
+  # Note the revision needs to be adjusted.
   version = "6.1-20190112";
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
-  src = fetchurl {
-    urls = [
-      "https://invisible-mirror.net/archives/ncurses/current/ncurses-${version}.tgz"
-      "ftp://ftp.invisible-island.net/ncurses/current/ncurses-${version}.tgz"
-    ];
-    sha256 = "10s9r1lci2zym401ddw4w9cb3jmgprjnzpzr08djl3mmr0vpqnx2";
+  # We cannot use fetchFromGitHub (which calls fetchzip)
+  # because we need to be able to use fetchurlBoot.
+  src = let
+    # Note the version needs to be adjusted.
+    rev = "acb4184f8f69fddd052a3daa8c8675f4bf8ce369";
+  in fetchurl {
+    url = "https://github.com/mirror/ncurses/archive/${rev}.tar.gz";
+    sha256 = "1z8v63cj2y7dxf4m1api8cvk0ns9frif9c60m2sxhibs06pjy4q0";
   };
 
   patches = lib.optional (!stdenv.cc.isClang) ./clang.patch;


### PR DESCRIPTION
Development releases of ncurses are uploaded but often also removed
again. This is causing a lot of trouble, so let's instead use a
GitHub mirror.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

