### PR TITLE
toggldesktop: bump qt-oauth-lib (see #53676)

### DIFF
--- a/pkgs/applications/misc/toggldesktop/default.nix
+++ b/pkgs/applications/misc/toggldesktop/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchzip, buildEnv, makeDesktopItem, runCommand, writeText, pkgconfig
 , cmake, qmake, cacert, jsoncpp, libX11, libXScrnSaver, lua, openssl, poco
-, qtbase, qtwebkit, qtx11extras, sqlite }:
+, qtbase, qtwebengine, qtx11extras, sqlite }:
 
 let
   name = "toggldesktop-${version}";
@@ -39,15 +39,15 @@ let
 
   qt-oauth-lib = stdenv.mkDerivation rec {
     name = "qt-oauth-lib-${version}";
-    version = "20180521.233208";
+    version = "20190125.190943";
 
     src = fetchzip {
       url = "https://github.com/yegortimoshenko/qt-oauth-lib/archive/${version}.tar.gz";
-      sha256 = "0f46d44slzvzaqx0lksvv14lsc1jp8vd2mragxd61r820hybf5z3";
+      sha256 = "0zmfgvdf6n79mgfvbda7lkdxxlzjmy86436gqi2r5x05vq04sfrj";
     };
 
     nativeBuildInputs = [ qmake ];
-    buildInputs = [ qtbase qtwebkit ];
+    buildInputs = [ qtbase qtwebengine ];
   };
 
   poco-pc = writeText "poco.pc" ''
@@ -100,7 +100,7 @@ let
       libtoggl
       qxtglobalshortcut
       qtbase
-      qtwebkit
+      qtwebengine
       qt-oauth-lib
       qtx11extras
       libX11


### PR DESCRIPTION
###### Motivation for this change

Fixes #53676.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

