### PR TITLE
one_gadget: init at 1.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -391,6 +391,15 @@
     github = "shados";
     name = "Alexei Robyn";
   };
+  artemist = {
+    email = "me@artem.ist";
+    github = "artemist";
+    name = "Artemis Tosini";
+    keys = [{
+      longkeyid = "rsa4096/0x4FDC96F161E7BA8A";
+      fingerprint = "3D2B B230 F9FA F0C5 1832  46DD 4FDC 96F1 61E7 BA8A";
+    }];
+  };
   artuuge = {
     email = "artuuge@gmail.com";
     github = "artuuge";

--- a/pkgs/development/tools/misc/one_gadget/Gemfile
+++ b/pkgs/development/tools/misc/one_gadget/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'one_gadget'

--- a/pkgs/development/tools/misc/one_gadget/Gemfile.lock
+++ b/pkgs/development/tools/misc/one_gadget/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bindata (2.4.4)
+    elftools (1.0.2)
+      bindata (~> 2)
+    one_gadget (1.6.2)
+      elftools (~> 1.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  one_gadget
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/development/tools/misc/one_gadget/default.nix
+++ b/pkgs/development/tools/misc/one_gadget/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "one_gadget";
+  gemdir = ./.;
+  exes = [ "one_gadget" ];
+
+  meta = with lib; {
+    description = "The best tool for finding one gadget RCE in libc.so.6";
+    homepage    = https://github.com/david942j/one_gadget;
+    license     = licenses.mit;
+    maintainers = [ maintainers.artemist ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/misc/one_gadget/gemset.nix
+++ b/pkgs/development/tools/misc/one_gadget/gemset.nix
@@ -1,0 +1,34 @@
+{
+  bindata = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0kz42nvxnk1j9cj0i8lcnhprcgdqsqska92g6l19ziadydfk2gqy";
+      type = "gem";
+    };
+    version = "2.4.4";
+  };
+  elftools = {
+    dependencies = ["bindata"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ajymn59fr9117dkwf5xl8vmr737h6xmrcf1033zjlj2l5qkxn4a";
+      type = "gem";
+    };
+    version = "1.0.2";
+  };
+  one_gadget = {
+    dependencies = ["elftools"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wacvysd7ddnbx2jl1vhzbkb28y974riyns7bpx889518zaa09z0";
+      type = "gem";
+    };
+    version = "1.6.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11757,6 +11757,8 @@ in
 
   olm = callPackage ../development/libraries/olm { };
 
+  one_gadget = callPackage ../development/tools/misc/one_gadget { };
+
   oneko = callPackage ../applications/misc/oneko { };
 
   oniguruma = callPackage ../development/libraries/oniguruma { };


### PR DESCRIPTION
###### Motivation for this change
one_gadget is a useful script for exploit development currently missing from the repositories. It is a simple Ruby package and I will be able to maintain it with little burden.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

