### PR TITLE
pythonPackages.minio: init at 4.0.11

### DIFF
--- a/nixos/tests/minio.nix
+++ b/nixos/tests/minio.nix
@@ -1,4 +1,24 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix ({ pkgs, ...} :
+let
+    accessKey = "BKIKJAA5BMMU2RHO6IBB";
+    secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";
+    minioPythonScript = pkgs.writeScript "minio-test.py" ''
+      #! ${pkgs.python3.withPackages(ps: [ ps.minio ])}/bin/python
+      import io
+      import os
+      from minio import Minio
+      minioClient = Minio('localhost:9000',
+                    access_key='${accessKey}',
+                    secret_key='${secretKey}',
+                    secure=False)
+      sio = io.BytesIO()
+      sio.write(b'Test from Python')
+      sio.seek(0, os.SEEK_END)
+      sio_len = sio.tell()
+      sio.seek(0)
+      minioClient.put_object('test-bucket', 'test.txt', sio, sio_len, content_type='text/plain')
+    '';
+  in {
   name = "minio";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ bachp ];
@@ -8,8 +28,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     machine = { pkgs, ... }: {
       services.minio = {
         enable = true;
-        accessKey = "BKIKJAA5BMMU2RHO6IBB";
-        secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";
+        inherit accessKey secretKey;
       };
       environment.systemPackages = [ pkgs.minio-client ];
 
@@ -25,9 +44,11 @@ import ./make-test.nix ({ pkgs, ...} : {
       $machine->waitForOpenPort(9000);
 
       # Create a test bucket on the server
-      $machine->succeed("mc config host add minio http://localhost:9000 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4");
+      $machine->succeed("mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} S3v4");
       $machine->succeed("mc mb minio/test-bucket");
+      $machine->succeed("${minioPythonScript}");
       $machine->succeed("mc ls minio") =~ /test-bucket/ or die;
+      $machine->succeed("mc cat minio/test-bucket/test.txt") =~ /Test from Python/ or die;
       $machine->shutdown;
 
     '';

--- a/pkgs/development/python-modules/minio/default.nix
+++ b/pkgs/development/python-modules/minio/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, isPy3k, fetchPypi
+, urllib3, python-dateutil , pytz, faker, mock, nose }:
+
+buildPythonPackage rec {
+  pname = "minio";
+  version = "4.0.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sbmv1lskm5cs3jmn8f2688pimgibly16g8ycc6fgnsjanyby35l";
+  };
+
+  disabled = !isPy3k;
+
+  checkInputs = [ faker mock nose ];
+  propagatedBuildInputs = [ urllib3 python-dateutil pytz ];
+
+  meta = with lib; {
+    description = "Simple APIs to access any Amazon S3 compatible object storage server";
+    homepage = https://github.com/minio/minio-py;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3192,6 +3192,8 @@ in {
 
   minimock = callPackage ../development/python-modules/minimock { };
 
+  minio = callPackage ../development/python-modules/minio { };
+
   moviepy = callPackage ../development/python-modules/moviepy { };
 
   mozterm = callPackage ../development/python-modules/mozterm { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

