### PR TITLE
 numix-icon-theme-{circle,square}: 18.09.19 -> 19.01.24

### DIFF
--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -1,17 +1,14 @@
 { stdenv, fetchFromGitHub, gtk3, numix-icon-theme }:
 
 stdenv.mkDerivation rec {
-  version = "18.09.19";
-
-  package-name = "numix-icon-theme-circle";
-
-  name = "${package-name}-${version}";
+  pname = "numix-icon-theme-circle";
+  version = "19.01.24";
 
   src = fetchFromGitHub {
     owner = "numixproject";
-    repo = package-name;
+    repo = pname;
     rev = version;
-    sha256 = "1a1ack4kpngnb3c281pssmp3snn2idcn2c5cv3l38a0dl5g5w8nq";
+    sha256 = "18asihcv41jlysb2ynbvbk6fn0lnj7ckaz1nyx1w25a7nk413dnm";
   };
 
   nativeBuildInputs = [ gtk3 numix-icon-theme ];

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchFromGitHub, gtk3, numix-icon-theme }:
 
 stdenv.mkDerivation rec {
-  name = "${package-name}-${version}";
-  package-name = "numix-icon-theme-square";
-  version = "18.09.19";
+  pname = "numix-icon-theme-square";
+  version = "19.01.24";
 
   src = fetchFromGitHub {
     owner = "numixproject";
-    repo = package-name;
+    repo = pname;
     rev = version;
-    sha256 = "0q5p901qj3gyzgpy5kk9q5sqb13ka5cfg6wvazlfch1k3kaqksz1";
+    sha256 = "0x3d21snfp4v9ippny1jmf2hw5dcscwrlasxvr5bgxhff1idf81c";
   };
 
   nativeBuildInputs = [ gtk3 numix-icon-theme ];


### PR DESCRIPTION
###### Motivation for this change

- numix-icon-theme-circle: 18.09.19 -> [19.01.24](https://github.com/numixproject/numix-icon-theme-circle/releases)
- numix-icon-theme-square: 18.09.19 -> [19.01.24](https://github.com/numixproject/numix-icon-theme-square/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).