### PR TITLE
nixos/prometheus: add `ec2_sd_configs` section to `scrape_configs`

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -322,12 +322,19 @@ let
           The AWS Region.
         '';
       };
+      endpoint = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Custom endpoint to be used.
+        '';
+      };
       access_key = mkOption {
         type = types.nullOr types.str;
         default = null;
         description = ''
           The AWS API key id. If blank, the environment variable
-          `AWS_ACCESS_KEY_ID` is used.
+          <literal>AWS_ACCESS_KEY_ID</literal> is used.
         '';
       };
       secret_key = mkOption {
@@ -335,7 +342,7 @@ let
         default = null;
         description = ''
           The AWS API key secret. If blank, the environment variable
-          `AWS_SECRET_ACCESS_KEY` is used.
+           <literal>AWS_SECRET_ACCESS_KEY</literal> is used.
         '';
       };
       profile = mkOption {
@@ -366,6 +373,32 @@ let
           The port to scrape metrics from. If using the public IP
           address, this must instead be specified in the relabeling
           rule.
+        '';
+      };
+      filters = mkOption {
+        type = types.nullOr (types.listOf promTypes.filter);
+        default = null;
+        description = ''
+          Filters can be used optionally to filter the instance list by other criteria.
+        '';
+      };
+    };
+  };
+
+  promTypes.filter = types.submodule {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = ''
+          See <link xlink:href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html">this list</link>
+          for the available filters.
+        '';
+      };
+      value = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Value of the filter.
         '';
       };
     };
@@ -545,7 +578,6 @@ let
     };
   };
 
- 
 in {
   options = {
     services.prometheus = {

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -277,6 +277,14 @@ let
           List of labeled target groups for this job.
         '';
       };
+      ec2_sd_configs = mkOption {
+        type = types.listOf promTypes.ec2_sd_config;
+        default = [];
+        apply = x: map _filter x;
+        description = ''
+          List of EC2 service discovery configurations.
+        '';
+      };
       relabel_configs = mkOption {
         type = types.listOf promTypes.relabel_config;
         default = [];
@@ -301,6 +309,63 @@ let
         default = {};
         description = ''
           Labels assigned to all metrics scraped from the targets.
+        '';
+      };
+    };
+  };
+
+  promTypes.ec2_sd_config = types.submodule {
+    options = {
+      region = mkOption {
+        type = types.str;
+        description = ''
+          The AWS Region.
+        '';
+      };
+      access_key = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          The AWS API key id. If blank, the environment variable
+          `AWS_ACCESS_KEY_ID` is used.
+        '';
+      };
+      secret_key = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          The AWS API key secret. If blank, the environment variable
+          `AWS_SECRET_ACCESS_KEY` is used.
+        '';
+      };
+      profile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Named AWS profile used to connect to the API.
+        '';
+      };
+      role_arn = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          AWS Role ARN, an alternative to using AWS API keys.
+        '';
+      };
+      refresh_interval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Refresh interval to re-read the instance list.
+        '';
+      };
+      port = mkOption {
+        type = types.int;
+        default = 80;
+        description = ''
+          The port to scrape metrics from. If using the public IP
+          address, this must instead be specified in the relabeling
+          rule.
         '';
       };
     };


### PR DESCRIPTION
###### Motivation for this change

Prometheus's configuration in Nix is exhaustively specified. To use any of the various service discovery mechanisms they must be defined in the module. This adds definitions for the EC2 service discovery according to the [Prometheus Documentation for version 1.8][], matching the default value of `config.services.prometheus.package`.

Applies cleanly to 18.09 where I tested it, and is purely additive. If merged, I'd like it to be backported as well.

In the interests of not having to closely track upstream changes, would it be preferable to have an `extraConfigs` inside `scrapeConfigs`, that is merged as pure data? For example, if a user wants to use prometheus 2.6, it has a new option in the EC2 service discovery section called `filters`. As is, this is impossible(?) without updating this module again, but with an `extraConfigs` there's an escape.

[Prometheus Documentation for version 1.8]: https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#ec2_sd_config

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

