### PR TITLE
luarocks: support more commands: pack/build

### DIFF
--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -1,4 +1,11 @@
-{stdenv, fetchurl, lua, curl, makeWrapper, which, unzip}:
+{stdenv, fetchurl
+, curl, makeWrapper, which, unzip
+, lua
+# for 'luarocks pack'
+, zip
+# some packages need to be compiled with cmake
+, cmake
+}:
 let
   s = # Generated upstream information
   rec {
@@ -36,17 +43,33 @@ stdenv.mkDerivation {
     for i in "$out"/bin/*; do
         test -L "$i" || {
 	    wrapProgram "$i" \
-	      --prefix LUA_PATH ";" "$(echo "$out"/share/lua/*/)?.lua" \
-	      --prefix LUA_PATH ";" "$(echo "$out"/share/lua/*/)?/init.lua" \
+	      --suffix LUA_PATH ";" "$(echo "$out"/share/lua/*/)?.lua" \
+	      --suffix LUA_PATH ";" "$(echo "$out"/share/lua/*/)?/init.lua" \
+	      --suffix LUA_CPATH ";" "$(echo "$out"/lib/lua/*/)?.so" \
+	      --suffix LUA_CPATH ";" "$(echo "$out"/share/lua/*/)?/init.lua"
 
 	}
     done
   '';
-  meta = {
+
+  propagatedBuildInputs = [ zip unzip cmake ];
+
+  # unpack hook for src.rock and rockspec files
+  setupHook = ./setup-hook.sh;
+
+  # cmake is just to compile packages with "cmake" buildType, not luarocks itself
+  dontUseCmakeConfigure = true;
+
+  shellHook = ''
+    export PATH="src/bin:''${PATH:-}"
+    export LUA_PATH="src/?.lua;''${LUA_PATH:-}"
+  '';
+
+  meta = with stdenv.lib; {
     inherit (s) version;
     description = ''A package manager for Lua'';
-    license = stdenv.lib.licenses.mit ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    license = licenses.mit ;
+    maintainers = with maintainers; [raskin teto];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -1,0 +1,9 @@
+{ luarocks, fetchFromGitHub }:
+luarocks.overrideAttrs(old: {
+  src = fetchFromGitHub {
+    owner = "teto";
+    repo = "luarocks";
+    rev = "d669e8e118e6ca8bff05f32dbc9e5589e6ac45d2";
+    sha256 = "1lay3905a5sx2a4y68lbys0913qs210hcj9kn2lbqinw86c1vyc3";
+  };
+})

--- a/pkgs/development/tools/misc/luarocks/setup-hook.sh
+++ b/pkgs/development/tools/misc/luarocks/setup-hook.sh
@@ -1,0 +1,20 @@
+unpackCmdHooks+=(_trySourceRock)
+unpackCmdHooks+=(_tryRockSpec)
+
+_tryRockSpec() {
+    if ! [[ "$curSrc" =~ \.rockspec$ ]]; then return 1; fi
+}
+
+_trySourceRock() {
+
+    if ! [[ "$curSrc" =~ \.src.rock$ ]]; then return 1; fi
+
+    export PATH=${unzip}/bin:$PATH
+
+    # luarocks expects a clean <name>.rock.spec name to be the package name
+    # so we have to strip the hash
+    renamed="$(stripHash $curSrc)"
+    cp "$curSrc" "$renamed"
+    luarocks unpack --force "$renamed"
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7860,6 +7860,7 @@ in
     luajit luajit_2_0 luajit_2_1;
 
   luarocks = luaPackages.luarocks;
+  luarocks-nix = luaPackages.luarocks-nix;
 
   toluapp = callPackage ../development/tools/toluapp {
     lua = lua5_1; # doesn't work with any other :(

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -43,6 +43,8 @@ let
     inherit lua;
   };
 
+  luarocks-nix = callPackage ../development/tools/misc/luarocks/luarocks-nix.nix { };
+
   basexx = buildLuaPackage rec {
     version = "0.4.0";
     name = "basexx-${version}";


### PR DESCRIPTION
###### Motivation for this change

Extracted from https://github.com/NixOS/nixpkgs/pull/33903. Endgoal is to improve lua support.
Some luarocks commands wouldn't work (pack/unpack) so I've added the required dependencies.

the 2nd commit is my fork of luarocks that converts luarocks packages into nix packages (providing the lua infrastructure in https://github.com/NixOS/nixpkgs/pull/33903 gets merged). As such it might represent some dead code so feel free to merge only the first commit. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

