### PR TITLE
unison: fix on darwin

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (rec {
   echo -e '\ninstall:\n\tcp $(FSMONITOR)$(EXEC_EXT) $(INSTALLDIR)' >> fsmonitor/linux/Makefile
   '';
 
-  makeFlags = "INSTALLDIR=$(out)/bin/" + (if enableX11 then " UISTYLE=gtk2" else "")
+  makeFlags = "INSTALLDIR=$(out)/bin/" + (if enableX11 then " UISTYLE=gtk2" else " UISTYLE=text")
     + (if ! ocaml.nativeCompilers then " NATIVE=false" else "");
 
   preInstall = "mkdir -p $out/bin";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1054,7 +1054,7 @@ let
     };
 
     unison = callPackage ../applications/networking/sync/unison {
-      enableX11 = config.unison.enableX11 or true;
+      enableX11 = config.unison.enableX11 or pkgs.stdenv.targetPlatform.isLinux;
     };
 
     hol_light = callPackage ../applications/science/logic/hol_light {


### PR DESCRIPTION
###### Motivation for this change

Unison is currently broken by default under Darwin due to a build
failure in libglade, which is a transient dependency for unison's gtk2
GUI.

Unison technically has a native macOS UI, so it should in principle be
possible to package it here and enable it instead of the gtk2 UI by
default in darwin, but I struggled to get there. Short of that, a
working unison install with a CLI but no GUI is preferable to no unison
at all on darwin.



###### Things done

The `UISTYLE=text` option tells the unison makefile to build without any
GUI support. This makes the package flag `enableX11 = false` effectively
disable any other unison GUI too, as a simple way of supporting the
darwin case above.

---
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

