### PR TITLE
slurp: init at 1.0

### DIFF
--- a/pkgs/tools/graphics/slurp/default.nix
+++ b/pkgs/tools/graphics/slurp/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, cairo, meson, ninja, wayland, pkgconfig, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "slurp-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "slurp";
+    rev = "v${version}";
+    sha256 = "03igv8r8n772xb0y7whhs1pa298l3d94jbnknaxpwp2n4fi04syb";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    cairo
+    wayland
+    wayland-protocols
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Select a region in a Wayland compositor";
+    homepage = https://github.com/emersion/slurp;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ florianfranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1638,6 +1638,8 @@ in
 
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
+  slurp = callPackage ../tools/graphics/slurp { };
+
   snipes = callPackage ../games/snipes { };
 
   socklog = callPackage ../tools/system/socklog { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Maintainer is defined in #54627. 