### PR TITLE
efitools: init at 1.9.2

### DIFF
--- a/pkgs/tools/security/efitools/default.nix
+++ b/pkgs/tools/security/efitools/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, gnu-efi, openssl, sbsigntool, perl, perlPackages,
+help2man, fetchgit }:
+stdenv.mkDerivation rec {
+  name = "efitools-${version}";
+  version = "1.9.2";
+
+  buildInputs = [
+    gnu-efi
+    openssl
+    sbsigntool
+  ];
+
+  nativeBuildInputs = [
+    perl
+    perlPackages.FileSlurp
+    help2man
+  ];
+
+  src = fetchgit {
+    url = "git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git";
+    rev = "v${version}";
+    sha256 = "0jabgl2pxvfl780yvghq131ylpf82k7banjz0ksjhlm66ik8gb1i";
+  };
+
+  postPatch = ''
+    sed -i -e 's#/usr/include/efi#${gnu-efi}/include/efi/#g' Make.rules
+    sed -i -e 's#/usr/lib64/gnuefi#${gnu-efi}/lib/#g' Make.rules
+    sed -i -e 's#$(DESTDIR)/usr#$(out)#g' Make.rules
+    patchShebangs .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools for manipulating UEFI secure boot platforms";
+    homepage = "https://git.kernel.org/cgit/linux/kernel/git/jejb/efitools.git";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.grahamc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3154,6 +3154,8 @@ in
   gx = callPackage ../tools/package-management/gx { };
   gx-go = callPackage ../tools/package-management/gx/go { };
 
+  efitools = callPackage ../tools/security/efitools { };
+
   sbsigntool = callPackage ../tools/security/sbsigntool { };
 
   gsmartcontrol = callPackage ../tools/misc/gsmartcontrol { };


### PR DESCRIPTION
###### Motivation for this change

Packaged as part of https://github.com/NixOS/nixpkgs/pull/53901

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

