### PR TITLE
kustomize: 1.0.10 -> 1.0.11

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -3,9 +3,9 @@
 
 buildGoPackage rec {
   name = "kustomize-${version}";
-  version = "1.0.10";
-  # rev is the 1.0.10 commit, mainly for kustomize version command output
-  rev = "383b3e798b7042f8b7431f93e440fb85631890a3";
+  version = "1.0.11";
+  # rev is the 1.0.11 commit, mainly for kustomize version command output
+  rev = "8f701a00417a812558a7b785e8354957afa469ae";
 
   goPackagePath = "sigs.k8s.io/kustomize";
 
@@ -17,7 +17,7 @@ buildGoPackage rec {
   '';
 
   src = fetchFromGitHub {
-    sha256 = "1z78d5j2w78x4ks4v745050g2ffmirj03v7129dib2lfhfjra8aj";
+  sha256 = "18kc23l6r2di35md9jbinyzxr791vvdjyklaf3k725imqksikwri";
     rev = "v${version}";
     repo = "kustomize";
     owner = "kubernetes-sigs";


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest security release 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

