### PR TITLE
typora: 0.9.53 -> 0.9.64, remove electron blob

### DIFF
--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -1,92 +1,36 @@
-{ stdenv, fetchurl, dpkg, lib, glib, dbus, makeWrapper, gnome2, gnome3, gtk3, atk, cairo, pango
-, gdk_pixbuf, freetype, fontconfig, nspr, nss, xorg, alsaLib, cups, expat, udev, wrapGAppsHook }:
+{ stdenv, fetchurl, makeWrapper, electron_3, dpkg, gtk3, glib, gnome3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "typora-${version}";
-  version = "0.9.53";
+  pname = "typora";
+  version = "0.9.64";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
-        sha256 = "02k6x30l4mbjragqbq5rn663xbw3h4bxzgppfxqf5lwydswldklb";
-      }
-    else
-      fetchurl {
-        url = "https://www.typora.io/linux/typora_${version}_i386.deb";
-        sha256 = "1wyq1ri0wwdy7slbd9dwyrdynsaa644x44c815jl787sg4nhas6y";
-      }
-    ;
+  src = fetchurl {
+    url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
+    sha256 = "0dffydc11ys2i38gdy8080ph1xlbbzhcdcc06hyfv0dr0nf58a09";
+  };
 
-    rpath = stdenv.lib.makeLibraryPath [
-      alsaLib
-      gnome2.GConf
-      gdk_pixbuf
-      pango
-      gnome3.defaultIconTheme
-      expat
-      gtk3
-      atk
-      nspr
-      nss
-      stdenv.cc.cc
-      glib
-      cairo
-      cups
-      dbus
-      udev
-      fontconfig
-      freetype
-      xorg.libX11
-      xorg.libXi
-      xorg.libXext
-      xorg.libXtst
-      xorg.libXfixes
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXrender
-      xorg.libXrandr
-      xorg.libXcomposite
-      xorg.libxcb
-      xorg.libXScrnSaver
-  ];
+  nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = [ gtk3 glib gnome3.gsettings-desktop-schemas ];
+
+  unpackPhase = "dpkg-deb -x $src .";
 
   dontWrapGApps = true;
 
-  buildInputs = [ dpkg makeWrapper ];
-
-  unpackPhase = "true";
   installPhase = ''
-    mkdir -p $out
-    dpkg -x $src $out
-    mv $out/usr/bin $out
-    mv $out/usr/share $out
-    rm $out/bin/typora
-    rmdir $out/usr
+    mkdir -p $out/bin $out/share/typora
+    {
+      cd usr
+      mv share/typora/resources/app/* $out/share/typora
+      mv share/applications $out/share
+      mv share/icons $out/share
+      mv share/doc $out/share
+    }
 
-    # Otherwise it looks "suspicious"
-    chmod -R g-w $out
-  '';
-
-  postFixup = ''
-     patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/share/typora:${rpath}" "$out/share/typora/Typora"
-
-    makeWrapper $out/share/typora/Typora $out/bin/typora
-
-    wrapProgram $out/bin/typora \
+    makeWrapper ${electron_3}/bin/electron $out/bin/typora \
+      --add-flags $out/share/typora \
       "''${gappsWrapperArgs[@]}" \
-      --suffix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-      --prefix XDG_DATA_DIRS : "${gnome3.defaultIconTheme}/share"
-
-    # Fix the desktop link
-    substituteInPlace $out/share/applications/typora.desktop \
-      --replace /usr/bin/ $out/bin/ \
-      --replace /usr/share/ $out/share/
-
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ]}"
   '';
 
   meta = with stdenv.lib; {
@@ -94,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = https://typora.io;
     license = licenses.unfree;
     maintainers = with maintainers; [ jensbin ];
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    inherit (electron_3.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Pretty sure that the archive this wanted to fetch is now non-existent.
Changelogs: https://typora.io/windows/dev_release.html

Note that the application is non-functional without the `LD_LIBRARY_PATH` hack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jensbin