### PR TITLE
pythonPackages.shodan: init at 1.10.4

### DIFF
--- a/pkgs/development/python-modules/shodan/default.nix
+++ b/pkgs/development/python-modules/shodan/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, click-plugins
+, colorama
+, requests
+, XlsxWriter
+}:
+
+buildPythonPackage rec {
+  pname = "shodan";
+  version = "1.10.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13966vqxww7v2b5hf2kjismdzvqyjvxlcdvpkzpbsrpxy9pvn2n4";
+  };
+
+  propagatedBuildInputs = [
+    click-plugins
+    colorama
+    requests
+    XlsxWriter
+  ];
+
+  # The tests require a shodan api key, so skip them.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python library and command-line utility for Shodan";
+    homepage = https://github.com/achillean/shodan-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lihop ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4005,6 +4005,8 @@ in {
 
   simplegeneric = callPackage ../development/python-modules/simplegeneric { };
 
+  shodan = callPackage ../development/python-modules/shodan { };
+
   should-dsl = callPackage ../development/python-modules/should-dsl { };
 
   simplejson = callPackage ../development/python-modules/simplejson { };


### PR DESCRIPTION
Python library and command-line interface for Shodan.

###### Motivation for this change

Library missing from nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

