### PR TITLE
Eternal-terminal: 5.1.8 -> 5.1.9

### DIFF
--- a/pkgs/tools/networking/eternal-terminal/default.nix
+++ b/pkgs/tools/networking/eternal-terminal/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "eternal-terminal-${version}";
-  version = "5.1.8";
+  version = "5.1.9";
 
   src = fetchFromGitHub {
     owner = "MisterTea";
     repo = "EternalTCP";
     rev = "refs/tags/et-v${version}";
-    sha256 = "0fq9a1fn0c77wfpypl3z7y23gbkw295ksy97wi9lhb5zj2m3dkq0";
+    sha256 = "07ynkcnk3z6wafdlnzdxcd308cw1rzabxyq47ybj79lyji3wsgk7";
   };
 
   nativeBuildInputs = [ cmake ninja ];


### PR DESCRIPTION
###### Motivation for this change
Minor bump. Tested working on my machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

