### PR TITLE
nginxModules.http_proxy_connect_module: init

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -1,5 +1,22 @@
 { fetchFromGitHub, lib, pkgs }:
 
+let
+
+  http_proxy_connect_module_generic = patchName: rec {
+    src = fetchFromGitHub {
+      owner = "chobits";
+      repo = "ngx_http_proxy_connect_module";
+      rev = "8201639082cba702211585b03d4cc7bc51c65167";
+      sha256 = "0z71x3xnlczrr2kq43w3drxj9g14fkk4jz66x921v0yb8r9mnn5a";
+    };
+
+    patches = [
+      "${src}/patch/${patchName}.patch"
+    ];
+  };
+
+in
+
 {
   brotli = {
     src = let gitsrc = pkgs.fetchFromGitHub {
@@ -317,5 +334,13 @@
       rev = "v0.1.18";
       sha256 = "1jq2s9k7hah3b317hfn9y3g1q4g4x58k209psrfsqs718a9sw8c7";
     };
+  };
+
+  http_proxy_connect_module_v15 = http_proxy_connect_module_generic "proxy_connect_rewrite_1015" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "15";
+  };
+
+  http_proxy_connect_module_v14 = http_proxy_connect_module_generic "proxy_connect_rewrite_1014" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "14";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This adds the nginx module `ngx_http_proxy_connect_module` which allows
to tunnel HTTPS through an nginx proxy[1].

As this module contained patches for several nginx version, some minor
adjustments were needed:

* Allowed each entry in `nginxModules` to provide patches.

* Added an optional `supports` attribute to ensure that each module can
  determine if it supports the currently built nginx version (e.g. stable
  1.14 ATM or mainline 1.15 ATM).

[1] https://github.com/chobits/ngx_http_proxy_connect_module


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

