### PR TITLE
openra: updated engines and mods

### DIFF
--- a/pkgs/games/openra/common.nix
+++ b/pkgs/games/openra/common.nix
@@ -79,7 +79,7 @@ in {
     dontStrip = true;
 
     meta = {
-      maintainers = with maintainers; [ msteen rardiol ];
+      maintainers = with maintainers; [ fusion809 msteen rardiol ];
       license = licenses.gpl3;
       platforms = platforms.linux;
     };

--- a/pkgs/games/openra/engines.nix
+++ b/pkgs/games/openra/engines.nix
@@ -11,9 +11,9 @@ let
       repo = "OpenRA" ;
       inherit rev sha256 extraPostFetch;
     };
-  } name).overrideAttrs (oldAttrs: {
+  } name).overrideAttrs (origAttrs: {
     postInstall = ''
-      ${oldAttrs.postInstall}
+      ${origAttrs.postInstall}
       cp -r mods/ts $out/lib/openra/mods/
       cp mods/ts/icon.png $(mkdirp $out/share/pixmaps)/openra-ts.png
       ( cd $out/share/applications; sed -e 's/Dawn/Sun/g' -e 's/cnc/ts/g' openra-cnc.desktop > openra-ts.desktop )
@@ -21,21 +21,21 @@ let
   });
 
 in {
-  release = buildUpstreamOpenRAEngine rec {
+  release = name: (buildUpstreamOpenRAEngine rec {
     version = "20181215";
-    rev = "release-${version}";
+    rev = "${name}-${version}";
     sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
-  };
+  } name);
 
-  playtest = buildUpstreamOpenRAEngine rec {
+  playtest = name: (buildUpstreamOpenRAEngine rec {
     version = "20190106";
-    rev = "playtest-${version}";
+    rev = "${name}-${version}";
     sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
-  };
+  } name);
 
-  bleed = let commit = "6de92de8d982094a766eab97a92225c240d85493"; in buildUpstreamOpenRAEngine {
-    version = abbrevCommit commit;
-    rev = commit;
-    sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
+  bleed = buildUpstreamOpenRAEngine {
+    version = "9c9cad1";
+    rev = "9c9cad1a15c3a34dc2a61b305e4a9a735381a5f8";
+    sha256 = "0100p7wrnnlvkmy581m0gbyg3cvi4i1w3lzx2gq91ndz1sbm8nd2";
   };
 }

--- a/pkgs/games/openra/mod-launch-game.sh
+++ b/pkgs/games/openra/mod-launch-game.sh
@@ -21,5 +21,5 @@ mono --debug OpenRA.Game.exe Game.Mod=@name@ Engine.LaunchPath="@out@/bin/openra
 
 # Show a crash dialog if something went wrong
 if [ $? -ne 0 -a $? -ne 1 ]; then
-  show_error "OpenRA - @title@ has encountered a fatal error.\nPlease refer to the crash logs for more information.\n\nLog files are located in ~/.openra/Logs"
+  show_error $'OpenRA - @title@ has encountered a fatal error.\nPlease refer to the crash logs for more information.\n\nLog files are located in ~/.openra/Logs'
 fi

--- a/pkgs/games/openra/mod-update.sh
+++ b/pkgs/games/openra/mod-update.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+# for mod in $(nix eval --raw '(
+#   with import <nixpkgs> { };
+#   with lib;
+#   let mods = attrNames (removeAttrs openraPackages.mods [ "recurseForDerivations" ]);
+#   in concatStringsSep " " mods
+# )'); do
+#   ./mod-update.sh "$mod"
+# done
+
+# Uses:
+# https://github.com/msteen/nix-prefetch
+# https://github.com/msteen/nix-update-fetch
+
+mod=$1
+commit_count=$2
+token=
+nixpkgs='<nixpkgs>'
+
+die() {
+  ret=$?
+  echo "$*" >&2
+  exit $ret
+}
+
+curl() {
+  command curl --silent --show-error "$@"
+}
+
+get_sha1() {
+  local owner=$1 repo=$2 ref=$3
+  # https://developer.github.com/v3/#authentication
+  curl -H "Authorization: token $token" -H 'Accept: application/vnd.github.VERSION.sha' "https://api.github.com/repos/$owner/$repo/commits/$ref"
+}
+
+[[ -n $token ]] || die "Please edit this script to include a GitHub API access token, which is required for API v4:
+https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/"
+
+# Get current mod_owner and mod_repo.
+vars=$(nix-prefetch --file "$nixpkgs" "openraPackages.mods.$mod" --index 0 --quiet --output json --skip-hash > >(
+  jq --raw-output 'with_entries(select(.value | contains("\n") | not)) | to_entries | .[] | .key + "=" + .value')) || exit
+
+while IFS='=' read -r key val; do
+  declare "mod_${key}=${val}"
+done <<< "$vars"
+
+if [[ -n $commit_count ]]; then
+  query_on_commit='{
+  history(first: 10) {
+    nodes {
+      abbreviatedOid
+      oid
+    }
+    totalCount
+  }
+}'
+else
+  query_on_commit='{
+  history(first: 0) {
+    totalCount
+  }
+  abbreviatedOid
+  oid
+}'
+fi
+
+query='query {
+  repository(owner: \"'"$mod_owner"'\", name: \"'"$mod_repo"'\") {
+    defaultBranchRef {
+      target {
+        ... on Commit '"$query_on_commit"'
+      }
+    }
+    licenseInfo {
+      key
+    }
+  }
+}'
+
+# Newlines are not allowed in a query.
+# https://developer.github.com/v4/guides/forming-calls/#communicating-with-graphql
+query=$(echo $query)
+
+# https://developer.github.com/v4/guides/using-the-explorer/#configuring-graphiql
+json=$(curl -H "Authorization: bearer $token" -X POST -d '{ "query": "'"$query"'" }' https://api.github.com/graphql) || exit
+
+if [[ -n $commit_count ]]; then
+  json=$(jq "$commit_count"' as $commit_count
+    | .data.repository.defaultBranchRef.target
+    |= (.history |= (. | del(.nodes) | .totalCount = $commit_count))
+    + (.history | .nodes[.totalCount - $commit_count])' <<< "$json") || exit
+fi
+
+vars=$(jq --raw-output '.data.repository | {
+  license_key: .licenseInfo.key,
+} + (.defaultBranchRef.target | {
+  version: ((.history.totalCount | tostring) + ".git." + .abbreviatedOid),
+  rev: .oid,
+}) | to_entries | .[] | .key + "=" + (.value | tostring)' <<< "$json") || exit
+
+while IFS='=' read -r key val; do
+  declare "mod_${key}=${val}"
+done <<< "$vars"
+
+mod_config=$(curl "https://raw.githubusercontent.com/$mod_owner/$mod_repo/$mod_rev/mod.config") || exit
+
+while IFS='=' read -r key val; do
+  declare "${key,,}=$(jq --raw-output . <<< "$val")"
+done < <(grep '^\(MOD_ID\|ENGINE_VERSION\|AUTOMATIC_ENGINE_MANAGEMENT\|AUTOMATIC_ENGINE_SOURCE\)=' <<< "$mod_config")
+
+for var in mod_id engine_version automatic_engine_management automatic_engine_source; do
+  echo "$var=${!var}" >&2
+done
+echo >&2
+
+[[ $mod_id == "$mod" ]] ||
+  die "The mod '$mod' reports being mod '$mod_id' instead."
+[[ $mod_license_key == gpl-3.0 ]] ||
+[[ $(echo $(head -2 <(curl "https://raw.githubusercontent.com/$mod_owner/$mod_repo/$mod_rev/COPYING"))) == 'GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007' ]] ||
+  die "The mod '$mod' is licensed under '$mod_license_key' while expecting 'gpl-3.0'."
+[[ $automatic_engine_management == True ]] ||
+  die "The mod '$mod' engine is not managed as a read-only dependency."
+[[ $automatic_engine_source =~ https://github.com/([a-zA-Z0-9_\-]+)/([a-zA-Z0-9_\-]+)/archive/([a-zA-Z0-9_\-\$\{\}]+).zip ]] ||
+  die "The mod '$mod' engine is not hosted on GitHub as an archive."
+
+engine_owner=${BASH_REMATCH[1]}
+engine_repo=${BASH_REMATCH[2]}
+[[ ${BASH_REMATCH[3]} == '${ENGINE_VERSION}' ]] || engine_version=${BASH_REMATCH[3]}
+engine_rev=$(get_sha1 "$engine_owner" "$engine_repo" "$engine_version")
+
+for type in mod engine; do
+  for name in version owner repo rev; do
+    var="${type}_${name}"
+    echo "$var=${!var}" >&2
+  done
+  echo >&2
+done
+
+i=0
+for type in mod engine; do
+  fetcher_args=()
+  for name in owner repo rev; do
+    var="${type}_${name}"
+    fetcher_args+=( "--$name" "${!var}" )
+  done
+  var="${type}_version"
+  version=${!var}
+  nix-update-fetch --yes --version "$version" "$(nix-prefetch --quiet --file "$nixpkgs" "openraPackages.mods.$mod" --index $i --output json --with-position --diff -- "${fetcher_args[@]}")"
+  (( i++ ))
+done

--- a/pkgs/games/openra/mod.nix
+++ b/pkgs/games/openra/mod.nix
@@ -67,7 +67,7 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
 
     make -C ${engineSourceName} install-engine install-common-mod-files DATA_INSTALL_DIR=$out/lib/${pname}
 
-    cp -r ${engineSourceName}/mods/{${concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/${mod.name} \
+    cp -r ${engineSourceName}/mods/{${concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/* \
       $out/lib/${pname}/mods/
 
     substitute ${./mod-launch-game.sh} $out/lib/${pname}/launch-game.sh \
@@ -81,7 +81,8 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
 
     substitute ${./openra-mod.desktop} $(mkdirp $out/share/applications)/${pname}.desktop \
       --subst-var-by name ${escapeShellArg mod.name} \
-      --subst-var-by title ${escapeShellArg mod.title}
+      --subst-var-by title ${escapeShellArg mod.title} \
+      --subst-var-by description ${escapeShellArg mod.description}
 
     cp README.md $(mkdirp $out/share/doc/packages/${pname})/README.md
 

--- a/pkgs/games/openra/mods.nix
+++ b/pkgs/games/openra/mods.nix
@@ -7,22 +7,22 @@ let
 
 in {
   ca = buildOpenRAMod {
-    version = "93";
+    version = "96.git.fc3cf0b";
     title = "Combined Arms";
     description = "A game that combines units from the official OpenRA Red Alert and Tiberian Dawn mods";
     homepage = https://github.com/Inq8/CAmod;
     src = fetchFromGitHub {
       owner = "Inq8";
       repo = "CAmod";
-      rev = "16fb77d037be7005c3805382712c33cec1a2788c";
-      sha256 = "11fjyr3692cy2a09bqzk5ya1hf6plh8hmdrgzds581r9xbj0q4pr";
+      rev = "fc3cf0baf2b827650eaae9e1d2335a3eed24bac9";
+      sha256 = "15w91xs253gyrlzsgid6ixxjazx0fbzick6vlkiay0znb58n883m";
     };
-    engine = let commit = "b8a7dd52ff893ed8225726d4ed4e14ecad748404"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "b8a7dd5";
       src = fetchFromGitHub {
         owner = "Inq8";
         repo = "CAengine" ;
-        rev = commit;
+        rev = "b8a7dd52ff893ed8225726d4ed4e14ecad748404";
         sha256 = "0dyk861qagibx8ldshz7d2nrki9q550f6f0wy8pvayvf1gv1dbxj";
         name = "engine";
         inherit extraPostFetch;
@@ -31,23 +31,23 @@ in {
   };
 
   d2 = unsafeBuildOpenRAMod rec {
-    version = "128";
+    version = "134.git.69a4aa7";
     title = "Dune II";
     description = "A modernization of the original ${title} game";
     homepage = https://github.com/OpenRA/d2;
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "d2";
-      rev = "bc969207b532a2def69e0d6ac09a4e8fb5d4e946";
-      sha256 = "18v154kf1fmfk2gnymb3ggsfy73ql8rr7jvbhiw60yhzwx89cdk8";
+      rev = "69a4aa708e2c26376469c0048fac13592aa452ca";
+      sha256 = "1mfch4s6c05slyqvxllklbxpqq8dqcbx3515n3gyylyq43gq481r";
     };
     engine = rec {
-      version = "20181215";
+      version = "release-20181215";
       mods = [ "cnc" "d2k" "ra" ];
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
-        rev = "release-${version}";
+        rev = version;
         sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
         name = "engine";
         inherit extraPostFetch;
@@ -60,23 +60,23 @@ in {
   };
 
   dr = buildOpenRAMod rec {
-    version = "244";
+    version = "266.git.920b476";
     title = "Dark Reign";
     description = "A re-imagination of the original Command & Conquer: ${title} game";
     homepage = https://github.com/drogoganor/DarkReign;
     src = fetchFromGitHub {
       owner = "drogoganor";
       repo = "DarkReign";
-      rev = "e21db398f4d995c91b9e1a0f31ffaa7d54f43742";
-      sha256 = "1gzvdf6idmx0rr8afaxd9dsbnxljif2kic6znkd9vcrwnqmp1fjr";
+      rev = "920b476be1b7751db087f1f7acd504b8a048d1e2";
+      sha256 = "11ir4pnichrnv4z9532fp9g166jl8fvy5kk03a2fgxssp3g40zz2";
     };
-    engine = let commit = "7fcfb1dcb2bd472fa6680ffa37bd3bbedb2c44c5"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "DarkReign";
       src = fetchFromGitHub {
         owner = "drogoganor";
         repo = "OpenRA" ;
-        rev = commit;
-        sha256 = "0x7k96j3q16dgay4jjlyv9kcgn4sc4v9ksw6ijnjws7q1r2rjs0m";
+        rev = "e08b75c2add30439228ea3dd61d6be60d1800329";
+        sha256 = "125vf962p69ajrh5pxgfwsi0ksczqwvlw5kn2fvffiwvh8d5in23";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -84,71 +84,76 @@ in {
   };
 
   gen = buildOpenRAMod {
-    version = "1133";
+    version = "1157.git.4f5e11d";
     title = "Generals Alpha";
     description = "Re-imagination of the original Command & Conquer: Generals game";
     homepage = https://github.com/MustaphaTR/Generals-Alpha;
     src = fetchFromGitHub {
       owner = "MustaphaTR";
       repo = "Generals-Alpha";
-      rev = "277d20d5a8b5e11eac9443031af133dc110c653f";
-      sha256 = "1k37545l99q7zphnh1ykvimsyp5daykannps07d4dgr2w9l7bmhg";
+      rev = "4f5e11d916e4a03d8cf1c97eef484ce2d77d7df2";
+      sha256 = "1wnl4qrlhynnlahgdlxwhgsdba5wgdg9yrv9f8hkgi69j60szypd";
     };
     engine = rec {
-      version = "gen-20180905";
+      version = "gen-20190128_3";
       src = fetchFromGitHub {
         owner = "MustaphaTR";
         repo = "OpenRA" ;
         rev = version;
-        sha256 = "0wy1h7fg0n8dpy6y91md7x0qnr9rk4xf6155jali4bi8gghw2g5v";
+        sha256 = "1x6byz37s8qcpqj902zvkvbv95rv2mv2kj35c12gbpyc92xkqkq0";
         name = "generals-alpha-engine";
         inherit extraPostFetch;
       };
     };
   };
 
-  kknd = buildOpenRAMod rec {
-    version = "142";
+  kknd = let version = "145.git.5530bab"; in name: (buildOpenRAMod rec {
+    inherit version;
     title = "Krush, Kill 'n' Destroy";
     description = "Re-imagination of the original ${title} game";
     homepage = https://kknd-game.com/;
     src = fetchFromGitHub {
       owner = "IceReaper";
       repo = "KKnD";
-      rev = "54d34292168d5c47529688c8d5ca7693c4001ef3";
-      sha256 = "1rsdig282cfr8b4iamr9ri6sshgppp8gllfyib6c2hvqqr301720";
+      rev = "5530babcb05170e0959e4cf2b079161e9fedde4f";
+      sha256 = "07jczrarmgm6zdk0myzwgq200x19yvpjyxrnhdac08mjgyz75zk1";
     };
-    engine = let commit = "4e8eab4ca00d1910203c8a103dfd2c002714daa8"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "4e8eab4ca00d1910203c8a103dfd2c002714daa8";
       src = fetchFromGitHub {
-        owner = "OpenRA";
+        owner = "IceReaper";
         repo = "OpenRA" ;
-        rev = commit;
+        rev = "4e8eab4ca00d1910203c8a103dfd2c002714daa8";
         sha256 = "1yyqparf93x8yzy1f46gsymgkj5jls25v2yc7ighr3f7mi3igdvq";
         name = "engine";
         inherit extraPostFetch;
       };
     };
-  };
+  } name).overrideAttrs (origAttrs: {
+    postPatch = ''
+      ${origAttrs.postPatch}
+      sed -i 's/{DEV_VERSION}/${version}/' mods/*/mod.yaml
+    '';
+  });
 
   mw = buildOpenRAMod rec {
-    version = "235";
+    version = "257.git.c9be8f2";
     title = "Medieval Warfare";
     description = "A re-imagination of the original Command & Conquer: ${title} game";
     homepage = https://github.com/CombinE88/Medieval-Warfare;
     src = fetchFromGitHub {
       owner = "CombinE88";
       repo = "Medieval-Warfare";
-      rev = "1e4fc7ea24d0806c5a7cd753490e967d804a3567";
-      sha256 = "0swa66mzb6wr8vf1yivrss54dl98jzzwh9b8qrjfwmfrq2i356iq";
+      rev = "c9be8f2a6f1dd710b1aedd9d5b00b4cf5020e2fe";
+      sha256 = "09fp7k95jd6hjqdasbspbd43z5670wkyzbbgqkll9dfsrv0sky0v";
     };
-    engine = let commit = "9f9617aa359ebc1923252b7a4a79def73ecfa8a2"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "MedievalWarfareEngine";
       src = fetchFromGitHub {
         owner = "CombinE88";
         repo = "OpenRA" ;
-        rev = commit;
-        sha256 = "02h29xnc1cb5zr001cnmaww5qnfnfaza4v28251jgzkby593r32q";
+        rev = "52109c0910f479753704c46fb19e8afaab353c83";
+        sha256 = "0ga3855j6bc7h81q03cw6laiaiz12915zg8aqah1idvxbzicfy7l";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -156,22 +161,22 @@ in {
   };
 
   ra2 = buildOpenRAMod rec {
-    version = "876";
+    version = "881.git.b37f4f9";
     title = "Red Alert 2";
     description = "Re-imagination of the original Command & Conquer: ${title} game";
     homepage = https://github.com/OpenRA/ra2;
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "ra2";
-      rev = "6a864b2a5887ae42291768fb3dec73082fee44ee";
-      sha256 = "19m4z9r00dj67746ps2f9a8i1icq8nm0iiww6dl975yl6gaxp5qy";
+      rev = "b37f4f9f07404127062d9061966e9cc89dd86445";
+      sha256 = "1jiww66ma3qdk9hzyvhbcaa5h4p2mxxk22kvrw92ckpxy0bqba3h";
     };
     engine = rec {
-      version = "20180923";
+      version = "release-20180923";
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
-        rev = "release-${version}";
+        rev = version;
         sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
         name = "engine";
         inherit extraPostFetch;
@@ -184,23 +189,23 @@ in {
   };
 
   raclassic = buildOpenRAMod {
-    version = "171";
+    version = "181.git.8240890";
     title = "Red Alert Classic";
     description = "A modernization of the original Command & Conquer: Red Alert game";
     homepage = https://github.com/OpenRA/raclassic;
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "raclassic";
-      rev = "a2319b3dfb367a8d4278bf7baf55a10abf615fbc";
-      sha256 = "1k67fx4d9hg8mckzp7pp8lxa6ngqxnnrnbqyfls99dqc4df1iw0a";
+      rev = "8240890b32191ce34241c22158b8a79e8c380879";
+      sha256 = "0dznyb6qa4n3ab87g1c4bihfc2nx53k6z0kajc7ynjdnwzvx69ww";
     };
     engine = rec {
-      version = "20181215";
+      version = "playtest-20190106";
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
-        rev = "release-${version}";
-        sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
+        rev = version;
+        sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -208,24 +213,24 @@ in {
   };
 
   rv = unsafeBuildOpenRAMod {
-    version = "1294";
+    version = "1330.git.9230e6f";
     title = "Romanov's Vengeance";
     description = "Re-imagination of the original Command & Conquer: Red Alert 2 game";
     homepage = https://github.com/MustaphaTR/Romanovs-Vengeance;
     src = fetchFromGitHub {
       owner = "MustaphaTR";
       repo = "Romanovs-Vengeance";
-      rev = "c21cb11579d7e12354c5ccb5c3c47e567c6b3d4f";
-      sha256 = "1vmc5b9awx8q0mahwv11fzgplw9w7m8kzvnx5cl7xr1w5wk87428";
+      rev = "9230e6f1dd9758467832aee4eda115e18f0e635f";
+      sha256 = "0bwbmmlhp1kh8rgk2nx1ca9vqssj849amndacf318d61gksc1w9n";
     };
-    engine = let commit = "e9e99074b294c32fbe88dd8727581cb8c512c2e2"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "f3873ae";
       mods = [ "as" ];
       src = fetchFromGitHub {
-        owner = "GraionDilach";
-        repo = "OpenRA" ;
-        rev = commit;
-        sha256 = "0bibnakpmbxwglf2dka6g04xp8dzwyms1zk5kqlbm8gpdp0aqmxp";
+        owner = "AttacqueSuperior";
+        repo = "Engine";
+        rev = "f3873ae242803051285994d77eb26f4b951594b5";
+        sha256 = "02rv29wja0p5d083pd087daz7x7pp5b9ym7sci2fhg3mrnaqgwkp";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -237,24 +242,24 @@ in {
   };
 
   sp = unsafeBuildOpenRAMod {
-    version = "153";
+    version = "176.git.fc89ae8";
     title = "Shattered Paradise";
     description = "Re-imagination of the original Command & Conquer: Tiberian Sun game";
     homepage = https://github.com/ABrandau/OpenRAModSDK;
     src = fetchFromGitHub {
       owner = "ABrandau";
       repo = "OpenRAModSDK";
-      rev = "89148b8cf89bf13911fafb74a1aa2b4cacf027e0";
-      sha256 = "1bb8hzd3mhnn76iqiah1161qz98f0yvyryhmrghq03xlbin3mhbi";
+      rev = "fc89ae8a10e0f765ac735f923e01aa24dd20e8d2";
+      sha256 = "0xyxhipmjlld0kp23fwsdwnspr7fci0mdnjd60gcsh34c7m0341p";
     };
-    engine = let commit = "82a2f234bdf3b768cea06408e3de30f9fbbe9412"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "SP-Bleed-Branch";
       mods = [ "as" "ts" ];
       src = fetchFromGitHub {
         owner = "ABrandau";
         repo = "OpenRA" ;
-        rev = commit;
-        sha256 = "1nl3brvx1bikxm5rmpc7xmd32n722jiyjh86pnar6b6idr1zj2ws";
+        rev = "d3545c0b751aea2105748eddaab5919313e35314";
+        sha256 = "1jsldl6vnf3r9dzppdm4z7kqbrzkidda5k74wc809i8c4jjnq9rq";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -262,23 +267,23 @@ in {
   };
 
   ss = buildOpenRAMod rec {
-    version = "72";
+    version = "77.git.23e1f3e";
     title = "Sole Survivor";
     description = "A re-imagination of the original Command & Conquer: ${title} game";
     homepage = https://github.com/MustaphaTR/sole-survivor;
     src = fetchFromGitHub {
       owner = "MustaphaTR";
       repo = "sole-survivor";
-      rev = "fad65579c8b487cef9a8145e872390ed77c16c69";
-      sha256 = "0h7is7x2qyvq7vqp0jgw5zrdkw8g7ndd82d843ldhnb0a3vyrk34";
+      rev = "23e1f3e5d8b98c936797b6680d95d56a69a9e2ab";
+      sha256 = "104clmxphchs7r8y7hpmw103bychayz80bqj98bp89i64nv9d89x";
     };
-    engine = let commit = "becfc154c5cd3891d695339ff86883db8b5790a5"; in {
-      version = abbrevCommit commit;
+    engine = {
+      version = "6de92de";
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
-        rev = commit;
-        sha256 = "0id8vf3cjr7h5pz4sw8pdaz3sc45lxr21k1fk4309kixsrpa7i0y";
+        rev = "6de92de8d982094a766eab97a92225c240d85493";
+        sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -286,7 +291,7 @@ in {
   };
 
   ura = buildOpenRAMod {
-    version = "431";
+    version = "431.git.128dc53";
     title = "Red Alert Unplugged";
     description = "Re-imagination of the original Command & Conquer: Red Alert game";
     homepage = http://redalertunplugged.com/;
@@ -310,22 +315,22 @@ in {
   };
 
   yr = unsafeBuildOpenRAMod rec {
-    version = "117";
+    version = "118.git.c26bf14";
     homepage = https://github.com/cookgreen/yr;
     title = "Yuri's Revenge";
     description = "Re-imagination of the original Command & Conquer: ${title} game";
     src = fetchFromGitHub {
       owner = "cookgreen";
       repo = "yr";
-      rev = "1d4beeb0687fe4b39b01ec31f3702cfb90a7f4f7";
-      sha256 = "1rd962ja1x72rz68kbmp19yiip3iif50hzlj3v8k1f5l94r2x2pn";
+      rev = "c26bf14155d040edf33c6c5eb3677517d07b39f8";
+      sha256 = "15k6gv4rx3490n0cs9q7ah7q31z89v0pddsw6nqv0fhcahhvq1bc";
     };
     engine = rec {
-      version = "20180923";
+      version = "release-20180923";
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
-        rev = "release-${version}";
+        rev = version;
         sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
         name = "engine";
         inherit extraPostFetch;


### PR DESCRIPTION
###### Motivation for this change
The bleed version of OpenRA had the wrong hash and most mods have had updates. The Zenity error now shows actual newlines rather than \n. Mods have been updated automatically with a script, which is included in the PR.

Update 2: Downgraded `kknd` to a older commit and upgraded `dr` to an even newer commit to make them both work. They should now all run.
Update: @fusion809 tested them and found that only `kknd` and `dr` need fixing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

