### PR TITLE
docker-machine: 0.14.0 -> 0.16.1

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/default.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "machine-${version}";
-  version = "0.14.0";
+  version = "0.16.1";
 
   goPackagePath = "github.com/docker/machine";
 
@@ -11,16 +11,16 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "docker";
     repo = "machine";
-    sha256 = "0hd5sklmvkhhpfn318hq9w0f7x14165h1l2mdn9iv4447z1iibff";
+    sha256 = "0xxzxi5v7ji9j2k7kxhi0ah91lfa7b9rg3nywgx0lkv8dlgp8kmy";
   };
 
   postInstall = ''
-    mkdir -p $bin/share/bash-completion/completions/
-    cp go/src/github.com/docker/machine/contrib/completion/bash/* $bin/share/bash-completion/completions/
-  '';
+    mkdir -p \
+      $bin/share/bash-completion/completions/ \
+      $bin/share/zsh/site-functions/
 
-  postFixup =  ''
-    mv $bin/bin/cmd $bin/bin/docker-machine
+    cp go/src/github.com/docker/machine/contrib/completion/bash/* $bin/share/bash-completion/completions/
+    cp go/src/github.com/docker/machine/contrib/completion/zsh/* $bin/share/zsh/site-functions/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

updade!

/cc @tailhook 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

