### PR TITLE
appimageTools: init

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -14,5 +14,6 @@
  <xi:include href="functions/fhs-environments.xml" />
  <xi:include href="functions/shell.xml" />
  <xi:include href="functions/dockertools.xml" />
+ <xi:include href="functions/appimagetools.xml" />
  <xi:include href="functions/prefer-remote-fetch.xml" />
 </chapter>

--- a/doc/functions/appimagetools.xml
+++ b/doc/functions/appimagetools.xml
@@ -1,0 +1,121 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xml:id="sec-pkgs-appimageTools">
+ <title>pkgs.appimageTools</title>
+
+ <para>
+   <varname>pkgs.appimageTools</varname> is a set of functions for extracting and wrapping
+   <link xlink:href="https://appimage.org/">AppImage</link> files.
+
+   They are meant to be used if traditional packaging from source is infeasible, or it would take too long.
+   To quickly run an AppImage file, <literal>pkgs.appimage-run</literal> can be used as well.
+ </para>
+
+ <warning>
+  <para>
+   The <varname>appimageTools</varname> API is unstable and may be subject to
+   backwards-incompatible changes in the future.
+  </para>
+ </warning>
+
+
+ <section xml:id="ssec-pkgs-appimageTools-formats">
+  <title>AppImage formats</title>
+
+  <para>
+   There are different formats for AppImages, see
+   <link xlink:href="https://github.com/AppImage/AppImageSpec/blob/74ad9ca2f94bf864a4a0dac1f369dd4f00bd1c28/draft.md#image-format">the specification</link> for details.
+  </para>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     Type 1 images are ISO 9660 files that are also ELF executables.
+    </para>
+   </listitem>
+
+   <listitem>
+    <para>
+     Type 2 images are ELF executables with an appended filesystem.
+    </para>
+   </listitem>
+  </itemizedlist>
+
+  <para>
+   They can be told apart with <command>file -k</command>:
+  </para>
+
+  <screen>
+<prompt>$ </prompt>file -k type1.AppImage
+type1.AppImage: ELF 64-bit LSB executable, x86-64, version 1 (SYSV) ISO 9660 CD-ROM filesystem data 'AppImage' (Lepton 3.x), scale 0-0,
+spot sensor temperature 0.000000, unit celsius, color scheme 0, calibration: offset 0.000000, slope 0.000000, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.18, BuildID[sha1]=d629f6099d2344ad82818172add1d38c5e11bc6d, stripped\012- data
+
+<prompt>$ </prompt>file -k type2.AppImage
+type2.AppImage: ELF 64-bit LSB executable, x86-64, version 1 (SYSV) (Lepton 3.x), scale 232-60668, spot sensor temperature -4.187500, color scheme 15, show scale bar, calibration: offset -0.000000, slope 0.000000 (Lepton 2.x), scale 4111-45000, spot sensor temperature 412442.250000, color scheme 3, minimum point enabled, calibration: offset -75402534979642766821519867692934234112.000000, slope 5815371847733706829839455140374904832.000000, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.18, BuildID[sha1]=79dcc4e55a61c293c5e19edbd8d65b202842579f, stripped\012- data
+  </screen>
+
+  <para>
+   Note how the type 1 AppImage is described as an <literal>ISO 9660 CD-ROM filesystem</literal>, and the type 2 AppImage is not.
+  </para>
+ </section>
+
+ <section xml:id="ssec-pkgs-appimageTools-wrapping">
+  <title>Wrapping</title>
+
+  <para>
+    Depending on the type of AppImage you're wrapping, you'll have to use
+    <varname>wrapType1</varname> or <varname>wrapType2</varname>.
+  </para>
+
+
+  <programlisting>
+appimageTools.wrapType2 { # or wrapType1
+  name = "patchwork"; <co xml:id='ex-appimageTools-wrapping-1' />
+  src = fetchurl { <co xml:id='ex-appimageTools-wrapping-2' />
+    url = https://github.com/ssbc/patchwork/releases/download/v3.11.4/Patchwork-3.11.4-linux-x86_64.AppImage;
+    sha256 =  "1blsprpkvm0ws9b96gb36f0rbf8f5jgmw4x6dsb1kswr4ysf591s";
+  };
+  extraPkgs = pkgs: with pkgs; [ ]; <co xml:id='ex-appimageTools-wrapping-3' />
+}</programlisting>
+
+
+  <calloutlist>
+   <callout arearefs='ex-appimageTools-wrapping-1'>
+    <para>
+     <varname>name</varname> specifies the name of the resulting image.
+    </para>
+   </callout>
+   <callout arearefs='ex-appimageTools-wrapping-2'>
+    <para>
+     <varname>src</varname> specifies the AppImage file to extract.
+    </para>
+   </callout>
+   <callout arearefs='ex-appimageTools-wrapping-2'>
+    <para>
+      <varname>extraPkgs</varname> allows you to pass a function to include additional packages
+      inside the FHS environment your AppImage is going to run in.
+
+      There are a few ways to learn which dependencies an application needs:
+
+      <itemizedlist>
+       <listitem>
+        <para>
+         Looking through the extracted AppImage files, reading its scripts and running <command>patchelf</command> and <command>ldd</command> on its executables.
+         This can also be done in <command>appimage-run</command>, by setting <command>APPIMAGE_DEBUG_EXEC=bash</command>.
+        </para>
+       </listitem>
+
+       <listitem>
+        <para>
+         Running <command>strace -vfefile</command> on the wrapped executable, looking for libraries that can't be found.
+        </para>
+       </listitem>
+      </itemizedlist>
+
+    </para>
+   </callout>
+  </calloutlist>
+
+ </section>
+</section>

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -1,0 +1,176 @@
+{ pkgs, stdenv, libarchive, patchelf, zlib, buildFHSUserEnv, writeScript }:
+
+rec {
+  # Both extraction functions could be unified, but then
+  # it would depend on libmagic to correctly identify ISO 9660s
+
+  extractType1 = { name, src }: stdenv.mkDerivation {
+    name = "${name}-extracted";
+    inherit src;
+
+    nativeBuildInputs = [ libarchive ];
+    buildCommand = ''
+      mkdir $out
+      bsdtar -x -C $out -f $src
+    '';
+  };
+
+  extractType2 = { name, src }: stdenv.mkDerivation {
+    name = "${name}-extracted";
+    inherit src;
+
+    nativeBuildInputs = [ patchelf ];
+    buildCommand = ''
+      install $src ./appimage
+      patchelf \
+        --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+        --replace-needed libz.so.1 ${zlib}/lib/libz.so.1 \
+        ./appimage
+
+      ./appimage --appimage-extract
+
+      cp -rv squashfs-root $out
+    '';
+  };
+
+  wrapAppImage = { name, src, extraPkgs }: buildFHSUserEnv (defaultFhsEnvArgs // {
+    inherit name;
+
+    targetPkgs = pkgs: defaultFhsEnvArgs.targetPkgs pkgs ++ extraPkgs pkgs;
+
+    runScript = writeScript "run" ''
+      #!${stdenv.shell}
+
+      export APPDIR=${src}
+      export APPIMAGE_SILENT_INSTALL=1
+      cd $APPDIR
+      exec ./AppRun "$@"
+    '';
+  });
+
+  wrapType1 = args@{ name, src, extraPkgs ? pkgs: [] }: wrapAppImage {
+    inherit name extraPkgs;
+    src = extractType1 { inherit name src; };
+  };
+
+  wrapType2 = args@{ name, src, extraPkgs ? pkgs: [] }: wrapAppImage {
+    inherit name extraPkgs;
+    src = extractType2 { inherit name src; };
+  };
+
+  defaultFhsEnvArgs = {
+    name = "appimage-env";
+
+    # Most of the packages were taken from the Steam chroot
+    targetPkgs = pkgs: with pkgs; [
+      gtk3
+      bashInteractive
+      gnome3.zenity
+      python2
+      xorg.xrandr
+      which
+      perl
+      xdg_utils
+      iana-etc
+      krb5
+    ];
+
+    multiPkgs = pkgs: with pkgs; [
+      desktop-file-utils
+      xorg.libXcomposite
+      xorg.libXtst
+      xorg.libXrandr
+      xorg.libXext
+      xorg.libX11
+      xorg.libXfixes
+      libGL
+
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-ugly
+      libdrm
+      xorg.xkeyboardconfig
+      xorg.libpciaccess
+
+      glib
+      gtk2
+      bzip2
+      zlib
+      gdk_pixbuf
+
+      xorg.libXinerama
+      xorg.libXdamage
+      xorg.libXcursor
+      xorg.libXrender
+      xorg.libXScrnSaver
+      xorg.libXxf86vm
+      xorg.libXi
+      xorg.libSM
+      xorg.libICE
+      gnome2.GConf
+      freetype
+      (curl.override { gnutlsSupport = true; sslSupport = false; })
+      nspr
+      nss
+      fontconfig
+      cairo
+      pango
+      expat
+      dbus
+      cups
+      libcap
+      SDL2
+      libusb1
+      udev
+      dbus-glib
+      libav
+      atk
+      at-spi2-atk
+      libudev0-shim
+      networkmanager098
+
+      xorg.libXt
+      xorg.libXmu
+      xorg.libxcb
+      libGLU
+      libuuid
+      libogg
+      libvorbis
+      SDL
+      SDL2_image
+      glew110
+      openssl
+      libidn
+      tbb
+      wayland
+      mesa_noglu
+      libxkbcommon
+
+      flac
+      freeglut
+      libjpeg
+      libpng12
+      libsamplerate
+      libmikmod
+      libtheora
+      libtiff
+      pixman
+      speex
+      SDL_image
+      SDL_ttf
+      SDL_mixer
+      SDL2_ttf
+      SDL2_mixer
+      gstreamer
+      gst-plugins-base
+      libappindicator-gtk2
+      libcaca
+      libcanberra
+      libgcrypt
+      libvpx
+      librsvg
+      xorg.libXft
+      libvdpau
+      alsaLib
+    ];
+  };
+}

--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -1,120 +1,12 @@
 { stdenv, writeScript, buildFHSUserEnv, coreutils, file, libarchive
-, extraPkgs ? pkgs: [] }:
+, extraPkgs ? pkgs: [], appimageTools }:
 
-buildFHSUserEnv {
+let
+  fhsArgs = appimageTools.defaultFhsEnvArgs;
+in buildFHSUserEnv (fhsArgs // {
   name = "appimage-run";
 
-  # Most of the packages were taken from the Steam chroot
-  targetPkgs = pkgs: with pkgs; [
-    gtk3
-    bashInteractive
-    gnome3.zenity
-    python2
-    xorg.xrandr
-    which
-    perl
-    xdg_utils
-    iana-etc
-  ] ++ extraPkgs pkgs;
-
-  multiPkgs = pkgs: with pkgs; [
-    desktop-file-utils
-    xorg.libXcomposite
-    xorg.libXtst
-    xorg.libXrandr
-    xorg.libXext
-    xorg.libX11
-    xorg.libXfixes
-    libGL
-
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-ugly
-    libdrm
-    xorg.xkeyboardconfig
-    xorg.libpciaccess
-
-    glib
-    gtk2
-    bzip2
-    zlib
-    gdk_pixbuf
-
-    xorg.libXinerama
-    xorg.libXdamage
-    xorg.libXcursor
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libXxf86vm
-    xorg.libXi
-    xorg.libSM
-    xorg.libICE
-    gnome2.GConf
-    freetype
-    (curl.override { gnutlsSupport = true; sslSupport = false; })
-    nspr
-    nss
-    fontconfig
-    cairo
-    pango
-    expat
-    dbus
-    cups
-    libcap
-    SDL2
-    libusb1
-    udev
-    dbus-glib
-    libav
-    atk
-    at-spi2-atk
-    libudev0-shim
-    networkmanager098
-
-    xorg.libXt
-    xorg.libXmu
-    xorg.libxcb
-    libGLU
-    libuuid
-    libogg
-    libvorbis
-    SDL
-    SDL2_image
-    glew110
-    openssl
-    libidn
-    tbb
-    wayland
-    mesa_noglu
-    libxkbcommon
-
-    flac
-    freeglut
-    libjpeg
-    libpng12
-    libsamplerate
-    libmikmod
-    libtheora
-    libtiff
-    pixman
-    speex
-    SDL_image
-    SDL_ttf
-    SDL_mixer
-    SDL2_ttf
-    SDL2_mixer
-    gstreamer
-    gst-plugins-base
-    libappindicator-gtk2
-    libcaca
-    libcanberra
-    libgcrypt
-    libvpx
-    librsvg
-    xorg.libXft
-    libvdpau
-    alsaLib
-    strace
-  ];
+  targetPkgs = pkgs: fhsArgs.targetPkgs pkgs ++ extraPkgs pkgs;
 
   runScript = writeScript "appimage-exec" ''
     #!${stdenv.shell}
@@ -153,4 +45,4 @@ buildFHSUserEnv {
 
     exec ./AppRun
   '';
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -105,6 +105,8 @@ in
   autoPatchelfHook = makeSetupHook { name = "auto-patchelf-hook"; }
     ../build-support/setup-hooks/auto-patchelf.sh;
 
+  appimageTools = callPackage ../build-support/appimage { };
+
   ensureNewerSourcesHook = { year }: makeSetupHook {}
     (writeScript "ensure-newer-sources-hook.sh" ''
       postUnpackHooks+=(_ensureNewerSources)


### PR DESCRIPTION
###### Motivation for this change

The appimageTools attrset contains utilities to prevent
the usage of appimage-run to package AppImages, like done/attempted
in #49370 and #53156.

This has the advantage of allowing for per-package environment changes,
and extracts into the store instead of the users home directory.

The package list was extracted into appimageTools to prevent
duplication.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

