### PR TITLE
tcl: link with libgcc_s

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/tclsh${release} $out/bin/tclsh
   '';
 
+  ${if stdenv.hostPlatform.libc == "glibc"
+    && stdenv.cc.isGNU then "NIX_LDFLAGS" else null
+   } = [
+    "-lgcc_s"
+  ];
+
   meta = with stdenv.lib; {
     description = "The Tcl scription language";
     homepage = http://www.tcl.tk/;


### PR DESCRIPTION
###### Motivation for this change

I'm not confident this is just the right condition to link to it only on platforms / environments where this is needed.

/cc @matthewbauer @dtzWill 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

