### PR TITLE
nixos/grafana: add provisioning of pre-configured Grafana  with dashb…

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1176,6 +1176,11 @@
     github = "dje4321";
     name = "Dje4321";
   };
+  dlifanov = {
+    email = "dmitriy.lifanov1@gmail.com";
+    github = "dlifanov";
+    name = "Dmitriy Lifanov";
+  };
   dmalikov = {
     email = "malikov.d.y@gmail.com";
     github = "dmalikov";


### PR DESCRIPTION

###### Motivation for this change

Grafana is deployed without pre-configured dashboard and datasource.
Add configuration to get already working dashboard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---