### PR TITLE
pythonPackages.favicon: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/favicon/default.nix
+++ b/pkgs/development/python-modules/favicon/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, requests, beautifulsoup4, pytest, requests-mock,
+  pytestrunner }:
+
+buildPythonPackage rec {
+  pname = "favicon";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01jhb66nrqbf22z6ybpi8ndw6zifgysdmnh547027g96nz51669y";
+  };
+
+  buildInputs = [ pytestrunner ];
+  checkInputs = [ pytest requests-mock ];
+  propagatedBuildInputs = [ requests beautifulsoup4 ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Find a website's favicon";
+    homepage = http://github.com/scottwernervt/favicon;
+    license = licenses.mit;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -366,6 +366,8 @@ in {
 
   fastpbkdf2 = callPackage ../development/python-modules/fastpbkdf2 {  };
 
+  favicon = callPackage ../development/python-modules/favicon {  };
+
   fido2 = callPackage ../development/python-modules/fido2 {  };
 
   filterpy = callPackage ../development/python-modules/filterpy { };


### PR DESCRIPTION
###### Motivation for this change
add the favicon package to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

