### PR TITLE
 gnome3.gnome-settings-daemon: bypass polkit by using an suid wrapper

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -255,6 +255,7 @@
   ./services/desktops/gnome3/gnome-online-accounts.nix
   ./services/desktops/gnome3/gnome-remote-desktop.nix
   ./services/desktops/gnome3/gnome-online-miners.nix
+  ./services/desktops/gnome3/gnome-settings-daemon.nix
   ./services/desktops/gnome3/gnome-terminal-server.nix
   ./services/desktops/gnome3/gnome-user-share.nix
   ./services/desktops/gnome3/gpaste.nix

--- a/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
@@ -1,0 +1,32 @@
+# GNOME Settings Daemon
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.gnome3.gnome-settings-daemon = {
+
+      enable = mkEnableOption "GNOME Settings Daemon";
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.gnome3.gnome-settings-daemon.enable {
+
+    environment.systemPackages = [ pkgs.gnome3.gnome-settings-daemon ];
+
+    services.udev.packages = [ pkgs.gnome3.gnome-settings-daemon ];
+
+  };
+
+}

--- a/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
@@ -27,6 +27,18 @@ with lib;
 
     services.udev.packages = [ pkgs.gnome3.gnome-settings-daemon ];
 
+    security.wrappers.gsd-backlight-helper.source = "${pkgs.gnome3.gnome-settings-daemon}/libexec/gsd-backlight-helper";
+
+    nixpkgs.overlays = [
+      (self: super: {
+        gnome3 = super.gnome3.overrideScope' (gself: gsuper: {
+          gnome-settings-daemon = gsuper.gnome-settings-daemon.override {
+            inherit (config.security) wrapperDir;
+          };
+        });
+      })
+    ];
+
   };
 
 }

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -133,6 +133,7 @@ in {
     services.gnome3.gnome-keyring.enable = true;
     services.gnome3.gnome-online-accounts.enable = mkDefault true;
     services.gnome3.gnome-remote-desktop.enable = mkDefault true;
+    services.gnome3.gnome-settings-daemon.enable = true;
     services.gnome3.gnome-terminal-server.enable = mkDefault true;
     services.gnome3.gnome-user-share.enable = mkDefault true;
     services.gnome3.gvfs.enable = true;
@@ -152,7 +153,6 @@ in {
     services.packagekit.enable = mkDefault true;
     hardware.bluetooth.enable = mkDefault true;
     services.xserver.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center
-    services.udev.packages = [ pkgs.gnome3.gnome-settings-daemon ];
     systemd.packages = [ pkgs.gnome3.vino ];
     services.flatpak.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, substituteAll, stdenv, meson, ninja, pkgconfig, gnome3, perl, gettext, glib, libnotify, lcms2, libXtst
 , libxkbfile, libpulseaudio, alsaLib, libcanberra-gtk3, upower, colord, libgweather, polkit
 , geoclue2, librsvg, xf86_input_wacom, udev, libgudev, libwacom, libxslt, libxml2, networkmanager
-, docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss }:
+, docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss, wrapperDir ? "/run/wrappers/bin" }:
 
 stdenv.mkDerivation rec {
   name = "gnome-settings-daemon-${version}";
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dudev_dir=${placeholder "out"}/lib/udev"
   ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(--set GSD_BACKLIGHT_HELPER "${wrapperDir}/gsd-backlight-helper")
+  '';
 
   postPatch = ''
     for f in gnome-settings-daemon/codegen.py plugins/power/gsd-power-constants-update.pl meson_post_install.py; do


### PR DESCRIPTION
###### Motivation for this change
This is intended to fix #14168 untli we have a better solution from
upstream GNOME.

cc @jameysharp @hedning @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
