### PR TITLE
redshift: Install systemd user unit files

### DIFF
--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -9,6 +9,7 @@
 , withGeolocation ? true
 , withCoreLocation ? withGeolocation && stdenv.isDarwin, CoreLocation, Foundation, Cocoa
 , withGeoclue ? withGeolocation && stdenv.isLinux, geoclue
+, useSystemd ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +45,7 @@ stdenv.mkDerivation rec {
     "--enable-drm=${if withDrm then "yes" else "no"}"
     "--enable-quartz=${if withQuartz then "yes" else "no"}"
     "--enable-corelocation=${if withCoreLocation then "yes" else "no"}"
-  ];
+  ] ++ stdenv.lib.optional (stdenv.isLinux && useSystemd) "--with-systemduserunitdir=\${out}/lib/systemd/user";
 
   buildInputs = [
     gobject-introspection


### PR DESCRIPTION
###### Motivation for this change
redshift's systemd user units currently aren't installed. This installs them.

###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

