### PR TITLE
amazon-ecr-credential-helper: 0.1.0 -> 0.3.0

### DIFF
--- a/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
+++ b/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "amazon-ecr-credential-helper-${version}";
-  version = "0.1.0";
+  version = "0.3.0";
 
   goPackagePath = "github.com/awslabs/amazon-ecr-credential-helper";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "awslabs";
     repo = "amazon-ecr-credential-helper";
     rev = "v${version}";
-    sha256 = "0mpwm21fphg117ryxda7696s8bnvi4bbc8rvi4zp2m1rhl04j2yy";
+    sha256 = "06pcwgahcbi13ca5rs6giwdw3w364lbvmzcs4ka82igvcffxjvnd";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

