### PR TITLE
Mfcl8690cdw update

### DIFF
--- a/pkgs/misc/cups/drivers/mfcl8690cdwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwcupswrapper/default.nix
@@ -3,11 +3,11 @@ mfcl8690cdwlpr, perl, stdenv}:
 
 stdenv.mkDerivation rec {
   name = "mfcl8690cdwcupswrapper-${version}";
-  version = "1.3.0-0";
+  version = "1.4.0-0";
 
   src = fetchurl {
     url = "http://download.brother.com/welcome/dlf103250/${name}.i386.deb";
-    sha256 = "16nnh3hd5yv0m4191wja9fvxxzngzfccfj2rfhcswbakajyk5ywn";
+    sha256 = "1bl9r8mmj4vnanwpfjqgq3c9lf2v46wp5k6r2n9iqprf7ldd1kb2";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper ];

--- a/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
@@ -3,11 +3,11 @@ makeWrapper, perl, pkgs, stdenv, which }:
 
 stdenv.mkDerivation rec {
   name = "mfcl8690cdwlpr-${version}";
-  version = "1.2.0-0";
+  version = "1.3.0-0";
 
   src = fetchurl {
     url = "http://download.brother.com/welcome/dlf103241/${name}.i386.deb";
-    sha256 = "02k43nh51pn4lf7gaid9yhil0a3ikpy4krw7dhgphmm5pap907sx";
+    sha256 = "0x8zd4b1psmw1znp2ibncs37xm5mljcy9yza2rx8jm8lp0a3l85v";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update CUPS drivers for Brother MFC-L8690CDW.

###### Things done

Tested the drivers locally…

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

