### PR TITLE
home-assistant-cli: 0.3.0 -> 0.4.2

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -73,7 +73,7 @@ in {
     $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"on\"'");
 
     # Toggle a binary sensor using hass-cli
-    $hass->succeed("${hassCli} entity get binary_sensor.mqtt_binary_sensor | grep -qF '\"state\": \"on\"'");
+    $hass->succeed("${hassCli} --output json entity get binary_sensor.mqtt_binary_sensor | grep -qF '\"state\": \"on\"'");
     $hass->succeed("${hassCli} entity edit binary_sensor.mqtt_binary_sensor --json='{\"state\": \"off\"}'");
     $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"off\"'");
 

--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -1,29 +1,29 @@
-{ lib, python3 }:
+{ lib, python3, glibcLocales }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "homeassistant-cli";
-  version = "0.3.0";
+  version = "0.4.2";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "42d7cb008801d7a448b62aed1fc46dd450ee67397bf16faabb02f691417db4b2";
+    sha256 = "e0b05af9e49baf88a44f1b36c3446a106223016dceefd5f9910e204af5901f44";
   };
 
   postPatch = ''
     # Ignore pinned versions
-    sed -i "s/'\(.*\)==.*'/'\1'/g" setup.py
+    sed -i "s/'\(.*\)\(==\|>=\).*'/'\1'/g" setup.py
   '';
 
   propagatedBuildInputs = with python3.pkgs; [
-    requests pyyaml netdisco click click-log tabulate idna jsonpath_rw jinja2
+    requests pyyaml netdisco click click-log tabulate idna jsonpath_rw jinja2 dateparser
   ];
 
   checkInputs = with python3.pkgs; [
-    pytest requests-mock
+    pytest requests-mock glibcLocales
   ];
 
   checkPhase = ''
-    pytest
+    LC_ALL=en_US.UTF-8 pytest
   '';
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -1,10 +1,11 @@
-{ lib, python3, glibcLocales }:
+# dateparser tests fail on pyton37: https://github.com/NixOS/nixpkgs/issues/52766
+{ lib, python36, glibcLocales }:
 
-python3.pkgs.buildPythonApplication rec {
+python36.pkgs.buildPythonApplication rec {
   pname = "homeassistant-cli";
   version = "0.4.2";
 
-  src = python3.pkgs.fetchPypi {
+  src = python36.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "e0b05af9e49baf88a44f1b36c3446a106223016dceefd5f9910e204af5901f44";
   };
@@ -14,11 +15,11 @@ python3.pkgs.buildPythonApplication rec {
     sed -i "s/'\(.*\)\(==\|>=\).*'/'\1'/g" setup.py
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python36.pkgs; [
     requests pyyaml netdisco click click-log tabulate idna jsonpath_rw jinja2 dateparser
   ];
 
-  checkInputs = with python3.pkgs; [
+  checkInputs = with python36.pkgs; [
     pytest requests-mock glibcLocales
   ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

