### PR TITLE
python.pkgs.keras-preprocessing: 1.0.5 -> 1.0.8

### DIFF
--- a/pkgs/development/python-modules/keras-preprocessing/default.nix
+++ b/pkgs/development/python-modules/keras-preprocessing/default.nix
@@ -1,23 +1,31 @@
-{ lib, buildPythonPackage, fetchPypi, numpy, scipy, six }:
+{ lib, buildPythonPackage, fetchPypi, numpy, six, scipy, pillow, pytest, Keras }:
 
 buildPythonPackage rec {
   pname = "Keras_Preprocessing";
-  version = "1.0.5";
+  version = "1.0.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ef2e482c4336fcf7180244d06f4374939099daa3183816e82aee7755af35b754";
+    sha256 = "6e669aa713727f0bc08f756616f64e0dfa75d822226cfc0dcf33297ab05cef7d";
   };
 
-  # Cyclic dependency: keras-preprocessing requires keras, which requires keras-preprocessing
-  postPatch = ''
-    sed -i "s/keras>=[^']*//" setup.py
+  propagatedBuildInputs = [
+    # required
+    numpy six
+    # optional
+    scipy pillow
+  ];
+
+  checkInputs = [
+    pytest Keras
+  ];
+
+  checkPhase = ''
+    py.test tests/
   '';
 
-  # No tests in PyPI tarball
+  # Cyclic dependency: keras-preprocessing's tests require Keras, which requires keras-preprocessing
   doCheck = false;
-
-  propagatedBuildInputs = [ numpy scipy six ];
 
   meta = with lib; {
     description = "Easy data preprocessing and data augmentation for deep learning models";

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -25,14 +25,6 @@ buildPythonPackage rec {
     keras-applications keras-preprocessing
   ];
 
-  # Keras 2.2.2 expects older versions of keras_applications
-  # and keras_preprocessing. These substitutions can be removed
-  # for for the next Keras release.
-  postPatch = ''
-    substituteInPlace setup.py --replace "keras_applications==1.0.4" "keras_applications==1.0.5"
-    substituteInPlace setup.py --replace "keras_preprocessing==1.0.2" "keras_preprocessing==1.0.3"
-  '';
-
   # Couldn't get tests working
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @danieldk @NikolaMandic @abbradar  