### PR TITLE
linux_testing_bcachefs,bcachefs-tools: 20190123

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,13 +1,13 @@
 { stdenv, buildPackages, fetchgit, perl, buildLinux, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.18.2018.10.12";
-  modDirVersion = "4.18.0";
+  version = "4.20.2019.01.23";
+  modDirVersion = "4.20.0";
 
   src = fetchgit {
     url = "https://evilpiepirate.org/git/bcachefs.git";
-    rev = "d7f6da1d60ec24266301231538ff6f09716537ed";
-    sha256 = "05d7dh41nc35www8vmrn47wlf2mr2b8i4rm15vq3zgm32d0xv3lk";
+    rev = "99750eab4d583132cf61f071082c7cf21f5295c0";
+    sha256 = "05wg9w5f68qg02yrciir9h1wx448869763hg3w7j23wc2qywhwqb";
   };
 
   extraConfig = "BCACHEFS_FS m";

--- a/pkgs/tools/filesystems/bcachefs-tools/default.nix
+++ b/pkgs/tools/filesystems/bcachefs-tools/default.nix
@@ -3,19 +3,19 @@
 
 stdenv.mkDerivation rec {
   pname = "bcachefs-tools";
-  version = "2019-01-13";
+  version = "2019-01-23";
 
   src = fetchgit {
     url = "https://evilpiepirate.org/git/bcachefs-tools.git";
-    rev = "47bd483d27ec13418978b24ec5951661d564ba35";
-    sha256 = "0h0mi68f8hxjplh0f8yw9h1ax9y6cz9c9hlvl95nqhs352lkdrfj";
+    rev = "35fca2f044d375b1590f499cfd34bef38ca0f8f1";
+    sha256 = "1mmpwksszdi4n7zv3fm7qnmfk94m56d65lfw30553bnfm3yaz3k7";
   };
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ attr libuuid libscrypt libsodium keyutils liburcu zlib libaio zstd lz4 ];
   installFlags = [ "PREFIX=${placeholder "out"}" ];
-  
+
   preInstall = ''
     substituteInPlace Makefile \
       --replace "INITRAMFS_DIR=/etc/initramfs-tools" \


### PR DESCRIPTION
###### Motivation for this change
Turns out the version have to be in sync in order for `mount -t bcachefs` to work, sad 2 days. `bcachefs format --encrypted` is still broken so yeah.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

