### PR TITLE
betterlockscreen: init at 3.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1495,6 +1495,11 @@
     github = "expipiplus1";
     name = "Joe Hermaszewski";
   };
+  eyjhb = {
+    email = "eyjhbb@gmail.com";
+    github = "eyJhb";
+    name = "eyJhb";
+  };
   f--t = {
     email = "git@f-t.me";
     github = "f--t";

--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -1,0 +1,39 @@
+{
+  stdenv, makeWrapper, fetchFromGitHub, substituteAll,
+  imagemagick, i3lock-color, xdpyinfo, xrandr, bc, feh
+}:
+
+stdenv.mkDerivation rec {
+  name = "betterlockscreen-${version}";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "pavanjadhaw";
+    repo = "betterlockscreen";
+    rev = version;
+    sha256 = "0jc8ifb69shmd0avx6vny4m1w5dfxkkf5vnm7qcrmc8yflb0s3z6";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [ ./replace-i3lock.patch ];
+
+  installPhase = 
+    let 
+      PATH = 
+        stdenv.lib.makeBinPath
+        [imagemagick i3lock-color xdpyinfo xrandr bc feh];
+    in ''
+      mkdir -p $out/bin
+      cp betterlockscreen $out/bin/betterlockscreen
+      wrapProgram "$out/bin/betterlockscreen" --prefix PATH : "$out/bin:${PATH}"
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Betterlockscreen is a simple minimal lock screen which allows you to cache images with different filters and lockscreen with blazing speed.";
+    homepage = https://github.com/pavanjadhaw/betterlockscreen;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/misc/screensavers/betterlockscreen/replace-i3lock.patch
+++ b/pkgs/misc/screensavers/betterlockscreen/replace-i3lock.patch
@@ -1,0 +1,12 @@
+--- a/betterlockscreen
++++ b/betterlockscreen
+@@ -76,7 +76,7 @@ prelock() {
+ lock() {
+ 	#$1 image path
+ 
+-	i3lock \
++	i3lock-color \
+ 		-t -i "$1" \
+ 		--timepos='x+110:h-70' \
+ 		--datepos='x+43:h-45' \
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17624,6 +17624,8 @@ in
 
   i3lock-pixeled = callPackage ../misc/screensavers/i3lock-pixeled { };
 
+  betterlockscreen = callPackage ../misc/screensavers/betterlockscreen { };
+
   i3minator = callPackage ../tools/misc/i3minator { };
 
   i3pystatus = callPackage ../applications/window-managers/i3/pystatus.nix { };


### PR DESCRIPTION
###### Motivation for this change
Getting betterlockscreen into the repo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

