### PR TITLE
nixos: make symlinks in `/etc` relative (except `/etc/static`)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -459,10 +459,16 @@
    </listitem>
    <listitem>
     <para>
-     Symlinks in <filename>/etc</filename> are now relative instead of absolute,
-     so that the links can be followed if the NixOS installation is not mounted as filesystem root.
-     In particular, this makes <filename>/etc/os-release</filename> adhere to
-     <link xlink:href="https://www.freedesktop.org/software/systemd/man/os-release.html">the standard</link>.
+     Symlinks in <filename>/etc</filename> (except <filename>/etc/static</filename>)
+     are now relative instead of absolute. This makes possible to examine
+     NixOS container's <filename>/etc</filename> directory from host system
+     (previously it pointed to host <filename>/etc</filename> when viewed from host,
+     and to container <filename>/etc</filename> when viewed from container chroot).
+    </para>
+    <para>
+     This also makes <filename>/etc/os-release</filename> adhere to
+     <link xlink:href="https://www.freedesktop.org/software/systemd/man/os-release.html">the standard</link>
+     for NixOS containers.
     </para>
    </listitem>
    <listitem>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -459,6 +459,14 @@
    </listitem>
    <listitem>
     <para>
+     Symlinks in <filename>/etc</filename> are now relative instead of absolute,
+     so that the links can be followed if the NixOS installation is not mounted as filesystem root.
+     In particular, this makes <filename>/etc/os-release</filename> adhere to
+     <link xlink:href="https://www.freedesktop.org/software/systemd/man/os-release.html">the standard</link>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
       Flat volumes are now disabled by default in <literal>hardware.pulseaudio</literal>.
       This has been done to prevent applications, which are unaware of this feature, setting
       their volumes to 100% on startup causing harm to your audio hardware and potentially your ears.

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -40,7 +40,7 @@ for ((n = 0; n < ${#objects[*]}; n++)); do
     symlink=${symlinks[$n]}
     if test "$symlink" != "none"; then
         mkdir -p $(dirname ./$symlink)
-        ln -s $object ./$symlink
+        ln -s --relative ./$object ./$symlink
     fi
 done
 

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -40,7 +40,7 @@ for ((n = 0; n < ${#objects[*]}; n++)); do
     symlink=${symlinks[$n]}
     if test "$symlink" != "none"; then
         mkdir -p $(dirname ./$symlink)
-        ln -s ./$object ./$symlink
+        ln -s $object ./$symlink
     fi
 done
 

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -40,7 +40,7 @@ for ((n = 0; n < ${#objects[*]}; n++)); do
     symlink=${symlinks[$n]}
     if test "$symlink" != "none"; then
         mkdir -p $(dirname ./$symlink)
-        ln -s --relative ./$object ./$symlink
+        ln -s ./$object ./$symlink
     fi
 done
 

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -10,6 +10,11 @@ users_=($users)
 groups_=($groups)
 set +f
 
+# Create relative symlinks, so that the links can be followed if
+# the NixOS installation is not mounted as filesystem root.
+# Absolute symlinks violate the os-release format
+# at https://www.freedesktop.org/software/systemd/man/os-release.html
+# and break e.g. systemd-nspawn and os-prober.
 for ((i = 0; i < ${#targets_[@]}; i++)); do
     source="${sources_[$i]}"
     target="${targets_[$i]}"
@@ -19,14 +24,14 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
         # If the source name contains '*', perform globbing.
         mkdir -p $out/etc/$target
         for fn in $source; do
-            ln -s "$fn" $out/etc/$target/
+            ln -s --relative "$fn" $out/etc/$target/
         done
 
     else
-        
+
         mkdir -p $out/etc/$(dirname $target)
         if ! [ -e $out/etc/$target ]; then
-            ln -s $source $out/etc/$target
+            ln -s --relative $source $out/etc/$target
         else
             echo "duplicate entry $target -> $source"
             if test "$(readlink $out/etc/$target)" != "$source"; then
@@ -34,13 +39,13 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
                 exit 1
             fi
         fi
-        
+
         if test "${modes_[$i]}" != symlink; then
             echo "${modes_[$i]}"  > $out/etc/$target.mode
             echo "${users_[$i]}"  > $out/etc/$target.uid
             echo "${groups_[$i]}" > $out/etc/$target.gid
         fi
-        
+
     fi
 done
 

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -13,17 +13,25 @@ sub atomicSymlink {
     my ($source, $target) = @_;
     my $tmp = "$target.tmp";
     unlink $tmp;
-    # Create relative symlinks, so that the links can be followed if
-    # the NixOS installation is not mounted as filesystem root.
-    # Absolute symlinks violate the os-release format
-    # at https://www.freedesktop.org/software/systemd/man/os-release.html
-    # and break e.g. systemd-nspawn and os-prober.
+    symlink $source, $tmp or return 0;
+    rename $tmp, $target or return 0;
+    return 1;
+}
+
+# Create relative symlinks, so that the links can be followed if
+# the NixOS installation is not mounted as filesystem root.
+# Absolute symlinks violate the os-release format
+# at https://www.freedesktop.org/software/systemd/man/os-release.html
+# and break e.g. systemd-nspawn and os-prober.
+sub atomicRelativeSymlink {
+    my ($source, $target) = @_;
+    my $tmp = "$target.tmp";
+    unlink $tmp;
     my $rel = File::Spec->abs2rel($source, dirname $target);
     symlink $rel, $tmp or return 0;
     rename $tmp, $target or return 0;
     return 1;
 }
-
 
 # Atomically update /etc/static to point at the etc files of the
 # current configuration.
@@ -37,8 +45,7 @@ sub isStatic {
 
     if (-l $path) {
         my $target = readlink $path;
-        my $rel = File::Spec->abs2rel("/etc/static", dirname $path);
-        return substr($target, 0, length $rel) eq $rel;
+        return substr($target, 0, length "/etc/static/") eq "/etc/static/";
     }
 
     if (-d $path) {
@@ -111,7 +118,7 @@ sub link {
     if (-e "$_.mode") {
         my $mode = read_file("$_.mode"); chomp $mode;
         if ($mode eq "direct-symlink") {
-            atomicSymlink readlink("$static/$fn"), $target or warn;
+            atomicRelativeSymlink readlink("$static/$fn"), $target or warn;
         } else {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
@@ -125,7 +132,7 @@ sub link {
         push @copied, $fn;
         print CLEAN "$fn\n";
     } elsif (-l "$_") {
-        atomicSymlink "$static/$fn", $target or warn;
+        atomicRelativeSymlink "$static/$fn", $target or warn;
     }
 }
 


### PR DESCRIPTION
###### Motivation for this change
Main motivation is to fix extra-container, so it can run declarative NixOS containers on non-NixOS (https://github.com/erikarvstedt/extra-container/issues/1#issuecomment-426211660).

But seriously, there is a real problem with symlinking stuff currently. Let me show an example. Here's a simple container, where we override NixOS version.
```
  containers.custom = {
    autoStart = true;
    config = {
      system.nixos.version = "CUSTOM";
    };
  };
```
Now let's see, if that works:
```
### good
$ sudo nixos-container run custom -- cat /etc/os-release | grep VERSION=
VERSION="CUSTOM (Koi)"

### bad
$ sudo cat /var/lib/containers/custom/etc/os-release | grep VERSION=
VERSION="19.03.git.0652f62 (Koi)"
```
Indeed, in second case `/var/lib/containers/custom/etc/os-release` points to `/etc/static/os-release` of the *host* system, not container! This is wrong, but even worse happens on non-NixOS, where there is no `/etc/static` on the host - container can be created and started, but can't be rebooted.

This builds on top of https://github.com/NixOS/nixpkgs/pull/35364, however, I am not fixing the original problem (allow `machinectl pull-tar` to run NixOS containers). I'll make a separate PR, which builds on top of this (and https://github.com/NixOS/nixpkgs/pull/35364) and makes `/etc` relative symlink for container tarballs.

cc @edolstra
cc @florianjacob as original author
cc @Ekleog @7c6f434c @erikarvstedt as potential interested parties
###### Things done

This makes symlinks relative in host's `/etc` too. Rebuild-switch is handled correctly, and my machine survives multiple reboots. Also, `simple` installer NixOS test passes.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

