### PR TITLE
grim: init at 1.0

### DIFF
--- a/pkgs/tools/graphics/grim/default.nix
+++ b/pkgs/tools/graphics/grim/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cairo, libjpeg, meson, ninja, wayland, pkgconfig, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "grim-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "grim";
+    rev = "v${version}";
+    sha256 = "1mpmxkzssgzqh9z263y8vk40dayw32kah66sb8ja7yw22rm7f4zf";
+  };
+
+  buildInputs = [
+    cairo
+    libjpeg
+    meson
+    ninja
+    pkgconfig
+    wayland
+    wayland-protocols
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Grab images from a Wayland compositor";
+    homepage = https://github.com/emersion/grim;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ buffet ];
+  };
+}

--- a/pkgs/tools/graphics/grim/default.nix
+++ b/pkgs/tools/graphics/grim/default.nix
@@ -11,12 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "1mpmxkzssgzqh9z263y8vk40dayw32kah66sb8ja7yw22rm7f4zf";
   };
 
-  buildInputs = [
-    cairo
-    libjpeg
+  nativeBuildInputs = [
     meson
     ninja
     pkgconfig
+  ];
+
+  buildInputs = [
+    cairo
+    libjpeg
     wayland
     wayland-protocols
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1493,6 +1493,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  grim = callPackage ../tools/graphics/grim { };
+
   gringo = callPackage ../tools/misc/gringo { };
 
   grobi = callPackage ../tools/X11/grobi { };


### PR DESCRIPTION
###### Motivation for this change
Screenshots are neat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

