### PR TITLE
birdfont: init at 2.25.0 (and add dep xmlbird)

### DIFF
--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, pkgconfig, python3, xmlbird,
+cairo, gdk_pixbuf, libgee, glib, gtk3, webkitgtk, libnotify, sqlite, vala,
+gobject-introspection, gsettings-desktop-schemas, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "birdfont";
+  version = "2.25.0";
+
+  src = fetchurl {
+    url = "https://birdfont.org/releases/${pname}-${version}.tar.xz";
+    sha256 = "0fi86km9iaxs9b8lqz81079vppzp346kqiqk44vk45dclr5r6x22";
+  };
+
+  nativeBuildInputs = [ python3 pkgconfig vala gobject-introspection wrapGAppsHook ];
+  buildInputs = [ xmlbird libgee cairo gdk_pixbuf glib gtk3 webkitgtk libnotify sqlite gsettings-desktop-schemas ];
+
+  postPatch = "patchShebangs .";
+
+  buildPhase = "./build.py";
+
+  installPhase = "./install.py";
+}

--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -19,4 +19,11 @@ stdenv.mkDerivation rec {
   buildPhase = "./build.py";
 
   installPhase = "./install.py";
+
+  meta = with stdenv.lib; {
+    description = "Font editor which can generate fonts in TTF, EOT, SVG and BIRDFONT format";
+    homepage = https://birdfont.org;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
 }

--- a/pkgs/tools/misc/birdfont/xmlbird.nix
+++ b/pkgs/tools/misc/birdfont/xmlbird.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, python3, pkgconfig, vala, glib, gobject-introspection }:
+
+stdenv.mkDerivation rec {
+  pname = "xmlbird";
+  version = "1.2.10";
+
+  src = fetchurl {
+    url = "https://birdfont.org/${pname}-releases/lib${pname}-${version}.tar.xz";
+    sha256 = "0qpqpqqd4wj711jzczfsr38fgcz1rzxchrqbssxnan659ycd9c78";
+  };
+
+  nativeBuildInputs = [ python3 pkgconfig vala gobject-introspection ];
+
+  buildInputs = [ glib ];
+
+  postPatch = "patchShebangs .";
+
+  buildPhase = "./build.py";
+
+  installPhase = "./install.py";
+}

--- a/pkgs/tools/misc/birdfont/xmlbird.nix
+++ b/pkgs/tools/misc/birdfont/xmlbird.nix
@@ -18,4 +18,11 @@ stdenv.mkDerivation rec {
   buildPhase = "./build.py";
 
   installPhase = "./install.py";
+
+  meta = with stdenv.lib; {
+    description = "XML parser for Vala and C programs";
+    homepage = https://birdfont.org/xmlbird.php;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1733,6 +1733,9 @@ in
 
   biber = callPackage ../tools/typesetting/biber { };
 
+  birdfont = callPackage ../tools/misc/birdfont { };
+  xmlbird = callPackage ../tools/misc/birdfont/xmlbird.nix { };
+
   blastem = callPackage ../misc/emulators/blastem {
     inherit (python27Packages) pillow;
   };


### PR DESCRIPTION
###### Motivation for this change

Haven't used it much but seems to work properly :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---