### PR TITLE
firefox 65

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "64.0.2";
+  version = "65.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ach/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ach/firefox-65.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "5515b876319c78adba81ee43a7e93182c4b9f64a8112d6a265d7e20e52c0cbd77031103b746ff8ed33d1698cd878c0742a174767cad70819ab60a59aca0fb991";
+      sha512 = "3bdf982f4646a019f2dc11f5367ab0c23695c9c8fced02927c2d9a862e15f6a1c9c1ef63da3ef6539d802095d0b8b48d6f55a9961a453ddd4a97d828e9372aaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/af/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/af/firefox-65.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "9a600a387309c27a211679435f9b246488f57a7629cbace1dfb214f09d7f41991c1fd915b03e3cab89f4791e4eab45e513c889d3f7041bcb96d550b69ca657c0";
+      sha512 = "2a010ce94b6f0108cfed973dd9c632691d4d2558ed006184ba9ded8ea89933fcc77d21f82fe3add259409861cb65dd12e48aed592fc932411ddc3226c0085d31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/an/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/an/firefox-65.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "92a76b0239b540554f1887af4832fce8c31a30e460b7d08043cea0293c2e1ef2bde7420226ae858ab3f71841c819876336f929547a9781563e4a3125c181d39c";
+      sha512 = "30f2cd15a3d43c4228aa8b49b44aa4716ce35968cfb63d57141a3c3027e95242f4c724aee50b6d7ffcf77384e101a17cd252beaec75840f59400e0db2c111f95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ar/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ar/firefox-65.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "e1f4c5d8078c4c7e2f098de4048ab89f49815a4ff2f3be671609295101ba0f72f176a25e75b59e5d179ac79136b546af95c00f273d0c0f96d2332e445dd0f333";
+      sha512 = "ad9846180c953ffdb73d519f1090a420deefd8b4bea531038318237ad639258bb05f4d9f88cf23650f1507034ce0700cc9e2bdda4ec02eb6e02c2d795b552cfd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/as/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/as/firefox-65.0.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "65515d3cd49512b513b9f8ff85f508f06c55b0b60416bd77da1d9122c0187d1ee3e25034843d064ea9154a87c2f8c86068af109cc61035022cd0c9a11d8eeeab";
+      sha512 = "a9babea676451cb0f0126711592d3d94f57865c520de370194023157a65d5633d26f63aba9aa71472e40885d67de98a694d0bc4b65f4c1c933e3e4feb0e6be71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ast/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ast/firefox-65.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "874d203bbeb51ec2bb925560c2f3b36556017f7664c189806dd52f3481e9fa36ba5f82500fe7f1ed990d355da11358df597ac62104b2872b0c4c7e1d0d98a4e1";
+      sha512 = "03bfbb6635c587c356fe622757b2b7f6e3b85fb04c7477857074cc198efa4e97e960e4d3b7c5d60aa9fda8639e605ae00d398899fdb2d05bd5fcf5dc494f4ded";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/az/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/az/firefox-65.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "c61f007ec5372c920c6a4c906ca2b68c3507ed18973a938ce0a5a24387ef372cb3ea15f79c739ea3b05330ffad8385facda72f3aeb011e0737b6d9fd90196949";
+      sha512 = "5201abfc1e7333acf0bb8967ba667742dacb2cdb8cab6b3ae60ec3d15cf756a1b48f6bc0904e02d433df5ab80440fe3cdcf4e260c4cd1c1f3da16f51c00c2962";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/be/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/be/firefox-65.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "76096a172c1a55105e7cc614070d5fa44fe21912198172fc4a2d0989bac7a600989e3f3c5fcd28276cde00d19de44d37b74bb91abea8ee1ee11d435c7910fffd";
+      sha512 = "68f400d8640620f2af6ccf5a3b8e4fe2c94e7169e1b258d875b693dfecb4dbe070a9bd6a97b9fd668362783b73cc2eb21925bbf0159b41c4df910946bbae3f3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/bg/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bg/firefox-65.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "d10c58cd6ce37aaac59bf71c1effd4e91ed9bd570889a335b453fd022b00659a0e0ebdc32a05d9e6cd16e5633285a1179a252ed1090ff223e127ccc974eba4d2";
+      sha512 = "6a7b6997b1efb726dfbda25e7f7eb024013ab1c782912e03e258c4fe72adf26ab926a05f88e62255c682e6352ed88b2158f1bc12ce9c8b91714291783397c379";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/bn-BD/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bn-BD/firefox-65.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "752d9f266939c64ae67a29718e7b76b1a9f0f2824989956a1bf31d4bee51489130bb276fa3c299a011d64d54e31e6aa7e937cab909e69f67afc9c0a1fcc2f50f";
+      sha512 = "1fe6f67067cc27f4d8b13eaa22a8ef2ca23fd3971a3140432ee389327fd97faf97be802add562b2f4ced0fc83f75b8c8c8c707c160e0ce3ec50648735704f9cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/bn-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bn-IN/firefox-65.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "b5c501b05695f16ea8af547d1aa76c401c536c31cf5d5bbb801ade6cdd351f0fb5ca06a132565177c32b4e8c907ccbe0b4e6ef7cc70b39cc7690616df6dcf834";
+      sha512 = "d5ad4b8673ab8c136e3aaf5c2627c7210d670351744d486a896d40dd1599ee17a5cf90fe2c967d1c70989ac644f180c0efe23fa25f5f76ea4ba4f0ca0f3492c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/br/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/br/firefox-65.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "a6d8ebbe61768d77e9babc031a85d1a0aa398857364ac95fe808fe1a983c1fa154f415f6c5c73b4a7ca8bc8f6988e807b0df553f4a4dc9222e9e6907e433cf60";
+      sha512 = "ca1196a2f2875b86c315a32d9c0091d0c72d8e2dd00d788f24000644028dc0d1f5eba7f9b2888353a2c5fbd16273412cf3737d39fd63ffeff7d0c5bfb7829922";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/bs/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bs/firefox-65.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "6369533de84d8d77fb5a67b86246243a725f840c21e6d2126be167586e47ac2cd57d0bf376a80b343919b22fbf9e57f7043c9ec48cc7a375926fb21424074fc6";
+      sha512 = "7fc343375a6f2947d2604d14a764d5cdce77209c6a1770f69cda713fc03662a7e84a6c656d1262148b57c4ec3c9c5172fd910ba424854f35b3b7fe7ce148b699";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ca/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ca/firefox-65.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "93332ea341e7781248f1169174d32b592110a141fd2029890e99cde3c20c5c2799699b1875124bd7a97184a40740379717d29ce32f578843b51644d62d99577a";
+      sha512 = "d62cfcfa8c575c905fe904f6819e5f82bc139d91186db956050dd82ed3ce65ca4eb407efab9b26049cb28d806c76d9c2516a176157b26608418f06d66167b13f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/cak/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/cak/firefox-65.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "6ac00ee11927ee376a483dfdbf0e0f49021df89f05601c6565e6b17d6ed5e748afe2b78b1faf1ec051ddb9466b7fa05de8070473aee81e84d8c26613c14ce457";
+      sha512 = "b1f4bbdf515d8ba548b0e915a53d212e74d099da64631b8f05f21b9914ca2545b4092291d21b28bfdcba75be6eba02b79cdcd57ea4b39a1c05a856aa73134e5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/cs/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/cs/firefox-65.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "1a83fb5b7a5360a88d73e557f5bb6ec7daa5df31af4303564f80152d5ef85122f6d447afe5a76cad051ee2794bffb6d4e41e2757f1fc25b0ce626dcbb135332a";
+      sha512 = "a98915ea6d8a5e1a374e34b836563ad450a48816d374917562078ade754dfb1cd5cfb6cef73de942fbb1c1c1abe41871ec3b9ff17a3a6a6bb2bb36df3a6c3763";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/cy/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/cy/firefox-65.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "dee73f92c82bec5ae649156ae4d94f88b50662b7291ece57bbfb6f6fa4921b1f9370bc563a8e677ec262879bc2e621c2591e049927021b75bc01ac83498370c2";
+      sha512 = "ad1e6640cb799acf17b8e151b26e78a86ce21960f2f8b5baca4890e7da2fe1d4739357058a551c161e31c1685d99d988d9715b6eb6a39d785e9e526f60c65009";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/da/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/da/firefox-65.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "06070e00fe03769155558f4c8d3fba1692107ca1d19cbd0eff5be00c49d1b9ad408a5bb25bd53a040a82fd99f09a2f00e5c86ba6545eaa517dd4a61d29063349";
+      sha512 = "983fbde10f8ed3971b2ddc8161d6387b56d8c94ef3724f7db2febcb7160d17b20a6cf406e48c3a266d0e1a74f024faf4950f8dee0bd60967ff1c1ec7bde21450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/de/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/de/firefox-65.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "aa7f3a0afde8f36e3aac31ef83a6f0b780dda4b4361736d5ccb4b681448a62606bb75b798e3566b8d5b153b5f566f3571a738de66441f97c79ce51f46a8d38c3";
+      sha512 = "59aa726477553aa261fa473b56e610807070999a1b120a3fd82a678ed029fcf2b541a71ec89f1d1a176bd40deda1cd659cc0bc1f486a283f2563a0a0236fe2ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/dsb/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/dsb/firefox-65.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "422f677bf367838fb1ee85020295ae950cb92ed1624e0039abe1f9a2a5c4b6449f634e2ec0d3a9da57ff021f86c0eec53968e016708b331cbfb7c4a221cf02e1";
+      sha512 = "cc270b9e372b799e6867a93dc1148e9929d67f4fd9a8b2a1fbf4c0c95b23c6f6fa0444efa95dc545c4906b488f44c1a2eee8d9a8b6c6c5a8a3322f1a9c9cf553";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/el/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/el/firefox-65.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "6ab24e3e7ddf2031e4a6648a9cd37a78c83cfd085c02061447c49b14f3ad87237b958f684da968d2780accf7f29240a17116df16a51b120f208b49ea3c6027d2";
+      sha512 = "170719eb9cac9d1d49be16609e5728bdf9773195196c51c6d4d6c6a1f18f72ab96b4f3124de258186f39a1b1e3a849b5de73d4b5ee48007b22a5e84370d694fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/en-CA/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-CA/firefox-65.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "84501a31e029698c34ced187bcc8bebd02f20709861faf901663b7eb35f74ad768c2e04b412f95ccd02391afa1e4cc5665ad027c689fb4de9d4fff55e00df784";
+      sha512 = "df694bf1dac6656b802285b91ce5fa5fb39e9ae6d4fced3054c7ff3c474aeec8679745f5a820b0975320bfd74108ebac83e5ca33f914c9f0be992295fd7556ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/en-GB/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-GB/firefox-65.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "4ed1a90353c92a0a5a180496248ed242434131314ea4b5059376b008ff55d5050e83e7e0a57989499bc94be6231782dae7571b5de79451616cc1788e894f3f34";
+      sha512 = "f7953b8c20891907e7cfc45d7399be70b58c66710f6070f18c493b5c668d4576919af7dffbe36172ca3d01d711992749201c66457803fdd7a3068e2d7f6be60e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/en-US/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-US/firefox-65.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "d6fce66e5f58fddb695c6acad01963d71bd19ac543daefc35cef499abc49ee690d2e5067c3dcdb43e0cec62676d4df9f8ef8e683fc9953325e2bf52a2c27e92c";
+      sha512 = "482bc1726399663532000749e600ea5c9c490022696b40d869e851951a9983745b26a7c4ec7f306bf174479e4213103996d075c11e2e1f9a721d392c7c615933";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/en-ZA/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-ZA/firefox-65.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "d25e803493372d07c764b5080620343113fa395ee0df87367a7bccdfd0ee2df56e123caa43f1a1152035c73b099b580fe124c3031f7c28f8fb8d5271caa5c384";
+      sha512 = "bf721a577a1a916779ebf0d8c0f673d0b4d1c0230b776b2045c976ebca96baa4a6856109a837d40f301465d921bbf4622cc4609f31624551cdb056284cb36644";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/eo/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/eo/firefox-65.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "cd4e9d22b7d4b06eff75b85fc3e52f0bcf71600ee5032bb36fe6cd944415cf0c0d7291608e8b3c85b1de5d03d53b661441b71c16d3a5018fac69d8896688c0cf";
+      sha512 = "ddeb25f719dee34c186fd1831c1fc5166ce17a413325cda1a3be97b4a1a65b302b84bd9162ef91577fdfb7b82180267026039cbb49d0ee434497eb23ace6ab98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/es-AR/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-AR/firefox-65.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "ef7cc10461798b3c8336b8f243ef215402220586ab1f4a1bb14a3e12e60ffa5e48ca36c2d420475e3c0dedd3aef690229f035d77655747063241edc3d7e1e235";
+      sha512 = "a81f7e9aa65e516632ecbea14dda6ccd65405388dfac801e179ced1caa9a1da4c671ac7a42c3337907af85612eea46730760707d3f12376d504fc2b1c629aceb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/es-CL/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-CL/firefox-65.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "d1c094adefcf7b493577af759a82d00c1f4920e8af6402995ae4e233d0671810abaf75c5bf7f07297d24fa75fa653ba138fd00c8eccf8aaef9d70ae502ee5ef2";
+      sha512 = "1243a4a02d82fc97bc760197c33c1e4e705ed8c47dd565a725e1c105b22e42b89b19824f7e35e844b4c5c52c78b3fde512a50d3f655ba548144ac2b6d73efa9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/es-ES/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-ES/firefox-65.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "03cb237766b18b78bf0c534b372d36a187a5613e265c9b04d627f8b28ec589f7b919498cfab6ee27fe0c31f3fe2f6eb172a462e2982995fa62b1d03ce57ca786";
+      sha512 = "c44b3a7b0fc6a13ffc075b7f282fa0ab1be16f98df872a7a168c3d479fd701d7e14502215ca6e211deb99c1b38bdb38ff0f4068eb978aad8d1f80b682839fd88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/es-MX/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-MX/firefox-65.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "f643712a7e05ea1f1e5f85d7646fa4a3185a44e04d0b1e97aaaa499aefb9d62e4370535aecbc1f7bc4393df2d7ba1f6bddaf53c647c59e4f9efd0a328171e2b6";
+      sha512 = "3b376e854a2498101fea9de4117f970bf41185b9ce74254d64088a58c77d21845c5a4ebee07c923cc6d8e616922b109cce0d25df9e2d47cf3dc62b726480dbfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/et/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/et/firefox-65.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "5cf5338b65c6eb3263e4a2f9e0603371daf2d71275310e3ba8e4e04cdfbb400584778695d4e3735a69254f1c1c81eda623a22d2abb31f469700d3bbef223ee63";
+      sha512 = "c55706aa897afee00d58741191dc4ef4ef9a0f4296c407770089e488449d95044bd4dc422c3fd79ada093abceea1e649b59a9f5f4e51738617716f497c6753ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/eu/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/eu/firefox-65.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "f19971d2d0117a7731b338e0cb114ee37a865c0d80c3c0b399e75a4058b0f95d840f4f55c2f6640c90dd36eae6c669f7462e4db7b2effe1c6dcaad6570586b6a";
+      sha512 = "5384aa5496a9e2e40acf0b014ef71e2e06b45bd9968441715cf38f5c9212c35dd1a5fe3bece97168870dce45bb1a91390fc172c2c170307b543d29d2a7ce6220";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/fa/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fa/firefox-65.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "00b611585f2bd6b09008c808f6b4ded7320231255ac1c7e63f387af8f4186a84813ff999a4dbc718b178efe987e23769ea5bedef1753a46c8ddf1f812918eb7c";
+      sha512 = "9b83dad076df5af63d4434dee22730770d94747b29ce13e551653b5d008b3741f33aa9819547527654c9667fc79f47d73633a384174cd92d786a02ffeefd5ef5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ff/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ff/firefox-65.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "652a2437e1bdf95911ac18f4a50548d6a678312f2e14e2585bfaba3066238861fb50e90feb4892cfe7405db9ea93aac99c07578f80bc5cbd5f452bb44d99db03";
+      sha512 = "fbe80240ac2347c05bde0a3240df050034777ee52e129165c5d8b11fac94bf9421c3ce413e9d3dd71643e2710b0328096d602795079bdcacf98bdb1fed8cf318";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/fi/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fi/firefox-65.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "9816a261bd67876c66e800b2c0c5d2e79b159ead2fd57c8ef59d3225fc6cb7d3d9305c9f312faa47ee28cec80977be24a0dfca0efd556f1c8e0a520b0de2e0b4";
+      sha512 = "809ebc16baa79ed287b980e211cd7ca3991057b538f70877f599df9447f1f787f9c0fa4fd4f54d12834ddbe35bd9d1162777ff579cc5703ea907cc70f08c93d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/fr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fr/firefox-65.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "f6aee20cd612cc54c2659b3ea8a3ad4ce000f09610d00fa472d3300770ecc3a22a7949852b62369ed85d9a5cb7febb830a8d5a3b548d05356a537c49700cac60";
+      sha512 = "98a6dada770067be7cf651b7f2d6e6bb57a0358b6ee54af47003a153844d521b15dbff65afd1ee0b05c23ec9e91aaf434d90065a21d3e729b9abc48fe27bb8b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/fy-NL/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fy-NL/firefox-65.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "61ce3d48495284ea411c702acde5a1a3ec38fc5674f59fe09bfe3db62fa8bba452ca842c992631c333145bc8d411f70ce0a5ad4ce9bbeea91df963ca4f7a5320";
+      sha512 = "2d49ea99934ed637a2e2c90a15c3be55f9470d275af6d1ed9f5868bf3b3eb7c8871728811dba87458c59a843b310f491712d61063b43d36409e8c8d7d5567e75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ga-IE/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ga-IE/firefox-65.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "5a84d385dc8210ea6c4779bcd6eb816b2977a681b76f3876f961f553a50c44f8d034d7f5ae6409064e6ed26d5756bb9c4f0deb8a84831c2b89e3f8a4cc376cef";
+      sha512 = "2a68fee8dcccb45f9f849eb61d54629a1216a247c246565516425e072387a7e1fd9e382c799e32884d681888563c982ef894276e84ac9e537a008fcd39ced893";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/gd/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gd/firefox-65.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "b0be9756452d75c535e8ca7a12c0f6a945a7ef0df31cc9a3549ef8d04a77fc3b3920331599192a3c3739ccc81c027d5cfe7c3b38e9bd77e651990ee1be7b8680";
+      sha512 = "a97c08e8632147d4b2a30ba63295e1d080e97d561163a4e87240667ca69f9094f98a8ebaeca8aa75b4d344e315ab4e72d605e06b800d4156c38fd1deb83b45b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/gl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gl/firefox-65.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "6d5081600518ccfe3c80a5e9ce1a01f0e3a898ce1512f6ad240fe7b056fdb55ead39ccc6b49f46b227f17c733cc03ff15b2760851d297dd6d42fdc306b6c4a51";
+      sha512 = "49d4d0afda162e23437f44a5b5ee9a43e1643c0e739bf6b74e662c79b4cd63f7bbbe9c56c73381e0a3756360b03ffef01eb73be1c1b506d20bf4cd4f968b2d47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/gn/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gn/firefox-65.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "3787497d746b99445b406780fd1977cc52c8d41359948b2250d7347008cbe8477a56b8eb4bd1d324f8665cfb1be144ca4f96ef6ba772c4a42c67e29752ad0f65";
+      sha512 = "7fc62ff745bc14419ecdc11e0cb880cc28f54cadbdb19980f87162e463eb97911858fb7673c2a9c1026ff6b786c01058c975c53c16644881e2a0b0d604a098ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/gu-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gu-IN/firefox-65.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "e7bfe98a504295727b3f8d83ad5532df8f0f282729e37c93c7555cd46233df67e9df68cc595cdd27000d9e0064925a2c66b32d66445e336d7d7f730d1a764162";
+      sha512 = "22a36860d0ed79f36ad804b636cf892c45b7dafe948df151a8a384c6400523617e1a191157f099ee26ae42d06b3ba3ef508f9ab5a4ff6f819f21ecf74f9c3296";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/he/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/he/firefox-65.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "6c56aa0a3531510819360130446186eab2e8dd9497ab6dd6edcb485687db5683ea6a5b0159a0e5607cd5b7f16625a361c8b55a6f06389f6ad0e301394db5997b";
+      sha512 = "2c46bf74a8053337958d37389f1fb457b814d18d27a337bed84d250acdde8c7a445b8dcde8507c1c502a13dea718f1df01895d76b3725e5ebd65290e1e6ce477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/hi-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hi-IN/firefox-65.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "ee0474be53ea0a7b89bdadb40bf7ce14bc99f770f3391780dad057eb33fc721ab470b255a77b5f7c45ff88f316f8be0cd6eb425aaca694f85cb06f1c94e288c2";
+      sha512 = "ba1724eb10d76c3a70a58c72b5f5a6482fd6f5e7e3b4c04283a03765e75eaba9abbd5c6e2d3e350f36d82909078987a4c1a6073d67e2e56456e1954e291fa3ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/hr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hr/firefox-65.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "41075f3e26ee616cf543484a860bff5548d07b0e388ef424e7cb90c5f4a601643b66acef968b383e425c7b12c1386cfdb1a945c6d61521ea84d32dbf31e6cfaa";
+      sha512 = "5fbe87ccc58b16725c10835ecd54d825f71099ab37eb2e4eca343c6cec5f8caa5f40ce8a5b2c6989c36a10a903378e69543d1b9e157f677032c47362db144d5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/hsb/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hsb/firefox-65.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "789bc21204491e4dadebd31fefbc3821b30f4a028d2452f02a1411cebc471b28f71b02312c57fe5db95a581f3c84a02335148517075b7be26da5e8b18810f49c";
+      sha512 = "9bf744b38cac34785f56bc308b2a4024b4973e7f489d4f9f3929fe42aad2872facd967fd35bce452beb40e7c936bf400f1022e0091a375a6c7aaeac2bedeb3a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/hu/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hu/firefox-65.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "7d9a7b55ed0081b1685bba73090f96fe869c900741a77ba75d28d9d60a721e909dddc9046c64a1a68177512ba532a1cbd2114064794d5003fbb0cbf98b62c69f";
+      sha512 = "11ead0e258d6a81d5a2b8d3bbbfc5cab8bad7d35e7ec853280f7d559650d121b56bbc66ca8a25416100506300b5ef148fde573609c4a922c775abc106ca59f1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/hy-AM/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hy-AM/firefox-65.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "7ac6311c1550600450e6c08e07c1bd3e471b94c88f58f5c8ae117c64d1c1264bb6d2e3d11cd2f9979396d2fc45c7b4747959b046f411eff15e1c6567f078c5d8";
+      sha512 = "67a6084fda25da7db2ade9596c6fccbb0cc191a748c8ba089bba68e1c498774a4d309680c8d36b61a49e7bb0795bfbf48d853df1a7846eda65e752d791394079";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ia/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ia/firefox-65.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "d457095633cb06b89c2810f1c6ceccc09de6933f95e25e657831b18734f67e72755f5f1e47f7da3089cf1b29b03ca3f77c340cd4755d7605f8b23c9e05cac49e";
+      sha512 = "fc2ba7e0c87c610018bf1c0705c7d263e301c6b0dfe080f44cb0708bff59e955754b4d0ea167eb5066f38a72c44312fecb13d7fcf855ac6125a7f6a833dff176";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/id/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/id/firefox-65.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "df7b8bf1eaca0b34fb9fa29cffd5cdfd653d7cb64d794febaddcb5a5a02b9b803673339206cd2292662416d17fe354021a203ddd7315d55bda3d99b2cda0a3fe";
+      sha512 = "c678461c38462616f731c2d0aab9c56f5963546f434e4ebcd2fb7b48aa94bdf7d4a7f14481cc4a17ebcea1decb767b27dae914fc3bb2503180106fda7adb74d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/is/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/is/firefox-65.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "a9438efa98b7774f16f6229a6df5bb41285c8aeadafffc17c585d66829088c719ddc8300b7f2704950f3d9bb263c5e222584eeba78b8366d44d62223551bf3fb";
+      sha512 = "00e1c27374e5b174ed5bcb335b2b8a0ef8638afbaa707df46952eff48ed94fa9a021af709d8f99169e3ab33c6c763af0673b3a33c30881e09bb12b541dce575a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/it/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/it/firefox-65.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "618132ced23955927bfb3539e20908346611ed4983555fa776ca7363c0d230e51ab2dce76dbd3c6d165f055b5a884e3f2c2ccffdc9d53107a9d191ddf7d21eac";
+      sha512 = "19d34371b514f718a6710aa9d00ed1c1b61db770b7974b50702e3a1845cb0e23a9606a3e5714d1dd4dbc13315508b266d1ac9b2876a3fd5311762462aea48b82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ja/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ja/firefox-65.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "fe24af80b68c9b4b16c505ddd6774e928e052eac344686fc7346b1910cf6457a6a0ef397e7ad6c426767894e4433f29d09510867b1ddf8ca4323f493b8aef1b2";
+      sha512 = "a909971593687b5b20f614ca51e6e3f37f4fa8bf9464cf714473950ec1f73912f3c3f1bb79410698511f38e86f743705d6cb8a60be6d9e2266464bc301785537";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ka/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ka/firefox-65.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "cbd6e45e9fdd5d3dc36b8f2eaf732f3899f7bafe8acc3c698d7ebdbb589bd53b050188d69842c4a881902bcacb927f10b1095d2daa91a52935789e136b7c2ac0";
+      sha512 = "8eeeebb0fc993caf80c088d96e2e31e579edfcca5225f622e3b0a592318308f2578998668638594a6f32cb0a984d4cf534532ae2a9418e32cc750df3c33c5361";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/kab/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/kab/firefox-65.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "306fbcf790f2f5a3471a02af5ce8ffa24a65b87fa965da1ebd78573124720e3e89ae039904702dcff7a8fa4cb4a3fd1c3f5fcfdd31a8d906e0b077e941fe0521";
+      sha512 = "cbb17638c972bda6fe83460dcd5d320c03888527b56b7d49e929f6ccb0edcc54251aa0a45162457a09929b7640c588aa210cd969ea43c1f9dbd68fc0ab60c55d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/kk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/kk/firefox-65.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "8d978750546334a01fed7fa09ef53fe92a5f30a79a58addd3a7682a45520d462efcec4e2d3563d494d2f3bf2b775f652ac63175cd701f5441c8224d1f3f62d22";
+      sha512 = "d3306176c90902b4b2739ff52cbad140bcbb6cc0ae39e9f820781490a35a69428c2cc3b0204c23832bca62833523ba0975d39b3c30d8504301fe64cf7a5af969";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/km/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/km/firefox-65.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "c4354114de0cea0a385ddd8128eb6f7461f75c5cd43ef223ac742124b0e3e9efe5d1c3f6b7792fd5d59323e13f097050ba7c01f213b04f56b12a59ee49b3a6fd";
+      sha512 = "f36fab6bdade43429941dd43da65a961dfe006001ed8d7a53041e6bdec0d668edbe09d96e383e76fe8d107e87122abda704b9aa14f7d6fa060bcdb283f30643d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/kn/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/kn/firefox-65.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "1ab483a1c88d44daedf9dc2196b23a713b0f167bbf061b88a8d09e5e01d4828b5f5b61952fa8eacd7940fe44dda6e647e3a16d76ec2069fd29060b6c31b18e21";
+      sha512 = "89c40234a72938d441704c4b03af679085294f20cb0065863fab92ab03446b01b7afa3d004a5b3330439682b6f9b44ac078fec3906b5f99b4a07427419442dd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ko/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ko/firefox-65.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "0f7fc6be243e54fef2b0dddd72589141c6a2c7a2f3befd742a3b5c1931718180853251c1d56379f6590fbb3aa3f4f0808f04133c640e8432f442b512d68af25b";
+      sha512 = "17d890cd0ebffcc24eb8b7abb4c9e29063bf8b784e0c603f4b69e3988aaf7c77cf864efc19d9774d94ad9a9610bad27a1adde53efe41240dbaad2b6a8d0ab1bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/lij/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/lij/firefox-65.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "d6905eb973303ff76fa719f1d9fdebad49fded149acb6021e32b6fb1d95c106cb80a480081448d3aed6c0ae1a9e87e420046eaa36931ad4d355f50784071d42c";
+      sha512 = "31265524009f12d22551c5d52cf158a3f7ae0068d10cc744ba18ea3c90e1835d2119951fe11d736809369ab4358f6415e9da7103eddfa90e415c1d721980100a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/lt/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/lt/firefox-65.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "e0ce04420e9dfd2b4b0843d40322da3ca92453afd8ced6b4073f514006f7a92a7bb33f7735f8e911ce70ae718093af72a49a35cb2d2fd934142b9e8dedecd804";
+      sha512 = "fd5c8a9cc4cfc5cd9e6539f0482c2dfb413a287811860a6658533865bf71b1d3c60c92c615fe588b982d2f021682776474b1420865eba66bac16cf3495747642";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/lv/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/lv/firefox-65.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "162184c877ac88d78c1d4dbb27ffd40524e937fbee8d9180295ef20a90c8d22e777fd91918556078657378e7363f5205c031fb403c3b9607ee025d82e160b883";
+      sha512 = "6dc4c5caf27b7ab2191f1e2ca4b22b7ed87b7387759139e4688da174d3382af2cc971fb5735fdbce400c53ff8d9bf294512b173920e2c4a62cb5fdb4e6ceec3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/mai/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/mai/firefox-65.0.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "5444f01c127fdb86309194cc742f03d468efb6738bbd5736758390b08286943f991ee763f60b92270c27fcacd20a006a8db25da478fd7f32cca60b6f2c83c2e6";
+      sha512 = "afea8c98a60408823d246c4d09d2b9a0ba4c974b02e2e9088e91872d9d4da98d82924c6f486a32274e8a8f99572ee563756c9c9f0596c1d72913a9536c8261e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/mk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/mk/firefox-65.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "e02900e8e7fb54c2ce935c159485ea7540dc9eb5cd9c4db47b0e6c463a30f1cf3de3c1ecab45a24ff5d97bbefbbaf25124af2ea9fb24402c1d47464fb8dbe120";
+      sha512 = "2d5cec8d0917694c3bac304454aa1770940310f9bfbf6ec233214989577e1f83c1f81326fbebf77fbcd880b3b03c3fb1928a0078925ac343c4b51ff72c481cee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ml/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ml/firefox-65.0.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "9f7c40c1f40b8a7e76cb1a9797b0ff4470dc7004134c15c90aa8bdb42bd7e6727047d4ef19a47be0450fd0398f15396748bf85c67b1343c28d17b1e5a35f30aa";
+      sha512 = "86585195d41312e5a990a388c14de87fda05c75c3cee02f0af40367a9cda9ec1034f21c4627da5c2fec020850ed94dcbafcbdb0f52302862ab23e8218e715c08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/mr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/mr/firefox-65.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "290c1b58d58c39ff1a18ab400ea3533aac6f14490f9c43eea711f2d381edb0660a828e45ddcd2ff723330a120d63702b962f02ab3bc7d81abd7ae6612bec2022";
+      sha512 = "f996ec4bd929311cfe481e45813deb1a6fb8667564ed2d63d0d4d2a814ee9f8c5671fce760fade3d6d9ac76e33772e09b5f1ac80e6afb1e4edd4c22c5cc69942";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ms/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ms/firefox-65.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "e9050d10dd3cad252781cca40f8c59aafaf84466a688ac575da589cd0f99817b4147525e07cb740048b999437f4a5c83301b392eb0ccac79889eb7520f7e1c1e";
+      sha512 = "da9b9b272dc5d33910cf014005b19db7a17fb7306c55cbf77030b1cbac9d9dadebf0ab64845b232c9f9afdd7a47d85b52db9264021e45f5a172dcc2b74c32459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/my/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/my/firefox-65.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "2143f58adf060dc73fa08bbe44de6c23426e40def9efa0f4a42ba60fac66f365f2773b645b4369f0c742b7acae8c3f013ca25c658481ebe795ea7d694987f4a3";
+      sha512 = "70c33d409656fb6e9b0c3fd5af1c9411ae6084339bc2c9eac55bd2e9d5d8e0811630e9f3ac5556b816c6fc3518657073f6786134299f5cdd9b3dc0f2c11792a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/nb-NO/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/nb-NO/firefox-65.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "d2df1efce100d559d5437838dece341c266ab6f0e33f260a137d49965e90436faa0d3ae37e15ac941db89c66e2e60e25eb1469bfd83c536e7aa4af202cd7538d";
+      sha512 = "8dcf198e0b120fa5a10e661c83b604a85333699a6a524b340f736e5cfe21ed9a96c9b009db625db0160c9a79c65b62b28a8a44957c07b05b6e576a0280beca84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ne-NP/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ne-NP/firefox-65.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "e94ce5e63541557828d4251d6ddef7f01dc4b555498c9c7ab2d621cd07a27c76c3dbb4f5a247428fe7d4ec75b486721754355720c5bb7b8c51de69e691608fb2";
+      sha512 = "fede145ef4f444a28d3d10339134b9dfbdfa8bc5be8a8c390c64ff797e5b38d24cc8a242f64d86b0091b4015a75fbd9589627aa0038da534600a9c68d06dae6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/nl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/nl/firefox-65.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "7c6ec34aef00e713e548ac9d56837adcdaa42c888959bff5f75407b91c7f2cb92597743e046ffad5cbed1e2586be444ada90a62a4bd0cf51db0abacfc3b8e84b";
+      sha512 = "c128881c182fd29eddde5047623902c3943cc9100add237dbc8f289a1476acd6cb45f82b8e88adfa21ec2e25f111d4dd3ed772c4cd711aad1a4b040e36a9da5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/nn-NO/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/nn-NO/firefox-65.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5d5e426ab55288e21150e4051b11dcaaffb112020dd54b9c9052c426b865602830f6e7a75e1d4d9b47645f2292247be80abb47da58ab837483b2182987f6114a";
+      sha512 = "48c706cde9c4f2f521d0e2b1d4ee6a8eb47f5afea1cea8e7424aae816f81d156a1fc08d0e315b5fbb47d9a44d329c458333b333b6c63467460d4e97c49ede199";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/oc/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/oc/firefox-65.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "7a808adcc5c9fbd1771865265241b9e0db92a13480f47a0bc140c8439790b194958b6a5016982f7d0abb183b8b9e2499e0e8472d925e077fddb2309d71b3a167";
+      sha512 = "88f91a0ef6dc1a234ee2e3ed4bb32bc12feb4dd368805bc837b8bd3f049ebccff535f6f02d2806276d43ba471620a274a51e35edfa8f195e043e85930bd44821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/or/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/or/firefox-65.0.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "73700c62608cafa9770a4aa2d34489b49aff7cfcb020459ebcd8613225871c542587e671ff7d3131e2ddce0855b46f5e361d797c9e269622ae47502791668893";
+      sha512 = "13c5f6c63bac0acc226e92207ba8c8c6ab06e0c99135965fc9ffec46f2a6867136a42ec488bfad411412a761dd7cbaccc08062376197217eb1d640028ced18bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/pa-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pa-IN/firefox-65.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "e4fdb3d6f8ff8579456478c975ccd4115adb0c99a4389f0f19b1ee68986785f62ec9ded2da472722fe1a106d9a2627335c975bff0e80a11a47808dedd2e71d6a";
+      sha512 = "89222f8b28198b53dcffcdcc58e5331b6bd6e099cb4b860b1f4a7804486c741109164f11e0950456b2ab61a4be8db8a81eb67ae3655ae361801835951cbb1890";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/pl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pl/firefox-65.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "67fd62f70dc22ccf7018f42513dbd3ce0f16d9e03cdeb085f8d7bae8dc9871ae28cd976f40dcdab5dfa57da011a8e125c7be2cbe645238b14cc561a48f4866e6";
+      sha512 = "780c81135a0e1c2e843518e6690b9e5ea472d90b985bd51588f8bbdf1f920bc07af75d8f294c5b30b627b48319fc89316667fa55e94a8531d5af65369af3e633";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/pt-BR/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pt-BR/firefox-65.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "7a2b8f3743ea3833452e538ab79e2468441b2a6043dd30045908dd6a6b118ce00ada5bdd9d9b416fe6b25f8947455daa33fedc6d924a57c454efaf5f33325f54";
+      sha512 = "213c00695d9b40bb35a02c1ad006da9f42551af1554324df8524318956b9c46f6cb772e6bf7d90c883f97df6be78d527af1601eee42bfc8a5014e46c44af3af5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/pt-PT/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pt-PT/firefox-65.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "5e2727f29145b9cb2d46c17b822fa7dfe620c3183a7fa8f986e6a7108c1d011774447c8c1003266a685ae686aba5c1a258873daa017be645dc0dea5ee72a54da";
+      sha512 = "56ee6d56f036925be13282db7edd518524b499810ba31289d287d7b6e3e5355cc1b944d1ecca7aab9d37ab55141fe94c3af3f23f175b2136f2ad3c099f201f67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/rm/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/rm/firefox-65.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "653d46c7a49aec297ca641361fe4edfec61ab777045de9af0b8b97806df317f25bbd26d61750f4da36809a911f8e3e2b038862737786329fc32ef7ebc9821e86";
+      sha512 = "33821af846c772f6601429a983365f4f79b3fc2df2cd20cb23f61219f544a4520fde8c4e5ec1b4474336c52a2063cfce6660928b0d0aa6336db41055f562c8e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ro/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ro/firefox-65.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "654d1ce64bf2dd3c833a01709c4f04f7c4e9bd81b2fbe4cd84c89abe879eebf436d4679c469ed98fb455d07769cab38a44479f38d554173a406aaf52ddb7578a";
+      sha512 = "bdf7a957ba453a1f50ca1831ec30c2ad3d2620e506ac6b5575304235764593ff9b545719a45f4c1143dc5e4a6e91c6024531be28bfe74904beb2f61f29db7b7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ru/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ru/firefox-65.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "dc7de77f6f605f7aed64a9ecd044f07802888d277fa6e9dce5beb6c29a06a7ced2c085c2da5f7dffb27c08d462610cf90e50a499cf946323f16d9a1f28b80034";
+      sha512 = "f77d8516b50dbe597ceb21cc5e643bd0b701718a2a88013338981cc8b7855e601884154fdd3ecc2b1edcd8b19e396d05979039ec7060f70f786aa263d9044a4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/si/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/si/firefox-65.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "a2a9cc67a82df1e73c86290fdacac7f18aae6a4dc832b50f066e22185adb4bf6bb15cd41ef565d641b798bb6528e1cbbc0f68ba91daac3b3ec84e3615e81b1f9";
+      sha512 = "ff747f4502626af21eaf008080477b1f19c4a2c6f6303ad96c65eb597b12e10bf1519bcdb09b79775b9e0247b521d73ab390f4930c3b2b174362b705dc65bdd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/sk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sk/firefox-65.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "09ccbf8f076e1f2ad3f52941261d78fb245726740eebb16345393d2f5cfeb172432f27147730beb7322fbe2ed3c4029e2ec7576140b25f7323b7370e717866c7";
+      sha512 = "ebf11e1a59e06b7394abc671deb59677c4850f9060d8f2c5381cf72c1f7e59079b669b9748bcd13af5b936f7bc49b9f4cbb798f402f47cff48c8631ae77b5c77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/sl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sl/firefox-65.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "32afe7c4902c53e144ac5de4019d762f66b955cc42b97e2d3ebd57e137affd9d5f3ef46091ca70ef5c56ca3c229cc20090f4a8c77f69e0bedaa88568fc8d0480";
+      sha512 = "b31834f097a8089adebb0f60f70803b74d65e824ef63c71a5db57ae1e25efec86e3e31fded1dfdf94f688817c0367c0c3118f15bf8fb01a0de8dd4992f689327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/son/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/son/firefox-65.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "d2ace5b3b4f8cbd847d7baeb216aa96593d586659c6f5671c14574b2c9f2ee2b376381ef1ba33461f6b5a6b3c52f92f8c3c5e1e923a1bcb56fc8850e54936dea";
+      sha512 = "c706f1c88cde86e2d66ba8ceedae19ef0d8fedd4dadce72df47b827b8ee8a0cd9da6c05951021b70e0329b2356ab63c35640065a61f5dc85ac2feefe612acc3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/sq/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sq/firefox-65.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "ece468d21b262a89b7044475a414aaef8b7cd7dfe15b100aa5f0348635b6c011d61cae849a02dd925d20364846e41b70c55b1e732175185283b08beb63ab6f98";
+      sha512 = "ca15bb1c507726920c1d1c554da2c0644c388858e02b6d85407a589d6027391c1145b01bb18cb1bef1cddcec987d5445056b51cb21584e5d9ce41b9540198ce0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/sr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sr/firefox-65.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "990e18cdab79d7dd3e7cee8d08e80cfb85fcf971a3ed37da926432aa0b6c94923d60144612248d0c707615d0a9e46ecba3268932d2fdb3476c80bf16a2abfbd3";
+      sha512 = "256b7b6526a9a80faf9bc754c65d2552572595c53322dd5a9b9ee04e923d2bdc42762990cc86b5cd9505d30952d311a9082bffbc90bb8e1538f93e43fdc36655";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/sv-SE/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sv-SE/firefox-65.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "d18023c6ae26719f1cfc5664fe14838087b23325c70406b7a4c4fd5a90c00f2fb8ec85ee577940f068aeb569d29a8285e7ee59d8b5bcad17d739f413382ebde8";
+      sha512 = "66295fecef20013a4499f0641d0da2e691cfbe166a5c03734fdbf364717fa8c2b6434a86f2bae48485aa42aa74aa802f743a37c5d9c60218298449d7a8529341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ta/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ta/firefox-65.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "1ce2abf63ae01a19ee9984b90f14d3dbb923fb24207d1fac2e493d65d0ddef38dead94a555f466ac65b6c7f0e8c3470c108217be7a6606d96a9b3505cb44e35d";
+      sha512 = "a021bcf2be37488d6c03ada0f7e8662fc57163d64c51aa17b72bc0e23c56d0be1dccb7f1699735908455ff23d62988f6541cb265050612ffe3782129f0a7d65d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/te/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/te/firefox-65.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "bce5a2528d5ec4863845f61ca3f5d718990eb699462c5fed7f6f4eadb6cf69461379c6a07822a97b5e1d586df25baf3f17c7f49018dcaec62419a23ef24253f1";
+      sha512 = "140d7b57909bc2f1eb34c88c8283b66183aed6647bea6164582ae45fc9a54c43b18a7455b60df37a2f7ef6028c92668810cb98d4a1bf3d9e6006a85ed2dc391a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/th/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/th/firefox-65.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "88c000c570bc60a427fcb598a5b69a8f1e6579f371648f469defbc27bf632aed5169317f0275f79298d06adf4af6160e5401ff85f110fef6eae74182ad8fea4d";
+      sha512 = "ef73b5976507930a1290b2e7b09c90da219dd376f6e838fd821992cfd1973e4e0c1a21b6da523b050acfb303d8bc28bf29c15e517f36096a88888498a243f7e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/tr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/tr/firefox-65.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "05e1916fd8d38ee063f385c2115cdb4ec570676e9cfb572fae73949f48c5aa047bb81a49f7579acebcf71e224a8ce3c89f607444db51d717e3608938ee76251f";
+      sha512 = "00bfe75ff631f08452e3ecec45df2623a15c69ac1e3985b1765f61ba34a7e4ba1bffd62e3f004da83d101a1f78900938472203f3a3d0df3c694ce24e17bf55e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/uk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/uk/firefox-65.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "5ec808d0ed7113a17e469f187a5b1b40615347539f29a4a884ef086ec1a1df18e49883d4d728880768439dc53b66dcc9e71fa7b5be3a29857d1aaf8b98f64baa";
+      sha512 = "8cab20c1a4cc960d15899d165ce0340e8f347155ce131d449dba8cc21bc9c882f8209b109330409eeab5ea149926eba6d0a2eb3a6689f98e4b99af1b4f7d6313";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/ur/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ur/firefox-65.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "df6293bba19e09108e49b8c0e7564c1427cc05a210d9407077bf3db9613badd74ba4c3d248bd7fe5b0e05312965adaa776afe7e460640ddb46174168c6010e72";
+      sha512 = "2265739a66dfd03ce0187decdc5472c2d773590314815e07f445e934ea8dddaea38c3fa44b7d05dd16bb21a0f6034ceaac5e7d277176503836165c6da04d4c8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/uz/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/uz/firefox-65.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "a51ded2f47d9565d85394a2613f8d8c333e0abfaa32f23a1dff32e6277682e3ebb28001118a81696fe12fdd532f2d039a6c39f8021f3a668549015d6bb474279";
+      sha512 = "226ed729da52643b6ba1728e761e69e6f6cd6949f394a18e67bd8b11558d87f15e7ff8a7c6e73eaa402c6839b1a78c34de8fa6a9a10b4f6d52b2a3e44cbad099";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/vi/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/vi/firefox-65.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "fc58adb34952e4b5bcf1497e121940afa935afd935786d8f708160693ce5578fc166e6332aad7ff4c5099a4e0ea9f3d5fe9b35b4ac39641240c4a10f28690394";
+      sha512 = "ed82e87e9afb51d1a4ca78905cc672279877b3dd221e97df245b9ba30e77ee01e48111efbb6b1a21c652802339efdcd979d9d3372fcc18490e86c46e87a7f3fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/xh/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/xh/firefox-65.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "17d0244ecf493f5b0d2a3f41f3a3623deabcaf0f5869dff172c896ee89699c12fed0702e42983d102d45ead90c178f5ff3a859786fc8015af8002b0c1fca69d3";
+      sha512 = "e3554422c28e6e571cf77b2db704f447e0120429d859150a5f1061dbcffc0227e9f1909bbd38aadee61bbc090f6316192948970531fab9388e15d92d581ae27a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/zh-CN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/zh-CN/firefox-65.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "5a9bda651722a181e3c60e3c1aca95c8d43aa039b4b0da066cb842f3bd708fee23ccd7b2e1b2af9e9946083b3e2f09406365192a9c8dcad9e5f1e5db5245f699";
+      sha512 = "3ec0e98f1b346a9a79c04e86f260f7fafd6fb4f3e71cd5c9de0f8a6f4854c5a67fe694cd2a10deae5f6e4b4e48da320b71b3b925413d6def030b00c7ba3bf60a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-x86_64/zh-TW/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/zh-TW/firefox-65.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "444c4246dab7bed17f8819f7ba48bd3865ee3b3105974a5eff170a40c8f9019de4bebb705ccdf22ff252b20383301c84eb1282827aeb71cdc5274a622dfe30dc";
+      sha512 = "84cd355bbf75a2d51f7014ad0d407664a5daf5bc5594e9f7a5e1b5cd1c3b5abc91e8acfa8b8972fea94c49149d6227320861d8e2751ae644893167c210360784";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ach/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ach/firefox-65.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "9bb766b46cb1edfe3ca6b749ed29ce34fb9937c594fac906dec394561dda99b48d52d9354140629a4f3d42635bfe9555022718b0a8e9273eb8a22f1a2dfc99a0";
+      sha512 = "a0aaa0d89be1c32f1f211e813bf42c3cdc1aa21f0980b2a13463227141f92293e05d144cf861b28dd66bf296b39f3c939c951c6997aaa9ab1c984e1adaf5422e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/af/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/af/firefox-65.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "556c570a1b678d35b2f41ae8c61d75acde51bcff281cb307240ec6d2378a42266a1dd78f45d4e2308dc867df7fe46d5491bbb898668ef2b7e02f6c42c564e4a9";
+      sha512 = "4a2d43d08a608a7f91370bed59a57a80359e7cfbf71141a1c960fa035a93fcfa2b2f06711dc2523a9d4aae85f9d23a886930922c9ecd717c45afee17a68317f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/an/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/an/firefox-65.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "c83079147210b76daf3eec927bbd90825871beef66f26467cfa6c2d035b903667984c0a069bfcac8c1811d68a50f8d30fb2b4c4b9dad1eb9e505a6de49ea8e77";
+      sha512 = "94cb4579e466e44c134308d9e8bc87fdeffc69f149a31e39d8e185aa86d14932bd41920a6106011a5420bd89b0d639d6fc7416caa53e701373d69a52eac4ceb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ar/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ar/firefox-65.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "bee60a424d9d06c15de65e084708e3d7a8e8b7e7cb77499130cb80590cb7d994b9a1f24364d7c55ed3950283d45fd8f32e87c028ea0ffef83ba2a0ca6a01dc35";
+      sha512 = "953c47a4585da68f7385f1de7e788fbd0f025434f6f7fee3cc4f8ecb2fa5ef4d711b856fad368fd58b9a655a74e178b29cf5e40403571e36fabebae22d825071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/as/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/as/firefox-65.0.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "3715901f212fc10c169837f03a8ad09c8d878f6b6981523cb14d4d5142142d76351bb24a9705309c5720f46d364387576059ab72ce4459cca907e5a84d7c7afa";
+      sha512 = "27008ad76e1a6dc3165a65fa4f3ec6570b21ed17761878bd51c6eb2d0f9592f482ac2ae77c85dde2794ac2398a87bf7b6857d241ba6f70507e322a47b5ba879c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ast/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ast/firefox-65.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "13c019234916fd2abc98a92982eb58ad7ef3dc26835a764008423019a632f9e09d197f398434ea2452fe6934d040f34877fa6dadf88f31b1cfc25d29dae70a4c";
+      sha512 = "a6ad5ec3380bc571d4b9bf486d07933996ef12d0fe18030e0decc9b30a3a1827c4ef41d48bb576ac18b5f498e3286aeb8facfc15e76f763bfba5756a4dee34e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/az/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/az/firefox-65.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "c119d64760bfa32c6dd7508bb3c4683432015b4c678235047e97f8b46a1ad1e47a9589c5f80dce377112f519e448fc697b7cd562853ae50201692729db610409";
+      sha512 = "d78e00aca8eadbf3008ee89d10495a2dc462598bf3b7a508c4147c97c77861b60681ceb8238c9b22d65498d177b0c230584cf2b9a3d9f0da31a6197254b64c56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/be/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/be/firefox-65.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "554151c3f0ac08677fd2c7512af4de712cbf570249bba75a193ffda6ee0f05dc16d5d51c51d0138ff4aa736ef5ff02a1aa6304f0811b50539be34c8bab779c13";
+      sha512 = "2585be70036521dd83f68f6f4fb4cf19713c2ff26a4f6907ff01dd0a8216127037f754041637608f715ef14cfbfe7271b4e0632dc26e351b50c00e8eb08358c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/bg/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bg/firefox-65.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "e64f900fda82ec716c2cc111447afbedfaddfaf9c5a937f05ac47d4cb103c5014d2260c20b18dea1e10187d89f67b25ae079c01c830d47ab43dbee531e8bd62f";
+      sha512 = "54d4b4096c679f10f7fcea13302eac7119e4a02f693a8c4880bebc5e4fd331ddef7f66ed67a7585f47f302274e977df237b25c2e0c41bae244e18a4d32f2f0ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/bn-BD/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bn-BD/firefox-65.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "dab5e51ac21d92896216b7c4f48fb7dfab23caaf3ece8f256ad8452a029f4e5057ea27330923553a4215bbfedf75ce04d789ae161004c63500e6f16f21ff2e3e";
+      sha512 = "9564b72566f535061c5ce2d7acffeaa049e8021adc6dce964c035c55cc5d118565dad54c933db771757429bcb81412a71421cbd52ec2f939bc47957f3e05d623";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/bn-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bn-IN/firefox-65.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "af8d3e32c7b20c70af02462e301503d06e02cea39e058f5c4cdd17675caa0e959a4ae753212e65bfb6efbbbad84b635129c2af3c21f790d19a1e4b44a9520a21";
+      sha512 = "e43676d023a668d215f39b084007812514ff663063b3a16fec72aa79e801a2463d93b292924687341be96101c58954465762dd68a4f44bb18c5f322f59beee3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/br/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/br/firefox-65.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "f6aa65607c617d4f8f87739f120afd00c02d8e3031eaa7bb91a613514d8efe3dd035765bfdc36af72857ab5d9bd3b03c68b767af2a0c933e35c1d6ed09b2ad70";
+      sha512 = "a1321fd5a1940f50eb7dc98feb6ca2795ff6710b8de7874d0726465b66ca5e1c668ec32da3f946511a21e96db8a3851cafd3ff8fe395accd68a3fe730069c6a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/bs/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bs/firefox-65.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "8668974c9d7e48e88a5a7a15c0af5cb1962f4f44bd919eef765ccd84f14c20b18a6075f425f77201b1e3f67dc303e0c10bf004b443a12042496b77fc71792e54";
+      sha512 = "c3dec84a9a667046d0509e4c09f8a17209753969c6d0d6aae56fb718f53c700a7d360759a0f04aaa1a575961e1fc70136478ae652b8e6d845f1b5df61c8b4dfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ca/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ca/firefox-65.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "1d173f851b9951808b8f1f1409f8048e230b84ffa0a7739c81c0c0f3e3ddbd32c204333ef40e65be310ca594e1e1dd794496b1d7f57a65031b696a4e0bfd8399";
+      sha512 = "6cebac4c11740848e36dfbb1237816aa1c9c7a698423c7d73e268c74a7407e10107ff8cc8802fcc0bae8c327b4ee6e559067fb78c81866de753ea781fcc10cde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/cak/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/cak/firefox-65.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "5a4227308bf964cfa6fafdd54fc55d02f766800da26c36a6c458e4a664622f2bce0c2f8d9c84c0f9a481f454fbbb9d8591dd2c9f32d36c701d4e70f1d55f8eea";
+      sha512 = "af6623230ae20f3dd7915cb395a200dbc7a5a7358bfd634e4428f978da46ac245b2c8faf0b6f2c0655b377f4472d67b8ce8bd6383cb1993dfcb407604f916413";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/cs/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/cs/firefox-65.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "7523386f16791c60ef754a277da7b9836d3d443b799e228dbb0d7b5fdedbcba3c42d82ab7993a015a93af224b5b4d09ddf147a76e5cd25a5573449ad6c234ff7";
+      sha512 = "854636af5f2a07f2c9cf86549c59f76df6d338f44c02970ed8024519fd8d7ed4e8f2746f62f009fe7cf8d72dc8a57fbb9b62fe8cb3f7f9218e8ef7f47f674730";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/cy/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/cy/firefox-65.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "ca979e40ede76678a6e54a96a0b5cd6d0911e697308233000fa75efdb40eb412376f134b893cd79f8d114670929141d02f72632311ae67d7c5a56224c908d87c";
+      sha512 = "6ec88891cce5878022e377da336010c8818271a4cc543341d2c0585a76184d5ea80f0712bc6a9fa18008670603103136da3195ddb2f7be6d94b4940e3307cb9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/da/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/da/firefox-65.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "e49eae7cacec235a91f0844239314ea52259b2ab7e54e0138cbde406f2ece94c6f1d54f8ceda6f59f68d35a9869c76a3c1cc987da3abe792aae0e382fc794e65";
+      sha512 = "d6db78a1e930304bf3629a02637cc2ae375d486654fdc4ed9e4d995049aaae402c9781ac72c6764084df3c87247fa8ba0ded438dc44955e84d90735733e84e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/de/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/de/firefox-65.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "9b467ceb3a0d3d0759e6efb2c7cc6c1261ea311706e3effbbb8406010b9efd689d6e2510937951ccabdf65d49eea64102059d3f5740838eeddcedac048ba69bc";
+      sha512 = "5e5a817987239c402d141cc7d42a334355b00facc68be1b89c2ca271dc1e9d79de5953dbc1da49254c1c03fc8afbd02cb1258cd2a238007ccb69601c860137b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/dsb/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/dsb/firefox-65.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "d78170f2106f26b92e8d2861ce590b9bf10016f773649e31a5ea1344c414e4499136e0f6a0683136c1e3c8db13d963c3c6d68801b4c007357eb34396b9132509";
+      sha512 = "6eda625b31d0ee8f7a245b6a0e769a4a35fff4352d1b33c668a0187708db892a317150d8744d65912f265cc68d72e981f6f26b781782a18f3c7691f746f0cb3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/el/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/el/firefox-65.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "78b6fe96492f8bc095788d5f189680b0cfd2b3adf19d86654f533251665a26049cd59dfe5485d349fb1db4b2990c84930420146fa8f769853350bc9c829b1b9c";
+      sha512 = "d9cbd4b31b216ae65c6cbcb633965fed19010d5b26fb7f1e35c5459cd1bf31b1ceab572056b00bbfd72b5a0d2f126fa3ebc2bf05acd7216e1470370075f6eb0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/en-CA/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-CA/firefox-65.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "2ec2d7b5051ddf79d95412850f3ce53b5c6c2c240f7af56ea7cc706720df5e2a1000c0982d0fee822165cadaff4bb7ac287be800af85b981fd320a1436c589ff";
+      sha512 = "b69b7033af141d38377d76202683a5ce362cd8f52f7d01d8d04482908279029a9fe4fb7129e4ccf409eab1eb081d24764a9ae1519796612ac524857a3fc37499";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/en-GB/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-GB/firefox-65.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "9a104a21eecd04562f08b347b5926e9b9530a863795083d7e63beceb6b797a875108ba50446410c7a4e67505b3e4f8154777f52d27356decc8b9603cdf53e9af";
+      sha512 = "3eaa085b84924d24c3e4726fc2e7084cae6a90dbc784d157b7f94b50fd49b02e49d736ae49330a2795938487842a4a8e128ee95d876e73cfdd1ec3c959205bf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/en-US/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-US/firefox-65.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "dc2cd76c4304a8f1e03f750a8e4898b5bfdabdb7f93dfbd3344474fc91a3533574029d18d6e1a4e0c98c29d790c255fae3b8a6a9ef7054e371b28bc7875eede8";
+      sha512 = "d7d8d14d25e4864fe3707d4d2ba7895556b92e2f375b237c73aa011afd952d3163e8492db8ec150337bdcb440c935917b3586240b44c9a5beeecbde545ec2821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/en-ZA/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-ZA/firefox-65.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "766a79d8d8f0070e0893bbcce47da99f59ab6471a252a7c419666f16e96547d3966329c3ef4acf981c37d0e96668c6cc10aa715b1b76aaab9722ba383284c2ea";
+      sha512 = "ea47abb33631e7d32288a9610d1c9d86f6414867206ad4923d23e8bd2107105a786570e1ef0f253a2ffb90fdbd890c033dcef0302a2a3145d77af51a0f11c0d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/eo/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/eo/firefox-65.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "cbc60a90e4f0b9ebe59595de095616fa278335725c5c4f3311f443c02f542532ae985a8994009b22c163f5e5ed3e804b095283f9defab530b7a5c224565fe567";
+      sha512 = "a656bddeab181d503342d0015ab1feaca887894c3335a39f1b4fb3f53c6dbed4ed7ba867e51b478ed651e86e152c7135fbd4419a451a35a5e8c11c82887ea1f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/es-AR/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-AR/firefox-65.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "a9569dd9ffc91797c3a408e3c6a061a8b97ca9a0067aaea8ede01f1b8aa9614454f81c4b743320e25900ed761be4c5236003b1ecd83de2b0b75d5798ddc3d835";
+      sha512 = "404ef7313904ccd11b8f4885bbf13f3f9c2123fc3789bf983ee225cbee9542b796e700bee82dbb7b32b11f3222e1ac9a39b8a0712a6746e6557eabf7979740db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/es-CL/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-CL/firefox-65.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "0cb918e3e47d94aa1400934297cb9bf466f87fe1b1785aebaccaca470460dbaee45d933a41341bacdfd380b6e20a8c111825d29ba90f4ec9e6601f6b2f71bfd0";
+      sha512 = "88b89da9b2d529cf7be8c9fa464fb17717e3f40f8b77bb47843957731aae4e59dd63f691af8fe863d74cb2db6e1fc9e66b514920dd50cedbb6e2a1646ce92df8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/es-ES/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-ES/firefox-65.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "e105925619e674c25ebc5a1ad3a4378162c6c6d84462cc5e27e853c56f4dfb87f3f16eaf893f52884b2e0484462caaf991f59248a57f48f501041f40428ca65b";
+      sha512 = "33444d60e3366d9875b22b2e99fa8ec674446f78a122c3b0719373a7abc55848bdadcb9f800ef1790531c9b76993ecd80d473dadd838867870f105b5b36a0d7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/es-MX/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-MX/firefox-65.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "2c83325f84cee7f2a2ffced885967e88dfde3d72996a9a833848920f4a27e2ebaa5103bc01bbe4e50bc32c71778bcecee6a3af050831b601f0493c8da67ef0ea";
+      sha512 = "f7d1e5a691a8e629e11059a9bc367c1e91c525a0ed69d88bfbecc3aeb22ebe668c1bb20f307f2256d3782f804490a77ce45cd2a8f55cb547e314b327973b8d74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/et/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/et/firefox-65.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "680e416c770bd675aa37bf1875cb6e36feef6c387992532cb24779c1b8c575f2c328cad367e749ec6147885a4cf9ef9d6bbb485a1b225f92c87bb0dca7112c41";
+      sha512 = "2399846600fe912de3b057a18b857f688ffd39692b9db5d2a7f70cd31dd35d8c1e09f4b73f058ce61808e22a61033963ed97e029a5170662043f684985e1a82d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/eu/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/eu/firefox-65.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "d11feac463b6631fe5f4ecd6014fd7b5295371e58339e846e930958829ec859792813b74a5e87774e2d8f68512f18c8313fd642e92838748893a1bd4732fac0b";
+      sha512 = "ffcce3c779c0f139bc47eb1b9782436db17977c6e3b340d0996d228a746d843a1927cdbebbe11955d659b1d39ca285e357e6e41cde09652dd762192dac641ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/fa/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fa/firefox-65.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "b7876cdf82a0c93fdcc5987c1aca64432e1cfa648d207b4e850ee6a3a5ebfdd0e2749ef9d335fb492f02ea8b2ac7168895e36d66ad599d00617a9796a57b8ff5";
+      sha512 = "a875e2a656a375f4ccd370078c73e72f8c6a1cf629db277b18928af35be74e10724f7bed1846d418266dd8cba1808a54108aa2a14acbe49a60b8c6d2ec6cd9f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ff/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ff/firefox-65.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "a26a735846844cfaa381cbc1affa0d916e3629dd9765bc767c0c9af1ce5380c64fe67dd8f0f10b76e3c26438d685a61835cba0d5ed830157752e4fc7e0e360da";
+      sha512 = "da41d26230041bcebda837d8d4c871f199b1ccdf6d872fb8024bcc4caafa57c2e409977d7c99b443eed8e2ea003210bb6564d8cd3666775cfa88336122b82b74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/fi/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fi/firefox-65.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "2406ea6bbbc0a3fb5b58c56e32eb913c2cf7ebad0ab13c42552becdfce17336386debeb536e5bb964753739060aaffae39e3e60ab672a050f8bbbbb67500fba7";
+      sha512 = "bbb3feeb706693a9f9f9733f9fd3b02aa8114b313af2a40ca00e22a30e8046aec58f91a0d47d6b3b83bec33f118dcf5f0b9f097560f32324ea9deed23b673ea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/fr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fr/firefox-65.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "3278bcdd7bdd78fb7f58d6975a45d69ac4ea60eb6d8db825e7a2c503f1610f8022b4956e2888a0e7d3fc585a0d539a906e5abf3d5e979bba01a983c04383dd9c";
+      sha512 = "877f704b152b18163d4dd4962b634b9ac3e8bc218ec8e6a53ae6c13991a06c84727c20012e820213a3698257f53d6007c992e7cf9885503358a46d236a8b18d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/fy-NL/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fy-NL/firefox-65.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "112240131e566cc80589e6054b15d046fa285dee87431415bce3937d78bd1f0b6f40f047c291a762a15e459141bdea4501c92a3a71f572d96284f232b613a052";
+      sha512 = "494c5ae227db4c468e5b66fdc480ae0d9adb25f28d76ebd94fb630c096eded631e44af6efd5586aecd5ebdf62f1ed307086f9bf7af0395ca6cb599a2eb9d77d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ga-IE/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ga-IE/firefox-65.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "2e81c5840bbd84c9542f3395484eb85977e6ab30ff61cb650b9b5e17be0709965e634a2f01ceba1343cf69d21e7d424f9c4d1818a7c689cdec02c93dab7bb375";
+      sha512 = "3e9e921fbaac835dc8745d3e3b46914fa79f64e65d412a39b659ede44ff9810298c8240966440e82a949191ace2207b7e7684530d930d0d1913913a320419c81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/gd/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gd/firefox-65.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "9946bdb69d3a51f5975b91a2b80008183fcf952d485ffc095d3222ee3fbc58056743a0f8620e4d78bf80676901febbf418125319f7df5aa0939806c8cbdafb4f";
+      sha512 = "b71e3a6f1f060b3132034c435b54a735f8fff377646420b408482cd6dc5440957782aa530285f8bf7d51c56d5df8532cd0fdd826fd8f1faa06ad0badb48fd35f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/gl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gl/firefox-65.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "fbe94dc6385e2e9c2ccb857d8bab72741131f7a0e1f4753db4a828c21aa0510ac496cc2f4a2b4d82fd7da69baf26108632a7f4e0de1b23390c2c0738bfb38b9e";
+      sha512 = "ba2dfa015a3de26750c8b59f3bac8ae395bb36435b4b00b0f30a6a09012c36986c6ab0a7a33d74def2e3cc89c04d34d0d9b65e830502f59b7028fcccdbb43519";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/gn/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gn/firefox-65.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "e24acbb8f13661024697f8f31778af42d8d5fbec3f93ed30e2f19af8204d670eade1f77e9ad7e220eed73118ddea46eb1b1eafc1dc802218d4276433450ab740";
+      sha512 = "24735e13619217c444d6ef5e89f765baaec014a56a5929b0cf4df1d5401a673965bc058d440d80cfef9efb0112cee600ea8e0e030c2f5c40ad738e0c8243a6fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/gu-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gu-IN/firefox-65.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "6fc62964902f6313eea77ab1fa37046709aaf0e1c5e069e9693fd6eae12eac3373e37b56c7c86b9d1e53c687b0934d268325d8db09f983c11074680030e79737";
+      sha512 = "e32a73588df2630bdb6e36186eddc7920e5866d1293f9bd7b8a4ecdb9a2d504e4a46810856a731bcdf5bd7852ce6193694330804a58daf82029a9070d2d58542";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/he/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/he/firefox-65.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "b4ab1f38231373112aeedc47012227bfb7346d5a6c6b2be941b3beabb4d4d581a1085effdafb9c83bed5f1e635d600ac4724b63754323c48e28dc69272facb43";
+      sha512 = "467c77c045760b7de01d0bc25c36527c0cebefb627346359f8b1fbc67d0678d31fdb3339998a596bf183e12378124479b171bcb4b6b8f2f7d10e3215f17e7f42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/hi-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hi-IN/firefox-65.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "706fc35dcac93f0a02c58b0757692ac4e69295a68f7f8cd45438d5d459d0599e6912113f4307b508bb71fee697b075ab509484203206f773bf7c69d587a00d0e";
+      sha512 = "d879dc631888b32ae06b5f99f1adbdde32e76a5bc3150bffe8f326d0728acf2d9d1b8443657194f2d5c26819017365be6af5525ca9d1b4324eff57b43eb77790";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/hr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hr/firefox-65.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "3306c9c8c783e782c65baf5027aba850cd9bc9b0afcefac17e153e78c93a75ac61aeaeee827f8fe82acde3f1068861eac87c5d94654c1c944dab343f8560e7e9";
+      sha512 = "dec69bf3795f99a070ad268e62414d7ae63f8c747a205289600c4ec4feda63aeffa6398802cddf6787fd17e735f376ca4842457ff45a9cb72c912a2b3cdc6cfe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/hsb/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hsb/firefox-65.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "4ac5adccfe790f6ac4afc50472f6dec0d9eba91f5000e9ce37ba1f32a89af7b857d15bc744b0eb6d27b63847c183e7721297e4b9a13064530dee6cd2c2a8bbb1";
+      sha512 = "120247d2c6bbf44a453a9afcd9175a41c2ba2b927286b33f749f51b6ef4aaa993f6a6d4662ad1eff56ae736ca91d742ce64260de12b493c9dbfc52621dc81b3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/hu/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hu/firefox-65.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "8b5b4c2d84904dc206a69127f38035aed540f258f0c821f95584beb07a6e75b4c4725a80739d85334ab62074e9e5a8898c98ae0aa4dc96f963a5063de7e46021";
+      sha512 = "fb9579d7abaab1208ec5a8a8172d57801789eac83445413cd2133c5785515ebec01824dcb76685d5c8507048025c4f9a16fe7f47233a4c5dbb0bd76fe74b6484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/hy-AM/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hy-AM/firefox-65.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "70fac27d287fb8a0250b050c8a3ebffe3afaa7392d6bc179af123796dbaf230f1c4945f6928563288123a4fce68f84b0babd3c76d4b1e6fead3896085018ad5a";
+      sha512 = "28f4436f9a977edd4b30519b98c1842724323df3fe638979839a87153400e806e22d73c9203eb0a2191bfaf4a389d6ea26bd81d498963aae59c926375a61cfa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ia/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ia/firefox-65.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "118e665c254d0c4d9689bb1b4658dc35648d23a68471ceb5ae081cd1f45fc5e75e120366bd944a3a71a7f1f6c89a5e146bb1a4baf6e029e6a95b5eca8cee37b1";
+      sha512 = "1bb69219eb12abe2d731d600dfe35511cde083de13d2277868970a52a77a558d5dedac074a45f3bed3d01e18e2b7c5695d4831638ad194217f977efdc38f3e6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/id/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/id/firefox-65.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "7c6d8ffa963186d2c601f242b40c915f3a7fa50315b0b4dd30154d0297b45436f80e131641d8477188bc392ed0fca5728f9f2048b1f616fc8c35bce0c2a88e99";
+      sha512 = "87698f7d5ce9f074b2dbcdce00fe864f36621107df7422e053b0db6ae76947238784f7ca0a045517800d3a936e065cca3e74e6bd9cd04a265d7eac3cf2e0ce4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/is/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/is/firefox-65.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "9fe93dbdc3c3c56a2991bf2ff6537cd4b2d71189acc15ac012683bdce22e69fe8703430f0dd392d95f3ca17f78900ceba9d9d3a7ecd8ffca044d421d099c3d45";
+      sha512 = "b1ef9f02c286a0ca274367394f72b980b9c59d45e4c629611c3c7dc55677e90bf9f44003038740b22d660e5e950c489acc18ef7317e67f211c629f0b86017264";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/it/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/it/firefox-65.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "2428c5d14353b6746c759eb26ec237965bd5a8a48596f8d92d998f7737c064881d076d33ffe6c06192935884ccab2bfcf9158f1c0822a472902b1a2985551e36";
+      sha512 = "8507dba0adcf5ecee9224e0b8cc20b5f57ce1392affde80486a3389e04b1cb1543208cbaf151b56ed26e6124af863365805a242c6d1106842fee8547363ba11e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ja/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ja/firefox-65.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "eff9a325a636540d56e07584f7afb40a5764469af53ec1b742a1650d24ae6edd1ff295c763d9756c326b7d4da1321fb2b4caed26051942134882295a9480663f";
+      sha512 = "ea41d66d37174c936b56a3bb86d707657814eba1e99daff7be915a4ce53e35ee64d7ce6c2da0d640fd101b7cb79ea41bb49b4dac144d8741b9f217a2a042f85f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ka/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ka/firefox-65.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "350c805dc3a10cef80ee88d778876d1021abe710b35be7dd6f09944c0d4ae38eedf44cac65fcff44f9939a762db4fa27aef9265dade79dd0b56fe59d82f3350d";
+      sha512 = "793cfb78a809f8e7acefba260197665980b8b5aef599d9a3a2dceb4e8dc83034c98ed04561abf9e4e6740859ce07f647e544d2bb4244b505ba248c8af3147403";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/kab/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/kab/firefox-65.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "bafa310e83da517b4f0817eb7ab7aaeb41f771a28b777a10098fff8e340b963e7f9fe0bde9d3764cc228d405a5aca13785d22403919513c9433c67ffe904f85a";
+      sha512 = "50ce6f27b5ca77048600db7d1f50c04a363dbf5118dc23b06395ec2fee401a205725aaa99dac3b21b5660fabca3ed3bff2a996a15ccbca4d35e73553f46a97a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/kk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/kk/firefox-65.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "1d30f1910b959d4045762fe78e8470676950fe4450a836e4dbb80273e0e5b5d54fe8f8c7ce93ffb13e7c8f41f43506f16004adea9007de385123996ac1aac7f4";
+      sha512 = "8b5de334b237751201679b8d54f2de5ee384182395cfec120bc2eddaf443e0fd896c1594e92e2ba71943f2020fefe44b691e2286fe9ed1c21d3fc9e11c763300";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/km/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/km/firefox-65.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "5a2bcf0969df0a519c26de9c54ea8c86741ad9fa0684265c16bb50a6086477604a8b29f1a6f8a414525660f2a8ae0dee2e229fef5248f00b0f3a998af970ec53";
+      sha512 = "1a64f732f2c19858cba7e109beb86726d1e51dd2a2b5a09aa380fc515041aada110eb90649c4c6ece5aa8a5857072968f4a2d43f3484dc2e311c61eeb4fb49ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/kn/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/kn/firefox-65.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "0b043d5f05f1f5d168e9d98badc88d7a412b1d4951f533c4c2e388be15e606f5077d2f35e11ed0b0a930ba7f69e4041264cd46c56966afaf0bfcf90581eca864";
+      sha512 = "149029ae8bd3a81151a17c00b7166e02e22bb9f737bae1150ed8f3fbc28becf19234a1a874ca0aa6400e1b0eb75f14465546ec7e0c5bf09b8c434a5ed9f651da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ko/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ko/firefox-65.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "35adf9102bce04be9b7aa2d19a32487a6cf014f0899685b40fa55da4c0f0fbb37f66384686bcfa0890e5ef316254f7077d021f1116ec098ccb65a28a8b67124d";
+      sha512 = "f7433f3da565969ae1e92ffb4d2fb48a2b513214b08e611de2b8cb3efadf16fc6af871b470916b0611d10eb616fec09e37648c98366ec0f6211693a9f3434df2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/lij/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/lij/firefox-65.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "5f14d3fab16c88b440aece9c07511cad56f30a49977edaef4775956f6586eb944091e98c6bcc77c365b2374631b1e1e65dee52ce1a4d0619fe92214d2369d760";
+      sha512 = "6b20b466ae15b9484c427a65388d099073eabd54f938c75eeaa886ba5db73bd1f91ba207308941b2229ee38f8dee4201599d1c11e228ef6a2e13ba0d74f7c427";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/lt/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/lt/firefox-65.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "cff33e500b68c402096e41a2820563081ed9bdd378423ace8c85a4d1b2743d499ac16203dbbf1224bbf1b3d54919a74d30d10be4f4ae5095b13ef555edbee568";
+      sha512 = "61a85a29003930d8deca7ba76269f437ccb47680ce8ae12b9c9913e79d6c6e6594297f890eb5a5e641610a38c1016a1947a866b8f79ca83ff316e925df8a8bd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/lv/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/lv/firefox-65.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "a3d8e26fe7e9f8d8e7f88d96f93adcbb64666aac1383bf8a233ad2d9eb39be9c1ad86bad4a8665258410b4198bedcc8075943d21922970b1cedcfb945d90ffc5";
+      sha512 = "21ca42042d0695c9a7c5c5b5866b1fb54e65f76543f42c45efd0436fba73f5989894e0d7b67e496b101674fe3e7f0c1c374c903c9b6bcf9f9a1c6730c5c865a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/mai/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/mai/firefox-65.0.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "df51e90dfe14dc8b856b27699faae0ef352a432d1379b63664d393c6d93d24371cd10fef128741083e077db404a8918b0185edee49da7c1ea78124e174db4975";
+      sha512 = "7108acddbab96033cf9cf822d93f0ef3c3ba46e75ebe09f5f1d211b7c5cce12fdf7e7bcf06621b1bbde3478441893fae8ff919a0952d76fc0f8e482a2bcd811a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/mk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/mk/firefox-65.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "dfb81c3b9bbe3e6943e7da417c9f7a978fc3ac38f1729bc9e371d7b504ffe40c9303729f8dd9848e69f566a04ed692a2db12542f15763c59b327e28d451fd6ab";
+      sha512 = "6e0c7a12413d351ff5cc95ce56df95e6f1bc4ae320db45dd988d0dd488f525820c62387aa43003744e3cf4040f91497d4f36b4bbe4a636f1a2d010d0a9479d32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ml/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ml/firefox-65.0.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "ca717a2b9c31e6cc9a3d905bfd5952fb96cf0a3330c3a966b669774afe793dab682d522b6b5e159b86bdbe518da0d40bc6ba2767591e7136f6c26b556aa0c66d";
+      sha512 = "03e6525cc76cc4a1f2333dbb67a3f29976d3d9068d73054711f561bdad0a8da9d14abc3f79df596696ff2c28fb51147010b7351052f3b3a8d0913b94e17b022c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/mr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/mr/firefox-65.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "176e78d8f141b16d1d13567fa2940ef4ccec4bea6f65648cca1b8e7cb961b2322f13031855664511575cc5c1e1e158865092908c64b37deaccccef985466c7a9";
+      sha512 = "43ef1fa19c05096b3465f985ebcd91e7581a29a380574cfa763269ab6c7f760241645d18e9475757069b7680e696be17c2e92028874c57c31b8bc2d1fc5d8be6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ms/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ms/firefox-65.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "7835652d3dc63b5c035535b1caaecd153c42205ed009289901d7031e4b27b87dbeb6b56092efa83687959e0ee06c6f5e11464ddda4745a04a267f6c15421acdd";
+      sha512 = "ad84ff57cd2a3048862f8572c3084c2fdacf04dfd080f4679cbe5b6cd1efd9535d4fc8298aa1225067f5a3e79a9d512d933e9257d1db2df0875dab8d9259352d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/my/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/my/firefox-65.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "e8098db4fa892702b80073b17ef8c064f0f8e577482478e63a7d1a6dd5fe24a085442df32161ddd8331da4f2cf8fff7bac8fd7d05221c437ba2809e175532276";
+      sha512 = "f6b51ce2a6f67193d3410bcf5210fba114d2b4a626bf2cc98930143679cb72e00657ae44116295d3fae92aaa63dbf5393a52b8d2123d024089c5efd0737200da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/nb-NO/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/nb-NO/firefox-65.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "4344f63ba7443221eca2ea20087e4bab4a9a14a34949ecadae9f5935aef0a555aefabd418954640486abca8d021a571b79e25d762b7fb590ffbec4381050c7e7";
+      sha512 = "8b416187023963128779f06cfd28db4a7bd6bed7b7bdaadc8396c51acf0964c8a1e1230082c9528e0f3ce2ff54a84383daa36e72bdacb6bf5768214b7a497edf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ne-NP/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ne-NP/firefox-65.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "3d5d129003e0a78f9fb580bf59fce41f3620863a8a219690a67b62949796f4feca942e3f5b6bb3d3fdbdbe0d03e6a72a3ba2fcf59b8f307121ed33f062d37a25";
+      sha512 = "0fec4f2b6b6944a29ef2ff0ca30c4d770d2a956564b697fcfb7a72517c488a252d990a31e9dea6ba36d9b5ee9c38f39dc8446edf2ec7caf946244bff3f1d18b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/nl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/nl/firefox-65.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "5ee1161579ff4dbbf36570678269b7b50afe920501a677b4377d0540a327b5ea96df18c12c032811e56fa5cc61542c5bbe828076a6af018ae7b2b25e8b561b06";
+      sha512 = "7fb3c8c0e441ec55c9a79ba13ac1f7d17ce3612ae6f6ba7e23a31bc2d854fc41abd38a4caa1991b9b45fd58bc2d8386c2875adfcbf40b07cbc8bf0641a4b8b10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/nn-NO/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/nn-NO/firefox-65.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "501ba0a01fc3165f9330b9b09f6eea91a66715d9e419c2bbf4a6695eed4d2857ba612e1c46a9c4cac0a5119660223b15f29e1512b90c0e65a1d54d0fdcc62044";
+      sha512 = "744f32b81f4a4287abc812ebe7209082c4c2f8637c0a135a9ce83377903e97e3d938037827283160a141ab89b51060313bac82fb93af8f24c71b3aabdce9a293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/oc/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/oc/firefox-65.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "b6db3e79317ab8328b3ca82ea2269304596dbff5fdb9decccaa87d190785079c8f4db03ef5ea4d794a045a6dca37f992e4cea9a56ffd64d790cbcd8e7bd8c907";
+      sha512 = "2722d769575b28e581da820a3a6bf8b407a1c4018d97c2e7315b15642f4165efcc44860710141c50829a8d5d57429e9fc47565852ea9c2c018504f3a4f11739e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/or/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/or/firefox-65.0.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "95c199a619e758120e74df5a9947f75370aaefc29a8263e1970cbf37ecdd9d1e244a4de55857069bcf22a7b984a338ffa1426c90fdaa78ce913b50470af29c2d";
+      sha512 = "3f757e2d19540ac963cf14d884079fc648f1ea4c1281c86ff342971fab250c4ec09708c54ce0fef7eb343db057bc6bf5e15971e70123212d8a1a90bdaebcde8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/pa-IN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pa-IN/firefox-65.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "e7bdc607cf7c387cfebb096de4fcb1b8b03a21e238532f7313e8ef7c9647dff89031e75d82b91afdfe4b307bf3b0d5fb154379fc3acb31b296e5df7645aa3307";
+      sha512 = "35bd0bc1938d6fec372356721236afa3d1a794bda57eb11d7bc86601951825a143c1ff028ad6f0b4cd50e068a5a233a08108d71035abf2cd69213b3af794849f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/pl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pl/firefox-65.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "00a657fb392803f94f37e49fdf6d3e6a1337222953f46f904dbfe99779bdb78fc4c01df53efa9396a70f8c7285730b026978114da1ba4871cc124ff6f7e33dde";
+      sha512 = "34c91e7c2434a233a6f458b28806ac110e4382a1f685d485a2f338d66e27ec362b0424a107c8bb17dbd22ba58c0a1bded15e1bbe5ee1de76a460aaf2dce9334c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/pt-BR/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pt-BR/firefox-65.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "05355fb054afc3e4638dece722335d02c7583ba629769e50fc51e1b6854e2546beb3791fb3765997749457c901ae5034c30d9f987dd41e34547057d43850f5af";
+      sha512 = "09e247ab05f9c02bb2ede75cc46e321a518629dfe2395be8536af77601a91d4acd1df4c1a34b54193aeaf24b0cda54582ed204258e9754126dc021e04066fe7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/pt-PT/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pt-PT/firefox-65.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "7a2df4989dddfc8748ffb9583f287110cc447851f7c5c61da4f3f21575ab16a47a8fb9fc2e0fd818c3c3cfe769dbc95416263d576229ce516d270344c11fff40";
+      sha512 = "3ac57c58851403af43cc01010cf8e55b734b5d1d2db60c3b6457dfc1def483d6918ccb0eb6cdc3c4a552ed8cc5975b8534bac3e644a5f7d08fb9f2b168c7c3b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/rm/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/rm/firefox-65.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "bb6e23a8b2162085685db1ed592a55c284ab708f4766f83dda8c68b47ba9c7c70949eb078be8fe728a3e468c22e1a315ff9ec7677edaba32bfd53575d7bd3bc6";
+      sha512 = "b73742b939435bbb8d2a0d307abff82f777ba015b808eb2e7e6789ca93d33f658ed2e550ce917f5318ffd9ee72d92b2a47b43e564a4a79f0293560555a69cf76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ro/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ro/firefox-65.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "06f0ed6e1b4fd427e000ef0dec30baa10d0e62ba4b639556524ca026a1541567c1e5d36cdca517fa88b04b097eac60520f386ef78679a7403c4e4de78e7b0752";
+      sha512 = "e53fbee87ed143d5f2f7c4190b648dfebf44881beac3ee866fbac2bb8170d08c2333b8ed634696c08dd18d26acc5bbf80b5dbe9544c5a6da48175acf4708d408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ru/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ru/firefox-65.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "fa7687eed48b0088044ed34853db7324ed67c117f15d6c3076f8d6dbb2b7f90f3ae018ac5f94b3698a5d2e85467321fbf7a9a4961ad90dffada4af848c880a91";
+      sha512 = "9a05d119cebb97b022ac038c36dbfd6ecf13054027b419ad37d07d6b6cb84e4bdf77c651603f88da62d116a046dec77e43c333ee370514ddcb63d53b1754c00c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/si/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/si/firefox-65.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "385b616c054131ea89509a8dda5d0a6f5551d388654a5e3056de7af63e142d9e41d60fd68b5e074a792d9354ef1a8468d7ab0c4df126cdc135f0e38d24e4f53a";
+      sha512 = "fe70747cdf4329fd860a05ad8f69e452dce9a8a0a4e65c9ab84348b870a628746de1a74f66db42caa15da7ac5d34b071aba6095aacaa818859b041052f8b4df4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/sk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sk/firefox-65.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "c44cebf2de8a41c888b9120b7610902a0aab3bd4193ba408fc85917e7aaf9eeb887df34d5623b9c73a1005e4726679eaa1498aa7858059a9854bc58be07fe66a";
+      sha512 = "8c76b164b6c2e9431dd23131a46fc613e24896cc2d02d67dde78ad4f7d2dce4baa1e08bb9120c02a243743231a54eeea68e10f2d0e1c44442e53533482afde13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/sl/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sl/firefox-65.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "18ef12bbb85ca7a873a57d54913fe4222baf5683ac83c4a212ff7deffcbc4a8224007e0bfe07c97671f614e4b554902303f7f7c490f0fc5c05d2855ba4859e2d";
+      sha512 = "26ed90dc4b5e1dcff81301eeb75fd6729b0a94ad0993b438867b8ae4287a03c20efbc425b8130c948bba46e71c654e6aa410a28a20fd407ca922b77f166e0feb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/son/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/son/firefox-65.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "e7e7453dee6de4c36167e5be06da2138a3d3b1fdd404cfeccbc604d0c569e52165b6406f8c658d9aaecf0d274bb86f629132d32e807e89590c470311d98a2634";
+      sha512 = "11809822767088ab739e47b6774374d619384e4ee2a69690fa5624a6168c0a3fa763b85b573a1bbbd0b97f50c5738999307d91880cde14a4fb3c6ae17b484224";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/sq/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sq/firefox-65.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "13f21e1596a17a9d17c0375f244f5a3321953d42242c5aa95373c79a127eaeccfa66348453f2f4d142bdda4600432597a363242fa242424310924b72e60b45b2";
+      sha512 = "22f699cc9a59332582149087418596dd8e6b138b1c7010344f4471396b3a69ebede79d924dfe5e025d82054f20f240356d4232e284d33f8805e4891bc7b30459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/sr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sr/firefox-65.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "3b3947ac609c89d576a0c5110387f0b20f891e4899ca86d84cefb5b5e4bc60c33680c8d749bed48574db53f6eabde222f6fa6efdcc913e2605b5933a6e2e39a3";
+      sha512 = "b2431890e7cdf5e1563387d9c566beb3c083d81a0f11c5c1843788b7bceec927cc55bda1a92f605210aaf2960ab4bd0fd42e4d558749b5623eb7f3fab0d7800d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/sv-SE/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sv-SE/firefox-65.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "35f3f11e8667eeab0322ad72eded5c507e93eaaedccbc3c249ffde5b4728461092fd297631a1febbc65840bf700992de7729edf8a065dda946febd5c6a948949";
+      sha512 = "c2b7399f1b6f75440a725289df834af2defc77c773ba73f0b330689244167abcc32190e185ade9dd3c8340f6a06fa2e026c0d4c426e90471a75cb1e79b45a086";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ta/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ta/firefox-65.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "498f8c035b17c1b231e631685d4f5a119afaf669ee3fb27fa6720f54637b55ce42a8914ffa8c7c3c21b64c0793cadab52521f82bc62806bcc05596168f328b4d";
+      sha512 = "b29e0db021afcfb246f980a2f5afb434c52be5324985877d2ee547a097d17ec77a7ea3e2ac9c2dc558236090954b1cba4a0fcaa10698da1425dbd5e31406aa4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/te/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/te/firefox-65.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "c4b8bb312d26dd8c2b98bdc50db653e91e3b7c2419db1255ecf77dfee060837f700649e8b517136e541e49a6681c742165329c9946b756e9d389e6e2923b67bb";
+      sha512 = "709ae0eeec912c6349bd2b41a5cd10bd58ee5279e50e70623be93d0fef1655c5e0ff74df47d60c6ecae5883c5b6102ad0a4d61924cd848973fbc10bbe112c18e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/th/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/th/firefox-65.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "6186b9e6ce38dc92cdccbf8d48739262a66d67ca8fd0a3ded0cee24003a81226455b55f4e9ef434a331ce00f0046f9e2b439b5ca79b256105f246b0eaa00a83b";
+      sha512 = "032fb59d5a502d593c1ee5f05d51d0d2a88bd3dd081857e27c9d429ae337b37252a0f0bc0c261adc71b8b2b57aa7b4321ed8ce3bac04eeefabcf97ccec4b2f78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/tr/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/tr/firefox-65.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "a3497fbd00ea1e6babfe8c1edd5c331c389b9732723e311d33e66fb42cecb7c1d743a166beae77a84a22f05855c084f0b21a0c2005d6b6840f86a9798bbef24b";
+      sha512 = "3ace64d030e0012f9acd06e242c52408f6b8407f65834d34b203910a18c459c6dd8a23e80d4b11b4d4792edb2ff71769c75e90ff919e80d7da71a2341115e571";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/uk/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/uk/firefox-65.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "7c6b6bc4b2783cca67da410e800e6dd8d1351e8e64a018f1a64b51d3f737252b71d193b3d37973a796200d2bd19d70a5ef2487a63deffb5b9e9bbfc86d729003";
+      sha512 = "730b747ccdb0b31738e2272f9763b9aad992e241dfee8d067122886b625a5b7f83d53fdcb8052a00ee68ac76512c8ab97097a640cbad0f308dcec1f4cd040503";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/ur/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ur/firefox-65.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "24f625367d0c94e4fa101910ad9417e66814eecdc4585eaf134988f784f06a69714e5180548e6b7714acf35b7a15369b5be824eead4cd87d2310ceb999eca351";
+      sha512 = "d10f6a9f708f27c7d935f190332c7db7d789f72a005a6474e127e6061a1e49776734c6e1a90e84213d8734c2ba1ec39063cafd5518ba482dd82bac323034b883";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/uz/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/uz/firefox-65.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "4766729c5cef60fd9fc4eb4d9586594fd323a4c8e759f360e7cb151cd9edb05b3a4ea7a949f6c2ad213bcc312cdd83efd72a5ffbc6f6c2ade3b7e82e67a8962a";
+      sha512 = "223fa76b020c0cb9aa9fc59344b0cb103088f2ae0c3fc8037f8a6c3055898312638769b51e98107864850b1286d11e711d4225b5bf570e0fb3f7c59ee740b197";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/vi/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/vi/firefox-65.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "cf2a51bc494ccc56f456ea929a24db7307ad62599d76bdb03d239341c4ad5e82d790beaee4afe1aced0c549ae08d44456e127470813fc0a72a9c990627173f87";
+      sha512 = "e3d1a93bea5f9b7b02e43a54f36544e0e7f6cf5553c5d3e42ff5227396eb66e62570917c5a6317fa21da3510251efc9d3d3524bc64f19fcae590825c75ce6896";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/xh/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/xh/firefox-65.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "86244d528c5edbb60e525724a7d577d8995096bb87996ecc0cd8cfb8f82d1d0916c5a9dccacbe06459762134d1993a68fd4c03624ed958774420bf114e3e7afe";
+      sha512 = "661183377c558e2355b9ce220f73807818d25b82e9bfc05c013cd58bd35234d73d979a42542b16c46b1c3c3efac0d9524ca28bb9874ad9c969b24c2a96d601e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/zh-CN/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/zh-CN/firefox-65.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "691acc92ddf95dd7316f3f851f6e7736c0accc7981a295b04fee6a82b4ced52de8d92d46b467f5be345fdc74531c58b06aacfd9b10e7c7368dea3c50f0f64961";
+      sha512 = "227ce1a00441fd3e5914143b00c2815544f989cc918e978700133c1232170a145fc2f0ce139989f3b9857387928439282f44bb735f4ee8dc7ed881fd006dfc62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0.2/linux-i686/zh-TW/firefox-64.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/zh-TW/firefox-65.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "0625955e3424368f533772cccfad9098c8d11b4cca0a0acf919da4dc16b03945f2580decd8445e094d31060485d1ff71a809260e7b6bf1c417aedfd5d8cf880e";
+      sha512 = "211b738aaeb0716ab60cf2923be9a4cf6bc38f8536a32c05cf713f987249ed3a735fc6ce07689fd8181230039a4b2e2a367b72743730672856fe4b02e41444cd";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -87,6 +87,11 @@ stdenv.mkDerivation rec {
 
   inherit src unpackPhase patches meta;
 
+  # Ignore trivial whitespace changes in patches, this fixes compatibility of
+  # ./env_var_for_system_dir.patch with Firefox >=65 without having to track
+  # two patches.
+  patchFlags = [ "-p1" "-l" ];
+
   buildInputs = [
     gtk2 perl zip libIDL libjpeg zlib bzip2
     dbus dbus-glib pango freetype fontconfig xorg.libXi xorg.libXcursor

--- a/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx65.patch
+++ b/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx65.patch
@@ -1,0 +1,23 @@
+diff -ur firefox-65.0-orig/docshell/base/nsAboutRedirector.cpp firefox-65.0/docshell/base/nsAboutRedirector.cpp
+--- firefox-65.0-orig/docshell/base/nsAboutRedirector.cpp       2019-01-23 00:48:28.988747428 +0100
++++ firefox-65.0/docshell/base/nsAboutRedirector.cpp    2019-01-23 00:51:13.378188397 +0100
+@@ -67,8 +67,6 @@
+     {"about", "chrome://global/content/aboutAbout.xhtml", 0},
+     {"addons", "chrome://mozapps/content/extensions/extensions.xul",
+      nsIAboutModule::ALLOW_SCRIPT},
+-    {"buildconfig", "chrome://global/content/buildconfig.html",
+-     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT},
+     {"checkerboard", "chrome://global/content/aboutCheckerboard.xhtml",
+      nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+          nsIAboutModule::ALLOW_SCRIPT},
+diff -ur firefox-65.0-orig/toolkit/content/jar.mn firefox-65.0/toolkit/content/jar.mn
+--- firefox-65.0-orig/toolkit/content/jar.mn    2019-01-23 00:48:35.033372506 +0100
++++ firefox-65.0/toolkit/content/jar.mn 2019-01-23 00:50:45.126565924 +0100
+@@ -36,7 +36,6 @@
+    content/global/plugins.css
+    content/global/browser-child.js
+    content/global/browser-content.js
+-*   content/global/buildconfig.html
+    content/global/buildconfig.css
+    content/global/contentAreaUtils.js
+    content/global/datepicker.xhtml

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -66,14 +66,14 @@ rec {
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    ffversion = "60.4.0esr";
+    ffversion = "60.5.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3a2r2xyxqw86ihzbmzmxmj8wh3ay4mrjqrnyn73yl6ry19m1pjqbmy1fxnsmxnykfn35a1w18gmbj26kpn1yy7hif37cvy05wmza6c1";
+      sha512 = "3n7l146gdjwhi0iq85awc0yykvi4x5m91mcylxa5mrq911bv6xgn2i92nzhgnhdilqap5218778vgvnalikzsh67irrncx1hy5f6iyx";
     };
 
     patches = nixpkgsPatches ++ [
-      ./no-buildconfig.patch
+      ./no-buildconfig-ffx65.patch
 
       # this one is actually an omnipresent bug
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -14,14 +14,14 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    ffversion = "64.0.2";
+    ffversion = "65.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "2xvzbx20i2qwld04g3wl9j6j8bkcja3i83sf9cpngayllhrjki29020izrwjxrgm0z3isg7zijw656v1v2zzmhlfkpkbk71n2gjj7md";
+      sha512 = "39bx76whgf53rkfqqy8gfhd44wikh89zpnqr930v4grqg3v0pfr8mbvp7xzjjlf5r7bski0wxibn9vyyy273fp99zyj1w2m5ihh9aqh";
     };
 
     patches = nixpkgsPatches ++ [
-      ./no-buildconfig.patch
+      ./no-buildconfig-ffx65.patch
     ];
 
     extraNativeBuildInputs = [ python3 ];

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -5,7 +5,7 @@ let
     url = http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz;
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
-  version = "3.41";
+  version = "3.42";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${name}.tar.gz";
-    sha256 = "0bbif42fzz5gk451sv3yphdrl7m4p6zgk5jk0307j06xs3sihbmb";
+    sha256 = "04rg0yar0plbx1sajrzywprqyhlskczkqxxsgxmcc0qqy64y8g2x";
   };
 
   buildInputs = [ perl zlib sqlite ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17130,7 +17130,7 @@ in
       libpng = libpng_apng;
       python = python2;
       gnused = gnused_422;
-      icu = icu59;
+      icu = icu63;
       inherit (darwin.apple_sdk.frameworks) CoreMedia ExceptionHandling
                                             Kerberos AVFoundation MediaToolbox
                                             CoreLocation Foundation AddressBook;


### PR DESCRIPTION
###### Motivation for this change

Preparding the master branch for the upcoming firefox 65 release (scheduled for 2019-01-29). There will be another PR for the 18.03 branch as welll

This is my WIP version for firefox 65. The beta attribute should be
removed and the "normal" `firefox` attribute should be updated after
the release.

There have been some more changes to the source tree which broke the
buildconfig patch. This commit adds another patch that can be used for
the future versions. Once all the flavors are based off a new(ish)
firefox release we can remove the old patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
     only executed the firefox binaries, I do not expect any failures of the tor browser though..
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after): almost the same, was even smaller by about 100kB
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

