### PR TITLE
nixos/gitlab: add openssh dependency to gitaly

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -497,7 +497,12 @@ in {
     systemd.services.gitaly = {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = with pkgs; [ gitAndTools.git cfg.packages.gitaly.rubyEnv cfg.packages.gitaly.rubyEnv.wrappedRuby ];
+      path = with pkgs; [
+        openssh
+        gitAndTools.git
+        cfg.packages.gitaly.rubyEnv
+        cfg.packages.gitaly.rubyEnv.wrappedRuby
+      ];
       serviceConfig = {
         Type = "simple";
         User = cfg.user;


### PR DESCRIPTION
###### Motivation for this change

Fixes GitLab repository mirroring using ssh (new feature, was only https before).  When trying to sync, I was receiving the following error:
```
Fetching remote remote_mirror_c187a6534238bb8e69db3948dfe1d8cd failed: ssh &#39;-oIdentityFile=&quot;/tmp/gitlab-shell-key-file20190130-1398-1w4swpe&quot;&#39; &#39;-oIdentitiesOnly=&quot;yes&quot;&#39; &#39;-oStrictHostKeyChecking=&quot;yes&quot;&#39; &#39;-oUserKnownHostsFile=&quot;/tmp/gitlab-shell-known-hosts20190130-1398-fdoq0r&quot;&#39;:  command not found
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
`command not found` was referring to `ssh`.  The GitLab repository mirroring is handled by Gitaly.  Adding openssh to Gitaly fixed the problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

