### PR TITLE
waybar: init at 0.4.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -136,6 +136,7 @@
   ./programs/vim.nix
   ./programs/wavemon.nix
   ./programs/way-cooler.nix
+  ./programs/waybar.nix
   ./programs/wireshark.nix
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix

--- a/nixos/modules/programs/waybar.nix
+++ b/nixos/modules/programs/waybar.nix
@@ -1,0 +1,20 @@
+{ lib, pkgs, config, ... }:
+
+with lib;
+
+{
+  options.programs.waybar = {
+    enable = mkEnableOption "waybar";
+  };
+
+  config = mkIf config.programs.waybar.enable {
+    systemd.user.services.waybar = {
+      description = "Waybar as systemd service";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      script = "${pkgs.waybar}/bin/waybar";
+    };
+  };
+
+  meta.maintainers = [ maintainers.FlorianFranzen ];
+}

--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, meson, pkgconfig, ninja
+, wayland, wlroots, gtkmm3, libinput, libsigcxx, jsoncpp, fmt
+, traySupport  ? true,  libdbusmenu-gtk3
+, pulseSupport ? false, libpulseaudio
+, nlSupport    ? true,  libnl
+, swaySupport  ? true,  sway
+}:
+  stdenv.mkDerivation rec {
+    name = "waybar-${version}";
+    version = "0.4.0";
+
+    src = fetchFromGitHub {
+      owner = "Alexays";
+      repo = "Waybar";
+      rev = version;
+      sha256 = "0vkx1b6bgr75wkx89ppxhg4103vl2g0sky22npmfkvbkpgh8dj38";
+    };
+
+    nativeBuildInputs = [
+      meson ninja pkgconfig
+    ];
+
+    buildInputs = with stdenv.lib;
+      [ wayland wlroots gtkmm3 libinput libsigcxx jsoncpp fmt ]
+      ++ optional  traySupport  libdbusmenu-gtk3
+      ++ optional  pulseSupport libpulseaudio
+      ++ optional  nlSupport    libnl
+      ++ optional  swaySupport  sway;
+
+    mesonFlags = [
+      "-Ddbusmenu-gtk=${ if traySupport then "enabled" else "disabled" }"
+      "-Dpulseaudio=${ if pulseSupport then "enabled" else "disabled" }"
+      "-Dlibnl=${ if nlSupport then "enabled" else "disabled" }"
+      "-Dout=${placeholder "out"}"
+    ];
+
+    meta = with stdenv.lib; {
+      description = "Highly customizable Wayland bar for Sway and Wlroots based compositors";
+      license = licenses.mit;
+      maintainers = [ maintainers.FlorianFranzen ];
+      platforms = platforms.unix;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17735,6 +17735,10 @@ in
   swayidle = callPackage ../applications/window-managers/sway/idle.nix { };
   swaylock = callPackage ../applications/window-managers/sway/lock.nix { };
 
+  waybar = callPackage ../applications/misc/waybar {
+    pulseSupport = config.pulseaudio or false;
+  };
+
   velox = callPackage ../applications/window-managers/velox {
     stConf = config.st.conf or null;
     stPatches = config.st.patches or null;


### PR DESCRIPTION
###### Motivation for this change

Initial addition of [waybar](https://github.com/Alexays/Waybar).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).