### PR TITLE
pybind11: 2.2.2 -> 2.2.4

### DIFF
--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -1,23 +1,29 @@
-{ stdenv, fetchFromGitHub, cmake, python }:
+{ stdenv, fetchFromGitHub, cmake, catch, python, eigen }:
 
 stdenv.mkDerivation rec {
   name = "pybind-${version}";
-  version = "2.2.2";
+  version = "2.2.4";
+
   src = fetchFromGitHub {
     owner = "pybind";
     repo = "pybind11";
     rev = "v${version}";
-    sha256 = "0x71i1n5d02hjbdcnkscrwxs9pb8kplmdpqddhsimabfp84fip48";
+    sha256 = "0pa79ymcasv8br5ifbx7878id5py2jpjac3i20cqxr6gs9l6ivlv";
   };
 
   nativeBuildInputs = [ cmake ];
+  checkInputs = with python.pkgs; [ catch eigen pytest numpy scipy ];
 
-  # disable tests as some tests (test_embed/test_interpreter) are failing at the moment
-  cmakeFlags = [
-     "-DPYTHON_EXECUTABLE=${python.interpreter}"
-     "-DPYBIND11_TEST=0"
+  # Disable test_cmake_build test, as it fails in sandbox
+  # https://github.com/pybind/pybind11/issues/1355
+  patches = [ ./no_test_cmake_build.patch ];
+
+  doCheck = true;
+
+  cmakeFlags = [ 
+    "-DPYTHON_EXECUTABLE=${python.interpreter}" 
+    "-DPYBIND11_TEST=${if doCheck then "ON" else "OFF"}"
   ];
-  doCheck = false;
 
   meta = {
     homepage = https://github.com/pybind/pybind11;
@@ -31,5 +37,4 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ yuriaisaka ];
   };
-
 }

--- a/pkgs/development/libraries/pybind11/no_test_cmake_build.patch
+++ b/pkgs/development/libraries/pybind11/no_test_cmake_build.patch
@@ -1,0 +1,7 @@
+--- a/tests/CMakeLists.txt	2019-01-28 14:13:55.822119328 +0100
++++ b/tests/CMakeLists.txt	2019-01-28 14:14:06.741161928 +0100
+@@ -233,4 +233,3 @@
+ add_subdirectory(test_embed)
+ 
+ # Test CMake build using functions and targets from subdirectory or installed location
+-add_subdirectory(test_cmake_build)


### PR DESCRIPTION
###### Motivation for this change

Update pybind11 to latest release.

Also enable the included test suite again, apart from mock install based test_cmake_build test, which always fails.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

