### PR TITLE
neovim: added custom aliases

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -19,6 +19,7 @@ let
     , vimAlias ? false
     , viAlias ? false
     , configure ? {}
+    , customAlias ? ""
   }:
   let
 
@@ -90,6 +91,8 @@ let
         ln -s $out/bin/nvim $out/bin/vim
       '' + optionalString viAlias ''
         ln -s $out/bin/nvim $out/bin/vi
+      '' + optionalString (customAlias != "") ''
+        ln -s $out/bin/nvim $out/bin/${customAlias}
       '' + optionalString (configure != {}) ''
         echo "Generating remote plugin manifest"
         export NVIM_RPLUGIN_MANIFEST=$out/rplugin.vim


### PR DESCRIPTION
###### Motivation for this change
Some people would like to use custom alias for neovim, not just vi or vim.
Also, i want to use many builds of neovim at the same time, so i need symlink for this.

###### Things done
I've just added three lines of code which are similar to those already written.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

