### PR TITLE
gitAndTools.grv: use buildGoPackage instead of buildGo19Package

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/grv/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/grv/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGo19Package, fetchFromGitHub, curl, libgit2_0_27, ncurses, pkgconfig, readline }:
+{ stdenv, buildGoPackage, fetchFromGitHub, curl, libgit2_0_27, ncurses, pkgconfig, readline }:
 let
   version = "0.3.1";
 in
-buildGo19Package {
+buildGoPackage {
   name = "grv-${version}";
 
   buildInputs = [ ncurses readline curl libgit2_0_27 ];


### PR DESCRIPTION
###### Motivation for this change

Fixing build of Grv after Go1.9 has been marked as insecure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

