### PR TITLE
openmpi: 3.1.3 -> 4.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -618,7 +618,7 @@
         The kubernetes module does no longer add the kubernetes package to
         <varname>environment.systemPackages</varname> implicitly.
       </para>
-    </listitem>    
+    </listitem>
     <listitem>
       <para>
         The <literal>intel</literal> driver has been removed from the default list of
@@ -633,6 +633,13 @@
         to add `intel` to `videoDrivers` and report an issue (or provide additional
         details in an existing one)
       </para>
+   </listitem>
+   <listitem>
+     <para>
+       Openmpi has been updated to version 4.0.0, which removes some deprecated MPI-1 symbols.
+       This may break some older applications that still rely on those symbols.
+       An upgrade guide can be found <link xlink:href="https://www.open-mpi.org/faq/?category=mpi-removed">here</link>.
+     </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/pkgs/development/libraries/globalarrays/default.nix
+++ b/pkgs/development/libraries/globalarrays/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchFromGitHub, automake, autoconf, libtool
+{ stdenv, fetchpatch, fetchFromGitHub, automake, autoconf, libtool
 , openblas, gfortran, openssh, openmpi
 } :
 
@@ -14,6 +14,18 @@ in stdenv.mkDerivation {
     rev = "v${version}";
     sha256 = "07i2idaas7pq3in5mdqq5ndvxln5q87nyfgk3vzw85r72c4fq5jh";
   };
+
+  # upstream patches for openmpi-4 compatibility
+  patches = [ (fetchpatch {
+    name = "MPI_Type_struct-was-deprecated-in-MPI-2";
+    url = "https://github.com/GlobalArrays/ga/commit/36e6458993b1df745f43b7db86dc17087758e0d2.patch";
+    sha256 = "058qi8x0ananqx980p03yxpyn41cnmm0ifwsl50qp6sc0bnbnclh";
+  })
+  (fetchpatch {
+    name = "MPI_Errhandler_set-was-deprecated-in-MPI-2";
+    url = "https://github.com/GlobalArrays/ga/commit/f1ea5203d2672c1a1d0275a012fb7c2fb3d033d8.patch";
+    sha256 = "06n7ds9alk5xa6hd7waw3wrg88yx2azhdkn3cjs2k189iw8a7fqk";
+  })];
 
   nativeBuildInputs = [ automake autoconf libtool ];
   buildInputs = [ openmpi openblas gfortran openssh ];

--- a/pkgs/development/libraries/globalarrays/default.nix
+++ b/pkgs/development/libraries/globalarrays/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchpatch, fetchFromGitHub, automake, autoconf, libtool
+{ stdenv, fetchpatch, fetchFromGitHub, autoreconfHook
 , openblas, gfortran, openssh, openmpi
 } :
 
@@ -27,11 +27,10 @@ in stdenv.mkDerivation {
     sha256 = "06n7ds9alk5xa6hd7waw3wrg88yx2azhdkn3cjs2k189iw8a7fqk";
   })];
 
-  nativeBuildInputs = [ automake autoconf libtool ];
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openmpi openblas gfortran openssh ];
 
   preConfigure = ''
-    autoreconf -ivf
     configureFlagsArray+=( "--enable-i8" \
                            "--with-mpi" \
                            "--with-mpi3" \

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -9,14 +9,14 @@
 }:
 
 let
-  version = "3.1.3";
+  version = "4.0.0";
 
 in stdenv.mkDerivation rec {
   name = "openmpi-${version}";
 
   src = with stdenv.lib.versions; fetchurl {
     url = "http://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${name}.tar.bz2";
-    sha256 = "1dks11scivgaskjs5955y9wprsl12wr3gn5r7wfl0l8gq03l7q4b";
+    sha256 = "0srnjwzsmyhka9hhnmqm86qck4w3xwjm8g6sbns58wzbrwv8l2rg";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, gfortran, perl, libnl, rdma-core, zlib
-, numactl, libevent, hwloc
+{ stdenv, fetchurl, fetchpatch, gfortran, perl, libnl
+, rdma-core, zlib, numactl, libevent, hwloc
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false
@@ -18,6 +18,14 @@ in stdenv.mkDerivation rec {
     url = "http://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${name}.tar.bz2";
     sha256 = "0srnjwzsmyhka9hhnmqm86qck4w3xwjm8g6sbns58wzbrwv8l2rg";
   };
+
+  patches = [ (fetchpatch {
+   # Fix a bug that ignores OMPI_MCA_rmaps_base_oversubscribe (upstream patch).
+   # This bug breaks the test from libs, such as scalapack,
+   # on machines with less than 4 cores.
+   url = https://github.com/open-mpi/ompi/commit/98c8492057e6222af6404b352430d0dd7553d253.patch;
+   sha256 = "1mpd8sxxprgfws96qqlzvqf58pn2vv2d0qa8g8cpv773sgw3b3gj";
+  }) ];
 
   postPatch = ''
     patchShebangs ./

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gfortran, perl, libnl, rdma-core, zlib
-, numactl
+, numactl, libevent, hwloc
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
   '';
 
   buildInputs = with stdenv; [ gfortran zlib ]
-    ++ lib.optionals isLinux [ libnl numactl ]
+    ++ lib.optionals isLinux [ libnl numactl libevent hwloc ]
     ++ lib.optional (isLinux || isFreeBSD) rdma-core;
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -44,8 +44,8 @@ stdenv.mkDerivation rec {
     homepage = http://www.netlib.org/scalapack/;
     description = "Library of high-performance linear algebra routines for parallel distributed memory machines";
     license = licenses.bsd3;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.costrouc ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ costrouc markuskowa ];
   };
 
 }

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "0p1r61ss1fq0bs8ynnx7xq4wwsdvs32ljvwjnx6yxr8gd6pawx0c";
   };
 
+  # patch to rename outdated MPI functions
+  patches = [ ./openmpi4.patch ];
+
   nativeBuildInputs = [ cmake openssh ];
   buildInputs = [ mpi gfortran openblasCompat ];
 

--- a/pkgs/development/libraries/science/math/scalapack/openmpi4.patch
+++ b/pkgs/development/libraries/science/math/scalapack/openmpi4.patch
@@ -1,0 +1,143 @@
+diff --git a/BLACS/SRC/blacs_get_.c b/BLACS/SRC/blacs_get_.c
+index e979767..d4b04cf 100644
+--- a/BLACS/SRC/blacs_get_.c
++++ b/BLACS/SRC/blacs_get_.c
+@@ -23,7 +23,7 @@ F_VOID_FUNC blacs_get_(int *ConTxt, int *what, int *val)
+    case SGET_MSGIDS:
+       if (BI_COMM_WORLD == NULL) Cblacs_pinfo(val, &val[1]);
+       iptr = &val[1];
+-      ierr=MPI_Attr_get(MPI_COMM_WORLD, MPI_TAG_UB, (BVOID **) &iptr,val);
++      ierr=MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, (BVOID **) &iptr,val);
+       val[0] = 0;
+       val[1] = *iptr;
+       break;
+diff --git a/BLACS/SRC/cgamn2d_.c b/BLACS/SRC/cgamn2d_.c
+index 2db6ccb..6958f32 100644
+--- a/BLACS/SRC/cgamn2d_.c
++++ b/BLACS/SRC/cgamn2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC cgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/cgamx2d_.c b/BLACS/SRC/cgamx2d_.c
+index 707c0b6..f802d01 100644
+--- a/BLACS/SRC/cgamx2d_.c
++++ b/BLACS/SRC/cgamx2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC cgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/dgamn2d_.c b/BLACS/SRC/dgamn2d_.c
+index dff23b4..a2627ac 100644
+--- a/BLACS/SRC/dgamn2d_.c
++++ b/BLACS/SRC/dgamn2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC dgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/dgamx2d_.c b/BLACS/SRC/dgamx2d_.c
+index a51f731..2a644d0 100644
+--- a/BLACS/SRC/dgamx2d_.c
++++ b/BLACS/SRC/dgamx2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC dgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/igamn2d_.c b/BLACS/SRC/igamn2d_.c
+index 16bc003..f6a7859 100644
+--- a/BLACS/SRC/igamn2d_.c
++++ b/BLACS/SRC/igamn2d_.c
+@@ -218,7 +218,7 @@ F_VOID_FUNC igamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/igamx2d_.c b/BLACS/SRC/igamx2d_.c
+index 8165cbe..a7cfcc6 100644
+--- a/BLACS/SRC/igamx2d_.c
++++ b/BLACS/SRC/igamx2d_.c
+@@ -218,7 +218,7 @@ F_VOID_FUNC igamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/sgamn2d_.c b/BLACS/SRC/sgamn2d_.c
+index d6c95e5..569c797 100644
+--- a/BLACS/SRC/sgamn2d_.c
++++ b/BLACS/SRC/sgamn2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC sgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/sgamx2d_.c b/BLACS/SRC/sgamx2d_.c
+index 4b0af6f..8897ece 100644
+--- a/BLACS/SRC/sgamx2d_.c
++++ b/BLACS/SRC/sgamx2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC sgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/zgamn2d_.c b/BLACS/SRC/zgamn2d_.c
+index 9de2b23..37897df 100644
+--- a/BLACS/SRC/zgamn2d_.c
++++ b/BLACS/SRC/zgamn2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC zgamn2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;
+diff --git a/BLACS/SRC/zgamx2d_.c b/BLACS/SRC/zgamx2d_.c
+index 414c381..0e9d474 100644
+--- a/BLACS/SRC/zgamx2d_.c
++++ b/BLACS/SRC/zgamx2d_.c
+@@ -221,7 +221,7 @@ F_VOID_FUNC zgamx2d_(int *ConTxt, F_CHAR scope, F_CHAR top, int *m, int *n,
+       {
+ #endif
+       i = 2;
+-      ierr=MPI_Type_struct(i, len, disp, dtypes, &MyType);
++      ierr=MPI_Type_create_struct(i, len, disp, dtypes, &MyType);
+       ierr=MPI_Type_commit(&MyType);
+       bp->N = bp2->N = 1;
+       bp->dtype = bp2->dtype = MyType;

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -13,11 +13,18 @@ buildPythonPackage rec {
     inherit mpi;
   };
 
-  patches = [ (fetchpatch {
-    # Disable tests failing with 3.1.x and MPI_THREAD_MULTIPLE
-    url = "https://bitbucket.org/mpi4py/mpi4py/commits/c2b6b7e642a182f9b00a2b8e9db363214470548a/raw";
-    sha256 = "0n6bz3kj4vcqb6q7d0mlj5vl6apn7i2bvfc9mpg59vh3wy47119q";
+  patches = [
+    (fetchpatch {
+      # Disable tests failing with 3.1.x and MPI_THREAD_MULTIPLE (upstream patch)
+      url = "https://bitbucket.org/mpi4py/mpi4py/commits/c2b6b7e642a182f9b00a2b8e9db363214470548a/raw";
+      sha256 = "0n6bz3kj4vcqb6q7d0mlj5vl6apn7i2bvfc9mpg59vh3wy47119q";
     })
+    (fetchpatch {
+      # Open MPI: Workaround removal of MPI_{LB|UB} (upstream patch)
+      url = "https://bitbucket.org/mpi4py/mpi4py/commits/39ca784226460f9e519507269ebb29635dc8bd90/raw";
+      sha256 = "02kxikdlsrlq8yr5hca42536mxbrq4k4j8nqv7p1p2r0q21a919q";
+    })
+
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/hdf5/0001-Updated-H5S-to-use-the-MPI-2-function-MPI_Type_get_e.patch
+++ b/pkgs/tools/misc/hdf5/0001-Updated-H5S-to-use-the-MPI-2-function-MPI_Type_get_e.patch
@@ -1,0 +1,58 @@
+From 38c202df4db8eddd5e6f6f7d6506ce97912a3111 Mon Sep 17 00:00:00 2001
+From: Dana Robinson <derobins@hdfgroup.org>
+Date: Mon, 26 Nov 2018 22:10:06 -0800
+Subject: [PATCH] Updated H5S to use the MPI-2 function MPI_Type_get_exten()
+ where available. OpenMPI 4.0 removed the deprecated MPI-1 MPI_type_extent()
+ call by default, so this avoids needing a special OpenMPI build.
+
+---
+ src/H5Smpio.c | 26 ++++++++++++++++++++++++--
+ 1 file changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/src/H5Smpio.c b/src/H5Smpio.c
+index 2bd275a729..e71e2cb858 100644
+--- a/src/H5Smpio.c
++++ b/src/H5Smpio.c
+@@ -879,7 +879,18 @@ H5S_mpio_hyper_type(const H5S_t *space, size_t elmt_size,
+                     HMPI_GOTO_ERROR(FAIL, "MPI_Type_contiguous failed", mpi_code)
+             }
+ 
+-            MPI_Type_extent (inner_type, &inner_extent);
++#if MPI_VERSION >= 2
++{
++            /* As of version 4.0, OpenMPI now turns off MPI-1 API calls by default,
++             * so we're using the MPI-2 version even though we don't need the lb
++             * value.
++             */
++            MPI_Aint unused_lb_arg;
++            MPI_Type_get_extent(inner_type, &unused_lb_arg, &inner_extent);
++}
++#else
++            MPI_Type_extent(inner_type, &inner_extent);
++#endif
+             stride_in_bytes = inner_extent * (MPI_Aint)d[i].strid;
+ 
+             /* If the element count is larger than what a 32 bit integer can hold,
+@@ -1500,7 +1511,18 @@ static herr_t H5S_mpio_create_large_type (hsize_t num_elements,
+             }
+         }
+ 
+-        MPI_Type_extent (old_type, &old_extent);
++#if MPI_VERSION >= 2
++{
++        /* As of version 4.0, OpenMPI now turns off MPI-1 API calls by default,
++         * so we're using the MPI-2 version even though we don't need the lb
++         * value.
++         */
++        MPI_Aint unused_lb_arg;
++        MPI_Type_get_extent(old_type, &unused_lb_arg, &old_extent);
++}
++#else
++        MPI_Type_extent(old_type, &old_extent);
++#endif
+ 
+         /* Set up the arguments for MPI_Type_struct constructor */
+         type[0] = outer_type;
+-- 
+2.18.1
+

--- a/pkgs/tools/misc/hdf5/0001-Yanked-all-MPI-1-calls.patch
+++ b/pkgs/tools/misc/hdf5/0001-Yanked-all-MPI-1-calls.patch
@@ -1,0 +1,115 @@
+From 8cf3bfb14bd2a80f13d269a9e84cd99f86f19254 Mon Sep 17 00:00:00 2001
+From: Dana Robinson <derobins@hdfgroup.org>
+Date: Tue, 27 Nov 2018 10:31:54 -0800
+Subject: [PATCH] Yanked all MPI-1 calls
+
+---
+ src/H5.c          |  2 +-
+ src/H5Smpio.c     | 24 ++++++++----------------
+ testpar/t_cache.c | 20 ++++++++++----------
+ 3 files changed, 19 insertions(+), 27 deletions(-)
+
+diff --git a/src/H5.c b/src/H5.c
+index d1967e611b..bf4643ca59 100644
+--- a/src/H5.c
++++ b/src/H5.c
+@@ -138,7 +138,7 @@ H5_init_library(void)
+         if (mpi_initialized && !mpi_finalized) {
+             int key_val;
+ 
+-            if(MPI_SUCCESS != (mpi_code = MPI_Comm_create_keyval(MPI_NULL_COPY_FN, 
++            if(MPI_SUCCESS != (mpi_code = MPI_Comm_create_keyval(MPI_COMM_NULL_COPY_FN, 
+                                                                  (MPI_Comm_delete_attr_function *)H5_mpi_delete_cb, 
+                                                                  &key_val, NULL)))
+                 HMPI_GOTO_ERROR(FAIL, "MPI_Comm_create_keyval failed", mpi_code)
+diff --git a/src/H5Smpio.c b/src/H5Smpio.c
+index e71e2cb858..935d27972e 100644
+--- a/src/H5Smpio.c
++++ b/src/H5Smpio.c
+@@ -879,18 +879,14 @@ H5S_mpio_hyper_type(const H5S_t *space, size_t elmt_size,
+                     HMPI_GOTO_ERROR(FAIL, "MPI_Type_contiguous failed", mpi_code)
+             }
+ 
+-#if MPI_VERSION >= 2
+-{
+             /* As of version 4.0, OpenMPI now turns off MPI-1 API calls by default,
+              * so we're using the MPI-2 version even though we don't need the lb
+              * value.
+              */
+-            MPI_Aint unused_lb_arg;
+-            MPI_Type_get_extent(inner_type, &unused_lb_arg, &inner_extent);
+-}
+-#else
+-            MPI_Type_extent(inner_type, &inner_extent);
+-#endif
++            {
++                MPI_Aint unused_lb_arg;
++                MPI_Type_get_extent(inner_type, &unused_lb_arg, &inner_extent);
++            }
+             stride_in_bytes = inner_extent * (MPI_Aint)d[i].strid;
+ 
+             /* If the element count is larger than what a 32 bit integer can hold,
+@@ -1511,18 +1507,14 @@ static herr_t H5S_mpio_create_large_type (hsize_t num_elements,
+             }
+         }
+ 
+-#if MPI_VERSION >= 2
+-{
+         /* As of version 4.0, OpenMPI now turns off MPI-1 API calls by default,
+          * so we're using the MPI-2 version even though we don't need the lb
+          * value.
+          */
+-        MPI_Aint unused_lb_arg;
+-        MPI_Type_get_extent(old_type, &unused_lb_arg, &old_extent);
+-}
+-#else
+-        MPI_Type_extent(old_type, &old_extent);
+-#endif
++        {
++            MPI_Aint unused_lb_arg;
++            MPI_Type_get_extent(old_type, &unused_lb_arg, &old_extent);
++        }
+ 
+         /* Set up the arguments for MPI_Type_struct constructor */
+         type[0] = outer_type;
+diff --git a/testpar/t_cache.c b/testpar/t_cache.c
+index 5e15ec274c..ca5ded9ecf 100644
+--- a/testpar/t_cache.c
++++ b/testpar/t_cache.c
+@@ -1217,15 +1217,15 @@ setup_derived_types(void)
+     struct mssg_t sample; /* used to compute displacements */
+ 
+     /* setup the displacements array */
+-    if ( ( MPI_SUCCESS != MPI_Address(&sample.req, &displs[0]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.src, &displs[1]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.dest, &displs[2]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.mssg_num, &displs[3]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.base_addr, &displs[4]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.len, &displs[5]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.ver, &displs[6]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.count, &displs[7]) ) ||
+-         ( MPI_SUCCESS != MPI_Address(&sample.magic, &displs[8]) ) ) {
++    if ( ( MPI_SUCCESS != MPI_Get_address(&sample.req, &displs[0]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.src, &displs[1]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.dest, &displs[2]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.mssg_num, &displs[3]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.base_addr, &displs[4]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.len, &displs[5]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.ver, &displs[6]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.count, &displs[7]) ) ||
++         ( MPI_SUCCESS != MPI_Get_address(&sample.magic, &displs[8]) ) ) {
+ 
+         nerrors++;
+         success = FALSE;
+@@ -1245,7 +1245,7 @@ setup_derived_types(void)
+ 
+     if ( success ) {
+ 
+-        result = MPI_Type_struct(9, block_len, displs, mpi_types, &mpi_mssg_t);
++        result = MPI_Type_create_struct(9, block_len, displs, mpi_types, &mpi_mssg_t);
+ 
+         if ( result != MPI_SUCCESS ) {
+ 
+-- 
+2.18.1
+

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/${name}/src/${name}.tar.bz2";
     sha256 = "1pr85fa1sh2ky6ai2hs3f21lp252grl2cq3wbyi4rh7dm83gyrqj";
- };
+  };
 
   passthru = {
     mpiSupport = (mpi != null);
@@ -45,7 +45,13 @@ stdenv.mkDerivation rec {
     ++ optionals (mpi != null) ["--enable-parallel" "CC=${mpi}/bin/mpicc"]
     ++ optional enableShared "--enable-shared";
 
-  patches = [./bin-mv.patch];
+  patches = [
+    ./bin-mv.patch
+    # upstream patches for openmpi-4 compatiblity
+    # To be removed with the upgrade to 1.10.5
+    ./0001-Updated-H5S-to-use-the-MPI-2-function-MPI_Type_get_e.patch
+    ./0001-Yanked-all-MPI-1-calls.patch
+  ];
 
   postInstall = ''
     find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +


### PR DESCRIPTION
###### Motivation for this change
This update removes some deprecated MPI-1 symbols. This breaks some applications still using these outdated symbols. Fortunately it is a simple function name change in most cases.

Upgrade guide: https://www.open-mpi.org/software/ompi/major-changes.php
Removed symbols: https://www.open-mpi.org/faq/?category=mpi-removed

CC potentially affected maintainers @costrouc @abbradar @bzizou 

###### Things done

* Add upstream patch to `mpi4py`
* patch deprecated functions in `scalapack`
* Add upstream patch to `globalarrays`
* Add upstream patches to `hfd5-mpi`
* added an entry to the release notes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
       -> ~+3MB
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

