### PR TITLE
pythonPackages.azure-keyvault: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/azure-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, azure-common, msrest, msrestazure }:
+
+buildPythonPackage rec {
+  pname = "azure-keyvault";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0jfxm8lx8dzs3v2b04ljizk8gfckbm5l2v86rm7k0npbfvryba1p";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests in pypi package, not sure how to do fetchFromGitHub with this monorepo
+  # doCheck = false;
+
+  meta = with lib; {
+    description = "Microsoft Azure Key Vault Client Library";
+    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-keyvault;
+    maintainers= with maintainers; [ peterromfeldhk ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, isodate, requests, requests_oauthlib }:
+
+buildPythonPackage rec {
+  pname = "msrest";
+  version = "0.6.4";
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "${pname}-for-python";
+    rev = "v${version}";
+    sha256 = "0ilrc06qq0dw4qqzq1dq2vs6nymc39h19w52dwcyawwfalalnjzi";
+  };
+
+  propagatedBuildInputs = [ isodate requests requests_oauthlib ];
+
+  # TypeError: async_poller() missing 4 required positional arguments: 'client',
+  # 'initial_response', 'deserialization_callback', and 'polling_method'
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Microsoft wrapper around requests";
+    homepage = https://github.com/Azure/msrest-for-python;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi
+, adal, msrest }:
+
+buildPythonPackage rec {
+  pname = "msrestazure";
+  version = "0.6.0";
+
+  # for some reason if i use fetchFromGitHub azure-keyvault can not find it anymore
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06s04f6nng4na2663kc12a3skiaqb631nscjfwpsrx4lzkf8bccr";
+  };
+
+  propagatedBuildInputs = [ adal msrest ];
+
+  # TypeError: async_poller() missing 4 required positional arguments: 'client',
+  # 'initial_response', 'deserialization_callback', and 'polling_method'
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Microsoft Azure REST operations";
+    homepage = https://github.com/Azure/msrestazure-for-python;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -226,6 +226,8 @@ in {
 
   azure-common = callPackage ../development/python-modules/azure-common { };
 
+  azure-keyvault = callPackage ../development/python-modules/azure-keyvault { };
+
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
 
   azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };
@@ -3107,6 +3109,10 @@ in {
       substituteInPlace setup.py --replace "TRANSITIONAL = False" "TRANSITIONAL = True"
     '';
   };
+
+  msrest = callPackage ../development/python-modules/msrest {};
+
+  msrestazure = callPackage ../development/python-modules/msrestazure {};
 
   msrplib = callPackage ../development/python-modules/msrplib { };
 


### PR DESCRIPTION
pythonPackages.msrestazure: init at 0.6.0
pythonPackages.msrest: init at 0.6.4

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

