### PR TITLE
coqPackages.coq-extensible-records: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3661,6 +3661,11 @@
     github = "PsyanticY";
     name = "Psyanticy";
   };
+  ptival = {
+    email = "valentin.robert.42@gmail.com";
+    github = "Ptival";
+    name = "Valentin Robert";
+  };
   puffnfresh = {
     email = "brian@brianmckenna.org";
     github = "puffnfresh";

--- a/pkgs/development/coq-modules/coq-extensible-records/default.nix
+++ b/pkgs/development/coq-modules/coq-extensible-records/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, coq }:
+
+stdenv.mkDerivation {
+  name = "coq${coq.coq-version}-coq-extensible-records-1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "gmalecha";
+    repo = "coq-extensible-records";
+    rev = "1.2.0";
+    sha256 = "0h5m04flqfk0v577syw0v1dw2wf7xrx6jaxv5gpmqzssf5hxafy4";
+  };
+
+  buildInputs = [ coq ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    make -f Makefile.coq COQLIB=$out/lib/coq/${coq.coq-version}/ install
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gmalecha/coq-extensible-records;
+    description = "Implementation of extensible records in Coq";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ptival ];
+    platforms = coq.meta.platforms;
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -17,6 +17,7 @@ let
       Cheerios = callPackage ../development/coq-modules/Cheerios {};
       CoLoR = callPackage ../development/coq-modules/CoLoR {};
       coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
+      coq-extensible-records = callPackage ../development/coq-modules/coq-extensible-records {};
       coq-haskell = callPackage ../development/coq-modules/coq-haskell { };
       coqprime = callPackage ../development/coq-modules/coqprime {};
       coquelicot = callPackage ../development/coq-modules/coquelicot {};


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

