### PR TITLE
sage: python-openid: move django and twill to checkInputs

### DIFF
--- a/pkgs/applications/science/math/sage/python-openid.nix
+++ b/pkgs/applications/science/math/sage/python-openid.nix
@@ -20,15 +20,13 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    django
-    twill
     pycrypto
   ];
 
   # Cannot access the djopenid example module.
   # I don't know how to fix that (adding the examples dir to PYTHONPATH doesn't work)
   doCheck = false;
-  checkInputs = [ nose ];
+  checkInputs = [ nose django twill ];
   checkPhase = ''
     nosetests
   '';


### PR DESCRIPTION
A search through the source code
(https://github.com/openid/python-openid/search?q=django and
https://github.com/openid/python-openid/search?q=twill) reveals
that they are only used in examples and tests.

###### Motivation for this change
reduce closure size

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

