### PR TITLE
 qgis: 2.18.22 -> 2.18.28

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "qgis-2.18.22";
+  name = "qgis-2.18.28";
 
   buildInputs = [ gdal qt4 flex openssl bison proj geos xlibsWrapper sqlite gsl qwt qscintilla
     fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags pkgconfig
@@ -35,14 +35,15 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://qgis.org/downloads/${name}.tar.bz2";
-    sha256 = "00b3a2hfn3i7bdx7x96vz2nj0976vpkhid4ss7n8c33fdvw3k82a";
+    sha256 = "18pijqls1isd2bpg0mkrw07jqvdfaiwwb9mvz7p2xrgqcjx7dxsq";
   };
 
   patches = [
-    # https://github.com/qgis/QGIS/pull/7765
+    # already merged upstream in QGIS-3.*, but needs to be backported to QGIS-2
     (fetchpatch {
-      url = "https://github.com/qgis/QGIS/commit/6b61ef361a77f057dc29eb07463007bd9012b253.patch";
-      sha256 = "1xibcahm18n7nxff1xvwwzjf505hvhiw5dk12is7aclv49h0rdf7";
+      url = "https://patch-diff.githubusercontent.com/raw/qgis/QGIS/pull/7263.patch";
+      name = "Ensure_qgis.db_is_writable_when_copied_from_RO_source";
+      sha256 = "19wr2kz0x8x6p2n0ylzd4lqrdmbkxyxr0zpwf2vl9hdp92rdjxbv";
     })
   ];
 

--- a/pkgs/development/libraries/libLAS/default.nix
+++ b/pkgs/development/libraries/libLAS/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     "-DGDAL_CONFIG=${gdal}/bin/gdal-config"
     "-DWITH_LASZIP=ON"
     "-DLASZIP_INCLUDE_DIR=${LASzip}/include"
+    "-DCMAKE_EXE_LINKER_FLAGS=-pthread"
   ];
 
   postFixup = stdenv.lib.optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

