### PR TITLE
nixos/pulseaudio: disable flat-volumes by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -423,6 +423,20 @@
       use <literal>nixos-rebuild boot; reboot</literal>.
      </para>
    </listitem>
+   <listitem>
+    <para>
+      Flat volumes are now disabled by default in <literal>hardware.pulseaudio</literal>.
+      This has been done to prevent applications, which are unaware of this feature, setting
+      their volumes to 100% on startup causing harm to your audio hardware and potentially your ears.
+    </para>
+    <note>
+     <para>
+      With this change application specific volumes are relative to the master volume which can be
+      adjusted independently, whereas before they were absolute; meaning that in effect, it scaled the
+      device-volume with the volume of the loudest application.
+     </para>
+    </note>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -180,7 +180,7 @@ in {
           type = types.attrsOf types.unspecified;
           default = {};
           description = ''Config of the pulse daemon. See <literal>man pulse-daemon.conf</literal>.'';
-          example = literalExample ''{ flat-volumes = "no"; }'';
+          example = literalExample ''{ realtime-scheduling = "yes"; }'';
         };
       };
 
@@ -241,6 +241,9 @@ in {
         { target = "libao.conf";
           source = writeText "libao.conf" "default_driver=pulse"; }
       ];
+
+      # Disable flat volumes to enable relative ones
+      hardware.pulseaudio.daemon.config.flat-volumes = mkDefault "no";
 
       # Allow PulseAudio to get realtime priority using rtkit.
       security.rtkit.enable = true;


### PR DESCRIPTION
###### Motivation for this change
Some applications are unaware of this feature and can set their volume to 100% on startup harming people ears and possiblly blowing someone's audio setup.

I noticed this in #54594 and by extension [epiphany](https://bugzilla.gnome.org/show_bug.cgi?id=675217
).

Please also note that many other distros have this default for the reason outlined above.

Closes #5632 #54594

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

