### PR TITLE
cmake: 3.12.1 -> 3.12.2

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -17,9 +17,9 @@ with stdenv.lib;
 let
   os = stdenv.lib.optionalString;
   majorVersion = "3.12";
-  minorVersion = "1";
+  minorVersion = "2";
   # from https://cmake.org/files/v3.12/cmake-3.12.1-SHA-256.txt
-  sha256 = "1ckswlaid3p2is1a80fmr4hgwpfsiif66giyx1z9ayhxx0n5qgf5";
+  sha256 = "19410mxgcyvk5q42phaclb1hz6rl08z4yj8iriq706p5k5bli5qg";
   version = "${majorVersion}.${minorVersion}";
 in
 


### PR DESCRIPTION
###### Motivation for this change
Trying to use cudatoolkit-10 with magma and running into a bug solved by upgrading cmake. Reference: https://github.com/clab/dynet/issues/1457#issuecomment-423931508

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not 100% sure how to test this locally. I tried checking `nix path-info -S` and `nix-shell -p nox --run "nox-review wip"`. nox returns `No uncommit changes. Did you mean to use the "--against" option?` and I'm a bit too new at nix to figure it out. I figure this will impact most packages and it might be easier to let CI do this. I have verified the binary on Ubuntu and NixOS, and have passed the current blocker I am facing with magma+cuda-10.
