### PR TITLE
Update ganttproject-bin from 2.7.2 to 2.8.10

### DIFF
--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchzip, makeDesktopItem, makeWrapper
-, jre }:
+{ stdenv, lib, fetchzip, makeDesktopItem, makeWrapper
+, jre
+}:
 
 stdenv.mkDerivation rec {
   name = "ganttproject-bin-${version}";
@@ -28,13 +29,19 @@ stdenv.mkDerivation rec {
       categories = "Office;Application;";
     };
 
+    javaOptions = [
+      "-Dawt.useSystemAAFontSettings=on"
+    ];
+
   in ''
     mkdir -pv "$out/share/ganttproject"
     cp -rv *  "$out/share/ganttproject"
 
     mkdir -pv "$out/bin"
     wrapProgram "$out/share/ganttproject/ganttproject" \
-      --set JAVA_HOME "${jre}"
+      --set JAVA_HOME "${jre}" \
+      --set _JAVA_OPTIONS "${builtins.toString javaOptions}"
+
     mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
 
     cp -rv "${desktopItem}/share/applications" "$out/share"

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -4,10 +4,10 @@
 
 stdenv.mkDerivation rec {
   name = "ganttproject-bin-${version}";
-  version = "2.8.9";
+  version = "2.8.10";
 
-  src = let build = "r2335"; in fetchzip {
-    sha256 = "1fmfrsy9z2nff0bxwj7xsfbwkb9y1dmssvy5wkmf9ngihyzj3w1k";
+  src = let build = "r2364"; in fetchzip {
+    sha256 = "0cclgyqv4f9pjsdlh93cqvgbzrp8ajvrpc2xszs03sknqz2kdh7r";
     url = "https://dl.ganttproject.biz/ganttproject-${version}/"
         + "ganttproject-${version}-${build}.zip";
   };

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -3,10 +3,10 @@
 
 stdenv.mkDerivation rec {
   name = "ganttproject-bin-${version}";
-  version = "2.7.2";
+  version = "2.8.9";
 
-  src = let build = "r1954"; in fetchzip {
-    sha256 = "0l655w6n88j7klz56af8xkpiv1pwlkfl5x1d33sqv9dnyisyw2hc";
+  src = let build = "r2335"; in fetchzip {
+    sha256 = "1fmfrsy9z2nff0bxwj7xsfbwkb9y1dmssvy5wkmf9ngihyzj3w1k";
     url = "https://dl.ganttproject.biz/ganttproject-${version}/"
         + "ganttproject-${version}-${build}.zip";
   };
@@ -37,9 +37,6 @@ stdenv.mkDerivation rec {
       --set JAVA_HOME "${jre}"
     mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
 
-    install -v -Dm644 \
-      plugins/net.sourceforge.ganttproject/data/resources/icons/ganttproject.png \
-      "$out/share/pixmaps/ganttproject.png"
     cp -rv "${desktopItem}/share/applications" "$out/share"
   '';
 

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation rec {
     # ‘GPL3-compatible’. See ${downloadPage} for detailed information.
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
+    maintainers = [ maintainers.vidbina ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I'm starting to use GanttProject and needed the latest update, then I also added a configuration option for anti-aliasing because I'm on a high-res display but don't want to force everyone to deal with AA as well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

