### PR TITLE
Backport fixes to Dask and Distributed to release-18.09

### DIFF
--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -26,12 +26,12 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "1.23.1";
+  version = "1.23.3";
 
   # get full repository need conftest.py to run tests
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9d4693442efe40e05e4304fe6d8174989c6eb4bad1afe70480c98263ef8e1cdb";
+    sha256 = "2d48a4de280fd7243ca76f9b12db5fe2486fc89dcdb510c77fa51f51733a04cc";
   };
 
   checkInputs = [ pytest pytest-repeat pytest-faulthandler pytest-timeout mock joblib ];

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pytest
 , pytest-repeat
 , pytest-faulthandler
@@ -26,14 +26,12 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "1.22.1";
+  version = "1.23.1";
 
   # get full repository need conftest.py to run tests
-  src = fetchFromGitHub {
-    owner = "dask";
-    repo = pname;
-    rev = version;
-    sha256 = "0xvx55rhbhlyys3kjndihwq6y6260qzy9mr3miclh5qddaiw2d5z";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9d4693442efe40e05e4304fe6d8174989c6eb4bad1afe70480c98263ef8e1cdb";
   };
 
   checkInputs = [ pytest pytest-repeat pytest-faulthandler pytest-timeout mock joblib ];

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -50,6 +50,9 @@ buildPythonPackage rec {
     py.test distributed -m "not avoid-travis" -r s --timeout-method=thread --timeout=0 --durations=20 --ignore="distributed/cli/tests"
   '';
 
+  # when tested random tests would fail and not repeatably
+  doCheck = false;
+
   meta = {
     description = "Distributed computation in Python.";
     homepage = http://distributed.readthedocs.io/en/latest/;

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytest-repeat
+, pytest-faulthandler
+, pytest-timeout
+, mock
+, joblib
+, click
+, cloudpickle
+, dask
+, msgpack
+, psutil
+, six
+, sortedcontainers
+, tblib
+, toolz
+, tornado
+, zict
+, pyyaml
+, pythonOlder
+, futures
+, singledispatch
+}:
+
+buildPythonPackage rec {
+  pname = "distributed";
+  version = "1.22.1";
+
+  # get full repository need conftest.py to run tests
+  src = fetchFromGitHub {
+    owner = "dask";
+    repo = pname;
+    rev = version;
+    sha256 = "0xvx55rhbhlyys3kjndihwq6y6260qzy9mr3miclh5qddaiw2d5z";
+  };
+
+  checkInputs = [ pytest pytest-repeat pytest-faulthandler pytest-timeout mock joblib ];
+  propagatedBuildInputs = [
+      click cloudpickle dask msgpack psutil six
+      sortedcontainers tblib toolz tornado zict pyyaml
+  ] ++ lib.optional (pythonOlder "3.2") [ futures ]
+    ++ lib.optional (pythonOlder "3.4") [ singledispatch ];
+
+  # tests take about 10-15 minutes
+  # ignore 5 cli tests out of 1000 total tests that fail due to subprocesses
+  # these tests are not critical to the library (only the cli)
+  checkPhase = ''
+    py.test distributed -m "not avoid-travis" -r s --timeout-method=thread --timeout=0 --durations=20 --ignore="distributed/cli/tests"
+  '';
+
+  meta = {
+    description = "Distributed computation in Python.";
+    homepage = http://distributed.readthedocs.io/en/latest/;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ teh costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-faulthandler/default.nix
+++ b/pkgs/development/python-modules/pytest-faulthandler/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pytest
+, pytest-mock
+, pythonOlder
+, faulthandler
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-faulthandler";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bf8634c3fd6309ef786ec03b913a5366163fdb094ebcfdebc35626400d790e0d";
+  };
+
+  buildInputs = [ setuptools_scm pytest ];
+  checkInputs = [ pytest-mock ];
+  propagatedBuildInputs = lib.optional (pythonOlder "3.0") faulthandler;
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = {
+    description = "Py.test plugin that activates the fault handler module for tests";
+    homepage = https://github.com/pytest-dev/pytest-faulthandler;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-repeat/default.nix
+++ b/pkgs/development/python-modules/pytest-repeat/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-repeat";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "84aba2fcca5dc2f32ae626a01708f469f17b3384ec3d1f507698077f274909d6";
+  };
+
+  buildInputs = [ setuptools_scm pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = {
+    description = "Pytest plugin for repeating tests";
+    homepage = https://github.com/pytest-dev/pytest-repeat;
+    maintainers = with lib.maintainers; [ costrouc ];
+    license = lib.licenses.mpl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1914,6 +1914,8 @@ in {
 
   pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
 
+  pytest-repeat = callPackage ../development/python-modules/pytest-repeat { };
+
   pytestrunner = callPackage ../development/python-modules/pytestrunner { };
 
   pytestquickcheck = callPackage ../development/python-modules/pytest-quickcheck { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -292,6 +292,8 @@ in {
 
   docutils = callPackage ../development/python-modules/docutils { };
 
+  distributed = callPackage ../development/python-modules/distributed { };
+
   dogtail = callPackage ../development/python-modules/dogtail { };
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
@@ -1982,34 +1984,6 @@ in {
   heapdict = callPackage ../development/python-modules/heapdict { };
 
   zict = callPackage ../development/python-modules/zict { };
-
-  distributed = buildPythonPackage rec {
-
-    name = "distributed-${version}";
-    version = "1.15.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/d/distributed/${name}.tar.gz";
-      sha256 = "037a07sdf2ch1d360nqwqz3b4ld8msydng7mw4i5s902v7xr05l6";
-    };
-
-    buildInputs = with self; [ pytest docutils ];
-    propagatedBuildInputs = with self; [
-      dask six boto3 s3fs tblib locket msgpack-python click cloudpickle tornado
-      psutil botocore zict lz4 sortedcollections sortedcontainers
-    ] ++ (if !isPy3k then [ singledispatch ] else []);
-
-    # py.test not picking up local config file, even when running
-    # manually: E ValueError: no option named '--runslow'
-    doCheck = false;
-
-    meta = {
-      description = "Distributed computation in Python.";
-      homepage = "http://distributed.readthedocs.io/en/latest/";
-      license = licenses.bsd3;
-      maintainers = with maintainers; [ teh ];
-    };
-  };
 
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1888,6 +1888,8 @@ in {
 
   pytest-django = callPackage ../development/python-modules/pytest-django { };
 
+  pytest-faulthandler = callPackage ../development/python-modules/pytest-faulthandler { };
+
   pytest-fixture-config = callPackage ../development/python-modules/pytest-fixture-config { };
 
   pytest-forked = callPackage ../development/python-modules/pytest-forked { };


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/54875

This PR fixes `import dask.distributed`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

