### PR TITLE
pythonPackage.psutil: 5.4.8 -> 5.5.1

### DIFF
--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -1,25 +1,17 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi, fetchpatch
+, fetchPypi
 , darwin
 }:
 
 buildPythonPackage rec {
   pname = "psutil";
-  version = "5.4.8";
+  version = "5.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6e265c8f3da00b015d24b842bfeb111f856b13d24f2c57036582568dc650d6c3";
+    sha256 = "045qaqvn6k90bj5bcy259yrwcd2afgznaav3sfhphy9b8ambzkkj";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "disk_io_counters_fails.patch";
-      url = "https://github.com/giampaolo/psutil/commit/8f99f3782663959062ee868bbfdbc336307a3a4d.diff";
-      sha256 = "0j7wdgq8y20k27wcpmbgc1chd0vmbkxy8j0zwni1s4i7hyk64hmk";
-    })
-  ];
 
   # No tests in archive
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
Update version to 5.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

