### PR TITLE
Mark LibreOffice dependencies as Darwin-compatible

### DIFF
--- a/pkgs/development/compilers/iasl/default.nix
+++ b/pkgs/development/compilers/iasl/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     description = "Intel ACPI Compiler";
     homepage = http://www.acpica.org/;
     license = stdenv.lib.licenses.iasl;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/CoinMP/default.nix
+++ b/pkgs/development/libraries/CoinMP/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://projects.coin-or.org/CoinMP/;
     description = "COIN-OR lightweight API for COIN-OR libraries CLP, CBC, and CGL";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.epl10;
   };
 }

--- a/pkgs/development/libraries/libabw/default.nix
+++ b/pkgs/development/libraries/libabw/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://wiki.documentfoundation.org/DLP/Libraries/libabw;
     description = "Library parsing abiword documents";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.mpl20;
   };
 }

--- a/pkgs/development/libraries/libcmis/default.nix
+++ b/pkgs/development/libraries/libcmis/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "C++ client library for the CMIS interface";
     homepage = https://sourceforge.net/projects/libcmis/;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libe-book/default.nix
+++ b/pkgs/development/libraries/libe-book/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation {
     description = ''Library for import of reflowable e-book formats'';
     license = stdenv.lib.licenses.lgpl21Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libmwaw/default.nix
+++ b/pkgs/development/libraries/libmwaw/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     description = ''Import library for some old mac text documents'';
     license = stdenv.lib.licenses.mpl20 ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libodfgen/default.nix
+++ b/pkgs/development/libraries/libodfgen/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation {
     description = ''A base library for generating ODF documents'';
     license = stdenv.lib.licenses.mpl20 ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libwps/default.nix
+++ b/pkgs/development/libraries/libwps/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://libwps.sourceforge.net/;
     description = "Microsoft Works document format import filter library";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.lgpl21;
   };
 }

--- a/pkgs/development/libraries/libzmf/default.nix
+++ b/pkgs/development/libraries/libzmf/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "libzmf";
   version = "0.0.2";
-  
+
   src = fetchurl {
     url = "http://dev-www.libreoffice.org/src/libzmf/${name}.tar.xz";
     sha256 = "08mg5kmkjrmqrd8j5rkzw9vdqlvibhb1ynp6bmfxnzq5rcq1l197";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = ''A library that parses the file format of Zoner Callisto/Draw documents'';
     license = stdenv.lib.licenses.mpl20;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     homepage = https://wiki.documentfoundation.org/DLP/Libraries/libzmf;
     downloadPage = "http://dev-www.libreoffice.org/src/libzmf/";
     updateWalker = true;

--- a/pkgs/development/python-modules/tlsh/default.nix
+++ b/pkgs/development/python-modules/tlsh/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     description = "Trend Micro Locality Sensitive Hash";
     homepage = https://github.com/trendmicro/tlsh;
     license = licenses.asl20;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 
 }

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = http://e2fsprogs.sourceforge.net/;
     description = "Tools for creating and checking ext2/ext3/ext4 filesystems";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/tools/graphics/sng/default.nix
+++ b/pkgs/tools/graphics/sng/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = http://sng.sourceforge.net/;
     license = licenses.zlib;
     maintainers = [ maintainers.dezgeg ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.tcpdump.org/;
     license = "BSD-style";
     maintainers = with stdenv.lib.maintainers; [ jgeerds ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/security/pgpdump/default.nix
+++ b/pkgs/tools/security/pgpdump/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.mew.org/~kazu/proj/pgpdump/en/;
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ primeos ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Part of #54573.

These all build fine on Darwin -- I don't think there's any reason for them to have been marked Linux-only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---