### PR TITLE
Use nativeBuildInputs for building Docker images

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -68,7 +68,7 @@ rec {
   # We need to sum layer.tar, not a directory, hence tarsum instead of nix-hash.
   # And we cannot untar it, because then we cannot preserve permissions ecc.
   tarsum = runCommand "tarsum" {
-    buildInputs = [ go ];
+    nativeBuildInputs = [ go ];
   } ''
     mkdir tarsum
     cd tarsum
@@ -157,7 +157,7 @@ rec {
         };
         inherit fromImage fromImageName fromImageTag;
 
-        buildInputs = [ utillinux e2fsprogs jshon rsync jq ];
+        nativeBuildInputs = [ utillinux e2fsprogs jshon rsync jq ];
       } ''
       rm -rf $out
 
@@ -282,7 +282,7 @@ rec {
     runCommand "${name}-granular-docker-layers" {
       inherit maxLayers;
       paths = referencesByPopularity closure;
-      buildInputs = [ jshon rsync tarsum ];
+      nativeBuildInputs = [ jshon rsync tarsum ];
       enableParallelBuilding = true;
     }
     ''
@@ -320,7 +320,7 @@ rec {
     uid ? 0, gid ? 0,
   }:
     runCommand "${name}-customisation-layer" {
-      buildInputs = [ jshon rsync tarsum ];
+      nativeBuildInputs = [ jshon rsync tarsum ];
       inherit extraCommands;
     }
     ''
@@ -365,7 +365,7 @@ rec {
   }:
     runCommand "docker-layer-${name}" {
       inherit baseJson contents extraCommands;
-      buildInputs = [ jshon rsync tarsum ];
+      nativeBuildInputs = [ jshon rsync tarsum ];
     }
     ''
       mkdir layer
@@ -520,7 +520,7 @@ rec {
             os = "linux";
           });
           impure = runCommand "${baseName}-standard-dynamic-date.json"
-            { buildInputs = [ jq ]; }
+            { nativeBuildInputs = [ jq ]; }
             ''
                jq ".created = \"$(TZ=utc date --iso-8601="seconds")\"" ${pure} > $out
             '';
@@ -541,7 +541,7 @@ rec {
           inherit uid gid extraCommands;
         };
       result = runCommand "docker-image-${baseName}.tar.gz" {
-        buildInputs = [ jshon pigz coreutils findutils jq ];
+        nativeBuildInputs = [ jshon pigz coreutils findutils jq ];
         # Image name and tag must be lowercase
         imageName = lib.toLower name;
         baseJson = configJson;
@@ -638,7 +638,7 @@ rec {
             os = "linux";
           });
           impure = runCommand "${baseName}-config.json"
-            { buildInputs = [ jq ]; }
+            { nativeBuildInputs = [ jq ]; }
             ''
                jq ".created = \"$(TZ=utc date --iso-8601="seconds")\"" ${pure} > $out
             '';
@@ -656,7 +656,7 @@ rec {
                   extraCommands;
         };
       result = runCommand "docker-image-${baseName}.tar.gz" {
-        buildInputs = [ jshon pigz coreutils findutils jq ];
+        nativeBuildInputs = [ jshon pigz coreutils findutils jq ];
         # Image name and tag must be lowercase
         imageName = lib.toLower name;
         imageTag = if tag == null then "" else lib.toLower tag;


### PR DESCRIPTION
###### Motivation for this change
To allow cross-compiling docker images for different platforms. This patch clarifies that tools used to build docker images are part of the build platform, not part of the host platform.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

