### PR TITLE
zsh: 5.6.2 -> 5.7

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ncurses, pcre, fetchpatch }:
 
 let
-  version = "5.6.2";
+  version = "5.7";
 
   documentation = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}-doc.tar.xz";
-    sha256 = "05014rg6hkwiv1p56iij8wn2rghmwjxs5qsj3d3xigbwaikk55wq";
+    sha256 = "0pgisyi82pg5mycx1k7vfx9hwzl6zq00r5s9v91lg4gqisvlvagh";
   };
 
 in
@@ -15,17 +15,8 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}.tar.xz";
-    sha256 = "17iffliqcj4hv91g0bd2sxsyfcz51mfyh97sp2iyrs2p0mndc2x5";
+    sha256 = "04ynid3ggvy6i5c26bk52mq6x5vyrdwgryid9hggmnb1nf8b41vq";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "search-xdg-data-dirs.patch";
-      url = https://github.com/zsh-users/zsh/commit/624219e0e4cbfdfb286e707bd2853f2d7b6a4a7d.patch;
-      sha256 = "0i0g7dc0px57vpklm1f4w20vyc92nv15y09r5clvib2kjkxjy2cf";
-      excludes = [ "ChangeLog" ];
-    })
-  ];
 
   buildInputs = [ ncurses pcre ];
 


### PR DESCRIPTION
###### Motivation for this change

Update zsh from 5.6.2 to 5.7.

Changes between 5.6.2 and 5.7
===
Incompatibilities
---

   * vcs_info git: The gen-unapplied-string hook receives the patches in order (next to be applied first). This is consistent with the hg backend and with one of two contradictory claims in the documentation (the other one has been corrected). In zsh through 5.6.2, the patches were passed in reverse order, next to be applied being last in the array. The gen-applied-string hook is unaffected; it still receives the patches in reverse order, from last applied to first applied.
  *  The option NO_UNSET now also applies when reading values from variables without a preceding '$' sign in shell arithmetic expansion and in the double-parentheses and 'let' arithmetic commands.

Changes
---

 *   Support for 24-bit true color terminals has been added. Hex triplets can be used when specifying colours for prompts and line editor highlighting. On 88 and 256 colour terminals, a new zsh/nearcolor module allows colours specified with hex triplets to be matched against the nearest available colour.
 *   The zsh/datetime module's strftime builtin now accepts an argument specifying the nanoseconds time component; both arguments can be omitted to use the current time.

http://zsh.sourceforge.net/releases.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

