### PR TITLE
python3Packages.just-start: init at 2018-10-25

### DIFF
--- a/pkgs/applications/misc/just-start/default.nix
+++ b/pkgs/applications/misc/just-start/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, lib, buildPythonApplication, fetchFromGitHub, isPy3k, pexpect, urwid, toml, pydantic, poetry
+, pytest, pytest-mock, coverage
+ }:
+
+buildPythonApplication rec {
+  pname = "just-start";
+  version = "2019-03-30";
+
+  src = fetchFromGitHub {
+    owner = "AliGhahraei";
+    repo = pname;
+    rev = "3c4a6102f304d1e58b8f0e116b607a1355c6544a";
+    sha256 = "0wg0nc7xglj1dw6c95nw08hvnxgqzdr4rc8cgv94yyx3ibfnscz6";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'pydantic = "^0.21.0"' \
+                'pydantic = ">=0.21.0"'
+  '';
+
+  format = "pyproject";
+
+  buildInputs = [ poetry ];
+  propagatedBuildInputs = [ pexpect urwid toml pydantic ];
+
+  LC_ALL = "C.UTF-8";
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkInputs = [ pytest pytest-mock coverage ];
+  doCheck = false; # check phase?
+
+  disabled = !isPy3k;
+
+  meta = with lib; {
+    description = "An app to defeat procrastination (terminal pomodoro w/taskwarrior)";
+    license = licenses.gpl3;
+    homepage = https://github.com/AliGhahraei/just-start;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, lib, ujson, email_validator }:
+
+buildPythonPackage rec {
+  pname = "pydantic";
+  version = "0.23";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13k8mysyrqp2jsd23sjv9r4lpkzrq2lbrnxkz36f3d56x421idsq";
+  };
+
+  buildInputs = [ ujson email_validator ];
+
+  meta = with lib; {
+    description = "Data validation and settings management using python type hinting";
+    homepage = https://pydantic-docs.helpmanual.io/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3737,6 +3737,8 @@ in
   jupyter = callPackage ../applications/editors/jupyter { };
 
   jupyter-kernel = callPackage ../applications/editors/jupyter/kernel.nix { };
+  
+  just-start = python3Packages.callPackage ../applications/misc/just-start { };
 
   jwhois = callPackage ../tools/networking/jwhois { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3772,6 +3772,8 @@ in {
 
   pycurl2 = callPackage ../development/python-modules/pycurl2 { };
 
+  pydantic = callPackage ../development/python-modules/pydantic { };
+
   pydispatcher = callPackage ../development/python-modules/pydispatcher { };
 
   pydot = callPackage ../development/python-modules/pydot {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---