### PR TITLE
pythonPackages.qscintilla: enable for python3

### DIFF
--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, qscintillaCpp
+, lndir
+, sip
+, python
+, pyqt5 }:
+
+buildPythonPackage rec {
+  pname = "qscintilla";
+  version = qscintillaCpp.version;
+  src = qscintillaCpp.src;
+  format = "other";
+
+  nativeBuildInputs = [ lndir sip ];
+  buildInputs = [ qscintillaCpp ];
+  propagatedBuildInputs = [ pyqt5 ];
+
+  preConfigure = ''
+    mkdir -p $out
+    lndir ${pyqt5} $out
+    rm -rf "$out/nix-support"
+    cd Python
+    ${python.executable} ./configure.py \
+      --pyqt=PyQt5 \
+      --destdir=$out/lib/${python.sitePackages}/PyQt5 \
+      --stubsdir=$out/lib/${python.sitePackages}/PyQt5 \
+      --apidir=$out/api/${python.libPrefix} \
+      --qsci-incdir=${qscintillaCpp}/include \
+      --qsci-libdir=${qscintillaCpp}/lib \
+      --pyqt-sipdir=${pyqt5}/share/sip/PyQt5 \
+      --qsci-sipdir=$out/share/sip/PyQt5
+  '';
+
+  meta = with lib; {
+    description = "A Python binding to QScintilla, Qt based text editing control";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ lsix ];
+    homepage = https://www.riverbankcomputing.com/software/qscintilla/;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3857,7 +3857,14 @@ in {
   # alias for an older package which did not support Python 3
   Quandl = callPackage ../development/python-modules/quandl { };
 
-  qscintilla = callPackage ../development/python-modules/qscintilla { };
+  qscintilla-qt4 = callPackage ../development/python-modules/qscintilla { };
+
+  qscintilla-qt5 = callPackage ../development/python-modules/qscintilla-qt5 {
+    qscintillaCpp = pkgs.libsForQt5.qscintilla;
+    lndir = pkgs.xorg.lndir;
+  };
+
+  qscintilla = self.qscintilla-qt4;
 
   qserve = callPackage ../development/python-modules/qserve { };
 


### PR DESCRIPTION
###### Motivation for this change

I plan to add Qgis3 into nixpkgs, and for that qscintilla for python3 is required.

This work is somehow based on https://github.com/NixOS/nixpkgs/pull/38022

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

