### PR TITLE
kde-applications: 18.12.0 -> 18.12.1

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.12.0/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/applications/18.12.1/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1723 +3,1723 @@
 
 {
   akonadi = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-18.12.0.tar.xz";
-      sha256 = "1c3frrfkcpr01684c1fkrwxbnzb7ipvwncm0jf5nb4d0waiv8q08";
-      name = "akonadi-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-18.12.1.tar.xz";
+      sha256 = "141j1wicfl8lgwdgs8yh0mcs4gw004wz8ck21pz55xc1mi4yh9cx";
+      name = "akonadi-18.12.1.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-calendar-18.12.0.tar.xz";
-      sha256 = "0amp79x3jwib7f0a8ksv96prb1mhfhpp475k09ryz7c054lmj1ys";
-      name = "akonadi-calendar-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-calendar-18.12.1.tar.xz";
+      sha256 = "108ax9bpng5qp3cbn3f2x096l9jsv0x3d8xckcfvd4a3svgap1ri";
+      name = "akonadi-calendar-18.12.1.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-calendar-tools-18.12.0.tar.xz";
-      sha256 = "0w2ng8lfy3cib49c0warqh0k43q17bfmkq3g4rjkwri9cqdqrahp";
-      name = "akonadi-calendar-tools-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-calendar-tools-18.12.1.tar.xz";
+      sha256 = "0a54jka0szi3d2dv4kr7s78lbm1sx6a47mccjzc2rp1w2x8dkagl";
+      name = "akonadi-calendar-tools-18.12.1.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadiconsole-18.12.0.tar.xz";
-      sha256 = "1qg889g1a1c5iwvwdwz8ygkj59v46yfk5cwpkf8q1jldjdxkrib5";
-      name = "akonadiconsole-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadiconsole-18.12.1.tar.xz";
+      sha256 = "06mhpk66ck37k6bfi83cmnjv39lwvm245m0climh1idfi6mn08wk";
+      name = "akonadiconsole-18.12.1.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-contacts-18.12.0.tar.xz";
-      sha256 = "0cn50nyrahb6pzshd35pc0issgiwg0r7j96xkmaxdigg9agjz9rn";
-      name = "akonadi-contacts-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-contacts-18.12.1.tar.xz";
+      sha256 = "1lnqq2qalvzq6g4dwfnlgvrz9wpnl4g64is8ylrb6jf4bvfg3kvq";
+      name = "akonadi-contacts-18.12.1.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-import-wizard-18.12.0.tar.xz";
-      sha256 = "1s477z6vb9qqz4q8bwprznn11fjjq0a6xfdmif6x0z30qrddllfd";
-      name = "akonadi-import-wizard-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-import-wizard-18.12.1.tar.xz";
+      sha256 = "09r5nspv1l8i1ipjxn5xwi6swkggy10hsa8p5bj0qqclsf17ip5j";
+      name = "akonadi-import-wizard-18.12.1.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-mime-18.12.0.tar.xz";
-      sha256 = "1w974gn81gyrp3m5r2l8jx7xrq610mhmmn005wqfl7ac1n3s65ln";
-      name = "akonadi-mime-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-mime-18.12.1.tar.xz";
+      sha256 = "0fyxls0qhvqcbhpw17vhr8m4h94s2d69c8bpf45k19f005gbb6dk";
+      name = "akonadi-mime-18.12.1.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-notes-18.12.0.tar.xz";
-      sha256 = "0b233nw7jcr4dnlfnnymwrm9my47a4mdmdbp9qsp2rmlzwddplvw";
-      name = "akonadi-notes-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-notes-18.12.1.tar.xz";
+      sha256 = "1m2v3qj06pbpdncxcb37131q6xhbsrwp6qv72rmlwlj0cj7xyfl4";
+      name = "akonadi-notes-18.12.1.tar.xz";
     };
   };
   akonadi-search = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akonadi-search-18.12.0.tar.xz";
-      sha256 = "1kg8q5jkzcc4vndc8l2q7hvkjkdw2v5500pjw8pszwifzmi5klln";
-      name = "akonadi-search-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akonadi-search-18.12.1.tar.xz";
+      sha256 = "1wwv92kmk4kwr8dj7y34nb2337s80hwnjblnfz4kl3z3ka782gd6";
+      name = "akonadi-search-18.12.1.tar.xz";
     };
   };
   akregator = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/akregator-18.12.0.tar.xz";
-      sha256 = "03968pcpvggn19721x89wn7d1n757xdk22f4rvxqq4d6qqh2myhd";
-      name = "akregator-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/akregator-18.12.1.tar.xz";
+      sha256 = "0zjc6vgf5pdbmj7b3kl15aqkamg5slaxd5n4092pf7nf3v3r74r9";
+      name = "akregator-18.12.1.tar.xz";
     };
   };
   analitza = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/analitza-18.12.0.tar.xz";
-      sha256 = "0g8iz69cq2gc0qsraaqji8h7z1wcqq1baic4x7158q3xkrc7hg1f";
-      name = "analitza-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/analitza-18.12.1.tar.xz";
+      sha256 = "0iwlkxcqj62l25ldpa325ymkvhim2mm152h3jqh3z1sc683hc1kv";
+      name = "analitza-18.12.1.tar.xz";
     };
   };
   ark = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ark-18.12.0.tar.xz";
-      sha256 = "16nmi8a9j4s00m4dnh4l7kcz1vjaqpcq1ilr0iv6wglpn3sycl1g";
-      name = "ark-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ark-18.12.1.tar.xz";
+      sha256 = "1pcaaq8qdj3w15f0zqfwy7xwknpmb70yc7g4nmj4p48ahq5s2r86";
+      name = "ark-18.12.1.tar.xz";
     };
   };
   artikulate = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/artikulate-18.12.0.tar.xz";
-      sha256 = "187qwl9adrggbkf6dyw12pmmxxxbjcp2swxbyvmqx10dca2pgbgn";
-      name = "artikulate-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/artikulate-18.12.1.tar.xz";
+      sha256 = "17msfgq83iy5dfl5qkmj4f89aa2gbk7p00f7bwiz2fnlg642wyq1";
+      name = "artikulate-18.12.1.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/audiocd-kio-18.12.0.tar.xz";
-      sha256 = "044ksczgc5k6ai1inmxqpibvcigjvxbqpf6n6irgl1jgavmxdpim";
-      name = "audiocd-kio-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/audiocd-kio-18.12.1.tar.xz";
+      sha256 = "0kv03d2w0vf9fpp89ymnkizzyhckz9pjj8fcqwbacb78k6p52g6p";
+      name = "audiocd-kio-18.12.1.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/baloo-widgets-18.12.0.tar.xz";
-      sha256 = "1sq70l529dg2ww8pcksnbbmgh1wi1baj69adakqiacxi5v893clg";
-      name = "baloo-widgets-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/baloo-widgets-18.12.1.tar.xz";
+      sha256 = "0axgx1zrbaki20vh9j9bd0h3qvn0ws4cza8smlgvlzx7fkbidmw3";
+      name = "baloo-widgets-18.12.1.tar.xz";
     };
   };
   blinken = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/blinken-18.12.0.tar.xz";
-      sha256 = "1dnp14g20a7gqy3zcysa7pxrj38zqxhgpyd4nxpdj6lzjgh2p7hx";
-      name = "blinken-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/blinken-18.12.1.tar.xz";
+      sha256 = "0ka47snqj1xwf8m1qqa1vxgjwm151dzlk22zg07yh987qgc6fbj2";
+      name = "blinken-18.12.1.tar.xz";
     };
   };
   bomber = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/bomber-18.12.0.tar.xz";
-      sha256 = "1vjvajbra1m4zjbijn1nxj5x66hyv8q65874b3ajshb3lmv7rklj";
-      name = "bomber-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/bomber-18.12.1.tar.xz";
+      sha256 = "0a5vvb2ka08lyvybr12gm3lfgvfj3r99kqw1prhr9n97w7f8yc1d";
+      name = "bomber-18.12.1.tar.xz";
     };
   };
   bovo = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/bovo-18.12.0.tar.xz";
-      sha256 = "1fslwk3zbxi16b1m7w7rbf8bgdhflnqrd6k90lpbwvlnxy6839iw";
-      name = "bovo-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/bovo-18.12.1.tar.xz";
+      sha256 = "19w4xfqx6bxs8fr8vkma57ibl5b1jdqfjax240fg81qyqzkx4xsp";
+      name = "bovo-18.12.1.tar.xz";
     };
   };
   calendarsupport = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/calendarsupport-18.12.0.tar.xz";
-      sha256 = "180qzjlx0y4cfasmrf06ah8jdckbym1wrbmqlpyzjfy55mkwyf40";
-      name = "calendarsupport-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/calendarsupport-18.12.1.tar.xz";
+      sha256 = "0hpq85wh94dlmrfabh1k76xdc9xqavfccjnfy20i71q2ml92gx4p";
+      name = "calendarsupport-18.12.1.tar.xz";
     };
   };
   cantor = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/cantor-18.12.0.tar.xz";
-      sha256 = "0isddvdd8gvaasigyj3njyl7ckcqc8ciqp82awlland3avll6rby";
-      name = "cantor-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/cantor-18.12.1.tar.xz";
+      sha256 = "132zlpcqkbjdb1vrcy6innf6qmxlqibzpf0bgdi33q797vw63drc";
+      name = "cantor-18.12.1.tar.xz";
     };
   };
   cervisia = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/cervisia-18.12.0.tar.xz";
-      sha256 = "1r55zjfvlh5by9cv6pzcsbz71igbjr1pvyiyjkdhc36sbaiv0r3x";
-      name = "cervisia-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/cervisia-18.12.1.tar.xz";
+      sha256 = "02ka1crhkb3dka3qp82vs624fz3hcwydm559x5dq0cdbibdmhqx7";
+      name = "cervisia-18.12.1.tar.xz";
     };
   };
   dolphin = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/dolphin-18.12.0.tar.xz";
-      sha256 = "10mzdk9i5x4kmsrpamm5q9ihy8ymii9w3iaccd7fgw4yy11qlzw3";
-      name = "dolphin-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/dolphin-18.12.1.tar.xz";
+      sha256 = "1d3m2h8czxqmgpd060lnj05f0r4bqirqibvbakrl1sv2xxafz8qq";
+      name = "dolphin-18.12.1.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/dolphin-plugins-18.12.0.tar.xz";
-      sha256 = "07pkslxhawl03030zjy889zjbym13d94nllg9fxvmd3402y2djiw";
-      name = "dolphin-plugins-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/dolphin-plugins-18.12.1.tar.xz";
+      sha256 = "0j2cj91732p2wh0g73xxjghbbivlva4mr91vdjrp6dkc4b2vjxh8";
+      name = "dolphin-plugins-18.12.1.tar.xz";
     };
   };
   dragon = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/dragon-18.12.0.tar.xz";
-      sha256 = "0j3d8a97ymh9lm6al0vv3abxalfw3wnf689i3mzkg7bdqkaaxz24";
-      name = "dragon-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/dragon-18.12.1.tar.xz";
+      sha256 = "0ffxpl30xdm5vgrfc6b1k2gzfp3jwakn6my4zq0zfrrlf75hbgkm";
+      name = "dragon-18.12.1.tar.xz";
     };
   };
   eventviews = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/eventviews-18.12.0.tar.xz";
-      sha256 = "0r3y3z8zzzs1154wqi16kwb7vjijphscsnna76hpxcllw23cnb7v";
-      name = "eventviews-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/eventviews-18.12.1.tar.xz";
+      sha256 = "0qvndqj8jhrn9p1g4d4p3l54d7hz9zzkkg92yfjcajcrnl2i0fn1";
+      name = "eventviews-18.12.1.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ffmpegthumbs-18.12.0.tar.xz";
-      sha256 = "0wwrhj6xblz96g1rpqds4m0savp9n08w1xlwlhrm9xq81kajpw5x";
-      name = "ffmpegthumbs-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ffmpegthumbs-18.12.1.tar.xz";
+      sha256 = "0j9vwqgsb9pz8hpacsmm4pxss25q7622fr7gq1n2dxf19f1zwxki";
+      name = "ffmpegthumbs-18.12.1.tar.xz";
     };
   };
   filelight = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/filelight-18.12.0.tar.xz";
-      sha256 = "1vayrsgs5q1ky34kx5a8fi198b57478w68641xwhxmzwllssd9sx";
-      name = "filelight-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/filelight-18.12.1.tar.xz";
+      sha256 = "1p9k1ajyjlb001mz8w8jli3ha84z91sc43721xdpngcshz7i8i6f";
+      name = "filelight-18.12.1.tar.xz";
     };
   };
   granatier = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/granatier-18.12.0.tar.xz";
-      sha256 = "145z4h7vwmg2zlvncp5dijm06m1d0z20hlmlz2zd69nfvs8w1lmz";
-      name = "granatier-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/granatier-18.12.1.tar.xz";
+      sha256 = "02lmap2axki56d3kfhmx7h6ibqjnx5ga73vsvvx1w4fjikgzm2rn";
+      name = "granatier-18.12.1.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/grantlee-editor-18.12.0.tar.xz";
-      sha256 = "0h5hcsnkh8gkqcnn620zs4kni5k8cpr65nbkkxybgxjf3kljapin";
-      name = "grantlee-editor-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/grantlee-editor-18.12.1.tar.xz";
+      sha256 = "0r85wirr4dcvja5cynjb0n51lmlijkffg35czqpjvnf2xv1claj4";
+      name = "grantlee-editor-18.12.1.tar.xz";
     };
   };
   grantleetheme = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/grantleetheme-18.12.0.tar.xz";
-      sha256 = "1k5q30viyvwx4c8nl5gxk2sqxd9l703n6fnxw5dz5q7hzsxykzzx";
-      name = "grantleetheme-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/grantleetheme-18.12.1.tar.xz";
+      sha256 = "1c4n27abzpynh6nykfw9z2rhxlmmicvvw0081gsm9h7w1r8n4flc";
+      name = "grantleetheme-18.12.1.tar.xz";
     };
   };
   gwenview = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/gwenview-18.12.0.tar.xz";
-      sha256 = "1p9g6q5bfaxbk60k91wbjhbv0wwzin5ai3hyasl7rg3c6hisp2rf";
-      name = "gwenview-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/gwenview-18.12.1.tar.xz";
+      sha256 = "01iraiynpsacp8hnmdc9cxlk6qakbbypdck939kcij6j7gm5l2fm";
+      name = "gwenview-18.12.1.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/incidenceeditor-18.12.0.tar.xz";
-      sha256 = "0f313zw1n4dgaianmxnmd5d5bqad40izli20ab08lqhv9d03sdkh";
-      name = "incidenceeditor-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/incidenceeditor-18.12.1.tar.xz";
+      sha256 = "1h1da8vg9x450hm9g936rms6n9d5ddqdl7jrwah3khbzihjpkgvz";
+      name = "incidenceeditor-18.12.1.tar.xz";
     };
   };
   juk = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/juk-18.12.0.tar.xz";
-      sha256 = "1jsxvcqpj87n6yv2v0a7rvmg832ayrk0fknmch04gc8bkb7w52az";
-      name = "juk-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/juk-18.12.1.tar.xz";
+      sha256 = "14zlpac1z3gaym83d5vmr7vvqwdzxhfscydwb2qv4ng947lrrs1n";
+      name = "juk-18.12.1.tar.xz";
     };
   };
   k3b = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/k3b-18.12.0.tar.xz";
-      sha256 = "1fmy94cda1nsqv5g4w3bnypx9c8ngrndbzf6l7l2pv5q889p73x1";
-      name = "k3b-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/k3b-18.12.1.tar.xz";
+      sha256 = "1f5l8jyi30qm225nxp0sahm7lwdk9r2gqzbdrrzhadx6gfm80a4s";
+      name = "k3b-18.12.1.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kaccounts-integration-18.12.0.tar.xz";
-      sha256 = "1wyjd7iv0z8q9adbgnkvwmz4zrhrz3wgkz0lp52i8j0511xby93r";
-      name = "kaccounts-integration-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kaccounts-integration-18.12.1.tar.xz";
+      sha256 = "1mb9rfp7vw9bkndlbwh5ayd9m3znwrl1i6kr0s5872sscmhx2giz";
+      name = "kaccounts-integration-18.12.1.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kaccounts-providers-18.12.0.tar.xz";
-      sha256 = "03kjjshbxgj1mj8vv60rbssn3kdf3gx9kqmgsbbwybxg46277w1r";
-      name = "kaccounts-providers-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kaccounts-providers-18.12.1.tar.xz";
+      sha256 = "0pjk7wsqbgibx8racd4qikv3i1j4iqgnbp81mm5nss7hilrnv1vi";
+      name = "kaccounts-providers-18.12.1.tar.xz";
     };
   };
   kaddressbook = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kaddressbook-18.12.0.tar.xz";
-      sha256 = "0dfmwn6swa6m11ih52aj2r8zfma6jffy8gsqhaph4xg4ba58nmpj";
-      name = "kaddressbook-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kaddressbook-18.12.1.tar.xz";
+      sha256 = "0n4abjcq2iana9xyzkghgrs6h9nr0k2vxqrxghnh5iqahn2766ak";
+      name = "kaddressbook-18.12.1.tar.xz";
     };
   };
   kajongg = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kajongg-18.12.0.tar.xz";
-      sha256 = "0k9nxcr2fpkrmckzc5fxani4l304fxj7kp80y2nrv1p5cagn2x7l";
-      name = "kajongg-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kajongg-18.12.1.tar.xz";
+      sha256 = "11c1iyfwqjqihyb3lqvnrb9jsrah0wl1kbrbm2lbmaqf0qnqqr8a";
+      name = "kajongg-18.12.1.tar.xz";
     };
   };
   kalarm = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kalarm-18.12.0.tar.xz";
-      sha256 = "1cmk6l8450sz3rfdk25p9dn26zcbhcrdwz9v242cpsndyvnl13i2";
-      name = "kalarm-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kalarm-18.12.1.tar.xz";
+      sha256 = "1z2rf30ad2rlkcc9ki09pkrvdd8b9f60vsjzvsqfgxx8i87z1lil";
+      name = "kalarm-18.12.1.tar.xz";
     };
   };
   kalarmcal = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kalarmcal-18.12.0.tar.xz";
-      sha256 = "0l90yxfkjwybff80z7zhgx4sbw7xz8nx0acg56avgrkh3230fv3i";
-      name = "kalarmcal-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kalarmcal-18.12.1.tar.xz";
+      sha256 = "0wykbg24llympx7m9bkf4aciv6pli359nnnzpli7rh4q58vbnfn7";
+      name = "kalarmcal-18.12.1.tar.xz";
     };
   };
   kalgebra = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kalgebra-18.12.0.tar.xz";
-      sha256 = "0hc3k4zm50n39nvw6fki6997vzz56fwjkn61q48fkbzd4jvcfqni";
-      name = "kalgebra-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kalgebra-18.12.1.tar.xz";
+      sha256 = "09g4v4f2xlilqrf2aqsz7zbjqnnrndhhlkkwbrypn148gdnxngs4";
+      name = "kalgebra-18.12.1.tar.xz";
     };
   };
   kalzium = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kalzium-18.12.0.tar.xz";
-      sha256 = "0j3a3r1j4vc0ssdw60lvgkdwmh02zz07xakdgxr5jrys4fix23ci";
-      name = "kalzium-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kalzium-18.12.1.tar.xz";
+      sha256 = "1c5li3dhrfiw7kpjv6kfby2c2pq22sraqb3vc0s4nz1h9jnjcah7";
+      name = "kalzium-18.12.1.tar.xz";
     };
   };
   kamera = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kamera-18.12.0.tar.xz";
-      sha256 = "098gg2v8bina5famp2bk0x8dakzz66zd0dxh8vjczjycvzac6hzd";
-      name = "kamera-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kamera-18.12.1.tar.xz";
+      sha256 = "177lgyhc5klrpssbk2bsdwmg5hnk92mbjwb7s39kl9h53kw0jmzj";
+      name = "kamera-18.12.1.tar.xz";
     };
   };
   kamoso = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kamoso-18.12.0.tar.xz";
-      sha256 = "0f4hvbw216xmyavgakvydplcspqcyv1v9bv0pqvwdk1swk1jp0r3";
-      name = "kamoso-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kamoso-18.12.1.tar.xz";
+      sha256 = "1j467cpga2shvibwx3df4vxksfkp5q1hp6az8kcky6gljcmxy06p";
+      name = "kamoso-18.12.1.tar.xz";
     };
   };
   kanagram = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kanagram-18.12.0.tar.xz";
-      sha256 = "1xbb04i06qrffb6pxk05ksn8h1n08r9pyaf9nkhrymgv90l62739";
-      name = "kanagram-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kanagram-18.12.1.tar.xz";
+      sha256 = "0ybn3aal51p29g28daalwmpm85306ivgl8rkxhccq7pzfwaww1bx";
+      name = "kanagram-18.12.1.tar.xz";
     };
   };
   kapman = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kapman-18.12.0.tar.xz";
-      sha256 = "0shq8bjfixjx9gqid27cgiybx0anwgbm69gsrvlczmragswcqxwi";
-      name = "kapman-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kapman-18.12.1.tar.xz";
+      sha256 = "117fkqhn0mg3z14sl64vmkz26rclfrjarf7kvxicvbw0x8s3vsgj";
+      name = "kapman-18.12.1.tar.xz";
     };
   };
   kapptemplate = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kapptemplate-18.12.0.tar.xz";
-      sha256 = "18q7lxkfim41lhzqwvv4ir2c45fhf9pxxajfwibg9a462b1jxk4a";
-      name = "kapptemplate-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kapptemplate-18.12.1.tar.xz";
+      sha256 = "1q52d30zz1ip6x8z56i25ll8hgzd6fp4pckfgr6byh82ymck8kxa";
+      name = "kapptemplate-18.12.1.tar.xz";
     };
   };
   kate = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kate-18.12.0.tar.xz";
-      sha256 = "15k66vipm1lqcmk73a44niz1279rkab3g23p9jqyvvbw41j1368l";
-      name = "kate-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kate-18.12.1.tar.xz";
+      sha256 = "0p9j9r2ffqh6p5pdxhk1pi8km1ypdsjs1h0g4ncnzwpvkir1rhk7";
+      name = "kate-18.12.1.tar.xz";
     };
   };
   katomic = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/katomic-18.12.0.tar.xz";
-      sha256 = "183pgb7pphzmi3lgza4lm5crzf9rs6l2d6fl1xwzvvb3ik77ccqz";
-      name = "katomic-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/katomic-18.12.1.tar.xz";
+      sha256 = "0pxj8vgx3ijvyznn5gvhv2scwbqhaqc2pmq2897b190vsx9mvkh6";
+      name = "katomic-18.12.1.tar.xz";
     };
   };
   kbackup = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kbackup-18.12.0.tar.xz";
-      sha256 = "1qwrgrrd408y7ipqfhajqfwcicn7pb32akvbls3rby17b2nwn16x";
-      name = "kbackup-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kbackup-18.12.1.tar.xz";
+      sha256 = "0x42d7zssddhxdsx7vpvk4630c69pvllpfz40dqk2n3hghx9xvsw";
+      name = "kbackup-18.12.1.tar.xz";
     };
   };
   kblackbox = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kblackbox-18.12.0.tar.xz";
-      sha256 = "0hx5bd97k1k4hdyal6g7r7y1xk70sf0779vxfqnin1dpzhgnq2dq";
-      name = "kblackbox-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kblackbox-18.12.1.tar.xz";
+      sha256 = "1wlwdfh23h175gsflmfmr63myds9vz3cs5dp8gr2zlxssdhc2s1p";
+      name = "kblackbox-18.12.1.tar.xz";
     };
   };
   kblocks = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kblocks-18.12.0.tar.xz";
-      sha256 = "0f0mapx67gxiy5s9k60qhgc9sfr21hwy62wzdiw4ssbxfhhqv7fa";
-      name = "kblocks-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kblocks-18.12.1.tar.xz";
+      sha256 = "1fzsyr8g536k54j3lgqr52a1cmcdmv85z11afhkz2186smnc63pa";
+      name = "kblocks-18.12.1.tar.xz";
     };
   };
   kblog = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kblog-18.12.0.tar.xz";
-      sha256 = "1slrwablxhsjzl3vj714rzm7rp59vnd9d0ri0k7yvc1ykc4aj8v6";
-      name = "kblog-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kblog-18.12.1.tar.xz";
+      sha256 = "0zdqjgan05049md0483l4c27gfwqdzmmx7wv3bziy91kd9bmfv0x";
+      name = "kblog-18.12.1.tar.xz";
     };
   };
   kbounce = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kbounce-18.12.0.tar.xz";
-      sha256 = "1r5rhlra9p89wn4mmjn81v7lgh78k53xfzhr0sz08dhg7qk2rb48";
-      name = "kbounce-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kbounce-18.12.1.tar.xz";
+      sha256 = "1209x02jip17n63ilvbi5knz4584k16c6zbrp8rg982qcabny355";
+      name = "kbounce-18.12.1.tar.xz";
     };
   };
   kbreakout = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kbreakout-18.12.0.tar.xz";
-      sha256 = "0bw84bl2r9am69zv0ik1rhqwcjzazfzwnwjg0zqzzwlyhww0ya5f";
-      name = "kbreakout-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kbreakout-18.12.1.tar.xz";
+      sha256 = "0myh4qncrvm2kd2gwvl7v2078cvv66czl9zsiava8lzq588wddwq";
+      name = "kbreakout-18.12.1.tar.xz";
     };
   };
   kbruch = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kbruch-18.12.0.tar.xz";
-      sha256 = "156varmig28a3swk099k2c2l0hn8kbr1khz5cd9c9wdy46ln6w8n";
-      name = "kbruch-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kbruch-18.12.1.tar.xz";
+      sha256 = "0jlq08c6zjmdalhbgh2fy5qghj65l12jn7wvr0j2h0s6fqck1djh";
+      name = "kbruch-18.12.1.tar.xz";
     };
   };
   kcachegrind = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcachegrind-18.12.0.tar.xz";
-      sha256 = "1jvpn2ly2pn9pnv6zx7i8z0zn91lb2kf6q9linqmpag47qbg0p7y";
-      name = "kcachegrind-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcachegrind-18.12.1.tar.xz";
+      sha256 = "0w7fdsflqmkisap6mr805b6knf83nrjrr6bxi1snrl43ipy5ls29";
+      name = "kcachegrind-18.12.1.tar.xz";
     };
   };
   kcalc = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcalc-18.12.0.tar.xz";
-      sha256 = "15wdyv5sgnd9amar41k14mgyz8p4d1aba0kw7gphzl7c9gms0y70";
-      name = "kcalc-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcalc-18.12.1.tar.xz";
+      sha256 = "0ffafikh53yfwrsaiyxr4qxy01v8lv02y4xvj56qmhi429j9ax93";
+      name = "kcalc-18.12.1.tar.xz";
     };
   };
   kcalcore = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcalcore-18.12.0.tar.xz";
-      sha256 = "04y7bdrdcbz98waydi9r5hw25mdzy8a0pzzdsmp2ky2lj4shph4h";
-      name = "kcalcore-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcalcore-18.12.1.tar.xz";
+      sha256 = "1383zmpw8nzx1fs3d55k38f3znbdc7rs21yrka6fmymgh5c3jkki";
+      name = "kcalcore-18.12.1.tar.xz";
     };
   };
   kcalutils = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcalutils-18.12.0.tar.xz";
-      sha256 = "1w10np6g02f3hh3bn3zksbj335mrzy0a5wg4lk2hny06rakk0hh0";
-      name = "kcalutils-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcalutils-18.12.1.tar.xz";
+      sha256 = "0w6kc39j3m5db8s47q4wh4wm0szl9vwr455i26d99vv8jay6mbpp";
+      name = "kcalutils-18.12.1.tar.xz";
     };
   };
   kcharselect = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcharselect-18.12.0.tar.xz";
-      sha256 = "0s4yqylc5jhgl7s3cs8gf8bb4r7n8nhxhl502sbnamss11lx7gqw";
-      name = "kcharselect-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcharselect-18.12.1.tar.xz";
+      sha256 = "1p4ap7vs1nd9gr4z71h6cx6fz99k1lliz28ibbky9a60wvnlfim6";
+      name = "kcharselect-18.12.1.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcolorchooser-18.12.0.tar.xz";
-      sha256 = "0za9isapgmbafmn5v6fwdw1vaafszwnia1iim9k4ga7bs9aakfhb";
-      name = "kcolorchooser-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcolorchooser-18.12.1.tar.xz";
+      sha256 = "1lhnnywpfb4v1hwlc8h71lrvb145pc7wcaz7f7wf2kyh5pjkfbzn";
+      name = "kcolorchooser-18.12.1.tar.xz";
     };
   };
   kcontacts = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcontacts-18.12.0.tar.xz";
-      sha256 = "1drp0rzhjbb9nqqjl9cmwpyqk8dgvnaw42rmn0cwla8l8qas5xs5";
-      name = "kcontacts-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcontacts-18.12.1.tar.xz";
+      sha256 = "0d32l8hhggcy6dyyps5im74k0psnxrwxa6yni5bmj8m0z7f298ba";
+      name = "kcontacts-18.12.1.tar.xz";
     };
   };
   kcron = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kcron-18.12.0.tar.xz";
-      sha256 = "02fxsnka3d3456j99nsrgvkxpjd677xl0z7hmqwsr0zx3bx0krk7";
-      name = "kcron-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kcron-18.12.1.tar.xz";
+      sha256 = "0211xs7zwii5a93827rsnp1gkay78h2hs49lvdc2kah9ccsh0kzn";
+      name = "kcron-18.12.1.tar.xz";
     };
   };
   kdav = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdav-18.12.0.tar.xz";
-      sha256 = "0fbw65yiskygbhhagsc48yrhdslg951fd13b6mzwf2ab55fw6vmf";
-      name = "kdav-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdav-18.12.1.tar.xz";
+      sha256 = "0kr07p4gnxyzrgnbj7vkh93wmqwnvv8sc06i2yardr8qp6jhpg77";
+      name = "kdav-18.12.1.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdebugsettings-18.12.0.tar.xz";
-      sha256 = "1gdrc1x5bavdi6ljqv5wh1hwvys1r2v00xi555dfyijjryr7kd27";
-      name = "kdebugsettings-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdebugsettings-18.12.1.tar.xz";
+      sha256 = "1wbi0f82dwd7a8s6szg0yc2mraiinng9a5wjw8xjacgkyyjpqbr3";
+      name = "kdebugsettings-18.12.1.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kde-dev-scripts-18.12.0.tar.xz";
-      sha256 = "03wmki422lw1r5i51gh17ha3w2gpdjv4ix7bndjakwq315iivlxi";
-      name = "kde-dev-scripts-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kde-dev-scripts-18.12.1.tar.xz";
+      sha256 = "1k0xjlwpmdl2qpj4x04q9x299wmva2ds4y2wpayah865knvx91j3";
+      name = "kde-dev-scripts-18.12.1.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kde-dev-utils-18.12.0.tar.xz";
-      sha256 = "0x2ji7jd12b1blww2jz0709yl79pb3slglx7mp4yyfi66c5ngl1q";
-      name = "kde-dev-utils-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kde-dev-utils-18.12.1.tar.xz";
+      sha256 = "06k01z2ljkcsdzz4zsdp8hr3flss552h0jgy25qv7y1izggk05dj";
+      name = "kde-dev-utils-18.12.1.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdeedu-data-18.12.0.tar.xz";
-      sha256 = "1p3rjsdhf4hy9468515vkbihkj69s2gpz6fxk3rqvi03ksmpdi5x";
-      name = "kdeedu-data-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdeedu-data-18.12.1.tar.xz";
+      sha256 = "1pnjydj3g768z5zxwbfwvxvlhdbg9rscr3vd1dw4srs338lp0maq";
+      name = "kdeedu-data-18.12.1.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdegraphics-mobipocket-18.12.0.tar.xz";
-      sha256 = "05gxnbrl4p1s6mccvp0482as4r41rhqsrfd84v57sqyd93mgzsji";
-      name = "kdegraphics-mobipocket-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdegraphics-mobipocket-18.12.1.tar.xz";
+      sha256 = "1bv3981nsy61m8shlwbry9yb37218s2q1k9fas3xgv1260rjmmfq";
+      name = "kdegraphics-mobipocket-18.12.1.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdegraphics-thumbnailers-18.12.0.tar.xz";
-      sha256 = "096acsz560k238sfa54nyjydx5wlc0b92khi4ahmvaqmllzjc9p4";
-      name = "kdegraphics-thumbnailers-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdegraphics-thumbnailers-18.12.1.tar.xz";
+      sha256 = "1rz578dz6nr3m23kd4njdcx01nmjgskxlla4zqgd33gg08kppmvj";
+      name = "kdegraphics-thumbnailers-18.12.1.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdenetwork-filesharing-18.12.0.tar.xz";
-      sha256 = "183f8fir8rx7jr35gyj074k852s51gjsd2q7hp1bgkj7g5avql4i";
-      name = "kdenetwork-filesharing-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdenetwork-filesharing-18.12.1.tar.xz";
+      sha256 = "1zxkbcdndbr3sygwpiiw70pxb71hil1x8zj7lgq2yyw968ianah4";
+      name = "kdenetwork-filesharing-18.12.1.tar.xz";
     };
   };
   kdenlive = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdenlive-18.12.0.tar.xz";
-      sha256 = "0jknpfs7gql527pbj0nb1bxvhxpbk0gnyjx4g6wdhlmk87w2g0wp";
-      name = "kdenlive-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdenlive-18.12.1.tar.xz";
+      sha256 = "189p0sqlmfkaxsdiy1mh0mmskw6ha4zi64fx99w7wnbid8x52bjf";
+      name = "kdenlive-18.12.1.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdepim-addons-18.12.0.tar.xz";
-      sha256 = "0dbys45cn00xism83x2j1ypidg5dp8zv29wx18a4bga4y8mfnrkp";
-      name = "kdepim-addons-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdepim-addons-18.12.1.tar.xz";
+      sha256 = "1gz6rqg39vl2arzs64srpr7xn1syxxiznz58gdss40152gz0hlsp";
+      name = "kdepim-addons-18.12.1.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdepim-apps-libs-18.12.0.tar.xz";
-      sha256 = "18y3n602b6v1jyl18lvqalasf2v795ln31nn79ih1z4y49j1s67x";
-      name = "kdepim-apps-libs-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdepim-apps-libs-18.12.1.tar.xz";
+      sha256 = "06q306m09666jh4cx3w0bif81x424hxlvsf31wjhfzdp737xfq3i";
+      name = "kdepim-apps-libs-18.12.1.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdepim-runtime-18.12.0.tar.xz";
-      sha256 = "0vmwgbbnwipi62aciy52pdd4ygrgx3l87i5g5nspkb03wlb5jl51";
-      name = "kdepim-runtime-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdepim-runtime-18.12.1.tar.xz";
+      sha256 = "1vb9rqzyjww7lkc3g2aw43ks7is1bg1nx2mbn8wvmc7cgga66nbc";
+      name = "kdepim-runtime-18.12.1.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdesdk-kioslaves-18.12.0.tar.xz";
-      sha256 = "0ca9cwxv836jl9crqik9s1v3dgk5z9jhvzxvbcvrbalvs1cyxg8b";
-      name = "kdesdk-kioslaves-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdesdk-kioslaves-18.12.1.tar.xz";
+      sha256 = "05bds4r70ys4mygmjl5x5hcrygds57mqqmzfv79zq9hcfp2b0g69";
+      name = "kdesdk-kioslaves-18.12.1.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdesdk-thumbnailers-18.12.0.tar.xz";
-      sha256 = "1q57c5i7pnrpd7g1dwrahac9lji9ljqyb60qkj9qx3v3fnr11v7f";
-      name = "kdesdk-thumbnailers-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdesdk-thumbnailers-18.12.1.tar.xz";
+      sha256 = "1584qy2aa8q7zzgf2zxqw7p2h2l2xfgsa2mrmxaa36xaxbglcvkb";
+      name = "kdesdk-thumbnailers-18.12.1.tar.xz";
     };
   };
   kdf = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdf-18.12.0.tar.xz";
-      sha256 = "1ds4z4adyaazmhbybq2f361qq02a8l73a9g2hwcrh95w0dcisyvp";
-      name = "kdf-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdf-18.12.1.tar.xz";
+      sha256 = "0zr6k8di9fvzmgvh4s8ji81zdynpkg5yrnddlc9mgid0w9czaw11";
+      name = "kdf-18.12.1.tar.xz";
     };
   };
   kdialog = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdialog-18.12.0.tar.xz";
-      sha256 = "04v2s3wlaihcm4c64kzcxmxs9niw6ghid0vdl4pw8h0ks1s8xz0g";
-      name = "kdialog-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdialog-18.12.1.tar.xz";
+      sha256 = "0i4c2kjyp0dix12vxhj078h7vbylcqxgqx10hzwaszx3wlrycwa2";
+      name = "kdialog-18.12.1.tar.xz";
     };
   };
   kdiamond = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kdiamond-18.12.0.tar.xz";
-      sha256 = "0c11v3c7hxllg15h8mq18jl5lqprwwpnz04rjjggwzz8c4iz2kjs";
-      name = "kdiamond-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kdiamond-18.12.1.tar.xz";
+      sha256 = "0j5g1gh267q528k0947brc8nvgq81690hqp7mrf90wxg8qp4ysm4";
+      name = "kdiamond-18.12.1.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/keditbookmarks-18.12.0.tar.xz";
-      sha256 = "1ia69amq6dfidfgxq297xa10f3812spibb00wsv9dj4cp36y89mm";
-      name = "keditbookmarks-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/keditbookmarks-18.12.1.tar.xz";
+      sha256 = "0fnxmgfgnh8d6sg7g7ai53xywa22qv4pn4xxj503rjs4a3fsm3j1";
+      name = "keditbookmarks-18.12.1.tar.xz";
     };
   };
   kfind = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kfind-18.12.0.tar.xz";
-      sha256 = "0km2f88pw9ynqbxsl3pwfkk120ni0by2rsaldqp2h3a26kyc5gzk";
-      name = "kfind-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kfind-18.12.1.tar.xz";
+      sha256 = "1vhi66syjhmc5i64ffgpilyxw9y10qb7633p3gx7vsnbjhvfx45b";
+      name = "kfind-18.12.1.tar.xz";
     };
   };
   kfloppy = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kfloppy-18.12.0.tar.xz";
-      sha256 = "0ng0d18dnnrdp9xccald0jn8hl40v2kshgmy8pnr4agl20aagh61";
-      name = "kfloppy-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kfloppy-18.12.1.tar.xz";
+      sha256 = "1fx40gb7h0z832qidn635jj7caipxcrzxmrbdfnj8ji2sczs1hyq";
+      name = "kfloppy-18.12.1.tar.xz";
     };
   };
   kfourinline = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kfourinline-18.12.0.tar.xz";
-      sha256 = "01wjqyg7aw2wi7nrrqri3znb545hr1qcanzibjiakhb2pbx5db3z";
-      name = "kfourinline-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kfourinline-18.12.1.tar.xz";
+      sha256 = "1dwa4nw6998ljbppr4bhwpdg201djk5rjrzjgfs5xv0pynamph0g";
+      name = "kfourinline-18.12.1.tar.xz";
     };
   };
   kgeography = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kgeography-18.12.0.tar.xz";
-      sha256 = "1fa2333xmxswlfjzl7d3ssl7s2hgwszhqxkdyi9db9lqxq0m3ckv";
-      name = "kgeography-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kgeography-18.12.1.tar.xz";
+      sha256 = "02xir13p0r67vx3csdra9nza82a25k807cjl3w2pq3dqcg9grrcf";
+      name = "kgeography-18.12.1.tar.xz";
     };
   };
   kget = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kget-18.12.0.tar.xz";
-      sha256 = "1f3ahslqcicgkhgdpdrvy9ydlsl1hwnnym7fw2v2k07h5mprw8hp";
-      name = "kget-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kget-18.12.1.tar.xz";
+      sha256 = "0jlpih49rifpqzxzgjc4kv3hv7y42v6pcamyvrmk6q1768lqp7nb";
+      name = "kget-18.12.1.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kgoldrunner-18.12.0.tar.xz";
-      sha256 = "0cmcjmfhair649nbfx74qdmsf67lx4j53qkj0xsr7bijv52pi4br";
-      name = "kgoldrunner-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kgoldrunner-18.12.1.tar.xz";
+      sha256 = "19qdw319lzfhmmmmawdpb0dlkz9k1iz6imkwf1qndfv89b6wklba";
+      name = "kgoldrunner-18.12.1.tar.xz";
     };
   };
   kgpg = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kgpg-18.12.0.tar.xz";
-      sha256 = "1hlcpgfcwpiyf1xfy62mris60cnws1mcgpni5nvvwdzdi4scad3g";
-      name = "kgpg-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kgpg-18.12.1.tar.xz";
+      sha256 = "1rar3hj3wc9vpxc81h0ly1mi87m9cdx17j58k9n02q91jqb8892y";
+      name = "kgpg-18.12.1.tar.xz";
     };
   };
   khangman = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/khangman-18.12.0.tar.xz";
-      sha256 = "0y05jjacnw2h70hjn5jbpnmcj53xgcx8304s39aa8zc1ry9jvsqq";
-      name = "khangman-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/khangman-18.12.1.tar.xz";
+      sha256 = "10wk0xdrs6pldg8j5bnsbdx835isxrapb1gm9gx4vjj49riq062q";
+      name = "khangman-18.12.1.tar.xz";
     };
   };
   khelpcenter = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/khelpcenter-18.12.0.tar.xz";
-      sha256 = "0cwxf6m3f6md4y51zpscxh89p9p9jzzsfslxh04y92p9g0l1qvwm";
-      name = "khelpcenter-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/khelpcenter-18.12.1.tar.xz";
+      sha256 = "143f61ngvljm4046q4allwxhx6fis0hd92xdqk8955xwdf42fq6y";
+      name = "khelpcenter-18.12.1.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kidentitymanagement-18.12.0.tar.xz";
-      sha256 = "1i0amb9m2vc00zaawv2wdyw7gzwz8lfw4bvz0mlnad4nrcmkvjyk";
-      name = "kidentitymanagement-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kidentitymanagement-18.12.1.tar.xz";
+      sha256 = "1pl8yzrhfvkxcxasywzklhpx2477whn662s13c5mp6yhpxyxl5xq";
+      name = "kidentitymanagement-18.12.1.tar.xz";
     };
   };
   kig = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kig-18.12.0.tar.xz";
-      sha256 = "0zq7z4jj8bsmhjggjh7byjv74ry6caps9pviwqqcsrdrl5357kzi";
-      name = "kig-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kig-18.12.1.tar.xz";
+      sha256 = "0cc093gwq2cr4ir3rdfkhijjsjvjddw4n7hvrxbshv7pqmnbrjgc";
+      name = "kig-18.12.1.tar.xz";
     };
   };
   kigo = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kigo-18.12.0.tar.xz";
-      sha256 = "03kl5hn8b2qbbv436rd8slqwr5w4034wz7vvm9z9cmjbpxavls2q";
-      name = "kigo-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kigo-18.12.1.tar.xz";
+      sha256 = "07m3p9r59c4qfwpgipb024mzxi4safiidpypm8gmx87vbsqc99f2";
+      name = "kigo-18.12.1.tar.xz";
     };
   };
   killbots = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/killbots-18.12.0.tar.xz";
-      sha256 = "0w8xl73ir9a3zxvsj3027gdlh7mskns3f0bk4mspirwg761zn1hf";
-      name = "killbots-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/killbots-18.12.1.tar.xz";
+      sha256 = "12jbvqmi0cx5ma7lai67qamml7qig269vhvjrcvm7jwlg0qx8v43";
+      name = "killbots-18.12.1.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kimagemapeditor-18.12.0.tar.xz";
-      sha256 = "0l17biqkq8jkc2vnnw51a6g13y29rnsfn9dx3afv88bdf2a52x1m";
-      name = "kimagemapeditor-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kimagemapeditor-18.12.1.tar.xz";
+      sha256 = "1mqzd3ja27c4askz9cxfaf6g8wcwlasjka79h4dmvjrw4rkqs4y4";
+      name = "kimagemapeditor-18.12.1.tar.xz";
     };
   };
   kimap = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kimap-18.12.0.tar.xz";
-      sha256 = "04m6sd36k6w4iiqanxy49v06am11p5xcb253gk99pyfrssb596m5";
-      name = "kimap-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kimap-18.12.1.tar.xz";
+      sha256 = "1v1qd91pr4xx0wsvvqlg8pcsbyi0n7c90ki0pz8v8z2vay5fagnm";
+      name = "kimap-18.12.1.tar.xz";
     };
   };
   kio-extras = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kio-extras-18.12.0.tar.xz";
-      sha256 = "1sbl7m8c4fy63389bv19ck89nzxjpf0l2855sc81fzy3zig89b65";
-      name = "kio-extras-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kio-extras-18.12.1.tar.xz";
+      sha256 = "17y5awdyck2zjrgb9l2s4rdyvp1pqc6jrdyjv5vhchjdkfb91vw3";
+      name = "kio-extras-18.12.1.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kirigami-gallery-18.12.0.tar.xz";
-      sha256 = "008ixa0kvqjjk98aq9mcapxd8d8svkjpz04v4ka64zwks8qyzdrk";
-      name = "kirigami-gallery-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kirigami-gallery-18.12.1.tar.xz";
+      sha256 = "1wrvhpdg2qk6ri1hjhdbk6w6rzyxamn6hxfl4mjcaip9gamjlbr0";
+      name = "kirigami-gallery-18.12.1.tar.xz";
     };
   };
   kiriki = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kiriki-18.12.0.tar.xz";
-      sha256 = "098gsl6pj8bdm29qa1w6pnyg7m25m0m2f97f7cwgqi1h4asyz9h8";
-      name = "kiriki-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kiriki-18.12.1.tar.xz";
+      sha256 = "1sxn7qvhyaaf4681hx1hgv2mmfhn64qn6q0rad9vps69cb1rx7pz";
+      name = "kiriki-18.12.1.tar.xz";
     };
   };
   kiten = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kiten-18.12.0.tar.xz";
-      sha256 = "1lkaicfc5z59g6gvcgmkdwpfl2i622s26w3pf1w0cmlw1hnspblc";
-      name = "kiten-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kiten-18.12.1.tar.xz";
+      sha256 = "1d964cc7bkr1vgsbbnm9c8na2nls3kmfk9wfkrzdgnj2643dl947";
+      name = "kiten-18.12.1.tar.xz";
     };
   };
   kitinerary = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kitinerary-18.12.0.tar.xz";
-      sha256 = "0q4fhfckvzlcza7r2gddygfn7f3dfj4kl82m644givb4394hjapd";
-      name = "kitinerary-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kitinerary-18.12.1.tar.xz";
+      sha256 = "14bkyi4xj00i8bzjq6z68y67iyylix0c1n8wr1nz0s05pmlg8sws";
+      name = "kitinerary-18.12.1.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kjumpingcube-18.12.0.tar.xz";
-      sha256 = "0j022vr1dj06s21cwxhsiv8xb1000l2yz2jz128rnkpr63b8darr";
-      name = "kjumpingcube-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kjumpingcube-18.12.1.tar.xz";
+      sha256 = "0i7lj2qi3mdvghpxyhwiakivxsd85ahy427d418sdykh7dfmn9ih";
+      name = "kjumpingcube-18.12.1.tar.xz";
     };
   };
   kldap = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kldap-18.12.0.tar.xz";
-      sha256 = "0359vzfhscqlha2vyaygqpai7qi924ircw290prwrmhn9jqzms5x";
-      name = "kldap-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kldap-18.12.1.tar.xz";
+      sha256 = "117w3jk4i77p8a7dvj03kgxqlhgbkmhyl7w282gl38kxyr7z8hbn";
+      name = "kldap-18.12.1.tar.xz";
     };
   };
   kleopatra = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kleopatra-18.12.0.tar.xz";
-      sha256 = "1j1s7dmg5wadfd8z76i5l81drii0sjdynahkcm8jdz3gvrsd773k";
-      name = "kleopatra-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kleopatra-18.12.1.tar.xz";
+      sha256 = "1njgfigld774r9xyckip118svxrkylh0a5ib5y8976zb0v71m5mj";
+      name = "kleopatra-18.12.1.tar.xz";
     };
   };
   klettres = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/klettres-18.12.0.tar.xz";
-      sha256 = "0gyd7vnm6mq7wy398h9nrny611pc6v4kksmdbhhsrkagvj4rvywq";
-      name = "klettres-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/klettres-18.12.1.tar.xz";
+      sha256 = "0xxrkx468wx2f3gb3d77i648xxmy6bq6q0nq121fk2apgdp2dzqk";
+      name = "klettres-18.12.1.tar.xz";
     };
   };
   klickety = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/klickety-18.12.0.tar.xz";
-      sha256 = "083w9lj6h6yxxk6vgmf72651vb423gakppbi7z7ii5i546miilyn";
-      name = "klickety-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/klickety-18.12.1.tar.xz";
+      sha256 = "14jvifvm47q0ca7jq7d152l53nswhbwggs0q067n3chmf07g2izy";
+      name = "klickety-18.12.1.tar.xz";
     };
   };
   klines = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/klines-18.12.0.tar.xz";
-      sha256 = "1v05ssjrb6x81c5nj9c8dpfqj9wr2m4mz9c883pnc5pjbc33fh0x";
-      name = "klines-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/klines-18.12.1.tar.xz";
+      sha256 = "1bs7vaqs67232msmsrsfi9avbqrzvyjihsakzxpkn976xwql3zxf";
+      name = "klines-18.12.1.tar.xz";
     };
   };
   kmag = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmag-18.12.0.tar.xz";
-      sha256 = "0micbc4wqi23jc2bpf1kjzy8xafqkd8gp70hg83id7mlncq12pm7";
-      name = "kmag-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmag-18.12.1.tar.xz";
+      sha256 = "1ig9fbnza2xvxvd1adh9riv3zmrdmm0km8jpqjmh124i8g416qpw";
+      name = "kmag-18.12.1.tar.xz";
     };
   };
   kmahjongg = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmahjongg-18.12.0.tar.xz";
-      sha256 = "1zv4dljkj1i4hxmy1cnyzpnipvdh6dmp6msmivgbsaz7yra1zqlx";
-      name = "kmahjongg-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmahjongg-18.12.1.tar.xz";
+      sha256 = "0ajml6xy4ljmrn5qbvy08mcf5v5jqzmclsbr6811rrxqxb5fqbqd";
+      name = "kmahjongg-18.12.1.tar.xz";
     };
   };
   kmail = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmail-18.12.0.tar.xz";
-      sha256 = "0ivzl7cpjcavqybbd5jfd9gk7qfvnfrly8gi20lwg97s07cih42x";
-      name = "kmail-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmail-18.12.1.tar.xz";
+      sha256 = "1wakrrlxp3v0k93hx2c8p136a3hd746l8fxks0g3cwvhl1immxw7";
+      name = "kmail-18.12.1.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmail-account-wizard-18.12.0.tar.xz";
-      sha256 = "04q3yrbarqqw5wd8waaacd4kb409y8k6rbwk0lsrr4gvs7b5h4jg";
-      name = "kmail-account-wizard-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmail-account-wizard-18.12.1.tar.xz";
+      sha256 = "0v3lwgk3b30ggv6573r6k5z09lcpfzspp5znnsn4650fgrrzg2j3";
+      name = "kmail-account-wizard-18.12.1.tar.xz";
     };
   };
   kmailtransport = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmailtransport-18.12.0.tar.xz";
-      sha256 = "0i3rgw4pf143jnkxnds84j8yg7smhgf2c5qkc1vk37i05vg81r76";
-      name = "kmailtransport-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmailtransport-18.12.1.tar.xz";
+      sha256 = "1ybaps485ic2m8nfy63kw6x7f3l2l67lhyy5zsm7rjipbaqgi2vm";
+      name = "kmailtransport-18.12.1.tar.xz";
     };
   };
   kmbox = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmbox-18.12.0.tar.xz";
-      sha256 = "03krrgzbvvhn0xcmbhx4whk347pxr26gqhnxh7mg82w5pzx7y6gm";
-      name = "kmbox-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmbox-18.12.1.tar.xz";
+      sha256 = "0anh25klbgb67ynl9mlcny2mrawsd98mzyffvgsd8xkback684zf";
+      name = "kmbox-18.12.1.tar.xz";
     };
   };
   kmime = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmime-18.12.0.tar.xz";
-      sha256 = "0kh1v62xxca6i6g48xznqrxfw4wfwqcbv338m0ybqr06w0kgcfr2";
-      name = "kmime-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmime-18.12.1.tar.xz";
+      sha256 = "05kjfqaadkflyh1vabzgbx33vr3c70sm2nkp8r9dsa7kg3wij0n2";
+      name = "kmime-18.12.1.tar.xz";
     };
   };
   kmines = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmines-18.12.0.tar.xz";
-      sha256 = "0lgzh1pa9g807jdq16k0a9n2akqgad0vgpx1zms6ldnaqvr7mm6w";
-      name = "kmines-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmines-18.12.1.tar.xz";
+      sha256 = "0dq1jirzb6ljhb7wdrrkyxvmlwg84xzhfikcn9v6nmz9f3pbliwi";
+      name = "kmines-18.12.1.tar.xz";
     };
   };
   kmix = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmix-18.12.0.tar.xz";
-      sha256 = "09m1d62w912ly6r8874b6ccimwdf6i9p2fyfb3pa5axc8d01lca9";
-      name = "kmix-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmix-18.12.1.tar.xz";
+      sha256 = "1ra7jmi5xlq9gbh7csv40sxr20lv8dz659m1jx4ixkzppcj42s73";
+      name = "kmix-18.12.1.tar.xz";
     };
   };
   kmousetool = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmousetool-18.12.0.tar.xz";
-      sha256 = "00nwk11w7ljn22bfh06l109gw8yhl9vccgwimqhyplq0p8c3cnb0";
-      name = "kmousetool-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmousetool-18.12.1.tar.xz";
+      sha256 = "07ywyxkm510faaqzywp5rw0lr2x1djhyhkjwyv8l42iw7231bn8x";
+      name = "kmousetool-18.12.1.tar.xz";
     };
   };
   kmouth = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmouth-18.12.0.tar.xz";
-      sha256 = "0ig1wxaxwjj6qv7k2djdzhlnbbx74yk5f1sk42qx6csprl2bgp39";
-      name = "kmouth-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmouth-18.12.1.tar.xz";
+      sha256 = "1g82shlrfm70ddfy2zfv12gv8hwzavz47q4qsyblyzq329kwgww5";
+      name = "kmouth-18.12.1.tar.xz";
     };
   };
   kmplot = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kmplot-18.12.0.tar.xz";
-      sha256 = "1mn7qrqwhwna9znprhb6fb2h127lcgjkx6m9csi8g11kklj95zi0";
-      name = "kmplot-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kmplot-18.12.1.tar.xz";
+      sha256 = "0xl913pajyrhadld2ij9y0ai2w558wa60qfx1y1xwsjfm8124qgf";
+      name = "kmplot-18.12.1.tar.xz";
     };
   };
   knavalbattle = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/knavalbattle-18.12.0.tar.xz";
-      sha256 = "16v4q2hn4d2d8iqj9mim0y8azx4nraja9a6fhym2h5nzqsz253gk";
-      name = "knavalbattle-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/knavalbattle-18.12.1.tar.xz";
+      sha256 = "1p03c980w4d10mkmvm01imi7vg6cp3wqz0wvw2d5vz47i0jhm2w8";
+      name = "knavalbattle-18.12.1.tar.xz";
     };
   };
   knetwalk = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/knetwalk-18.12.0.tar.xz";
-      sha256 = "1pgk7wnll793hmjmc0r416vvrgpicyyf88g459a5ybmj28hi5xqi";
-      name = "knetwalk-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/knetwalk-18.12.1.tar.xz";
+      sha256 = "0x5794f91b84l4d8hgkqi33rdqa7s1plhprhmbfvsi4grpms6c0c";
+      name = "knetwalk-18.12.1.tar.xz";
     };
   };
   knights = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/knights-18.12.0.tar.xz";
-      sha256 = "10p994q5rycs3p5yn6r0gn8fjj3m8gsrx2gdvzdavizbsp5xv0qb";
-      name = "knights-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/knights-18.12.1.tar.xz";
+      sha256 = "17n7zi100q62wjavfr87369yqp2mjxqz0lyqalagjp25d80z18l2";
+      name = "knights-18.12.1.tar.xz";
     };
   };
   knotes = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/knotes-18.12.0.tar.xz";
-      sha256 = "1r0p5k66gadglm329dcmr6x93wr56z32r03v8zd2r4ffbvp2hvqr";
-      name = "knotes-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/knotes-18.12.1.tar.xz";
+      sha256 = "12n40znf9vczvbf5xfj4zsxwbj2rdj7l1iasmiiil2md8iyjs6dz";
+      name = "knotes-18.12.1.tar.xz";
     };
   };
   kolf = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kolf-18.12.0.tar.xz";
-      sha256 = "0j5scf9ynq71z5pcbiqm13a3asz62man5nirjxr9fcj4mb1zirfk";
-      name = "kolf-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kolf-18.12.1.tar.xz";
+      sha256 = "072nmvsxm8ky1nz2pp6ri74ms3rql0qqg004mzbbq061dil4k63i";
+      name = "kolf-18.12.1.tar.xz";
     };
   };
   kollision = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kollision-18.12.0.tar.xz";
-      sha256 = "1zifm52q8yc2l5mqrc7wnddz9a0r1yz4dnk85c9dj2cndk8jz05p";
-      name = "kollision-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kollision-18.12.1.tar.xz";
+      sha256 = "0idjjfgj8fk0c0l5i6x80cg20p1rpq6kab8z9rh2izvg1v6h7qvl";
+      name = "kollision-18.12.1.tar.xz";
     };
   };
   kolourpaint = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kolourpaint-18.12.0.tar.xz";
-      sha256 = "1m0j0bdcrhhk8k1imnz7xm33yi8dcbsx432866ikh31l68i44wgc";
-      name = "kolourpaint-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kolourpaint-18.12.1.tar.xz";
+      sha256 = "0h454h5rzk0wki8lbmz57xx3859c27sy9vk1mwawfj963785f2nd";
+      name = "kolourpaint-18.12.1.tar.xz";
     };
   };
   kompare = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kompare-18.12.0.tar.xz";
-      sha256 = "02f4laclz3vhgbyzfxhi3f79k62z27fwa5qhdwwsvbn1xlgzbpx4";
-      name = "kompare-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kompare-18.12.1.tar.xz";
+      sha256 = "099fkxmk7g19l07lf2v3hmqrgfd17fbsv4m5cxdjci8alizw8pp9";
+      name = "kompare-18.12.1.tar.xz";
     };
   };
   konqueror = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/konqueror-18.12.0.tar.xz";
-      sha256 = "0yzldqi0i1hiw33ppiccn8vpvy5ygf2vf4m3awfcj2376bzz7d4r";
-      name = "konqueror-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/konqueror-18.12.1.tar.xz";
+      sha256 = "08j4x2xi1iv5661gjpcakp2dmdhvhw3jad98kq3xj9989s7phpfy";
+      name = "konqueror-18.12.1.tar.xz";
     };
   };
   konquest = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/konquest-18.12.0.tar.xz";
-      sha256 = "1w7r1a7ilakz9k0f1z4jrfsjscf9z8l18rdfry5b1h8zz70j5j0z";
-      name = "konquest-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/konquest-18.12.1.tar.xz";
+      sha256 = "0mlk2vm53nc9dc7ca9ah3ly9qs94md24pi2gmv68pz1ysr51i483";
+      name = "konquest-18.12.1.tar.xz";
     };
   };
   konsole = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/konsole-18.12.0.tar.xz";
-      sha256 = "04qmldzfb0qjwddz56nv20gffi8z6vhm0vsvqd59q5nhkj9shnr3";
-      name = "konsole-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/konsole-18.12.1.tar.xz";
+      sha256 = "15w1jizs4q6mivv7qjkf0gkqlz0jnrz7b2i59r3kx2fvwwwl18rg";
+      name = "konsole-18.12.1.tar.xz";
     };
   };
   kontact = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kontact-18.12.0.tar.xz";
-      sha256 = "0i9hj2rrwa5vzzh7p586d7vkzgk69inq3c7bvvjr6lhy0xrcy9cb";
-      name = "kontact-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kontact-18.12.1.tar.xz";
+      sha256 = "0bqn9vh75wpkks1l9hd2bm33k1im356x2091xlnnzs70m4gjxhag";
+      name = "kontact-18.12.1.tar.xz";
     };
   };
   kontactinterface = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kontactinterface-18.12.0.tar.xz";
-      sha256 = "05kx0jrxh13f42az6p9kj90wyqjl3ansqni9pa06fd1klq0ssncz";
-      name = "kontactinterface-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kontactinterface-18.12.1.tar.xz";
+      sha256 = "0khba3wnpwji4mm5n56bcnffd1v9w4a1b1r7lhlz88dqkakqyb61";
+      name = "kontactinterface-18.12.1.tar.xz";
     };
   };
   kopete = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kopete-18.12.0.tar.xz";
-      sha256 = "1xzriv2zqpf7vzny2k7qn39slx0b6cls8414c757ppd9ai4yh32a";
-      name = "kopete-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kopete-18.12.1.tar.xz";
+      sha256 = "12q62nj287qc4gz8q66spk1d0xykrwkphwaxrh2i3sd07bjmyzqs";
+      name = "kopete-18.12.1.tar.xz";
     };
   };
   korganizer = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/korganizer-18.12.0.tar.xz";
-      sha256 = "0pk8psl90xmb06y0h87ar35kbqr9pjl31l05h01ig32w1vr0rw8c";
-      name = "korganizer-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/korganizer-18.12.1.tar.xz";
+      sha256 = "1g8wjrghzxgx9xhqf98z9xlq5svl2v931ifczsfkvs9d3smx2zsg";
+      name = "korganizer-18.12.1.tar.xz";
     };
   };
   kpat = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kpat-18.12.0.tar.xz";
-      sha256 = "18q0pa4aijjkgjcg3v1v7ap2nvyavqsgh4s672v74jrxijd353gw";
-      name = "kpat-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kpat-18.12.1.tar.xz";
+      sha256 = "1ami2bssnjm01k3i6bqqciszablkw6975hac2d8zzvg2bz8g4a2a";
+      name = "kpat-18.12.1.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kpimtextedit-18.12.0.tar.xz";
-      sha256 = "0fg3cfh6v2hkhca9yb2kcvc9rq7f94a2wxkyi6cx88r3k3plh212";
-      name = "kpimtextedit-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kpimtextedit-18.12.1.tar.xz";
+      sha256 = "13ki9gjgakyqcxx4hvs0plqgw0rqx0z95dnyaqv1safqkwrr76hb";
+      name = "kpimtextedit-18.12.1.tar.xz";
     };
   };
   kpkpass = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kpkpass-18.12.0.tar.xz";
-      sha256 = "07rmjzgkww405f0f16w3fgd5kwz335xbl9gjlc1lkh6lhddmbjc6";
-      name = "kpkpass-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kpkpass-18.12.1.tar.xz";
+      sha256 = "1sw3gpvai71lliq4y1snxrhzi9jhl1vxkimlxl2nmhg951nzd4xx";
+      name = "kpkpass-18.12.1.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kqtquickcharts-18.12.0.tar.xz";
-      sha256 = "01vdg2l48521pgkkx7h1vkgbrjl7gpzzinldk3aa7ki0997rff6h";
-      name = "kqtquickcharts-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kqtquickcharts-18.12.1.tar.xz";
+      sha256 = "0i8qww267q797pxk3k66d09b0dp7ixbxf92p5bsqf7z4p2graayl";
+      name = "kqtquickcharts-18.12.1.tar.xz";
     };
   };
   krdc = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/krdc-18.12.0.tar.xz";
-      sha256 = "0yvk15grdk82flf7s9zsfgfhrmcy9wvcjhgdqjng2m9hd9sviix4";
-      name = "krdc-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/krdc-18.12.1.tar.xz";
+      sha256 = "1smdav92rfr92mxk8q7wcmmvrf746vn2xyw36hyszq561ycgwwrx";
+      name = "krdc-18.12.1.tar.xz";
     };
   };
   kreversi = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kreversi-18.12.0.tar.xz";
-      sha256 = "04mpkpa8lar7l8blrgkz9n5xzq0br15qxxginh3hgp9vcp83njpb";
-      name = "kreversi-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kreversi-18.12.1.tar.xz";
+      sha256 = "171w76xv9dbhy7pxs9swq7xknrwkjk5ndgq4waj6m5dh0109qmx4";
+      name = "kreversi-18.12.1.tar.xz";
     };
   };
   krfb = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/krfb-18.12.0.tar.xz";
-      sha256 = "107z3bwq5xb2l4p88qpv9zibjzbgdbhf3d13bp220vnpwkwaxhpm";
-      name = "krfb-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/krfb-18.12.1.tar.xz";
+      sha256 = "0bhhlp4ask2xqzq9igw0akxr0gb0iilaljwqrcw91fx36sxq46p4";
+      name = "krfb-18.12.1.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kross-interpreters-18.12.0.tar.xz";
-      sha256 = "1xr7cb3v40lm2wh78vhzxw3v34g52ngrd1baf4g4yi00y85y42bf";
-      name = "kross-interpreters-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kross-interpreters-18.12.1.tar.xz";
+      sha256 = "0k57qprmpspp9b8vb124h1whgyskmwd6q7l60vswqizc64xa2src";
+      name = "kross-interpreters-18.12.1.tar.xz";
     };
   };
   kruler = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kruler-18.12.0.tar.xz";
-      sha256 = "0ms875n8rr19lvvbmq7jjbbgd4l4p4k8fqxhay7wil2mgdpkd087";
-      name = "kruler-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kruler-18.12.1.tar.xz";
+      sha256 = "1wfxapw6grx860wa6fyya8fnvlrpmdzsz64fnx64h0mky09j21r6";
+      name = "kruler-18.12.1.tar.xz";
     };
   };
   kshisen = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kshisen-18.12.0.tar.xz";
-      sha256 = "0bd9wbn343glgsf6qnyqqdhqrkw61lywgnjslsmc4bb1parka8ww";
-      name = "kshisen-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kshisen-18.12.1.tar.xz";
+      sha256 = "0wz4jfrqqvzz2p5f6hwyj7rpijsnhbzmm2m7jhjrljjl5lfdqd3x";
+      name = "kshisen-18.12.1.tar.xz";
     };
   };
   ksirk = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ksirk-18.12.0.tar.xz";
-      sha256 = "1nm8y05im0h6vdkdqlbh21ci68dalan7qmjiiwamrzc5dsvh9lwi";
-      name = "ksirk-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ksirk-18.12.1.tar.xz";
+      sha256 = "108bw284jsff3qgg98vzs93m6dl8wjfkmbrkjgij03w00jb47bqf";
+      name = "ksirk-18.12.1.tar.xz";
     };
   };
   ksmtp = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ksmtp-18.12.0.tar.xz";
-      sha256 = "1caqqml7q41rk49mxq0wj439h87ln827jvxsbiv11qphkp6041y4";
-      name = "ksmtp-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ksmtp-18.12.1.tar.xz";
+      sha256 = "0zj4gpfz2njrdnfbjy7s9xci0il7qmmzargkszgj9jdzpm5qlaas";
+      name = "ksmtp-18.12.1.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ksnakeduel-18.12.0.tar.xz";
-      sha256 = "06acl0bc87fcixkj67l4n4csa060lnaqkh8p3s7r3zccsy660ya4";
-      name = "ksnakeduel-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ksnakeduel-18.12.1.tar.xz";
+      sha256 = "1l0gfh5vfcfnk3sdl8wsqbc2vcmsdf9frpngfacv4ndm4xc371ql";
+      name = "ksnakeduel-18.12.1.tar.xz";
     };
   };
   kspaceduel = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kspaceduel-18.12.0.tar.xz";
-      sha256 = "08dbmwbjqy8d0xidxipadndi0lxm1n2h0dxksjk8imsprz5r4j2l";
-      name = "kspaceduel-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kspaceduel-18.12.1.tar.xz";
+      sha256 = "01pcnqpzbrnwxavmfpdib78kc44am9in711012j2621cccx2r9cw";
+      name = "kspaceduel-18.12.1.tar.xz";
     };
   };
   ksquares = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ksquares-18.12.0.tar.xz";
-      sha256 = "0a6kf3arxvakd7mcr6xxasls8gmgc16gsnm0bjvviaxfc9f3wx8x";
-      name = "ksquares-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ksquares-18.12.1.tar.xz";
+      sha256 = "1gyd7qipp821jzn94yrw4b0d46ays0hs26q17hxnbx07hyfj3kcb";
+      name = "ksquares-18.12.1.tar.xz";
     };
   };
   ksudoku = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ksudoku-18.12.0.tar.xz";
-      sha256 = "1bm4lx5w4d3drgydqz2wxi3gh2778q8nl3k6ac4pm4iq8amgmgi6";
-      name = "ksudoku-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ksudoku-18.12.1.tar.xz";
+      sha256 = "1cm5r4fkc7ha0c3mbcank9h2fhym7qc8k1q69lpmzrbm9hw2kgrs";
+      name = "ksudoku-18.12.1.tar.xz";
     };
   };
   ksystemlog = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ksystemlog-18.12.0.tar.xz";
-      sha256 = "0gh83ih9y0ydhm4g2drbcjkqh58g5a1flg1zqxr7rak8kf1pchnm";
-      name = "ksystemlog-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ksystemlog-18.12.1.tar.xz";
+      sha256 = "1s5b4j67q6nm7r4b1ibvypsd5z9la7cri7z1r7hzihv4nry8pk5c";
+      name = "ksystemlog-18.12.1.tar.xz";
     };
   };
   kteatime = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kteatime-18.12.0.tar.xz";
-      sha256 = "1p4a3kahsjgfw9f6mw16bzz1bzk1jnssgvhzqh9ragqyp5qpn3s3";
-      name = "kteatime-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kteatime-18.12.1.tar.xz";
+      sha256 = "01p4d61d16k2pppf51sz52y0w4qc1dyqnmhjlnr5w75rfmwvvivg";
+      name = "kteatime-18.12.1.tar.xz";
     };
   };
   ktimer = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktimer-18.12.0.tar.xz";
-      sha256 = "1lv64bk64k7nb2y9qahc45cg3n51qrb4ahk5l9mrbj9q5yvm1acs";
-      name = "ktimer-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktimer-18.12.1.tar.xz";
+      sha256 = "0wqkfvbdcnwh1jzn2ac7k4pa8amr51ajhljc95mvps03m9d92rsf";
+      name = "ktimer-18.12.1.tar.xz";
     };
   };
   ktnef = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktnef-18.12.0.tar.xz";
-      sha256 = "1ca9gga65h9kygfcsr1yvy50ccq3587scml36p740iwrxms8lrcb";
-      name = "ktnef-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktnef-18.12.1.tar.xz";
+      sha256 = "0id7hkmgr5zc12zfrj5ydxyhgdrlx4ip1dsw301i27id104fqb69";
+      name = "ktnef-18.12.1.tar.xz";
     };
   };
   ktouch = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktouch-18.12.0.tar.xz";
-      sha256 = "1221xagypm1j56lx2g4845wrw0w01f2s4x8r3jwr32wzxvi8bxs3";
-      name = "ktouch-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktouch-18.12.1.tar.xz";
+      sha256 = "0v3lhxx45l41bw14wi7n4k29d1c9xmacrscjyj84fmy09nlyyaa5";
+      name = "ktouch-18.12.1.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-accounts-kcm-18.12.0.tar.xz";
-      sha256 = "0bx97zalwk78340klgh87rb5fadma8flg6q0bg436j01dsld0s0p";
-      name = "ktp-accounts-kcm-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-accounts-kcm-18.12.1.tar.xz";
+      sha256 = "1aswmp7504kpwlb37rvxx514ac5256h5lhwj9xl479vyxgaazxsn";
+      name = "ktp-accounts-kcm-18.12.1.tar.xz";
     };
   };
   ktp-approver = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-approver-18.12.0.tar.xz";
-      sha256 = "1cvixdcws126x7wll57dv6w78p3fb06lgd411i9jf7n02sx3l09q";
-      name = "ktp-approver-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-approver-18.12.1.tar.xz";
+      sha256 = "1jr5kxlj2229rknxhi5jsgdjgx9n0n5jx7lc4aa2c96kd843n2ah";
+      name = "ktp-approver-18.12.1.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-auth-handler-18.12.0.tar.xz";
-      sha256 = "0zfdq7q1v48vcaj4raz5r6l400xhz7ngjylg3kd7jabarljjv2gs";
-      name = "ktp-auth-handler-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-auth-handler-18.12.1.tar.xz";
+      sha256 = "1fwcibz8dh94xaprpyybn0dlh1fyd6rsx9zsx8cyxqhx96fq8v28";
+      name = "ktp-auth-handler-18.12.1.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-call-ui-18.12.0.tar.xz";
-      sha256 = "1q9z6g0djk7mszy48bwrw4mvja15xkcg6x88391sw1lvanps9hmk";
-      name = "ktp-call-ui-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-call-ui-18.12.1.tar.xz";
+      sha256 = "1f63w374d9smz7147lax9zqfvikqhl2hllvnlb03zl49kh13s8h3";
+      name = "ktp-call-ui-18.12.1.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-common-internals-18.12.0.tar.xz";
-      sha256 = "00smq4q4m8hvvfaz0b9iyxxz3dl15qs0is6zbkh4scvxxp54n056";
-      name = "ktp-common-internals-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-common-internals-18.12.1.tar.xz";
+      sha256 = "1frnzsql9mk78bjfc2kpwmsf8nkx1ybhm1snq125kkzayqipvdkp";
+      name = "ktp-common-internals-18.12.1.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-contact-list-18.12.0.tar.xz";
-      sha256 = "0kyllg9f0kj1w00jhk2khmsfdqqixnz8s74jvg5fjw8bbibjbn3y";
-      name = "ktp-contact-list-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-contact-list-18.12.1.tar.xz";
+      sha256 = "13aiy156372qapwddr2i3nf1jkzbj9905rvd55akwpa8sy70m3kw";
+      name = "ktp-contact-list-18.12.1.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-contact-runner-18.12.0.tar.xz";
-      sha256 = "1hpapg3fnmwsgai7jb9kbh5f71hp8qfzphgczcmf6h5151g2l6jj";
-      name = "ktp-contact-runner-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-contact-runner-18.12.1.tar.xz";
+      sha256 = "1grpgg3fgyzf97n60jmpjgviz5194awmrl6yfaal7hd1cdkfrs34";
+      name = "ktp-contact-runner-18.12.1.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-desktop-applets-18.12.0.tar.xz";
-      sha256 = "1dfcjjmbplgx7b45q9vklq8kvc0ajclzy6cmyq3maj577747h5xz";
-      name = "ktp-desktop-applets-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-desktop-applets-18.12.1.tar.xz";
+      sha256 = "0iikcp7rvvrn7189kdzj1i4qzhkgh06gzr8hm49gy29qxqk36ykn";
+      name = "ktp-desktop-applets-18.12.1.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-filetransfer-handler-18.12.0.tar.xz";
-      sha256 = "1dzrzv6nmv6ighiqq8hi9crasnqdbqimg3qdssyryxrqs64m9h29";
-      name = "ktp-filetransfer-handler-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-filetransfer-handler-18.12.1.tar.xz";
+      sha256 = "04dnh7yb0jajs79xh1wyq9d48nklvldc7lnk1lp194iz8yydvylx";
+      name = "ktp-filetransfer-handler-18.12.1.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-kded-module-18.12.0.tar.xz";
-      sha256 = "0720yayzz4rwrmplwjpq6bfb86k0jhmxc5k25yqj9fg7n6w2qsx3";
-      name = "ktp-kded-module-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-kded-module-18.12.1.tar.xz";
+      sha256 = "0kmw8pifb4xry3zqpq671rh39ziaka8zx60p5xzs10rl17rmxwzs";
+      name = "ktp-kded-module-18.12.1.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-send-file-18.12.0.tar.xz";
-      sha256 = "0jfy8qqm6n5pm2s24pbvxmmcibxxq71gggg4xf0miqkhdvx5b9kw";
-      name = "ktp-send-file-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-send-file-18.12.1.tar.xz";
+      sha256 = "01i059vsaydw410sv15vzwysgxcy2n9wm3qcnal4fx7wgw5xx163";
+      name = "ktp-send-file-18.12.1.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktp-text-ui-18.12.0.tar.xz";
-      sha256 = "14ln91srqfkk0fgp197wvlqxgagw23x4h94j1v1m51pia0v6226b";
-      name = "ktp-text-ui-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktp-text-ui-18.12.1.tar.xz";
+      sha256 = "14smhdcvy0v1s1rbkss1g6jyzfm6y1nqjp8a9wcbygbzh88g0bjy";
+      name = "ktp-text-ui-18.12.1.tar.xz";
     };
   };
   ktuberling = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/ktuberling-18.12.0.tar.xz";
-      sha256 = "0ms20qffd5mwlrxbd8ajb0lx3ny7mhlx25n59w2paq2x313qcsfk";
-      name = "ktuberling-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/ktuberling-18.12.1.tar.xz";
+      sha256 = "0h0w2knfs97bzxaja3dkc78fjfymic09b6zid41kxd4mi41lngkk";
+      name = "ktuberling-18.12.1.tar.xz";
     };
   };
   kturtle = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kturtle-18.12.0.tar.xz";
-      sha256 = "0ik44282gc6rmzsg6xv4fvpx1yzb4y4gv7jmslxgwi6rwc1q0m5v";
-      name = "kturtle-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kturtle-18.12.1.tar.xz";
+      sha256 = "0b2505gmys2p11ryj7bqr60zgh0ydp16xidhkv6hhykmrmp2bsm1";
+      name = "kturtle-18.12.1.tar.xz";
     };
   };
   kubrick = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kubrick-18.12.0.tar.xz";
-      sha256 = "0h4jx41wawbifdx7mzqbsx9nfrn2r9rkb01y0d63f5s2835hs2yc";
-      name = "kubrick-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kubrick-18.12.1.tar.xz";
+      sha256 = "0vq8djk5xc00cz4a2inbw62x9pigxxjcxi92h8qayigi7cf9xrll";
+      name = "kubrick-18.12.1.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kwalletmanager-18.12.0.tar.xz";
-      sha256 = "0znbrp1hk7jky9y3p9bc47sqn8mqd54x5j8kw52sg9v4428aag09";
-      name = "kwalletmanager-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kwalletmanager-18.12.1.tar.xz";
+      sha256 = "1d3kdxc53n2ss73r9ld6rr5w9zhvkglrcbw8whq2hsam79mh0vsn";
+      name = "kwalletmanager-18.12.1.tar.xz";
     };
   };
   kwave = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kwave-18.12.0.tar.xz";
-      sha256 = "00h5i0iax9hd79pw71wvv4p75rv6z61zpfg2s4n6zqjx8c312rhh";
-      name = "kwave-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kwave-18.12.1.tar.xz";
+      sha256 = "150lqffzzyb2ajyg97sprzbm6zq1iq4psl6vics51lw7sybwj4m3";
+      name = "kwave-18.12.1.tar.xz";
     };
   };
   kwordquiz = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/kwordquiz-18.12.0.tar.xz";
-      sha256 = "0a0i7khsvn68rxwwm3q5h4ymf6j3bdm3sc3q3z74rj3n0s03dnww";
-      name = "kwordquiz-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/kwordquiz-18.12.1.tar.xz";
+      sha256 = "1da9jjdk2avdmdm16s63h0hk5swml37afwdnsd777ilj2x8a5ndf";
+      name = "kwordquiz-18.12.1.tar.xz";
     };
   };
   libgravatar = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libgravatar-18.12.0.tar.xz";
-      sha256 = "077qkpsg2v77mzg2q5jw7fr6sss07x5998f9x65pqgqlc9b6h494";
-      name = "libgravatar-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libgravatar-18.12.1.tar.xz";
+      sha256 = "1a7b46zqv5m7c9arfmcxhrcnrkcligz3ryygxv801zfa7277l8j6";
+      name = "libgravatar-18.12.1.tar.xz";
     };
   };
   libkcddb = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkcddb-18.12.0.tar.xz";
-      sha256 = "15dmbb5cvr9rcaspizrc2laxkwhfrsnlczdns0biq3lysajblwfa";
-      name = "libkcddb-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkcddb-18.12.1.tar.xz";
+      sha256 = "1k9rbkf12g1hsn23nyhc65zrppkikk8xplm7l321kxpnq2prm155";
+      name = "libkcddb-18.12.1.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkcompactdisc-18.12.0.tar.xz";
-      sha256 = "1jrw16hbp8fn48l70gqxpiy6iwpisk087sixvs3cbn94dmczgpka";
-      name = "libkcompactdisc-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkcompactdisc-18.12.1.tar.xz";
+      sha256 = "0v7fh9s9qbljgfjyi3bd9w7wp69y4qjg0jj8cmn11snrsd8zzaac";
+      name = "libkcompactdisc-18.12.1.tar.xz";
     };
   };
   libkdcraw = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkdcraw-18.12.0.tar.xz";
-      sha256 = "0n3b5blda31gf38hyplpb29mp6aa187adgqqyijzhnvvm1mfwa5z";
-      name = "libkdcraw-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkdcraw-18.12.1.tar.xz";
+      sha256 = "1g58cpzqzl6vl62lbrqd8fyscxspqypxq4lyj3d2k9b0b66hjc6c";
+      name = "libkdcraw-18.12.1.tar.xz";
     };
   };
   libkdegames = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkdegames-18.12.0.tar.xz";
-      sha256 = "01i00n4cjpq1srag5ca8siw6rjc1gwhdzfib6cg3xf9my5sl0hbv";
-      name = "libkdegames-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkdegames-18.12.1.tar.xz";
+      sha256 = "0iksk5gnl860xcmpaj56wxaamhm9zhjnyszj4nssppssn8kr1r65";
+      name = "libkdegames-18.12.1.tar.xz";
     };
   };
   libkdepim = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkdepim-18.12.0.tar.xz";
-      sha256 = "188jf33dihrrq0zzmdddg6sx4ck2lp5gj1br4xfsqgrc1qf9z5hd";
-      name = "libkdepim-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkdepim-18.12.1.tar.xz";
+      sha256 = "1qvzj68p630mzafwyv7f3q1fd615yca7amc0q7kp2cs08fnv67fp";
+      name = "libkdepim-18.12.1.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkeduvocdocument-18.12.0.tar.xz";
-      sha256 = "1fa6pgpcarqabc18bph4lijsx1paf1a1arisrlf5mgkivg2yvy2k";
-      name = "libkeduvocdocument-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkeduvocdocument-18.12.1.tar.xz";
+      sha256 = "0zgl0dw8sb5lffzv580nql04i0n31ma8569wrhh75kg12qb5yd7w";
+      name = "libkeduvocdocument-18.12.1.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkexiv2-18.12.0.tar.xz";
-      sha256 = "1x3pxcii60kn8c1bmgrra9h4ahblwwp5vjd6p2wg2f4jkpmjz1ha";
-      name = "libkexiv2-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkexiv2-18.12.1.tar.xz";
+      sha256 = "1jgk14dgf30czsah0mjrs7lsll0s4aks2075pfmvrnsl71vfbsj3";
+      name = "libkexiv2-18.12.1.tar.xz";
     };
   };
   libkgapi = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkgapi-18.12.0.tar.xz";
-      sha256 = "0d79p7f6gmb8vjbp2nmc5rz9rabj08np96jbqf4wzgcjcxxi64kp";
-      name = "libkgapi-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkgapi-18.12.1.tar.xz";
+      sha256 = "1g5mzdw4mrlqhi9zby51m1sgkq1gjmkd7smja287kjf7whdx0sn3";
+      name = "libkgapi-18.12.1.tar.xz";
     };
   };
   libkgeomap = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkgeomap-18.12.0.tar.xz";
-      sha256 = "1pmicj4p3d17i7nj6alns8a24ay0xrs852d1x1xrcdkv7h7y5hvi";
-      name = "libkgeomap-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkgeomap-18.12.1.tar.xz";
+      sha256 = "0ijf71ss8qirrgx45x4wnry049d2bllgnlzm8gll4mj1hv9jhjdz";
+      name = "libkgeomap-18.12.1.tar.xz";
     };
   };
   libkipi = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkipi-18.12.0.tar.xz";
-      sha256 = "0cfn09x7splycpqwz0fy52lnkpc9dsq6i2j2q3r4fjgpblj9m86h";
-      name = "libkipi-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkipi-18.12.1.tar.xz";
+      sha256 = "1372kmqni0vb8bryv0h30pljikabjdq44v1fjpgg81f4v1n4pfxv";
+      name = "libkipi-18.12.1.tar.xz";
     };
   };
   libkleo = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkleo-18.12.0.tar.xz";
-      sha256 = "14iy3wis79rfri7najbyvx94ym2aa7si8h35rx4977flhc80nzin";
-      name = "libkleo-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkleo-18.12.1.tar.xz";
+      sha256 = "1p1bw0wzwg2zccgkqs50j92rzkpvcspjdj85zanmryg568mz9r1x";
+      name = "libkleo-18.12.1.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkmahjongg-18.12.0.tar.xz";
-      sha256 = "12pki8hkcv8ihcwwdnhpcz21h4676zra5qwf56aa5cj5qpdgf4gx";
-      name = "libkmahjongg-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkmahjongg-18.12.1.tar.xz";
+      sha256 = "1q590f7l10a1zjcg3dv3ns1003xrnr7zlmff03zg3a9zcqj11kwv";
+      name = "libkmahjongg-18.12.1.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libkomparediff2-18.12.0.tar.xz";
-      sha256 = "0xbccawxqk29f2qvr6hcbpan4fhahzksg7bl7jnv8xsv01lbm3rs";
-      name = "libkomparediff2-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libkomparediff2-18.12.1.tar.xz";
+      sha256 = "0ik6bclbipp01gfy3zfkijvl5m0y3z2dfxr76jvzmi53ypm7g0xn";
+      name = "libkomparediff2-18.12.1.tar.xz";
     };
   };
   libksane = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libksane-18.12.0.tar.xz";
-      sha256 = "1vdxyik47fij9mm1fs6p9bn0n56wsajzqd5am03nrwkwanva25xj";
-      name = "libksane-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libksane-18.12.1.tar.xz";
+      sha256 = "15dgc5dshs6yzv03wvc5xvqfz70gqy51a0r54qzbr5fc9s6pywr8";
+      name = "libksane-18.12.1.tar.xz";
     };
   };
   libksieve = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/libksieve-18.12.0.tar.xz";
-      sha256 = "1hwasycmfnjzqyxfh0kir1jhx002qci6dclv4cysv1ww33wsyskp";
-      name = "libksieve-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/libksieve-18.12.1.tar.xz";
+      sha256 = "0kcg94bsww3vlc3vpybw20c4iax0bfkamicy7hwyyyzwgx38dvd1";
+      name = "libksieve-18.12.1.tar.xz";
     };
   };
   lokalize = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/lokalize-18.12.0.tar.xz";
-      sha256 = "07rnx40836xncndqbcvpircvgnaywmwzbkfl16665ciphxrilm6q";
-      name = "lokalize-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/lokalize-18.12.1.tar.xz";
+      sha256 = "1spzi7zbckvxy3izmcqjnslmqf4vgr7zrwa0idmqi4q59dcsgw9g";
+      name = "lokalize-18.12.1.tar.xz";
     };
   };
   lskat = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/lskat-18.12.0.tar.xz";
-      sha256 = "1cw9z22gvyd9d44sg1qxir923q1ilmmqdgzzrh8wrb5p3m0mn0nz";
-      name = "lskat-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/lskat-18.12.1.tar.xz";
+      sha256 = "0603lxw1fxz9vpawy59z3qga0f1bvvgv9yqk29b16fmp5hf5qgxm";
+      name = "lskat-18.12.1.tar.xz";
     };
   };
   mailcommon = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/mailcommon-18.12.0.tar.xz";
-      sha256 = "0aigxd6pkw9xwy8q1kx9vqp17vljrzwv8skq6qmh9fvkjiampw84";
-      name = "mailcommon-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/mailcommon-18.12.1.tar.xz";
+      sha256 = "0l1b115vnxfl2ykwnj09ikv7vlfa5bvfzlii6jj2znkmspi9y7r2";
+      name = "mailcommon-18.12.1.tar.xz";
     };
   };
   mailimporter = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/mailimporter-18.12.0.tar.xz";
-      sha256 = "06nsn7vfgrvfgrmx4qyy21rq4a8bj5vxi4hrfd7377pd1sx58qvi";
-      name = "mailimporter-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/mailimporter-18.12.1.tar.xz";
+      sha256 = "1k8gqjabcvafcvsqwclvz58r15k1bpz52wnnnbwcp0y27ab08a98";
+      name = "mailimporter-18.12.1.tar.xz";
     };
   };
   marble = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/marble-18.12.0.tar.xz";
-      sha256 = "0ljzv2ygpqwz4a387ja280p7cd47bkjv7m40c3yn2yijiladyffv";
-      name = "marble-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/marble-18.12.1.tar.xz";
+      sha256 = "0hamj04ma9qycfisjv48myxj1427rz7g0lmw7pwanzghg610fgwy";
+      name = "marble-18.12.1.tar.xz";
     };
   };
   mbox-importer = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/mbox-importer-18.12.0.tar.xz";
-      sha256 = "08rfgf5zcp6vhd78rj2yikmzrgddhdn7cykw9pqfgmhy0nci14sm";
-      name = "mbox-importer-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/mbox-importer-18.12.1.tar.xz";
+      sha256 = "1h2abj7v6v3rmvsv9bb1wj7sabhh9f35bx1yfk2hhfzf6l4r5f2n";
+      name = "mbox-importer-18.12.1.tar.xz";
     };
   };
   messagelib = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/messagelib-18.12.0.tar.xz";
-      sha256 = "189bn6lblqq4vr1a2pk99pj3y3xh5q8xxdrg2hrdcc10wmjk9knv";
-      name = "messagelib-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/messagelib-18.12.1.tar.xz";
+      sha256 = "1hfk54w0dhp82fxa4q19d4224pjnw5f8m7ap4gwlrqdj350liqd8";
+      name = "messagelib-18.12.1.tar.xz";
     };
   };
   minuet = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/minuet-18.12.0.tar.xz";
-      sha256 = "1hma6r3z7k382gpd0wccxdbss1a17gvkb5fvdaii5xm7c9ca63r7";
-      name = "minuet-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/minuet-18.12.1.tar.xz";
+      sha256 = "160wq3j7vcf1k0ayd8axg37ghj5ymn56g7znaz4gzc8ar1q5nccz";
+      name = "minuet-18.12.1.tar.xz";
     };
   };
   okular = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/okular-18.12.0.tar.xz";
-      sha256 = "184r6lqsyx1x63zjirn709w0pd81hyh4f5j6m37m5hr6dg8l6mli";
-      name = "okular-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/okular-18.12.1.tar.xz";
+      sha256 = "1k1srr2434j665v6m89vl7x42361pqxaw45dc5b4bhw8q2xfipyl";
+      name = "okular-18.12.1.tar.xz";
     };
   };
   palapeli = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/palapeli-18.12.0.tar.xz";
-      sha256 = "09fbsw0id1p81zvd7kfimjx81m3zz36kdvd40jwbsffrqi682iww";
-      name = "palapeli-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/palapeli-18.12.1.tar.xz";
+      sha256 = "0pwflnnnbfxf185m3r4vdw5jpd5jld0wm0qnwk2gl41v2ahb5pqd";
+      name = "palapeli-18.12.1.tar.xz";
     };
   };
   parley = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/parley-18.12.0.tar.xz";
-      sha256 = "1mnp835g1b7vwz5gnzl78x3s80sw1ps4gsddg4ywrdkjr5b099gk";
-      name = "parley-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/parley-18.12.1.tar.xz";
+      sha256 = "1yv4m9f4jhc36ffnrxd6rq5117rj163hs6835mkkzja7z13csn6z";
+      name = "parley-18.12.1.tar.xz";
     };
   };
   picmi = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/picmi-18.12.0.tar.xz";
-      sha256 = "0y6fnh8629zj98ih4cwgy31gknpc6ipn4aqxcjg8hfic8jxnppyp";
-      name = "picmi-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/picmi-18.12.1.tar.xz";
+      sha256 = "0dmhvxy0g4jjbxk53bz1g1r8vqdzhzbcwg0f1ck85gz7f5g67b7v";
+      name = "picmi-18.12.1.tar.xz";
     };
   };
   pimcommon = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/pimcommon-18.12.0.tar.xz";
-      sha256 = "1rchq4clw6r08vm6cw9kw52bn7z1nfjmp2lmi0sq3pjfqlxif2zc";
-      name = "pimcommon-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/pimcommon-18.12.1.tar.xz";
+      sha256 = "09av3zdr463gjc877ipa5vz84yf4qpj2ixs9x4ajmfmsmb5m6w7z";
+      name = "pimcommon-18.12.1.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/pim-data-exporter-18.12.0.tar.xz";
-      sha256 = "0ywxcd02crwjrqx8ikkc4rgx1z93zvzqadqg3sjh636iz8svv5jc";
-      name = "pim-data-exporter-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/pim-data-exporter-18.12.1.tar.xz";
+      sha256 = "111n4l9z3dazz7qhv67k00s88p515r8ai2sm419pbyfdn6wxpzmb";
+      name = "pim-data-exporter-18.12.1.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/pim-sieve-editor-18.12.0.tar.xz";
-      sha256 = "144frbny1pq1viam527b96fxalc9iv5ppqrrvpndqsvjrlsrll45";
-      name = "pim-sieve-editor-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/pim-sieve-editor-18.12.1.tar.xz";
+      sha256 = "0i0jrmz4cyjcpapga89ixfqx7xg0nyk3r75ymfzw891fyhm7ns67";
+      name = "pim-sieve-editor-18.12.1.tar.xz";
     };
   };
   poxml = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/poxml-18.12.0.tar.xz";
-      sha256 = "1gnk9rzpa6rgff9xhawizx8cgsw84jqkpkr8aa2ki8zs4s6n9zl6";
-      name = "poxml-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/poxml-18.12.1.tar.xz";
+      sha256 = "0hrpvpsy3mbyrikj68lr2af9m162w3nzhcpdqgrhsv5ji3j0bpqb";
+      name = "poxml-18.12.1.tar.xz";
     };
   };
   print-manager = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/print-manager-18.12.0.tar.xz";
-      sha256 = "03jgjj7xfc57bsq3nx3l836pmpqywlchqis9109k5cpygqvgqkr5";
-      name = "print-manager-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/print-manager-18.12.1.tar.xz";
+      sha256 = "01kk592gi2rrqwaxmfd1fycnya0rvjafxxv6lrk3rs0nm4g9phxr";
+      name = "print-manager-18.12.1.tar.xz";
     };
   };
   rocs = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/rocs-18.12.0.tar.xz";
-      sha256 = "1gg0xg732wb9vzf1c69r5cqqhayxygv2brvbk3gvq6b201hv1q90";
-      name = "rocs-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/rocs-18.12.1.tar.xz";
+      sha256 = "0d34bv8ya5lrdrbqqlc927x4cdfjwyr8q2xbmx4c1vaw8w29glw9";
+      name = "rocs-18.12.1.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/signon-kwallet-extension-18.12.0.tar.xz";
-      sha256 = "0izmwyv1bw4iqgyhjrsq85xg7m5bp1v9khy5fxh1mhvh52w9zq8s";
-      name = "signon-kwallet-extension-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/signon-kwallet-extension-18.12.1.tar.xz";
+      sha256 = "018vyzd3rspfsqansxfbv4q0izgj7dfpmzjj04x8pffg1w0x902n";
+      name = "signon-kwallet-extension-18.12.1.tar.xz";
     };
   };
   spectacle = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/spectacle-18.12.0.tar.xz";
-      sha256 = "0nnsv0y28pxxhvf3r76nqgmn0ncixhr8d783mm3i3a3yz1z8a45c";
-      name = "spectacle-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/spectacle-18.12.1.tar.xz";
+      sha256 = "1r9iapwi1lp1p7x0dimblpmsizv1ys9708vdlzrk8q4m8rwn7ld9";
+      name = "spectacle-18.12.1.tar.xz";
     };
   };
   step = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/step-18.12.0.tar.xz";
-      sha256 = "0gqcwvv2xb321zx7y4bg28haqpzz5h8r7cxn6z4x5qnj6ijkx0zr";
-      name = "step-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/step-18.12.1.tar.xz";
+      sha256 = "1gn8l09r5rllz1mypsw2wfjhijy0i0bi4lspp271dinms6ryx6p4";
+      name = "step-18.12.1.tar.xz";
     };
   };
   svgpart = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/svgpart-18.12.0.tar.xz";
-      sha256 = "1nqbbzndbyj9ikgw7fhy52621swb5blzycd5qn9if9ymsi524217";
-      name = "svgpart-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/svgpart-18.12.1.tar.xz";
+      sha256 = "06rvbav94ysifha47lp52pvpc77y33p4zq4yfbmyh1pqkiw5db2s";
+      name = "svgpart-18.12.1.tar.xz";
     };
   };
   sweeper = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/sweeper-18.12.0.tar.xz";
-      sha256 = "0pq991zxdg1816j8dbhc3vjxj84plif17zpvp3smiscr4n6x209h";
-      name = "sweeper-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/sweeper-18.12.1.tar.xz";
+      sha256 = "0bp0my9gf4n5p7v3g0q390lf9q4lh42mg2zngwadqcvrsi2w4av4";
+      name = "sweeper-18.12.1.tar.xz";
     };
   };
   umbrello = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/umbrello-18.12.0.tar.xz";
-      sha256 = "15r5wv0k1dwfxp4l2mc4886s17ck390a2mpy1l08jvg93w1cbm3f";
-      name = "umbrello-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/umbrello-18.12.1.tar.xz";
+      sha256 = "12kk04frx8fxcih22nv5c1765wawlf7wpiscaqmzlmrpa611x65r";
+      name = "umbrello-18.12.1.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "18.12.0";
+    version = "18.12.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.0/src/zeroconf-ioslave-18.12.0.tar.xz";
-      sha256 = "1qvmsr88kl1gq3wrn5g4wf4ka24pbbhdy54c8n25bhxd8pv0rd07";
-      name = "zeroconf-ioslave-18.12.0.tar.xz";
+      url = "${mirror}/stable/applications/18.12.1/src/zeroconf-ioslave-18.12.1.tar.xz";
+      sha256 = "1gzr50kqlwd2d47yc2k6yz2v0w2gp10c7glhb61jpdzsqy7r7cvp";
+      name = "zeroconf-ioslave-18.12.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---