### PR TITLE
fontconfig: fix FC_ARCHITECTURE to match use elsewhere

### DIFF
--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -1,8 +1,11 @@
 { stdenv, fetchurl, pkgconfig, freetype, expat
 }:
-
+let
+  FC_ARCHITECTURE = import ./fc-arch.nix { platform = stdenv.hostPlatform; };
+in
 stdenv.mkDerivation rec {
-  name = "fontconfig-2.10.2";
+  name = "fontconfig-${version}";
+  version = "2.10.2";
 
   src = fetchurl {
     url = "http://fontconfig.org/release/${name}.tar.bz2";
@@ -16,13 +19,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ expat ];
 
   configureFlags = [
-    "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
+    "--with-arch=${FC_ARCHITECTURE}"
     "--sysconfdir=/etc"
     "--with-cache-dir=/var/cache/fontconfig"
     "--disable-docs"
     "--with-default-fonts="
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -15,6 +15,7 @@
 
 let
   configVersion = "2.11"; # bump whenever fontconfig breaks compatibility with older configurations
+  FC_ARCHITECTURE = import ./fc-arch.nix { platform = stdenv.hostPlatform; };
 in
 stdenv.mkDerivation rec {
   name = "fontconfig-${version}";
@@ -39,13 +40,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ expat ];
 
   configureFlags = [
-    "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
+    "--with-arch=${FC_ARCHITECTURE}"
     "--with-cache-dir=/var/cache/fontconfig" # otherwise the fallback is in $out/
     "--disable-docs"
     # just <1MB; this is what you get when loading config fails for some reason
     "--with-default-fonts=${dejavu_fonts.minimal}"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/fontconfig/fc-arch.nix
+++ b/pkgs/development/libraries/fontconfig/fc-arch.nix
@@ -1,0 +1,36 @@
+{ platform }:
+
+## commit 1845f3100d15927cc536bc3d38f140c139fb5614
+## Author: Behdad Esfahbod <behdad@behdad.org>
+## Date:   Wed Nov 18 14:39:34 2009 -0500
+## 
+##     [fc-arch] Rename architecture names to better reflect what they are
+## 
+##     We only care about three properties in the arch:
+## 
+##       - endianness
+##       - pointer size
+##       - for 32-bit archs, whether double is aligned on 4 or 8 bytes
+## 
+##     This leads to the following 6 archs (old name -> new name):
+## 
+##             x86    -> le32d4
+##             mipsel -> le32d8
+##             x86-64 -> le64
+##             m68k   -> be32d4
+##             ppc    -> be32d8
+##             ppc64  -> be64
+
+
+# TODO: Handle double alignment
+
+let
+  cpu = platform.parsed.cpu;
+  endian = {
+    littleEndian = "le";
+    bigEndian = "be";
+  }."${cpu.significantByte.name}" or (throw "unhandled endianness");
+  FC_ARCHITECTURE = endian + (toString cpu.bits);
+
+in
+  FC_ARCHITECTURE


### PR DESCRIPTION
As-is we force it to be something like "x86_64"
instead of "le64" generally used on this platform.

This causes our software to interact badly with software
using the other (default!) values.
Small bonus: all le64 platforms can use same cache, maybe.


###### Motivation for this change

I'm not sure this was ever intended to be set twice (!)
as we presently are doing, looks like unintended result
of merging in some simplifications re:crossAttrs usage?

Anyway, cross or not, lets set this to the same values
the rest of the Linux world uses so we interop better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---