### PR TITLE
b612-font: init at 1.003

### DIFF
--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchzip, lib }:
+
+let
+  version = "1.003";
+  pname = "b612";
+in
+
+fetchzip rec {
+  name = "${pname}-font-${version}";
+  url = "http://git.polarsys.org/c/${pname}/${pname}.git/snapshot/${pname}-bd14fde2544566e620eab106eb8d6f2b7fb1347e.zip";
+  sha256 = "07gadk9b975k69pgw9gj54qx8d5xvxphid7wrmv4cna52jyy4464";
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype/${pname}
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://b612-font.com/;
+    description = "Highly legible font family for use on aircraft cockpit screens";
+    longDescription = ''
+      B612 is the result of a research project initiated by Airbus. The font
+      was designed by Nicolas Chauveau and Thomas Paillot (intactile DESIGN) with the
+      support of Jean‑Luc Vinot (ENAC). Prior research by Jean‑Luc Vinot (DGAC/DSNA)
+      and Sylvie Athènes (Université de Toulouse III). The challenge for the
+      "Aeronautical Font" was to improve the display of information on the cockpit
+      screens, in particular in terms of legibility and comfort of reading, and to
+      optimize the overall homogeneity of the cockpit.
+
+      Intactile DESIGN was hired to work on the design of eight typographic
+      variants of the font. This one, baptized B612 in reference to the
+      imaginary asteroid of the aviator Saint‑Exupéry, benefited from a complete
+      hinting on all the characters.
+      '';
+    license = with licenses; [ ofl epl10 bsd3 ] ;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15405,6 +15405,8 @@ in
 
   aurulent-sans = callPackage ../data/fonts/aurulent-sans { };
 
+  b612  = callPackage ../data/fonts/b612 { };
+
   babelstone-han = callPackage ../data/fonts/babelstone-han { };
 
   baekmuk-ttf = callPackage ../data/fonts/baekmuk-ttf { };


### PR DESCRIPTION
###### Motivation for this change

Interesting screen font for critical environments. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

