### PR TITLE
pythonPackages.moderngl: init at 5.5.0

### DIFF
--- a/pkgs/development/python-modules/moderngl/default.nix
+++ b/pkgs/development/python-modules/moderngl/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, libGL
+, libX11
+}:
+
+buildPythonPackage rec {
+  pname = "moderngl";
+  version = "5.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0x8xblc3zybp7jw9cscpm4r5pmmilj9l4yi1rkxyf0y80kchlxq4";
+  };
+
+  disabled = !isPy3k;
+
+  buildInputs = [ libGL libX11 ];
+
+  # Tests need a display to run.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/cprogrammer1994/ModernGL;
+    description = "High performance rendering for Python 3";
+    license = licenses.mit;
+    platforms = platforms.linux; # should be mesaPlatforms, darwin build breaks.
+    maintainers = with maintainers; [ c0deaddict ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3068,6 +3068,8 @@ in {
 
   mockito = callPackage ../development/python-modules/mockito { };
 
+  moderngl = callPackage ../development/python-modules/moderngl { };
+
   modestmaps = callPackage ../development/python-modules/modestmaps { };
 
   # Needed here because moinmoin is loaded as a Python library.


### PR DESCRIPTION
###### Motivation for this change

Library is missing from Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

