### PR TITLE
qownnotes: init at 19.1.8

### DIFF
--- a/pkgs/applications/office/qownnotes/default.nix
+++ b/pkgs/applications/office/qownnotes/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, qmake, qttools, qtbase, qtsvg, qttranslations, qtdeclarative, qtxmlpatterns, qtwayland, qtwebsockets }:
+
+stdenv.mkDerivation rec {
+  pname = "qownnotes";
+  version = "19.1.8";
+
+  src = fetchurl {
+    url = "https://download.tuxfamily.org/${pname}/src/${pname}-${version}.tar.xz";
+    # Can grab official version like so:
+    # $ curl https://download.tuxfamily.org/qownnotes/src/qownnotes-19.1.8.tar.xz.sha256
+    sha256 = "873ed9e3a711bc19744a13b98ac5cb3659bd97e753c7e089fbc49bd044cec4fb";
+  };
+
+  nativeBuildInputs = [ qmake qttools ];
+  buildInputs = [
+    qtbase qtsvg qtdeclarative qtxmlpatterns qtwebsockets
+  ] ++ stdenv.lib.optional stdenv.isLinux qtwayland;
+
+  meta = with stdenv.lib; {
+    description = "Plain-text file notepad and todo-list manager with markdown support and ownCloud / Nextcloud integration";
+
+    homepage = https://www.qownnotes.org/;
+    platforms = platforms.all;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5011,6 +5011,8 @@ in
 
   qjoypad = callPackage ../tools/misc/qjoypad { };
 
+  qownnotes = libsForQt5.callPackage ../applications/office/qownnotes { };
+
   qpdf = callPackage ../development/libraries/qpdf { };
 
   qprint = callPackage ../tools/text/qprint { };


### PR DESCRIPTION
###### Motivation for this change



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---