### PR TITLE
cargo-web: 0.6.15 -> 0.6.23

### DIFF
--- a/pkgs/development/tools/cargo-web/default.nix
+++ b/pkgs/development/tools/cargo-web/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchFromGitHub, openssl, pkgconfig, rustPlatform
+{ stdenv, fetchFromGitHub, openssl, perl, pkgconfig, rustPlatform
 , CoreServices, Security
 }:
 
 rustPlatform.buildRustPackage rec {
   name = "cargo-web-${version}";
-  version = "0.6.15";
+  version = "0.6.23";
 
   src = fetchFromGitHub {
     owner = "koute";
     repo = "cargo-web";
     rev = version;
-    sha256 = "076g7cd9v53vi8xvd4kfsiyzw1m2hhd1lwlwcv2dx2s5vlw4dxzh";
+    sha256 = "1qbi3z4x39il07xlhfvq5ckzjqrf0yf6p8qidf24fp92gb940zxr";
   };
 
-  cargoSha256 = "157av9zkirr00w9v11mh7yp8w36sy7rw6i80i5jmi0mgrdvcg5si";
+  cargoSha256 = "16wzgyn3k0yn70y0ciliyx1sjgppmkv9b4bn9p4x0qi6l0ah7fdp";
 
-  nativeBuildInputs = [ openssl pkgconfig ];
+  nativeBuildInputs = [ openssl perl pkgconfig ];
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update cargo-web.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

