### PR TITLE
crex: init at 0.2.5

### DIFF
--- a/pkgs/tools/misc/crex/default.nix
+++ b/pkgs/tools/misc/crex/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "crex";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "octobanana";
+    repo = "crex";
+    rev = version;
+    sha256 = "086rvwl494z48acgsq3yq11qh1nxm8kbf11adn16aszai4d4ipr3";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace "/usr/local/bin" "bin"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Explore, test, and check regular expressions in the terminal.";
+    homepage = https://octobanana.com/software/crex;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/crex/default.nix
+++ b/pkgs/tools/misc/crex/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
-    description = "Explore, test, and check regular expressions in the terminal.";
+    description = "Explore, test, and check regular expressions in the terminal";
     homepage = https://octobanana.com/software/crex;
     license = licenses.mit;
     maintainers = with maintainers; [ dtzWill ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1185,6 +1185,8 @@ in
 
   cppclean = callPackage ../development/tools/cppclean {};
 
+  crex = callPackage ../tools/misc/crex { };
+
   cri-tools = callPackage ../tools/virtualization/cri-tools {};
 
   crip = callPackage ../applications/audio/crip { };


### PR DESCRIPTION
(promoting from my NUR repo)


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---