### PR TITLE
texlive: fix latexindent runtime

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -4,7 +4,7 @@
 */
 { stdenv, lib, fetchurl, runCommand, writeText, buildEnv
 , callPackage, ghostscriptX, harfbuzz, poppler_min
-, makeWrapper, python, ruby, perl
+, makeWrapper, python, ruby, perlPackages
 , useFixedHashes ? true
 , recurseIntoAttrs
 }:
@@ -25,7 +25,7 @@ let
   # function for creating a working environment from a set of TL packages
   combine = import ./combine.nix {
     inherit bin combinePkgs buildEnv fastUnique lib makeWrapper writeText
-      stdenv python ruby perl;
+      stdenv python ruby perlPackages;
     ghostscript = ghostscriptX; # could be without X, probably, but we use X above
   };
 


### PR DESCRIPTION
latexindent currently fails due to missing perlPackages dependencies

Resolves: #35537

This was tested using
```
nix-shell -p "texlive.combine { inherit (texlive) scheme-minimal latexindent; }" \
  --pure --run latexindent
```

`lib.closePropagation` is deprecated, so we shouldn't use it, probably. Normally the closure would be constructed by adding packages to `buildInputs` and dumping resulting $PERL5LIB into the wrapper. This change will become much more obtrusive if I go that way.