### PR TITLE
libstdcxx: don’t set stdlib automatically

### DIFF
--- a/pkgs/development/compilers/gcc/libstdc++-hook.sh
+++ b/pkgs/development/compilers/gcc/libstdc++-hook.sh
@@ -2,4 +2,3 @@
 getHostRole
 
 export NIX_${role_pre}CXXSTDLIB_COMPILE+=" -isystem $(echo -n @gcc@/include/c++/*) -isystem $(echo -n @gcc@/include/c++/*)/$(@gcc@/bin/gcc -dumpmachine)"
-export NIX_${role_pre}CXXSTDLIB_LINK=" -stdlib=libstdc++"


### PR DESCRIPTION
We don’t need to set -stdlib=libstdc++. This only works on Clang so it
is not good to set it globally. In addition, Clang knows to use
libstdc++ on Linux by default if no stdlib is set:

https://github.com/llvm-mirror/clang/blob/324f918438715b4a0d024af5930628c1674f4fcd/lib/Driver/ToolChains/Linux.cpp#L456

It’s a good policy to just leave off stdlib for now.

Fixes #29877.
