### PR TITLE
maintainers/maintainer-list: Add my GPG/PGP key

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1456,6 +1456,10 @@
     email = "elis@hirwing.se";
     github = "etu";
     name = "Elis Hirwing";
+    keys = [{
+      longkeyid = "rsa4096/0xD57EFA625C9A925F";
+      fingerprint = "67FE 98F2 8C44 CF22 1828  E12F D57E FA62 5C9A 925F";
+    }];
   };
   evck = {
     email = "eric@evenchick.com";


### PR DESCRIPTION
###### Motivation for this change
Got inspired to do this when I saw #54467.

And I always sign my commits and emails using this key.