### PR TITLE
pythonPackages.limitlessled: init at 1.1.3

### DIFF
--- a/pkgs/development/python-modules/limitlessled/default.nix
+++ b/pkgs/development/python-modules/limitlessled/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "limitlessled";
+  version = "1.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pd71wxqjvznx10brsj1sgy3420bz7awbzk9jlj422rrdxql754j";
+  };
+
+  meta = with lib; {
+    description = "Control LimitlessLED products";
+    homepage = https://github.com/happyleavesaoc/python-limitlessled/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ sephalon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -440,6 +440,8 @@ in {
 
   libmr = callPackage ../development/python-modules/libmr { };
 
+  limitlessled = callPackage ../development/python-modules/limitlessled { };
+
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
   logster = callPackage ../development/python-modules/logster { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

