### PR TITLE
pythonPackages.pybind11: init at 2.2.4

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pybind11";
+  version = "2.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kz1z2cg3q901q9spkdhksmcfiskaghzmbb9ivr5mva856yvnak4";
+  };
+
+  # Current PyPi version does not include test suite
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/pybind/pybind11;
+    description = "Seamless operability between C++11 and Python";
+    longDescription = ''
+      Pybind11 is a lightweight header-only library that exposes
+      C++ types in Python and vice versa, mainly to create Python
+      bindings of existing C++ code.
+    '';
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.yuriaisaka ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -556,6 +556,8 @@ in {
 
   pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };
 
+  pybind11 = callPackage ../development/python-modules/pybind11 { };
+
   pycairo = callPackage ../development/python-modules/pycairo { };
 
   pycangjie = disabledIf (!isPy3k) (callPackage ../development/python-modules/pycangjie { });


### PR DESCRIPTION
###### Motivation for this change

Add the pypi version of pybind11 to address #53497.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).