### PR TITLE
electrum: 3.2.4 -> 3.3.2 plus new dependencies

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3, python3Packages, zbar }:
+{ stdenv, fetchFromGitHub, python3, python3Packages, zbar, secp256k1 }:
 
 let
   qdarkstyle = python3Packages.buildPythonPackage rec {
@@ -16,9 +16,11 @@ python3Packages.buildPythonApplication rec {
   pname = "electrum";
   version = "3.3.2";
 
-  src = fetchurl {
-    url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "0vgfdhwvrrl6dr4rd4hhxr8304bxm00sh7fw4nalm4hf7gfsbcji";
+  src = fetchFromGitHub {
+    owner = "spesmilo";
+    repo = "electrum";
+    rev = version;
+    sha256 = "1jsn02azdydpq4plr2552s7ijyqgw6zqm2zx8skwsalgbwmhx12i";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -39,7 +41,6 @@ python3Packages.buildPythonApplication rec {
     qrcode
     requests
     tlslite-ng
-    typing
 
     # plugins
     keepkey
@@ -56,6 +57,7 @@ python3Packages.buildPythonApplication rec {
     # Recording the creation timestamps introduces indeterminism to the build
     sed -i '/Created: .*/d' electrum/gui/qt/icons_rc.py
     sed -i "s|name = 'libzbar.*'|name='${zbar}/lib/libzbar.so'|" electrum/qrscanner.py
+    substituteInPlace ./electrum/ecc_fast.py --replace libsecp256k1.so.0 ${secp256k1}/lib/libsecp256k1.so.0
   '';
 
   postInstall = ''
@@ -68,10 +70,10 @@ python3Packages.buildPythonApplication rec {
       --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u"
   '';
 
-  doCheck = false;
+  checkInputs = with python3Packages; [ pytest ];
 
-  doInstallCheck = true;
-  installCheckPhase = ''
+  checkPhase = ''
+    py.test electrum/tests
     $out/bin/electrum help >/dev/null
   '';
 

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -13,15 +13,18 @@ let
 in
 
 python3Packages.buildPythonApplication rec {
-  name = "electrum-${version}";
-  version = "3.2.4";
+  pname = "electrum";
+  version = "3.3.2";
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "0nwipn1alk3r54zpsv2bdwsqxw4f08bxnfmygnwakfkiaifmmhxg";
+    sha256 = "0vgfdhwvrrl6dr4rd4hhxr8304bxm00sh7fw4nalm4hf7gfsbcji";
   };
 
   propagatedBuildInputs = with python3Packages; [
+    aiorpcx
+    aiohttp
+    aiohttp-socks
     dnspython
     ecdsa
     jsonrpclib-pelix

--- a/pkgs/development/python-modules/aiohttp-socks/default.nix
+++ b/pkgs/development/python-modules/aiohttp-socks/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "aiohttp-socks";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "aiohttp_socks";
+    sha256 = "0473702jk66xrgpm28wbdgpnak4v0dh2qmdjw7ky7hf3lwwqkggf";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # Checks needs internet access
+  doCheck = false;
+
+  disabled = pythonOlder "3.5.3";
+
+  meta = {
+    description = "SOCKS proxy connector for aiohttp";
+    license = lib.licenses.asl20;
+    homepage = https://github.com/romis2012/aiohttp-socks;
+  };
+}

--- a/pkgs/development/python-modules/aiorpcx/default.nix
+++ b/pkgs/development/python-modules/aiorpcx/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, attrs }:
+
+buildPythonPackage rec {
+  pname = "aiorpcx";
+  version = "0.10.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "aiorpcX";
+    sha256 = "1p88k15jh0d2a18pnnbfcamsqi2bxvmmhpizmdlxfdxf8vy5ggyj";
+  };
+
+  propagatedBuildInputs = [ attrs ];
+
+  disabled = pythonOlder "3.6";
+
+  # Checks needs internet access
+  doCheck = false;
+
+  meta = {
+    description = "Transport, protocol and framing-independent async RPC client and server implementation";
+    license = lib.licenses.mit;
+    homepage = https://github.com/kyuupichan/aiorpcX;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -822,6 +822,8 @@ in {
 
   aiohttp-remotes = callPackage ../development/python-modules/aiohttp-remotes { };
 
+  aiohttp-socks = callPackage ../development/python-modules/aiohttp-socks { };
+
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
   ajpy = callPackage ../development/python-modules/ajpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -826,6 +826,8 @@ in {
 
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
+  aiorpcx = callPackage ../development/python-modules/aiorpcx { };
+
   ajpy = callPackage ../development/python-modules/ajpy { };
 
   alabaster = callPackage ../development/python-modules/alabaster {};


### PR DESCRIPTION
###### Motivation for this change

Previous PR was closed, I applied required fixes
:warning:  I did not test execution at this time

Also the aio libraries are missing tests, maybe they are not included in the Pypi package

cc @clefru @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

