### PR TITLE
adoptopenjdk-bin: 11.0.1 -> 11.0.2 (hotspot aarch64-linux, x86_64-mac)

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk11-darwin.nix
@@ -5,6 +5,5 @@ in
   jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk11.mac.jdk.hotspot;
   jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.hotspot;
   jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jdk.openj9;
-  # openj9 jre builds are currently missing: https://github.com/AdoptOpenJDK/openjdk-build/issues/796
-  #jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.openj9;
+  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk11.mac.jre.openj9;
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -4,10 +4,10 @@
       "jdk": {
         "hotspot": {
           "aarch64": {
-            "build": "13",
-            "sha256": "b66121b9a0c2e7176373e670a499b9d55344bcb326f67140ad6d0dc24d13d3e2",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.1_13.tar.gz",
-            "version": "11.0.1"
+            "build": "7",
+            "sha256": "95b14e954f96185d02afda1a3ab146011076a4d97b457c9333556bd5d9263c41",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.2_7.tar.gz",
+            "version": "11.0.2"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -32,10 +32,10 @@
       "jre": {
         "hotspot": {
           "aarch64": {
-            "build": "28",
-            "sha256": "6fd756bda392e3fddb48382460daae263c6fb5708683a691c8d30af2eb870bb8",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_aarch64_linux_hotspot_11_28.tar.gz",
-            "version": "11"
+            "build": "7",
+            "sha256": "b101c86948742a5a580f94596654ef7d200f629cfc1ffdded10fb6a0cbe34c34",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.2_7.tar.gz",
+            "version": "11.0.2"
           },
           "packageType": "jre",
           "vmType": "hotspot",
@@ -64,10 +64,10 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "13",
-            "sha256": "e219e7e2d586ed09ae65f4ec390fca5d5f0c37a61b47677648610194daf1aaa7",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_hotspot_11.0.1_13.tar.gz",
-            "version": "11.0.1"
+            "build": "7",
+            "sha256": "c52dd6e34b5a0521e41715d4fe4fd7ba071a5fed7035e7348844e88b37480448",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.2_7.tar.gz",
+            "version": "11.0.2"
           }
         },
         "openj9": {
@@ -86,10 +86,10 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "28",
-            "sha256": "ef4dbfe5aed6ab2278fcc14db6cc73abbaab56e95f6ebb023790a7ebc6d7f30c",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_mac_hotspot_11_28.tar.gz",
-            "version": "11"
+            "build": "7",
+            "sha256": "53febef8465b4e901309e5b91172a3f91ea3052ba20822abccd1ccb8c37e83a2",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jre_x64_mac_hotspot_11.0.2_7.tar.gz",
+            "version": "11.0.2"
           }
         }
       }

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -12,9 +12,9 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "d89304a971e5186e80b6a48a9415e49583b7a5a9315ba5552d373be7782fc528",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_7.tar.gz",
+            "build": "9",
+            "sha256": "d02089d834f7702ac1a9776d8d0d13ee174d0656cf036c6b68b9ffb71a6f610e",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz",
             "version": "11.0.2"
           }
         },
@@ -22,10 +22,10 @@
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "13",
-            "sha256": "ef9bf07cba79082285a9d426ea4eb3e8df57561ce2afe07cc5f299a8fa203279",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_linux_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz",
-            "version": "11.0.1"
+            "build": "9",
+            "sha256": "02de51ebe86897081f7998dd2f256e33fb8b15c70cf26715020795326cc50511",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_openj9_11.0.2_9_openj9-0.12.0.tar.gz",
+            "version": "11.0.2"
           }
         }
       },
@@ -40,9 +40,9 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "59c34373eec16b53798aedac73776b19e43f396fdff8a2879e66dc4b0cfd73cc",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_7.tar.gz",
+            "build": "9",
+            "sha256": "e762e4cd50cebd1c63dee2cf0d5737016e9e057520b67761df5ad2dc7bbc7d54",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.2_9.tar.gz",
             "version": "11.0.2"
           }
         },
@@ -50,10 +50,10 @@
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "28",
-            "sha256": "83a7c95e6b2150a739bdd5e8a6fe0315904fd13d8867c95db67c0318304a2c42",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jre_x64_linux_openj9_11_28.tar.gz",
-            "version": "11"
+            "build": "9",
+            "sha256": "9c6283485a9fa07c1dca882e6427d785c9f4a99d2e49e91ccefbc6147da27343",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jre_x64_linux_openj9_11.0.2_9_openj9-0.12.0.tar.gz",
+            "version": "11.0.2"
           }
         }
       }
@@ -64,9 +64,9 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "c52dd6e34b5a0521e41715d4fe4fd7ba071a5fed7035e7348844e88b37480448",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.2_7.tar.gz",
+            "build": "9",
+            "sha256": "fffd4ed283e5cd443760a8ec8af215c8ca4d33ec5050c24c1277ba64b5b5e81a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.2_9.tar.gz",
             "version": "11.0.2"
           }
         },
@@ -74,10 +74,10 @@
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "13",
-            "sha256": "b8960753a66190fa81982682357a2449b4183f3e23c20a5e3b4cf01e2989846b",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_mac_openj9_jdk-11.0.1_13_openj9-0.11.0_11.0.1_13.tar.gz",
-            "version": "11.0.1"
+            "build": "9",
+            "sha256": "0589fea4f9012299267dd3c533417a37540a3db61ae86f411bda67195b3636f4",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_mac_openj9_11.0.2_9_openj9-0.12.0.tar.gz",
+            "version": "11.0.2"
           }
         }
       },
@@ -86,9 +86,19 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "53febef8465b4e901309e5b91172a3f91ea3052ba20822abccd1ccb8c37e83a2",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B7/OpenJDK11U-jre_x64_mac_hotspot_11.0.2_7.tar.gz",
+            "build": "9",
+            "sha256": "7e70784f7833751b63cee9e197230877a4059b178a24858261f834ea39b29fd5",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jre_x64_mac_hotspot_11.0.2_9.tar.gz",
+            "version": "11.0.2"
+          }
+        },
+        "openj9": {
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "9",
+            "sha256": "40d70bf570b2098b381b77ae62dfddfb8cf6fc500ed539d82b78405593a9c9e5",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jre_x64_mac_openj9_11.0.2_9_openj9-0.12.0.tar.gz",
             "version": "11.0.2"
           }
         }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6635,11 +6635,9 @@ in
     then callPackage adoptopenjdk-bin-11-packages-linux.jdk-openj9 {}
     else callPackage adoptopenjdk-bin-11-packages-darwin.jdk-openj9 {};
 
-  # openj9 jre builds for mac are currently missing (upstream)
-  #adoptopenjdk-jre-openj9-bin-11 = if stdenv.isLinux
-  #  then callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {}
-  #  else callPackage adoptopenjdk-bin-11-packages-darwin.jre-openj9 {};
-  adoptopenjdk-jre-openj9-bin-11 = callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {};
+  adoptopenjdk-jre-openj9-bin-11 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {}
+    else callPackage adoptopenjdk-bin-11-packages-darwin.jre-openj9 {};
 
   adoptopenjdk-bin = adoptopenjdk-hotspot-bin-11;
   adoptopenjdk-jre-bin = adoptopenjdk-jre-hotspot-bin-11;


### PR DESCRIPTION
###### Motivation for this change

- Security fixes
- Other updates

https://www.oracle.com/technetwork/java/javase/11-0-2-relnotes-5188746.html
https://www.oracle.com/technetwork/security-advisory/cpujan2019-5072801.html#AppendixJAVA

Related: #54496

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only on `x86_64-mac`.

---

