### PR TITLE
epson-escpr2: init at 1.0.29

### DIFF
--- a/pkgs/misc/drivers/epson-escpr2/cups-filter-ppd-dirs.patch
+++ b/pkgs/misc/drivers/epson-escpr2/cups-filter-ppd-dirs.patch
@@ -1,0 +1,55 @@
+diff --git a/configure.orig b/configure
+index e9d400f..dac1943 100755
+--- a/configure.orig
++++ b/configure
+@@ -12184,48 +12184,8 @@ esac
+ #	*)		ESCPR_LIB_NAME="escpr2_32" ;;
+ #esac
+ 
+-
+-
+-# Check whether --with-cupsfilterdir was given.
+-if test "${with_cupsfilterdir+set}" = set; then :
+-  withval=$with_cupsfilterdir;
+-else
+-  with_cupsfilterdir=no
+-fi
+-
+-if test "xno" = "x${with_cupsfilterdir}"; then
+-   if test "xyes" = "x$have_cups_config" ; then
+-            CUPS_FILTER_DIR="${cups_default_prefix}`cups-config --serverbin | sed -e 's,^/[^/][^/]*,,'`/filter"
+-   else
+-      CUPS_FILTER_DIR="${cups_default_prefix}/lib/cups/filter"
+-   fi
+-else
+-   CUPS_FILTER_DIR="${with_cupsfilterdir}"
+-fi
+-
+-
+-# Check whether --with-cupsppddir was given.
+-if test "${with_cupsppddir+set}" = set; then :
+-  withval=$with_cupsppddir;
+-else
+-  with_cupsppddir=no
+-fi
+-
+-if test "xno" = "x${with_cupsppddir}"; then
+-   if test -d "${cups_default_prefix}/share/ppd" ; then
+-      CUPS_PPD_DIR="${cups_default_prefix}/share/ppd"
+-   elif test "xyes" = "x$have_cups_config" ; then
+-            CUPS_PPD_DIR="${cups_default_prefix}`cups-config --datadir | sed -e 's,^/[^/][^/]*,,'`/model"
+-   else
+-      CUPS_PPD_DIR="${cups_default_prefix}/share/cups/model"
+-   fi
+-else
+-   CUPS_PPD_DIR="${with_cupsppddir}"
+-fi
+-
+-
+-
+-
++CUPS_FILTER_DIR="${prefix}/lib/cups/filter"
++CUPS_PPD_DIR="${prefix}/share/cups/model"
+ 
+ # Check whether --enable-lsb was given.
+ if test "${enable_lsb+set}" = set; then :

--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, cups, busybox }:
+
+stdenv.mkDerivation rec {
+  name = "epson-inkjet-printer-escpr2-${version}";
+  version = "1.0.29";
+
+  src = fetchurl {
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/09/02/31/a332507b6398c6e2e007c05477dd6c3d5a8e50eb/${name}-1lsb3.2.src.rpm";
+    sha256 = "064br52akpw5yrxb2wqw2klv4jrvyipa7w0rjj974xgyi781lqs5";
+  };
+
+  patches = [ ./cups-filter-ppd-dirs.patch ];
+
+  buildInputs = [ cups busybox ];
+
+  unpackPhase = ''
+    rpm2cpio $src | cpio -idmv
+
+    tar xvf ${name}-1lsb3.2.tar.gz
+    cd ${name}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://download.ebz.epson.net/dsc/search/01/search/";
+    description = "ESC/P-R 2 Driver (generic driver)";
+    longDescription = ''
+      Epson Inkjet Printer Driver 2 (ESC/P-R 2) for Linux and the
+      corresponding PPD files.
+
+      Refer to the description of epson-escpr for usage.
+    '';
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ma9e ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22206,6 +22206,7 @@ in
   epson-alc1100 = callPackage ../misc/drivers/epson-alc1100 { };
 
   epson-escpr = callPackage ../misc/drivers/epson-escpr { };
+  epson-escpr2 = callPackage ../misc/drivers/epson-escpr2 { };
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };
 


### PR DESCRIPTION
###### Motivation for this change

Printer drivers for e.g. EPSON WF-2860 were missing and require epson-escpr2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

