### PR TITLE
elixir: remember where a package is defined

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -7,7 +7,7 @@
 , sha256 ? null
 , rev ? "v${version}"
 , src ? fetchFromGitHub { inherit rev sha256; owner = "elixir-lang"; repo = "elixir"; }
-}:
+} @ args:
 
 let
   inherit (stdenv.lib) getVersion versionAtLeast;
@@ -62,6 +62,7 @@ in
             --replace "/usr/bin/env elixir" "${coreutils}/bin/env elixir"
     '';
 
+    pos = builtins.unsafeGetAttrPos "sha256" args;
     meta = with stdenv.lib; {
       homepage = https://elixir-lang.org/;
       description = "A functional, meta-programming aware language built on top of the Erlang VM";


### PR DESCRIPTION
###### Motivation for this change
A bunch of human-facing things around Nixpkgs depend on knowing where a package was defined. This PR makes it so ofborg can ping elixir maintainers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

