### PR TITLE
nixos/overlayfs: add test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -172,6 +172,7 @@ in
   osquery = handleTest ./osquery.nix {};
   osrm-backend = handleTest ./osrm-backend.nix {};
   ostree = handleTest ./ostree.nix {};
+  overlayfs = handleTest ./overlayfs.nix {};
   pam-oath-login = handleTest ./pam-oath-login.nix {};
   pam-u2f = handleTest ./pam-u2f.nix {};
   pantheon = handleTest ./pantheon.nix {};

--- a/nixos/tests/overlayfs.nix
+++ b/nixos/tests/overlayfs.nix
@@ -1,0 +1,57 @@
+import ./make-test.nix ({ pkgs, ... }: {
+  name = "overlayfs";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ bachp ];
+
+  machine = { pkgs, ... }: {
+    virtualisation.emptyDiskImages = [ 512 ];
+    networking.hostId = "deadbeef";
+    environment.systemPackages = with pkgs; [ parted ];
+  };
+
+  testScript = ''
+    $machine->succeed("ls /dev");
+
+    $machine->succeed("mkdir -p /tmp/mnt");
+
+    # Test ext4 + overlayfs
+    $machine->succeed(
+
+      "mkfs.ext4 -F -L overlay-ext4 /dev/vdb",
+      "mount -t ext4 /dev/vdb /tmp/mnt",
+
+      "mkdir -p /tmp/mnt/upper /tmp/mnt/lower /tmp/mnt/work /tmp/mnt/merged",
+
+      # Setup some existing files
+      "echo 'Replace' > /tmp/mnt/lower/replace.txt",
+      "echo 'Append' > /tmp/mnt/lower/append.txt",
+      "echo 'Overwrite' > /tmp/mnt/lower/overwrite.txt",
+
+      "mount -t overlay overlay -o lowerdir=/tmp/mnt/lower,upperdir=/tmp/mnt/upper,workdir=/tmp/mnt/work /tmp/mnt/merged",
+
+      # Test new
+      "echo 'New' > /tmp/mnt/merged/new.txt",
+      "[[ \"\$(cat /tmp/mnt/merged/new.txt)\" == \"New\" ]]",
+
+      # Test replace
+      "[[ \"\$(cat /tmp/mnt/merged/replace.txt)\" == \"Replace\" ]]",
+      "echo 'Replaced' > /tmp/mnt/merged/replace-tmp.txt",
+      "mv /tmp/mnt/merged/replace-tmp.txt /tmp/mnt/merged/replace.txt",
+      "[[ \"\$(cat /tmp/mnt/merged/replace.txt)\" == \"Replaced\" ]]",
+
+      # Overwrite
+      "[[ \"\$(cat /tmp/mnt/merged/overwrite.txt)\" == \"Overwrite\" ]]",
+      "echo 'Overwritten' > /tmp/mnt/merged/overwrite.txt",
+      "[[ \"\$(cat /tmp/mnt/merged/overwrite.txt)\" == \"Overwritten\" ]]",
+
+      # Test append
+      "[[ \"\$(cat /tmp/mnt/merged/append.txt)\" == \"Append\" ]]",
+      "echo 'ed' >> /tmp/mnt/merged/append.txt",
+      #"cat /tmp/mnt/merged/append.txt && exit 1",
+      "[[ \"\$(cat /tmp/mnt/merged/append.txt)\" == \"Append\ned\" ]]",
+
+      "umount /tmp/mnt/merged",
+      "umount /tmp/mnt",
+      "udevadm settle"
+    );
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

Make sure overlayfs is bahving as intended

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

