### PR TITLE
Add a programs.podman module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -113,6 +113,7 @@
   ./programs/npm.nix
   ./programs/oblogout.nix
   ./programs/plotinus.nix
+  ./programs/podman.nix
   ./programs/qt5ct.nix
   ./programs/screen.nix
   ./programs/sedutil.nix

--- a/nixos/modules/programs/podman.nix
+++ b/nixos/modules/programs/podman.nix
@@ -1,0 +1,110 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.podman;
+
+in
+
+{
+  ###### interface
+  options = {
+    programs.podman = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to configure podman
+        '';
+        type = types.bool;
+      };
+      package = mkOption {
+        default = pkgs.podman;
+        description = "podman package to be used";
+        type = types.package;
+      };
+      runcPackage = mkOption {
+        default = pkgs.runc;
+        description = "runc package to be used";
+        type = types.package;
+      };
+      conmonPackage = mkOption {
+        default = pkgs.conmon;
+        description = "conmon package to be used";
+        type = types.package;
+      };
+      cniPackage = mkOption {
+        default = pkgs.cni;
+        description = "cni package to be used";
+        type = types.package;
+      };
+      cniPluginsPackage = mkOption {
+        default = pkgs.cni-plugins;
+        description = "cni-plugins package to be used";
+        type = types.package;
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+
+    environment.etc."containers/libpod.conf".text = ''
+      image_default_transport = "docker://"
+      runtime_path = ["${cfg.runcPackage}/bin/runc"]
+      conmon_path = ["${cfg.conmonPackage}/bin/conmon"]
+      cni_plugin_dir = ["${cfg.cniPluginsPackage}/bin/"]
+      cgroup_manager = "systemd"
+      cni_config_dir = "/etc/cni/net.d/"
+      cni_default_network = "podman"
+      # pause
+      pause_image = "k8s.gcr.io/pause:3.1"
+      pause_command = "/pause"
+    '';
+
+    environment.etc."containers/registries.conf".text = ''
+      [registries.search]
+      registries = ['docker.io', 'registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com', 'registry.centos.org']
+    '';
+
+    environment.etc."containers/policy.json".text = ''
+    {
+      "default": [
+        { "type": "insecureAcceptAnything" }
+      ]
+    }
+    '';
+
+    environment.etc."cni/net.d/87-podman-bridge.conflist".text = ''
+{
+    "cniVersion": "0.3.0",
+    "name": "podman",
+    "plugins": [
+      {
+        "type": "bridge",
+        "bridge": "cni0",
+        "isGateway": true,
+        "ipMasq": true,
+        "ipam": {
+            "type": "host-local",
+            "subnet": "10.88.0.0/16",
+            "routes": [
+                { "dst": "0.0.0.0/0" }
+            ]
+        }
+      },
+      {
+        "type": "portmap",
+        "capabilities": {
+          "portMappings": true
+        }
+      }
+    ]
+}
+    '';
+
+    environment.systemPackages = with pkgs; [ cfg.package cfg.conmonPackage cfg.runcPackage ];
+
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

`podman` requires some configuration files, and system package available. This allows to do that by just using `programs.podman.enable = true` in a nixos configuration.
(it's a port of my [own module](https://github.com/vdemeester/nixos-configuration/blob/master/modules/programs/podman.nix))

/cc @nlewo @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

