### PR TITLE
lib/modules: Change mkAliasOptionModule to use the priority for the alias

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -109,7 +109,7 @@ let
       mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
       mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule mkAliasOptionModuleWithPriority doRename filterModules;
+      mkAliasOptionModule doRename filterModules;
     inherit (options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption getValues
       getFiles optionAttrSetToDocList optionAttrSetToDocList'

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -609,6 +609,9 @@ rec {
 
      forwards any definitions of boot.copyKernels to
      boot.loader.grub.copyKernels while printing a warning.
+
+     This also copies over the priority from the aliased option to the
+     non-aliased option.
   */
   mkRenamedOptionModule = from: to: doRename {
     inherit from to;
@@ -703,16 +706,7 @@ rec {
     use = id;
   };
 
-  /* Like ‘mkAliasOptionModule’, but copy over the priority of the option as well. */
-  mkAliasOptionModuleWithPriority = from: to: doRename {
-    inherit from to;
-    visible = true;
-    warn = false;
-    use = id;
-    withPriority = true;
-  };
-
-  doRename = { from, to, visible, warn, use, withPriority ? false }:
+  doRename = { from, to, visible, warn, use, withPriority ? true }:
     { config, options, ... }:
     let
       fromOpt = getAttrFromPath from options;

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,7 +149,7 @@ checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-long-list.ni
 # Check loaOf with many merges of lists.
 checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-merges.nix
 
-# Check mkAliasOptionModuleWithPriority.
+# Check mkAliasOptionModule.
 checkConfigOutput "true" config.enable ./alias-with-priority.nix
 checkConfigOutput "true" config.enableAlias ./alias-with-priority.nix
 checkConfigOutput "false" config.enable ./alias-with-priority-can-override.nix

--- a/lib/tests/modules/alias-with-priority-can-override.nix
+++ b/lib/tests/modules/alias-with-priority-can-override.nix
@@ -32,7 +32,7 @@ with lib;
 
   imports = [
     # Create an alias for the "enable" option.
-    (mkAliasOptionModuleWithPriority [ "enableAlias" ] [ "enable" ])
+    (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
 
     # Disable the aliased option, but with a default (low) priority so it
     # should be able to be overridden by the next import.

--- a/lib/tests/modules/alias-with-priority-can-override.nix
+++ b/lib/tests/modules/alias-with-priority-can-override.nix
@@ -1,5 +1,8 @@
 # This is a test to show that mkAliasOptionModule sets the priority correctly
 # for aliased options.
+#
+# This test shows that an alias with a high priority is able to override
+# a non-aliased option.
 
 { config, lib, ... }:
 
@@ -34,8 +37,8 @@ with lib;
     # Create an alias for the "enable" option.
     (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
 
-    # Disable the aliased option, but with a default (low) priority so it
-    # should be able to be overridden by the next import.
+    # Disable the aliased option with a high priority so it
+    # should override the next import.
     ( { config, lib, ... }:
       {
         enableAlias = lib.mkForce false;

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -1,5 +1,8 @@
 # This is a test to show that mkAliasOptionModule sets the priority correctly
 # for aliased options.
+#
+# This test shows that an alias with a low priority is able to be overridden
+# with a non-aliased option.
 
 { config, lib, ... }:
 

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -32,7 +32,7 @@ with lib;
 
   imports = [
     # Create an alias for the "enable" option.
-    (mkAliasOptionModuleWithPriority [ "enableAlias" ] [ "enable" ])
+    (mkAliasOptionModule [ "enableAlias" ] [ "enable" ])
 
     # Disable the aliased option, but with a default (low) priority so it
     # should be able to be overridden by the next import.


### PR DESCRIPTION
This commit changes the `mkAliasOptionModule` function to make sure that the priority for the aliased option is propagated to the non-aliased option.

This also affects the `mkRenamedOptionModule` function in a similar fashion.

This also removes the `mkAliasOptionModuleWithPriority` function, since its functionality is now subsumed by `mkAliasOptionModule`.

This change was recommended by @nbp to see what would be the effect of doing this:
https://github.com/NixOS/nixpkgs/pull/53397#discussion_r245487432

###### Motivation for this change

The motivation for this change (as well as a use-case) is listed in https://github.com/NixOS/nixpkgs/pull/53397#issue-242220506.

Pinging @nbp, since he suggested this change.  Also pinging @Infinisil since he helped with the original PR that inspired this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

