### PR TITLE
gem-config: add semian

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -358,6 +358,10 @@ in
       '';
     } else {};
 
+  semian = attrs: {
+    buildInputs = [ openssl ];
+  };
+
   sequel_pg = attrs: {
     buildInputs = [ postgresql ];
   };


### PR DESCRIPTION
###### Motivation for this change

Building the [semian gem](https://github.com/Shopify/semian) with `bundlerEnv` results in this error on Ubuntu/Debian because it [needs openssl](https://github.com/Shopify/semian/blob/22e6dcf4d4425752a71db5e6284046cdc03fa1c4/ext/semian/extconf.rb#L16)

<details><summary>error output</summary>

```
building '/nix/store/m8k2p5dczdrnhsar4hd0v7m4abyz27h0-ruby2.3.8-semian-0.8.6.drv'...
unpacking sources
patching sources
configuring
no configure script, doing nothing
installing
buildFlags: 
WARNING:  You build with buildroot.
  Build root: /
  Bin dir: /nix/store/g0jqf0h066an4i9zmq0jq7rd9sxgsygf-ruby2.3.8-semian-0.8.6/lib/ruby/gems/2.3.0/bin
  Gem home: /nix/store/g0jqf0h066an4i9zmq0jq7rd9sxgsygf-ruby2.3.8-semian-0.8.6/lib/ruby/gems/2.3.0
Building native extensions. This could take a while...
ERROR:  Error installing /nix/store/gj5is0zci89d3ldlqpjw5li9kbrvl0k5-semian-0.8.6.gem:
        ERROR: Failed to build gem native extension.

    current directory: /nix/store/g0jqf0h066an4i9zmq0jq7rd9sxgsygf-ruby2.3.8-semian-0.8.6/lib/ruby/gems/2.3.0/gems/semian-0.8.6/ext/semian
/nix/store/nw0k7lw6i79bij8rp0l6v9rqjm4j7386-ruby-2.3.8/bin/ruby -r ./siteconf20190125-12320-o96lio.rb extconf.rb
checking for openssl/sha.h... no
openssl is missing. please install openssl.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/nix/store/nw0k7lw6i79bij8rp0l6v9rqjm4j7386-ruby-2.3.8/bin/$(RUBY_BASE_NAME)

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /nix/store/g0jqf0h066an4i9zmq0jq7rd9sxgsygf-ruby2.3.8-semian-0.8.6/lib/ruby/gems/2.3.0/extensions/x86_64-linux/2.3.0/semian-0.8.6/mkmf.log

extconf failed, exit code 1
```

</details>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions: Debian 9.5
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

