### PR TITLE
mautrix-telegram: init at 0.4.0.post1

### DIFF
--- a/pkgs/development/python-modules/future-fstrings/default.nix
+++ b/pkgs/development/python-modules/future-fstrings/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "future-fstrings";
+  version = "0.4.5";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "future_fstrings";
+    sha256 = "891c5d5f073b3e3ff686bebde0a4c45c479065f45c8cbd6de19323d5a50738a8";
+  };
+
+  # No tests included in Pypi archive
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/asottile/future-fstrings;
+    description = "A backport of fstrings to python<3.6";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/development/python-modules/mautrix-appservice/default.nix
+++ b/pkgs/development/python-modules/mautrix-appservice/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, aiohttp, future-fstrings, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "mautrix-appservice";
+  version = "0.3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1615220f5bb75e2093ad1e30f4c2e1243499b0b20caef014fd73faadd3bfea6c";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    future-fstrings
+  ];
+
+  # No tests available
+  doCheck = false;
+
+  disabled = pythonOlder "3.5";
+
+  meta = with lib; {
+    homepage = https://github.com/tulir/mautrix-appservice-python;
+    description = "A Python 3 asyncio-based Matrix application service framework";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/development/python-modules/telethon-session-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/telethon-session-sqlalchemy/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, sqlalchemy, telethon }:
+
+buildPythonPackage rec {
+  pname = "telethon-session-sqlalchemy";
+  version = "0.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b392096b14e5cdc4040d3900cc2be7847b160ed77e5c861a6bd07d75d8e17a85";
+  };
+
+  propagatedBuildInputs = [
+    sqlalchemy
+  ];
+
+  # No tests available
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/tulir/telethon-session-sqlalchemy;
+    description = "SQLAlchemy backend for Telethon session storage";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchPypi, async_generator, rsa, pyaes, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "telethon";
+  version = "1.5.4";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Telethon";
+    sha256 = "52cb4929bf37c98ab5f3e173325dbb3cb9c1ca3f4fe6ba87d35c43e2f98858ce";
+  };
+
+  propagatedBuildInputs = [
+    async_generator
+    rsa
+    pyaes
+  ];
+
+  # No tests available
+  doCheck = false;
+
+  disabled = pythonOlder "3.5";
+
+  meta = with lib; {
+    homepage = https://github.com/LonamiWebs/Telethon;
+    description = "Full-featured Telegram client library for Python 3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -1,0 +1,50 @@
+{ lib, fetchpatch, python3 }:
+
+with python3.pkgs;
+
+buildPythonPackage rec {
+  pname = "mautrix-telegram";
+  version = "0.4.0.post1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7a51e55a7f362013ce1cce7d850c65dc8d4651dd05c63004429bc521b461d029";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/tulir/mautrix-telegram/commit/a258c59ca3558ad91b1fee190c624763ca835d2f.patch";
+      sha256 = "04z4plsmqmg38rsw9irp5xc9wdgjvg6xba69mixi5v82h9lg3zzp";
+    })
+
+    ./fix_patch_conflicts.patch
+
+    (fetchpatch {
+      url = "https://github.com/tulir/mautrix-telegram/commit/8021fcc24cbf8c88d9bcb2601333863c9615bd4f.patch";
+      sha256 = "0cdfv8ggnjdwdhls1lk6498b233lvnb6175xbxr206km5mxyvqyk";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    mautrix-appservice
+    sqlalchemy
+    alembic
+    CommonMark
+    ruamel_yaml
+    future-fstrings
+    python_magic
+    telethon
+    telethon-session-sqlalchemy
+  ];
+
+  # No tests available
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/tulir/mautrix-telegram;
+    description = "A Matrix-Telegram hybrid puppeting/relaybot bridge";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/servers/mautrix-telegram/fix_patch_conflicts.patch
+++ b/pkgs/servers/mautrix-telegram/fix_patch_conflicts.patch
@@ -1,0 +1,27 @@
+diff --git a/mautrix_telegram/abstract_user.py b/mautrix_telegram/abstract_user.py
+index 11273f8..aadaf5d 100644
+--- a/mautrix_telegram/abstract_user.py
++++ b/mautrix_telegram/abstract_user.py
+@@ -21,14 +21,14 @@ import logging
+ import platform
+ 
+ from sqlalchemy import orm
+-from telethon.tl.types import Channel, ChannelForbidden, Chat, ChatForbidden, Message, \
+-    MessageActionChannelMigrateFrom, MessageService, PeerUser, TypeUpdate, \
+-    UpdateChannelPinnedMessage, UpdateChatAdmins, UpdateChatParticipantAdmin, \
+-    UpdateChatParticipants, UpdateChatUserTyping, UpdateDeleteChannelMessages, \
+-    UpdateDeleteMessages, UpdateEditChannelMessage, UpdateEditMessage, UpdateNewChannelMessage, \
+-    UpdateNewMessage, UpdateReadHistoryOutbox, UpdateShortChatMessage, UpdateShortMessage, \
+-    UpdateUserName, UpdateUserPhoto, UpdateUserStatus, UpdateUserTyping, User, UserStatusOffline, \
+-    UserStatusOnline
++from telethon.tl.patched import MessageService, Message
++from telethon.tl.types import (
++    Channel, ChannelForbidden, Chat, ChatForbidden, MessageActionChannelMigrateFrom, PeerUser,
++    TypeUpdate, UpdateChannelPinnedMessage, UpdateChatAdmins, UpdateChatParticipantAdmin,
++    UpdateChatParticipants, UpdateChatUserTyping, UpdateDeleteChannelMessages, UpdateDeleteMessages,
++    UpdateEditChannelMessage, UpdateEditMessage, UpdateNewChannelMessage, UpdateNewMessage,
++    UpdateReadHistoryOutbox, UpdateShortChatMessage, UpdateShortMessage, UpdateUserName,
++    UpdateUserPhoto, UpdateUserStatus, UpdateUserTyping, User, UserStatusOffline, UserStatusOnline)
+ 
+ from mautrix_appservice import MatrixRequestError, AppService
+ from alchemysession import AlchemySessionContainer

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3803,6 +3803,8 @@ in
 
   matrix-synapse = callPackage ../servers/matrix-synapse { };
 
+  mautrix-telegram = callPackage ../servers/mautrix-telegram { };
+
   mdbook = callPackage ../tools/text/mdbook {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1752,6 +1752,8 @@ in {
 
   functools32 = callPackage ../development/python-modules/functools32 { };
 
+  future-fstrings = callPackage ../development/python-modules/future-fstrings { };
+
   gateone = callPackage ../development/python-modules/gateone { };
 
   # TODO: Remove after 19.03 is branched off:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4415,6 +4415,8 @@ in {
 
   taskw = callPackage ../development/python-modules/taskw { };
 
+  telethon = callPackage ../development/python-modules/telethon { };
+
   terminaltables = callPackage ../development/python-modules/terminaltables { };
 
   testpath = callPackage ../development/python-modules/testpath { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3003,6 +3003,8 @@ in {
 
   matrix-client = callPackage ../development/python-modules/matrix-client { };
 
+  mautrix-appservice = callPackage ../development/python-modules/mautrix-appservice { };
+
   maya = callPackage ../development/python-modules/maya { };
 
   mccabe = callPackage ../development/python-modules/mccabe { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4417,6 +4417,8 @@ in {
 
   telethon = callPackage ../development/python-modules/telethon { };
 
+  telethon-session-sqlalchemy = callPackage ../development/python-modules/telethon-session-sqlalchemy { };
+
   terminaltables = callPackage ../development/python-modules/terminaltables { };
 
   testpath = callPackage ../development/python-modules/testpath { };


### PR DESCRIPTION
###### Motivation for this change

Bridge library between Matrix and Telegram

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

