### PR TITLE
defaultGemConfig.tzinfo: fix for >=2.0

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -425,10 +425,16 @@ in
 
   tzinfo = attrs: lib.optionalAttrs (lib.versionAtLeast attrs.version "1.0") {
     dontBuild = false;
-    postPatch = ''
-      substituteInPlace lib/tzinfo/zoneinfo_data_source.rb \
-        --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
-    '';
+    postPatch =
+      let
+        path = if lib.versionAtLeast attrs.version "2.0"
+               then "lib/tzinfo/data_sources/zoneinfo_data_source.rb"
+               else "lib/tzinfo/zoneinfo_data_source.rb";
+      in
+        ''
+          substituteInPlace ${path} \
+            --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
+        '';
   };
 
   uuid4r = attrs: {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---