### PR TITLE
b612: init at 2019-01-21

### DIFF
--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit }:
+stdenv.mkDerivation {
+  name = "b612-font-2019-01-21";
+
+  src = fetchgit {
+    url = "git://git.polarsys.org/gitroot/b612/b612.git";
+    rev = "bd14fde2544566e620eab106eb8d6f2b7fb1347e";
+    sha256 = "1w1w9za599w3asmdkhng9amb9w0riq6mg400p43w1qnj0zqazy3d";
+  };
+
+  buildPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts
+    cp ./TTF/*.ttf $out/share/fonts
+  '';
+
+  meta = {
+    description = "a highly legible open source font family designed and tested to be used on aircraft cockpit screens";
+    homepage = "http://b612-font.com/";
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.epl10;
+    maintainers = [ stdenv.lib.maintainers.grahamc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15395,6 +15395,8 @@ in
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };
 
+  b612 = callPackage ../data/fonts/b612 { };
+
   babelstone-han = callPackage ../data/fonts/babelstone-han { };
 
   baekmuk-ttf = callPackage ../data/fonts/baekmuk-ttf { };


### PR DESCRIPTION
###### Motivation for this change

Package the font b612.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

