### PR TITLE
dvc: init at 0.24.3

### DIFF
--- a/pkgs/applications/version-management/dvc/default.nix
+++ b/pkgs/applications/version-management/dvc/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, enableGoogle ? false
+, enableAWS ? false
+, enableAzure ? false
+, enableSSH ? false
+}:
+
+with python3Packages;
+buildPythonApplication rec {
+  pname = "dvc";
+  version = "0.24.3";
+
+  # PyPi only has wheel
+  src = fetchFromGitHub {
+    owner = "iterative";
+    repo = "dvc";
+    rev = version;
+    sha256 = "1wqq4i23hppilp20fx5a5nj93xwf3wwwr2f8aasvn6jkv2l22vpl";
+  };
+
+  propagatedBuildInputs = [
+    ply
+    configparser
+    zc_lockfile
+    future
+    colorama
+    configobj
+    networkx
+    pyyaml
+    GitPython
+    setuptools
+    nanotime
+    pyasn1
+    schema
+    jsonpath_rw
+    requests
+    grandalf
+    asciimatics
+    distro
+    appdirs
+  ]
+  ++ lib.optional enableGoogle google_cloud_storage
+  ++ lib.optional enableAWS boto3
+  ++ lib.optional enableAzure azure-storage-blob
+  ++ lib.optional enableSSH paramiko;
+
+  # tests require access to real cloud services
+  # nix build tests have to be isolated and run locally
+  doCheck = false;
+
+  patches = [ ./dvc-daemon.patch ];
+
+  postPatch = ''
+    substituteInPlace dvc/daemon.py --subst-var-by dvc "$out/bin/dcv"
+  '';
+
+  meta = with lib; {
+    description = "Version Control System for Machine Learning Projects";
+    license = licenses.asl20;
+    homepage = https://dvc.org;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/applications/version-management/dvc/dvc-daemon.patch
+++ b/pkgs/applications/version-management/dvc/dvc-daemon.patch
@@ -1,0 +1,21 @@
+diff --git a/dvc/daemon.py b/dvc/daemon.py
+index 1d67a37..7ce6fde 100644
+--- a/dvc/daemon.py
++++ b/dvc/daemon.py
+@@ -67,14 +67,8 @@ def daemon(args):
+     Args:
+         args (list): list of arguments to append to `dvc daemon` command.
+     """
+-    cmd = [sys.executable]
+-    if not is_binary():
+-        cmd += ['-m', 'dvc']
+-    cmd += ['daemon', '-q'] + args
+-
+-    env = fix_env()
+-    file_path = os.path.abspath(inspect.stack()[0][1])
+-    env['PYTHONPATH'] = os.path.dirname(os.path.dirname(file_path))
++    cmd = [ "@dvc@" , "daemon", "-q"] + args
++    env = None
+ 
+     logger.debug("Trying to spawn '{}' with env '{}'".format(cmd, env))
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1345,6 +1345,15 @@ in
 
   duperemove = callPackage ../tools/filesystems/duperemove { };
 
+  dvc = callPackage ../applications/version-management/dvc { };
+
+  dvc-with-remotes = callPackage ../applications/version-management/dvc {
+    enableGoogle = true;
+    enableAWS = true;
+    enableAzure = true;
+    enableSSH = true;
+  };
+
   dylibbundler = callPackage ../tools/misc/dylibbundler { };
 
   dynamic-colors = callPackage ../tools/misc/dynamic-colors { };


### PR DESCRIPTION
###### Motivation for this change

Adds dvc. Fixes https://github.com/NixOS/nixpkgs/issues/49438

DVC is a version control system for data science that integrates with Git. But doesn't really actually need git.

Since it's a application and not a library, I thought to just put it in `pkgs/applications/version-management/dvc/default.nix`.

Futhermore, I've decided to use `python3Packages` set instead of just `pythonPackages` as we should be using Python 3 for any applications now.

They only have a wheel on the on Pypi, and I've asked them to push up their source distribution to the Pypi as well  https://github.com/iterative/dvc/issues/1509.

In the case that is done, this can be changed to use the source distribution and hopefully run some tests as well.

One thing is that after I built this, and tried to run dvc, I get this at the end:

```
/nix/store/vs6d2fjkl4kb3jb7rwibsd76k9v2n4xy-bash-4.4-p23/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/home/cmcdragonkai/.includes_sh/shell_environment_common.conf: line 31: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
Error: the following arguments are required: COMMAND

Having any troubles? Hit us up at https://dvc.org/support, we are always happy to help!
usage: dvc [-h] [-q | -v] [-V] COMMAND ...

Data Version Control

optional arguments:
  -h, --help     show this help message and exit
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
  -V, --version  Show program's version.

Available Commands:
  COMMAND        Use dvc COMMAND --help for command-specific help.
    init         Initialize dvc over a directory (should already be a git dir).
    destroy      Destroy dvc. Will remove all project's information, data files and cache.
    add          Add files/directories to dvc.
    remove       Remove outputs of DVC file.
    move         Move output of DVC file.
    unprotect    Unprotect data file/directory.
    run          Generate a stage file from a given command and execute the command.
    repro        Reproduce DVC file. Default file name - 'Dvcfile'.
    pull         Pull data files from the cloud.
    push         Push data files to the cloud.
    fetch        Fetch data files from the cloud.
    status       Show the project status.
    gc           Collect garbage.
    add          Add files/directories to dvc.
    import       Import files from URL.
    config       Get or set config options.
    checkout     Checkout data files from cache.
    remote       Manage set of tracked repositories.
    cache        Manage cache settings.
    metrics      Get metrics from all branches.
    install      Install dvc hooks into the repository.
    root         Relative path to project's directory.
    lock         Lock DVC file.
    unlock       Unlock DVC file.
    pipeline     Manage pipeline.
    daemon       Service daemon.
/nix/store/ydk0mfpvn9smcmn72wc9i20slv1d2b79-python3-3.7.2/bin/python3.7: No module named dvc
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

