### PR TITLE
picocom: Enable on Darwin

### DIFF
--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchFromGitHub, makeWrapper, lrzsz }:
+{ stdenv, fetchFromGitHub, makeWrapper, lrzsz, IOKit }:
+
+assert stdenv.isDarwin -> IOKit != null;
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "picocom-${version}";
@@ -11,7 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1vvjydqf0ax47nvdyyl67jafw5b3sfsav00xid6qpgia1gs2r72n";
   };
 
-  buildInputs = [ makeWrapper ];
+  buildInputs = [ makeWrapper ]
+    ++ optionals stdenv.isDarwin [ IOKit ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
@@ -26,6 +31,6 @@ stdenv.mkDerivation rec {
     description = "Minimal dumb-terminal emulation program";
     homepage = https://github.com/npat-efault/picocom/;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # arbitrary choice
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18821,7 +18821,9 @@ in
 
   picard = callPackage ../applications/audio/picard { };
 
-  picocom = callPackage ../tools/misc/picocom { };
+  picocom = callPackage ../tools/misc/picocom {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
 
   pidgin = callPackage ../applications/networking/instant-messengers/pidgin {
     openssl = if config.pidgin.openssl or true then openssl else null;


### PR DESCRIPTION
###### Motivation for this change

The source package already supports Darwin. This change allows using the package with Nix on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

