### PR TITLE
zxing-cpp: init at git-20180320

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5133,4 +5133,9 @@
     github = "mredaelli";
     name = "Massimo Redaelli";
   };
+  voobscout = {
+    email = "nixpkgs@njk.li";
+    github = "voobscout";
+    name = "Alex Lee";
+  };
 }

--- a/pkgs/tools/graphics/zxing-cpp/default.nix
+++ b/pkgs/tools/graphics/zxing-cpp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, makeWrapper }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "20180320";
+  name = "zxing-cpp-${version}";
+
+  src = fetchFromGitHub {
+    owner = "glassechidna";
+    repo = "zxing-cpp";
+    rev = "5aad4744a3763d814df98a18886979893e638274";
+    sha256 = "07xshbh656a26bi8bii6ffw3fahnfj6755f6ybmmmplk55xxnlg8";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/glassechidna/zxing-cpp;
+    description = "Unofficial C++ Port of Java ZXing library";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ voobscout ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6549,6 +6549,8 @@ in
 
   zxing = callPackage ../tools/graphics/zxing {};
 
+  zxing-cpp = callPackage ../tools/graphics/zxing-cpp {};
+
 
   ### SHELLS
 


### PR DESCRIPTION
This port takes considerably less space in nix store,
usecases: containers, squashfs, iso images

###### Motivation for this change
When storage space is at a premium, like a netboot image, this helps by not requiring java deps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

