### PR TITLE
netsurf: 3.5 -> 3.8

### DIFF
--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -19,13 +19,13 @@
 stdenv.mkDerivation rec {
 
   name = "netsurf-${version}";
-  version = "3.5";
+  version = "3.8";
 
   # UI libs incldue Framebuffer, and gtk
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${version}-src.tar.gz";
-    sha256 = "1k0x8mzgavfy7q9kywl6kzsc084g1xlymcnsxi5v6jp279nsdwwq";
+    sha256 = "0hjm1h4m1i913y4mhkl7yqdifn8k70fwi58zdh6faypawzryc3m0";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     cmd=$(case "${uilib}" in framebuffer) echo nsfb;; gtk) echo nsgtk;; esac)
     cp $cmd $out/bin/netsurf
     wrapProgram $out/bin/netsurf --set NETSURFRES $out/share/Netsurf/${uilib}/res
-    tar -hcf - ${uilib}/res | (cd $out/share/Netsurf/ && tar -xvpf -)
+    tar -hcf - frontends/${uilib}/res | (cd $out/share/Netsurf/ && tar -xvpf -)
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -14,6 +14,7 @@
 , libnsgif
 , libnsutils
 , libutf8proc
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +29,12 @@ stdenv.mkDerivation rec {
     sha256 = "0hjm1h4m1i913y4mhkl7yqdifn8k70fwi58zdh6faypawzryc3m0";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig
+  ] ++ stdenv.lib.optionals (uilib == "gtk") [
+    wrapGAppsHook
+  ];
+
   buildInputs = [ libpng openssl curl gtk2 check libxml2 libidn perl
     nettools perlPackages.HTMLParser libXcursor libXrandr makeWrapper SDL
     buildsystem

--- a/pkgs/applications/misc/netsurf/libcss/default.nix
+++ b/pkgs/applications/misc/netsurf/libcss/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libcss";
-  version = "0.6.0";
+  version = "0.8.0";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0qp4p1q1dwgdra4pkrzd081zjzisxkgwx650ijx323j8bj725daf";
+    sha256 = "0pxdqbxn6brj03nv57bsvac5n70k4scn3r5msaw0jgn2k06lk81m";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libdom/default.nix
+++ b/pkgs/applications/misc/netsurf/libdom/default.nix
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libdom";
-  version = "0.3.0";
+  version = "0.3.3";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1kk6qbqagx5ypiy9kf0059iqdzyz8fqaw336vzhb5gnrzjw3wv4a";
+    sha256 = "1919757mdl3gii2pl6kzm8b1cal0h06r5nqd2y0kny6hc5yrhsp0";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libhubbub/default.nix
+++ b/pkgs/applications/misc/netsurf/libhubbub/default.nix
@@ -7,11 +7,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libhubbub";
-  version = "0.3.3";
+  version = "0.3.5";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "101781iw32p47386fxqr01nrkywi12w17ajh02k2vlga4z8zyv86";
+    sha256 = "13yq1k96a7972x4r71i9bcsz9yiglj0yx7lj0ziq5r94w5my70ma";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsbmp/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsbmp/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsbmp";
-  version = "0.1.3";
+  version = "0.1.5";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0gmvzw1whh7553d6s98vr4ri2whjwrgggcq1z5b160gwjw20mzyy";
+    sha256 = "0lib2m07d1i0k80m4blkwnj0g7rha4jbm5vrgd0wwbkyfa0hvk35";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsfb/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsfb/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsfb";
-  version = "0.1.4";
+  version = "0.2.0";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "176f8why9gzbaca9nnxjqasl02qzc6g507z5w3dzkcjifnkz4mzl";
+    sha256 = "04caizmarx43dc83iq9f1r4w6l5xmq52pk93pcam8y6r7mcvl4f0";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsgif/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsgif/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsgif";
-  version = "0.1.3";
+  version = "0.2.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1a4z45gh0fw4iybf34fig725av25h31ffk0azi0snzh4130cklnk";
+    sha256 = "0jwshypgmx16xlsbx3d8njk8a5khazlplca5mxd3rdbhrlsabbly";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsutils/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsutils";
-  version = "0.0.2";
+  version = "0.0.5";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "03p4xmd08yhj70nyj7acjccmmshs59lv4n4zsqpsn5lgkwa23lzy";
+    sha256 = "09w1rixps1iiq6wirjwxmd6h87llvjzvw565rahjb3rlyhcplfqf";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libparserutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libparserutils/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libparserutils";
-  version = "0.2.3";
+  version = "0.2.4";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "01gzlsabgl6x0icd8758d9jqs8rrf9574bdkjainn04w3fs3znf5";
+    sha256 = "1n2794y2l0c8nv8z2pxwfnbn882987ifmxjv60zdxkhcndhswarj";
   };
 
   buildInputs = [ buildsystem perl ];

--- a/pkgs/applications/misc/netsurf/libutf8proc/default.nix
+++ b/pkgs/applications/misc/netsurf/libutf8proc/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libutf8proc";
-  version = "1.3.1";
+  version = "2.2.0-1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0xf659y3c6ikjnip47r30wv796a34d71p6qhc4xjs64iqszm1sbq";
+    sha256 = "0hv5nxdj3505f7hkh4h15yn374igfmfpx95wbippx75xghd85km5";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
+++ b/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libwapcaplet";
-  version = "0.3.0";
+  version = "0.4.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0cs1dd2afjgc3wf5gqg434hv6jdabrp9qvlpl4dp53nhkyfywna3";
+    sha256 = "134pljlm8kby1yy49826f0ixnpig8iqak6xpyl3aivagnsjnxzy8";
   };
 
   buildInputs = [ buildsystem ];

--- a/pkgs/applications/misc/netsurf/nsgenbind/default.nix
+++ b/pkgs/applications/misc/netsurf/nsgenbind/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
 
   name = "netsurf-nsgenbind-${version}";
-  version = "0.3";
+  version = "0.6";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/nsgenbind-${version}-src.tar.gz";
-    sha256 = "16xsazly7gxwywmlkf2xix9b924sj3skhgdak7218l0nc62a08gg";
+    sha256 = "0v1cb1rz5fix9ql31nzmglj7sybya6d12b2fkaypm1avcca59xwj";
   };
 
   buildInputs = [ buildsystem flex bison ];


### PR DESCRIPTION
###### Motivation for this change

Updates netsurf and related libraries.

The default config for netsurf (using sixel ui) wasn't tested, I can't get it to work, in the previous iteration either. The gtk ui, though works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

