### PR TITLE
gajim: 1.0.3 -> 1.1.2

### DIFF
--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "nbxmpp";
-  version = "0.6.8";
+  version = "0.6.9";
   name = "${pname}-${version}";
 in buildPythonPackage rec {
   inherit pname version;
@@ -11,7 +11,7 @@ in buildPythonPackage rec {
     name = "${name}.tar.bz2";
     url = "https://dev.gajim.org/gajim/python-nbxmpp/repository/archive.tar.bz2?"
         + "ref=${name}";
-    sha256 = "09zrqz01j45kvayfscd66avkrnn237lbjg9li5hjhyw92h6hkkc4";
+    sha256 = "14xrq0r5k1dk7rwj4cxyxfapi6gbnqg70mz94g6hn9ij06284mi7";
   };
 
   propagatedBuildInputs = [ pyopenssl ];

--- a/pkgs/development/python-modules/precis-i18n/default.nix
+++ b/pkgs/development/python-modules/precis-i18n/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "precis-i18n";
+  version = "1.0.0";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    pname = "precis_i18n";
+    inherit version;
+    sha256 = "0gjhvwd8aifx94rl1ag08vlmndyx2q3fkyqb0c4i46x3p2bc2yi2";
+  };
+
+  meta = {
+    homepage = https://github.com/byllyfish/precis_i18n;
+    description = "Internationalized usernames and passwords";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22299,9 +22299,9 @@ in
 
   foomatic-filters = callPackage ../misc/drivers/foomatic-filters {};
 
-  gajim = python3.pkgs.callPackage ../applications/networking/instant-messengers/gajim {
+  gajim = callPackage ../applications/networking/instant-messengers/gajim {
     inherit (gst_all_1) gstreamer gst-plugins-base gst-libav gst-plugins-ugly;
-    inherit (gnome3) gspell;
+    inherit (gnome3) gspell defaultIconTheme;
   };
 
   gammu = callPackage ../applications/misc/gammu { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3459,6 +3459,8 @@ in {
     name = "${python.libPrefix}-${pkgs.kmsxx.name}";
   });
 
+  precis-i18n = callPackage ../development/python-modules/precis-i18n { };
+
   pvlib = callPackage ../development/python-modules/pvlib { };
 
   pybase64 = callPackage ../development/python-modules/pybase64 { };


### PR DESCRIPTION
The list of upstream changes is huge, so I'm not pasting it here in the commit message, but here is the upstream URL:

  https://dev.gajim.org/gajim/gajim/blob/gajim-1.1.2/ChangeLog

One of the most visible updates are the design changes for various dialogs and the Emoji overhauls.

On our end, we now need three more dependencies, namely `cssutils`, `precis-i18n` and `keyring`, which I added accordingly.

In addition, the test runner is now integrated into setup.py, which we now use.

I also cleaned up the package expression a bit, eg. it's no longer wrapped in a big `with lib;`, so that `nix-instantiate --parse` is able to detect attribute errors (which is very useful if you have editor integration).