### PR TITLE
openssl_1_1: use the same default CA path as 1.0.*

### DIFF
--- a/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs-darwin.patch
+++ b/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs-darwin.patch
@@ -1,0 +1,13 @@
+diff --git a/include/internal/cryptlib.h b/include/internal/cryptlib.h
+index 329ef62..9a8df64 100644
+--- a/include/internal/cryptlib.h
++++ b/include/internal/cryptlib.h
+@@ -56,7 +56,7 @@ DEFINE_LHASH_OF(MEM);
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+ #  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_FILE          "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
+ # else

--- a/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs.patch
+++ b/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs.patch
@@ -1,0 +1,13 @@
+diff --git a/include/internal/cryptlib.h b/include/internal/cryptlib.h
+index 329ef62..9a8df64 100644
+--- a/include/internal/cryptlib.h
++++ b/include/internal/cryptlib.h
+@@ -56,7 +56,7 @@ DEFINE_LHASH_OF(MEM);
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+ #  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_FILE          "/etc/ssl/certs/ca-certificates.crt"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
+ # else

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -134,7 +134,13 @@ in {
   openssl_1_1 = common {
     version = "1.1.1a";
     sha256 = "0hcz7znzznbibpy3iyyhvlqrq44y88plxwdj32wjzgbwic7i687w";
-    patches = [ ./1.1/nix-ssl-cert-file.patch ];
+    patches = [
+      ./1.1/nix-ssl-cert-file.patch
+
+      (if stdenv.hostPlatform.isDarwin
+       then ./1.1/use-etc-ssl-certs-darwin.patch
+       else ./1.1/use-etc-ssl-certs.patch)
+    ];
     withDocs = true;
   };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/54437

###### Motivation for this change

I can't see any motivation for the difference.

It actually seems like Robin wanted to try a higher version quickly without dealing with the non-applying patch, and later noone noticed it was dropped.  Still, I may be missing something; e.g. it amazes me how long this has gone without being noticed (?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of ~all~ **some** binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

TODO: perhaps deduplicate the 2x2 patches somehow?