### PR TITLE
Security Update: pythonPackages.python-gnupg: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -3,11 +3,11 @@
 buildPythonPackage rec {
   name    = "${pname}-${version}";
   pname   = "python-gnupg";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2d158dfc6b54927752b945ebe57e6a0c45da27747fa3b9ae66eccc0d2147ac0d";
+    sha256 = "45daf020b370bda13a1429c859fcdff0b766c0576844211446f9266cae97fb0e";
   };
 
   propagatedBuildInputs = [ gnupg1 ];

--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -1,7 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, gnupg1 }:
 
 buildPythonPackage rec {
-  name    = "${pname}-${version}";
   pname   = "python-gnupg";
   version = "0.4.4";
 
@@ -9,8 +8,6 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "45daf020b370bda13a1429c859fcdff0b766c0576844211446f9266cae97fb0e";
   };
-
-  propagatedBuildInputs = [ gnupg1 ];
 
   # Let's make the library default to our gpg binary
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes CVE-2019-6690

https://blog.hackeriet.no/cve-2019-6690-python-gnupg-vulnerability/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

