### PR TITLE
joplin-desktop: init at 1.0.120

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3694,6 +3694,16 @@
       fingerprint = "7573 56D7 79BB B888 773E  415E 736C CDF9 EF51 BD97";
     }];
   };
+  rafaelgg = {
+    email = "rafael.garcia.gallego@gmail.com";
+    github = "rafaelgg";
+    name = "Rafael García";
+  };
+  raquelgb = {
+    email = "raquel.garcia.bautista@gmail.com";
+    github = "raquelgb";
+    name = "Raquel García";
+  };
   ragge = {
     email = "r.dahlen@gmail.com";
     github = "ragnard";

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, appimage-run, fetchurl }:
+
+let
+  version = "1.0.120";
+  sha256 = "0j32rg6hm5dirdcibhfhrclnx7vm37fbm4iwkzzinqhzj4jfgbfm";
+in
+  stdenv.mkDerivation rec {
+  name = "joplin-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}-x86_64.AppImage";
+    inherit sha256;
+  };
+
+  buildInputs = [ appimage-run ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp $src $out/share/joplin.AppImage
+    echo "#!/bin/sh" > $out/bin/joplin-desktop
+    echo "${appimage-run}/bin/appimage-run $out/share/joplin.AppImage" >> $out/bin/joplin-desktop
+    chmod +x $out/bin/joplin-desktop $out/share/joplin.AppImage
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open source note taking and to-do application with synchronisation capabilities";
+    longDescription = ''
+      Joplin is a free, open source note taking and to-do application, which can
+      handle a large number of notes organised into notebooks. The notes are
+      searchable, can be copied, tagged and modified either from the
+      applications directly or from your own text editor. The notes are in
+      Markdown format.
+    '';
+    homepage = https://joplin.cozic.net/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ rafaelgg raquelgb ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3517,6 +3517,8 @@ in
 
   john = callPackage ../tools/security/john { };
 
+  joplin-desktop = callPackage ../applications/misc/joplin-desktop { };
+
   journalbeat = callPackage ../tools/system/journalbeat { };
 
   journaldriver = callPackage ../tools/misc/journaldriver { };


### PR DESCRIPTION
###### Motivation for this change
Add AppImage from https://joplin.cozic.net/ as `joplin-desktop`

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

