### PR TITLE
pythonPackages.kconfiglib: init at 10.36.0

### DIFF
--- a/pkgs/development/python-modules/kconfiglib/default.nix
+++ b/pkgs/development/python-modules/kconfiglib/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "kconfiglib";
+  version = "10.36.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qhy4vv1rpgx4r1la14symxv3cpz7klqakn1rqdagwyaqp667g9b";
+  };
+
+  # doesnt work out of the box but might be possible
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A flexible Python 2/3 Kconfig implementation and library";
+    homepage = https://github.com/ulfalizer/Kconfiglib;
+    license = licenses.isc;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -418,6 +418,8 @@ in {
 
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };
 
+  kconfiglib = callPackage ../development/python-modules/kconfiglib { };
+
   lammps-cython = callPackage ../development/python-modules/lammps-cython {
     mpi = pkgs.openmpi;
   };


### PR DESCRIPTION
python library to deal with kernel Kconfig system.

###### Motivation for this change
hopefully we can use this library to generate proper kernel configurations, like enabling an option will enable all the required configs to enable it (while this currently has to be done manually).

As a reference, there seems to be some code on how to achieve this here
- https://www4.cs.fau.de/Ausarbeitung/MA-I4-2015-04-Hengelein.pdf
- https://kernelnewbies.org/KernelProjects/kconfig-sat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

