### PR TITLE
Revert "python: pytest_37: init at 3.7.4"

### DIFF
--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -2,59 +2,46 @@
 , setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k, more-itertools
 , atomicwrites, mock, writeText, pathlib2
 }:
+buildPythonPackage rec {
+  version = "3.9.3";
+  pname = "pytest";
 
-let generic = { version, sha256 }:
-  buildPythonPackage rec {
-    pname = "pytest";
-    inherit version;
+  preCheck = ''
+    # don't test bash builtins
+    rm testing/test_argcomplete.py
+  '';
 
-    preCheck = ''
-      # don't test bash builtins
-      rm testing/test_argcomplete.py
-    '';
-
-    src = fetchPypi {
-      inherit pname version sha256;
-    };
-
-    checkInputs = [ hypothesis mock ];
-    buildInputs = [ setuptools_scm ];
-    propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites]
-      ++ stdenv.lib.optionals (!isPy3k) [ funcsigs ]
-      ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];
-
-    checkPhase = ''
-      runHook preCheck
-      $out/bin/py.test -x testing/
-      runHook postCheck
-    '';
-
-    # Remove .pytest_cache when using py.test in a Nix build
-    setupHook = writeText "pytest-hook" ''
-      pytestcachePhase() {
-          find $out -name .pytest_cache -type d -exec rm -rf {} +
-      }
-
-      preDistPhases+=" pytestcachePhase"
-    '';
-
-    meta = with stdenv.lib; {
-      homepage = https://docs.pytest.org;
-      description = "Framework for writing tests";
-      maintainers = with maintainers; [ domenkozar lovek323 madjar lsix ];
-      license = licenses.mit;
-      platforms = platforms.unix;
-    };
-  };
-
-in {
-  pytest_39 = generic {
-    version = "3.9.3";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "a9e5e8d7ab9d5b0747f37740276eb362e6a76275d76cebbb52c6049d93b475db";
   };
 
-  pytest_37 = generic {
-    version = "3.7.4";
-    sha256 = "2d7c49e931316cc7d1638a3e5f54f5d7b4e5225972b3c9838f3584788d27f349";
+  checkInputs = [ hypothesis mock ];
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites]
+    ++ stdenv.lib.optionals (!isPy3k) [ funcsigs ]
+    ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];
+
+  checkPhase = ''
+    runHook preCheck
+    $out/bin/py.test -x testing/
+    runHook postCheck
+  '';
+
+  # Remove .pytest_cache when using py.test in a Nix build
+  setupHook = writeText "pytest-hook" ''
+    pytestcachePhase() {
+        find $out -name .pytest_cache -type d -exec rm -rf {} +
+    }
+
+    preDistPhases+=" pytestcachePhase"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://docs.pytest.org;
+    description = "Framework for writing tests";
+    maintainers = with maintainers; [ domenkozar lovek323 madjar lsix ];
+    license = licenses.mit;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1440,10 +1440,10 @@ in {
 
   pytest = self.pytest_39;
 
-  inherit (callPackage ../development/python-modules/pytest {
+  pytest_39 = callPackage ../development/python-modules/pytest {
     # hypothesis tests require pytest that causes dependency cycle
     hypothesis = self.hypothesis.override { doCheck = false; };
-  }) pytest_39 pytest_37;
+  };
 
   pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
 


### PR DESCRIPTION
###### Motivation for this change
This reverts commit eb2d56cb275672a0ccb8667e22e68cfe162a9b4e
since python.pkgs.pytest_37 is no longer used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

