### PR TITLE
xorg.luit: fix darwin build

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,7 +1,7 @@
 { abiCompat ? null,
   stdenv, makeWrapper, lib, fetchurl, fetchpatch, buildPackages,
 
-  automake, autoconf, libtool, intltool, mtdev, libevdev, libinput,
+  automake, autoconf, libiconv, libtool, intltool, mtdev, libevdev, libinput,
   freetype, tradcpp, fontconfig, meson, ninja,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm,
   mesa_noglu, udev, bootstrap_cmds, bison, flex, clangStdenv, autoreconfHook,
@@ -143,10 +143,12 @@ self: super:
     outputs = [ "out" "dev" "devdoc" ];
   });
 
-  # See https://bugs.freedesktop.org/show_bug.cgi?id=47792
-  # Once the bug is fixed upstream, this can be removed.
   luit = super.luit.overrideAttrs (attrs: {
+    # See https://bugs.freedesktop.org/show_bug.cgi?id=47792
+    # Once the bug is fixed upstream, this can be removed.
     configureFlags = [ "--disable-selective-werror" ];
+
+    buildInputs = attrs.buildInputs ++ [libiconv];
   });
 
   libICE = super.libICE.overrideAttrs (attrs: {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

