### PR TITLE
clmagma: init at 1.3

### DIFF
--- a/pkgs/development/libraries/science/math/clmagma/default.nix
+++ b/pkgs/development/libraries/science/math/clmagma/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchurl, gfortran, opencl-headers, clblas, ocl-icd, mkl, intel-ocl }:
+
+with stdenv.lib;
+
+let 
+  version = "1.3.0";
+  incfile = builtins.toFile "make.inc.custom" ''
+    CC        = g++
+    FORT      = gfortran
+    
+    ARCH      = ar
+    ARCHFLAGS = cr
+    RANLIB    = ranlib
+
+    OPTS      = -fPIC -O3 -DADD_ -Wall
+    FOPTS     = -fPIC -O3 -DADD_ -Wall -x f95-cpp-input
+    F77OPTS   = -fPIC -O3 -DADD_ -Wall
+    LDOPTS    = -fPIC
+   
+    -include make.check-mkl
+    -include make.check-clblas
+    
+    # Gnu mkl is not available I guess?
+    #LIB       = -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lpthread -lm -fopenmp
+    LIB        = -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lm -fopenmp
+    LIB       += -lclBLAS -lOpenCL
+    
+    LIBDIR    = -L$(MKLROOT)/lib/intel64 \
+                -L$(MKLROOT)/../compiler/lib/intel64 \
+                -L$(clBLAS)/lib64
+    
+    INC       = -I$(clBLAS)/include 
+               #-I$(AMDAPP)/include
+  '';  
+in stdenv.mkDerivation {
+  name = "clmagma-${version}";
+  src = fetchurl {
+    url = "http://icl.cs.utk.edu/projectsfiles/magma/cl/clmagma-${version}.tar.gz";
+    sha256 = "1n27ny0xhwirw2ydn46pfcwy53gzia9zbam4irx44fd4d7f9ydv7";
+    name = "clmagma-${version}.tar.gz";
+  };
+
+  buildInputs = [ 
+    gfortran 
+    clblas 
+    opencl-headers 
+    ocl-icd  
+    mkl
+    intel-ocl
+  ];
+
+  enableParallelBuilding=true;
+
+  MKLROOT   = "${mkl}";
+  clBLAS    = "${clblas}";
+
+  # Otherwise build looks for it in /run/opengl-driver/etc/OpenCL/vendors, 
+  # which is not available.
+  OPENCL_VENDOR_PATH="${intel-ocl}/etc/OpenCL/vendors";
+
+  preBuild = ''  
+    # By default it tries to use GPU, and thus fails for CPUs
+    sed -i "s/CL_DEVICE_TYPE_GPU/CL_DEVICE_TYPE_DEFAULT/" interface_opencl/clmagma_runtime.cpp   
+    sed -i "s%/usr/local/clmagma%/$out%" Makefile.internal
+    cp ${incfile} make.inc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Matrix Algebra on GPU and Multicore Architectures, OpenCL port";
+    license = licenses.bsd3;
+    homepage = http://icl.cs.utk.edu/magma/index.html;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ volhovm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22542,6 +22542,7 @@ in
   lie = callPackage ../applications/science/math/LiE { };
 
   magma = callPackage ../development/libraries/science/math/magma { };
+  clmagma = callPackage ../development/libraries/science/math/clmagma { };
 
   mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };


### PR DESCRIPTION
###### Motivation for this change

CLMagma is introduced, as magma is only available for CUDA. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` *doesn't apply*
- [x] Tested execution of all binary files (usually in `./result/bin/`) *doesn't apply*
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

