### PR TITLE
Backport #54900

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -260,7 +260,10 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     #     bash$ nix-shell --run "cabal new-build all"
     shellFor = { packages, withHoogle ? false, ... } @ args:
       let
-        selected = packages self;
+        nullSrc = p: overrideCabal p (_: { src = null; });
+
+        # Make sure we *never* accidentally suck in src.
+        selected = map nullSrc (packages self);
 
         packageInputs = map getBuildInputs selected;
 
@@ -272,7 +275,8 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
         # because cabal will end up ignoring that built version, assuming
         # new-style commands.
         haskellInputs = pkgs.lib.filter
-          (input: pkgs.lib.all (p: input.outPath != p.outPath) selected)
+          # nullSrc in case a dep is one of the selected packages.
+          (input: pkgs.lib.all (p: (nullSrc input).outPath != p.outPath) selected)
           (pkgs.lib.concatMap (p: p.haskellBuildInputs) packageInputs);
         systemInputs = pkgs.lib.concatMap (p: p.systemBuildInputs) packageInputs;
 


### PR DESCRIPTION
###### Motivation for this change

Backport #54900 for `nixos-18.09`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

