### PR TITLE
openblas: make the optimization target overridable

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -3,6 +3,10 @@
 # pointer width, but some expect to use 32-bit integers always
 # (for compatibility with reference BLAS).
 , blas64 ? null
+
+# Select a specifc optimization target (other than the default)
+# See https://github.com/xianyi/OpenBLAS/blob/develop/TargetList.txt
+, target ? null
 }:
 
 with stdenv.lib;
@@ -10,11 +14,13 @@ with stdenv.lib;
 let blas64_ = blas64; in
 
 let
+  setTarget = x: if target == null then x else target;
+
   # To add support for a new platform, add an element to this set.
   configs = {
     armv6l-linux = {
       BINARY = "32";
-      TARGET = "ARMV6";
+      TARGET = setTarget "ARMV6";
       DYNAMIC_ARCH = "0";
       CC = "gcc";
       USE_OPENMP = "1";
@@ -22,7 +28,7 @@ let
 
     armv7l-linux = {
       BINARY = "32";
-      TARGET = "ARMV7";
+      TARGET = setTarget "ARMV7";
       DYNAMIC_ARCH = "0";
       CC = "gcc";
       USE_OPENMP = "1";
@@ -30,7 +36,7 @@ let
 
     aarch64-linux = {
       BINARY = "64";
-      TARGET = "ARMV8";
+      TARGET = setTarget "ARMV8";
       DYNAMIC_ARCH = "1";
       CC = "gcc";
       USE_OPENMP = "1";
@@ -38,7 +44,7 @@ let
 
     i686-linux = {
       BINARY = "32";
-      TARGET = "P2";
+      TARGET = setTarget "P2";
       DYNAMIC_ARCH = "1";
       CC = "gcc";
       USE_OPENMP = "1";
@@ -46,7 +52,7 @@ let
 
     x86_64-darwin = {
       BINARY = "64";
-      TARGET = "ATHLON";
+      TARGET = setTarget "ATHLON";
       DYNAMIC_ARCH = "1";
       # Note that clang is available through the stdenv on OSX and
       # thus is not an explicit dependency.
@@ -57,7 +63,7 @@ let
 
     x86_64-linux = {
       BINARY = "64";
-      TARGET = "ATHLON";
+      TARGET = setTarget "ATHLON";
       DYNAMIC_ARCH = "1";
       CC = "gcc";
       USE_OPENMP = "1";


### PR DESCRIPTION
###### Motivation for this change
The optimization target is fixed in the configurations at the moment. This modification allows for an override of the optimization target so that one can obtain an openblas version that is optimized for newer CPUs for example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

