### PR TITLE
linux: Convert hardened config to structured config

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -7,142 +7,60 @@
 # flexibility.
 #
 # See also <nixos/modules/profiles/hardened.nix>
-
 { stdenv, version }:
 
 with stdenv.lib;
 
-assert (versionAtLeast version "4.9");
+with import ../../../../lib/kernel.nix { inherit (stdenv) lib; inherit version; };
 
-''
-# Report BUG() conditions and kill the offending process.
-BUG y
-
-${optionalString (versionAtLeast version "4.10") ''
-  BUG_ON_DATA_CORRUPTION y
-''}
-
-${optionalString (stdenv.hostPlatform.platform.kernelArch == "x86_64") ''
-  DEFAULT_MMAP_MIN_ADDR 65536 # Prevent allocation of first 64K of memory
-
-  # Reduce attack surface by disabling various emulations
-  IA32_EMULATION n
-  X86_X32 n
-  # Note: this config depends on EXPERT y and so will not take effect, hence
-  # it is left "optional" for now.
-  MODIFY_LDT_SYSCALL? n
-
-  VMAP_STACK y # Catch kernel stack overflows
-
-  # Randomize position of kernel and memory.
-  RANDOMIZE_BASE y
-  RANDOMIZE_MEMORY y
-
-  # Disable legacy virtual syscalls by default (modern glibc use vDSO instead).
-  #
-  # Note that the vanilla default is to *emulate* the legacy vsyscall mechanism,
-  # which is supposed to be safer than the native variant (wrt. ret2libc), so
-  # disabling it mainly helps reduce surface.
-  LEGACY_VSYSCALL_NONE y
-''}
-
-# Safer page access permissions (wrt. code injection).  Default on >=4.11.
-${optionalString (versionOlder version "4.11") ''
-  DEBUG_RODATA y
-  DEBUG_SET_MODULE_RONX y
-''}
-
-# Mark LSM hooks read-only after init.  SECURITY_WRITABLE_HOOKS n
-# conflicts with SECURITY_SELINUX_DISABLE y; disabling the latter
-# implicitly marks LSM hooks read-only after init.
-#
-# SELinux can only be disabled at boot via selinux=0
-#
-# We set SECURITY_WRITABLE_HOOKS n primarily for documentation purposes; the
-# config builder fails to detect that it has indeed been unset.
-${optionalString (versionAtLeast version "4.12") ''
-  SECURITY_SELINUX_DISABLE n
-  SECURITY_WRITABLE_HOOKS? n
-''}
-
-DEBUG_WX y # boot-time warning on RWX mappings
-${optionalString (versionAtLeast version "4.11") ''
-  STRICT_KERNEL_RWX y
-''}
-
-# Stricter /dev/mem
-STRICT_DEVMEM? y
-IO_STRICT_DEVMEM? y
-
-# Perform additional validation of commonly targeted structures.
-DEBUG_CREDENTIALS y
-DEBUG_NOTIFIERS y
-DEBUG_LIST y
-DEBUG_PI_LIST y # doesn't BUG()
-DEBUG_SG y
-SCHED_STACK_END_CHECK y
-
-${optionalString (versionAtLeast version "4.13") ''
-  REFCOUNT_FULL y
-''}
-
-# Perform usercopy bounds checking.
-HARDENED_USERCOPY y
-${optionalString (versionAtLeast version "4.16") ''
-  HARDENED_USERCOPY_FALLBACK n  # for full whitelist enforcement
-''}
-
-# Randomize allocator freelists.
-SLAB_FREELIST_RANDOM y
-
-${optionalString (versionAtLeast version "4.14") ''
-  SLAB_FREELIST_HARDENED y
-''}
-
-# Allow enabling slub/slab free poisoning with slub_debug=P
-SLUB_DEBUG y
-
-# Wipe higher-level memory allocations on free() with page_poison=1
-PAGE_POISONING y
-PAGE_POISONING_NO_SANITY y
-PAGE_POISONING_ZERO y
-
-# Reboot devices immediately if kernel experiences an Oops.
-PANIC_ON_OOPS y
-PANIC_TIMEOUT -1
-
-GCC_PLUGINS y # Enable gcc plugin options
-# Gather additional entropy at boot time for systems that may not have appropriate entropy sources.
-GCC_PLUGIN_LATENT_ENTROPY y
-
-${optionalString (versionAtLeast version "4.11") ''
-  GCC_PLUGIN_STRUCTLEAK y # A port of the PaX structleak plugin
-''}
-${optionalString (versionAtLeast version "4.14") ''
-  GCC_PLUGIN_STRUCTLEAK_BYREF_ALL y # Also cover structs passed by address
-''}
-${optionalString (versionAtLeast version "4.20") ''
-  GCC_PLUGIN_STACKLEAK y # A port of the PaX stackleak plugin
-''}
-
-${optionalString (versionAtLeast version "4.13") ''
-  GCC_PLUGIN_RANDSTRUCT y # A port of the PaX randstruct plugin
-  GCC_PLUGIN_RANDSTRUCT_PERFORMANCE y
-''}
-
-# Disable various dangerous settings
-ACPI_CUSTOM_METHOD n # Allows writing directly to physical memory
-PROC_KCORE n # Exposes kernel text image layout
-INET_DIAG n # Has been used for heap based attacks in the past
-
-# Use -fstack-protector-strong (gcc 4.9+) for best stack canary coverage.
-${optionalString (versionOlder version "4.18") ''
-  CC_STACKPROTECTOR_REGULAR n
-  CC_STACKPROTECTOR_STRONG y
-''}
-
-# Enable compile/run-time buffer overflow detection ala glibc's _FORTIFY_SOURCE
-${optionalString (versionAtLeast version "4.13") ''
-  FORTIFY_SOURCE y
-''}
-''
+{
+  ACPI_CUSTOM_METHOD                    = no;
+  BUG                                   = yes;
+  BUG_ON_DATA_CORRUPTION                = whenAtLeast "4.10" yes;
+  CC_STACKPROTECTOR_REGULAR             = whenOlder "4.18" no;
+  CC_STACKPROTECTOR_STONG               = whenOlder "4.18" yes;
+  DEBUG_CREDENTIALS                     = yes;
+  DEBUG_LIST                            = yes;
+  DEBUG_NOTIFIERS                       = yes;
+  DEBUG_PI_LIST                         = yes;
+  DEBUG_RODATA                          = whenOlder "4.11" yes;
+  DEBUG_SET_MODULE_RONX                 = whenOlder "4.11" yes;
+  DEBUG_SG                              = yes;
+  DEBUG_WX                              = yes;
+  FORTIFY_SOURCE                        = whenAtLeast "4.13" yes;
+  GCC_PLUGINS                           = yes;
+  GCC_PLUGIN_LATENT_ENTROPY             = yes;
+  GCC_PLUGIN_RANDSTRUCT                 = whenAtLeast "4.13" yes;
+  GCC_PLUGIN_RANDSTRUCT_PERFORMANCE     = whenAtLeast "4.13" yes;
+  GCC_PLUGIN_STACKLEAK                  = whenAtLeast "4.20" yes;
+  GCC_PLUGIN_STRUCTLEAK                 = whenAtLeast "4.11" yes;
+  GCC_PLUGIN_STRUCTLEAK_BYREF_ALL       = whenAtLeast "4.14" yes;
+  HARDENED_USERCOPY                     = yes;
+  HARDENED_USERCOPY_FALLBACK            = whenAtLeast "4.16" yes;
+  INET_DIAG                             = no;
+  IO_STRICT_DEVMEM                      = option yes;
+  PAGE_POISONING                        = yes;
+  PAGE_POISONING_NO_SANITY              = yes;
+  PAGE_POISONING_ZERO                   = yes;
+  PANIC_ON_OOPS                         = yes;
+  PANIC_TIMEOUT                         = "-1";
+  PROC_KCORE                            = no;
+  REFCOUNT_FULL                         = whenAtLeast "4.13" yes;
+  SCHED_STACK_END_CHECK                 = yes;
+  SECURITY_SELINUX_DISABLE              = no;
+  SECURITY_WRITABLE_HOOKS               = option no;
+  SLAB_FREELIST_HARDENED                = whenAtLeast "4.14" yes;
+  SLAB_FREELIST_RANDOM                  = yes;
+  SLUB_DEBUG                            = yes;
+  STRICT_DEVMEM                         = option yes;
+  STRICT_KERNEL_RWX                     = whenAtLeast "4.11" yes;
+} // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
+  DEFAULT_MMAP_MIN_ADDR                 = "65536"; # Prevent allocation of first 64k of memory
+  IA32_EMULATION                        = no;
+  LEGACY_VSYSCALL_NONE                  = yes;
+  MODIFY_LDT_SYSCALL                    = option no;
+  RANDOMIZE_BASE                        = yes;
+  RANDOMIZE_MEMORY                      = yes;
+  X86_X32                               = no;
+  VMAP_STACK                            = yes;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14756,7 +14756,7 @@ in
   # Hardened linux
   hardenedLinuxPackagesFor = kernel: linuxPackagesFor (kernel.override {
     features.ia32Emulation = false;
-    extraConfig = import ../os-specific/linux/kernel/hardened-config.nix {
+    structuredExtraConfig = import ../os-specific/linux/kernel/hardened-config.nix {
       inherit stdenv;
       inherit (kernel) version;
     };


### PR DESCRIPTION
###### Motivation for this change
Modernize hardened config, making it more user/maintenance friendly

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

