### PR TITLE
adoptopenjdk: 11.0.1 -> 11.0.2 (x86_64-linux only)

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
+++ b/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
@@ -38,21 +38,15 @@ def generate_sources(release, assets):
         type_map = out.setdefault(asset["os"], {})
         impl_map = type_map.setdefault(asset["binary_type"], {})
         arch_map = impl_map.setdefault(asset["openjdk_impl"], {
-            "version": version,
-            "build": build,
             "packageType": asset["binary_type"],
             "vmType": asset["openjdk_impl"],
         })
 
-        if arch_map["version"] != version or arch_map["build"] != build:
-            print("error: architectures have different latest versions ({}+{} vs {}+{})".format(
-                arch_map["version"], arch_map["build"], version, build
-            ), file=sys.stderr)
-            sys.exit(1)
-
         arch_map[arch_to_nixos[asset["architecture"]]] = {
             "url": asset["binary_link"],
             "sha256": get_sha256(asset["checksum_link"]),
+            "version": version,
+            "build": build,
         }
 
     return out

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -5,13 +5,14 @@ sourcePerArch:
 , fetchurl
 }:
 
-let result = stdenv.mkDerivation rec {
+let cpuName = stdenv.hostPlatform.parsed.cpu.name;
+    result = stdenv.mkDerivation rec {
   name = if sourcePerArch.packageType == "jdk"
-    then "adoptopenjdk-${sourcePerArch.vmType}-bin-${sourcePerArch.version}"
-    else "adoptopenjdk-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin-${sourcePerArch.version}";
+    then "adoptopenjdk-${sourcePerArch.vmType}-bin-${sourcePerArch.${cpuName}.version}"
+    else "adoptopenjdk-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin-${sourcePerArch.${cpuName}.version}";
 
   src = fetchurl {
-    inherit (sourcePerArch.${stdenv.hostPlatform.parsed.cpu.name}) url sha256;
+    inherit (sourcePerArch.${cpuName}) url sha256;
   };
 
   # See: https://github.com/NixOS/patchelf/issues/10

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -42,15 +42,17 @@ let
     xorg.libXrender
     stdenv.cc.cc
   ]);
+
+  cpuName = stdenv.hostPlatform.parsed.cpu.name;
 in
 
 let result = stdenv.mkDerivation rec {
   name = if sourcePerArch.packageType == "jdk"
-    then "adoptopenjdk-${sourcePerArch.vmType}-bin-${sourcePerArch.version}"
-    else "adoptopenjdk-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin-${sourcePerArch.version}";
+    then "adoptopenjdk-${sourcePerArch.vmType}-bin-${sourcePerArch.${cpuName}.version}"
+    else "adoptopenjdk-${sourcePerArch.packageType}-${sourcePerArch.vmType}-bin-${sourcePerArch.${cpuName}.version}";
 
   src = fetchurl {
-    inherit (sourcePerArch.${stdenv.hostPlatform.parsed.cpu.name}) url sha256;
+    inherit (sourcePerArch.${cpuName}) url sha256;
   };
 
   nativeBuildInputs = [ file ];

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -4,52 +4,56 @@
       "jdk": {
         "hotspot": {
           "aarch64": {
+            "build": "13",
             "sha256": "b66121b9a0c2e7176373e670a499b9d55344bcb326f67140ad6d0dc24d13d3e2",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.1_13.tar.gz"
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.1_13.tar.gz",
+            "version": "11.0.1"
           },
-          "build": "13",
           "packageType": "jdk",
-          "version": "11.0.1",
           "vmType": "hotspot",
           "x86_64": {
-            "sha256": "22bd2f1a2e0cb6e4075967bfeda4a960b0325879305aa739a0ba2d6e5cd4c3e2",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_hotspot_11.0.1_13.tar.gz"
+            "build": "7",
+            "sha256": "d89304a971e5186e80b6a48a9415e49583b7a5a9315ba5552d373be7782fc528",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_7.tar.gz",
+            "version": "11.0.2"
           }
         },
         "openj9": {
-          "build": "13",
           "packageType": "jdk",
-          "version": "11.0.1",
           "vmType": "openj9",
           "x86_64": {
+            "build": "13",
             "sha256": "ef9bf07cba79082285a9d426ea4eb3e8df57561ce2afe07cc5f299a8fa203279",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz"
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz",
+            "version": "11.0.1"
           }
         }
       },
       "jre": {
         "hotspot": {
           "aarch64": {
+            "build": "28",
             "sha256": "6fd756bda392e3fddb48382460daae263c6fb5708683a691c8d30af2eb870bb8",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_aarch64_linux_hotspot_11_28.tar.gz"
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_aarch64_linux_hotspot_11_28.tar.gz",
+            "version": "11"
           },
-          "build": "28",
           "packageType": "jre",
-          "version": "11",
           "vmType": "hotspot",
           "x86_64": {
-            "sha256": "346448142d46c6e51d0fadcaadbcde31251d7678922ec3eb010fcb1b6e17804c",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_hotspot_11_28.tar.gz"
+            "build": "7",
+            "sha256": "59c34373eec16b53798aedac73776b19e43f396fdff8a2879e66dc4b0cfd73cc",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_7.tar.gz",
+            "version": "11.0.2"
           }
         },
         "openj9": {
-          "build": "28",
           "packageType": "jre",
-          "version": "11",
           "vmType": "openj9",
           "x86_64": {
+            "build": "28",
             "sha256": "83a7c95e6b2150a739bdd5e8a6fe0315904fd13d8867c95db67c0318304a2c42",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz"
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz",
+            "version": "11"
           }
         }
       }
@@ -57,35 +61,35 @@
     "mac": {
       "jdk": {
         "hotspot": {
-          "build": "13",
           "packageType": "jdk",
-          "version": "11.0.1",
           "vmType": "hotspot",
           "x86_64": {
+            "build": "13",
             "sha256": "e219e7e2d586ed09ae65f4ec390fca5d5f0c37a61b47677648610194daf1aaa7",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_hotspot_11.0.1_13.tar.gz"
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_hotspot_11.0.1_13.tar.gz",
+            "version": "11.0.1"
           }
         },
         "openj9": {
-          "build": "13",
           "packageType": "jdk",
-          "version": "11.0.1",
           "vmType": "openj9",
           "x86_64": {
-            "sha256": "c9a816d6a3f8aac9dc5b3b41c5a9e4e5460af433a06e003ae25d5a06dea8375f",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_macosXL-jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz"
+            "build": "13",
+            "sha256": "b8960753a66190fa81982682357a2449b4183f3e23c20a5e3b4cf01e2989846b",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz",
+            "version": "11.0.1"
           }
         }
       },
       "jre": {
         "hotspot": {
-          "build": "28",
           "packageType": "jre",
-          "version": "11",
           "vmType": "hotspot",
           "x86_64": {
+            "build": "28",
             "sha256": "ef4dbfe5aed6ab2278fcc14db6cc73abbaab56e95f6ebb023790a7ebc6d7f30c",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_mac_hotspot_11_28.tar.gz"
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_mac_hotspot_11_28.tar.gz",
+            "version": "11"
           }
         }
       }


### PR DESCRIPTION
###### Motivation for this change

- Security fixes
- Other updates

https://www.oracle.com/technetwork/java/javase/11-0-2-relnotes-5188746.html
https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html#AppendixJAVA

Updated the expressions and `generate-sources.py` to have different version numbers for each archs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

