### PR TITLE
rustc: mark compileprocess as timeconsuming

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -166,6 +166,8 @@ stdenv.mkDerivation {
   # https://github.com/rust-lang/rust/issues/30181
   # enableParallelBuilding = false;
 
+  requiredSystemFeatures = [ "big-parallel" ];
+
   meta = with stdenv.lib; {
     homepage = https://www.rust-lang.org/;
     description = "A safe, concurrent, practical language";


### PR DESCRIPTION
###### Motivation for this change
Hydra is failing to build rustc, because of timeout: https://hydra.nixos.org/build/87373242

@grahamc @Mic92 