### PR TITLE
argo: init at 2.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1764,6 +1764,11 @@
     github = "dguibert";
     name = "David Guibert";
   };
+  groodt = {
+    email = "groodt@gmail.com";
+    github = "groodt";
+    name = "Greg Roodt";
+  };
   guibou = {
     email = "guillaum.bouchard@gmail.com";
     github = "guibou";

--- a/pkgs/applications/networking/cluster/argo/default.nix
+++ b/pkgs/applications/networking/cluster/argo/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "argo-${version}";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "argoproj";
+    repo = "argo";
+    rev = "v${version}";
+    sha256 = "0x3aizwbqkg2712021wcq4chmwjhw2df702wbr6zd2a2cdypwb67";
+  };
+
+  goDeps = ./deps.nix;
+  goPackagePath = "github.com/argoproj/argo";
+
+  meta = with lib; {
+    description = "Container native workflow engine for Kubernetes";
+    homepage = https://github.com/argoproj/argo;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ groodt ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/cluster/argo/deps.nix
+++ b/pkgs/applications/networking/cluster/argo/deps.nix
@@ -1,0 +1,687 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "64a2037ec6be8a4b0c1d1f706ed35b428b989239";
+      sha256 = "149v3ci17g6wd2pm18mzcncq5qpl9hwdjnz3rlbn5rfidyn46la1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Knetic/govaluate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Knetic/govaluate";
+      rev =  "9aa49832a739dcd78a5542ff189fb82c3e423116";
+      sha256 = "12klijhq4fckzbhv0cwygbazj6lvhmdqksha9y6jgfmwzv51kwv5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/PuerkitoBio/purell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/purell";
+      rev =  "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4";
+      sha256 = "0vsxyn1fbm7g873b8kf3hcsgqgncb5nmfq3zfsc35a9yhzarka91";
+    };
+  }
+  {
+    goPackagePath  = "github.com/PuerkitoBio/urlesc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/urlesc";
+      rev =  "de5bf2ad457846296e2031421a34e2568e304e35";
+      sha256 = "0n0srpqwbaan1wrhh2b7ysz543pjs1xw2rghvqyffg9l0g8kzgcw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/argoproj/pkg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/argoproj/pkg";
+      rev =  "1aa3e0c55668da17703adba5c534fff6930db589";
+      sha256 = "0lr1dimm443qq3zzcrpialvxq9bl8pb3317zn34gmf1sycqh4iii";
+    };
+  }
+  {
+    goPackagePath  = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev =  "3a771d992973f24aa725d07868b467d1ddfceafb";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/spdystream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/spdystream";
+      rev =  "bc6354cbbc295e925e4c611ffe90c1f287ee54db";
+      sha256 = "08746a15snvmax6cnzn2qy7cvsspxbsx97vdbjpdadir3pypjxya";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev =  "9f541cc9db5d55bce703bd99987c9d5cb8eea45e";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/emicklei/go-restful";
+    fetch = {
+      type = "git";
+      url = "https://github.com/emicklei/go-restful";
+      rev =  "3eb9738c1697594ea6e71a7156a9bb32ed216cf0";
+      sha256 = "1zqcjhg4q7788hyrkhwg4b6r1vc4qnzbw8c5j994mr18x42brxzg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/emirpasic/gods";
+    fetch = {
+      type = "git";
+      url = "https://github.com/emirpasic/gods";
+      rev =  "f6c17b524822278a87e3b3bd809fec33b51f5b46";
+      sha256 = "1zhkppqzy149fp561pif8d5d92jd9chl3l9z4yi5f8n60ibdmmjf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/evanphx/json-patch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/evanphx/json-patch";
+      rev =  "afac545df32f2287a079e2dfb7ba2745a643747e";
+      sha256 = "1d90prf8wfvndqjn6nr0k405ykia5vb70sjw4ywd49s9p3wcdyn8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev =  "c7ce16629ff4cd059ed96ed06419dd3856fd3577";
+      sha256 = "10cyv1gy3zwwkr04kk8cvhifb7xddakyvnk5s13yfcqj9hcjz8d1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev =  "358ee7663966325963d4e8b2e1fbd570c5195153";
+      sha256 = "1zr51xaka7px1pmfndm12fvg6a3cr24kg77j28zczbfcc6h339gy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/jsonpointer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/jsonpointer";
+      rev =  "3a0015ad55fa9873f41605d3e8f28cd279c32ab2";
+      sha256 = "02an755ashhckqwxyq2avgn8mm4qq3hxda2jsj1a3bix2gkb45v7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/jsonreference";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/jsonreference";
+      rev =  "3fb327e6747da3043567ee86abd02bb6376b6be2";
+      sha256 = "0zwsrmqqcihm0lj2pc18cpm7wnn1dzwr4kvrlyrxf0lnn7dsdsbm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/spec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/spec";
+      rev =  "bce47c9386f9ecd6b86f450478a80103c3fe1402";
+      sha256 = "0agys8v5rkfyinvmjd8hzgwvb20hnqninwkxwqkwbbsnakhi8shk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-openapi/swag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/swag";
+      rev =  "2b0bd4f193d011c203529df626a65d63cb8a79e8";
+      sha256 = "14c998wkycmy69jhjqkrah8acrr9xfam1dxbzl0lf4s2ghwn7bdn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "636bf0302bc95575d69441b25a2603156ffdddf1";
+      sha256 = "1525pq7r6h3s8dncvq8gxi893p2nq8dxpzvq0nfl5b4p6mq0v1c2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev =  "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "b4deda0973fb4c70b50d226b1af49f3da59f5265";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev =  "24818f796faf91cd76ec7bddd72458fbced7a6c1";
+      sha256 = "0cq90m2lgalrdfrwwyycrrmn785rgnxa3l3vp9yxkvnv88bymmlm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/googleapis/gnostic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gnostic";
+      rev =  "7c663266750e7d82587642f65e60bc4083f1f84e";
+      sha256 = "0yh3ckd7m0r9h50wmxxvba837d0wb1k5yd439zq4p1kpp4390z12";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
+      sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev =  "0fb14efe8c47ae851c0034ed7a448854d3d34cf3";
+      sha256 = "0vg4yn3088ym4sj1d34kr13lp4v5gya7r2nxshp2bz70n46fsqn2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/howeyc/gopass";
+    fetch = {
+      type = "git";
+      url = "https://github.com/howeyc/gopass";
+      rev =  "bf9dde6d0d2c004a008c27aaee91170c786f6db8";
+      sha256 = "1jxzyfnqi0h1fzlsvlkn10bncic803bfhslyijcxk55mgh297g45";
+    };
+  }
+  {
+    goPackagePath  = "github.com/imdario/mergo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/imdario/mergo";
+      rev =  "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4";
+      sha256 = "1lbzy8p8wv439sqgf0n21q52flf2wbamp6qa1jkyv6an0nc952q7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jbenet/go-context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-context";
+      rev =  "d14ea06fba99483203c19d92cfcd13ebe73135f4";
+      sha256 = "0q91f5549n81w3z5927n4a1mdh220bdmgl42zi3h992dcc4ls0sl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev =  "1624edc4454b8682399def8740d46db5e4362ba4";
+      sha256 = "11wn4hpmrs8bmpvd93wqk49jfbbgylakhi35f9k5qd7jd479ci4s";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kevinburke/ssh_config";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kevinburke/ssh_config";
+      rev =  "9fc7bb800b555d63157c65a904c86a2cc7b4e795";
+      sha256 = "102icrla92zmr5zngipc8c9yfbqhf73zs2w2jq6s7p0gdjifigc8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mailru/easyjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mailru/easyjson";
+      rev =  "03f2033d19d5860aef995fe360ac7d395cd8ce65";
+      sha256 = "0r62ym6m1ijby7nwplq0gdnhak8in63njyisrwhr3xpx9vkira97";
+    };
+  }
+  {
+    goPackagePath  = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev =  "c12348ce28de40eed0136aa2b644d0ee0650e56c";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath  = "github.com/minio/minio-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/minio-go";
+      rev =  "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992";
+      sha256 = "0xvvnny59v4p1y2kbvz90ga5xvc5sq1gc4wv6cym82rdbvgzb2ax";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev =  "58046073cbffe2f25d425fe1331102f55cf719de";
+      sha256 = "0kwflrwsjdsy8vbhyzicc4c2vdi7lhdvn4rarfr18x1qsrb7n1bx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev =  "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev =  "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd";
+      sha256 = "1721y3yr3dpx5dx5ashf063qczk2awy5zjir1jvp1h5hn7qz4i49";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-buffruneio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-buffruneio";
+      rev =  "c37440a7cf42ac63b919c752ca73a85067e05992";
+      sha256 = "0l83p1gg6g5mmhmxjisrhfimhbm71lwn1r2w7d6siwwqm9q08sd2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev =  "c5b7fccd204277076155f10851dad72b76a49317";
+      sha256 = "1xqny3147g12n4j03kxm8s9mvdbs3ln6i56c655mybrn9jjy48kd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev =  "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f";
+      sha256 = "04psf81l9fjcwascsys428v03fx4fi894h7fhrj2vvcz723q57k0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev =  "c7de2306084e37d54b8be01f3541a8464345e9a5";
+      sha256 = "11dqfm2d0m4sjjgyrnayman96g59x2apmvvqby9qmww2qj2k83ig";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev =  "05ee40e3a273f7245e8777337fc7b46e533a9a92";
+      sha256 = "0f6fnczxa42b9rys2h3l0m8fy3x5hrhaq707vq0lbx5fcylw8lis";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev =  "1744e2970ca51c86172c8190fadad617561ed6e7";
+      sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "3e01752db0189b9157070a0e1668a620f9a85da2";
+      sha256 = "029irw2lsbqi944gdrbkwdw0m2794sqni4g21gsnmz142hbzds8c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "7c4570c3ebeb8129a1f7456d0908a8b676b6f9f1";
+      sha256 = "16amh0prlzqrrbg5j629sg0f688nfzfgn9sair8jyybqampr3wc7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "583c0c0531f06d5278b7d917446061adc344b5cd";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/src-d/gcfg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/src-d/gcfg";
+      rev =  "f187355171c936ac84a82793659ebb4936bc1c23";
+      sha256 = "1hrdxlha4kkcpyydmjqd929rmwn5a9xq7arvwhryxppxq7502axk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev =  "477a77ecc69700c7cdeb1fa9e129548e1c1c393c";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "f35b8ab0b5a2cef36673838d662e249dd9c94686";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tidwall/gjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tidwall/gjson";
+      rev =  "1e3f6aeaa5bad08d777ea7807b279a07885dd8b2";
+      sha256 = "0b0kvpzq0xxk2fq4diy3ab238yjx022s56h5jv1lc9hglds80lnn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tidwall/match";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tidwall/match";
+      rev =  "1731857f09b1f38450e2c12409748407822dc6be";
+      sha256 = "14nv96h0mjki5q685qx8y331h4yga6hlfh3z9nz6acvnv284q578";
+    };
+  }
+  {
+    goPackagePath  = "github.com/valyala/bytebufferpool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/valyala/bytebufferpool";
+      rev =  "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7";
+      sha256 = "01lqzjddq6kz9v41nkky7wbgk7f1cw036sa7ldz10d82g5klzl93";
+    };
+  }
+  {
+    goPackagePath  = "github.com/valyala/fasttemplate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/valyala/fasttemplate";
+      rev =  "dcecefd839c4193db0d35b88ec65b4c12d360ab0";
+      sha256 = "0kkxn0ad5a36533djh50n9l6wsylmnykridkm91dqlqbjirn7216";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xanzy/ssh-agent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xanzy/ssh-agent";
+      rev =  "640f0ab560aeb89d523bb6ac322b1244d5c3796c";
+      sha256 = "069nlriymqswg52ggiwi60qhwrin9nzhd2g65a7h59z2qbcvk2hy";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "f027049dab0ad238e394a753dba2d14753473a04";
+      sha256 = "026475grqvylk9n2ld4ygaxmzck6v97j48sc2x58jjsmqflnhzld";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "f9ce57c11b242f0f1599cf25c89d8cb02c45295a";
+      sha256 = "1m507gyjd9246cr3inpn6lgv3vnc3i11x4fgz0k0hdxv3cn9dyx2";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "3d292e4d0cdc3a0113e6d207bb137145ef1de42f";
+      sha256 = "0jvivlvx7snacd6abd1prqxa7h1z6b7s6mqahn8lpqlag3asryrl";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "904bdc257025c7b3f43c19360ad3ab85783fad78";
+      sha256 = "1pmj9axkj898bk4i4lny03b3l0zbkpvxj03gyjckliabqimqz0az";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev =  "fbb02b2291d28baffd63558aa44b4b56f178d650";
+      sha256 = "0jjqcv6rzihlgg4i797q80g1f6ch5diz2kxqh6488gwkb6nds4h4";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev =  "ca6481ae56504398949d597084558e50ad07117a";
+      sha256 = "0pza1pd0wy9r0pf9b9hham9ldr2byyg1slqf8p56dhf8b6j9jw9v";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "b1f26356af11148e710935ed1ac8a7f5702c7612";
+      sha256 = "1pz202zszg8f35dk5pfhwgcdi3r6dx1l4yk6x6ly7nb4j45zi96x";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/inf.v0";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-inf/inf";
+      rev =  "d2d2541c53f18d2a059457998ce2876cc8e67cbf";
+      sha256 = "00k5iqjcp371fllqxncv7jkf80hn1zww92zm78cclbcn4ybigkng";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/src-d/go-billy.v4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/src-d/go-billy";
+      rev =  "83cf655d40b15b427014d7875d10850f96edba14";
+      sha256 = "18fghcyk69g460px8rvmhmqldkbhw17dpnhg45qwdvaq90b0bkx9";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/src-d/go-git.v4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/src-d/go-git";
+      rev =  "3bd5e82b2512d85becae9677fa06b5a973fd4cfb";
+      sha256 = "1krg24ncckwalmhzs2vlp8rwyk4rfnhfydwg8iw7gaywww2c1wfc";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/warnings.v0";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-warnings/warnings";
+      rev =  "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b";
+      sha256 = "1kzj50jn708cingn7a13c2wdlzs6qv89dr2h4zj8d09647vlnd81";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/api";
+      rev =  "0f11257a8a25954878633ebdc9841c67d8f83bdb";
+      sha256 = "1y8k0b03ibr8ga9dr91dc2imq2cbmy702a1xqggb97h8lmb6jqni";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/apimachinery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apimachinery";
+      rev =  "e386b2658ed20923da8cc9250e552f082899a1ee";
+      sha256 = "0lgwpsvx0gpnrdnkqc9m96xwkifdq50l7cj9rvh03njws4rbd8jz";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/client-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/client-go";
+      rev =  "a312bfe35c401f70e5ea0add48b50da283031dc3";
+      sha256 = "0z360np4iv7jdgacw576gdxbzl8ss810kbqwyrjk39by589rfkl9";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/code-generator";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/code-generator";
+      rev =  "9de8e796a74d16d2a285165727d04c185ebca6dc";
+      sha256 = "09858ykfrd3cyzkkpafzhqs6h7bk3n90s3p52x3axn4f7ikjh7k4";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/gengo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/gengo";
+      rev =  "c42f3cdacc394f43077ff17e327d1b351c0304e4";
+      sha256 = "05vbrqfa96izm5j2q9f4yiyrbyx23nrkj5yv4fhfc7pvwb35iy04";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/kube-openapi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/kube-openapi";
+      rev =  "e3762e86a74c878ffed47484592986685639c2cd";
+      sha256 = "1n9j08dwnj77iflzj047hrk0zg6nh1m4a5pljjdsvvf3xgka54pz";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16121,6 +16121,8 @@ in
 
   inherit (python3Packages) arelle;
 
+  argo = callPackage ../applications/networking/cluster/argo { };
+
   ario = callPackage ../applications/audio/ario { };
 
   arora = callPackage ../applications/networking/browsers/arora { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

