### PR TITLE
make-derivation: fix position in trace

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -28,7 +28,7 @@ let params =
       propagatedBuildInputs = [ coq-ext-lib simple-io ];
     };
   };
-  param = params."${coq.coq-version}";
+  param = params."${coq.coq-version}" or params."8.8";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/Velisarios/default.nix
+++ b/pkgs/development/coq-modules/Velisarios/default.nix
@@ -20,7 +20,7 @@ let params =
       sha256 = "0l9885nxy0n955fj1gnijlxl55lyxiv9yjfmz8hmfrn9hl8vv1m2";
     };
   };
-  param = params."${coq.coq-version}";
+  param = params."${coq.coq-version}" or params."8.8";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -18,7 +18,7 @@ let
     "8.7" = v20180709;
     "8.8" = v20181016;
   };
-  param = params."${coq.coq-version}";
+  param = params."${coq.coq-version}" or params."8.8";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -26,7 +26,7 @@ let params =
       sha256 = "09dq1vvshhlhgjccrhqgbhnq2hrys15xryfszqq11rzpgvl2zgdv";
     };
   };
-  param = params."${coq.coq-version}";
+  param = params."${coq.coq-version}" or params."8.8";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -14,7 +14,7 @@ let params =
     "8.8" = v_8_8;
     "8.9" = v_8_8;
     };
-  param = params."${coq.coq-version}"
+  param = params."${coq.coq-version}" or params."8.9"
 ; in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -22,7 +22,7 @@ let params = {
     sha256 = "0qvar8gfbrcs9fmvkph5asqz4l5fi63caykx3bsn8zf0xllkwv0n";
   };
 };
-param = params."${coq.coq-version}";
+param = params."${coq.coq-version}" or params."8.8";
 in
 
 stdenv.mkDerivation {

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -20,7 +20,7 @@ let
       sha256 = "0dd7zd5j2sv5cw3mfwg33ss2vcj634q3qykakc41sv7f3rfgqfnn";
     };
   };
-  param = params."${coq.coq-version}";
+  param = params."${coq.coq-version}" or params."8.8";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -21,6 +21,6 @@ in stdenv.mkDerivation {
   patches = [ ./osvi.patch ];
 
   meta = {
-    platforms = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.windows;
   };
 }

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -81,8 +81,6 @@ rec {
     , ... } @ attrs:
 
     let
-      computedName = if name != "" then name else "${attrs.pname}-${attrs.version}";
-
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
       # no package has `doCheck = true`.
       doCheck' = doCheck && stdenv.hostPlatform == stdenv.buildPlatform;
@@ -179,15 +177,15 @@ rec {
            "checkInputs" "installCheckInputs"
            "__impureHostDeps" "__propagatedImpureHostDeps"
            "sandboxProfile" "propagatedSandboxProfile"])
-        // {
-          name = computedName + lib.optionalString
-            # Fixed-output derivations like source tarballs shouldn't get a host
-            # suffix. But we have some weird ones with run-time deps that are
-            # just used for their side-affects. Those might as well since the
-            # hash can't be the same. See #32986.
-            (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)
-            ("-" + stdenv.hostPlatform.config);
-
+        // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)) {
+          # Fixed-output derivations like source tarballs shouldn't get a host
+          # suffix. But we have some weird ones with run-time deps that are
+          # just used for their side-affects. Those might as well since the
+          # hash can't be the same. See #32986.
+          name = "${if name != "" then name else "${attrs.pname}-${attrs.version}"}-${stdenv.hostPlatform.config}";
+        } // (lib.optionalAttrs (name == "")) {
+          name = "${attrs.pname}-${attrs.version}";
+        } // {
           builder = attrs.realBuilder or stdenv.shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
           inherit stdenv;
@@ -276,7 +274,7 @@ rec {
       meta = {
           # `name` above includes cross-compilation cruft (and is under assert),
           # lets have a clean always accessible version here.
-          name = computedName;
+          name = if name != "" then name else "${attrs.pname}-${attrs.version}";
 
           # If the packager hasn't specified `outputsToInstall`, choose a default,
           # which is the name of `p.bin or p.out or p`;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -177,14 +177,14 @@ rec {
            "checkInputs" "installCheckInputs"
            "__impureHostDeps" "__propagatedImpureHostDeps"
            "sandboxProfile" "propagatedSandboxProfile"])
-        // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)) {
+        // (lib.optionalAttrs (name == "")) {
+          name = "${attrs.pname}-${attrs.version}";
+        } // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)) {
           # Fixed-output derivations like source tarballs shouldn't get a host
           # suffix. But we have some weird ones with run-time deps that are
           # just used for their side-affects. Those might as well since the
           # hash can't be the same. See #32986.
           name = "${if name != "" then name else "${attrs.pname}-${attrs.version}"}-${stdenv.hostPlatform.config}";
-        } // (lib.optionalAttrs (name == "")) {
-          name = "${attrs.pname}-${attrs.version}";
         } // {
           builder = attrs.realBuilder or stdenv.shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -94,7 +94,7 @@ rec {
                                       ++ depsHostHost ++ depsHostHostPropagated
                                       ++ buildInputs ++ propagatedBuildInputs
                                       ++ depsTargetTarget ++ depsTargetTargetPropagated) == 0;
-      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || stdenv.cc == null;
+      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || (stdenv.noCC or false);
       supportedHardeningFlags = [ "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro" "bindnow" ];
       defaultHardeningFlags = if stdenv.hostPlatform.isMusl
                               then supportedHardeningFlags

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6762,7 +6762,7 @@ in
   # built with, and use, that cross-compiled libc.
   gccCrossStageStatic = assert stdenv.targetPlatform != stdenv.hostPlatform; let
     libcCross1 =
-      if stdenv.targetPlatform.libc == "msvcrt" then windows.mingw_w64_headers
+      if stdenv.targetPlatform.libc == "msvcrt" then targetPackages.windows.mingw_w64_headers
       else if stdenv.targetPlatform.libc == "libSystem" then darwin.xcode
       else null;
     binutils1 = wrapBintoolsWith {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33,7 +33,7 @@ in
   # just the plain stdenv.
   stdenv_32bit = lowPrio (if stdenv.hostPlatform.is32bit then stdenv else multiStdenv);
 
-  stdenvNoCC = stdenv.override { cc = null; };
+  stdenvNoCC = stdenv.override { cc = null; extraAttrs.noCC = true; };
 
   stdenvNoLibs = let
     bintools = stdenv.cc.bintools.override {


### PR DESCRIPTION
For a long time now, tracing has been broken in Nixpkgs. So when you
have an eval error you would get something like this:

```
  error: while evaluating the attribute 'buildInputs' of the derivation 'hello-2.10' at /home/mbauer/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:185:11:
  while evaluating 'chooseDevOutputs' at /home/mbauer/nixpkgs/lib/attrsets.nix:474:22, called from undefined position:
  while evaluating 'optionals' at /home/mbauer/nixpkgs/lib/lists.nix:257:5, called from /home/mbauer/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:132:17:
```

This is coming from how Nix handles string context and how
make-derivation messes with the "name" attribute. This commit should
restore the old behavior so you get a nice line number like:

```
  error: while evaluating the attribute 'buildInputs' of the derivation 'hello-2.10' at /home/mbauer/nixpkgs/pkgs/applications/misc/hello/default.nix:4:3:
  while evaluating 'chooseDevOutputs' at /home/mbauer/nixpkgs/lib/attrsets.nix:474:22, called from undefined position:
  while evaluating 'optionals' at /home/mbauer/nixpkgs/lib/lists.nix:257:5, called from /home/mbauer/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:132:17:
```

NOTE: This will still be broken for cross compilation due to the
prefixes we are adding to name. It might also still be broken if you use "pname" & "version".

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

