### PR TITLE
scons: update 3.0.4 hash

### DIFF
--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -9,6 +9,6 @@ in {
   };
   scons_latest = mkScons {
     version = "3.0.4";
-    sha256 = "1jzvcbn77ayibd7zhzs7vz316f34mxb8akfrxccjni6i09mpv96n";
+    sha256 = "06lv3pmdz5l23rx3kqsi1k712bdl36i942hgbjh209s94mpb7f72";
   };
 }


### PR DESCRIPTION
It appears that they updated their 3.0.4 distribution in-place with some additional patches:

https://github.com/SCons/scons/commit/73b2c02d7088c6d6490fdede8396d88103b00482

The changes are mainly cosmetic, so should be fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

