### PR TITLE
wrap-gapps-hook.sh: only wrap links when required

### DIFF
--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -36,16 +36,40 @@ wrapGAppsHook() {
   done
 
   if [[ -z "$dontWrapGApps" ]]; then
+    targetDirsThatExist=()
+    targetDirsRealPath=()
+
+    # wrap binaries
     targetDirs=( "${prefix}/bin" "${prefix}/libexec" )
     for targetDir in "${targetDirs[@]}"; do
       if [[ -d "${targetDir}" ]]; then
-        find -L "${targetDir}" -type f -executable -print0 \
+        targetDirsThatExist+=("${targetDir}")
+        targetDirsRealPath+=("$(realpath "${targetDir}")/")
+        find "${targetDir}" -type f -executable -print0 \
           | while IFS= read -r -d '' file; do
-          echo "Wrapping program ${file}"
+          echo "Wrapping program '${file}'"
           wrapProgram "${file}" "${gappsWrapperArgs[@]}"
         done
       fi
     done
+
+    # wrap links to binaries that point outside targetDirs
+    # Note: links to binaries within targetDirs do not need
+    #       to be wrapped as the binaries have already been wrapped
+    if [[ ${#targetDirsThatExist[@]} -ne 0 ]]; then
+      find "${targetDirsThatExist[@]}" -type l -xtype f -executable -print0 \
+        | while IFS= read -r -d '' linkPath; do
+        linkPathReal=$(realpath "${linkPath}")
+        for targetPath in "${targetDirsRealPath[@]}"; do
+          if [[ "$linkPathReal" == "$targetPath"* ]]; then
+            echo "Not wrapping link: '$linkPath' (already wrapped)"
+            continue 2
+          fi
+        done
+        echo "Wrapping link: '$linkPath'"
+        wrapProgram "${linkPath}" "${gappsWrapperArgs[@]}"
+      done
+    fi
   fi
 }
 


### PR DESCRIPTION
Unless dontWrapGapps is set, the wrap-gapps-hook.sh will currently
wrap all executables (and symbolic links to executables) found under
the target directories: bin and libexec.

As a result, if a symbolic link in a target directory points to an
executable in a target directory, both will get wrapped.  This
causes an extra shell/exec when following the symbolic link,
as well as increasing the size of the final executable's environment.

To avoid wrapping a link to an already wrapped executable, this
commit splits the determination of what gets wrapped into two phases:

1. All binaries under the target directories are wrapped and logged
   with "Wrapping program ..."

2. All links to executables under the target directories are
   identified and checked to see if they reference an executable
   under one of the target directories.

   If yes, the required wrapping has already been performed on
   the associated binary (in phase 1), so no wrapping is done
   and "Not wrapping link: ... (already wrapped)" is logged.

   If no, the link points at an executable that hasn't been
   wrapped, so the link is wrapped and "Wrapping link: ..." is logged.

As an example, the yelp package has a bin directory that contains
an executable "yelp" and a symbolic link "gnome-help" -> "yelp".

Prior to this commit, the bin directory would contain these files
after wrapping:

```
  gnome-help          -- wrapper to exec .gnome-help-wrapped
  .gnome-help-wrapped -- a symbolic link to yelp
  yelp                -- wrapper to exec .yelp-wrapped
  .yelp-wrapped       -- the original yelp binary

```
After this commit, the bin directory will instead contain:

 ```
 gnome-help          -- a symbolic link to yelp
  yelp                -- wrapper to exec .yelp-wrapped
  .yelp-wrapped       -- the original yelp binary

```
NOTE: The primary motivation for this commit is to avoid obscuring
the fact that two or more paths are simple aliases and expected to
behave identically. It also reduces the likelihood of hitting
limits related to environment variable size.

LIMITATION: The method used above is intended to be conservative
and will still wrap symbolic links to other symbolic links when
the ultimate target is outside of bin or libexec.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

NOTE: Tested with nix-review. Used grep on logs to find packages with symbolic links that would no longer be wrapped after this commit. Here's a list:

```
package                         symbolic link -- no longer wrapped
===========================     ===========================================
cozy                            cozy-0.6.7/bin/cozy
emacs25                         emacs-25.3/bin/emacs
emacs                           emacs-26.1/bin/emacs
gksu                            gksu-2.0.2/bin/gksudo
gnome3.gedit                    gedit-3.30.2/bin/gnome-text-editor
gnome3.gucharmap                gucharmap-11.0.3/bin/charmap
gnome3.gucharmap                gucharmap-11.0.3/bin/gnome-character-map
gnome3.yelp                     yelp-3.30.0/bin/gnome-help
gnumeric                        gnumeric-1.12.44/bin/gnumeric
libreoffice-fresh-unwrapped     libreoffice-6.1.4.2/bin/libreoffice
libreoffice-still-unwrapped     libreoffice-6.0.7.3/bin/libreoffice
lumina                          lumina-1.4.0-p1/bin/lte
mate.mate-calc                  mate-calc-1.20.3/bin/mate-calculator
mate.mate-utils                 mate-utils-1.20.2/bin/mate-panel-screenshot
xfce.thunar-bare                thunar-build-1.6.10/bin/Thunar

sgtpuzzles                      [ 39 symbolic links not wrapped]
```
You can build any of these packages to test this commit. Also, there is a default.nix that can be used to test link wrapping more comprehensively here:
https://gist.github.com/tollb/4a21b890058ca3ab7d44618e345d0e28