### PR TITLE
nixos/collectd: restart on failure

### DIFF
--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -88,6 +88,8 @@ in {
         ExecStart = "${cfg.package}/sbin/collectd -C ${conf} -f";
         User = cfg.user;
         PermissionsStartOnly = true;
+        Restart = "on-failure";
+        RestartSec = 3;
       };
 
       preStart = ''


### PR DESCRIPTION
###### Motivation for this change

`collectd' might fail because of a failure in any of numerous plugins.
For example `virt' plugin sometimes fails if `collectd' is started before `libvirtd'
