### PR TITLE
sudo-font: init at 0.37

### DIFF
--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "0.37";
+in fetchzip rec {
+  name = "sudo-font-${version}";
+  url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
+  sha256 = "16x6vs016wz6rmd4p248ri9fn35xq7r3dc8hv4w2c4rz1xl8c099";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype/
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
+  '';
+  meta = with stdenv.lib; {
+    description = "Font for programmers and command line users";
+    homepage = https://www.kutilek.de/sudo-font/;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15851,6 +15851,8 @@ in
   source-han-serif-simplified-chinese = sourceHanSerifPackages.simplified-chinese;
   source-han-serif-traditional-chinese = sourceHanSerifPackages.traditional-chinese;
 
+  sudo-font = callPackage ../data/fonts/sudo { };
+
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme {


### PR DESCRIPTION
###### Motivation for this change

font! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
   - (there are none! :innocent:)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---