### PR TITLE
[18.09] nss 3.41 -> 3.42, firefox 64 -> 65

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "64.0";
+  version = "65.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ach/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ach/firefox-65.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "3710c5a03f3ac8a5c741c3e580d512130f961b2065f9ff5dcea0d4a9586e0c28e6521b694e3bb4d540cd34d4c44a8bfbfabec5bce986ad75abdf473bfe0580e1";
+      sha512 = "3bdf982f4646a019f2dc11f5367ab0c23695c9c8fced02927c2d9a862e15f6a1c9c1ef63da3ef6539d802095d0b8b48d6f55a9961a453ddd4a97d828e9372aaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/af/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/af/firefox-65.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "e1fef7ea27463eda862cb88b16f69ca672d1f020b4b7d6f1e629df734bf5b2f320b23d18c203fe0ecaf84299450769460905600ae73b36f6c33081fd7d110cee";
+      sha512 = "2a010ce94b6f0108cfed973dd9c632691d4d2558ed006184ba9ded8ea89933fcc77d21f82fe3add259409861cb65dd12e48aed592fc932411ddc3226c0085d31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/an/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/an/firefox-65.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "09c40a75c4659ae65c6e52e17975ce96e940acecf6da47bc335cea943a810dd2be6650db2cf459301b0bba7eae683dd58a7482f21df9adf75f4cf07d158fc038";
+      sha512 = "30f2cd15a3d43c4228aa8b49b44aa4716ce35968cfb63d57141a3c3027e95242f4c724aee50b6d7ffcf77384e101a17cd252beaec75840f59400e0db2c111f95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ar/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ar/firefox-65.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "7c1831c1f35df13ddf6a72e858e5c8b2461975278274d078858d88dad4f7fa07030c5833f1bdb9c82d1e2aed7d85d9d0f127981488b62bf9c8277401c6ccaf56";
+      sha512 = "ad9846180c953ffdb73d519f1090a420deefd8b4bea531038318237ad639258bb05f4d9f88cf23650f1507034ce0700cc9e2bdda4ec02eb6e02c2d795b552cfd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/as/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/as/firefox-65.0.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "fe9f71632a8a5cfd01590e9e8fa2d20680f32d94265f670609609599f790f741ca0b55341f86f471962139faebbccd29db0ebdfafb900f0434c7a059297456fc";
+      sha512 = "a9babea676451cb0f0126711592d3d94f57865c520de370194023157a65d5633d26f63aba9aa71472e40885d67de98a694d0bc4b65f4c1c933e3e4feb0e6be71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ast/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ast/firefox-65.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "ee925e8e8e73e05ff3a4ca13cf461130a924c297ff72f304c35969d15dbe75cec2255b6ad9e5338d4c26b0e978f0f7769ea963b349b176c20fc506e5d76e9ad7";
+      sha512 = "03bfbb6635c587c356fe622757b2b7f6e3b85fb04c7477857074cc198efa4e97e960e4d3b7c5d60aa9fda8639e605ae00d398899fdb2d05bd5fcf5dc494f4ded";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/az/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/az/firefox-65.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "d8feaf6685d7844dda3168da899cb01f9749b284c70f3d61567f7ebc62a407ed14c271001090499b3a6d86f59824438bd7c62dee745cf727e3381c71e6f5fa6b";
+      sha512 = "5201abfc1e7333acf0bb8967ba667742dacb2cdb8cab6b3ae60ec3d15cf756a1b48f6bc0904e02d433df5ab80440fe3cdcf4e260c4cd1c1f3da16f51c00c2962";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/be/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/be/firefox-65.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "a10e5e467d4709b8ad099b257b56319da95cb8990a88b82859057d93a82bdc44167ba89b25d3bd25f2c73873603fe86ac15851592f60ca3a69ea6176e13e4a83";
+      sha512 = "68f400d8640620f2af6ccf5a3b8e4fe2c94e7169e1b258d875b693dfecb4dbe070a9bd6a97b9fd668362783b73cc2eb21925bbf0159b41c4df910946bbae3f3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/bg/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bg/firefox-65.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "697fc3f302bfc4f68fcbc87e9a5b030599260f16375abe0b3f5c5a7617dd6a869b4d7f8f4e7e828e0080104a9e026eeb83c10f7d0a70c77fe0fd95196f2a4d86";
+      sha512 = "6a7b6997b1efb726dfbda25e7f7eb024013ab1c782912e03e258c4fe72adf26ab926a05f88e62255c682e6352ed88b2158f1bc12ce9c8b91714291783397c379";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/bn-BD/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bn-BD/firefox-65.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "c91cf6e80527c714d174913e7b650f448bef8c79a413ff711094a0224717466e899f7a21dae9d4ac1abf48ba091d27f172781dfb9aa44a26d22dabd1bc125465";
+      sha512 = "1fe6f67067cc27f4d8b13eaa22a8ef2ca23fd3971a3140432ee389327fd97faf97be802add562b2f4ced0fc83f75b8c8c8c707c160e0ce3ec50648735704f9cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/bn-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bn-IN/firefox-65.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "fe8aa202cab31f76413f048c21bdb1d5bb38c0a8d65fdf682bde34aefc12aeaf1ee18814c17022abc6c75941fa3a983d1c4c13c89dd22a94352e950bdd37401a";
+      sha512 = "d5ad4b8673ab8c136e3aaf5c2627c7210d670351744d486a896d40dd1599ee17a5cf90fe2c967d1c70989ac644f180c0efe23fa25f5f76ea4ba4f0ca0f3492c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/br/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/br/firefox-65.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "6784b2b452469f4b505028c1060bb76dd2048e9220f2aebdc38b071551a7c41406111287bb450dd2cb9a860cbc686149072d2b2e330d4420c5d0d4d30a64c10b";
+      sha512 = "ca1196a2f2875b86c315a32d9c0091d0c72d8e2dd00d788f24000644028dc0d1f5eba7f9b2888353a2c5fbd16273412cf3737d39fd63ffeff7d0c5bfb7829922";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/bs/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/bs/firefox-65.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "30fce8473040ef957675a0125411584047a5978ae35a897478d33dbc11b7d08fb61b25a6b4bc1f1d9e7ad729f3ae84ae27c5267684068e9e0753cecef784ba0c";
+      sha512 = "7fc343375a6f2947d2604d14a764d5cdce77209c6a1770f69cda713fc03662a7e84a6c656d1262148b57c4ec3c9c5172fd910ba424854f35b3b7fe7ce148b699";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ca/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ca/firefox-65.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "d209b95b471871a2771e2ad8f027996fc181471b9620f6468123f5f2f35b19c1f90b28d31c9ae8ec18d3fea66df53da5618812744b4403ee12357c9fbce69249";
+      sha512 = "d62cfcfa8c575c905fe904f6819e5f82bc139d91186db956050dd82ed3ce65ca4eb407efab9b26049cb28d806c76d9c2516a176157b26608418f06d66167b13f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/cak/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/cak/firefox-65.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "313f627b01a2627e924fcdaf57030455d0b36493fefd2e7373957a6c7064b61a9b40b466f72c0d14f509c1d13771134b179954f8d8ac2986aad7da288a42e4b8";
+      sha512 = "b1f4bbdf515d8ba548b0e915a53d212e74d099da64631b8f05f21b9914ca2545b4092291d21b28bfdcba75be6eba02b79cdcd57ea4b39a1c05a856aa73134e5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/cs/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/cs/firefox-65.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "85f17519c6c49dfcbe6f2da41aa95b20c53b6491b7a10958e0ee72b1da4b3b0f59f473ce33c72774438d96a0814c7542a5cf79159840d551abf7b3df77c31ca9";
+      sha512 = "a98915ea6d8a5e1a374e34b836563ad450a48816d374917562078ade754dfb1cd5cfb6cef73de942fbb1c1c1abe41871ec3b9ff17a3a6a6bb2bb36df3a6c3763";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/cy/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/cy/firefox-65.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "bfcdea53243eda98567e769f3662054c84c4b43a38e83639babeb72ff4bf4ccfa36390bc9b6eb247bb8a8afbe2b9c79a91b96134e0f6222c9df14921d2c14f5e";
+      sha512 = "ad1e6640cb799acf17b8e151b26e78a86ce21960f2f8b5baca4890e7da2fe1d4739357058a551c161e31c1685d99d988d9715b6eb6a39d785e9e526f60c65009";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/da/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/da/firefox-65.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "128e4e3f5aa74f299beb9480079f32ca093307f1f49a89873f37b824bd223f1436918734f8f171607b36c3de80b6e92a758d3175a687f5017c56448528da181e";
+      sha512 = "983fbde10f8ed3971b2ddc8161d6387b56d8c94ef3724f7db2febcb7160d17b20a6cf406e48c3a266d0e1a74f024faf4950f8dee0bd60967ff1c1ec7bde21450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/de/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/de/firefox-65.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "4dce77e64190483c25469f1a55fa80865f3030fbc1f0c2f1cdde0c023a540b96f40b85f12ba7e4ff66ca4e9cbc5dda3eed849d0480aea6c76e9e5a461534d425";
+      sha512 = "59aa726477553aa261fa473b56e610807070999a1b120a3fd82a678ed029fcf2b541a71ec89f1d1a176bd40deda1cd659cc0bc1f486a283f2563a0a0236fe2ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/dsb/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/dsb/firefox-65.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "a544f615cd0c79d677f669e1a62a79e685f831315a5139a3271ddca8501ecb80c6744d19faf369df41edfd11590436e5086b0696d84d2bd842482978988ed2d0";
+      sha512 = "cc270b9e372b799e6867a93dc1148e9929d67f4fd9a8b2a1fbf4c0c95b23c6f6fa0444efa95dc545c4906b488f44c1a2eee8d9a8b6c6c5a8a3322f1a9c9cf553";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/el/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/el/firefox-65.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "2d7f9da2285951320e0cd3e8317f7e8031dd229215ef8d83af90c7d158e3292588c65f29976576d4c0f70780dca739d1c1d20301dc5ea248fce46a30389cd04f";
+      sha512 = "170719eb9cac9d1d49be16609e5728bdf9773195196c51c6d4d6c6a1f18f72ab96b4f3124de258186f39a1b1e3a849b5de73d4b5ee48007b22a5e84370d694fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/en-CA/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-CA/firefox-65.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "3b74adbdb2ce8bae0e488228e016fb663229b1be7c0e6808b4d80b0156d9d98c98d3afcc019c120be6dc8c07a70fc82e1b3dc6a399f2e73473e1b7b76092d922";
+      sha512 = "df694bf1dac6656b802285b91ce5fa5fb39e9ae6d4fced3054c7ff3c474aeec8679745f5a820b0975320bfd74108ebac83e5ca33f914c9f0be992295fd7556ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/en-GB/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-GB/firefox-65.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "4e3e6217a8c7b0c51e5a956dade6d2b346b7ce4b802af7c2a1be7a89d4458c8e7b3fbfdc4f3c38c20d425ce7b8095b9365693a781b81932f4f4445348c5a8ec8";
+      sha512 = "f7953b8c20891907e7cfc45d7399be70b58c66710f6070f18c493b5c668d4576919af7dffbe36172ca3d01d711992749201c66457803fdd7a3068e2d7f6be60e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/en-US/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-US/firefox-65.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "47a6a77ad478c4c87c408657f060bf60e0a646e7083cef9d7820c03b1be4e050d83054499a79445de993d1b9f5582c3dbcc023589a5ac7fd0742ea08b8564a26";
+      sha512 = "482bc1726399663532000749e600ea5c9c490022696b40d869e851951a9983745b26a7c4ec7f306bf174479e4213103996d075c11e2e1f9a721d392c7c615933";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/en-ZA/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/en-ZA/firefox-65.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "e9696651669db18f36bac1d06ca415946e850d6822b14ee51451cc02ea5651e8c66d2a73ba9b2b826ca6246a19bd6bd2ce00fe5111320e9365a2385accbfb480";
+      sha512 = "bf721a577a1a916779ebf0d8c0f673d0b4d1c0230b776b2045c976ebca96baa4a6856109a837d40f301465d921bbf4622cc4609f31624551cdb056284cb36644";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/eo/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/eo/firefox-65.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "1cb62e90c767171079c999c6e13916286e69c7e70c2977ce857b3c8d756d7aaa61ac1404089dbfea27b5b110f1ab51a3cb4faeb690709a933d927da1fca98dc6";
+      sha512 = "ddeb25f719dee34c186fd1831c1fc5166ce17a413325cda1a3be97b4a1a65b302b84bd9162ef91577fdfb7b82180267026039cbb49d0ee434497eb23ace6ab98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/es-AR/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-AR/firefox-65.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "4d2b5365e97d6b49847aed1e86076dd74b840c703f0d5b206d8e076934dc465155e8998af204cd78c17ea0f19d5ce51f08273d51dbed55494c1e2b405b61b753";
+      sha512 = "a81f7e9aa65e516632ecbea14dda6ccd65405388dfac801e179ced1caa9a1da4c671ac7a42c3337907af85612eea46730760707d3f12376d504fc2b1c629aceb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/es-CL/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-CL/firefox-65.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "23fef30ab7c2d43529be5000381c799e7cf6f72ca4fad1e06a0f94f69e995649296907c6004c4db65d939035d2cd7ae130eaa563a42df9ac5539503ce6fea9f3";
+      sha512 = "1243a4a02d82fc97bc760197c33c1e4e705ed8c47dd565a725e1c105b22e42b89b19824f7e35e844b4c5c52c78b3fde512a50d3f655ba548144ac2b6d73efa9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/es-ES/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-ES/firefox-65.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "6c6f8f7f6b7e7ffcc6eddccbc6513a7f024e8bf00107581088121ea8e4bf931719074ebb74f26e87a37ec92b6ea2a655156c2c67f30c505894b750d80443a9f2";
+      sha512 = "c44b3a7b0fc6a13ffc075b7f282fa0ab1be16f98df872a7a168c3d479fd701d7e14502215ca6e211deb99c1b38bdb38ff0f4068eb978aad8d1f80b682839fd88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/es-MX/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/es-MX/firefox-65.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "b0afd492026015f062b15c6442ae65815704b8b7d42e92b05c1448c381ead2adfdd171db51fcd9cf1a6b7df1ad96f92b692e0143faf7f06abb2f46fa29ede834";
+      sha512 = "3b376e854a2498101fea9de4117f970bf41185b9ce74254d64088a58c77d21845c5a4ebee07c923cc6d8e616922b109cce0d25df9e2d47cf3dc62b726480dbfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/et/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/et/firefox-65.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "76f3252c84540c159c08859652f4f70a742d015cdf80275f4cef02eff6b292b9f07babd001418fe7cdf46d357f79eaba12844c33665c8964471ffe02bdfa14ce";
+      sha512 = "c55706aa897afee00d58741191dc4ef4ef9a0f4296c407770089e488449d95044bd4dc422c3fd79ada093abceea1e649b59a9f5f4e51738617716f497c6753ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/eu/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/eu/firefox-65.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "40d1bdebfca7d50cf9b5ca52d330b4e57fd38d8b84788b48992be85a771dc911bb7b7ea34a6dd32c26c3ec2416e917bb4e1a19a2dcf30045a69fcfe44493246f";
+      sha512 = "5384aa5496a9e2e40acf0b014ef71e2e06b45bd9968441715cf38f5c9212c35dd1a5fe3bece97168870dce45bb1a91390fc172c2c170307b543d29d2a7ce6220";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/fa/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fa/firefox-65.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "8164523a87b88c6acd243c0835debe472f81ec14fcfe099ec4744c543415ba54466142e4245a38a759ed14230e70bf4be0d086b46cf39a32b7fa874bf1553acb";
+      sha512 = "9b83dad076df5af63d4434dee22730770d94747b29ce13e551653b5d008b3741f33aa9819547527654c9667fc79f47d73633a384174cd92d786a02ffeefd5ef5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ff/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ff/firefox-65.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "7d470198e655e78a5b48e127063d55e33e6be01a5134c98b82045f1b4bb750bce8915db151a15da0ec7b175c7b76cbb9c9d051d5ef6b61628b0325bd434d9cd0";
+      sha512 = "fbe80240ac2347c05bde0a3240df050034777ee52e129165c5d8b11fac94bf9421c3ce413e9d3dd71643e2710b0328096d602795079bdcacf98bdb1fed8cf318";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/fi/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fi/firefox-65.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "4010c8510ac35e35b1d9c9b79cd64316b9de2ba82fb751653713871623d49b2f5cc795ed093398a739dca2d2c7f837f83db61b49dcf34405c5d3ae0950e92375";
+      sha512 = "809ebc16baa79ed287b980e211cd7ca3991057b538f70877f599df9447f1f787f9c0fa4fd4f54d12834ddbe35bd9d1162777ff579cc5703ea907cc70f08c93d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/fr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fr/firefox-65.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "65b16a2d493957ef51b6e36e2dd1bd9c5176571edbc8262b458296915be599fb5b8651114734939ce366f0c017567732f4a540ce5bc6500bc7400be6368e7c39";
+      sha512 = "98a6dada770067be7cf651b7f2d6e6bb57a0358b6ee54af47003a153844d521b15dbff65afd1ee0b05c23ec9e91aaf434d90065a21d3e729b9abc48fe27bb8b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/fy-NL/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/fy-NL/firefox-65.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "153177aa8fef00a967d09d015dbb2e03d4f73b04abda15146d9729f520fcbaac6f07eaa5fa88c723bde659c701c07f0f2de0436761a1a5c42e4a02cc5255ec9b";
+      sha512 = "2d49ea99934ed637a2e2c90a15c3be55f9470d275af6d1ed9f5868bf3b3eb7c8871728811dba87458c59a843b310f491712d61063b43d36409e8c8d7d5567e75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ga-IE/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ga-IE/firefox-65.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "39f6ee1e0d55966c80a13a7a15995af68bccaf6ee8b8a067254b0cdc6ed95751c4f8125231155f327d2093fc598076f0ef6aa8d15385b70a6e0e9f0773c5b791";
+      sha512 = "2a68fee8dcccb45f9f849eb61d54629a1216a247c246565516425e072387a7e1fd9e382c799e32884d681888563c982ef894276e84ac9e537a008fcd39ced893";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/gd/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gd/firefox-65.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "585830e055d7c89f53fd49a57c58879ba83707c70b3566cd5178a66e204e29525c0dee621bd9806d260e2cab440147aa7f150693af199545f6744aaa8340b93a";
+      sha512 = "a97c08e8632147d4b2a30ba63295e1d080e97d561163a4e87240667ca69f9094f98a8ebaeca8aa75b4d344e315ab4e72d605e06b800d4156c38fd1deb83b45b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/gl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gl/firefox-65.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "48531324d321c466c65b094313e441d70e8c34adf3e741f3b2f133e4bf01c7a57a1f30b5851fa954bec373124692b85c452740fd927eba61f1fe7f149a5e132e";
+      sha512 = "49d4d0afda162e23437f44a5b5ee9a43e1643c0e739bf6b74e662c79b4cd63f7bbbe9c56c73381e0a3756360b03ffef01eb73be1c1b506d20bf4cd4f968b2d47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/gn/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gn/firefox-65.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "2c18c606d321d889cf9618b49d284cf4c8b547a0db47f1defbc4060aa7b7620f73cb6f8eb015491d166c782c197b5c72d2c6f2fb34fbf4da3793eaeeec101185";
+      sha512 = "7fc62ff745bc14419ecdc11e0cb880cc28f54cadbdb19980f87162e463eb97911858fb7673c2a9c1026ff6b786c01058c975c53c16644881e2a0b0d604a098ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/gu-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/gu-IN/firefox-65.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "402aee6067b960e3f03daac299fd7377ca7e6cfa458b4d9e344d96c3b30bf6635e600be1e28663200fe699b57eafc444307768be1f004d1fe494ff8447ebe5c3";
+      sha512 = "22a36860d0ed79f36ad804b636cf892c45b7dafe948df151a8a384c6400523617e1a191157f099ee26ae42d06b3ba3ef508f9ab5a4ff6f819f21ecf74f9c3296";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/he/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/he/firefox-65.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "31a99a521b35e2e4a15ad6794fc10441969b8de79969e405438f9a30fda42ad09fe002628ee5f2a402791d889db9a557e8e651602f9513ffb834cdfe2ac215e9";
+      sha512 = "2c46bf74a8053337958d37389f1fb457b814d18d27a337bed84d250acdde8c7a445b8dcde8507c1c502a13dea718f1df01895d76b3725e5ebd65290e1e6ce477";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/hi-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hi-IN/firefox-65.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "6e31a76ba7269d963d8737478ce3228fe32e39c43432cc3ba738d3ec5b2c2c6caa77b5bb064b21ad3d354ad7a672e83e5817718c2dd51145b509c56079370473";
+      sha512 = "ba1724eb10d76c3a70a58c72b5f5a6482fd6f5e7e3b4c04283a03765e75eaba9abbd5c6e2d3e350f36d82909078987a4c1a6073d67e2e56456e1954e291fa3ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/hr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hr/firefox-65.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "4bde8bd44a7827a88185be243eca333bcd23d478d4f0ada062add6257da1c849d03087d1f1faa553d0e03a66667c50d3127c789ca238268345351b29181d85ea";
+      sha512 = "5fbe87ccc58b16725c10835ecd54d825f71099ab37eb2e4eca343c6cec5f8caa5f40ce8a5b2c6989c36a10a903378e69543d1b9e157f677032c47362db144d5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/hsb/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hsb/firefox-65.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "96915b58a3867641b8412e2ae6c664dca3a6b42bce7b7a08c7647be1e30308d2e43730d21ed9c7af264a0b835d08f7fd86b10491b44d7309ccf5e88b9527231a";
+      sha512 = "9bf744b38cac34785f56bc308b2a4024b4973e7f489d4f9f3929fe42aad2872facd967fd35bce452beb40e7c936bf400f1022e0091a375a6c7aaeac2bedeb3a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/hu/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hu/firefox-65.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "f3e5931ef224e4e839dde1955b14ecad25f9c0a85b4c1e1f69aa37038129a0ea96807c4676a2daded45bf94448152557818de060ed8fc0f40828870fb0e5ddd6";
+      sha512 = "11ead0e258d6a81d5a2b8d3bbbfc5cab8bad7d35e7ec853280f7d559650d121b56bbc66ca8a25416100506300b5ef148fde573609c4a922c775abc106ca59f1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/hy-AM/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/hy-AM/firefox-65.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "f7efd18f70b525c3372dbb2f91f54b1c6ff248d87984c6d510942514e3cf57c07a1d5af9a46270f2b42c835f95a874bd085c7d131b432bd176ca72463ede4b92";
+      sha512 = "67a6084fda25da7db2ade9596c6fccbb0cc191a748c8ba089bba68e1c498774a4d309680c8d36b61a49e7bb0795bfbf48d853df1a7846eda65e752d791394079";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ia/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ia/firefox-65.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "1daa9025c4efff34c968747d9799799616efb37bc313bd178b1b90c39dce3e3f7a9792648983ee44f6b65478cc35bb84343a08d7a5a68d03ce34feb5f1e9ecdc";
+      sha512 = "fc2ba7e0c87c610018bf1c0705c7d263e301c6b0dfe080f44cb0708bff59e955754b4d0ea167eb5066f38a72c44312fecb13d7fcf855ac6125a7f6a833dff176";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/id/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/id/firefox-65.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "e1b5b5447132a03eff6c5003cd5c23c64c221f74f2510cb990e61047df47d59b1ba06751eb91ef332e930e2fd4f0ff2fcd751680684886976bae295cf8e5a168";
+      sha512 = "c678461c38462616f731c2d0aab9c56f5963546f434e4ebcd2fb7b48aa94bdf7d4a7f14481cc4a17ebcea1decb767b27dae914fc3bb2503180106fda7adb74d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/is/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/is/firefox-65.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "d18f78338dd41befe97210800208cfe0a56f394f0eaf21f8025f9b643d6cbf5370ca0c7c56539e2bdd54b96357f1c27423333824551825351b5135aaa6f4b873";
+      sha512 = "00e1c27374e5b174ed5bcb335b2b8a0ef8638afbaa707df46952eff48ed94fa9a021af709d8f99169e3ab33c6c763af0673b3a33c30881e09bb12b541dce575a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/it/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/it/firefox-65.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "38c49e1424e458d09437fbbb03facfe9352b48e9bbde99f7033c8bc246347b93f66f86ae7daf960a414fcf316990fb9500d06a346baf53acbf0cfc5ddb15590a";
+      sha512 = "19d34371b514f718a6710aa9d00ed1c1b61db770b7974b50702e3a1845cb0e23a9606a3e5714d1dd4dbc13315508b266d1ac9b2876a3fd5311762462aea48b82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ja/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ja/firefox-65.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "9f45fa365052807b015868cb14e687a49d5843d529c3ddce22099730e172ac4d5896fe68992453a146bb35263d41f0fb9a51bd839cb8f887b469dbe055c93979";
+      sha512 = "a909971593687b5b20f614ca51e6e3f37f4fa8bf9464cf714473950ec1f73912f3c3f1bb79410698511f38e86f743705d6cb8a60be6d9e2266464bc301785537";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ka/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ka/firefox-65.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "c6affb4239c752497a766ddf26e1ddcd86378cbece94d41c01ed381c569d6124bf9657451598915c41517174229eb8ce33eed622685ac362cbd28a014eed9f60";
+      sha512 = "8eeeebb0fc993caf80c088d96e2e31e579edfcca5225f622e3b0a592318308f2578998668638594a6f32cb0a984d4cf534532ae2a9418e32cc750df3c33c5361";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/kab/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/kab/firefox-65.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "759ec0854401ada26a0393ee9a8dc79edeff2f7bdd8ccfb1a68e430e5c0c4a20ebb5971048cb1ab1ea735a2ce15b477074122210363b364fb79fd44b08ccb443";
+      sha512 = "cbb17638c972bda6fe83460dcd5d320c03888527b56b7d49e929f6ccb0edcc54251aa0a45162457a09929b7640c588aa210cd969ea43c1f9dbd68fc0ab60c55d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/kk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/kk/firefox-65.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "6c0c587b62b0b68114cb7ea5eb78366cd473112602862baa16a1a374997a45a3ac1ab1a95d190fbcf0b8ae47deca4289cfedd328a4b9fbade2a64476a9bbbc61";
+      sha512 = "d3306176c90902b4b2739ff52cbad140bcbb6cc0ae39e9f820781490a35a69428c2cc3b0204c23832bca62833523ba0975d39b3c30d8504301fe64cf7a5af969";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/km/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/km/firefox-65.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "47bb7c459514d8a1c7f6e02dcd2bff0d6cce4a0ec0537bc5214547ac9a8744d9c8c6a4e789999de8aaf01f4815373bd4130251cff13ff58b49254b18deb78539";
+      sha512 = "f36fab6bdade43429941dd43da65a961dfe006001ed8d7a53041e6bdec0d668edbe09d96e383e76fe8d107e87122abda704b9aa14f7d6fa060bcdb283f30643d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/kn/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/kn/firefox-65.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "5559d5361b25fc0d9d2c5dd9bb62909d4fd3bfb79c5801fac80e5c9eeb9ea214c1e748dab78b0c54715b624d64d5f54b541f49bd2c665185adba75f46d62e145";
+      sha512 = "89c40234a72938d441704c4b03af679085294f20cb0065863fab92ab03446b01b7afa3d004a5b3330439682b6f9b44ac078fec3906b5f99b4a07427419442dd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ko/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ko/firefox-65.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "06ad114dffe1741796cdde8ec6172c1642d04a25d9ba922a74f3be5c70e7046012286ff73ba41f4543ac92df3068a7a1879f2782d934eef1ac90fbf1cdbaa9aa";
+      sha512 = "17d890cd0ebffcc24eb8b7abb4c9e29063bf8b784e0c603f4b69e3988aaf7c77cf864efc19d9774d94ad9a9610bad27a1adde53efe41240dbaad2b6a8d0ab1bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/lij/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/lij/firefox-65.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "3be90a0864e83ffec4ca0f1e453468b79b157ca99a4937154eff24924b959ecf0abe4b80cc76f2711be8e1addcfa2df7f3036e1addeb963c9581c9bc7f966e8c";
+      sha512 = "31265524009f12d22551c5d52cf158a3f7ae0068d10cc744ba18ea3c90e1835d2119951fe11d736809369ab4358f6415e9da7103eddfa90e415c1d721980100a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/lt/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/lt/firefox-65.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f394a4fbf6c105a84a18342ee655d532901e1249ed0965a0513f1e8490f064c0a3be2163acd16ceabb286a1e67d9633d0a67d6b4b77d5918c9ec8a22cfaeacb8";
+      sha512 = "fd5c8a9cc4cfc5cd9e6539f0482c2dfb413a287811860a6658533865bf71b1d3c60c92c615fe588b982d2f021682776474b1420865eba66bac16cf3495747642";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/lv/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/lv/firefox-65.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "faa71e843c9b8bc4137edb2cf4f44bf7570f5f45c456a8cc45c5ac0b9df45f5d4080570f40f5ef29ac8697a7d79f32736a56f7fdcba8366ef531d3f67c4b5e76";
+      sha512 = "6dc4c5caf27b7ab2191f1e2ca4b22b7ed87b7387759139e4688da174d3382af2cc971fb5735fdbce400c53ff8d9bf294512b173920e2c4a62cb5fdb4e6ceec3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/mai/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/mai/firefox-65.0.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "5f49ffe83b61c125ec9f1036244dd3e4777c4e6988547eaa8abce53fa1222f691ef2a41278be31d68c667bae2155833a214ccf15a4c64d938f89db95a2b9271a";
+      sha512 = "afea8c98a60408823d246c4d09d2b9a0ba4c974b02e2e9088e91872d9d4da98d82924c6f486a32274e8a8f99572ee563756c9c9f0596c1d72913a9536c8261e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/mk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/mk/firefox-65.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "2660b36cd91efd31d4e33896c204821e164bc30f1befeacb4677fc2a95332ceba0b84e4e963b501acafd3278ee7f7f0002c61ede46405cc307e3425525880252";
+      sha512 = "2d5cec8d0917694c3bac304454aa1770940310f9bfbf6ec233214989577e1f83c1f81326fbebf77fbcd880b3b03c3fb1928a0078925ac343c4b51ff72c481cee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ml/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ml/firefox-65.0.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "9b617992699691484dbe5922fc67e740b7fded722286b56a2c0da624ffc3cec7aca366437b83b67008145c0c06f7fe1c1a39a05a10ff1ce456602d8484be2a52";
+      sha512 = "86585195d41312e5a990a388c14de87fda05c75c3cee02f0af40367a9cda9ec1034f21c4627da5c2fec020850ed94dcbafcbdb0f52302862ab23e8218e715c08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/mr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/mr/firefox-65.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "b173140ccbb5fb1976eb07011bd6611851ffae5629a449b9b25999c72c3bd505e6f1b57d62bb0576c4383fa034cb2a114b981fcbb0d7800e506ca814a73d5530";
+      sha512 = "f996ec4bd929311cfe481e45813deb1a6fb8667564ed2d63d0d4d2a814ee9f8c5671fce760fade3d6d9ac76e33772e09b5f1ac80e6afb1e4edd4c22c5cc69942";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ms/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ms/firefox-65.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "475ea5fc3b594fc0c79303399ea780a95ad434980e5a76004620d2fa2062a72b31f3982b5f8649cce83ee6c74d4c9ce30b17952e2120d655eab4f43a325a571d";
+      sha512 = "da9b9b272dc5d33910cf014005b19db7a17fb7306c55cbf77030b1cbac9d9dadebf0ab64845b232c9f9afdd7a47d85b52db9264021e45f5a172dcc2b74c32459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/my/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/my/firefox-65.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "d488d6b8d49aecc8fb390c56717b8761ac41cec26f579ca980df04b21ae0fbb0f2154d4dd7a110c7e6ca4cc460fa657071860dc02b56a8cee9ba09f031791e42";
+      sha512 = "70c33d409656fb6e9b0c3fd5af1c9411ae6084339bc2c9eac55bd2e9d5d8e0811630e9f3ac5556b816c6fc3518657073f6786134299f5cdd9b3dc0f2c11792a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/nb-NO/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/nb-NO/firefox-65.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "f44745f0b7781899d0fa9640ab1a6edba97bac28c924237ed70be56b1a257f6c96cec586f931077755ecc7ac6424bd5b9b844ca451c9db66b2b453f21f201579";
+      sha512 = "8dcf198e0b120fa5a10e661c83b604a85333699a6a524b340f736e5cfe21ed9a96c9b009db625db0160c9a79c65b62b28a8a44957c07b05b6e576a0280beca84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ne-NP/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ne-NP/firefox-65.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "9134ebf12468513fa2ca9a5975d990ad7fb9ced38f6166567875e56f429fe22c0214d901e601f5a9b0513f2ba1e3e4153f0e52b2c97ec7a5e70bc0519ba6b548";
+      sha512 = "fede145ef4f444a28d3d10339134b9dfbdfa8bc5be8a8c390c64ff797e5b38d24cc8a242f64d86b0091b4015a75fbd9589627aa0038da534600a9c68d06dae6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/nl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/nl/firefox-65.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "195788d10dc728d58aa29e1272030bbf7663759f639c34e7a62472a8876f3ee2bf03b2fbe9ec14d681de5304e3e822a270a2d2f8ac55f9d3b50d9cebc8bc11c8";
+      sha512 = "c128881c182fd29eddde5047623902c3943cc9100add237dbc8f289a1476acd6cb45f82b8e88adfa21ec2e25f111d4dd3ed772c4cd711aad1a4b040e36a9da5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/nn-NO/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/nn-NO/firefox-65.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "d734daa50ef51045c5b7c3a938291d32b416a41550e0d1ecbb526f5aacc67815874cdcdfe8623588f1edb4eac4d6abf8bec7809ce6c8b963752a87035d9f9249";
+      sha512 = "48c706cde9c4f2f521d0e2b1d4ee6a8eb47f5afea1cea8e7424aae816f81d156a1fc08d0e315b5fbb47d9a44d329c458333b333b6c63467460d4e97c49ede199";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/oc/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/oc/firefox-65.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "dfb14e36caec916aa0df46b566fd2247ee68d14e9e76745c58a51a6e947fc67d585cc2f9d77267665e7339d6c53997b757be5b807f8fe7bd5c0c3f2f6f7c975c";
+      sha512 = "88f91a0ef6dc1a234ee2e3ed4bb32bc12feb4dd368805bc837b8bd3f049ebccff535f6f02d2806276d43ba471620a274a51e35edfa8f195e043e85930bd44821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/or/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/or/firefox-65.0.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "7a094b0695b5f81630112c6a7022f316f06aeaa420b5416c4227cd949ca35efc3e542077d02f8d88b055e3f37e4d62dc5bdb8525db944cc5a51ff124502a742f";
+      sha512 = "13c5f6c63bac0acc226e92207ba8c8c6ab06e0c99135965fc9ffec46f2a6867136a42ec488bfad411412a761dd7cbaccc08062376197217eb1d640028ced18bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/pa-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pa-IN/firefox-65.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "8e586213da95006801244f9529a3917bef7cf5b9ffe482329135ded1411f72edcfb92b1f3d4e8699ead671b0a3161f7e4ff32f8baa6a29aad22e8bdca4e77899";
+      sha512 = "89222f8b28198b53dcffcdcc58e5331b6bd6e099cb4b860b1f4a7804486c741109164f11e0950456b2ab61a4be8db8a81eb67ae3655ae361801835951cbb1890";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/pl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pl/firefox-65.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "60132298bc587af9e122b7d6f55ef57b8a870859c2d550c3b6dcd538dc4ef32171757f5658586646386e87ea9f92a46dd434237b67d7e19beed7ebd8fb16337b";
+      sha512 = "780c81135a0e1c2e843518e6690b9e5ea472d90b985bd51588f8bbdf1f920bc07af75d8f294c5b30b627b48319fc89316667fa55e94a8531d5af65369af3e633";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/pt-BR/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pt-BR/firefox-65.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "4be8301b834b29834d2b6c369341e1b7a106838c79921d720d62a9d624d672dcee2ddac9d4cd1a3bf37da4fdbc9d9b80799c19f8b0cf29935b9dd304999ea33c";
+      sha512 = "213c00695d9b40bb35a02c1ad006da9f42551af1554324df8524318956b9c46f6cb772e6bf7d90c883f97df6be78d527af1601eee42bfc8a5014e46c44af3af5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/pt-PT/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/pt-PT/firefox-65.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "2fbd9e199043b266903892303332396b138621606e51a460dc45f3caa4d9bf8e48c955293ddfd0a85cb5fe2294111fb155417245771c792472e3567384231902";
+      sha512 = "56ee6d56f036925be13282db7edd518524b499810ba31289d287d7b6e3e5355cc1b944d1ecca7aab9d37ab55141fe94c3af3f23f175b2136f2ad3c099f201f67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/rm/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/rm/firefox-65.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "02aaaa30bfaa6b149c304bbd82df7238073168ad49692fb03413d811d69858e738207fdd52718f10d16075ce660cd04124e4fac43f57910f52aed3006d1fa6a0";
+      sha512 = "33821af846c772f6601429a983365f4f79b3fc2df2cd20cb23f61219f544a4520fde8c4e5ec1b4474336c52a2063cfce6660928b0d0aa6336db41055f562c8e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ro/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ro/firefox-65.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "63803eda091f187cb65d0e765b778a957f46bc20ed49a4ea07bb0be15c662307d2858ca9ee9797ad8c4dee97e5e63e11e8be0695a530664984652884edc75f60";
+      sha512 = "bdf7a957ba453a1f50ca1831ec30c2ad3d2620e506ac6b5575304235764593ff9b545719a45f4c1143dc5e4a6e91c6024531be28bfe74904beb2f61f29db7b7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ru/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ru/firefox-65.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "0630ee2da0e981649a2cd95c940af62a1e99362a836efefab151a3d0395d2b6c1b5eb31a2ba96f24a7e4b718af5215d0d911d3967d6bbd53718c6bae0077fb13";
+      sha512 = "f77d8516b50dbe597ceb21cc5e643bd0b701718a2a88013338981cc8b7855e601884154fdd3ecc2b1edcd8b19e396d05979039ec7060f70f786aa263d9044a4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/si/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/si/firefox-65.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "bbff1c3b7040285f5b7188f967d96f1593af7b12cc75845af1ec3ad965199a5b05890f9f70aaa30ff6f32f2a89f0b56e41bbdfd7b926630ea96303d82904fb3c";
+      sha512 = "ff747f4502626af21eaf008080477b1f19c4a2c6f6303ad96c65eb597b12e10bf1519bcdb09b79775b9e0247b521d73ab390f4930c3b2b174362b705dc65bdd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/sk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sk/firefox-65.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "5ff341dcf32ff25e2cc53ddea76a6581fc4efab6e37582dcf64c8714d40269908cdf615b5435d34416bd6e027664726d34a364d2ea09f6cd5252825885812bc1";
+      sha512 = "ebf11e1a59e06b7394abc671deb59677c4850f9060d8f2c5381cf72c1f7e59079b669b9748bcd13af5b936f7bc49b9f4cbb798f402f47cff48c8631ae77b5c77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/sl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sl/firefox-65.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c2305c0a97b1b8c62453efe2ed0a24023637202f493eda44d34a64fabcd1573866bdeb488c2795b5f9ed2372d7189b57dc8b8d9a7f8e51b53ff2d85530ac5515";
+      sha512 = "b31834f097a8089adebb0f60f70803b74d65e824ef63c71a5db57ae1e25efec86e3e31fded1dfdf94f688817c0367c0c3118f15bf8fb01a0de8dd4992f689327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/son/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/son/firefox-65.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "250de55bab9ead2d7c9a24e293c69e6d1e0a06bf228c418dddf6083fccee13ed469b8c2a72c3c1cc2328706ffd54602d205347e50d6adaec34ebdae10ed0dd90";
+      sha512 = "c706f1c88cde86e2d66ba8ceedae19ef0d8fedd4dadce72df47b827b8ee8a0cd9da6c05951021b70e0329b2356ab63c35640065a61f5dc85ac2feefe612acc3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/sq/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sq/firefox-65.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "240bbd1adb3b4415b58ee58971c5d138894b7f8590b9ac26140385c62564ceab82470fe327b36c19b19774645a9dfbc9b24f64986c906269ff0a5c538c1508a7";
+      sha512 = "ca15bb1c507726920c1d1c554da2c0644c388858e02b6d85407a589d6027391c1145b01bb18cb1bef1cddcec987d5445056b51cb21584e5d9ce41b9540198ce0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/sr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sr/firefox-65.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "92026ae2c63827c660231d32bf8923953e61c3f687ee6965e215b807371baa439910561a4506f9484c0a14f0ece7271b11d6d43594171c56566c6a827cf35e7f";
+      sha512 = "256b7b6526a9a80faf9bc754c65d2552572595c53322dd5a9b9ee04e923d2bdc42762990cc86b5cd9505d30952d311a9082bffbc90bb8e1538f93e43fdc36655";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/sv-SE/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/sv-SE/firefox-65.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "cecd3fa7f9253d2b0ed368520d72d01d054e856d3a7fe7caaf8f53ca710fbd9aa5c69057a71875cdb6dbfc6b58add8ed1538b9e9e9dfb50853e25e51987642b4";
+      sha512 = "66295fecef20013a4499f0641d0da2e691cfbe166a5c03734fdbf364717fa8c2b6434a86f2bae48485aa42aa74aa802f743a37c5d9c60218298449d7a8529341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ta/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ta/firefox-65.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "0ecd2d6c2bfa048b126a6a3b71b543a89a234f7088f5440d2a5b73752ddf1895fdd7ac3629619e4b2ad14443b51cd8077df7f7b1e8c816f61217ffd3383bd477";
+      sha512 = "a021bcf2be37488d6c03ada0f7e8662fc57163d64c51aa17b72bc0e23c56d0be1dccb7f1699735908455ff23d62988f6541cb265050612ffe3782129f0a7d65d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/te/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/te/firefox-65.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "ae919a5beb3906b7e32b9929388fe1252beed1a495af4a8708c7fe71c1278036c390f52e10eff5d2541de069df41e6114d236a75553949054ce2fa960dedd3dd";
+      sha512 = "140d7b57909bc2f1eb34c88c8283b66183aed6647bea6164582ae45fc9a54c43b18a7455b60df37a2f7ef6028c92668810cb98d4a1bf3d9e6006a85ed2dc391a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/th/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/th/firefox-65.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "b0c6758783d2873efc20cad1ae4d5ab4adb6d179e98f307d7b07763b5bcb1e8feb6f31c68b890c746574902ff408b6a7eccde2a74d9399714414c317235669ed";
+      sha512 = "ef73b5976507930a1290b2e7b09c90da219dd376f6e838fd821992cfd1973e4e0c1a21b6da523b050acfb303d8bc28bf29c15e517f36096a88888498a243f7e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/tr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/tr/firefox-65.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "d081a793fa41b369a640e5ba637ad377a04eb2089de9c979c564e8f09be7ccaa8dfd02eef218bf911921d1a0f97eba4da281f5504d3d971f712ab15c59e79737";
+      sha512 = "00bfe75ff631f08452e3ecec45df2623a15c69ac1e3985b1765f61ba34a7e4ba1bffd62e3f004da83d101a1f78900938472203f3a3d0df3c694ce24e17bf55e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/uk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/uk/firefox-65.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "6fb2758391aa6995c4988ec0c04e7557137953ce0dd89429d074c99d04b5bd4283ced47f7f7c93534700f5d3a9c6b7b602f50e7729c3095a6406accf8eb1f6bd";
+      sha512 = "8cab20c1a4cc960d15899d165ce0340e8f347155ce131d449dba8cc21bc9c882f8209b109330409eeab5ea149926eba6d0a2eb3a6689f98e4b99af1b4f7d6313";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/ur/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/ur/firefox-65.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "a253a28cd903372d80cd5506b756fcd437c443eb638051dc1051f39366cf355c8454495633a1cdfd8b384cbc697eb654845ef97467fa06d9aa94dda26b489c28";
+      sha512 = "2265739a66dfd03ce0187decdc5472c2d773590314815e07f445e934ea8dddaea38c3fa44b7d05dd16bb21a0f6034ceaac5e7d277176503836165c6da04d4c8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/uz/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/uz/firefox-65.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "c386894ffa93a17ab7456b392a485338deb1980289f1331bab635bad60527ca764a6e7a495b192103a6ab70181433260260e76e82993e4564ca6f542d8326cb1";
+      sha512 = "226ed729da52643b6ba1728e761e69e6f6cd6949f394a18e67bd8b11558d87f15e7ff8a7c6e73eaa402c6839b1a78c34de8fa6a9a10b4f6d52b2a3e44cbad099";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/vi/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/vi/firefox-65.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "e15d48bc479134d2c50df8e5ef4ae356ca1e91144d16ef19c853f1da5567d60ba037c6df72c253be3a02f60e33eaa0b7fe573d1b2777bff114e770198f241f43";
+      sha512 = "ed82e87e9afb51d1a4ca78905cc672279877b3dd221e97df245b9ba30e77ee01e48111efbb6b1a21c652802339efdcd979d9d3372fcc18490e86c46e87a7f3fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/xh/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/xh/firefox-65.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "4f2275c4761d9b8cf9caa61e89fc57bde5ab4372177b9647fbf250969d8a76dbba5640f85003c53eb7523f8dd9ef6fc46db5ca191afe8071fd08705eacc906ce";
+      sha512 = "e3554422c28e6e571cf77b2db704f447e0120429d859150a5f1061dbcffc0227e9f1909bbd38aadee61bbc090f6316192948970531fab9388e15d92d581ae27a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/zh-CN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/zh-CN/firefox-65.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "d81fb2e3e4fcedce4b6754e4d6964f95e766b7de3e917f90be2555ea6b69f11ad0e1809195221e06956e2de2aa971cf9c37b10839b42b393345e7ac472495b2b";
+      sha512 = "3ec0e98f1b346a9a79c04e86f260f7fafd6fb4f3e71cd5c9de0f8a6f4854c5a67fe694cd2a10deae5f6e4b4e48da320b71b3b925413d6def030b00c7ba3bf60a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-x86_64/zh-TW/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-x86_64/zh-TW/firefox-65.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "8ec43ee30d086eb663c2fe3e88479be672e2ae9eaeb555c6414d06556598e7df61189a0fa3db5379c01cc8d6fa11cd6e3fc3426145f956bb1e9b44a44ece9b43";
+      sha512 = "84cd355bbf75a2d51f7014ad0d407664a5daf5bc5594e9f7a5e1b5cd1c3b5abc91e8acfa8b8972fea94c49149d6227320861d8e2751ae644893167c210360784";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ach/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ach/firefox-65.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "8b382d8356f16695c8677e1a7f93c5bcfee12ff0854a498e28eab155c9cccde49f5c7f2e877dbc2cd8af61039187604818d86afcfada106976ae3c0010d4677f";
+      sha512 = "a0aaa0d89be1c32f1f211e813bf42c3cdc1aa21f0980b2a13463227141f92293e05d144cf861b28dd66bf296b39f3c939c951c6997aaa9ab1c984e1adaf5422e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/af/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/af/firefox-65.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "7cbe6843ff38fc5c717f846224a34610f5bb3e9a597420eb634a28d0e84e987d162d2a96a8fcfb3fc7cb9777f4e48a8d4424783663882b89c2f46679707188f6";
+      sha512 = "4a2d43d08a608a7f91370bed59a57a80359e7cfbf71141a1c960fa035a93fcfa2b2f06711dc2523a9d4aae85f9d23a886930922c9ecd717c45afee17a68317f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/an/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/an/firefox-65.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "63ebe2dce50e884b3a7e76ea8b0a4bce8b1c2a69167f5a5ede5b51499824c620ec0d086365c312a9edd3fae2bd777eed4d44d606c1593d3227af9fd13aff3005";
+      sha512 = "94cb4579e466e44c134308d9e8bc87fdeffc69f149a31e39d8e185aa86d14932bd41920a6106011a5420bd89b0d639d6fc7416caa53e701373d69a52eac4ceb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ar/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ar/firefox-65.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "e69e50709c540ebabcae287f410063e716ad58366aab7d9773c566c97b751b3459d72825c0e9398ee8ff146429b943bd30274ceb96f4bffe3945c83af93c37c3";
+      sha512 = "953c47a4585da68f7385f1de7e788fbd0f025434f6f7fee3cc4f8ecb2fa5ef4d711b856fad368fd58b9a655a74e178b29cf5e40403571e36fabebae22d825071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/as/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/as/firefox-65.0.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "65dfb87c5542a3375b1af1ab0d01da7a17e3df22cd56a35198579c4fef43e8f0e5fd6a678a0650a737d01a32f0263ea71019b0f17d6d8805b3b286f1325bd04d";
+      sha512 = "27008ad76e1a6dc3165a65fa4f3ec6570b21ed17761878bd51c6eb2d0f9592f482ac2ae77c85dde2794ac2398a87bf7b6857d241ba6f70507e322a47b5ba879c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ast/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ast/firefox-65.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a746102d8d5a3abe4e7fd75fa3eeeb4281e5c7fadcbc0fe59f05d33108fd37785f5ab53350307ea4bebd93c7d15e32a59148b09179482dae413125990d18de2a";
+      sha512 = "a6ad5ec3380bc571d4b9bf486d07933996ef12d0fe18030e0decc9b30a3a1827c4ef41d48bb576ac18b5f498e3286aeb8facfc15e76f763bfba5756a4dee34e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/az/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/az/firefox-65.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "d4b9f5f97dd3542ebdc4f971b734f4ef2987c15ea356c899cc77d3962edefedf5d1579e49e3c4a9f4428f524856fd55b3b1f55eb372f6b98faf24069b3a0337f";
+      sha512 = "d78e00aca8eadbf3008ee89d10495a2dc462598bf3b7a508c4147c97c77861b60681ceb8238c9b22d65498d177b0c230584cf2b9a3d9f0da31a6197254b64c56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/be/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/be/firefox-65.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "d880b29a40a04ce9e89ff5edf6391c6e4cf10e70aa19916f19af6f071482f82be4484224dba91620d205d693feb5396367e73ccc99c8cdfbf856809990e1d7a8";
+      sha512 = "2585be70036521dd83f68f6f4fb4cf19713c2ff26a4f6907ff01dd0a8216127037f754041637608f715ef14cfbfe7271b4e0632dc26e351b50c00e8eb08358c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/bg/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bg/firefox-65.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "f294a256d1135dfb9a6a6cfa0727540cd13228c07e4a8643d585d240c6e7f2fa96991bdc2ca32e167b1efc5c6f245daa634d56e9321ec15723bf04aea783d756";
+      sha512 = "54d4b4096c679f10f7fcea13302eac7119e4a02f693a8c4880bebc5e4fd331ddef7f66ed67a7585f47f302274e977df237b25c2e0c41bae244e18a4d32f2f0ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/bn-BD/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bn-BD/firefox-65.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "91182fe1d7cbf24fcc189471176834d955cd929520e4ebc7b325bda58e22f8ce79313fce6b2d36bf17ad8ed447104650f8c40413e057b6605894e4148a69c2d3";
+      sha512 = "9564b72566f535061c5ce2d7acffeaa049e8021adc6dce964c035c55cc5d118565dad54c933db771757429bcb81412a71421cbd52ec2f939bc47957f3e05d623";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/bn-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bn-IN/firefox-65.0.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "cfa4224f07743723af2b8a14bb48d7538c340752f9d02baf7801cdacc368bcadf5168d213a77bcd3b5b7cb25eb279ea1fc64ecbcd34e55a4a9c2e412bb6faaf8";
+      sha512 = "e43676d023a668d215f39b084007812514ff663063b3a16fec72aa79e801a2463d93b292924687341be96101c58954465762dd68a4f44bb18c5f322f59beee3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/br/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/br/firefox-65.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "b3bda92511ba516996ab2be3d7556c84c504cc11a0a1482fdaabd3afb6d997d332d65e2ce5fe915c11f268b500b972bd1e7c3a869926b2c4e6f324cdd2f485f2";
+      sha512 = "a1321fd5a1940f50eb7dc98feb6ca2795ff6710b8de7874d0726465b66ca5e1c668ec32da3f946511a21e96db8a3851cafd3ff8fe395accd68a3fe730069c6a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/bs/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/bs/firefox-65.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "a46f31956ddffe5736f0aa4ba66ac71d15a392275ceb1b87e40f369b95366f2f8939d4c6f661692775a91b4d9ba16350cd8f634ddfbe8283537e66fb007c000f";
+      sha512 = "c3dec84a9a667046d0509e4c09f8a17209753969c6d0d6aae56fb718f53c700a7d360759a0f04aaa1a575961e1fc70136478ae652b8e6d845f1b5df61c8b4dfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ca/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ca/firefox-65.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "c096b01c5deb62941e430dc74ab2e130e99c6c979e4e0cf50abce96398ad1ccf7e0a5d4a5e4d40adc594ccb18b50cfe6c32eed060565878d9d84cef25d8daa98";
+      sha512 = "6cebac4c11740848e36dfbb1237816aa1c9c7a698423c7d73e268c74a7407e10107ff8cc8802fcc0bae8c327b4ee6e559067fb78c81866de753ea781fcc10cde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/cak/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/cak/firefox-65.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "94f30cd5a693186d0790c6e5ff0e39d5708a055ef95e00afc20556736ddc05d5956cdd5ca783b063714c850f392a1ee602d3d3b2fa93f5e5b43224c72ea14cf1";
+      sha512 = "af6623230ae20f3dd7915cb395a200dbc7a5a7358bfd634e4428f978da46ac245b2c8faf0b6f2c0655b377f4472d67b8ce8bd6383cb1993dfcb407604f916413";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/cs/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/cs/firefox-65.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "dee18af4ef0f849742c223e136be3580acc11c1727f0360e551c39322ec59266591814dad29887ea267f16af9bace4f4cb04777b3ec18c49b979e21fb1038147";
+      sha512 = "854636af5f2a07f2c9cf86549c59f76df6d338f44c02970ed8024519fd8d7ed4e8f2746f62f009fe7cf8d72dc8a57fbb9b62fe8cb3f7f9218e8ef7f47f674730";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/cy/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/cy/firefox-65.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "044d878806797314f51e419d2641072e22ea3a94aaf9f469f0a0d23e76173345d40ca337f40eeba05c18632f7b7b78b93c39c850ecaf24f0a206f063202576ae";
+      sha512 = "6ec88891cce5878022e377da336010c8818271a4cc543341d2c0585a76184d5ea80f0712bc6a9fa18008670603103136da3195ddb2f7be6d94b4940e3307cb9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/da/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/da/firefox-65.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "40694d162b6f156a845e853bf6ea8cb13db1da8f02ed5da2e640169986557d5521836e1a4dfe0a54ad1c822decadbc9551608001d245990c5e134ed1d8c73ff9";
+      sha512 = "d6db78a1e930304bf3629a02637cc2ae375d486654fdc4ed9e4d995049aaae402c9781ac72c6764084df3c87247fa8ba0ded438dc44955e84d90735733e84e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/de/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/de/firefox-65.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "496482af47cc88149feb1f2a850cff0ec7c78292635e9b8b9ed61c966e7d1f8596364e6169c669de204c481e510473e97a70812c0afdfe13a2fa2567ed6e6746";
+      sha512 = "5e5a817987239c402d141cc7d42a334355b00facc68be1b89c2ca271dc1e9d79de5953dbc1da49254c1c03fc8afbd02cb1258cd2a238007ccb69601c860137b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/dsb/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/dsb/firefox-65.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "d6b471a9629ce8c387ac195eab1fba4f255ec18b3fe0868fd32ec89604f117693b8069f8ea2b7f3b07bcbb502e38e7702ac54e7944ba1c06471701b0e6cda113";
+      sha512 = "6eda625b31d0ee8f7a245b6a0e769a4a35fff4352d1b33c668a0187708db892a317150d8744d65912f265cc68d72e981f6f26b781782a18f3c7691f746f0cb3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/el/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/el/firefox-65.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "bd2967a225cc10281368a5fa3fb42ccbed74da18f0b64fa4bfe3da8e62c883872db0da05b9271cd541a28c4c19abcf6787d7576a4ab06c840f9e8ab82c7d4b1f";
+      sha512 = "d9cbd4b31b216ae65c6cbcb633965fed19010d5b26fb7f1e35c5459cd1bf31b1ceab572056b00bbfd72b5a0d2f126fa3ebc2bf05acd7216e1470370075f6eb0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/en-CA/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-CA/firefox-65.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "61c3dbb80d8af02d41569a2054bc3727f14717505c6bb67769ed4de3455054b5e390107f6f7f85a4d21054c69452cf6be4cb5a6593c155354f3878139a247bb0";
+      sha512 = "b69b7033af141d38377d76202683a5ce362cd8f52f7d01d8d04482908279029a9fe4fb7129e4ccf409eab1eb081d24764a9ae1519796612ac524857a3fc37499";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/en-GB/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-GB/firefox-65.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "4c153a00edccccf1ba23194e61ec2b559155563d07d2b04465454c4ca7128026e0fb4b6b45d0173a0088671a83ee64591f441f08bdb4bc760303f29625df3e22";
+      sha512 = "3eaa085b84924d24c3e4726fc2e7084cae6a90dbc784d157b7f94b50fd49b02e49d736ae49330a2795938487842a4a8e128ee95d876e73cfdd1ec3c959205bf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/en-US/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-US/firefox-65.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "09651679e1c7966e4df1285ee6d3b5ed99b4f91e32ffe430d75122224eb303b80673aebec524b7cf27ad15699a0c4ff908e694f54689d0e4a6c0352438be4704";
+      sha512 = "d7d8d14d25e4864fe3707d4d2ba7895556b92e2f375b237c73aa011afd952d3163e8492db8ec150337bdcb440c935917b3586240b44c9a5beeecbde545ec2821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/en-ZA/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/en-ZA/firefox-65.0.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "3b6b8d16dded7bf308017fcadace078258d1e7e365a1adea676b8882161beb5f4cf7aad8e804e82f388738d1a6b2cdc192ce740342b0f79b6f6ae3c02f5b7c08";
+      sha512 = "ea47abb33631e7d32288a9610d1c9d86f6414867206ad4923d23e8bd2107105a786570e1ef0f253a2ffb90fdbd890c033dcef0302a2a3145d77af51a0f11c0d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/eo/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/eo/firefox-65.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "2c1921f9f19f1abf9f2940f88f705664a2277dc55493f51136da1ec9efcb0bf49510d18bc4ed13e0c32e8331081156627cf18610d0b9fc909a04e63ec7834dc8";
+      sha512 = "a656bddeab181d503342d0015ab1feaca887894c3335a39f1b4fb3f53c6dbed4ed7ba867e51b478ed651e86e152c7135fbd4419a451a35a5e8c11c82887ea1f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/es-AR/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-AR/firefox-65.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "be80f220a86ceaaa3045472c7e5a15b631ebd9bf55a10152164f99d151e96fc599e25f7eebb4a670f122fb6aebe5097650b12611e595fc9b749af60320d01d5b";
+      sha512 = "404ef7313904ccd11b8f4885bbf13f3f9c2123fc3789bf983ee225cbee9542b796e700bee82dbb7b32b11f3222e1ac9a39b8a0712a6746e6557eabf7979740db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/es-CL/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-CL/firefox-65.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "bc52fc5433a43b275918c45e96584e29e048a46ca0db7c2cedd851e3a763500a04f2696871aae132ac07f5a44b67b5a604b6b142d92f49e67ed33d17ff7f9d96";
+      sha512 = "88b89da9b2d529cf7be8c9fa464fb17717e3f40f8b77bb47843957731aae4e59dd63f691af8fe863d74cb2db6e1fc9e66b514920dd50cedbb6e2a1646ce92df8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/es-ES/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-ES/firefox-65.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "c2e022ce5672bf1e1a825535acc8968b5a538fe3cd2cbf7d11896b6a1fd77422d92114d855dc79caeff620278e092d6c2510f82e55fd316c6dce05b1e3ffad09";
+      sha512 = "33444d60e3366d9875b22b2e99fa8ec674446f78a122c3b0719373a7abc55848bdadcb9f800ef1790531c9b76993ecd80d473dadd838867870f105b5b36a0d7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/es-MX/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/es-MX/firefox-65.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "3363c5e6c198490ee2600778b931d44a0abb86baab887d8ba3bec70d4a025a7f9d840492b8644ad6ab32f24a0f9e4d403b9ba0d6349d8a99bbbdcd0e180701f9";
+      sha512 = "f7d1e5a691a8e629e11059a9bc367c1e91c525a0ed69d88bfbecc3aeb22ebe668c1bb20f307f2256d3782f804490a77ce45cd2a8f55cb547e314b327973b8d74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/et/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/et/firefox-65.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "04f472440779ba04a6cdc1aab9e86418ce7ac6a042921e2ad8afe9a2ac7d931dfb15a771bf7120130c0fea3f894dc35a1167f8b8dc246f133f95be8deafb9e8b";
+      sha512 = "2399846600fe912de3b057a18b857f688ffd39692b9db5d2a7f70cd31dd35d8c1e09f4b73f058ce61808e22a61033963ed97e029a5170662043f684985e1a82d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/eu/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/eu/firefox-65.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "e9db84be9fe224641ed11414c07ff6d23b583711e25253f602bdf57a5dc249151c700e65722dab103b3d9448a3930ba73c4d4ae223ef935ae38f85488a68ae86";
+      sha512 = "ffcce3c779c0f139bc47eb1b9782436db17977c6e3b340d0996d228a746d843a1927cdbebbe11955d659b1d39ca285e357e6e41cde09652dd762192dac641ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/fa/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fa/firefox-65.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "06d6a28c780cd39412463cc55b5afc3c4eb29fd22a4b5a916456820a871c7f150c84beddd24d69a5ed1c2c0392a0b69a5d89771be929afbb46995499bfac24a7";
+      sha512 = "a875e2a656a375f4ccd370078c73e72f8c6a1cf629db277b18928af35be74e10724f7bed1846d418266dd8cba1808a54108aa2a14acbe49a60b8c6d2ec6cd9f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ff/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ff/firefox-65.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "e8c54e872c63d0b5f814a31e9d8f98b6d53f94ca471e9728c21b8f7374b85a235ac4f6fddf7811333d71a1094cbb5b4dea20c1035b9438d4db8bd4b0ea47aa4e";
+      sha512 = "da41d26230041bcebda837d8d4c871f199b1ccdf6d872fb8024bcc4caafa57c2e409977d7c99b443eed8e2ea003210bb6564d8cd3666775cfa88336122b82b74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/fi/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fi/firefox-65.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "29b90160fd55a3e7bdbb9eafd52e052a9e4138591d21ef52f4cb097496494a3dec44e359a299c358f242704437817af4e1b55771035b34e7126307ddca312f13";
+      sha512 = "bbb3feeb706693a9f9f9733f9fd3b02aa8114b313af2a40ca00e22a30e8046aec58f91a0d47d6b3b83bec33f118dcf5f0b9f097560f32324ea9deed23b673ea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/fr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fr/firefox-65.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "7ce7f12c11ce2cd212648639f34cbc6c0b161e69b6082f41a4ba6a8609502d034b9865f542dfecb683dea9da374cbe617c28771ab8867b207fb6d31413898143";
+      sha512 = "877f704b152b18163d4dd4962b634b9ac3e8bc218ec8e6a53ae6c13991a06c84727c20012e820213a3698257f53d6007c992e7cf9885503358a46d236a8b18d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/fy-NL/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/fy-NL/firefox-65.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "2d074fd18ddb80b18e24d1ea2868b0bbc0575e173740827ae849110f98c2467c4f401622d2099287b5f536c97dfeefa65f89b6c9601ad2ff90689a0f92c0878a";
+      sha512 = "494c5ae227db4c468e5b66fdc480ae0d9adb25f28d76ebd94fb630c096eded631e44af6efd5586aecd5ebdf62f1ed307086f9bf7af0395ca6cb599a2eb9d77d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ga-IE/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ga-IE/firefox-65.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "051f416c6ca3a0a42f8da96098c17c8188af2e55d585ab5c9f2eb54fc25c1f3bb35810e39ce51968e35f528959b6249284b29ebf1aa660b26cbeebffa3d628d6";
+      sha512 = "3e9e921fbaac835dc8745d3e3b46914fa79f64e65d412a39b659ede44ff9810298c8240966440e82a949191ace2207b7e7684530d930d0d1913913a320419c81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/gd/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gd/firefox-65.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "795f6ab4835f9e2f84277072d67ea29f9d5ce25ae913007ff04f839fd38301ea161ed825d53ac4d9d444245cd48161392ff868c162fece5e77c40c1e2330463a";
+      sha512 = "b71e3a6f1f060b3132034c435b54a735f8fff377646420b408482cd6dc5440957782aa530285f8bf7d51c56d5df8532cd0fdd826fd8f1faa06ad0badb48fd35f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/gl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gl/firefox-65.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "3419ff231fb3705aba5ad6d20e18fee2f271a489248644ab5da197a27d3079ea27db82c4a19e64cb7709df79e323c0b7575072321a4484a20aba88f2da9948c8";
+      sha512 = "ba2dfa015a3de26750c8b59f3bac8ae395bb36435b4b00b0f30a6a09012c36986c6ab0a7a33d74def2e3cc89c04d34d0d9b65e830502f59b7028fcccdbb43519";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/gn/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gn/firefox-65.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "0d4d54c3f79b1e3cf7ea8df71067d4e2f654f2b1c1895db72476bdd55acd861a5a4bcdf60ce4d70bb21af4b3295981a086b348fcf85495dde0b1b2045e60b47d";
+      sha512 = "24735e13619217c444d6ef5e89f765baaec014a56a5929b0cf4df1d5401a673965bc058d440d80cfef9efb0112cee600ea8e0e030c2f5c40ad738e0c8243a6fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/gu-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/gu-IN/firefox-65.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "269ec2149865fca892c0e1b402af3e737c65ef4ef9db68cde4f9550a60e3e228d9ff218a920c63c03f74f66d348956f28e77e3a495d477916a9ac673afe7abc3";
+      sha512 = "e32a73588df2630bdb6e36186eddc7920e5866d1293f9bd7b8a4ecdb9a2d504e4a46810856a731bcdf5bd7852ce6193694330804a58daf82029a9070d2d58542";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/he/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/he/firefox-65.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "db78a15d2584d66ce27f9d0efa4d29e5329f4cfe1357623f7406105212c50e58195e492d059ab6157d9f0f37c947da77c384c0b2aeda1bd9691b2d0deb4fd330";
+      sha512 = "467c77c045760b7de01d0bc25c36527c0cebefb627346359f8b1fbc67d0678d31fdb3339998a596bf183e12378124479b171bcb4b6b8f2f7d10e3215f17e7f42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/hi-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hi-IN/firefox-65.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "a638a07ee771a623755bc69a352719675172f96ca86be2ac142ffe8670eb4921bbad7e2965c6464df11f7a345e965a4350457331806d2e01724791f2a419b3b9";
+      sha512 = "d879dc631888b32ae06b5f99f1adbdde32e76a5bc3150bffe8f326d0728acf2d9d1b8443657194f2d5c26819017365be6af5525ca9d1b4324eff57b43eb77790";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/hr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hr/firefox-65.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "2cc12574d807102e4ca7c2b37f252d132da11c891ca05e30559bcdf7c054a237e1d1a17eeb61023c33d0ac62e7fe703328db2152cfea48f880cddb90aaca5717";
+      sha512 = "dec69bf3795f99a070ad268e62414d7ae63f8c747a205289600c4ec4feda63aeffa6398802cddf6787fd17e735f376ca4842457ff45a9cb72c912a2b3cdc6cfe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/hsb/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hsb/firefox-65.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "528d7131ea6379c828e2215703d210b600bb1d9ce6b25c14371ae3793c4231e34fda7f4f9132a15c8d30dc1480e53db8d4b69f9c2128ec39da4e96b6995e5409";
+      sha512 = "120247d2c6bbf44a453a9afcd9175a41c2ba2b927286b33f749f51b6ef4aaa993f6a6d4662ad1eff56ae736ca91d742ce64260de12b493c9dbfc52621dc81b3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/hu/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hu/firefox-65.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "30af286d2a5615dd5dd62de938990fc448e85450671955ba28303f52c853e47020fd95badc4b0f15a044900ac7e509c82eb2964f581311ae2a2c5c5303ef5ce4";
+      sha512 = "fb9579d7abaab1208ec5a8a8172d57801789eac83445413cd2133c5785515ebec01824dcb76685d5c8507048025c4f9a16fe7f47233a4c5dbb0bd76fe74b6484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/hy-AM/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/hy-AM/firefox-65.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "e934ddaa4ca206213dd556454dbb1ef4f0d3b567fe15df7997bbc43b16e38e23603f06bdc69490d9e26121ec2140518d610fdd3a125b5ddee14a4556adab4bb7";
+      sha512 = "28f4436f9a977edd4b30519b98c1842724323df3fe638979839a87153400e806e22d73c9203eb0a2191bfaf4a389d6ea26bd81d498963aae59c926375a61cfa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ia/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ia/firefox-65.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "ebc92c0eb3639612feb69b281a9240c7335a4d9e792df77f0bf8b5591b37089c5994d6a0681ba90c75228dca3c7d9f9d9d292ea37692bfd761eab4d93e32db88";
+      sha512 = "1bb69219eb12abe2d731d600dfe35511cde083de13d2277868970a52a77a558d5dedac074a45f3bed3d01e18e2b7c5695d4831638ad194217f977efdc38f3e6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/id/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/id/firefox-65.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "dfe6b103ccdac88212d82cf26e02bf4803336a742e3dc1b6ba0c4e3efdb3efd13a743731052353eb3d7947237ad010cfa6ef1bc735e9acbd08f0668cc0ce3fd3";
+      sha512 = "87698f7d5ce9f074b2dbcdce00fe864f36621107df7422e053b0db6ae76947238784f7ca0a045517800d3a936e065cca3e74e6bd9cd04a265d7eac3cf2e0ce4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/is/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/is/firefox-65.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "7744c9137571f3c4c9a830ae801c81651d4f979be67664fed8a503f3e8357251e37349acd323b7f6b6d843c68a499fdd544d09c02db22e64f52e057831c1e366";
+      sha512 = "b1ef9f02c286a0ca274367394f72b980b9c59d45e4c629611c3c7dc55677e90bf9f44003038740b22d660e5e950c489acc18ef7317e67f211c629f0b86017264";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/it/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/it/firefox-65.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "7d24a74d456ef99e1c212679887c4b53703bf37b1f76827b7e7e41dc056cb46457243ad321e5ca41e73839dd6f62f1f674a1b5f5430f775a658f1a90563992f2";
+      sha512 = "8507dba0adcf5ecee9224e0b8cc20b5f57ce1392affde80486a3389e04b1cb1543208cbaf151b56ed26e6124af863365805a242c6d1106842fee8547363ba11e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ja/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ja/firefox-65.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "31696b0834306f0ddda94aa4b44e59bf570796ec50e744eaf5ac65c803a160d811e8c19df3923534bb607eb406c86262ac281dae2739c1b1a158f397dde85689";
+      sha512 = "ea41d66d37174c936b56a3bb86d707657814eba1e99daff7be915a4ce53e35ee64d7ce6c2da0d640fd101b7cb79ea41bb49b4dac144d8741b9f217a2a042f85f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ka/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ka/firefox-65.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "8ae0b80f22251ea7d1da8e151d94fc8c6452ab95af89a76a461ddeae88d7bfa8801c7c37454a88097d228d404ef8362c88a4968d197bbbb6e925dd60e2d24c31";
+      sha512 = "793cfb78a809f8e7acefba260197665980b8b5aef599d9a3a2dceb4e8dc83034c98ed04561abf9e4e6740859ce07f647e544d2bb4244b505ba248c8af3147403";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/kab/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/kab/firefox-65.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "401faa908365eeb8790f7895fc17bd19d9b8cb294fb18567ac3b69bf54d37acb381c992ea969e8fdc5888d165c91a757b187cf4422f6a184b2378ea189b984eb";
+      sha512 = "50ce6f27b5ca77048600db7d1f50c04a363dbf5118dc23b06395ec2fee401a205725aaa99dac3b21b5660fabca3ed3bff2a996a15ccbca4d35e73553f46a97a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/kk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/kk/firefox-65.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7819b959b86c728f568c1088827e6e55c4ce4bff6d52a51540d47f014d59cff79d28bd45793d3d09b1951b8bb7690f0f1a8c5c4854500c375297d595806c9f9f";
+      sha512 = "8b5de334b237751201679b8d54f2de5ee384182395cfec120bc2eddaf443e0fd896c1594e92e2ba71943f2020fefe44b691e2286fe9ed1c21d3fc9e11c763300";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/km/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/km/firefox-65.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "90acc7ac9eeb55398d6624525808ad93a5cd506a363b465feb33b336bfb3c48c47d8ef9e057ff26b972534e50fca59ec14a5c7f8425f0cfd9ff6e81877d973f3";
+      sha512 = "1a64f732f2c19858cba7e109beb86726d1e51dd2a2b5a09aa380fc515041aada110eb90649c4c6ece5aa8a5857072968f4a2d43f3484dc2e311c61eeb4fb49ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/kn/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/kn/firefox-65.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "93203bbf5ab4e41723711e13a9d0cf76a436089f15c37e8cf01c2d3afe2d7d0c0d1a5d0bb34ad5042384493a6ab5ccff2123c5cb044dcddd36156ce3b4bd6213";
+      sha512 = "149029ae8bd3a81151a17c00b7166e02e22bb9f737bae1150ed8f3fbc28becf19234a1a874ca0aa6400e1b0eb75f14465546ec7e0c5bf09b8c434a5ed9f651da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ko/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ko/firefox-65.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "6cc2fa7d1ef44d99db1c011a74f394880dac2f433e93aa01d18db0d00fb1511995e0e090edda30764ad60275b345e251d2458014f63760612d515ed3a10fed60";
+      sha512 = "f7433f3da565969ae1e92ffb4d2fb48a2b513214b08e611de2b8cb3efadf16fc6af871b470916b0611d10eb616fec09e37648c98366ec0f6211693a9f3434df2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/lij/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/lij/firefox-65.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "43b94a4571e639120a848980b7ac0edf73b840788a3f333c1200fe814ae37835d859f83c318382d3fd4e96cd010c55b542f72c6d5f46b999b526e4cef5705d7d";
+      sha512 = "6b20b466ae15b9484c427a65388d099073eabd54f938c75eeaa886ba5db73bd1f91ba207308941b2229ee38f8dee4201599d1c11e228ef6a2e13ba0d74f7c427";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/lt/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/lt/firefox-65.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "785fc150962fa875a32830f8e71b116e4e3e734b4f4ad429ed50fb3e93e430aab6796c1f867c78d3a3b714799ca35971591a8668f3bd4421d80ac0e3c8f816ec";
+      sha512 = "61a85a29003930d8deca7ba76269f437ccb47680ce8ae12b9c9913e79d6c6e6594297f890eb5a5e641610a38c1016a1947a866b8f79ca83ff316e925df8a8bd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/lv/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/lv/firefox-65.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "1877f1ffc2ee5c76db3afb47788db1a251085e594b5ce7aff4e959caf7b2bf7a292d828735937966b3ad0138046dc0055ab25186250f4c800fcdc13b6f4927da";
+      sha512 = "21ca42042d0695c9a7c5c5b5866b1fb54e65f76543f42c45efd0436fba73f5989894e0d7b67e496b101674fe3e7f0c1c374c903c9b6bcf9f9a1c6730c5c865a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/mai/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/mai/firefox-65.0.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "942f8fb48f1b1086614f122596286c0ff66fedf742ff81ade4ff2c60fcd7cbdcfb18489a35c3abf0de85200905f47681e55a96905907482122b748e4360edaa7";
+      sha512 = "7108acddbab96033cf9cf822d93f0ef3c3ba46e75ebe09f5f1d211b7c5cce12fdf7e7bcf06621b1bbde3478441893fae8ff919a0952d76fc0f8e482a2bcd811a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/mk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/mk/firefox-65.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "1ed365e89a0e2f100a6b19c0060284aa6af06d9ecb57fa9d1200797f06c5613009ae466454bec794fd4ee8ca2edd0e465dcb6428b78285e77e8d2392c49da591";
+      sha512 = "6e0c7a12413d351ff5cc95ce56df95e6f1bc4ae320db45dd988d0dd488f525820c62387aa43003744e3cf4040f91497d4f36b4bbe4a636f1a2d010d0a9479d32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ml/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ml/firefox-65.0.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "bb6f35d2fd419231ec0139745fffc85ecaabd17a51915cddc286abb555538b15491b88ae099a9d2713f2902662c869597bf9c1b2622e4f3f2469c25e68cdbab0";
+      sha512 = "03e6525cc76cc4a1f2333dbb67a3f29976d3d9068d73054711f561bdad0a8da9d14abc3f79df596696ff2c28fb51147010b7351052f3b3a8d0913b94e17b022c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/mr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/mr/firefox-65.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "40201bb8eb70feecda000a88d16a9a0f4e65518dc35b85f31f311785bf402d80babd33d940fcb6c349e46c09668d21b9c0985538975d04b06127e60a5b64ce7c";
+      sha512 = "43ef1fa19c05096b3465f985ebcd91e7581a29a380574cfa763269ab6c7f760241645d18e9475757069b7680e696be17c2e92028874c57c31b8bc2d1fc5d8be6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ms/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ms/firefox-65.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "35b9969191730e94143b28f5a0316733a9046bf4f39d3552b88b75392029bb964b1b7f963f1a770bc9afa5f6beaaeb29d04e89636d55f0e5bccb412e2f912e32";
+      sha512 = "ad84ff57cd2a3048862f8572c3084c2fdacf04dfd080f4679cbe5b6cd1efd9535d4fc8298aa1225067f5a3e79a9d512d933e9257d1db2df0875dab8d9259352d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/my/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/my/firefox-65.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "cba958f5e8055456765ad9ae8f6bf20d347e14fb20681f972e7172503151c3ed19b24c5f11c800eb73e58dd21282dd59b9e9e74869779086dc9973355dde49a1";
+      sha512 = "f6b51ce2a6f67193d3410bcf5210fba114d2b4a626bf2cc98930143679cb72e00657ae44116295d3fae92aaa63dbf5393a52b8d2123d024089c5efd0737200da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/nb-NO/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/nb-NO/firefox-65.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "a886ab50a74c7e01c7be43937e38ad370a20465dca3cd22dfc1fecb84d71e7acc0291df1f289ee059cb546987424bfbc77ec6792dc1cb6ed3e4ad8cf10087436";
+      sha512 = "8b416187023963128779f06cfd28db4a7bd6bed7b7bdaadc8396c51acf0964c8a1e1230082c9528e0f3ce2ff54a84383daa36e72bdacb6bf5768214b7a497edf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ne-NP/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ne-NP/firefox-65.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "300f48a200ffe2115a5e2fcea2ea995224a2a6e75c20881d9934554f077056b251dac14b19b2a6227b7c813108a6ac4614e7880ef6330c155e594894faec1074";
+      sha512 = "0fec4f2b6b6944a29ef2ff0ca30c4d770d2a956564b697fcfb7a72517c488a252d990a31e9dea6ba36d9b5ee9c38f39dc8446edf2ec7caf946244bff3f1d18b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/nl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/nl/firefox-65.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "4d0e8711022bf6aab64ba2a6d0f2381c0ee2b29282e87411ea3a2a192dfc06b6be0b304f680c1d0cae171d4bf531ef9a68dbffdd671245747d2e7b292be69234";
+      sha512 = "7fb3c8c0e441ec55c9a79ba13ac1f7d17ce3612ae6f6ba7e23a31bc2d854fc41abd38a4caa1991b9b45fd58bc2d8386c2875adfcbf40b07cbc8bf0641a4b8b10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/nn-NO/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/nn-NO/firefox-65.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "e3fe55836442e0c6275103608d167461110357836cd0631e84ea755ecd2b46a46452d85dfbf71e669697995b30da3fd1b0cc878372525a9c0446db64cbf497fe";
+      sha512 = "744f32b81f4a4287abc812ebe7209082c4c2f8637c0a135a9ce83377903e97e3d938037827283160a141ab89b51060313bac82fb93af8f24c71b3aabdce9a293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/oc/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/oc/firefox-65.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "a90268805c8d999bb657c79a3638b0b580ed6407a233a532cb417d7061b68c4d6cee9d6b5c3f05e9b2611180cf7649a405e2d2c631bf09adce8ebde9bbde8314";
+      sha512 = "2722d769575b28e581da820a3a6bf8b407a1c4018d97c2e7315b15642f4165efcc44860710141c50829a8d5d57429e9fc47565852ea9c2c018504f3a4f11739e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/or/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/or/firefox-65.0.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "16092e2ec183344850e32606f058cd356c26fb91703300fd2bcf36a278d2f0504370a0a619ccd35b2f1ca998c5b9b5a393fcdeab7a78295774f84e2e468e6e27";
+      sha512 = "3f757e2d19540ac963cf14d884079fc648f1ea4c1281c86ff342971fab250c4ec09708c54ce0fef7eb343db057bc6bf5e15971e70123212d8a1a90bdaebcde8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/pa-IN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pa-IN/firefox-65.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "7ccdbcadc26d9b5c5e451ec2d3b8af913995678eab8648582593327ad7c0b726922c54ed60f44632b9aabf66845dac01b464f695f9606466c248f8d694f3a237";
+      sha512 = "35bd0bc1938d6fec372356721236afa3d1a794bda57eb11d7bc86601951825a143c1ff028ad6f0b4cd50e068a5a233a08108d71035abf2cd69213b3af794849f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/pl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pl/firefox-65.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "59819654afdc622f8a82ff62bbc2347589083f847f21d100dd6e625a75dbd0eb5c15acdcb504353c2e8d3351e0021c0494e674b54e7583c3432d568252811ad5";
+      sha512 = "34c91e7c2434a233a6f458b28806ac110e4382a1f685d485a2f338d66e27ec362b0424a107c8bb17dbd22ba58c0a1bded15e1bbe5ee1de76a460aaf2dce9334c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/pt-BR/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pt-BR/firefox-65.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "dbda83f708aba63d5c761bb95f4d50007afe0021d8677f94995c00656370ce86a9fac6ab8afe0d8c4a5af15ff9465f8db2888c0b2ef1e08d458f356ae1a40bd4";
+      sha512 = "09e247ab05f9c02bb2ede75cc46e321a518629dfe2395be8536af77601a91d4acd1df4c1a34b54193aeaf24b0cda54582ed204258e9754126dc021e04066fe7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/pt-PT/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/pt-PT/firefox-65.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "4565296177aa7046e08d4db4b60cf9cc0c93e794963d0280191c096d5239af9c719752041901e04221597359adad8dcf3171842ef085e32dc7d8c3146e4abf5d";
+      sha512 = "3ac57c58851403af43cc01010cf8e55b734b5d1d2db60c3b6457dfc1def483d6918ccb0eb6cdc3c4a552ed8cc5975b8534bac3e644a5f7d08fb9f2b168c7c3b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/rm/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/rm/firefox-65.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "67b396e074900fb233a7fcc14e975f2f774936cce4a68150f9d1e94656cf097fcd34549605ab94ab121c4aef2673367f2c7d80d54cc97597cbff3da82a5d4291";
+      sha512 = "b73742b939435bbb8d2a0d307abff82f777ba015b808eb2e7e6789ca93d33f658ed2e550ce917f5318ffd9ee72d92b2a47b43e564a4a79f0293560555a69cf76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ro/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ro/firefox-65.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "c5a9ad2a4f49df543d1f03569a9de5e698cc20f163131cec1892183d855c28b00a8cce7b97faafc7bafdd1bbfa2487ce294e3bf3a8cbe26162d52da5d0474398";
+      sha512 = "e53fbee87ed143d5f2f7c4190b648dfebf44881beac3ee866fbac2bb8170d08c2333b8ed634696c08dd18d26acc5bbf80b5dbe9544c5a6da48175acf4708d408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ru/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ru/firefox-65.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "078ea67e6d295e4d7605f09ee04992b301557444e5c195a9b29a8cb328a748d30a82bd005b1d569cc238e258402d057cc861b9dcd68ec30ad8314f108944884a";
+      sha512 = "9a05d119cebb97b022ac038c36dbfd6ecf13054027b419ad37d07d6b6cb84e4bdf77c651603f88da62d116a046dec77e43c333ee370514ddcb63d53b1754c00c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/si/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/si/firefox-65.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "80e6dfd4714de9b73dc068061488980b257df1e7dd660b260251dd63993db5279c2d54007f42ba9886d3ff88416bd20aa2eec1ea107e121dcf15b80639db1c32";
+      sha512 = "fe70747cdf4329fd860a05ad8f69e452dce9a8a0a4e65c9ab84348b870a628746de1a74f66db42caa15da7ac5d34b071aba6095aacaa818859b041052f8b4df4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/sk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sk/firefox-65.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "be8eb2f4ed1dbc3898e623ff435e6a9345287729d46633b353a8e244caee9b566be3b6ca4b3f5499626b0c931b26469ffb3ff140b8ab8c32f8ddb99db55307e2";
+      sha512 = "8c76b164b6c2e9431dd23131a46fc613e24896cc2d02d67dde78ad4f7d2dce4baa1e08bb9120c02a243743231a54eeea68e10f2d0e1c44442e53533482afde13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/sl/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sl/firefox-65.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "99a0f9892c7af215e203a8643aa499597fab232d30d7f9a4cf00c30ba1d29f578e65db2a97a16bd3d11e7838323537cc391c07f85ee969312622b87e84f096e6";
+      sha512 = "26ed90dc4b5e1dcff81301eeb75fd6729b0a94ad0993b438867b8ae4287a03c20efbc425b8130c948bba46e71c654e6aa410a28a20fd407ca922b77f166e0feb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/son/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/son/firefox-65.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "ef0136de2033b656f715d98414e14dc19f1a36ab4b0f0dbb1bc33bbd195c50b21bc3452577f90f5104421c438d95ee7cda42e15dbfc6e2db7df723e5b803afbb";
+      sha512 = "11809822767088ab739e47b6774374d619384e4ee2a69690fa5624a6168c0a3fa763b85b573a1bbbd0b97f50c5738999307d91880cde14a4fb3c6ae17b484224";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/sq/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sq/firefox-65.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "781468c8bd431d6e5e2b56bfd4d39a014edf53b5757d5147a1d77e0d79107d2e7a71ecc7ad0e53498bd36d72e612dcea3b3453f4e0fd782eb034768ee270ffee";
+      sha512 = "22f699cc9a59332582149087418596dd8e6b138b1c7010344f4471396b3a69ebede79d924dfe5e025d82054f20f240356d4232e284d33f8805e4891bc7b30459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/sr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sr/firefox-65.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "4bd80b0b38156865543a335bf17a847ffb7c9001547a8415836fbc52b57927dee22fa21e6f0de834bc40ecc8f2f1b518c5f7ac4dcc00b0db26a82aa7ac4a106a";
+      sha512 = "b2431890e7cdf5e1563387d9c566beb3c083d81a0f11c5c1843788b7bceec927cc55bda1a92f605210aaf2960ab4bd0fd42e4d558749b5623eb7f3fab0d7800d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/sv-SE/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/sv-SE/firefox-65.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "260c9aa46d9323ffb4f8e9607b876a4fcb46aea5a1e62fa7d3b9d3c6158175d50b8948053df5577bdd6361fecdbc933d85051ee294b941c7c78509a6d75f4812";
+      sha512 = "c2b7399f1b6f75440a725289df834af2defc77c773ba73f0b330689244167abcc32190e185ade9dd3c8340f6a06fa2e026c0d4c426e90471a75cb1e79b45a086";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ta/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ta/firefox-65.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "bfebd565d0bd1792b40799e2bdf82b502a64c26d390103b9b4363c0785d4f1a075d364b27d3a209f6246b9a2e82c65e82ffa2c55507229d4ac2ffa905050784a";
+      sha512 = "b29e0db021afcfb246f980a2f5afb434c52be5324985877d2ee547a097d17ec77a7ea3e2ac9c2dc558236090954b1cba4a0fcaa10698da1425dbd5e31406aa4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/te/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/te/firefox-65.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "2c41381d816aaf7782a6a0ff3b15a12a1f82aa6673e6d18d9685340eb0ebea20db8bf1596fe0000e8666c97b464aff76962dfa889fd0c71443147fba74ef549b";
+      sha512 = "709ae0eeec912c6349bd2b41a5cd10bd58ee5279e50e70623be93d0fef1655c5e0ff74df47d60c6ecae5883c5b6102ad0a4d61924cd848973fbc10bbe112c18e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/th/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/th/firefox-65.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "532b0db2482445312d726237d44982eeb94378ce5e3e6a779f97f551b85016394b97b683feb168917eb43f987ad47d7b8249b68716cce0c8b66f8b8be644108a";
+      sha512 = "032fb59d5a502d593c1ee5f05d51d0d2a88bd3dd081857e27c9d429ae337b37252a0f0bc0c261adc71b8b2b57aa7b4321ed8ce3bac04eeefabcf97ccec4b2f78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/tr/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/tr/firefox-65.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "37eedff76225ccf7485516da0061b6c48e4e5696e8d6d2179718adfd2c1e4070c338773bddd176b8dc62ad8cddba2445be4b2e59bfb6c372d11d1b65d0b7a0df";
+      sha512 = "3ace64d030e0012f9acd06e242c52408f6b8407f65834d34b203910a18c459c6dd8a23e80d4b11b4d4792edb2ff71769c75e90ff919e80d7da71a2341115e571";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/uk/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/uk/firefox-65.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "d3a010bbe98c8fb16d3bb89e0f7ed8f18d61c995f0fed28051de798e0f89ec864766ee75a51c1c2a3f82bf7d0c5b8f4e89c2751c4d4a96e145fb7ceef1852799";
+      sha512 = "730b747ccdb0b31738e2272f9763b9aad992e241dfee8d067122886b625a5b7f83d53fdcb8052a00ee68ac76512c8ab97097a640cbad0f308dcec1f4cd040503";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/ur/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/ur/firefox-65.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "721d2cc23eccca01fbb2ffc5dafeae516d295328785fa50c0cc279b9786914b21b68488174a6c91e1bdd906dbd08ea70d359d8130dd1559738f6c18346a8329a";
+      sha512 = "d10f6a9f708f27c7d935f190332c7db7d789f72a005a6474e127e6061a1e49776734c6e1a90e84213d8734c2ba1ec39063cafd5518ba482dd82bac323034b883";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/uz/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/uz/firefox-65.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "558edf58991a72fbdbd8861a19a2d0bd3e4dcbbb2c9de6a190042d516baf38796dcceb7fcb75b87fa0d184d1a7129e645f0993ee2150527ec61cd930fc1683b2";
+      sha512 = "223fa76b020c0cb9aa9fc59344b0cb103088f2ae0c3fc8037f8a6c3055898312638769b51e98107864850b1286d11e711d4225b5bf570e0fb3f7c59ee740b197";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/vi/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/vi/firefox-65.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "f4a119b311a55d2eb8439731b96676e5e840381e79f36ad3239fe1d4802bc61b2750447f70fbcd089e2d58c3b5bb923da38e7c0905ec5c55030b9e3be434e7ca";
+      sha512 = "e3d1a93bea5f9b7b02e43a54f36544e0e7f6cf5553c5d3e42ff5227396eb66e62570917c5a6317fa21da3510251efc9d3d3524bc64f19fcae590825c75ce6896";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/xh/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/xh/firefox-65.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "a3b6f6d0d2e6c3f6be3defa1283a4e4857a337b2c195de5583c8ef46a73ab1c0b3a6c1619c8370aef238ebee9f0b6a817e08c8fd35affddbc0a8b657e65df413";
+      sha512 = "661183377c558e2355b9ce220f73807818d25b82e9bfc05c013cd58bd35234d73d979a42542b16c46b1c3c3efac0d9524ca28bb9874ad9c969b24c2a96d601e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/zh-CN/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/zh-CN/firefox-65.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "c37d51b46139f9d5fda1cecbe6a816a7e01ea00db72df780db3b0c305a078c4525825352eb31e4fa389fc3cd98880ea1a915b96e9f11e06b04040d718dd29e39";
+      sha512 = "227ce1a00441fd3e5914143b00c2815544f989cc918e978700133c1232170a145fc2f0ce139989f3b9857387928439282f44bb735f4ee8dc7ed881fd006dfc62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/64.0/linux-i686/zh-TW/firefox-64.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/65.0/linux-i686/zh-TW/firefox-65.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "b89684613a006d59b1143d6070476d99190e86b9e2ec51c575d71a3f95163978b85a9c293d736fea4654f7ba8427e2b7a1b671aba860e5f736cef7e812241a09";
+      sha512 = "211b738aaeb0716ab60cf2923be9a4cf6bc38f8536a32c05cf713f987249ed3a735fc6ce07689fd8181230039a4b2e2a367b72743730672856fe4b02e41444cd";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx65.patch
+++ b/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx65.patch
@@ -1,0 +1,23 @@
+diff -ur firefox-65.0-orig/docshell/base/nsAboutRedirector.cpp firefox-65.0/docshell/base/nsAboutRedirector.cpp
+--- firefox-65.0-orig/docshell/base/nsAboutRedirector.cpp       2019-01-23 00:48:28.988747428 +0100
++++ firefox-65.0/docshell/base/nsAboutRedirector.cpp    2019-01-23 00:51:13.378188397 +0100
+@@ -67,8 +67,6 @@
+     {"about", "chrome://global/content/aboutAbout.xhtml", 0},
+     {"addons", "chrome://mozapps/content/extensions/extensions.xul",
+      nsIAboutModule::ALLOW_SCRIPT},
+-    {"buildconfig", "chrome://global/content/buildconfig.html",
+-     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT},
+     {"checkerboard", "chrome://global/content/aboutCheckerboard.xhtml",
+      nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+          nsIAboutModule::ALLOW_SCRIPT},
+diff -ur firefox-65.0-orig/toolkit/content/jar.mn firefox-65.0/toolkit/content/jar.mn
+--- firefox-65.0-orig/toolkit/content/jar.mn    2019-01-23 00:48:35.033372506 +0100
++++ firefox-65.0/toolkit/content/jar.mn 2019-01-23 00:50:45.126565924 +0100
+@@ -36,7 +36,6 @@
+    content/global/plugins.css
+    content/global/browser-child.js
+    content/global/browser-content.js
+-*   content/global/buildconfig.html
+    content/global/buildconfig.css
+    content/global/contentAreaUtils.js
+    content/global/datepicker.xhtml

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -20,14 +20,14 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "64.0";
+    version = "65.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "10zbzwpdadj3ap2z66d0bz8l11qkgzlzd22nj7n3k2bzy7rd0m6cfznd9d4mgyl4ivxjv6wz8pasvacrala2dr0m78ysxiz2fpvrahs";
+      sha512 = "39bx76whgf53rkfqqy8gfhd44wikh89zpnqr930v4grqg3v0pfr8mbvp7xzjjlf5r7bski0wxibn9vyyy273fp99zyj1w2m5ihh9aqh";
     };
 
     patches = nixpkgsPatches ++ [
-      ./no-buildconfig.patch
+      ./no-buildconfig-ffx65.patch
     ];
 
     extraNativeBuildInputs = [ python3 ];

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -70,14 +70,14 @@ rec {
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    version = "60.4.0esr";
+    version = "60.5.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "3a2r2xyxqw86ihzbmzmxmj8wh3ay4mrjqrnyn73yl6ry19m1pjqbmy1fxnsmxnykfn35a1w18gmbj26kpn1yy7hif37cvy05wmza6c1";
+      sha512 = "3n7l146gdjwhi0iq85awc0yykvi4x5m91mcylxa5mrq911bv6xgn2i92nzhgnhdilqap5218778vgvnalikzsh67irrncx1hy5f6iyx";
     };
 
     patches = nixpkgsPatches ++ [
-      ./no-buildconfig.patch
+      ./no-buildconfig-ffx65.patch
 
       # this one is actually an omnipresent bug
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -5,7 +5,7 @@ let
     url = http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz;
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
-  version = "3.41";
+  version = "3.42";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${name}.tar.gz";
-    sha256 = "0bbif42fzz5gk451sv3yphdrl7m4p6zgk5jk0307j06xs3sihbmb";
+    sha256 = "04rg0yar0plbx1sajrzywprqyhlskczkqxxsgxmcc0qqy64y8g2x";
   };
 
   buildInputs = [ perl zlib sqlite ]


### PR DESCRIPTION
###### Motivation for this change

Follow-up to #54505 (port of #54504).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

