### PR TITLE
notmuch-bower: 0.9 -> 0.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1427,6 +1427,10 @@
     email = "justin.humm@posteo.de";
     github = "erictapen";
     name = "Justin Humm";
+    keys = [{
+      longkeyid = "rsa4096/0x438871E000AA178E";
+      fingerprint = "984E 4BAD 9127 4D0E AE47  FF03 4388 71E0 00AA 178E";
+    }];
   };
   erikryb = {
     email = "erik.rybakken@math.ntnu.no";

--- a/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "notmuch-bower-${version}";
-  version = "0.9";
+  version = "0.10";
 
   src = fetchFromGitHub {
     owner = "wangp";
     repo = "bower";
     rev = version;
-    sha256 = "0f8djiclq4rz9isbx18bpzymbvb2q0spvjp982b149hr1my6klaf";
+    sha256 = "0jpaxlfxz7mj76z3cyj8sq053p0mkp46kaw05nimzwaq5yx923fv";
   };
 
   nativeBuildInputs = [ gawk mercury pandoc ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

Also added my PGP key to maintainers-list.nix.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

