### PR TITLE
krita: 4.1.5 -> 4.1.7.101

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -8,13 +8,21 @@
 , python3
 }:
 
+let
+
+major = "4.1";
+minor = "7";
+patch = "101";
+
+in
+
 mkDerivation rec {
   name = "krita-${version}";
-  version = "4.1.5";
+  version = "${major}.${minor}.${patch}";
 
   src = fetchurl {
-    url = "https://download.kde.org/stable/krita/${version}/${name}.tar.gz";
-    sha256 = "1by8p8ifdp03f05bhg8ygdd1j036anfpjjnzbx63l2fbmy9k6q10";
+    url = "https://download.kde.org/stable/krita/${major}.${minor}/${name}.tar.gz";
+    sha256 = "0pvghb17vj3y19wa1n1zfg3yl5206ir3y45znrgdgdw076m5pjav";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];


### PR DESCRIPTION
###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/issues/54470
Also no longer see the issue I noticed in https://github.com/NixOS/nixpkgs/pull/52247

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

