### PR TITLE
pulseaudio-dlna: downgrade dep zeroconf to 0.19.1

### DIFF
--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -30,7 +30,7 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = with pythonPackages; [
     dbus-python docopt requests setproctitle protobuf psutil futures
-    chardet notify2 netifaces pyroute2 pygobject2 lxml zeroconf ]
+    chardet notify2 netifaces pyroute2 pygobject2 lxml zeroconf_19 ]
     ++ stdenv.lib.optional mp3Support lame
     ++ stdenv.lib.optional opusSupport opusTools
     ++ stdenv.lib.optional faacSupport faac

--- a/pkgs/development/python-modules/zeroconf/0.19.1.nix
+++ b/pkgs/development/python-modules/zeroconf/0.19.1.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, netifaces, six, enum-compat }:
+
+buildPythonPackage rec {
+  pname = "zeroconf";
+  version = "0.19.1";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ykzg730n915qbrq9bn5pn06bv6rb5zawal4sqjyfnjjm66snkj3";
+  };
+
+  propagatedBuildInputs = [ netifaces six enum-compat ];
+
+  meta = with stdenv.lib; {
+    description = "A pure python implementation of multicast DNS service discovery";
+    homepage = https://github.com/jstasiak/python-zeroconf;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ abbradar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5039,6 +5039,8 @@ in {
   zeitgeist = disabledIf isPy3k
     (toPythonModule (pkgs.zeitgeist.override{python2Packages=self;})).py;
 
+  zeroconf_19 = callPackage ../development/python-modules/zeroconf/0.19.1.nix { };
+
   zeroconf = callPackage ../development/python-modules/zeroconf { };
 
   zipfile36 = callPackage ../development/python-modules/zipfile36 { };


### PR DESCRIPTION
###### Motivation for this change

The Python package zeroconf dropped support for Python 2 starting from
version 0.20.0, so we need to use the previous version, 0.19.1, for
pulseaudio-dlna.

0.19.1.nix was taken from 8655259bfe22b97686598345377062601480e615

See: https://github.com/jstasiak/python-zeroconf#0200

On `nixpkgs-unstable` the derivation of `pulseaudio-dlna` fails to evaluate. On `nixos-18.09` it builds but **non-fatally** throws a exception on start. **The exception does not seem to affect other functionalities.**

```plain
Exception in thread zeroconf-Engine:
Traceback (most recent call last):
  File "/nix/store/zr5b2d8hdyf3avsami9nfdmnqr1mvcq5-python-2.7.15/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/nix/store/7yj4sncwz0fi6h528jyjqk1xg76cx8qi-python2.7-zeroconf-0.20.0/lib/python2.7/site-packages/zeroconf.py", line 1133, in run
    reader.handle_read(socket_)
  File "/nix/store/7yj4sncwz0fi6h528jyjqk1xg76cx8qi-python2.7-zeroconf-0.20.0/lib/python2.7/site-packages/zeroconf.py", line 1175, in handle_read
    msg = DNSIncoming(data)
  File "/nix/store/7yj4sncwz0fi6h528jyjqk1xg76cx8qi-python2.7-zeroconf-0.20.0/lib/python2.7/site-packages/zeroconf.py", line 644, in __init__
    self.read_questions()
  File "/nix/store/7yj4sncwz0fi6h528jyjqk1xg76cx8qi-python2.7-zeroconf-0.20.0/lib/python2.7/site-packages/zeroconf.py", line 667, in read_questions
    name = self.read_name()
  File "/nix/store/7yj4sncwz0fi6h528jyjqk1xg76cx8qi-python2.7-zeroconf-0.20.0/lib/python2.7/site-packages/zeroconf.py", line 756, in read_name
    t = length & 0xC0
TypeError: unsupported operand type(s) for &: 'str' and 'int'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

