### PR TITLE
Update gambit and gerbil from upstream

### DIFF
--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
   tarball_version = "v4_9_1";
 
   src = fetchurl {
-    url    = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-${tarball_version}-devel.tgz";
-    sha256 = "10kzv568gimp9nzh5xw0h01vw50wi68z3awfp9ibqrpq2l0n7mw7";
+    url    = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-${tarball_version}.tgz";
+    sha256 = "14x9xa0yh7187alzw2m937jnh4csj0dyywi3va8bhi7aaw4p5qai";
   };
 
-  buildInputs = [ autoconf git ];
+  buildInputs = [ autoconf ];
 
   configurePhase = ''
     ./configure --prefix=$out

--- a/pkgs/development/compilers/gambit/bootstrap.nix
+++ b/pkgs/development/compilers/gambit/bootstrap.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name    = "gambit-bootstrap-${version}";
-  version = "4.9.1";
-  tarball_version = "v4_9_1";
+  version = "4.9.2";
+  tarball_version = "v4_9_2";
 
   src = fetchurl {
     url    = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-${tarball_version}.tgz";
-    sha256 = "14x9xa0yh7187alzw2m937jnh4csj0dyywi3va8bhi7aaw4p5qai";
+    sha256 = "1cpganh3jgjdw6qsapcbwxdbp1xwgx5gvdl4ymwf8p2c5k018dwy";
   };
 
   buildInputs = [ autoconf ];

--- a/pkgs/development/compilers/gambit/default.nix
+++ b/pkgs/development/compilers/gambit/default.nix
@@ -1,10 +1,10 @@
 { stdenv, callPackage, fetchurl }:
 
 callPackage ./build.nix {
-  version = "4.9.1";
+  version = "4.9.2";
   src = fetchurl {
-    url = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-v4_9_1-devel.tgz";
-    sha256 = "10kzv568gimp9nzh5xw0h01vw50wi68z3awfp9ibqrpq2l0n7mw7";
+    url = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.9/source/gambit-v4_9_2-devel.tgz";
+    sha256 = "1xpjm3m1pxwj3n0g36lbb3p6wx2nc1iry95xc22pnq3m2374gjxv";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,13 +1,13 @@
 { stdenv, callPackage, fetchFromGitHub }:
 
 callPackage ./build.nix {
-  version = "unstable-2018-11-19";
-# git-version = "4.9.1-8-g61c6cb50";
+  version = "unstable-2019-01-18";
+# git-version = "4.9.2";
   src = fetchFromGitHub {
     owner = "feeley";
     repo = "gambit";
-    rev = "61c6cb500f4756be1e52095d5ab4501752525a70";
-    sha256 = "1knpb40y1g09c6yqd2fsxm3bk56bl5xrrwfsd7nqa497x6ngm5pn";
+    rev = "cf5688ecf35d85b9355c645f535c1e057b3064e7";
+    sha256 = "1xr7j4iws6hlrdbvlii4n98apr78k4adbnmy4ggzyik65bynh1kl";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -24,9 +24,13 @@ stdenv.mkDerivation rec {
 
     patchShebangs .
 
-    find . -type f -executable -print0 | while IFS= read -r -d ''$'\0' f; do
+    grep -Fl '#!/usr/bin/env' `find . -type f -executable` | while read f ; do
       substituteInPlace "$f" --replace '#!/usr/bin/env' '#!${coreutils}/bin/env'
     done
+    grep -Fl '"gsc"' `find . -type f -name '*.s*'` | while read f ; do
+      substituteInPlace "$f" --replace '"gsc"' '"${gambit}/bin/gsc"'
+    done
+    substituteInPlace "etc/gerbil.el" --replace '"gxc"' "\"$out/bin/gxc\""
 
     cat > etc/gerbil_static_libraries.sh <<EOF
 #OPENSSL_LIBCRYPTO=${makeStaticLibraries openssl}/lib/libcrypto.a # MISSING!

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,14 +1,14 @@
 { stdenv, callPackage, fetchFromGitHub, gambit }:
 
 callPackage ./build.nix rec {
-  version = "0.14";
-  git-version = "0.14";
+  version = "0.15";
+  git-version = "0.15";
   inherit gambit;
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
     rev = "v${version}";
-    sha256 = "0n078lkf8m391kr99ipb1v2dpi5vkikz9nj0p7kfjg43868my3v7";
+    sha256 = "1ff1gpl0bl1pbs68bxax82ikw4bzbkrj4a6l775ziwyfndjggl66";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,14 +1,14 @@
 { stdenv, callPackage, fetchFromGitHub, gambit-unstable }:
 
 callPackage ./build.nix {
-  version = "unstable-2018-11-19";
-  git-version = "0.15-DEV-2-g7d09a4ce";
+  version = "unstable-2019-01-25";
+  git-version = "0.15";
   gambit = gambit-unstable;
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
-    rev = "7d09a4cebe03d755a1791e77279e156a74e07685";
-    sha256 = "1mqi9xcjk59sqbh1fx65a4fa4mqm35py4xqxq6086bcyhkm1nzwa";
+    rev = "8c1aa2ca129a380de9cf668a7f3f6d56e56cbf94";
+    sha256 = "1ff1gpl0bl1pbs68bxax82ikw4bzbkrj4a6l775ziwyfndjggl66";
   };
   inherit stdenv;
 }


### PR DESCRIPTION
###### Motivation for this change

New upstream releases.
A few packaging improvements (download less for gambit, statically link gambit path into gerbil).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
