### PR TITLE
fetchgit: allow configuring credential.helper for private git repos

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -64,7 +64,7 @@ stdenvNoCC.mkDerivation {
   GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars ++ [
-    "GIT_PROXY_COMMAND" "SOCKS_SERVER"
+    "GIT_PROXY_COMMAND" "NIX_PREFETCH_GIT_CREDENTIAL_HELPER" "SOCKS_SERVER"
   ];
 
   inherit preferLocalBuild;

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -11,6 +11,7 @@ leaveDotGit=$NIX_PREFETCH_GIT_LEAVE_DOT_GIT
 fetchSubmodules=
 builder=
 branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
+credential_helper="$NIX_PREFETCH_GIT_CREDENTIAL_HELPER"
 
 # ENV params
 out=${out:-}
@@ -100,6 +101,10 @@ init_remote(){
     git init
     git remote add origin "$url"
     ( [ -n "$http_proxy" ] && git config http.proxy "$http_proxy" ) || true
+
+    # on darwin, system git config sets credential.helper to osxkeychain, which pops up an annoying dialog "a keychain cannot be found to store $user"
+    [ -n "$credential_helper" ] && export GIT_CONFIG_NOSYSTEM=1 || true
+    ( [ -n "$credential_helper" ] && git config credential.helper "$credential_helper" ) || true
 }
 
 # Return the reference of an hash if it exists on the remote repository.


### PR DESCRIPTION
Allows running something like this:

    $ export NIX_PREFETCH_GIT_CREDENTIAL_HELPER="netrc -f $HOME/.netrc"
    $ nix-build -A something-with-private-git-repo

such that fetchgit can obtain credentials to a private git
repository. Tested successfully on darwin with GitHub using an API key
password to fetch a private repo over https. See gitcredentials [1].

Alternative is something like fetchgitPrivate [2] which requires SSH keys.

[1] https://git-scm.com/docs/gitcredentials
[2] https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgit/private.nix

###### Motivation for this change

Want to fetch private git repositories over https using username/password (rather than ssh keys).

Seeking feedback on this approach.

This probably requires mass rebuild...?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

