### PR TITLE
Add gzip and gnutar to default bazel-bash tools.

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
@@ -1,0 +1,42 @@
+{ stdenv, writeText, runCommandCC, bazel }:
+
+# Tests that certain executables are available in bazel-executed bash shells.
+
+let
+  WORKSPACE = writeText "WORKSPACE" ''
+    workspace(name = "our_workspace")
+  '';
+
+  fileIn = writeText "input.txt" ''
+  one
+  two
+  three
+  '';
+
+  fileBUILD = writeText "BUILD" ''
+    genrule(
+      name = "tool_usage",
+      srcs = [ ":input.txt" ],
+      outs = [ "output.txt" ],
+      cmd = "cat $(location :input.txt) | gzip - | gunzip - | awk '/t/' > $@",
+    )
+  '';
+
+  runLocal = name: script: runCommandCC name { preferLocalBuild = true; } script;
+
+  workspaceDir = runLocal "our_workspace" ''
+    mkdir $out
+    cp ${WORKSPACE} $out/WORKSPACE
+    cp ${fileIn} $out/input.txt
+    cp ${fileBUILD} $out/BUILD
+  '';
+
+  testBazel = runLocal "bazel-test-bash-tools" ''
+    export HOME=$(mktemp -d)
+    cp -r ${workspaceDir} wd && chmod +w wd && cd wd
+    ${bazel}/bin/bazel build :tool_usage
+    cp bazel-genfiles/output.txt $out
+    echo "Testing content" && [ "$(cat $out | wc -l)" == "2" ] && echo "OK"
+  '';
+
+in testBazel

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -24,6 +24,33 @@ let
   '';
 
   defaultShellPath = lib.makeBinPath
+    # Keep this list conservative. For more exotic tools, prefer to use
+    # @rules_nixpkgs to pull in tools from the nix repository. Example:
+    #
+    # WORKSPACE:
+    #
+    #     nixpkgs_git_repository(
+    #         name = "nixpkgs",
+    #         revision = "def5124ec8367efdba95a99523dd06d918cb0ae8",
+    #     )
+    #
+    #     # This defines an external Bazel workspace.
+    #     nixpkgs_package(
+    #         name = "bison",
+    #         repositories = { "nixpkgs": "@nixpkgs//:default.nix" },
+    #     )
+    #
+    # some/BUILD.bazel:
+    #
+    #     genrule(
+    #        ...
+    #        cmd = "$(location @bison//:bin/bison) -other -args",
+    #        tools = [
+    #            ...
+    #            "@bison//:bin/bison",
+    #        ],
+    #     )
+    #
     [ bash coreutils findutils gawk gnugrep gnutar gnused gzip which unzip ];
 
 in
@@ -39,9 +66,14 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux ++ platforms.darwin;
   };
 
-  # additional tests that check bazel’s functionality
+  # Additional tests that check bazel’s functionality. Execute
+  #
+  #     nix-build . -A bazel.tests
+  #
+  # in the nixpkgs checkout root to exercise them locally.
   passthru.tests = {
     pythonBinPath = callPackage ./python-bin-path-test.nix {};
+    bashTools = callPackage ./bash-tools-test.nix {};
   };
 
   name = "bazel-${version}";

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,6 +1,6 @@
 { stdenv, callPackage, lib, fetchurl, fetchpatch, runCommand, makeWrapper
 , jdk, zip, unzip, bash, writeCBin, coreutils
-, which, python, perl, gawk, gnused, gnugrep, findutils
+, which, python, perl, gawk, gnused, gnutar, gnugrep, gzip, findutils
 # Apple dependencies
 , cctools, clang, libcxx, CoreFoundation, CoreServices, Foundation
 # Allow to independently override the jdks used to build and run respectively
@@ -23,7 +23,8 @@ let
     for i in ${builtins.toString srcDeps}; do cp $i $out/$(stripHash $i); done
   '';
 
-  defaultShellPath = lib.makeBinPath [ bash coreutils findutils gawk gnugrep gnused which unzip ];
+  defaultShellPath = lib.makeBinPath
+    [ bash coreutils findutils gawk gnugrep gnutar gnused gzip which unzip ];
 
 in
 stdenv.mkDerivation rec {

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -42,8 +42,10 @@ let
 
   testBazel = runLocal "bazel-test-builtin-rules" ''
     export HOME=$(mktemp -d)
-    cp -r ${workspaceDir}/* .
-    ${bazel}/bin/bazel --output_base=/tmp/bazel-tests/wd\
+    # Note https://github.com/bazelbuild/bazel/issues/5763#issuecomment-456374609
+    # about why to create a subdir for the workspace.
+    cp -r ${workspaceDir} wd && chmod u+w wd && cd wd
+    ${bazel}/bin/bazel \
       test \
         --test_output=errors \
         --host_javabase='@local_jdk//:jdk' \


### PR DESCRIPTION
###### Motivation for this change

These are often used by rules, mostly due to Bazel's one-output restriction, where multi-output results are tarred up or archived in other way. Also, these are harmless tools to include.

Continuation of https://github.com/NixOS/nixpkgs/pull/50765.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @Profpatsch 
