### PR TITLE
Support wrapping a file system under LUKS

### DIFF
--- a/nixos/lib/wrap-luks.nix
+++ b/nixos/lib/wrap-luks.nix
@@ -1,0 +1,35 @@
+{ vmTools
+, runCommand
+, utillinux
+, cryptsetup
+, kmod
+}:
+
+fileSystem:
+
+vmTools.runInLinuxVM (runCommand "wrap-luks"
+  {
+    FILE_SYSTEM=fileSystem;
+
+    nativeBuildInputs = [ utillinux cryptsetup kmod ];
+    __impure = true;
+  }
+  ''
+    BLOCKS=$(du -B 512 $(realpath $FILE_SYSTEM) | cut -d $'\t' -f1)
+
+    modprobe loop
+
+    rmdir $out
+    fallocate -x -l $(( 512 * ($BLOCKS + 4096) )) $out
+
+    # A Nix way to change the passphrase is purposely not added,
+    # as the passphrase will be added to the /nix/store.
+    # Instead, you can change the passphrase once the image is built.
+    # See: https://askubuntu.com/a/384936
+    cryptsetup luksFormat $out <<< PASSPHRASE
+    cryptsetup luksOpen $out cryptbackup <<< PASSPHRASE
+
+    dd if=$FILE_SYSTEM of=/dev/mapper/cryptbackup bs=512
+
+    cryptsetup luksClose cryptbackup
+  '')


### PR DESCRIPTION
###### Motivation for this change
Produces a luks-encrypted image to be mounted by https://github.com/NixOS/nixpkgs/pull/53600

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

