### PR TITLE
gprof2dot: 2015-04-27 -> 2017-09-19

### DIFF
--- a/pkgs/development/python-modules/gprof2dot/default.nix
+++ b/pkgs/development/python-modules/gprof2dot/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ lib, fetchFromGitHub, buildPythonApplication }:
 
-pythonPackages.buildPythonApplication {
-  name = "gprof2dot-2015-04-27";
+buildPythonApplication {
+  name = "gprof2dot-2017-09-19";
 
   src = fetchFromGitHub {
     owner = "jrfonseca";
     repo = "gprof2dot";
-    rev = "6fbb81559609c12e7c64ae5dce7d102a414a7514";
-    sha256 = "1fff7w6dm6lld11hp2ij97f85ma1154h62dvchq19c5jja3zjw3c";
+    rev = "2017.09.19";
+    sha256 = "1b5wvjv5ykbhz7aix7l3y7mg1hxi0vgak4a49gr92sdlz8blj51v";
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/jrfonseca/gprof2dot;
     description = "Python script to convert the output from many profilers into a dot graph";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
+    maintainers = [ maintainers.pmiddend ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3013,8 +3013,6 @@ in
     callPackage ../tools/misc/graylog/plugins.nix { }
   );
 
-  gprof2dot = callPackage ../development/tools/profiling/gprof2dot { };
-
   graphviz = callPackage ../tools/graphics/graphviz {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -394,6 +394,8 @@ in {
 
   grandalf = callPackage ../development/python-modules/grandalf { };
 
+  gprof2dot = callPackage ../development/python-modules/gprof2dot { };
+
   gsd = callPackage ../development/python-modules/gsd { };
 
   gssapi = callPackage ../development/python-modules/gssapi { };


### PR DESCRIPTION
###### Motivation for this change

The version of gprof2dot in nixpkgs was very old, so I updated it.

Also, you really need two versions of this tool: for Python 2 and Python 3. Apparently you cannot analyze profiler outputs from Python 3 with the (current) Python 2 version. I hope `_py2` and `_py3` are okay as prefixes?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

