### PR TITLE
xlayoutdisplay: init at 1.0.2

### DIFF
--- a/pkgs/tools/X11/xlayoutdisplay/default.nix
+++ b/pkgs/tools/X11/xlayoutdisplay/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, xorg, boost, cmake, gtest }:
+
+stdenv.mkDerivation rec {
+  name = "xlayoutdisplay-${version}";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "alex-courtis";
+    repo = "xlayoutdisplay";
+    rev = "v${version}";
+    sha256 = "1cqn98lpx9rkfhavbqalaaljw351hvqsrszgqnwvcyq05vq26dwx";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = with xorg; [ libX11 libXrandr libXcursor boost ];
+  checkInputs = [ gtest ];
+
+  doCheck = true;
+
+  # format security fixup
+  postPatch = ''
+    substituteInPlace test/test-Monitors.cpp \
+      --replace 'fprintf(lidStateFile, contents);' \
+                'fputs(contents, lidStateFile);'
+
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Detects and arranges linux display outputs, using XRandR for detection and xrandr for arrangement";
+    homepage = https://github.com/alex-courtis/xlayoutdisplay;
+    maintainers = with maintainers; [ dtzWill ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23011,6 +23011,8 @@ in
 
   xinput_calibrator = callPackage ../tools/X11/xinput_calibrator { };
 
+  xlayoutdisplay = callPackage ../tools/X11/xlayoutdisplay { };
+
   xlog = callPackage ../applications/misc/xlog { };
 
   xmagnify = callPackage ../tools/X11/xmagnify { };


### PR DESCRIPTION
###### Motivation for this change

(promoting from my NUR repo)

Useful utility :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---