### PR TITLE
nvidia_x11_beta: nvidia_x11 -> 418.30

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -74,7 +74,9 @@ installPhase() {
     if [ -n "$bin" ]; then
         # Install the X drivers.
         mkdir -p $bin/lib/xorg/modules
-        cp -p libnvidia-wfb.* $bin/lib/xorg/modules/
+        if [ -f libnvidia-wfb.so ]; then
+            cp -p libnvidia-wfb.* $bin/lib/xorg/modules/
+        fi
         mkdir -p $bin/lib/xorg/modules/drivers
         cp -p nvidia_drv.so $bin/lib/xorg/modules/drivers
         mkdir -p $bin/lib/xorg/modules/extensions

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -19,7 +19,12 @@ rec {
   stable = if stdenv.hostPlatform.system == "x86_64-linux" then stable_415 else legacy_390;
 
   # No active beta right now
-  beta = stable;
+  beta = generic {
+    version = "418.30";
+    sha256_64bit = "0n1rw80qw1bc9l8sxvk4f6qvaj85yawcxfa9h6irw10a119y5bf1";
+    settingsSha256 = "12yfvphr5h8fkgbvbwjx7nr9lr7xqmw6kf4c31i2cx3ji224yns1";
+    persistencedSha256 = "1sjp44hs92kkxiqdnb25l3dz64233hrxf7g8bj97iix257dgvv10";
+  };
 
   stable_415 = generic {
     version = "415.27";


### PR DESCRIPTION
###### Motivation for this change
Built and tested on `4.20.5` patched with `bcachefs` support.
Where should `libnvidia-opticalflow.so` be put?
```
Added initial support for G-SYNC Compatible monitors. See the README for details.
Added support for stereo presentation in Vulkan.
Fixed a bug that could cause OpenGL applications to crash after repeated VT-switches.
Fixed a bug that could sometimes prevent PRIME displays from being selected in the display settings page of nvidia-settings.

NVIDIA Video Codec SDK 9.0

A new release of the Video Codec SDK will be available in Q1 2019.
For more information and early access sign-up, refer to https://developer.nvidia.com/nvidia-video-codec-sdk

The main features available in this release are listed below:
Support for Turing NVENC/NVDEC.
The NVDECODE API (also known as the NVCUVID API) has been updated to support YUV 4:4:4 decoding for HEVC on Turing GPUs.
NvEncodeAPI has been updated to support HEVC B-frames on Turing GPUs. NvEncodeAPI adds the capability to output the encoded bitstream, and motion vectors from motion estimation-only mode, to video memory. This avoids the overhead of copying the output from system to video memory for processing pipelines operating directly on video memory.
NvEncodeAPI now accepts CUarrays as input buffers. The SDK contains a sample application to demonstrate how to feed a Vulkan image to NVENC using the Vulkan-CUDA interop.

Added NVIDIA optical flow support.

A new library libnvidia-opticalflow.so is included in the driver package. The NVIDIA optical flow library can be used for hardware-accelerated computation of optical flow vectors and stereo disparity values. The API header files, sample applications and documentation will be available in a separate Optical Flow SDK package in Q1 2019.

For more information and early access sign-up, refer to https://developer.nvidia.com/opticalflow-sdk

Removed libnvidia-wfb.so from the driver package. This module was only used on X servers that did not provide their own implementation of libwfb, and all X.Org xserver versions now supported by the driver do so.
Updated the VDPAU driver to reject decoding to YUV 4:2:2 video surfaces. The NVIDIA VDPAU driver always produces YUV 4:2:0 content. Previously, the VDPAU driver implicitly converted a YUV 4:2:2 video surface to YUV 4:2:0 during decode. Now, the VDPAU driver will fail the decode request.
Optimized nvidia-installer to only run depmod(1) once when installing, rather than twice (once during the uninstall phase and again when installing new kernel modules).
Removed the NVreg_UseThreadedInterrupts kernel module parameter from nvidia.ko. This removes the ability to forcibly fall back to an older mechanism (tasklets) for running the bottom-half interrupt handler. Instead, threaded IRQs (the default since 367.44) are always used.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

