### PR TITLE
pythonPackages.faker: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/faker/default.nix
+++ b/pkgs/development/python-modules/faker/default.nix
@@ -8,11 +8,11 @@ assert pythonOlder "3.3" -> ipaddress != null;
 
 buildPythonPackage rec {
   pname = "Faker";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "067mdy9p1vbkypr3vazmrb0sga6maqbk542hr7hmzcb5lp3dr8sj";
+    sha256 = "0v1pjzn9z20ckgv3kji7c8nwcsm7670z4i43ic9skjrdbcqylwfq";
   };
 
   buildInputs = [ pytestrunner ];
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   ] ++ lib.optional (pythonOlder "3.3") ipaddress;
 
   postPatch = ''
+    find tests -type d -name "__pycache__" | xargs rm -r
     substituteInPlace setup.py --replace "pytest>=3.8.0,<3.9" "pytest"
   '';
 


### PR DESCRIPTION
Fixes tests for at least Python 3.6

###### Motivation for this change
#54425 for testing `todo.sr.ht`.

`nix-build -A python2Packages.faker -A python35Packages.fake -A python36Packages.faker -A python3Packages.faker`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

