### PR TITLE
nix-review: 1.0.2 -> 1.0.4

### DIFF
--- a/pkgs/tools/package-management/nix-review/default.nix
+++ b/pkgs/tools/package-management/nix-review/default.nix
@@ -8,13 +8,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "nix-review";
-  version = "1.0.2";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nix-review";
     rev = version;
-    sha256 = "0vgar8sb2471zipxa1cw0n90mrnn5da7wqdlxhamnkrylbh0mc0d";
+    sha256 = "0mlcr4iscw43m04sby1m4i58fqv5c1qq1vkbgg2wgr0rpr0rf0ik";
   };
 
   makeWrapperArgs = [


### PR DESCRIPTION
- also accept the full url of pull request i.e.
  https://github.com/NixOS/nixpkgs/pull/54323
- stream-parse nix-env's eval output
- fix logs for failed builds issued by remote builders
- prepare code for overlays like: https://github.com/NixOS/nixpkgs/pull/53934


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using ~~`nix-shell -p nox --run "nox-review wip"`~~
```
$ nix-shell -p nix-review --command "nix-review pr https://github.com/NixOS/nixpkgs/pull/54422"
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---