### PR TITLE
googleearth: adding application launcher and icons

### DIFF
--- a/pkgs/applications/misc/googleearth/default.nix
+++ b/pkgs/applications/misc/googleearth/default.nix
@@ -79,6 +79,15 @@ stdenv.mkDerivation rec {
     for a in $out/opt/google/earth/free/*.so* ; do
       patchelf --set-rpath "${fullPath}:\$ORIGIN" $a
     done
+    
+    # Add desktop config file and icons
+    mkdir -p $out/share/{applications,icons/hicolor/{16x16,22x22,24x24,32x32,48x48,64x64,128x128,256x256}/apps,pixmaps}
+    ln -s $out/opt/google/earth/free/google-earth.desktop $out/share/applications/google-earth.desktop
+    sed -i -e "s|Exec=.*|Exec=$out/bin/googleearth|g" $out/opt/google/earth/free/google-earth.desktop
+    for size in 16 22 24 32 48 64 128 256; do
+      ln -s $out/opt/google/earth/free/product_logo_"$size".png $out/share/icons/hicolor/"$size"x"$size"/apps/google-earth.png
+    done
+    ln -s $out/opt/google/earth/free/product_logo_256.png $out/share/pixmaps/google-earth.png
   '';
 
   checkPhase = ''


### PR DESCRIPTION
I am adding an application launcher (desktop configuration file) and icons to the appropriate locations in the `share/` directory for the `googleearth` package. I am merely using those already in `opt/`, with the only modification being made to them being to make the `Exec=` line in the desktop configuration file point to the correct executable for the program.

###### Motivation for this change
Presently the `googleearth` package provides no application launcher, so the only way to start it is by manually executing `googleearth` as a command. In this PR I am rectifying this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

