### PR TITLE
cc-wrapper: add libcxx for libcxxClang

### DIFF
--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -59,6 +59,7 @@ let
 
     libcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
+      libcxx = targetLlvmLibraries.libcxx;
       extraPackages = [
         targetLlvmLibraries.libcxx
         targetLlvmLibraries.libcxxabi

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -59,6 +59,7 @@ let
 
     libcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
+      libcxx = targetLlvmLibraries.libcxx;
       extraPackages = [
         targetLlvmLibraries.libcxx
         targetLlvmLibraries.libcxxabi

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -59,6 +59,7 @@ let
 
     libcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
+      libcxx = targetLlvmLibraries.libcxx;
       extraPackages = [
         targetLlvmLibraries.libcxx
         targetLlvmLibraries.libcxxabi


### PR DESCRIPTION
clang needs to find headers + libraries for compiling with libc++. We
need to add a libcxx argument to cc-wrapper. This means you do not
have to pass in c++ headers directly.

This resolves the last case remaining of #30670. Darwin clang++ now
works properly.

Fixes #30670
