### PR TITLE
qtkeychain: remove CMP0025 hack

### DIFF
--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -20,13 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = if withQt5 then null else [ ./0001-Fixes-build-with-Qt4.patch ];
 
-  cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ]
-    ++ stdenv.lib.optional stdenv.isDarwin [
-       # correctly detect the compiler
-       # for details see cmake --help-policy CMP0025
-       "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
-       ]
-   ;
+  cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
###### Motivation for this change

`CMAKE_POLICY_DEFAULT_CMP0025` is already set in cmake setup hook:
https://github.com/NixOS/nixpkgs/blob/9310fc3e1345d35afec56e2ba3261f5f627576c6/pkgs/development/tools/build-managers/cmake/setup-hook.sh#L61

Also see #54606

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---