### PR TITLE
pnpm: fix build error "unsupported URL Type link"

### DIFF
--- a/pkgs/development/node-packages/default-v10.nix
+++ b/pkgs/development/node-packages/default-v10.nix
@@ -70,6 +70,11 @@ nodePackages // {
 
   pnpm = nodePackages.pnpm.override {
     nativeBuildInputs = [ pkgs.makeWrapper ];
+
+    preRebuild = ''
+      sed 's/"link:/"file:/g' --in-place package.json
+    '';
+
     postInstall = let
       pnpmLibPath = stdenv.lib.makeBinPath [
         nodejs.passthru.python


### PR DESCRIPTION
###### Motivation for this change

fixes https://github.com/svanderburg/node2nix/issues/79#issuecomment-441526589

based on https://github.com/codaxy/cxjs/issues/279#issuecomment-335096573 `link:` is same as `file:`

Before build was failed with error https://pastebin.com/69G0DgKu

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

