### PR TITLE
Add tests for Sonarr, Radarr, Lidarr and Jackett

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -107,6 +107,7 @@ in
   initrdNetwork = handleTest ./initrd-network.nix {};
   installer = handleTest ./installer.nix {};
   ipv6 = handleTest ./ipv6.nix {};
+  jackett = handleTest ./jackett.nix {};
   jenkins = handleTest ./jenkins.nix {};
   #kafka = handleTest ./kafka.nix {}; # broken since openjdk: 8u181 -> 8u192
   kerberos = handleTest ./kerberos/default.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -120,6 +120,7 @@ in
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   ldap = handleTest ./ldap.nix {};
   leaps = handleTest ./leaps.nix {};
+  lidarr = handleTest ./lidarr.nix {};
   #lightdm = handleTest ./lightdm.nix {};
   login = handleTest ./login.nix {};
   #logstash = handleTest ./logstash.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -194,6 +194,7 @@ in
   smokeping = handleTest ./smokeping.nix {};
   snapper = handleTest ./snapper.nix {};
   solr = handleTest ./solr.nix {};
+  sonarr = handleTest ./sonarr.nix {};
   strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
   sudo = handleTest ./sudo.nix {};
   switchTest = handleTest ./switch-test.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -178,6 +178,7 @@ in
   quagga = handleTest ./quagga.nix {};
   quake3 = handleTest ./quake3.nix {};
   rabbitmq = handleTest ./rabbitmq.nix {};
+  radarr = handleTest ./radarr.nix {};
   radicale = handleTest ./radicale.nix {};
   redmine = handleTest ./redmine.nix {};
   roundcube = handleTest ./roundcube.nix {};

--- a/nixos/tests/jackett.nix
+++ b/nixos/tests/jackett.nix
@@ -1,0 +1,18 @@
+import ./make-test.nix ({ lib, ... }:
+
+with lib;
+
+rec {
+  name = "jackett";
+  meta.maintainers = with maintainers; [ etu ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    { services.jackett.enable = true; };
+
+  testScript = ''
+    $machine->waitForUnit('jackett.service');
+    $machine->waitForOpenPort('9117');
+    $machine->succeed("curl --fail http://localhost:9117/");
+  '';
+})

--- a/nixos/tests/lidarr.nix
+++ b/nixos/tests/lidarr.nix
@@ -1,0 +1,18 @@
+import ./make-test.nix ({ lib, ... }:
+
+with lib;
+
+rec {
+  name = "lidarr";
+  meta.maintainers = with maintainers; [ etu ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    { services.lidarr.enable = true; };
+
+  testScript = ''
+    $machine->waitForUnit('lidarr.service');
+    $machine->waitForOpenPort('8686');
+    $machine->succeed("curl --fail http://localhost:8686/");
+  '';
+})

--- a/nixos/tests/radarr.nix
+++ b/nixos/tests/radarr.nix
@@ -1,0 +1,18 @@
+import ./make-test.nix ({ lib, ... }:
+
+with lib;
+
+rec {
+  name = "radarr";
+  meta.maintainers = with maintainers; [ etu ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    { services.radarr.enable = true; };
+
+  testScript = ''
+    $machine->waitForUnit('radarr.service');
+    $machine->waitForOpenPort('7878');
+    $machine->succeed("curl --fail http://localhost:7878/");
+  '';
+})

--- a/nixos/tests/sonarr.nix
+++ b/nixos/tests/sonarr.nix
@@ -1,0 +1,18 @@
+import ./make-test.nix ({ lib, ... }:
+
+with lib;
+
+rec {
+  name = "sonarr";
+  meta.maintainers = with maintainers; [ etu ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    { services.sonarr.enable = true; };
+
+  testScript = ''
+    $machine->waitForUnit('sonarr.service');
+    $machine->waitForOpenPort('8989');
+    $machine->succeed("curl --fail http://localhost:8989/");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
The first application (Sonarr) is a quite clunky mono-application that can be quite weird sometimes. And then we have Radarr and Lidarr which both are forks of Sonarr but are re-purposed so they can't be used for the same things. So all three are relevant to test.

I haven't seen breakage yet, but I'm always a bit scared when it comes to these three.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

