### PR TITLE
python.pkgs.django_1_8: mark as insecure

### DIFF
--- a/pkgs/development/python-modules/django/1_8.nix
+++ b/pkgs/development/python-modules/django/1_8.nix
@@ -25,6 +25,11 @@ buildPythonPackage rec {
     description = "A high-level Python Web framework";
     homepage = https://www.djangoproject.com/;
     license = licenses.bsd0;
+    knownVulnerabilities = [
+      # The patches were not backported due to Django 1.8 having reached EOL
+      https://www.djangoproject.com/weblog/2018/aug/01/security-releases/
+      https://www.djangoproject.com/weblog/2019/jan/04/security-releases/
+    ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
Since CVE-2018-14574 and CVE-2019-3498 affect 1.11, it is very likely
they also apply to 1.8. However, Django 1.8 has reached EOL in April
2018 and the patches were not backported.

related to https://github.com/NixOS/nixpkgs/issues/52679

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @rickynils @offlinehacker @basvandijk