### PR TITLE
sxiv: 24 -> 25

### DIFF
--- a/pkgs/applications/graphics/sxiv/default.nix
+++ b/pkgs/applications/graphics/sxiv/default.nix
@@ -3,14 +3,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "sxiv-${version}";
-  version = "24";
+  pname = "sxiv";
+  version = "25";
 
   src = fetchFromGitHub {
     owner = "muennich";
-    repo = "sxiv";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "020n1bdxbzqncprh8a4rnjzc4frp335yxbqh5w6dr970f7n5qm8d";
+    sha256 = "13s1lfar142hq1j7xld0ri616p4bqs57b17yr4d0b9a9w7liz4hp";
   };
 
   postUnpack = ''


### PR DESCRIPTION
> Support font fallback for missing glyphs
>
> Fix busy loop when built without inotify
>
> Use background/foreground colors from X resource database

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

