### PR TITLE
standardnotes: use appimageTools instead of appimage-run

### DIFF
--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, appimage-run, fetchurl, runtimeShell }:
+{ stdenv, appimageTools, fetchurl }:
 
 let
   version = "3.0.6";
@@ -12,9 +12,7 @@ let
     "i386-linux" = "0czhlbacjks9x8y2w46nzlvk595psqhqw0vl0bvsq7sz768dk0ni";
     "x86_64-linux" = "0haji9h8rrm9yvqdv6i2y6xdd0yhsssjjj83hmf6cb868lwyigsf";
   }.${stdenv.hostPlatform.system};
-in
-
-stdenv.mkDerivation rec {
+in appimageTools.wrapType2 rec {
   name = "standardnotes-${version}";
 
   src = fetchurl {
@@ -22,17 +20,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  buildInputs = [ appimage-run ];
-
-  unpackPhase = ":";
-
-  installPhase = ''
-    mkdir -p $out/{bin,share}
-    cp $src $out/share/standardNotes.AppImage
-    echo "#!${runtimeShell}" > $out/bin/standardnotes
-    echo "${appimage-run}/bin/appimage-run $out/share/standardNotes.AppImage" >> $out/bin/standardnotes
-    chmod +x $out/bin/standardnotes $out/share/standardNotes.AppImage
-  '';
+  extraInstallCommands = "ln -s $out/bin/${name} $out/bin/standardnotes";
 
   meta = with stdenv.lib; {
     description = "A simple and private notes app";


### PR DESCRIPTION
Includes #54693 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

