### PR TITLE
slurp: init at 1.0

### DIFF
--- a/pkgs/tools/misc/slurp/default.nix
+++ b/pkgs/tools/misc/slurp/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, cairo, meson, ninja, wayland, pkgconfig, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "slurp-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "slurp";
+    rev = "v${version}";
+    sha256 = "03igv8r8n772xb0y7whhs1pa298l3d94jbnknaxpwp2n4fi04syb";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    cairo
+    wayland
+    wayland-protocols
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Grab images from a Wayland compositor";
+    homepage = https://github.com/emersion/grim;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ buffet ];
+  };
+}

--- a/pkgs/tools/misc/slurp/default.nix
+++ b/pkgs/tools/misc/slurp/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Grab images from a Wayland compositor";
-    homepage = https://github.com/emersion/grim;
+    homepage = https://github.com/emersion/slurp;
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ buffet ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14138,8 +14138,6 @@ in
 
   slurm-spank-x11 = callPackage ../servers/computing/slurm-spank-x11 { };
 
-  slurp = callPackage ../tools/misc/slurp { };
-
   systemd-journal2gelf = callPackage ../tools/system/systemd-journal2gelf { };
 
   inherit (callPackages ../servers/http/tomcat { })
@@ -19306,6 +19304,8 @@ in
   slop = callPackage ../tools/misc/slop {};
 
   slrn = callPackage ../applications/networking/newsreaders/slrn { };
+
+  slurp = callPackage ../tools/misc/slurp { };
 
   sniproxy = callPackage ../applications/networking/sniproxy { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14138,6 +14138,8 @@ in
 
   slurm-spank-x11 = callPackage ../servers/computing/slurm-spank-x11 { };
 
+  slurp = callPackage ../tools/misc/slurp { };
+
   systemd-journal2gelf = callPackage ../tools/system/systemd-journal2gelf { };
 
   inherit (callPackages ../servers/http/tomcat { })


### PR DESCRIPTION
###### Motivation for this change
Allows it to easily screenshot regions using this and grim

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

