### PR TITLE
txr: init at 208

### DIFF
--- a/pkgs/tools/misc/txr/default.nix
+++ b/pkgs/tools/misc/txr/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, bison, flex, libffi }:
+
+stdenv.mkDerivation rec {
+  name = "txr-${version}";
+  version = "208";
+
+  src = fetchurl {
+    url = "http://www.kylheku.com/cgit/txr/snapshot/${name}.tar.bz2";
+    sha256 = "091yki3a24pscwd0lg2ymy86r223amjnz9c71z4a2kxz5brhl5my";
+  };
+
+  nativeBuildInputs = [ bison flex ];
+  buildInputs = [ libffi ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  checkTarget = "tests";
+
+  # Remove failing test-- mentions 'usr/bin' so probably related :)
+  preCheck = "rm -rf tests/017";
+
+  # TODO: install 'tl.vim', make avail when txr is installed or via plugin
+
+  meta = with stdenv.lib; {
+    description = "Programming language for convenient data munging";
+    license = licenses.bsd2;
+    homepage = http://nongnu.org/txr;
+    maintainers = with stdenv.lib.maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5851,6 +5851,8 @@ in
   twitterBootstrap3 = callPackage ../development/web/twitter-bootstrap {};
   twitterBootstrap = twitterBootstrap3;
 
+  txr = callPackage ../tools/misc/txr { stdenv = clangStdenv; };
+
   txt2man = callPackage ../tools/misc/txt2man { };
 
   txt2tags = callPackage ../tools/text/txt2tags { };


### PR DESCRIPTION
###### Motivation for this change

Promoting from my NUR repo.

Build w/clang as it fixes test crash for some reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---