### PR TITLE
pythonPackages.django-sesame: init at 1.4

### DIFF
--- a/pkgs/development/python-modules/django-sesame/default.nix
+++ b/pkgs/development/python-modules/django-sesame/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi
+, django }:
+
+buildPythonPackage rec {
+  pname = "django-sesame";
+  version = "1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "081q3vd9waiajiipg99flw0vlzk920sz07067v3n5774gx0qhbaa";
+  };
+
+  checkInputs = [ django ];
+
+  checkPhase = ''
+    PYTHONPATH="$(pwd):$PYTHONPATH" \
+    DJANGO_SETTINGS_MODULE=sesame.test_settings \
+      django-admin test sesame
+  '';
+
+  meta = with lib; {
+    description = "URLs with authentication tokens for automatic login";
+    homepage = http://github.com/aaugustin/django-sesame;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -274,6 +274,8 @@ in {
 
   braintree = callPackage ../development/python-modules/braintree { };
 
+  django-sesame = callPackage ../development/python-modules/django-sesame { };
+
   breathe = callPackage ../development/python-modules/breathe { };
 
   brotli = callPackage ../development/python-modules/brotli { };


### PR DESCRIPTION
###### Motivation for this change
add django-sesame to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

