### PR TITLE
magma: 2.0.2 -> 2.0.2, 2.3.0, 2.4.0, + mklSupport

### DIFF
--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -1,46 +1,20 @@
-{ stdenv, fetchurl, cmake, gfortran, cudatoolkit, libpthreadstubs, liblapack }:
+{ callPackage ? (import <nixpkgs> {}).callPackage }:
 
-with stdenv.lib;
+let
+  generic = args: callPackage (import ./generic.nix args) { };
 
-let version = "2.0.2";
-
-in stdenv.mkDerivation {
-  name = "magma-${version}";
-  src = fetchurl {
-    url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${version}.tar.gz";
-    sha256 = "0w3z6k1npfh0d3r8kpw873f1m7lny29sz2bvvfxzk596d4h083lk";
-    name = "magma-${version}.tar.gz";
-  };
-
-  buildInputs = [ gfortran cudatoolkit libpthreadstubs liblapack cmake ];
-
-  doCheck = false;
-  #checkTarget = "tests";
-
-  enableParallelBuilding=true;
-
-  # MAGMA's default CMake setup does not care about installation. So we copy files directly.
-  installPhase = ''
-    mkdir -p $out
-    mkdir -p $out/include
-    mkdir -p $out/lib
-    mkdir -p $out/lib/pkgconfig
-    cp -a ../include/*.h $out/include
-    #cp -a sparse-iter/include/*.h $out/include
-    cp -a lib/*.a $out/lib
-    cat ../lib/pkgconfig/magma.pc.in                   | \
-    sed -e s:@INSTALL_PREFIX@:"$out":          | \
-    sed -e s:@CFLAGS@:"-I$out/include":    | \
-    sed -e s:@LIBS@:"-L$out/lib -lmagma -lmagma_sparse": | \
-    sed -e s:@MAGMA_REQUIRED@::                       \
-        > $out/lib/pkgconfig/magma.pc
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Matrix Algebra on GPU and Multicore Architectures";
-    license = licenses.bsd3;
-    homepage = http://icl.cs.utk.edu/magma/index.html;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ianwookim ];
-  };
+  magma_2_0_2 = generic
+    { version = "2.0.2"; sha256 = "0w3z6k1npfh0d3r8kpw873f1m7lny29sz2bvvfxzk596d4h083lk"; };
+  magma_2_3_0 = generic
+    { version = "2.3.0"; sha256 = "0256kvfng7i8grrn650mr49nkl7kb04zrgr6jixyb8bsgl2ll2h1"; };
+  magma_2_4_0 = generic
+    { version = "2.4.0"; sha256 = "0kws3ygidlc07xbldbvnz45h2xl4aznv9xd6r0lzs1al56qkkf2f"; };
+in
+{
+  inherit
+    magma_2_0_2
+    magma_2_3_0
+    magma_2_4_0;
+  magma = magma_2_3_0;
 }
+

--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -1,0 +1,59 @@
+{ version
+, sha256
+}:
+
+{ stdenv, fetchurl, cmake, gfortran, cudatoolkit, libpthreadstubs
+, mklSupport ? false, blas ? null, liblapack ? null, mkl ? null
+}:
+
+assert  mklSupport -> mkl != null;
+assert !mklSupport -> blas != null && liblapack != null;
+
+with stdenv.lib;
+
+stdenv.mkDerivation {
+  name = "magma-${version}";
+
+  inherit version;
+
+  src = fetchurl {
+    url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${version}.tar.gz";
+    inherit sha256;
+    name = "magma-${version}.tar.gz";
+  };
+
+  buildInputs = [ gfortran cudatoolkit libpthreadstubs cmake ]
+    ++ (if mklSupport then [mkl] else [blas liblapack]);
+
+  doCheck = false;
+  #checkTarget = "tests";
+
+  cmakeFlags = stdenv.lib.optional mklSupport "-DMKLROOT=${mkl} -DMAGMA_WITH_MKL=true";
+
+  enableParallelBuilding=true;
+
+  # MAGMA's default CMake setup does not care about installation. So we copy files directly.
+  installPhase = ''
+    mkdir -p $out
+    mkdir -p $out/include
+    mkdir -p $out/lib
+    mkdir -p $out/lib/pkgconfig
+    cp -a ../include/*.h $out/include
+    #cp -a sparse-iter/include/*.h $out/include
+    cp -a lib/*.a $out/lib
+    cat ../lib/pkgconfig/magma.pc.in                   | \
+    sed -e s:@INSTALL_PREFIX@:"$out":          | \
+    sed -e s:@CFLAGS@:"-I$out/include":    | \
+    sed -e s:@LIBS@:"-L$out/lib -lmagma -lmagma_sparse": | \
+    sed -e s:@MAGMA_REQUIRED@::                       \
+        > $out/lib/pkgconfig/magma.pc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Matrix Algebra on GPU and Multicore Architectures";
+    license = licenses.bsd3;
+    homepage = http://icl.cs.utk.edu/magma/index.html;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ianwookim ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
I am trying to use magma with cuda-10, which involved bumping magma to 2.3.0 to support my gpu's architecture. Note that this PR uses the default `cudatoolbelt` so nuances addressed in #54836 do not apply here.  

From what I can see on their website [the current stable version seems to be 2.3.0](http://icl.cs.utk.edu/projectsfiles/magma/doxygen/installing.html). That said, it looks like 2.4.0 is complete and v2.5.0 is in active development. I've included all of the versions listed, except for 2.5.0, using [cudnn/default.nix](https://github.com/NixOS/nixpkgs/blob/5f755425a1fb461b429f40c6bc5c9bf5975234fc/pkgs/development/libraries/science/math/cudnn/default.nix) as a reference for the code.

Magma also supports mkl, I've added it as an optional dependency.

Again, from #54836, I'm not terribly affluent with building nix packages (many kudos to @tstat for helping me get through the build errors). I've tested this on ubuntu with 2.3.0 and 2.4.0 with defaults, mkl, and with cuda-10. I can't build 2.0.2 on my machine because of an incompatible gpu architecture.

CI should break because I'm not sure how best to package this in `pkgs/top-level/all-packages.nix`, I'm hoping for some feedback/guidelines here.

Thank you!
-s

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

