### PR TITLE
kubecfg: 0.6.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -1,6 +1,6 @@
 { lib, buildGoPackage, fetchFromGitHub, ... }:
 
-let version = "0.6.0"; in
+let version = "0.9.1"; in
 
 buildGoPackage {
   name = "kubecfg-${version}";
@@ -9,7 +9,7 @@ buildGoPackage {
     owner = "ksonnet";
     repo = "kubecfg";
     rev = "v${version}";
-    sha256 = "12kv1p707kdxjx5l8rcikd1gjwp5xjxdmmyvlpnvyagrphgrwpsf";
+    sha256 = "010k33arxa4spaq923iazsisxgsaj8c7w4z250y9yrch8xxd74bi";
   };
 
   goPackagePath = "github.com/ksonnet/kubecfg";


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

