### PR TITLE
iperf2: 2.0.12 -> 2.0.13

### DIFF
--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "iperf-2.0.12";
+  name = "iperf-2.0.13";
 
   src = fetchurl {
     url = "mirror://sourceforge/iperf2/files/${name}.tar.gz";
-    sha256 = "0ii6sgp62x9ly2gyk00w58dy9qwcw2kvhhcfa7v16jr6n4gnazrn";
+    sha256 = "1bbq6xr0vrd88zssfiadvw3awyn236yv94fsdl9q2sh9cv4xx2n8";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   hardeningDisable = [ "format" ];
+  configureFlags = [ "--enable-fastsampling" ];
 
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/iperf/;


### PR DESCRIPTION
###### Motivation for this change

New release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

