### PR TITLE
htop: cleanup patchShebangs

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
     [ ncurses ] ++
     lib.optionals stdenv.isDarwin [ IOKit ];
 
-  prePatch = ''
-    patchShebangs scripts/MakeHeader.py
-  '';
-
   meta = with stdenv.lib; {
     description = "An interactive process viewer for Linux";
     homepage = https://hisham.hm/htop/;


### PR DESCRIPTION
This was patched out already at https://github.com/hishamhm/htop/commit/1eda099d06837651a0e6fac4585e80f83363d4ef

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
