### PR TITLE
chelf: init at 0.2.2

### DIFF
--- a/pkgs/tools/misc/chelf/default.nix
+++ b/pkgs/tools/misc/chelf/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "chelf-${version}";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Gottox";
+    repo = "chelf";
+    rev = "v${version}";
+    sha256 = "0xwd84aynyqsi2kcndbff176vmhrak3jmn3lfcwya59653pppjr6";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv chelf $out/bin/chelf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "change or display the stack size of an ELF binary";
+    homepage = https://github.com/Gottox/chelf;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1112,6 +1112,8 @@ in
 
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
+  chelf = callPackage ../tools/misc/chelf { };
+
   cht-sh = callPackage ../tools/misc/cht.sh { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };


### PR DESCRIPTION
###### Motivation for this change

Utility for changing default thread stack size
(via PT_GNU_STACK program header)
as supported by musl 1.1.21+.

patchelf for default thread stack size :).

This makes it possible to use a larger value
without changing the source, which is preferred
but may be awkward or otherwise undesirable in some cases.

The value can also be set via LDFLAGS with some linkers,
such as with GNU ld using "-Wl,-z,stack-size=N".

See:
https://git.musl-libc.org/cgit/musl/commit/?id=7b3348a98c139b4b4238384e52d4b0eb237e4833


(promoting from my NUR repo, FWIW)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---