### PR TITLE
pythonPackages.yubico-client: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/yubico-client/default.nix
+++ b/pkgs/development/python-modules/yubico-client/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi
+, requests }:
+
+buildPythonPackage rec {
+  pname = "yubico-client";
+  version = "1.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0skkmrpvpb1pwyqjf3lh9vq46xagvwdx9kagpdbba2v5dgrk34d1";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # pypi package missing test_utils and github releases is behind
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Verifying Yubico OTPs based on the validation protocol version 2.0";
+    homepage = https://github.com/Kami/python-yubico-client/;
+    maintainers= with maintainers; [ peterromfeldhk ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5061,6 +5061,8 @@ in {
 
   yowsup = callPackage ../development/python-modules/yowsup { };
 
+  yubico-client = callPackage ../development/python-modules/yubico-client { };
+
   wptserve = callPackage ../development/python-modules/wptserve { };
 
   yenc = callPackage ../development/python-modules/yenc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

