### PR TITLE
emacs: link libXcursor when using lucid toolkit

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm, Xaw3d
+{ stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm, Xaw3d, libXcursor
 , pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
 , alsaLib, cairo, acl, gpm, cf-private, AppKit, GSS, ImageIO, m17n_lib, libotf
@@ -116,6 +116,17 @@ stdenv.mkDerivation rec {
     mkdir -p $out/Applications
     mv nextstep/Emacs.app $out/Applications
   '';
+
+  postFixup =
+    let libPath = lib.makeLibraryPath [
+      libXcursor
+    ];
+    in lib.optionalString (withX && toolkit == "lucid") ''
+      patchelf --set-rpath \
+        "$(patchelf --print-rpath "$out/bin/emacs"):${libPath}" \
+        "$out/bin/emacs"
+      patchelf --add-needed "libXcursor.so.1" "$out/bin/emacs"
+    '';
 
   meta = with stdenv.lib; {
     description = "The extensible, customizable GNU text editor";


### PR DESCRIPTION
###### Motivation for this change

(The implementation is) as ugly as it gets but the cursors are pretty. See https://github.com/NixOS/nixpkgs/pull/51609.

/cc @benley 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

