### PR TITLE
lua-5 setup-hook: quiet noisy 'cd -' printing path repeatedly

### DIFF
--- a/pkgs/development/interpreters/lua-5/setup-hook.sh
+++ b/pkgs/development/interpreters/lua-5/setup-hook.sh
@@ -40,7 +40,7 @@ addToLuaPath() {
     do
         addToLuaSearchPathWithCustomDelimiter LUA_CPATH "$PWD/$pattern"
     done
-    cd -
+    cd - >/dev/null
 }
 
 addEnvHooks "$hostOffset" addToLuaPath


### PR DESCRIPTION
###### Motivation for this change

This may depend on what /bin/sh is used, didn't check,
but on my builder as well as with my normal shell
using `cd -` (helpfully, usually) prints the path name to stdout
which unfortunately can cause a fair amount of log spam
since this is executed for many store paths.

(although the path printed was `/build` repeatedly in what I saw)

Anyway this just quiets the print.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---