### PR TITLE
gnumeric: fix wrapping

### DIFF
--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, perlPackages
-, goffice, gnome3, makeWrapper, gtk3, bison, pythonPackages
+, goffice, gnome3, wrapGAppsHook, gtk3, bison, pythonPackages
 , itstool
 }:
 
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-component" ];
 
-  nativeBuildInputs = [ pkgconfig intltool bison itstool makeWrapper ];
+  nativeBuildInputs = [ pkgconfig intltool bison itstool wrapGAppsHook ];
 
   # ToDo: optional libgda, introspection?
   buildInputs = [
@@ -25,14 +25,6 @@ in stdenv.mkDerivation rec {
   ] ++ (with perlPackages; [ perl XMLParser ]);
 
   enableParallelBuilding = true;
-
-  preFixup = ''
-    for f in "$out"/bin/gnumeric-*; do
-      wrapProgram $f \
-        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-        ${stdenv.lib.optionalString (!stdenv.isDarwin) "--prefix GIO_EXTRA_MODULES : '${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules'"}
-    done
-  '';
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
Incorporate wrapGAppsHook so that all gnumeric binaries are wrapped,
following the convention used by many gnome applications.

This addresses two issues:

1.  The packaged ssconvert, ssdiff, ssgrep, and ssindex executables
    in bin are not currently wrapped so some expected environment
    variables including XDG_DATA_DIRS and GIO_EXTRA_MODULES are not
    set. The result is many warnings on stderr when running these
    commands, e.g.

    CRITICAL **:...go_conf_add_monitor: assertion 'node || key' failed
    CRITICAL **:...go_conf_get_node: assertion 'parent || key' failed
    WARNING **:...unknown GOConfMonitor id.

2.  None of the binaries, including gnumeric, currently wrap the
    environment variable GDK_PIXBUF_MODULE_FILE. This can cause
    segfaults if an incompatible GDK_PIXBUF_MODULE_FILE is already set
    in the environment (e.g. by plasma5). This could be encountered
    running a nixos pre-19.03 gnumeric binary from a nixos 18.09 KDE
    session.

NOTE 1: This change could potentially impact the darwin package as it
removes an explicit isDarwin check related to GIO_EXTRA_MODULES. The
Darwin case is hopefully handled correctly by conditional code in
wrapGAppsHook. Testing required.

NOTE 2: As with other packages wrapped by wrapGAppsHook, the wrapping
introduces an extra level of wrapping when it encounters a soft link
to an executable in bin. In this package, there is a soft link
from gnumeric to gnumeric-1.12.44. After wrapping with wrapGAppsHook,
the execution flow for gnumeric looks like this:

    gnumeric execs .gnumeric-wrapped which is a link to
    gnumeric-1.12.44 that then execs .gnumeric-1.12.44-wrapped

This may not be optimal, but seems harmless, and could be fixed by
a future update to wrapGAppsHook.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

