### PR TITLE
[WIP] oldschool-runescape: init package

### DIFF
--- a/pkgs/games/oldschool-runescape/default.nix
+++ b/pkgs/games/oldschool-runescape/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchurl, makeDesktopItem, p7zip, cabextract, jre }:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "OSRuneScape";
+    exec = "oldschool-runescape";
+    icon = "jagexappletviewer";
+    terminal = "false";
+    comment = "An MMO based off of the 2007 version of RuneScape";
+    type = "Application";
+    categories = "Game;RolePlaying;";
+    desktopName = "Old School RuneScape";
+    genericName = "Old School RuneScape";
+    startupNotify = "false";
+  };
+in stdenv.mkDerivation rec {
+  name = "oldschool-runescape";
+
+  src = fetchurl {
+    name = "oldschool.msi";
+    url = http://www.runescape.com/downloads/oldschool.msi?1548915139541;
+    sha256 = "1h0h7wakr20k2kq01yap45wfz9y47flqd0sr2grg7fya8hsbmgqb";
+  };
+
+  phases = [ "buildPhase" "installPhase" ];
+
+  nativeBuildInputs = [ p7zip cabextract ];
+
+  buildInputs = [ jre ];
+
+  buildPhase = ''
+    ${p7zip}/bin/7z x ${src}
+    ${cabextract}/bin/cabextract rslauncher.cab
+
+    mv JagexAppletViewerJarFile.F77C1A97_9A40_44D4_983D_751571B24CE4 jagexappletviewer.jar
+    mv JagexAppletViewerPngFile jagexappletviewer.png
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share $out/bin
+
+    cp -r ${desktopItem}/share/applications $out/share
+    install -Dm644 jagexappletviewer.png $out/share/icons/hicolor/64x64/jagexappletviewer.png
+    install -Dm644 jagexappletviewer.jar $out/share/java/jagexappletviewer.jar
+
+    cat > $out/bin/oldschool-runescape <<EOF
+    #! $shell
+    if [ ! -d "\$USER/.jagexclient" ]
+    then
+      mkdir -p \$USER/.jagexclient/images
+      cp $out/share/icons/hicolor/64x64/jagexappletviewer.png \$USER/.jagexclient/images
+    fi
+
+    exec ${jre}/bin/java -Dsun.java2d.uiScale=2.5 -Djava.class.path=$out/share/java/jagexappletviewer.jar \
+                         -Dcom.jagex.config=http://oldschool.runescape.com/jav\_config.ws \
+                         -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 \
+                         jagexappletviewer \$USER/.jagexclient/images
+    EOF
+
+    chmod a+x $out/bin/oldschool-runescape
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://oldschool.runescape.com;
+    description = "Old School Runescape is an MMO based off of the 2007 version of RuneScape";
+    maintainers = [ maintainers.MP2E ];
+    platforms = platforms.unix;
+    license = licenses.unfreeRedistributable;
+  };
+}

--- a/pkgs/games/oldschool-runescape/default.nix
+++ b/pkgs/games/oldschool-runescape/default.nix
@@ -53,6 +53,7 @@ in stdenv.mkDerivation rec {
 
     exec ${jre}/bin/java -Dsun.java2d.uiScale=2.5 -Djava.class.path=$out/share/java/jagexappletviewer.jar \
                          -Dcom.jagex.config=http://oldschool.runescape.com/jav\_config.ws \
+                         -Xmx512m -Xss2m -XX:CompileThreshold=1500 -XX:+UseConcMarkSweepGC \
                          -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 \
                          jagexappletviewer \$USER/.jagexclient/images
     EOF

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8898,6 +8898,8 @@ in
 
   omniorb = callPackage ../development/tools/omniorb { };
 
+  oldschool-runescape = callPackage ../games/oldschool-runescape { jre = jdk11; };
+
   opengrok = callPackage ../development/tools/misc/opengrok { };
 
   openocd = callPackage ../development/tools/misc/openocd { };


### PR DESCRIPTION
This packages one of Jagex's massive online multiplayer games, Old School RuneScape. I have tested this package for a few hours and found no problems. Audio may cut out after some time without the alsaLib updates in staging/staging-next, but will be solved when those are merged to master.

I have made this package depend on openjdk11, because JDK 8 doesn't support UI scaling from the command line, and RuneScape's User Interface is absurdly small without it.

Upstream has not provided any version numbering for this client, however it does not seem as though it is updated often at all, as it automatically downloads any Old School RuneScape updates on launch to the user's home directory

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

