### PR TITLE
ghcHEAD to ghc-8.8

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.3-binary.nix
@@ -1,0 +1,164 @@
+{ stdenv
+, fetchurl, perl, gcc, llvm_39
+, ncurses5, gmp, glibc, libiconv
+}:
+
+# Prebuilt only does native
+assert stdenv.targetPlatform == stdenv.hostPlatform;
+
+let
+  libPath = stdenv.lib.makeLibraryPath ([
+    ncurses5 gmp
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv);
+
+  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+    + "LD_LIBRARY_PATH";
+
+  glibcDynLinker = assert stdenv.isLinux;
+    if stdenv.hostPlatform.libc == "glibc" then
+       # Could be stdenv.cc.bintools.dynamicLinker, keeping as-is to avoid rebuild.
+       ''"$(cat $NIX_CC/nix-support/dynamic-linker)"''
+    else
+      "${stdenv.lib.getLib glibc}/lib/ld-linux*";
+
+in
+
+stdenv.mkDerivation rec {
+  version = "8.6.3";
+
+  name = "ghc-${version}-binary";
+
+  src = fetchurl ({
+    "i686-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-deb8-linux.tar.xz";
+      sha256 = "0bw8a7fxcbskf93rb4m542ff66vrmx5i5kj77qx37cbhijx70w5m";
+    };
+    "x86_64-linux" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb8-linux.tar.xz";
+      sha256 = "1m9gaga2pzi2cx5gvasg0rx1dlvr68gmi20l67652kag6xjsa719";
+    };
+    "x86_64-darwin" = {
+      url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+      sha256 = "1hbzk57v45176kxcx848p5jn5p1xbp2129ramkbzsk6plyhnkl3r";
+    };
+  }.${stdenv.hostPlatform.system}
+    or (throw "cannot bootstrap GHC on this platform"));
+
+  nativeBuildInputs = [ perl ];
+  buildInputs = stdenv.lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ llvm_39 ];
+
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location/
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find . -type f -executable); do
+        isScript $exe && continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib -change /usr/local/lib/gcc/6/libgcc_s.1.dylib ${gcc.cc.lib}/lib/libgcc_s.1.dylib $exe
+      done
+    '' +
+
+    # Some scripts used during the build need to have their shebangs patched
+    ''
+      patchShebangs ghc-${version}/utils/
+      patchShebangs ghc-${version}/configure
+    '' +
+
+    # Strip is harmful, see also below. It's important that this happens
+    # first. The GHC Cabal build system makes use of strip by default and
+    # has hardcoded paths to /usr/bin/strip in many places. We replace
+    # those below, making them point to our dummy script.
+    ''
+      mkdir "$TMP/bin"
+      for i in strip; do
+        echo '#! ${stdenv.shell}' > "$TMP/bin/$i"
+        chmod +x "$TMP/bin/$i"
+      done
+      PATH="$TMP/bin:$PATH"
+    '' +
+    # We have to patch the GMP paths for the integer-gmp package.
+    ''
+      find . -name integer-gmp.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      find . -name base.buildinfo \
+          -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
+    '' +
+    # Rename needed libraries and binaries, fix interpreter
+    stdenv.lib.optionalString stdenv.isLinux ''
+      find . -type f -perm -0100 -exec patchelf \
+          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.5 libncurses.so \
+          --replace-needed libtinfo.so libtinfo.so.5 \
+          --interpreter ${glibcDynLinker} {} \;
+
+      sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+      sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+    '';
+
+  configurePlatforms = [ ];
+  configureFlags = [
+    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
+    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
+
+  # Stripping combined with patchelf breaks the executables (they die
+  # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)
+  dontStrip = true;
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    for p in $(find "$out" -type f -executable); do
+      if isELF "$p"; then
+        echo "Patchelfing $p"
+        patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+      fi
+    done
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # not enough room in the object files for the full path to libiconv :(
+    for exe in $(find "$out" -type f -executable); do
+      isScript $exe && continue
+      ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+      install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib -change /usr/local/lib/gcc/6/libgcc_s.1.dylib ${gcc.cc.lib}/lib/libgcc_s.1.dylib $exe
+    done
+
+    for file in $(find "$out" -name setup-config); do
+      substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+    done
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    unset ${libEnvVar}
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  passthru = {
+    targetPrefix = "";
+    enableShared = true;
+  };
+
+  meta.license = stdenv.lib.licenses.bsd3;
+  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+}

--- a/pkgs/development/haskell-modules/configuration-ghc-head.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-head.nix
@@ -1,11 +1,18 @@
+##
+## Caveat: a copy of configuration-ghc-8.6.x.nix with minor changes:
+##
+##  1. "8.7" strings
+##  2. llvm 6
+##  3. disabled library update: parallel
+##
 { pkgs, haskellLib }:
 
 with haskellLib;
 
 self: super: {
 
-  # This compiler version needs llvm 5.x.
-  llvmPackages = pkgs.llvmPackages_5;
+  # This compiler version needs llvm 6.x.
+  llvmPackages = pkgs.llvmPackages_6;
 
   # Disable GHC 8.7.x core libraries.
   array = null;
@@ -20,12 +27,15 @@ self: super: {
   ghc-boot = null;
   ghc-boot-th = null;
   ghc-compact = null;
-  ghc-prim = null;
+  ghc-heap = null;
   ghci = null;
+  ghc-prim = null;
   haskeline = null;
   hpc = null;
   integer-gmp = null;
+  libiserv = null;
   mtl = null;
+  parallel = null;
   parsec = null;
   pretty = null;
   process = null;
@@ -39,60 +49,34 @@ self: super: {
   unix = null;
   xhtml = null;
 
-  # jailbreak-cabal can use the native Cabal library.
-  jailbreak-cabal = super.jailbreak-cabal.override { Cabal = null; };
+  # https://github.com/tibbe/unordered-containers/issues/214
+  unordered-containers = dontCheck super.unordered-containers;
 
-  # haddock: No input file(s).
-  nats = dontHaddock super.nats;
-  bytestring-builder = dontHaddock super.bytestring-builder;
+  # Test suite does not compile.
+  cereal = dontCheck super.cereal;
+  data-clist = doJailbreak super.data-clist;  # won't cope with QuickCheck 2.12.x
+  dates = doJailbreak super.dates; # base >=4.9 && <4.12
+  Diff = dontCheck super.Diff;
+  HaTeX = doJailbreak super.HaTeX; # containers >=0.4 && <0.6 is too tight; https://github.com/Daniel-Diaz/HaTeX/issues/126
+  hpc-coveralls = doJailbreak super.hpc-coveralls; # https://github.com/guillaume-nargeot/hpc-coveralls/issues/82
+  http-api-data = doJailbreak super.http-api-data;
+  persistent-sqlite = dontCheck super.persistent-sqlite;
+  psqueues = dontCheck super.psqueues;    # won't cope with QuickCheck 2.12.x
+  system-fileio = dontCheck super.system-fileio;  # avoid dependency on broken "patience"
+  unicode-transforms = dontCheck super.unicode-transforms;
+  wl-pprint-extras = doJailbreak super.wl-pprint-extras; # containers >=0.4 && <0.6 is too tight; https://github.com/ekmett/wl-pprint-extras/issues/17
+  RSA = dontCheck super.RSA; # https://github.com/GaloisInc/RSA/issues/14
+  monad-par = dontCheck super.monad-par;  # https://github.com/simonmar/monad-par/issues/66
+  github = dontCheck super.github; # hspec upper bound exceeded; https://github.com/phadej/github/pull/341
+  binary-orphans = dontCheck super.binary-orphans; # tasty upper bound exceeded; https://github.com/phadej/binary-orphans/commit/8ce857226595dd520236ff4c51fa1a45d8387b33
 
-  # We have time 1.5
-  aeson = disableCabalFlag super.aeson "old-locale";
+  # https://github.com/jgm/skylighting/issues/55
+  skylighting-core = dontCheck super.skylighting-core;
 
-  # Setup: At least the following dependencies are missing: base <4.8
-  hspec-expectations = overrideCabal super.hspec-expectations (drv: {
-    postPatch = "sed -i -e 's|base < 4.8|base|' hspec-expectations.cabal";
-  });
-  utf8-string = overrideCabal super.utf8-string (drv: {
-    postPatch = "sed -i -e 's|base >= 4.3 && < 4.10|base|' utf8-string.cabal";
-  });
+  # Break out of "yaml >=0.10.4.0 && <0.11": https://github.com/commercialhaskell/stack/issues/4485
+  stack = doJailbreak super.stack;
 
-  # bos/attoparsec#92
-  attoparsec = dontCheck super.attoparsec;
-
-  # test suite hangs silently for at least 10 minutes
-  split = dontCheck super.split;
-
-  # Test suite fails with some (seemingly harmless) error.
-  # https://code.google.com/p/scrapyourboilerplate/issues/detail?id=24
-  syb = dontCheck super.syb;
-
-  # Test suite has stricter version bounds
-  retry = dontCheck super.retry;
-
-  # Test suite fails with time >= 1.5
-  http-date = dontCheck super.http-date;
-
-  # Version 1.19.5 fails its test suite.
-  happy = dontCheck super.happy;
-
-  # Workaround for a workaround, see comment for "ghcjs" flag.
-  jsaddle = let jsaddle' = disableCabalFlag super.jsaddle "ghcjs";
-            in addBuildDepends jsaddle' [ self.glib self.gtk3 self.webkitgtk3
-                                          self.webkitgtk3-javascriptcore ];
-
-  # The compat library is empty in the presence of mtl 2.2.x.
-  mtl-compat = dontHaddock super.mtl-compat;
-
-  # Won't work with LLVM 3.5.
-  llvm-general = markBrokenVersion "3.4.5.3" super.llvm-general;
-
-  # A bunch of jailbreaks due to 'base' bump
-  old-time = doJailbreak super.old-time;
-  old-locale = doJailbreak super.old-locale;
-  primitive = doJailbreak super.primitive;
-  test-framework = doJailbreak super.test-framework;
-  atomic-primops = doJailbreak (appendPatch super.atomic-primops ./patches/atomic-primops-Cabal-1.25.patch);
-  hashable = doJailbreak super.hashable;
+  # Fix build with ghc 8.6.x.
+  git-annex = appendPatch super.git-annex ./patches/git-annex-fix-ghc-8.6.x-build.patch;
 
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -391,7 +391,7 @@ stdenv.mkDerivation ({
         rmdir "$packageConfFile"
       fi
       for packageConfFile in "$packageConfDir/"*; do
-        local pkgId=$( ${gnused}/bin/sed -n -e 's|^id: ||p' $packageConfFile )
+        local pkgId=$( ${gnused}/bin/sed -n -e 's|^id:[ ]\+||p' $packageConfFile )
         mv $packageConfFile $packageConfDir/$pkgId.conf
       done
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -6,6 +6,7 @@ let
   # These are attributes in compiler and packages that don't support integer-simple.
   integerSimpleExcludes = [
     "ghc822Binary"
+    "ghc863Binary"
     "ghc844"
     "ghcjs"
     "ghcjs82"
@@ -43,6 +44,8 @@ in {
   compiler = {
 
     ghc822Binary = callPackage ../development/compilers/ghc/8.2.2-binary.nix { };
+
+    ghc863Binary = callPackage ../development/compilers/ghc/8.6.3-binary.nix { };
 
     ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix {
       bootPkgs = packages.ghc822Binary;
@@ -114,6 +117,12 @@ in {
       buildHaskellPackages = bh.packages.ghc822Binary;
       ghc = bh.compiler.ghc822Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
+      packageSetConfig = bootstrapPackageSet;
+    };
+    ghc863Binary = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc863Binary;
+      ghc = bh.compiler.ghc863Binary;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.6.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };
     ghc822 = callPackage ../development/haskell-modules {

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -78,10 +78,10 @@ in {
       llvmPackages = pkgs.llvmPackages_6;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
-      bootPkgs = packages.ghc822Binary;
+      bootPkgs = packages.ghc863Binary;
       inherit (buildPackages.python3Packages) sphinx;
-      buildLlvmPackages = buildPackages.llvmPackages_5;
-      llvmPackages = pkgs.llvmPackages_5;
+      buildLlvmPackages = buildPackages.llvmPackages_6;
+      llvmPackages = pkgs.llvmPackages_6;
     };
     ghcjs = compiler.ghcjs84;
     ghcjs82 = callPackage ../development/compilers/ghcjs-ng {


### PR DESCRIPTION
1. This causes a haskell-wide rebuild because of the change in `generic-builder.nix` -- perhaps this should target the staging branch instead?
2. I'm seeing a lot of haddock SIGSEGVs.
3. There's a bunch of overrides for common packages to be made in `ghcHEAD`'s configuration -- I think that's better submitted as a separate PR.