### PR TITLE
mathematica: 11.2.0 -> 11.3.0

### DIFF
--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -5,10 +5,10 @@ with lib;
   l10ns = flip map
   [
     {
-      version = "11.2.0";
+      version = "11.3.0";
       lang = "en";
       language = "English";
-      sha256 = "4a1293cc1c404303aa1cab1bd273c7be151d37ac5ed928fbbb18e9c5ab2d8df9";
+      sha256 = "0fcfe208c1eac8448e7be3af0bdb84370b17bd9c5d066c013928c8ee95aed10e";
     }
     {
       version = "11.2.0";


### PR DESCRIPTION
Update Mathematica to the latest version. Note that this only affects the English version, as I do not have a license to download the Japanese version. All executables are functional and I am able to run things in the Mathematica GUI

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

