### PR TITLE
exa: 0.8.0 -> 2019-01-26

### DIFF
--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -6,15 +6,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "exa-${version}";
-  version = "0.8.0";
+  version = "2019-01-26";
 
-  cargoSha256 = "08zzn3a32xfjkmpawcjppn1mr26ws3iv40cckiz8ldz4qc8y9gdh";
+  cargoSha256 = "1kv4g31cl6x68nigxg38iixm4gjfj9x27zyjlfpaf5jx6lkwda44";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = "exa";
-    rev = "v${version}";
-    sha256 = "0jy11a3xfnfnmyw1kjmv4ffavhijs8c940kw24vafklnacx5n88m";
+    rev = "058b4a57bdb1e25cbdacc0fbd1eefc09bc5f1e95";
+    sha256 = "17rj4cavmj3r75296p4m907wccd9gwl95488i62lddy5j1xxm927";
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];


### PR DESCRIPTION
###### Motivation for this change
`exa` has not had a release in more than a year, but the master branch seems stable. A new release has been requested (https://github.com/ogham/exa/issues/441) but still not here.
This updates `exa` to the latest master version.
Ping maintainer @ehegnes if you think this is legitimate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

