### PR TITLE
mfc9340cdw{lpr,cupswrapper}: init at 1.1.2-1 and 1.1.4-0

### DIFF
--- a/pkgs/misc/cups/drivers/mfc9340cdwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9340cdwcupswrapper/default.nix
@@ -1,0 +1,55 @@
+{ coreutils, dpkg, fetchurl, mfc9340cdwlpr, stdenv, perl, gnugrep, gnused, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "mfc9340cdwcupswrapper-${version}";
+  version = "1.1.4-0";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf007029/${name}.i386.deb";
+    sha256 = "0dlwpcmknqf4rndjjg3jh1141x536a71l3i2i8kpyvn7xs4bv8kv";
+  };
+
+  nativeBuildInputs = [ dpkg perl makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    basedir=${mfc9340cdwlpr}/opt/brother/Printers/mfc9340cdw
+    dir=$out/opt/brother/Printers/mfc9340cdw
+
+    orig_filter="$dir/cupswrapper/cupswrappermfc9340cdw"
+    dest_filter="$out/lib/cups/filter/brother_lpdwrapper_mfc9340cdw"
+
+    substituteInPlace $orig_filter \
+      --replace "/opt/brother/Printers/$``{printer_model}``/inf/" "${mfc9340cdwlpr}/opt/brother/Printers/mfc9340cdw/inf/" \
+      --replace "/opt/brother/$``{device_model}``/$``{printer_model}``/lpd/" "${mfc9340cdwlpr}/opt/brother/Printers/mfc9340cdw/lpd/" \
+      --replace "/opt/brother/$``{device_model}``/$``{printer_model}``/cupswrapper/" "$dir/cupswrapper/" \
+      --replace "/opt/brother/$``{device_model}``/$``{printer_model}``/inf/" "$dir/inf/" \
+      --replace "/var/tmp/" "/tmp/" \
+      --replace "/usr/share/" "$out/share/" \
+      --replace "/usr/lib/cups/filter" "$out/lib/cups/filter" \
+      --replace "sleep 2s" "echo sleep 2s" \
+      --replace "lpinfo -v" "true" \
+      --replace "lpadmin -p" "echo lpadmin -p"
+
+    chmod +x $orig_filter
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    bash $orig_filter
+    test -x $dest_filter
+
+    wrapProgram $dest_filter \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnugrep gnused ]}
+  '';
+
+  meta = {
+    description = "Brother MFC-9340CDW CUPS wrapper driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/misc/cups/drivers/mfc9340cdwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfc9340cdwlpr/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, cups, dpkg, ghostscript, a2ps, coreutils, gnused, gawk, file, makeWrapper, pkgs }:
+
+stdenv.mkDerivation rec {
+  name = "mfc9340cdwlpr-${version}";
+  version = "1.1.2-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf007027/${name}.i386.deb";
+    sha256 = "1zldpi26n969j5q8z16m8k0wl174cjbfnfra1rl09n8x747h5485";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    substituteInPlace $out/opt/brother/Printers/mfc9340cdw/lpd/filtermfc9340cdw \
+      --replace /opt "$out/opt" \
+
+    wrapProgram $out/opt/brother/Printers/mfc9340cdw/lpd/filtermfc9340cdw \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ ghostscript a2ps file gnused coreutils ] }
+
+    sed -i '/GHOST_SCRIPT=/c\GHOST_SCRIPT=gs' $out/opt/brother/Printers/mfc9340cdw/lpd/psconvertij2
+
+    wrapProgram $out/opt/brother/Printers/mfc9340cdw/lpd/psconvertij2 \
+      --prefix PATH ":" ${ stdenv.lib.makeBinPath [ ghostscript gnused coreutils gawk ] }
+
+    patchelf --set-interpreter ${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2 $out/opt/brother/Printers/mfc9340cdw/lpd/brmfc9340cdwfilter
+  '';
+
+  meta = {
+    description = "Brother MFC-9340CDW LPR printer driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22865,6 +22865,9 @@ in
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 
+  mfc9340cdwcupswrapper = callPackage ../misc/cups/drivers/mfc9340cdwcupswrapper { };
+  mfc9340cdwlpr = callPackage ../misc/cups/drivers/mfc9340cdwlpr { };
+
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung/1.00.37.nix { };
   samsung-unified-linux-driver_4_00_39 = callPackage ../misc/cups/drivers/samsung/4.00.39 { };
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };


### PR DESCRIPTION
###### Motivation for this change

CUPS driver for Brother MFC-9340CDW printer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

