### PR TITLE
treewide: remove wkennington as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4908,11 +4908,6 @@
     github = "wjlroe";
     name = "William Roe";
   };
-  wkennington = {
-    email = "william@wkennington.com";
-    github = "wkennington";
-    name = "William A. Kennington III";
-  };
   wmertens = {
     email = "Wout.Mertens@gmail.com";
     github = "wmertens";

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -23,7 +23,7 @@ in
 {
   name = "bittorrent";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ domenkozar eelco chaoflow rob wkennington bobvanderlinden ];
+    maintainers = [ domenkozar eelco chaoflow rob bobvanderlinden ];
   };
 
   nodes =

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -200,7 +200,7 @@ let
       name = "installer-" + name;
       meta = with pkgs.stdenv.lib.maintainers; {
         # put global maintainers here, individuals go into makeInstallerTest fkt call
-        maintainers = [ wkennington ] ++ (meta.maintainers or []);
+        maintainers = (meta.maintainers or []);
       };
       nodes = {
 

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -8,7 +8,7 @@ import ./make-test.nix ({ pkgs, ...} : let
 in {
   name = "mongodb";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ bluescreen303 offline wkennington cstrahan rvl ];
+    maintainers = [ bluescreen303 offline cstrahan rvl ];
   };
 
   nodes = {

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -24,7 +24,7 @@ import ./make-test.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false,
     name = "nat" + (if withFirewall then "WithFirewall" else "Standalone")
                  + (lib.optionalString withConntrackHelpers "withConntrackHelpers");
     meta = with pkgs.stdenv.lib.maintainers; {
-      maintainers = [ eelco chaoflow rob wkennington ];
+      maintainers = [ eelco chaoflow rob ];
     };
 
     nodes =

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -606,7 +606,4 @@ let
 
 in mapAttrs (const (attrs: makeTest (attrs // {
   name = "${attrs.name}-Networking-${if networkd then "Networkd" else "Scripted"}";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ wkennington ];
-  };
 }))) testCases

--- a/nixos/tests/nfs.nix
+++ b/nixos/tests/nfs.nix
@@ -20,7 +20,7 @@ in
 {
   name = "nfs";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ eelco chaoflow wkennington ];
+    maintainers = [ eelco chaoflow  ];
   };
 
   nodes =

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -379,7 +379,7 @@ let
     '';
 
     meta = with pkgs.stdenv.lib.maintainers; {
-      maintainers = [ aszlig wkennington cdepillabout ];
+      maintainers = [ aszlig cdepillabout ];
     };
   };
 

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation rec {
     description = "A cross-desktop display manager.";
     platforms = platforms.linux;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ocharles wkennington worldofpeace ];
+    maintainers = with maintainers; [ ocharles worldofpeace ];
   };
 }

--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     homepage = https://launchpad.net/lightdm-gtk-greeter;
     platforms = platforms.linux;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ocharles wkennington ];
+    maintainers = with maintainers; [ ocharles ];
   };
 }

--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -84,6 +84,6 @@ stdenv.mkDerivation rec {
     description = "A software suite to create, edit, compose, or convert bitmap images";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.asl20;
-    maintainers = with maintainers; [ the-kenny wkennington ];
+    maintainers = with maintainers; [ the-kenny ];
   };
 }

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.imagemagick.org/;
     description = "A software suite to create, edit, compose, or convert bitmap images";
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ the-kenny wkennington ];
+    maintainers = with maintainers; [ the-kenny ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.bitlbee.org/;
     license = licenses.gpl2Plus;
 
-    maintainers = with maintainers; [ wkennington pSub ];
+    maintainers = with maintainers; [ pSub ];
     platforms = platforms.gnu ++ platforms.linux;  # arbitrary choice
   };
 }

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -63,7 +63,7 @@ let
       description = "Low-latency, high quality voice chat software";
       homepage = https://mumble.info;
       license = licenses.bsd3;
-      maintainers = with maintainers; [ jgeerds wkennington ];
+      maintainers = with maintainers; [ jgeerds ];
       platforms = platforms.linux;
     };
   });

--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.freerdp.com/;
     license = licenses.asl20;
-    maintainers = with maintainers; [ wkennington peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -43,6 +43,5 @@ stdenv.mkDerivation rec {
     homepage = https://wayland.freedesktop.org/;
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     homepage = https://curl.haxx.se/docs/caextract.html;
     description = "A bundle of X.509 certificates of public Certificate Authorities (CA)";
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -156,7 +156,7 @@ stdenv.mkDerivation rec {
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan wkennington ];
+    maintainers = with maintainers; [ cstrahan ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/compilers/go/1.9.nix
+++ b/pkgs/development/compilers/go/1.9.nix
@@ -178,7 +178,7 @@ stdenv.mkDerivation rec {
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan orivej wkennington ];
+    maintainers = with maintainers; [ cstrahan orivej ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -171,7 +171,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = https://www.rust-lang.org/;
     description = "A safe, concurrent, practical language";
-    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy wkennington ];
+    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy ];
     license = [ licenses.mit licenses.asl20 ];
     platforms = platforms.linux ++ platforms.darwin;
     broken = broken;

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.tcl.tk/;
     license = licenses.tcltk;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington vrthra ];
+    maintainers = with maintainers; [ vrthra ];
   };
 
   passthru = rec {

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation {
 
     platforms = (platforms.unix ++ platforms.windows);
     badPlatforms = stdenv.lib.optional (versionOlder version "1.59") "aarch64-linux";
-    maintainers = with maintainers; [ peti wkennington ];
+    maintainers = with maintainers; [ peti ];
   };
 
   preConfigure = ''

--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation rec {
 
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/ctl/default.nix
+++ b/pkgs/development/libraries/ctl/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation {
     homepage = http://ampasctl.sourceforge.net;
     license = "A.M.P.A.S";
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 
   passthru.source = source;

--- a/pkgs/development/libraries/czmq/3.x.nix
+++ b/pkgs/development/libraries/czmq/3.x.nix
@@ -22,6 +22,5 @@ stdenv.mkDerivation rec {
     description = "High-level C Binding for ZeroMQ";
     license = licenses.mpl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/czmq/4.x.nix
+++ b/pkgs/development/libraries/czmq/4.x.nix
@@ -17,6 +17,5 @@ stdenv.mkDerivation rec {
     description = "High-level C Binding for ZeroMQ";
     license = licenses.mpl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/dclxvi/default.nix
+++ b/pkgs/development/libraries/dclxvi/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = https://github.com/agl/dclxvi;
     description = "Naehrig, Niederhagen and Schwabe's pairings code, massaged into a shared library";
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.x86_64;
     license = licenses.publicDomain;
   };

--- a/pkgs/development/libraries/fcgi/default.nix
+++ b/pkgs/development/libraries/fcgi/default.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.fastcgi.com/;
     license = "FastCGI see LICENSE.TERMS";
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -21,6 +21,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     description = "Library for application-level logging";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
 
     homepage = https://www.gnu.org/software/gnutls/;
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ eelco wkennington fpletz ];
+    maintainers = with maintainers; [ eelco fpletz ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     description = "Fast, multi-threaded malloc() and nifty performance analysis tools";
     platforms = with platforms; linux ++ darwin;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ vcunat wkennington ];
+    maintainers = with maintainers; [ vcunat ];
   };
 }

--- a/pkgs/development/libraries/gss/default.nix
+++ b/pkgs/development/libraries/gss/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.gnu.org/software/gss/;
     description = "Generic Security Service";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ bjg wkennington ];
+    maintainers = with maintainers; [ bjg ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -23,6 +23,5 @@ stdenv.mkDerivation rec {
     # Actually, you can chose between GPLv3, BSD or HIDAPI license (more liberal)
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/hiredis/default.nix
+++ b/pkgs/development/libraries/hiredis/default.nix
@@ -18,6 +18,5 @@ stdenv.mkDerivation rec {
     description = "Minimalistic C client for Redis >= 1.2";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/idnkit/default.nix
+++ b/pkgs/development/libraries/idnkit/default.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     description = "Provides functionalities about i18n domain name processing";
     license = "idnkit-2 license";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.openexr.com/;
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/jansson/default.nix
+++ b/pkgs/development/libraries/jansson/default.nix
@@ -13,6 +13,5 @@ stdenv.mkDerivation rec {
     description = "C library for encoding, decoding and manipulating JSON data";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/jbigkit/default.nix
+++ b/pkgs/development/libraries/jbigkit/default.nix
@@ -37,6 +37,5 @@ stdenv.mkDerivation rec {
     description = "A software implementation of the JBIG1 data compression standard";
     license = licenses.gpl2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/jemalloc/common.nix
+++ b/pkgs/development/libraries/jemalloc/common.nix
@@ -39,6 +39,5 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.bsd2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     sed -i '/^DEFAULT_INCLUDES/ s,$, -I..,' source/cf/Makefile.am.common
-    sed -i -e 's/date/date --date="@$SOURCE_DATE_EPOCH"/' source/configure.ac 
+    sed -i -e 's/date/date --date="@$SOURCE_DATE_EPOCH"/' source/configure.ac
   '';
 
   preConfigure = ''
@@ -92,7 +92,6 @@ stdenv.mkDerivation rec {
     description = "An implementation of Kerberos 5 (and some more stuff)";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 
   passthru.implementation = "heimdal";

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation rec {
     homepage = http://web.mit.edu/kerberos/;
     license = licenses.mit;
     platforms = platforms.unix ++ platforms.windows;
-    maintainers = with maintainers; [ wkennington ];
   };
 
   passthru.implementation = "krb5";

--- a/pkgs/development/libraries/kinetic-cpp-client/default.nix
+++ b/pkgs/development/libraries/kinetic-cpp-client/default.nix
@@ -54,6 +54,5 @@ stdenv.mkDerivation rec {
     description = "Code for producing C and C++ kinetic clients";
     license = licenses.lgpl21;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/kyotocabinet/default.nix
+++ b/pkgs/development/libraries/kyotocabinet/default.nix
@@ -37,6 +37,5 @@ stdenv.mkDerivation rec {
     description = "A library of routines for managing a database";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     description = "A LDAP-like embedded database";
     homepage = https://ldb.samba.org/;
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -38,6 +38,5 @@ stdenv.mkDerivation rec {
     description = "Fast and lightweight key/value database library by Google";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libasyncns/default.nix
+++ b/pkgs/development/libraries/libasyncns/default.nix
@@ -13,6 +13,5 @@ stdenv.mkDerivation rec {
     description = "A C library for Linux/Unix for executing name service queries asynchronously";
     license = licenses.lgpl21;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libclc/default.nix
+++ b/pkgs/development/libraries/libclc/default.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation {
     description = "Implementation of the library requirements of the OpenCL C programming language";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -52,12 +52,11 @@ stdenv.mkDerivation rec {
     # Remove the unneeded var/lib directories
     rm -rf $out/var
   '';
-    
+
   meta = {
     homepage = http://libdbi-drivers.sourceforge.net/;
     description = "Database drivers for libdbi";
     platforms = platforms.all;
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libdbi/default.nix
+++ b/pkgs/development/libraries/libdbi/default.nix
@@ -13,6 +13,5 @@ stdenv.mkDerivation rec {
     description = "DB independent interface to DB";
     license = licenses.lgpl21;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libestr/default.nix
+++ b/pkgs/development/libraries/libestr/default.nix
@@ -13,6 +13,5 @@ stdenv.mkDerivation rec {
     description = "Some essentials for string handling";
     license = licenses.lgpl21;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -68,6 +68,5 @@ stdenv.mkDerivation rec {
     homepage = http://libevent.org/;
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libfpx/default.nix
+++ b/pkgs/development/libraries/libfpx/default.nix
@@ -28,6 +28,5 @@ stdenv.mkDerivation rec {
     description = "A library for manipulating FlashPIX images";
     license = "Flashpix";
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libgcrypt/1.5.nix
+++ b/pkgs/development/libraries/libgcrypt/1.5.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     description = "General-pupose cryptographic library";
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
     repositories.git = git://git.gnupg.org/libgcrypt.git;
   };
 }

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "General-purpose cryptographic library";
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
-    maintainers = [ maintainers.wkennington maintainers.vrthra ];
+    maintainers = with maintainers; [ vrthra ];
     repositories.git = git://git.gnupg.org/libgcrypt.git;
   };
 }

--- a/pkgs/development/libraries/libibmad/default.nix
+++ b/pkgs/development/libraries/libibmad/default.nix
@@ -14,6 +14,5 @@ stdenv.mkDerivation rec {
     homepage = https://www.openfabrics.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libibumad/default.nix
+++ b/pkgs/development/libraries/libibumad/default.nix
@@ -12,6 +12,5 @@ stdenv.mkDerivation rec {
     homepage = https://www.openfabrics.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -50,6 +50,5 @@ stdenv.mkDerivation rec {
     description = "An Open Source implementation of the iCalendar protocols";
     license = licenses.mpl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libiec61883/default.nix
+++ b/pkgs/development/libraries/libiec61883/default.nix
@@ -18,6 +18,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.linux1394.org;
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     homepage    = http://www.freedesktop.org/wiki/Software/libinput;
     license     = licenses.mit;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ codyopel wkennington ];
+    maintainers = with maintainers; [ codyopel ];
   };
 }

--- a/pkgs/development/libraries/libksba/default.nix
+++ b/pkgs/development/libraries/libksba/default.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation rec {
     description = "CMS and X.509 access library";
     platforms = platforms.all;
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libksi/default.nix
+++ b/pkgs/development/libraries/libksi/default.nix
@@ -23,6 +23,5 @@ stdenv.mkDerivation rec {
     description = "Keyless Signature Infrastructure API library";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/liblogging/default.nix
+++ b/pkgs/development/libraries/liblogging/default.nix
@@ -25,6 +25,5 @@ stdenv.mkDerivation rec {
     description = "Lightweight signal-safe logging library";
     license = licenses.bsd2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/liblognorm/default.nix
+++ b/pkgs/development/libraries/liblognorm/default.nix
@@ -18,6 +18,5 @@ stdenv.mkDerivation rec {
     description = "Help to make sense out of syslog data, or, actually, any event data that is present in text form";
     license = licenses.lgpl21;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -22,6 +22,5 @@ stdenv.mkDerivation rec {
     description = "Library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libmongo-client/default.nix
+++ b/pkgs/development/libraries/libmongo-client/default.nix
@@ -24,6 +24,5 @@ stdenv.mkDerivation rec {
     description = "An alternative C driver for MongoDB";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libnet/default.nix
+++ b/pkgs/development/libraries/libnet/default.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     description = "Portable framework for low-level network packet construction";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libnftnl/default.nix
+++ b/pkgs/development/libraries/libnftnl/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = http://netfilter.org/projects/libnftnl;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/development/libraries/libomxil-bellagio/default.nix
+++ b/pkgs/development/libraries/libomxil-bellagio/default.nix
@@ -21,6 +21,5 @@ stdenv.mkDerivation rec {
     description = "An opensource implementation of the Khronos OpenMAX Integration Layer API to access multimedia components";
     license = licenses.lgpl21;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libopus/default.nix
+++ b/pkgs/development/libraries/libopus/default.nix
@@ -24,6 +24,5 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd3;
     homepage = http://www.opus-codec.org/;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libotr/default.nix
+++ b/pkgs/development/libraries/libotr/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     repositories.git = git://git.code.sf.net/p/otr/libotr;
     license = licenses.lgpl21;
     description = "Library for Off-The-Record Messaging";
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libqb/default.nix
+++ b/pkgs/development/libraries/libqb/default.nix
@@ -15,6 +15,5 @@ stdenv.mkDerivation rec{
     description = "A library providing high performance logging, tracing, ipc, and poll";
     license = licenses.lgpl21;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -24,6 +24,5 @@ stdenv.mkDerivation rec {
     description = "Modem protocol helper library";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libraw1394/default.nix
+++ b/pkgs/development/libraries/libraw1394/default.nix
@@ -13,6 +13,5 @@ stdenv.mkDerivation rec {
     homepage = "https://ieee1394.wiki.kernel.org/index.php/Libraries#libraw1394";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/librelp/default.nix
+++ b/pkgs/development/libraries/librelp/default.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     description = "A reliable logging library";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -29,7 +29,7 @@ let
       homepage    = "https://www.libressl.org";
       license = with licenses; [ publicDomain bsdOriginal bsd0 bsd3 gpl3 isc ];
       platforms   = platforms.all;
-      maintainers = with maintainers; [ thoughtpolice wkennington fpletz globin ];
+      maintainers = with maintainers; [ thoughtpolice fpletz globin ];
     };
   };
 

--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -21,6 +21,5 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     description = "Implementation of the rsync remote-delta algorithm";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libsamplerate/default.nix
+++ b/pkgs/development/libraries/libsamplerate/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     description = "Sample Rate Converter for audio";
     homepage    = http://www.mega-nerd.com/SRC/index.html;
     license     = licenses.bsd2;
-    maintainers = with maintainers; [ lovek323 wkennington ];
+    maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libseccomp/default.nix
+++ b/pkgs/development/libraries/libseccomp/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     license     = licenses.lgpl21;
     platforms   = platforms.linux;
     badPlatforms = platforms.riscv;
-    maintainers = with maintainers; [ thoughtpolice wkennington ];
+    maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = "A modern and easy-to-use crypto library";
     homepage = http://doc.libsodium.org/;
     license = licenses.isc;
-    maintainers = with maintainers; [ raskin wkennington ];
+    maintainers = with maintainers; [ raskin ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libstatgrab/default.nix
+++ b/pkgs/development/libraries/libstatgrab/default.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     description = "A library that provides cross platforms access to statistics about the running system";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libtasn1/default.nix
+++ b/pkgs/development/libraries/libtasn1/default.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
       portable, and only require an ANSI C89 platform.
     '';
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.theora.org/;
     description = "Library for Theora, a free and open video compression format";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ spwhitt wkennington ];
+    maintainers = with maintainers; [ spwhitt ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -22,6 +22,5 @@ stdenv.mkDerivation rec {
     description = "A C library and command-line tool that implements the host-side of the U2F protocol";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     description = "C++ wrapper for the libxml2 XML parser library";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ phreedom wkennington ];
+    maintainers = with maintainers; [ phreedom ];
   };
 }

--- a/pkgs/development/libraries/libyaml/default.nix
+++ b/pkgs/development/libraries/libyaml/default.nix
@@ -31,6 +31,5 @@ stdenv.mkDerivation {
     description = "A YAML 1.1 parser and emitter written in C";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libykneomgr/default.nix
+++ b/pkgs/development/libraries/libykneomgr/default.nix
@@ -20,6 +20,5 @@ stdenv.mkDerivation rec {
     description = "A C library to interact with the CCID-part of the Yubikey NEO";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/libyubikey/default.nix
+++ b/pkgs/development/libraries/libyubikey/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
     homepage = http://opensource.yubico.com/yubico-c/;
     description = "C library for manipulating Yubico YubiKey One-Time Passwords (OTPs)";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/mbedtls/1.3.nix
+++ b/pkgs/development/libraries/mbedtls/1.3.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     description = "Portable cryptographic and SSL/TLS library, aka polarssl";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     description = "Portable cryptographic and TLS library, formerly known as PolarSSL";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/development/libraries/msgpack/generic.nix
+++ b/pkgs/development/libraries/msgpack/generic.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "MessagePack implementation for C and C++";
     homepage    = https://msgpack.org;
     license     = licenses.asl20;
-    maintainers = with maintainers; [ redbaron wkennington ];
+    maintainers = with maintainers; [ redbaron ];
     platforms   = platforms.all;
   };
 }

--- a/pkgs/development/libraries/mtdev/default.nix
+++ b/pkgs/development/libraries/mtdev/default.nix
@@ -16,10 +16,9 @@ stdenv.mkDerivation rec {
       kernel MT events to the slotted type B protocol. The events put into
       mtdev may be from any MT device, specifically type A without contact
       tracking, type A with contact tracking, or type B with contact tracking.
-      See the kernel documentation for further details. 
+      See the kernel documentation for further details.
     '';
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -165,7 +165,6 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.wkennington ];
   };
 
   passthru = {

--- a/pkgs/development/libraries/nettle/generic.nix
+++ b/pkgs/development/libraries/nettle/generic.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation (rec {
 
      homepage = http://www.lysator.liu.se/~nisse/nettle/;
 
-     maintainers = with maintainers; [ wkennington ];
      platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -50,6 +50,5 @@ stdenv.mkDerivation rec {
     description = "A C implementation of HTTP/2";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/nss_wrapper/default.nix
+++ b/pkgs/development/libraries/nss_wrapper/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
     description = "A wrapper for the user, group and hosts NSS API";
     homepage = "https://git.samba.org/?p=nss_wrapper.git;a=summary;";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/ntdb/default.nix
+++ b/pkgs/development/libraries/ntdb/default.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     description = "The not-so trivial database";
     homepage = https://tdb.samba.org/;
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/openct/default.nix
+++ b/pkgs/development/libraries/openct/default.nix
@@ -5,7 +5,7 @@
 stdenv.mkDerivation rec {
   name = "openct-${version}";
   version = "0.6.20";
-  
+
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "openct";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i 's,$(DESTDIR),$(out),g' etc/Makefile.am
   '';
-  
+
   configureFlags = [
     "--enable-api-doc"
     "--enable-usb"
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/OpenSC/openct/;
     license = licenses.lgpl21;
     description = "Drivers for several smart card readers";
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -31,6 +31,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.openexr.com/;
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://p11-glue.freedesktop.org/;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
     license = licenses.mit;
   };
 }

--- a/pkgs/development/libraries/protobufc/generic.nix
+++ b/pkgs/development/libraries/protobufc/generic.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     description = "C bindings for Google's Protocol Buffers";
     license = licenses.bsd2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/rabbitmq-c/default.nix
+++ b/pkgs/development/libraries/rabbitmq-c/default.nix
@@ -18,6 +18,5 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/alanxz/rabbitmq-c;
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/rdkafka/default.nix
+++ b/pkgs/development/libraries/rdkafka/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/edenhill/librdkafka;
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ boothead wkennington ];
+    maintainers = with maintainers; [ boothead ];
   };
 }

--- a/pkgs/development/libraries/resolv_wrapper/default.nix
+++ b/pkgs/development/libraries/resolv_wrapper/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     description = "A wrapper for the user, group and hosts NSS API";
     homepage = "https://git.samba.org/?p=uid_wrapper.git;a=summary;";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation rec {
     description = "A library that provides an embeddable, persistent key-value store for fast storage";
     license = licenses.bsd3;
     platforms = platforms.x86_64;
-    maintainers = with maintainers; [ adev wkennington ];
+    maintainers = with maintainers; [ adev ];
   };
 }

--- a/pkgs/development/libraries/sbc/default.nix
+++ b/pkgs/development/libraries/sbc/default.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.bluez.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -28,6 +28,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     description = "Compression/decompression library for very high speeds";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/socket_wrapper/default.nix
+++ b/pkgs/development/libraries/socket_wrapper/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     description = "A library passing all socket communications through unix sockets";
     homepage = "https://git.samba.org/?p=socket_wrapper.git;a=summary;";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/speex/default.nix
+++ b/pkgs/development/libraries/speex/default.nix
@@ -29,6 +29,5 @@ stdenv.mkDerivation rec {
     description = "An Open Source/Free Software patent-free audio compression format designed for speech";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/speexdsp/default.nix
+++ b/pkgs/development/libraries/speexdsp/default.nix
@@ -25,6 +25,5 @@ stdenv.mkDerivation rec {
     description = "An Open Source/Free Software patent-free audio compression format designed for speech";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/svrcore/default.nix
+++ b/pkgs/development/libraries/svrcore/default.nix
@@ -16,6 +16,5 @@ stdenv.mkDerivation rec {
     description = "Secure PIN handling using NSS crypto";
     license = licenses.mpl11;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
     description = "Hierarchical pool based memory allocator with destructors";
     homepage = https://tdb.samba.org/;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://tdb.samba.org/;
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     description = "An event system based on the talloc memory management library";
     homepage = https://tevent.samba.org/;
     license = licenses.lgpl3Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation {
     homepage = http://www.tcl.tk/;
     license = licenses.tcltk;
     platforms = platforms.all;
-    maintainers = with maintainers; [ lovek323 vrthra wkennington ];
+    maintainers = with maintainers; [ lovek323 vrthra ];
   };
 }

--- a/pkgs/development/libraries/uid_wrapper/default.nix
+++ b/pkgs/development/libraries/uid_wrapper/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     description = "A wrapper for the user, group and hosts NSS API";
     homepage = "https://git.samba.org/?p=uid_wrapper.git;a=summary;";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/wayland/1.9.nix
+++ b/pkgs/development/libraries/wayland/1.9.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     homepage    = https://wayland.freedesktop.org/;
     license     = lib.licenses.mit;
     platforms   = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ codyopel wkennington ];
+    maintainers = with lib.maintainers; [ codyopel ];
   };
 
   passthru.version = version;

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage    = https://wayland.freedesktop.org/;
     license     = lib.licenses.mit;
     platforms   = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ codyopel wkennington ];
+    maintainers = with lib.maintainers; [ codyopel ];
   };
 
   passthru.version = version;

--- a/pkgs/development/libraries/webrtc-audio-processing/default.nix
+++ b/pkgs/development/libraries/webrtc-audio-processing/default.nix
@@ -19,6 +19,5 @@ stdenv.mkDerivation rec {
     description = "A more Linux packaging friendly copy of the AudioProcessing module from the WebRTC project";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/wiredtiger/default.nix
+++ b/pkgs/development/libraries/wiredtiger/default.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
     description = "";
     license = licenses.gpl2;
     platforms = intersectLists platforms.unix platforms.x86_64;
-    maintainers = with maintainers; [ wkennington ];
     broken = true; # Broken by f689a6d1c6796c4a4f116ffec6c4624379e04bc9.
   };
 }

--- a/pkgs/development/libraries/zeromq/3.x.nix
+++ b/pkgs/development/libraries/zeromq/3.x.nix
@@ -18,6 +18,5 @@ stdenv.mkDerivation rec {
     description = "The Intelligent Transport Layer";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "The Intelligent Transport Layer";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/development/tools/misc/dejagnu/default.nix
+++ b/pkgs/development/tools/misc/dejagnu/default.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
 
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington vrthra ];
+    maintainers = with maintainers; [ vrthra ];
   };
 }

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation rec {
     # Different types of licenses available: http://www.swig.org/Release/LICENSE .
     license = licenses.gpl3Plus;
     platforms = with platforms; linux ++ darwin;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/misc/gnuk/generic.nix
+++ b/pkgs/misc/gnuk/generic.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation {
     homepage = http://www.fsij.org/pages/gnuk;
     description = "An implementation of USB cryptographic token for gpg";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
     homepage = http://jackaudio.org;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ goibhniu wkennington ];
+    maintainers = with maintainers; [ goibhniu ];
   };
 }

--- a/pkgs/misc/jackaudio/jack1.nix
+++ b/pkgs/misc/jackaudio/jack1.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     url = "http://jackaudio.org/downloads/jack-audio-connection-kit-${version}.tar.gz";
     sha256 = "0i6l25dmfk2ji2lrakqq9icnwjxklgcjzzk65dmsff91z2zva5rm";
   };
-  
+
   configureFlags = [
     (stdenv.lib.enableFeature (optLibffado != null) "firewire")
   ];
@@ -29,12 +29,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ optAlsaLib optDb optLibffado optCelt ];
   propagatedBuildInputs = [ optLibuuid ];
-  
+
   meta = with stdenv.lib; {
     description = "JACK audio connection kit";
     homepage = http://jackaudio.org;
     license = "GPL";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/cgmanager/default.nix
+++ b/pkgs/os-specific/linux/cgmanager/default.nix
@@ -22,6 +22,5 @@ stdenv.mkDerivation rec {
     description = "A central privileged daemon that manages all your cgroups";
     license = licenses.lgpl21;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/edac-utils/default.nix
+++ b/pkgs/os-specific/linux/edac-utils/default.nix
@@ -33,6 +33,5 @@ stdenv.mkDerivation {
     description = "Handles the reporting of hardware-related memory errors";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.ffado.org;
     description = "FireWire audio drivers";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ goibhniu wkennington ];
+    maintainers = with maintainers; [ goibhniu ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
     repositories.git = git://w1.fi/hostap.git;
     description = "A user space daemon for access point and authentication servers";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ phreedom wkennington ];
+    maintainers = with maintainers; [ phreedom ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     description = "A collection of utilities for controlling TCP/IP networking and traffic control in Linux";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ eelco wkennington fpletz ];
+    maintainers = with maintainers; [ eelco fpletz ];
   };
 }

--- a/pkgs/os-specific/linux/ipset/default.nix
+++ b/pkgs/os-specific/linux/ipset/default.nix
@@ -18,6 +18,5 @@ stdenv.mkDerivation rec {
     description = "Administration tool for IP sets";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/libcap-ng/default.nix
+++ b/pkgs/os-specific/linux/libcap-ng/default.nix
@@ -35,6 +35,5 @@ stdenv.mkDerivation rec {
     homepage = https://people.redhat.com/sgrubb/libcap-ng/;
     platforms = platforms.linux;
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -83,6 +83,6 @@ stdenv.mkDerivation rec {
     '';
 
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington globin fpletz ];
+    maintainers = with maintainers; [ globin fpletz ];
   };
 }

--- a/pkgs/os-specific/linux/microcode/amd.nix
+++ b/pkgs/os-specific/linux/microcode/amd.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
     description = "AMD Processor microcode patch";
     homepage = http://www.amd64.org/support/microcode.html;
     license = licenses.unfreeRedistributableFirmware;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/microcode/intel.nix
+++ b/pkgs/os-specific/linux/microcode/intel.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.intel.com/;
     description = "Microcode for Intel processors";
     license = licenses.unfreeRedistributableFirmware;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/mstpd/default.nix
+++ b/pkgs/os-specific/linux/mstpd/default.nix
@@ -19,6 +19,5 @@ stdenv.mkDerivation {
     homepage = https://sourceforge.net/projects/mstpd/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -25,6 +25,5 @@ stdenv.mkDerivation rec {
     homepage = http://netfilter.org/projects/nftables;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/numactl/default.nix
+++ b/pkgs/os-specific/linux/numactl/default.nix
@@ -27,6 +27,5 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/numactl/numactl;
     license = with licenses; [ gpl2 lgpl21 ]; # libnuma is lgpl21
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/pam_krb5/default.nix
+++ b/pkgs/os-specific/linux/pam_krb5/default.nix
@@ -19,6 +19,5 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.linux;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -51,6 +51,6 @@ stdenv.mkDerivation rec {
     homepage = http://zfsonlinux.org/;
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
+    maintainers = with maintainers; [ jcumming wizeman fpletz globin ];
   };
 }

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation rec {
     homepage = http://hostap.epitest.fi/wpa_supplicant/;
     description = "A tool for connecting to WPA and WPA2-protected wireless networks";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ marcweber wkennington ];
+    maintainers = with maintainers; [ marcweber ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -149,7 +149,7 @@ let
         homepage = http://zfsonlinux.org/;
         license = licenses.cddl;
         platforms = platforms.linux;
-        maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
+        maintainers = with maintainers; [ jcumming wizeman fpletz globin ];
       };
     };
 in {

--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation rec {
     description = "A Group Communication System with features for implementing high availability within applications";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington montag451 ];
+    maintainers = with maintainers; [ montag451 ];
   };
 }

--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -57,6 +57,6 @@ stdenv.mkDerivation rec {
     description = "A daemon that provides mouse support on the Linux console";
     license = licenses.gpl2;
     platforms = platforms.linux ++ platforms.cygwin;
-    maintainers = with maintainers; [ eelco wkennington ];
+    maintainers = with maintainers; [ eelco ];
   };
 }

--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -60,6 +60,5 @@ stdenv.mkDerivation rec {
     description = "Enterprise-class Open Source LDAP server for Linux";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -57,6 +57,5 @@ stdenv.mkDerivation rec {
     homepage = http://net-snmp.sourceforge.net/;
     license = licenses.bsd3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/servers/nosql/mongodb/default.nix
+++ b/pkgs/servers/nosql/mongodb/default.nix
@@ -97,7 +97,7 @@ in stdenv.mkDerivation rec {
     homepage = http://www.mongodb.org;
     license = licenses.agpl3;
 
-    maintainers = with maintainers; [ bluescreen303 offline wkennington cstrahan ];
+    maintainers = with maintainers; [ bluescreen303 offline cstrahan ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
     description = "Sound server for POSIX and Win32 systems";
     homepage    = http://www.pulseaudio.org/;
     license     = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ lovek323 wkennington ];
+    maintainers = with lib.maintainers; [ lovek323 ];
     platforms   = lib.platforms.unix;
 
     longDescription = ''

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -100,7 +100,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.samba.org/;
     description = "The standard Windows interoperability suite of programs for Linux and Unix";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/shishi/default.nix
+++ b/pkgs/servers/shishi/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     homepage    = https://www.gnu.org/software/shishi/;
     description = "An implementation of the Kerberos 5 network security system";
     license     = licenses.gpl3Plus;
-    maintainers = with maintainers; [ bjg lovek323 wkennington ];
+    maintainers = with maintainers; [ bjg lovek323 ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -90,7 +90,7 @@ common = rec { # attributes common to both builds
     description = "An enhanced, drop-in replacement for MySQL";
     homepage    = https://mariadb.org/;
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ thoughtpolice wkennington ];
+    maintainers = with maintainers; [ thoughtpolice ];
     platforms   = platforms.all;
   };
 };

--- a/pkgs/servers/sql/pgpool/default.nix
+++ b/pkgs/servers/sql/pgpool/default.nix
@@ -31,6 +31,5 @@ stdenv.mkDerivation rec {
     description = "A middleware that works between postgresql servers and postgresql clients";
     license = licenses.free;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -35,7 +35,6 @@ let
       description = "Controller for Ubiquiti UniFi access points";
       license = licenses.unfree;
       platforms = platforms.unix;
-      maintainers = with maintainers; [ wkennington ];
     };
   };
 

--- a/pkgs/tools/backup/bareos/default.nix
+++ b/pkgs/tools/backup/bareos/default.nix
@@ -77,6 +77,5 @@ stdenv.mkDerivation rec {
     description = "A fork of the bacula project";
     license = licenses.agpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Utilities for the btrfs filesystem";
     homepage = https://btrfs.wiki.kernel.org/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ raskin wkennington ];
+    maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -165,7 +165,7 @@ stdenv.mkDerivation {
     homepage = https://ceph.com/;
     description = "Distributed storage system";
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ adev ak wkennington ];
+    maintainers = with maintainers; [ adev ak ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/tools/misc/bandwidth/default.nix
+++ b/pkgs/tools/misc/bandwidth/default.nix
@@ -34,6 +34,5 @@ stdenv.mkDerivation rec {
     description = "Artificial benchmark for identifying weaknesses in the memory subsystem";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -38,6 +38,5 @@ stdenv.mkDerivation rec {
     homepage = http://expect.sourceforge.net/;
     license = "Expect";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/misc/mstflint/default.nix
+++ b/pkgs/tools/misc/mstflint/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.openfabrics.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
     broken = true; # 2018-04-11
   };
 }

--- a/pkgs/tools/misc/ttylog/default.nix
+++ b/pkgs/tools/misc/ttylog/default.nix
@@ -22,6 +22,5 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/misc/yubico-piv-tool/default.nix
+++ b/pkgs/tools/misc/yubico-piv-tool/default.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
       certificates, and create certificate requests, and other operations.
       A shared library and a command-line tool is included.
     '';
-    maintainers = with maintainers; [ wkennington ];
     license = licenses.bsd2;
     platforms = platforms.all;
   };

--- a/pkgs/tools/misc/yubikey-personalization-gui/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization-gui/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig qmake ];
   buildInputs = [ yubikey-personalization qtbase libyubikey ];
-  
+
   installPhase = ''
     mkdir -p $out/bin
     cp build/release/yubikey-personalization-gui $out/bin
@@ -21,6 +21,5 @@ stdenv.mkDerivation rec {
     description = "A QT based cross-platform utility designed to facilitate reconfiguration of the Yubikey";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/misc/yubikey-personalization/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization/default.nix
@@ -28,6 +28,5 @@ stdenv.mkDerivation rec {
     description = "A library and command line tool to personalize YubiKeys";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -72,6 +72,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.isc.org/products/DHCP/;
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -23,10 +23,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://software.es.net/iperf/; 
+    homepage = http://software.es.net/iperf/;
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = platforms.unix;
     license = "as-is";
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/tools/networking/keepalived/default.nix
+++ b/pkgs/tools/networking/keepalived/default.nix
@@ -30,6 +30,5 @@ stdenv.mkDerivation rec {
     description = "Routing software written in C";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/networking/ndisc6/default.nix
+++ b/pkgs/tools/networking/ndisc6/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://www.remlab.net/ndisc6/;
     description = "A small collection of useful tools for IPv6 networking";
-    maintainers = with maintainers; [ eelco wkennington ];
+    maintainers = with maintainers; [ eelco ];
     platforms = platforms.linux;
     license = licenses.gpl2;
   };

--- a/pkgs/tools/networking/openntpd/default.nix
+++ b/pkgs/tools/networking/openntpd/default.nix
@@ -37,6 +37,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     description = "OpenBSD NTP daemon (Debian port)";
     platforms = platforms.all;
-    maintainers = with maintainers; [ wkennington ];
   };
 }

--- a/pkgs/tools/networking/radvd/default.nix
+++ b/pkgs/tools/networking/radvd/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     description = "IPv6 Router Advertisement Daemon";
     platforms = platforms.linux;
     license = licenses.bsdOriginal;
-    maintainers = with maintainers; [ wkennington fpletz ];
+    maintainers = with maintainers; [ fpletz ];
   };
 }

--- a/pkgs/tools/networking/tinc/pre.nix
+++ b/pkgs/tools/networking/tinc/pre.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage="http://www.tinc-vpn.org/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ wkennington fpletz lassulus ];
+    maintainers = with maintainers; [ fpletz lassulus ];
   };
 }

--- a/pkgs/tools/security/ccid/default.nix
+++ b/pkgs/tools/security/ccid/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
     description = "ccid drivers for pcsclite";
     homepage = https://ccid.apdu.fr/;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       frontend applications and libraries are available.  Version 2 of GnuPG
       also provides support for S/MIME.
     '';
-    maintainers = with maintainers; [ wkennington peti fpletz vrthra ];
+    maintainers = with maintainers; [ peti fpletz vrthra ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
     description = "Set of libraries and utilities to access smart cards";
     homepage = https://github.com/OpenSC/OpenSC/wiki;
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ wkennington ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
     description = "Middleware to access a smart card using SCard API (PC/SC)";
     homepage = https://pcsclite.apdu.fr/;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ wkennington ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -110,6 +110,5 @@ stdenv.mkDerivation rec {
     description = "Enhanced syslog implementation";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wkennington ];
   };
 }


### PR DESCRIPTION
He prefers to contribute to his own nixpkgs fork triton.
Since he is still marked as maintainer in many packages
this leaves the wrong impression he still maintains those.
