### PR TITLE
neovim: remove spurious references to compilation flags

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -46,6 +46,13 @@ let
 
     lualibs = [ luaPackages.mpack luaPackages.lpeg luaPackages.luabitop ];
 
+    # nvim --version output retains compilation flags and references to build tools
+    postPatch = ''
+      substituteInPlace src/nvim/version.c --replace NVIM_VERSION_CFLAGS "";
+    '';
+    # check that the above patching actually works
+    disallowedReferences = [ stdenv.cc ];
+
     cmakeFlags = [
       "-DLUA_PRG=${luaPackages.lua}/bin/lua"
       "-DGPERF_PRG=${gperf}/bin/gperf"


### PR DESCRIPTION
###### Motivation for this change
Neovim used to retain references to compilation flags:
```
$  nvim --version
NVIM v0.3.1
Build type: Release
LuaJIT 2.1.0-beta3
Compilation: /nix/store/nwy73lby94rv8jql92xhxp0wx6gxwjb2-gcc-wrapper-7.3.0/bin/gcc -Wconversion -O2 -DNDEBUG -DMIN_LOG_LEVEL=3 -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fdiagnostics-color=auto -Wno-array-bounds -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -I/build/source/build/config -I/build/source/src -I/nix/store/012lvk3fknblpvqdlvvx46yp2s2mpl4v-libuv-1.21.0/include -I/nix/store/dfrq2gx4drrih6b9s5vwawlgn2ld57hj-msgpack-3.0.1/include -I/nix/store/ljlp1wcvrb99iq4cgc01g399ibjfxlib-unibilium-2.0.0/include -I/nix/store/x6547gcsl0grgpb605kmhckaajacj3vw-libtermkey-0.20/include -I/nix/store/nmh18pbxnlh2kdspbphwndwz167hg2aj-neovim-libvterm-2017-11-05/include -I/nix/store/3bz4x4ajkrrxvs6b6iv0lbmwr5rwp08a-jemalloc-5.0.1/include -I/nix/store/f3l058q0zvnzr7nvl0jj789pyvljqadw-glibc-2.27-dev/include -I/build/source/build/src/nvim/auto -I/build/source/build/include
Compilé par nixbld

Features: +acl +iconv +jemalloc +tui 
See ":help feature-compile"

         fichier vimrc système : "$VIM/sysinit.vim"
               $VIM par défaut : "
/nix/store/dvqb2f8gh79bmmss3kwbsgm3bfsz3hrw-neovim-unwrapped-0.3.1/share/nvim"

Run :checkhealth for more info

```
By removing this, we reduce the closure size from 249672136 to 71369128.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

