### PR TITLE
pythonPackages.scikit-build: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1535,6 +1535,11 @@
     github = "flokli";
     name = "Florian Klink";
   };
+  FlorianFranzen = {
+    email = "Florian.Franzen@gmail.com";
+    github = "FlorianFranzen";
+    name = "Florian Franzen";
+  };
   florianjacob = {
     email = "projects+nixos@florianjacob.de";
     github = "florianjacob";

--- a/pkgs/development/python-modules/scikit-build/default.nix
+++ b/pkgs/development/python-modules/scikit-build/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildPythonPackage, fetchPypi, wheel, setuptools, packaging
+, cmake, ninja, cython, codecov, coverage, six, virtualenv, pathpy
+, pytest, pytestcov, pytest-virtualenv, pytest-mock, pytestrunner
+, requests, flake8 }:
+
+buildPythonPackage rec {
+  pname = "scikit-build";
+  version = "0.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hh275lj98wgwi53mr9fqk8wh1dajjksch52xjax6a79gld4391a";
+  };
+
+  # Fixes incorrect specified requirement (part of next release)
+  patches = [ ./fix_pytestrunner_req.patch ];
+
+  propagatedBuildInputs = [ wheel setuptools packaging ];
+  checkInputs = [ 
+    cmake ninja cython codecov coverage six virtualenv pathpy
+    pytest pytestcov pytest-mock pytest-virtualenv pytestrunner
+    requests flake8
+  ];
+
+  disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) ([
+    "test_hello_develop" # tries setuptools develop install
+    "test_wheel" # pip has no way to install missing dependencies
+    "test_fortran_compiler" # passes if gfortran is available
+    "test_install_command" # tries to alter out path
+    "test_test_command" # tries to alter out path
+  ]);
+
+  checkPhase = ''
+    py.test -k '${disabledTests}'
+  '';
+
+  meta = with lib; {
+    homepage = http://scikit-build.org/;
+    description = "Improved build system generator for CPython C/C++/Fortran/Cython extensions";
+    license = with licenses; [ mit bsd2 ]; # BSD due to reuses of PyNE code
+    maintainers = [ maintainers.FlorianFranzen ];
+  };
+}

--- a/pkgs/development/python-modules/scikit-build/fix_pytestrunner_req.patch
+++ b/pkgs/development/python-modules/scikit-build/fix_pytestrunner_req.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index dd348fa..4de89c6 100755
+--- a/setup.py
++++ b/setup.py
+@@ -22,7 +22,7 @@ with open('requirements-dev.txt', 'r') as fp:
+     dev_requirements = list(filter(bool, (line.strip() for line in fp)))
+ 
+ # Require pytest-runner only when running tests
+-pytest_runner = (['pytest-runner>=2.0,<3dev']
++pytest_runner = (['pytest-runner>=2.0']
+                  if any(arg in sys.argv for arg in ('pytest', 'test'))
+                  else [])
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3987,6 +3987,8 @@ in {
 
   scikit-bio = callPackage ../development/python-modules/scikit-bio { };
 
+  scikit-build = callPackage ../development/python-modules/scikit-build { };
+
   scp = callPackage ../development/python-modules/scp {};
 
   seaborn = callPackage ../development/python-modules/seaborn { };


### PR DESCRIPTION
###### Motivation

Tool to build easily build Python extensions with CMake.

###### Things done

Included patch was submitted upstream and is part of next release.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).