### PR TITLE
proot: 20171015 -> 20181214

### DIFF
--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -8,7 +8,7 @@
   src = fetchFromGitHub {
     inherit rev sha256;
     repo = "proot";
-    owner = "cedric-vincent";
+    owner = "proot-me";
   };
 
   buildInputs = [ talloc ];
@@ -35,7 +35,7 @@
     description = "User-space implementation of chroot, mount --bind and binfmt_misc";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ianwookim makefu ];
+    maintainers = with maintainers; [ ianwookim makefu veprbl ];
   };
 })
 (if stdenv.isAarch64 then rec {

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -49,8 +49,8 @@
     })
   ];
 } else {
-  version = "5.1.0.20171015";
-  sha256 = "0jam87msh5jx8vpb19n6xwxw1xlig5amdcqif7gn2rc8nhswpxif";
-  rev = "0bf2ee17daafeeadfed079cec97fe1ac781e696a";
+  version = "5.1.0.20181214";
+  sha256 = "07g1gfyjq7rypjdwxw495sk8k1y2i3y3nsm1rh9kgx3z47z28aah";
+  rev = "11972c0dab34e088c55c16a94d26c399ca7a26d8";
   patches = [];
 })


### PR DESCRIPTION
Proot now includes a fix for the seccomp bug on recent kernels


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---