### PR TITLE
virt-viewer: Fix USB redirection

### DIFF
--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
   ];
 
+  # Required for USB redirection PolicyKit rules file
+  propagatedUserEnvPkgs = optional spiceSupport spice-gtk;
+
   meta = {
     description = "A viewer for remote virtual machines";
     maintainers = [ maintainers.raskin ];


### PR DESCRIPTION
###### Motivation for this change

Fixes the same issue reported in #39129 but for virt-viewer.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

