### PR TITLE
[18.09] prometheus-node-exporter: remove go 1.9 pinning

### DIFF
--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -1,8 +1,6 @@
-{ stdenv, buildGo19Package, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
-# Go 1.10 causes segfaults:
-# https://github.com/prometheus/node_exporter/issues/870
-buildGo19Package rec {
+buildGoPackage rec {
   name = "node_exporter-${version}";
   version = "0.16.0";
   rev = "v${version}";


### PR DESCRIPTION
###### Motivation for this change

Since Go1.9 has been marked as insecure (5a3e195) all setups relying on the prometheus-node-exporter would fail to build a new generation.

With Go1.11 the daemon seems to work just fine. I was unable to observe
any crashes (due to the wifi module being loaded).

cc @WilliButz, can you verify that it also runs for you?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - The `varnish` exporter test failed but the others succeded. It did not look like this change could have potentially introduced the varnish error so I ignored it.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

