### PR TITLE
freeswitch: expose compilation option to enable postgres support

### DIFF
--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -1,6 +1,9 @@
-{ fetchurl, stdenv, ncurses, curl, pkgconfig, gnutls, readline
+{ fetchurl, stdenv, lib, ncurses, curl, pkgconfig, gnutls, readline
 , openssl, perl, sqlite, libjpeg, speex, pcre
 , ldns, libedit, yasm, which, lua, libopus, libsndfile
+
+, postgresql
+, enablePostgres ? true
 
 , SystemConfiguration
 }:
@@ -23,11 +26,15 @@ stdenv.mkDerivation rec {
     openssl ncurses curl gnutls readline perl libjpeg
     sqlite pcre speex ldns libedit yasm which lua libopus
     libsndfile
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [ SystemConfiguration ];
+  ]
+  ++ lib.optionals enablePostgres [ postgresql ]
+  ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
   hardeningDisable = [ "format" ];
+
+  configureFlags = lib.optionals enablePostgres [ "--enable-core-pgsql-support" ];
 
   meta = {
     description = "Cross-Platform Scalable FREE Multi-Protocol Soft Switch";


### PR DESCRIPTION
###### Motivation for this change

To run freeswitch with postgresql backend.

Tested with `nix-build -E 'with import ./. { }; freeswitch.override { enablePostgres = true; }'`

Not sure if enabling postgres should be the default or not. It would simplify my life it it was  (closure size 135 to 142 MiB with postgres)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

