### PR TITLE
nix-prefetch-git: propagate errors under --quiet

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -270,7 +270,7 @@ make_deterministic_repo(){
 }
 
 
-_clone_user_rev() {
+clone_user_rev() {
     local dir="$1"
     local url="$2"
     local rev="${3:-HEAD}"
@@ -307,19 +307,29 @@ _clone_user_rev() {
     fi
 }
 
-clone_user_rev() {
-    if ! test -n "$QUIET"; then
-        _clone_user_rev "$@"
-    else
-        errfile="$(mktemp "${TMPDIR:-/tmp}/git-checkout-err-XXXXXXXX")"
-        # shellcheck disable=SC2064
-        trap "rm -rf \"$errfile\"" EXIT
-        _clone_user_rev "$@" 2> "$errfile" || (
-            status="$?"
-            cat "$errfile" >&2
-            exit "$status"
-        )
+exit_handlers=()
+
+run_exit_handlers() {
+    exit_status=$?
+    for handler in "${exit_handlers[@]}"; do
+        eval "$handler $exit_status"
+    done
+}
+
+trap run_exit_handlers EXIT
+
+quiet_exit_handler() {
+    exec 2>&3 3>&-
+    if [ $1 -ne 0 ]; then
+        cat "$errfile" >&2
     fi
+    rm -f "$errfile"
+}
+
+quiet_mode() {
+    errfile="$(mktemp "${TMPDIR:-/tmp}/git-checkout-err-XXXXXXXX")"
+    exit_handlers+=(quiet_exit_handler)
+    exec 3>&2 2>"$errfile"
 }
 
 json_escape() {
@@ -362,6 +372,14 @@ EOF
     fi
 }
 
+remove_tmpPath() {
+    rm -rf "$tmpPath"
+}
+
+if test -n "$QUIET"; then
+    quiet_mode
+fi
+
 if test -z "$branchName"; then
     branchName=fetchgit
 fi
@@ -390,8 +408,7 @@ else
     if test -z "$finalPath"; then
 
         tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/git-checkout-tmp-XXXXXXXX")"
-        # shellcheck disable=SC2064
-        trap "rm -rf \"$tmpPath\"" EXIT
+        exit_handlers+=(remove_tmpPath)
 
         tmpFile="$tmpPath/$(url_to_name "$url" "$rev")"
         mkdir -p "$tmpFile"


### PR DESCRIPTION
###### Motivation for this change

`nix-prefetch-git` with `--quiet` masks errors. This mode is consumed by scripts, and the failure is often buried several layers deep.

```sh
$ nix-prefetch-git https://github.com/sensu/yaml --rev f00f00f00; echo $?
Initialized empty Git repository in /....
[...]
fatal: 'f00f00f00' is not a commit and a branch 'fetchgit' cannot be created from it
Unable to checkout f00f00f00 from https://github.com/sensu/yaml.
1
```

```
$ nix-prefetch-git https://github.com/sensu/yaml --rev f00f00f00 --quiet; echo $?
{
  "url": "https://github.com/sensu/yaml",
  "rev": "refs/heads/fetchgit",
  "date": "",
  "sha256": "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5",
  "fetchSubmodules": false
}
0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

