### PR TITLE
signal-cli: init at 0.6.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchurl, makeWrapper, jre_headless }:
+
+stdenv.mkDerivation rec {
+  name = "signal-cli-${version}";
+  version = "0.6.2";
+
+  # Building from source would be preferred, but is much more involved.
+  src = fetchurl {
+    url = "https://github.com/AsamK/signal-cli/releases/download/v${version}/signal-cli-${version}.tar.gz";
+    sha256 = "050nizf7v10jlrwr8f4awzi2368qr01pzpvl2qkrwhdk25r505yr";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r lib $out/lib
+    cp bin/signal-cli $out/bin/signal-cli
+    wrapProgram $out/bin/signal-cli \
+      --prefix PATH : ${lib.makeBinPath [ jre_headless ]} \
+      --set JAVA_HOME ${jre_headless}
+  '';
+
+  # Execution in the macOS (10.13) sandbox fails with
+  # dyld: Library not loaded: /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
+  #   Referenced from: /nix/store/5ghc2l65p8jcjh0bsmhahd5m9k5p8kx0-zulu1.8.0_121-8.20.0.5/bin/java
+  #   Reason: no suitable image found.  Did find:
+  #         /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa: file system sandbox blocked stat()
+  #         /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa: file system sandbox blocked stat()
+  # /nix/store/in41dz8byyyz4c0w132l7mqi43liv4yr-stdenv-darwin/setup: line 1310:  2231 Abort trap: 6           signal-cli --version
+  doInstallCheck = stdenv.isLinux;
+  installCheckPhase = ''
+    export PATH=$PATH:$out/bin
+    # --help returns non-0 exit code even when working
+    signal-cli --version
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/AsamK/signal-cli;
+    description = "Command-line and dbus interface for communicating with the Signal messaging service";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ivan ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5449,6 +5449,8 @@ in
 
   sigil = libsForQt5.callPackage ../applications/editors/sigil { };
 
+  signal-cli = callPackage ../applications/networking/instant-messengers/signal-cli { };
+
   signal-desktop = callPackage ../applications/networking/instant-messengers/signal-desktop { };
 
   slither-analyzer = with python3Packages; toPythonApplication slither-analyzer;


### PR DESCRIPTION
###### Motivation for this change

Add [signal-cli](https://github.com/AsamK/signal-cli) to fix #51330.  This is a command-line interface for sending messages on [Signal](https://signal.org/).  Using it requires registering a separate phone number with `signal-cli`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I manually tested to confirm that `echo "message" | signal-cli -u FROM-NUMBER send TO-NUMBER` works on NixOS and macOS 10.13.