### PR TITLE
compton-git: 2 -> 5

### DIFF
--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -89,10 +89,9 @@ let
       libxdg_basedir
     ];
 
-    postPatch = ''
-      substituteInPlace meson.build \
-        --replace "run_command('git', 'describe')" \
-                  "run_command('echo', 'v${version}')"
+    preBuild = ''
+      git() { echo "v${version}"; }
+      export -f git
     '';
 
     NIX_CFLAGS_COMPILE = [ "-fno-strict-aliasing" ];

--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -1,18 +1,14 @@
 { stdenv, lib, fetchFromGitHub, pkgconfig, asciidoc, docbook_xml_dtd_45
-, docbook_xsl, libxslt, libxml2, makeWrapper
+, docbook_xsl, libxslt, libxml2, makeWrapper, meson, ninja
+, xorgproto, libxcb ,xcbutilrenderutil, xcbutilimage, pixman, libev
 , dbus, libconfig, libdrm, libGL, pcre, libX11, libXcomposite, libXdamage
-, libXinerama, libXrandr, libXrender, libXext, xwininfo }:
+, libXinerama, libXrandr, libXrender, libXext, xwininfo, libxdg_basedir }:
 
 let
   common = source: stdenv.mkDerivation (source // rec {
     name = "${source.pname}-${source.version}";
 
-    buildInputs = [
-      dbus libX11 libXcomposite libXdamage libXrender libXrandr libXext
-      libXinerama libdrm pcre libxml2 libxslt libconfig libGL
-    ];
-
-    nativeBuildInputs = [
+    nativeBuildInputs = (source.nativeBuildInputs or []) ++ [
       pkgconfig
       asciidoc
       docbook_xml_dtd_45
@@ -48,6 +44,11 @@ let
 
     COMPTON_VERSION = version;
 
+    buildInputs = [
+      dbus libX11 libXcomposite libXdamage libXrender libXrandr libXext
+      libXinerama libdrm pcre libxml2 libxslt libconfig libGL
+    ];
+
     src = fetchFromGitHub {
       owner = "chjj";
       repo = "compton";
@@ -62,16 +63,45 @@ let
 
   gitSource = rec {
     pname = "compton-git";
-    version = "2";
+    version = "5";
 
     COMPTON_VERSION = "v${version}";
+
+    nativeBuildInputs = [ meson ninja ];
 
     src = fetchFromGitHub {
       owner  = "yshui";
       repo   = "compton";
       rev    = COMPTON_VERSION;
-      sha256 = "1b6jgkkjbmgm7d7qjs94h722kgbqjagcxznkh2r84hcmcl8pibjq";
+      sha256 = "1x5r2dch023imgdqhgf1zxi05cc742s7xr7jzpymvl9ldqly8ppa";
     };
+
+    buildInputs = [
+      dbus libX11 libXext
+      xorgproto
+      libXinerama libdrm pcre libxml2 libxslt libconfig libGL
+      # Removed:
+      # libXcomposite libXdamage libXrender libXrandr
+
+      # New:
+      libxcb xcbutilrenderutil xcbutilimage
+      pixman libev
+      libxdg_basedir
+    ];
+
+    postPatch = ''
+      substituteInPlace meson.build \
+        --replace "run_command('git', 'describe')" \
+                  "run_command('echo', 'v${version}')"
+    '';
+
+    NIX_CFLAGS_COMPILE = [ "-fno-strict-aliasing" ];
+
+    mesonFlags = [
+      "-Dvsync_drm=true"
+      "-Dnew_backends=true"
+      "-Dbuild_docs=true"
+    ];
 
     meta = {
       homepage = https://github.com/yshui/compton/;


### PR DESCRIPTION
https://github.com/yshui/compton/releases/tag/v3
https://github.com/yshui/compton/releases/tag/v4
https://github.com/yshui/compton/releases/tag/v5

Some fixes were made shortly after v5,
should pick them up or wait for next release.
(as-is it's somewhat broken unfortunately)

Even so, submitting to hopefuly avoid sitting
on these updates even longer :).

###### Motivation for this change

home-manager users may be interested in
https://github.com/dtzWill/home-manager/commit/c4c2ed4ac1432c08f9458f58ea162c732692f10f
(otherwise the generated config is rejected by compton)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---