### PR TITLE
qt511: 5.11.1 -> 5.11.3, qt56 & qt59 security fixes

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.11/fetch.sh
@@ -1,2 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.11/5.11.1/submodules/ \
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.11/5.11.3/submodules/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.11/qtbase.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtbase.patch
@@ -1,8 +1,7 @@
-diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
-index 5208379f9a..92fe29a0ac 100644
---- a/mkspecs/common/mac.conf
-+++ b/mkspecs/common/mac.conf
-@@ -23,7 +23,7 @@ QMAKE_INCDIR_OPENGL     = \
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/common/mac.conf qtbase-everywhere-src-5.11.3/mkspecs/common/mac.conf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/common/mac.conf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/common/mac.conf	2019-01-31 00:42:55.843577249 +0100
+@@ -23,7 +23,7 @@
  
  QMAKE_FIX_RPATH         = install_name_tool -id
  
@@ -11,11 +10,10 @@ index 5208379f9a..92fe29a0ac 100644
  QMAKE_LFLAGS_GCSECTIONS = -Wl,-dead_strip
  
  QMAKE_LFLAGS_REL_RPATH  =
-diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
-index 2ed708e085..05e60ff45f 100644
---- a/mkspecs/features/create_cmake.prf
-+++ b/mkspecs/features/create_cmake.prf
-@@ -21,7 +21,7 @@ load(cmake_functions)
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/create_cmake.prf qtbase-everywhere-src-5.11.3/mkspecs/features/create_cmake.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/create_cmake.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/create_cmake.prf	2019-01-31 00:42:55.843577249 +0100
+@@ -21,7 +21,7 @@
  # at cmake time whether package has been found via a symlink, and correct
  # that to an absolute path. This is only done for installations to
  # the /usr or / prefix.
@@ -24,7 +22,7 @@ index 2ed708e085..05e60ff45f 100644
  contains(CMAKE_INSTALL_LIBS_DIR, ^(/usr)?/lib(64)?.*): CMAKE_USR_MOVE_WORKAROUND = $$CMAKE_INSTALL_LIBS_DIR
  
  CMAKE_OUT_DIR = $$MODULE_BASE_OUTDIR/lib/cmake
-@@ -51,45 +51,20 @@ split_incpath {
+@@ -51,45 +51,20 @@
          $$cmake_extra_source_includes.output
  }
  
@@ -81,7 +79,7 @@ index 2ed708e085..05e60ff45f 100644
  
  static|staticlib:CMAKE_STATIC_TYPE = true
  
-@@ -169,7 +144,7 @@ contains(CONFIG, plugin) {
+@@ -169,7 +144,7 @@
        cmake_target_file
  
      cmake_qt5_plugin_file.files = $$cmake_target_file.output
@@ -90,7 +88,7 @@ index 2ed708e085..05e60ff45f 100644
      INSTALLS += cmake_qt5_plugin_file
  
      return()
-@@ -316,7 +291,7 @@ exists($$cmake_macros_file.input) {
+@@ -316,7 +291,7 @@
      cmake_qt5_module_files.files += $$cmake_macros_file.output
  }
  
@@ -99,11 +97,10 @@ index 2ed708e085..05e60ff45f 100644
  
  # We are generating cmake files. Most developers of Qt are not aware of cmake,
  # so we require automatic tests to be available. The only module which should
-diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-index 27f4c277d6..18b4813e25 100644
---- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-+++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-@@ -3,30 +3,6 @@ if (CMAKE_VERSION VERSION_LESS 3.1.0)
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qtbase-everywhere-src-5.11.3/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2019-01-31 00:42:55.843577249 +0100
+@@ -3,30 +3,6 @@
      message(FATAL_ERROR \"Qt 5 $${CMAKE_MODULE_NAME} module requires at least CMake version 3.1.0\")
  endif()
  
@@ -134,7 +131,7 @@ index 27f4c277d6..18b4813e25 100644
  !!IF !equals(TEMPLATE, aux)
  # For backwards compatibility only. Use Qt5$${CMAKE_MODULE_NAME}_VERSION instead.
  set(Qt5$${CMAKE_MODULE_NAME}_VERSION_STRING "$$eval(QT.$${MODULE}.VERSION)")
-@@ -52,11 +28,7 @@ endmacro()
+@@ -52,11 +28,7 @@
  macro(_populate_$${CMAKE_MODULE_NAME}_target_properties Configuration LIB_LOCATION IMPLIB_LOCATION)
      set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
  
@@ -146,7 +143,7 @@ index 27f4c277d6..18b4813e25 100644
      _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
          \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}\"
-@@ -69,11 +41,7 @@ macro(_populate_$${CMAKE_MODULE_NAME}_target_properties Configuration LIB_LOCATI
+@@ -69,11 +41,7 @@
      )
  
  !!IF !isEmpty(CMAKE_WINDOWS_BUILD)
@@ -158,7 +155,7 @@ index 27f4c277d6..18b4813e25 100644
      _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_implib})
      if(NOT \"${IMPLIB_LOCATION}\" STREQUAL \"\")
          set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
-@@ -89,24 +57,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -89,24 +57,13 @@
  !!IF !no_module_headers
  !!IF !isEmpty(CMAKE_BUILD_IS_FRAMEWORK)
      set(_Qt5$${CMAKE_MODULE_NAME}_OWN_INCLUDE_DIRS
@@ -187,7 +184,7 @@ index 27f4c277d6..18b4813e25 100644
      )
  !!ELSE
      set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
-@@ -122,7 +79,6 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -122,7 +79,6 @@
      set(Qt5$${CMAKE_MODULE_NAME}_PRIVATE_INCLUDE_DIRS \"\")
  !!ENDIF
  !!ENDIF
@@ -195,7 +192,7 @@ index 27f4c277d6..18b4813e25 100644
  !!IF !isEmpty(CMAKE_ADD_SOURCE_INCLUDE_DIRS)
      include(\"${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake\" OPTIONAL)
  !!ENDIF
-@@ -269,25 +225,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -269,25 +225,13 @@
  !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
  !!IF isEmpty(CMAKE_DEBUG_TYPE)
  !!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
@@ -221,7 +218,7 @@ index 27f4c277d6..18b4813e25 100644
          _populate_$${CMAKE_MODULE_NAME}_target_properties(DEBUG \"$${CMAKE_LIB_FILE_LOCATION_DEBUG}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_DEBUG}\" )
  !!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
      endif()
-@@ -306,25 +250,13 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -306,25 +250,13 @@
  !!IF !isEmpty(CMAKE_FIND_OTHER_LIBRARY_BUILD)
  !!IF isEmpty(CMAKE_RELEASE_TYPE)
  !!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
@@ -247,7 +244,7 @@ index 27f4c277d6..18b4813e25 100644
          _populate_$${CMAKE_MODULE_NAME}_target_properties(RELEASE \"$${CMAKE_LIB_FILE_LOCATION_RELEASE}\" \"$${CMAKE_IMPLIB_FILE_LOCATION_RELEASE}\" )
  !!ENDIF // CMAKE_STATIC_WINDOWS_BUILD
      endif()
-@@ -343,11 +275,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
+@@ -343,11 +275,7 @@
      macro(_populate_$${CMAKE_MODULE_NAME}_plugin_properties Plugin Configuration PLUGIN_LOCATION)
          set_property(TARGET Qt5::${Plugin} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
  
@@ -259,11 +256,10 @@ index 27f4c277d6..18b4813e25 100644
          _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
-diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index 21d487f1f9..a0e5c68b7e 100644
---- a/mkspecs/features/mac/default_post.prf
-+++ b/mkspecs/features/mac/default_post.prf
-@@ -24,196 +24,3 @@ qt {
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/mac/default_post.prf qtbase-everywhere-src-5.11.3/mkspecs/features/mac/default_post.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/mac/default_post.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/mac/default_post.prf	2019-01-31 00:45:14.585621324 +0100
+@@ -62,199 +62,3 @@
          }
      }
  }
@@ -458,12 +454,15 @@ index 21d487f1f9..a0e5c68b7e 100644
 -xcode_product_bundle_identifier_setting.value = $$QMAKE_TARGET_BUNDLE_PREFIX
 -isEmpty(xcode_product_bundle_identifier_setting.value): \
 -    xcode_product_bundle_identifier_setting.value = "com.yourcompany"
--xcode_product_bundle_identifier_setting.value = "$${xcode_product_bundle_identifier_setting.value}.${PRODUCT_NAME:rfc1034identifier}"
+-xcode_product_bundle_target = $$QMAKE_BUNDLE
+-isEmpty(xcode_product_bundle_target): \
+-    xcode_product_bundle_target = ${PRODUCT_NAME:rfc1034identifier}
+-xcode_product_bundle_identifier_setting.value = "$${xcode_product_bundle_identifier_setting.value}.$${xcode_product_bundle_target}"
 -QMAKE_MAC_XCODE_SETTINGS += xcode_product_bundle_identifier_setting
-diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index e3534561a5..3b01424e67 100644
---- a/mkspecs/features/mac/default_pre.prf
-+++ b/mkspecs/features/mac/default_pre.prf
+Only in qtbase-everywhere-src-5.11.3/mkspecs/features/mac: default_post.prf.orig
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/mac/default_pre.prf qtbase-everywhere-src-5.11.3/mkspecs/features/mac/default_pre.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/mac/default_pre.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/mac/default_pre.prf	2019-01-31 00:42:55.843577249 +0100
 @@ -1,60 +1,2 @@
  CONFIG = asset_catalogs rez $$CONFIG
  load(default_pre)
@@ -525,10 +524,9 @@ index e3534561a5..3b01424e67 100644
 -xcode_copy_phase_strip_setting.name = COPY_PHASE_STRIP
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
-diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
-index 8360dd8b38..8b13789179 100644
---- a/mkspecs/features/mac/sdk.prf
-+++ b/mkspecs/features/mac/sdk.prf
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/mac/sdk.prf qtbase-everywhere-src-5.11.3/mkspecs/features/mac/sdk.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/mac/sdk.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/mac/sdk.prf	2019-01-31 00:42:55.843577249 +0100
 @@ -1,58 +1 @@
  
 -isEmpty(QMAKE_MAC_SDK): \
@@ -588,11 +586,10 @@ index 8360dd8b38..8b13789179 100644
 -    $$tool = $$sysrooted $$member(value, 1, -1)
 -    cache($$tool_variable, set stash, $$tool)
 -}
-diff --git a/mkspecs/features/qml_module.prf b/mkspecs/features/qml_module.prf
-index 4db0040dc5..65d6da1f4d 100644
---- a/mkspecs/features/qml_module.prf
-+++ b/mkspecs/features/qml_module.prf
-@@ -23,13 +23,8 @@ for(qmlf, AUX_QML_FILES): fq_aux_qml_files += $$absolute_path($$qmlf, $$_PRO_FIL
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qml_module.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qml_module.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qml_module.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qml_module.prf	2019-01-31 00:42:55.843577249 +0100
+@@ -23,13 +23,8 @@
  
  load(qt_build_paths)
  
@@ -608,11 +605,10 @@ index 4db0040dc5..65d6da1f4d 100644
  
  !qml1_target:static: CONFIG += builtin_resources
  
-diff --git a/mkspecs/features/qml_plugin.prf b/mkspecs/features/qml_plugin.prf
-index d49f4c49c1..097dcd7d39 100644
---- a/mkspecs/features/qml_plugin.prf
-+++ b/mkspecs/features/qml_plugin.prf
-@@ -48,13 +48,8 @@ exists($$QMLTYPEFILE): AUX_QML_FILES += $$QMLTYPEFILE
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qml_plugin.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qml_plugin.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qml_plugin.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qml_plugin.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -48,13 +48,8 @@
  
  load(qt_build_paths)
  
@@ -628,11 +624,10 @@ index d49f4c49c1..097dcd7d39 100644
  
  target.path = $$instbase/$$TARGETPATH
  INSTALLS += target
-diff --git a/mkspecs/features/qt_app.prf b/mkspecs/features/qt_app.prf
-index 883f8ca215..81db8eb2d4 100644
---- a/mkspecs/features/qt_app.prf
-+++ b/mkspecs/features/qt_app.prf
-@@ -33,7 +33,7 @@ host_build:force_bootstrap {
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_app.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_app.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_app.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_app.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -33,7 +33,7 @@
      target.path = $$[QT_HOST_BINS]
  } else {
      !build_pass:qtConfig(debug_and_release): CONFIG += release
@@ -641,11 +636,10 @@ index 883f8ca215..81db8eb2d4 100644
      CONFIG += relative_qt_rpath  # Qt's tools and apps should be relocatable
  }
  INSTALLS += target
-diff --git a/mkspecs/features/qt_build_paths.prf b/mkspecs/features/qt_build_paths.prf
-index 1848f00e90..2af93675c5 100644
---- a/mkspecs/features/qt_build_paths.prf
-+++ b/mkspecs/features/qt_build_paths.prf
-@@ -23,6 +23,6 @@ exists($$MODULE_BASE_INDIR/.git): \
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_build_paths.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_build_paths.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_build_paths.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_build_paths.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -24,6 +24,6 @@
  !force_independent {
      # If the module is not built independently, everything ends up in qtbase.
      # This is the case in non-prefix builds, except for selected modules.
@@ -654,11 +648,11 @@ index 1848f00e90..2af93675c5 100644
 +    MODULE_BASE_OUTDIR = $$NIX_OUTPUT_OUT
 +    MODULE_QMAKE_OUTDIR = $$NIX_OUTPUT_OUT
  }
-diff --git a/mkspecs/features/qt_common.prf b/mkspecs/features/qt_common.prf
-index 415044bb64..7163ef56cd 100644
---- a/mkspecs/features/qt_common.prf
-+++ b/mkspecs/features/qt_common.prf
-@@ -32,8 +32,8 @@ contains(TEMPLATE, .*lib) {
+Only in qtbase-everywhere-src-5.11.3/mkspecs/features: qt_build_paths.prf.orig
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_common.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_common.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_common.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_common.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -32,8 +32,8 @@
          qqt_libdir = \$\$\$\$[QT_HOST_LIBS]
          qt_libdir = $$[QT_HOST_LIBS]
      } else {
@@ -669,11 +663,10 @@ index 415044bb64..7163ef56cd 100644
      }
      contains(QMAKE_DEFAULT_LIBDIRS, $$qt_libdir) {
          lib_replace.match = "[^ ']*$$rplbase/lib"
-diff --git a/mkspecs/features/qt_docs.prf b/mkspecs/features/qt_docs.prf
-index 3139c443c6..1b4f2fddd8 100644
---- a/mkspecs/features/qt_docs.prf
-+++ b/mkspecs/features/qt_docs.prf
-@@ -45,7 +45,7 @@ QMAKE_DOCS_OUTPUTDIR = $$QMAKE_DOCS_BASE_OUTDIR/$$QMAKE_DOCS_TARGETDIR
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_docs.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_docs.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_docs.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_docs.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -45,7 +45,7 @@
  
  QDOC += -outputdir $$shell_quote($$QMAKE_DOCS_OUTPUTDIR)
  !build_online_docs: \
@@ -682,7 +675,7 @@ index 3139c443c6..1b4f2fddd8 100644
  PREP_DOC_INDEXES =
  DOC_INDEXES =
  !isEmpty(QTREPOS) {
-@@ -64,8 +64,8 @@ DOC_INDEXES =
+@@ -64,8 +64,8 @@
          DOC_INDEXES += -indexdir $$shell_quote($$qrep/doc)
  } else {
      prepare_docs: \
@@ -693,7 +686,7 @@ index 3139c443c6..1b4f2fddd8 100644
  }
  
  qtattributionsscanner.target = qtattributionsscanner
-@@ -88,12 +88,12 @@ prepare_docs {
+@@ -88,12 +88,12 @@
      qch_docs.commands = $$QHELPGENERATOR $$shell_quote($$QMAKE_DOCS_OUTPUTDIR/$${QMAKE_DOCS_TARGET}.qhp) -o $$shell_quote($$QMAKE_DOCS_BASE_OUTDIR/$${QMAKE_DOCS_TARGET}.qch)
  
      inst_html_docs.files = $$QMAKE_DOCS_OUTPUTDIR
@@ -708,11 +701,10 @@ index 3139c443c6..1b4f2fddd8 100644
      inst_qch_docs.CONFIG += no_check_exist no_default_install no_build
      INSTALLS += inst_qch_docs
  
-diff --git a/mkspecs/features/qt_example_installs.prf b/mkspecs/features/qt_example_installs.prf
-index 43b58817fe..e635b8f67a 100644
---- a/mkspecs/features/qt_example_installs.prf
-+++ b/mkspecs/features/qt_example_installs.prf
-@@ -88,7 +88,7 @@ sourcefiles += \
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_example_installs.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_example_installs.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_example_installs.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_example_installs.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -88,7 +88,7 @@
      $$SOURCES $$HEADERS $$FORMS $$RESOURCES $$TRANSLATIONS \
      $$DBUS_ADAPTORS $$DBUS_INTERFACES
  addInstallFiles(sources.files, $$sourcefiles)
@@ -721,11 +713,10 @@ index 43b58817fe..e635b8f67a 100644
  INSTALLS += sources
  
  check_examples {
-diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 1903e509c8..ae7b585989 100644
---- a/mkspecs/features/qt_functions.prf
-+++ b/mkspecs/features/qt_functions.prf
-@@ -69,7 +69,7 @@ defineTest(qtHaveModule) {
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_functions.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_functions.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_functions.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_functions.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -69,7 +69,7 @@
  defineTest(qtPrepareTool) {
      cmd = $$eval(QT_TOOL.$${2}.binary)
      isEmpty(cmd) {
@@ -734,10 +725,9 @@ index 1903e509c8..ae7b585989 100644
          exists($${cmd}.pl) {
              $${1}_EXE = $${cmd}.pl
              cmd = perl -w $$system_path($${cmd}.pl)
-diff --git a/mkspecs/features/qt_installs.prf b/mkspecs/features/qt_installs.prf
-index 8f98987b99..21b3bb8b32 100644
---- a/mkspecs/features/qt_installs.prf
-+++ b/mkspecs/features/qt_installs.prf
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_installs.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_installs.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_installs.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_installs.prf	2019-01-31 00:42:55.844577264 +0100
 @@ -12,16 +12,10 @@
  #library
  !qt_no_install_library {
@@ -797,11 +787,10 @@ index 8f98987b99..21b3bb8b32 100644
          privpritarget.files = $$MODULE_PRIVATE_PRI
          INSTALLS += privpritarget
      }
-diff --git a/mkspecs/features/qt_plugin.prf b/mkspecs/features/qt_plugin.prf
-index bf90adcf1e..b3de698ff7 100644
---- a/mkspecs/features/qt_plugin.prf
-+++ b/mkspecs/features/qt_plugin.prf
-@@ -88,7 +88,7 @@ CONFIG(static, static|shared)|prefix_build {
+diff -ur qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_plugin.prf qtbase-everywhere-src-5.11.3/mkspecs/features/qt_plugin.prf
+--- qtbase-everywhere-src-5.11.3-orig/mkspecs/features/qt_plugin.prf	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/mkspecs/features/qt_plugin.prf	2019-01-31 00:42:55.844577264 +0100
+@@ -88,7 +88,7 @@
      }
  }
  
@@ -810,84 +799,10 @@ index bf90adcf1e..b3de698ff7 100644
  INSTALLS += target
  
  TARGET = $$qt5LibraryTarget($$TARGET)
-diff --git a/src/corelib/Qt5CoreConfigExtras.cmake.in b/src/corelib/Qt5CoreConfigExtras.cmake.in
-index e0652fdcf9..450b2a2d28 100644
---- a/src/corelib/Qt5CoreConfigExtras.cmake.in
-+++ b/src/corelib/Qt5CoreConfigExtras.cmake.in
-@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qmake)
-     add_executable(Qt5::qmake IMPORTED)
- 
- !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
--    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
-+    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
- !!ELSE
-     set(imported_location \"$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
- !!ENDIF
-@@ -18,7 +18,7 @@ if (NOT TARGET Qt5::moc)
-     add_executable(Qt5::moc IMPORTED)
- 
- !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
--    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
-+    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
- !!ELSE
-     set(imported_location \"$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
- !!ENDIF
-@@ -35,7 +35,7 @@ if (NOT TARGET Qt5::rcc)
-     add_executable(Qt5::rcc IMPORTED)
- 
- !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
--    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
-+    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
- !!ELSE
-     set(imported_location \"$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
- !!ENDIF
-@@ -116,7 +116,7 @@ if (NOT TARGET Qt5::WinMain)
- !!IF !isEmpty(CMAKE_RELEASE_TYPE)
-     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
- !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
--    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
-+    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
- !!ELSE
-     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
- !!ENDIF
-@@ -130,7 +130,7 @@ if (NOT TARGET Qt5::WinMain)
-     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
- 
- !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
--    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
-+    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
- !!ELSE
-     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
- !!ENDIF
-diff --git a/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in b/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
-index c357237d0e..6f0c75de3c 100644
---- a/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
-+++ b/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
-@@ -1,6 +1,6 @@
- 
- !!IF isEmpty(CMAKE_HOST_DATA_DIR_IS_ABSOLUTE)
--set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
-+set(_qt5_corelib_extra_includes \"$$NIX_OUTPUT_DEV/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
- !!ELSE
- set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
- !!ENDIF
-diff --git a/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in b/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
-index 706304cf34..546420f6ad 100644
---- a/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
-+++ b/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
-@@ -1,6 +1,6 @@
- 
- !!IF isEmpty(CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE)
--set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
-+set(_qt5_corelib_extra_includes \"$$NIX_OUTPUT_DEV/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
- !!ELSE
- set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
- !!ENDIF
-diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index 4e32f90964..503aeffd0c 100644
---- a/src/corelib/kernel/qcoreapplication.cpp
-+++ b/src/corelib/kernel/qcoreapplication.cpp
-@@ -2613,6 +2613,15 @@ QStringList QCoreApplication::libraryPaths()
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/corelib/kernel/qcoreapplication.cpp qtbase-everywhere-src-5.11.3/src/corelib/kernel/qcoreapplication.cpp
+--- qtbase-everywhere-src-5.11.3-orig/src/corelib/kernel/qcoreapplication.cpp	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/corelib/kernel/qcoreapplication.cpp	2019-01-31 00:42:55.845577279 +0100
+@@ -2612,6 +2612,15 @@
          QStringList *app_libpaths = new QStringList;
          coreappdata()->app_libpaths.reset(app_libpaths);
  
@@ -903,11 +818,81 @@ index 4e32f90964..503aeffd0c 100644
          const QByteArray libPathEnv = qgetenv("QT_PLUGIN_PATH");
          if (!libPathEnv.isEmpty()) {
              QStringList paths = QFile::decodeName(libPathEnv).split(QDir::listSeparator(), QString::SkipEmptyParts);
-diff --git a/src/corelib/tools/qtimezoneprivate_tz.cpp b/src/corelib/tools/qtimezoneprivate_tz.cpp
-index 6a5df6272a..a6136ca4cd 100644
---- a/src/corelib/tools/qtimezoneprivate_tz.cpp
-+++ b/src/corelib/tools/qtimezoneprivate_tz.cpp
-@@ -70,7 +70,11 @@ typedef QHash<QByteArray, QTzTimeZone> QTzTimeZoneHash;
+Only in qtbase-everywhere-src-5.11.3/src/corelib/kernel: qcoreapplication.cpp.orig
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/corelib/Qt5CoreConfigExtras.cmake.in qtbase-everywhere-src-5.11.3/src/corelib/Qt5CoreConfigExtras.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/src/corelib/Qt5CoreConfigExtras.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/corelib/Qt5CoreConfigExtras.cmake.in	2019-01-31 00:42:55.844577264 +0100
+@@ -3,7 +3,7 @@
+     add_executable(Qt5::qmake IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}qmake$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -18,7 +18,7 @@
+     add_executable(Qt5::moc IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}moc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -35,7 +35,7 @@
+     add_executable(Qt5::rcc IMPORTED)
+ 
+ !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
++    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_BIN_DIR}rcc$$CMAKE_BIN_SUFFIX\")
+ !!ENDIF
+@@ -116,7 +116,7 @@
+ !!IF !isEmpty(CMAKE_RELEASE_TYPE)
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
++    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_RELEASE}\")
+ !!ENDIF
+@@ -130,7 +130,7 @@
+     set_property(TARGET Qt5::WinMain APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+ 
+ !!IF isEmpty(CMAKE_LIB_DIR_IS_ABSOLUTE)
+-    set(imported_location \"${_qt5Core_install_prefix}/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
++    set(imported_location \"$$NIX_OUTPUT_DEV/$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ELSE
+     set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
+ !!ENDIF
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in qtbase-everywhere-src-5.11.3/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in	2019-01-31 00:42:55.844577264 +0100
+@@ -1,6 +1,6 @@
+ 
+ !!IF isEmpty(CMAKE_HOST_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"$$NIX_OUTPUT_DEV/$${CMAKE_HOST_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in qtbase-everywhere-src-5.11.3/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in	2019-01-31 00:42:55.844577264 +0100
+@@ -1,6 +1,6 @@
+ 
+ !!IF isEmpty(CMAKE_INSTALL_DATA_DIR_IS_ABSOLUTE)
+-set(_qt5_corelib_extra_includes \"${_qt5Core_install_prefix}/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
++set(_qt5_corelib_extra_includes \"$$NIX_OUTPUT_DEV/$${CMAKE_INSTALL_DATA_DIR}/mkspecs/$${CMAKE_MKSPEC}\")
+ !!ELSE
+ set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
+ !!ENDIF
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/corelib/tools/qtimezoneprivate_tz.cpp qtbase-everywhere-src-5.11.3/src/corelib/tools/qtimezoneprivate_tz.cpp
+--- qtbase-everywhere-src-5.11.3-orig/src/corelib/tools/qtimezoneprivate_tz.cpp	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/corelib/tools/qtimezoneprivate_tz.cpp	2019-01-31 00:42:55.845577279 +0100
+@@ -70,7 +70,11 @@
  // Parse zone.tab table, assume lists all installed zones, if not will need to read directories
  static QTzTimeZoneHash loadTzTimeZones()
  {
@@ -920,7 +905,7 @@ index 6a5df6272a..a6136ca4cd 100644
      if (!QFile::exists(path))
          path = QStringLiteral("/usr/lib/zoneinfo/zone.tab");
  
-@@ -644,12 +648,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
+@@ -644,12 +648,16 @@
          if (!tzif.open(QIODevice::ReadOnly))
              return;
      } else {
@@ -942,10 +927,9 @@ index 6a5df6272a..a6136ca4cd 100644
          }
      }
  
-diff --git a/src/dbus/Qt5DBusConfigExtras.cmake.in b/src/dbus/Qt5DBusConfigExtras.cmake.in
-index 1d947159e2..b36865fc48 100644
---- a/src/dbus/Qt5DBusConfigExtras.cmake.in
-+++ b/src/dbus/Qt5DBusConfigExtras.cmake.in
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/dbus/Qt5DBusConfigExtras.cmake.in qtbase-everywhere-src-5.11.3/src/dbus/Qt5DBusConfigExtras.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/src/dbus/Qt5DBusConfigExtras.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/dbus/Qt5DBusConfigExtras.cmake.in	2019-01-31 00:42:55.845577279 +0100
 @@ -2,11 +2,7 @@
  if (NOT TARGET Qt5::qdbuscpp2xml)
      add_executable(Qt5::qdbuscpp2xml IMPORTED)
@@ -959,7 +943,7 @@ index 1d947159e2..b36865fc48 100644
      _qt5_DBus_check_file_exists(${imported_location})
  
      set_target_properties(Qt5::qdbuscpp2xml PROPERTIES
-@@ -17,11 +13,7 @@ endif()
+@@ -17,11 +13,7 @@
  if (NOT TARGET Qt5::qdbusxml2cpp)
      add_executable(Qt5::qdbusxml2cpp IMPORTED)
  
@@ -972,10 +956,9 @@ index 1d947159e2..b36865fc48 100644
      _qt5_DBus_check_file_exists(${imported_location})
  
      set_target_properties(Qt5::qdbusxml2cpp PROPERTIES
-diff --git a/src/gui/Qt5GuiConfigExtras.cmake.in b/src/gui/Qt5GuiConfigExtras.cmake.in
-index 07869efd7d..fb4183bada 100644
---- a/src/gui/Qt5GuiConfigExtras.cmake.in
-+++ b/src/gui/Qt5GuiConfigExtras.cmake.in
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/gui/Qt5GuiConfigExtras.cmake.in qtbase-everywhere-src-5.11.3/src/gui/Qt5GuiConfigExtras.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/src/gui/Qt5GuiConfigExtras.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/gui/Qt5GuiConfigExtras.cmake.in	2019-01-31 00:42:55.845577279 +0100
 @@ -2,7 +2,7 @@
  !!IF !isEmpty(CMAKE_ANGLE_EGL_DLL_RELEASE)
  
@@ -985,7 +968,7 @@ index 07869efd7d..fb4183bada 100644
  !!ELSE
  set(Qt5Gui_EGL_INCLUDE_DIRS \"$$CMAKE_INCLUDE_DIR/QtANGLE\")
  !!ENDIF
-@@ -17,13 +17,13 @@ macro(_populate_qt5gui_gl_target_properties TargetName Configuration LIB_LOCATIO
+@@ -17,13 +17,13 @@
      set_property(TARGET Qt5::${TargetName} APPEND PROPERTY IMPORTED_CONFIGURATIONS ${Configuration})
  
  !!IF isEmpty(CMAKE_DLL_DIR_IS_ABSOLUTE)
@@ -1001,11 +984,10 @@ index 07869efd7d..fb4183bada 100644
  !!ELSE
      set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
  !!ENDIF
-diff --git a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-index b5a0a5bbeb..6c20305f4d 100644
---- a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-+++ b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-@@ -265,12 +265,9 @@ void TableGenerator::initPossibleLocations()
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp qtbase-everywhere-src-5.11.3/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
+--- qtbase-everywhere-src-5.11.3-orig/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp	2019-01-31 00:42:55.845577279 +0100
+@@ -265,12 +265,9 @@
      m_possibleLocations.reserve(7);
      if (qEnvironmentVariableIsSet("QTCOMPOSE"))
          m_possibleLocations.append(QString::fromLocal8Bit(qgetenv("QTCOMPOSE")));
@@ -1019,11 +1001,10 @@ index b5a0a5bbeb..6c20305f4d 100644
  }
  
  QString TableGenerator::findComposeFile()
-diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-index cc982b3379..0c5005d3d7 100644
---- a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-+++ b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
-@@ -648,9 +648,14 @@ QFunctionPointer QGLXContext::getProcAddress(const char *procName)
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp qtbase-everywhere-src-5.11.3/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp
+--- qtbase-everywhere-src-5.11.3-orig/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qglxintegration.cpp	2019-01-31 00:42:55.845577279 +0100
+@@ -650,9 +650,14 @@
  #if QT_CONFIG(library)
                  extern const QString qt_gl_library_name();
  //                QLibrary lib(qt_gl_library_name());
@@ -1040,11 +1021,11 @@ index cc982b3379..0c5005d3d7 100644
                  glXGetProcAddressARB = (qt_glXGetProcAddressARB) lib.resolve("glXGetProcAddressARB");
  #endif
              }
-diff --git a/src/plugins/platforms/xcb/qxcbcursor.cpp b/src/plugins/platforms/xcb/qxcbcursor.cpp
-index b401100dd4..b45a290065 100644
---- a/src/plugins/platforms/xcb/qxcbcursor.cpp
-+++ b/src/plugins/platforms/xcb/qxcbcursor.cpp
-@@ -316,10 +316,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
+Only in qtbase-everywhere-src-5.11.3/src/plugins/platforms/xcb/gl_integrations/xcb_glx: qglxintegration.cpp.orig
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/plugins/platforms/xcb/qxcbcursor.cpp qtbase-everywhere-src-5.11.3/src/plugins/platforms/xcb/qxcbcursor.cpp
+--- qtbase-everywhere-src-5.11.3-orig/src/plugins/platforms/xcb/qxcbcursor.cpp	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/plugins/platforms/xcb/qxcbcursor.cpp	2019-01-31 00:42:55.846577295 +0100
+@@ -316,10 +316,10 @@
  #if QT_CONFIG(xcb_xlib) && QT_CONFIG(library)
      static bool function_ptrs_not_initialized = true;
      if (function_ptrs_not_initialized) {
@@ -1057,10 +1038,9 @@ index b401100dd4..b45a290065 100644
              xcursorFound = xcursorLib.load();
          }
          if (xcursorFound) {
-diff --git a/src/plugins/platformthemes/gtk3/main.cpp b/src/plugins/platformthemes/gtk3/main.cpp
-index fb1c425d8e..bb8bab9795 100644
---- a/src/plugins/platformthemes/gtk3/main.cpp
-+++ b/src/plugins/platformthemes/gtk3/main.cpp
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/plugins/platformthemes/gtk3/main.cpp qtbase-everywhere-src-5.11.3/src/plugins/platformthemes/gtk3/main.cpp
+--- qtbase-everywhere-src-5.11.3-orig/src/plugins/platformthemes/gtk3/main.cpp	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/plugins/platformthemes/gtk3/main.cpp	2019-01-31 00:42:55.846577295 +0100
 @@ -39,6 +39,7 @@
  
  #include <qpa/qplatformthemeplugin.h>
@@ -1069,7 +1049,7 @@ index fb1c425d8e..bb8bab9795 100644
  
  QT_BEGIN_NAMESPACE
  
-@@ -54,8 +55,22 @@ public:
+@@ -54,8 +55,22 @@
  QPlatformTheme *QGtk3ThemePlugin::create(const QString &key, const QStringList &params)
  {
      Q_UNUSED(params);
@@ -1093,10 +1073,9 @@ index fb1c425d8e..bb8bab9795 100644
  
      return 0;
  }
-diff --git a/src/testlib/qtestassert.h b/src/testlib/qtestassert.h
-index 6498ea84ef..d821ced7fc 100644
---- a/src/testlib/qtestassert.h
-+++ b/src/testlib/qtestassert.h
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/testlib/qtestassert.h qtbase-everywhere-src-5.11.3/src/testlib/qtestassert.h
+--- qtbase-everywhere-src-5.11.3-orig/src/testlib/qtestassert.h	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/testlib/qtestassert.h	2019-01-31 00:42:55.846577295 +0100
 @@ -44,10 +44,13 @@
  
  QT_BEGIN_NAMESPACE
@@ -1113,11 +1092,10 @@ index 6498ea84ef..d821ced7fc 100644
  
  QT_END_NAMESPACE
  
-diff --git a/src/widgets/Qt5WidgetsConfigExtras.cmake.in b/src/widgets/Qt5WidgetsConfigExtras.cmake.in
-index 99d87e2e46..a4eab2aa72 100644
---- a/src/widgets/Qt5WidgetsConfigExtras.cmake.in
-+++ b/src/widgets/Qt5WidgetsConfigExtras.cmake.in
-@@ -3,7 +3,7 @@ if (NOT TARGET Qt5::uic)
+diff -ur qtbase-everywhere-src-5.11.3-orig/src/widgets/Qt5WidgetsConfigExtras.cmake.in qtbase-everywhere-src-5.11.3/src/widgets/Qt5WidgetsConfigExtras.cmake.in
+--- qtbase-everywhere-src-5.11.3-orig/src/widgets/Qt5WidgetsConfigExtras.cmake.in	2018-11-25 13:51:11.000000000 +0100
++++ qtbase-everywhere-src-5.11.3/src/widgets/Qt5WidgetsConfigExtras.cmake.in	2019-01-31 00:42:55.846577295 +0100
+@@ -3,7 +3,7 @@
      add_executable(Qt5::uic IMPORTED)
  
  !!IF isEmpty(CMAKE_BIN_DIR_IS_ABSOLUTE)

--- a/pkgs/development/libraries/qt-5/5.11/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.11/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   qt3d = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qt3d-everywhere-src-5.11.1.tar.xz";
-      sha256 = "03fkbrghj40rp8pf5r5979pcvq7qjsj7db446r6fl6slwphmk1nb";
-      name = "qt3d-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qt3d-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1awyv40jgbb30yp5zxf6j9wq96nmk8zyhbh4fpn9gn35ychmr984";
+      name = "qt3d-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtactiveqt-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1f9w3dc2wvhz7pqhrsb2p908kc2c6xrqsp82ny8akil4xx6nrvn6";
-      name = "qtactiveqt-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtactiveqt-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0g35yhp01c34m91fp5vzzq0d2kzz0yswpjjk5cg36j0ddnfcsh4d";
+      name = "qtactiveqt-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtandroidextras-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1qiggrz2hdb7vrkvsh71hqdipj3klak0jpn2nq8qpilqxgb9dx76";
-      name = "qtandroidextras-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtandroidextras-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0clqz10ry70f0v8hbw37fhlwrsr5jddg99yjsk9db250dwbqzq27";
+      name = "qtandroidextras-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtbase = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtbase-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0ipv18ypbgpxhh49rfplqmflskmnhhwj1bjr5hrwi0jpvar4gl50";
-      name = "qtbase-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtbase-everywhere-src-5.11.3.tar.xz";
+      sha256 = "071yc9iz14qs4s8yvrwllyfdzp5yjxsdpvbjxdrf0g5q69vqigy6";
+      name = "qtbase-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtcanvas3d-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1pif3m1f44jrly2nh0hzid6dmdxqiy5qgx645hz6g5fmpl113d8g";
-      name = "qtcanvas3d-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtcanvas3d-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0f110z7cmkzns9k00aa5zhzq2fpybfxkd7gdlwzcbhc8hn20986m";
+      name = "qtcanvas3d-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtcharts-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0avscsni84zrzydilkkp456sbaypyzhkn42qygjdq7wcn045zxk2";
-      name = "qtcharts-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtcharts-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1p4m1nkbbxlkwmbmasx5r83skzssmlcgfzyvj30x2dyrqkmz7627";
+      name = "qtcharts-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtconnectivity-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0mz6mbf069yqdvi6mcvp6izskcn9wzig4s3dzmygwd430pmx93kk";
-      name = "qtconnectivity-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtconnectivity-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0amks3qad31i7cha85kvcaxvlmmgkc3gm4jdkw2p02ixxfygr30l";
+      name = "qtconnectivity-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtdatavis3d-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0gay0dsz05xfrlx190y95hp9wipzb988h02fqbqvyn00ds3s178w";
-      name = "qtdatavis3d-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtdatavis3d-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1kqwr3avcvcyy4i28vjgxk1bsjj9011zr668hsk1zrjxnnwjwdl3";
+      name = "qtdatavis3d-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtdeclarative-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0fjg9ii64mhx2ww70rj44cy65rwwkwyjxcm435kwp3v1pzv5xkwy";
-      name = "qtdeclarative-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtdeclarative-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1rhsf9bma2zwwpixk2fsg31x7c1pmsk144npypgc9w86swhkc9lf";
+      name = "qtdeclarative-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtdoc-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1z0sqmn0pw5g4ycdi8igsi89151cw6p3kv9g97pxl2qx3my1ppmc";
-      name = "qtdoc-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtdoc-everywhere-src-5.11.3.tar.xz";
+      sha256 = "06nl8lzrilj8yify5qy4fm9la6dh71aamg19jhvvi657cshiclsq";
+      name = "qtdoc-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtgamepad-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1n97w9rcbg8mzkvjgn3i8jbfmplp7w0p80ykdchpml47gxk1kwma";
-      name = "qtgamepad-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtgamepad-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1k222cx18zq48sfna91hmy427qzk2n2xz3dlyz59iyz72k6915g9";
+      name = "qtgamepad-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtgraphicaleffects-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1ws8aj7bq3rxpzjs370dcyqk8a5v1y6fwvrdhf70j8b2d4v75lnr";
-      name = "qtgraphicaleffects-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtgraphicaleffects-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1qjpdzkamf27cg5n1wsf0zk939lcgppgydfjzap9s4fxzj1nkn0l";
+      name = "qtgraphicaleffects-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtimageformats-everywhere-src-5.11.1.tar.xz";
-      sha256 = "05jnyrq7klr3mdiz0r9c151vl829yc8y9cxfbw5dwbp1rkndwl7b";
-      name = "qtimageformats-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtimageformats-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0zq8igsjyyhxsjr43vpaasrqjw3x0g6rwqf8kaz7y9vs7ny63ch4";
+      name = "qtimageformats-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtlocation-everywhere-src-5.11.1.tar.xz";
-      sha256 = "03vrbymwbn4nqsypcmr4ccqv20nvwdfs9gb01pi3jxr6x0wrlb0p";
-      name = "qtlocation-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtlocation-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1sq0f41jwmsimv9a1wl2nk5nifjppm5j92rr4n4s7qwnnjjrir2q";
+      name = "qtlocation-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtmacextras-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1wf3n5n4gg8gmjnjq88lmymkssg8q5s3qkrpsxd1hb6pd3n32gpn";
-      name = "qtmacextras-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtmacextras-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1j9sqmcwswr8v9z8mcbm10bj7nz8nv9mir0xsc5123ik1gw2c3lk";
+      name = "qtmacextras-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtmultimedia-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0369b0mh7sr718l119b07grb1v8xqlq6l4damyd6lrmlj1wbb2zj";
-      name = "qtmultimedia-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtmultimedia-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0h9wx86zj20n4xc3qnml0i360x2dc1yd2z2af1flj8fwyzppi03j";
+      name = "qtmultimedia-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtnetworkauth-everywhere-src-5.11.1.tar.xz";
-      sha256 = "05p4pvfp3k5612d54anvpj39bgc7v572x6kgk3fy69xgn7lhbd02";
-      name = "qtnetworkauth-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtnetworkauth-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0dd35698wzg89975vi2ijl2lym495fjizsl03mjixsjnvb1x0q50";
+      name = "qtnetworkauth-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtpurchasing-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0crm39fy9aqns10mjlbxvkkna9xklic49zfp3f7v7cwl66wap6dc";
-      name = "qtpurchasing-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtpurchasing-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1fd0gxdj5mrh81iwimq1243i3n47sqv9ik8nslahfh0q3dsx7k8n";
+      name = "qtpurchasing-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtquickcontrols-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0mn662j0gkpama7zlrsn4h27sjrk49kpbha1h0zxxyiza5cpzsms";
-      name = "qtquickcontrols-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtquickcontrols-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0dvmy31qbl76yy0j5y8m7mvnmqyg2c01fmlkn0snvc5h5ah5skjf";
+      name = "qtquickcontrols-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtquickcontrols2-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0hn4kvrkz5ivwrp9p6yzwlw7cn4j72kcpm2nqyi3dbai1px6dc5x";
-      name = "qtquickcontrols2-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtquickcontrols2-everywhere-src-5.11.3.tar.xz";
+      sha256 = "11nhpb0xckv5jjkqj5szr94c2rvyjwr89ch58hh64nsqaav30mpl";
+      name = "qtquickcontrols2-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtremoteobjects-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1yv9f2329nv4viiyqmq7ciz51574wd11grj8s88qm0ndcb36jbgb";
-      name = "qtremoteobjects-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtremoteobjects-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1d3jzsxfyjhgb6wj9iv1388bv7j6pi08346nmkm1c1a4iykhc0zp";
+      name = "qtremoteobjects-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtscript = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtscript-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0z6sb4b9ds5lwkr0sxrnx6nim3aq2qx4a8illjy5vclfdv80yhqw";
-      name = "qtscript-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtscript-everywhere-src-5.11.3.tar.xz";
+      sha256 = "027cvggbcvwyz76cn1bl1zvqg0nq7iica1b7yx7xyy0hb36g715v";
+      name = "qtscript-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtscxml-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0f1k4fnk2aydagxqvkb636pcsi17sbq2zj2fn0ad50dvq013yiph";
-      name = "qtscxml-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtscxml-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1mv8mz36v34dckrzy5r41mq3sqznbalrhndk3avz2154xmkjf5qk";
+      name = "qtscxml-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtsensors-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1yn065l6kzs3fn74950pkxxglqi55lzk7alf15klsd1wnxc0zsfb";
-      name = "qtsensors-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtsensors-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0n88c8xi9pbyh7q1pcqv4yjv6nx62abflj8qgfr4qzb0sp8m6mx7";
+      name = "qtsensors-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtserialbus-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0jjmdd6vkvs5izqazp1rsrad0b1fzk6knrbdjl37lvcsawyfxfyk";
-      name = "qtserialbus-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtserialbus-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0vf12jk1ma0v0dlpliw1x9i04iaik1kjkiaby7gaxm2abprxwr2n";
+      name = "qtserialbus-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtserialport-everywhere-src-5.11.1.tar.xz";
-      sha256 = "18v4pbq7bnmrl81m8s11ksbjlvzbb4kw5py6ji2dhmnm44w9k9sn";
-      name = "qtserialport-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtserialport-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1nkbfsxzgicwns3k11hhzjxy2hgrigj8xcw2by0jc1j71mnmxi4n";
+      name = "qtserialport-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtspeech-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1nwvbaijg35i98yaiqgnyn5vv0cn4v3wrxhwi1s0hfv9sv3q5iyw";
-      name = "qtspeech-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtspeech-everywhere-src-5.11.3.tar.xz";
+      sha256 = "158p7zqd0vg55gf88jzc3d4f7649ihh80k0m1q46m2yp6fpdjbxr";
+      name = "qtspeech-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtsvg-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0drhig0jcss3cf01aqfmafajf8gzf6bh468g1ikyrkh46czgyshx";
-      name = "qtsvg-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtsvg-everywhere-src-5.11.3.tar.xz";
+      sha256 = "14a4rprbj9f9rhixbk7143xdz34d7d39xh9v2sc1w43q9sf2rsi1";
+      name = "qtsvg-everywhere-src-5.11.3.tar.xz";
     };
   };
   qttools = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qttools-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1zhl8p29mbabf07rhaks13qcm45zdckzymvz9qn95nxfj9piiyxp";
-      name = "qttools-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qttools-everywhere-src-5.11.3.tar.xz";
+      sha256 = "13lzdxxi02yhvx4mflhisl6aqv2fiss5m804cqccd1wvp8dyh1f2";
+      name = "qttools-everywhere-src-5.11.3.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qttranslations-everywhere-src-5.11.1.tar.xz";
-      sha256 = "01kid5dc20jnzjmd4ycjmacrsmrw4hsh2s4y5k9y9p34z8m9pn0j";
-      name = "qttranslations-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qttranslations-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0j8i2kabz22vqb0qj41pkjv848zblqxs71sydc3xcd5av22b517s";
+      name = "qttranslations-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtvirtualkeyboard-everywhere-src-5.11.1.tar.xz";
-      sha256 = "16xzpdqn07z8j6f8iywy3967djap5bbi2myqp37s4xh9fz60scsv";
-      name = "qtvirtualkeyboard-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtvirtualkeyboard-everywhere-src-5.11.3.tar.xz";
+      sha256 = "17jb7cbfy5c19fr9frql6q22in3ra3a4fbff0kjykllxb8j40p4c";
+      name = "qtvirtualkeyboard-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwayland-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1sj4lsza48xji1qhmi1wqpx07jgm1mpa95gmd2w1kxw240hbr6p0";
-      name = "qtwayland-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwayland-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1chz4wchgkzd45h143i5hkqg0whcgdbj37gkg7j4kj31whllzjb2";
+      name = "qtwayland-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebchannel-everywhere-src-5.11.1.tar.xz";
-      sha256 = "11rfjkb4h8dzxfmk889x7kkc73cbk26smc7h62lnh35f2nppd95r";
-      name = "qtwebchannel-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwebchannel-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1wrdawlqvcw84h8q52mvbjhp1vkd6fhz6c8ijlg9rw0s3fj4y99w";
+      name = "qtwebchannel-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebengine-everywhere-src-5.11.1.tar.xz";
-      sha256 = "136lc2kw4af4bilgn7vn9hdckpk62xvyjb4kr0gc2firr919z79q";
-      name = "qtwebengine-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwebengine-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1zmqsdais85cdfh2jh8h4a5jcamp1mzdk3vgqm6xnldqf6nrxd2v";
+      name = "qtwebengine-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwebglplugin = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebglplugin-everywhere-src-5.11.1.tar.xz";
-      sha256 = "108yhi3sj6d1ysmlpka69ivb20mx9h6jpra6yq099i3jw4gc753x";
-      name = "qtwebglplugin-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwebglplugin-everywhere-src-5.11.3.tar.xz";
+      sha256 = "0wqz8lycmi7pffzy0pz5960w109lbk4mkbw0l1lh64avl6clq7b9";
+      name = "qtwebglplugin-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebsockets-everywhere-src-5.11.1.tar.xz";
-      sha256 = "1bj82y3f1nd2adnj3ljfr4vlx4bkgdlm3zvhlsas2lz837vi5aks";
-      name = "qtwebsockets-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwebsockets-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1ffmapfy68xwwbxbg19ng6b5h8v42cf78s21j7rgq49gm70r0402";
+      name = "qtwebsockets-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebview-everywhere-src-5.11.1.tar.xz";
-      sha256 = "18da6a13wpb23vb6mbg9v75gphdf5mjmch7q3v1qjrv2sdwbpjbp";
-      name = "qtwebview-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwebview-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1njmn1n03dp4md8cz58cq2z6bsxd8nwlw0238zmavh7px3jzc9kh";
+      name = "qtwebview-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwinextras-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0qxwfhg962a456lb9b6y7xhi6fvvvb42z0li6v7695vfbckifbzz";
-      name = "qtwinextras-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtwinextras-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1xf9gc0wqk9jz2ayx29vx0vmm72x9h4qxp2fvgpclns621wyhw72";
+      name = "qtwinextras-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtx11extras-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0rccpmhz48kq4xs441lj9mnwpbi6kxwl8y7dj7w7g5zvpv41kwmw";
-      name = "qtx11extras-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtx11extras-everywhere-src-5.11.3.tar.xz";
+      sha256 = "11fd2mc20qmnyv1vqhaqad2q6m0i4lmkr432rmqvpkgphpkfp7pr";
+      name = "qtx11extras-everywhere-src-5.11.3.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.11.1";
+    version = "5.11.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtxmlpatterns-everywhere-src-5.11.1.tar.xz";
-      sha256 = "0n5gacpni019i2872m4b1p5qaqibhszsdl3xhw3xsckvr0hf25v1";
-      name = "qtxmlpatterns-everywhere-src-5.11.1.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.3/submodules/qtxmlpatterns-everywhere-src-5.11.3.tar.xz";
+      sha256 = "1vhfvgi39miqsx3iq7c9sii2sykq0yfng69b70i0smr20zihpl4b";
+      name = "qtxmlpatterns-everywhere-src-5.11.3.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -26,7 +26,7 @@ existing packages here and modify it as necessary.
 
 {
   newScope,
-  stdenv, fetchurl, makeSetupHook,
+  stdenv, fetchurl, fetchpatch, makeSetupHook,
   bison, cups ? null, harfbuzz, libGL, perl,
   gstreamer, gst-plugins-base,
 
@@ -46,13 +46,62 @@ let
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
 
   patches = {
-    qtbase = [ ./qtbase.patch ./qtbase-fixguicmake.patch ];
+    qtbase = [
+      ./qtbase.patch
+      ./qtbase-fixguicmake.patch
+      (fetchpatch {
+        name = "CVE-2018-15518.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=28a6e642af2ccb454dd019f551c2908753f76f08";
+        sha256 = "0nyssg7d0br7qgzp481f1w8b4p1bj2ggv9iyfrm1mng5v9fypdd7";
+      })
+      (fetchpatch {
+        name = "CVE-2018-19873.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=patch;h=c9b9f663d7243988bcb5fee9180ea9cb3a321a86";
+        sha256 = "1q01cafy92c1j8cgrv4sk133mi3d48x8kbg3glbnnbijpc4k6di5";
+      })
+      (fetchpatch {
+        name = "CVE-2018-19870.patch";
+        url = "http://code.qt.io/cgit/qt/qtbase.git/patch/?id=ac0a910756f91726e03c0e6a89d213bdb4f48fec";
+        sha256 = "00qb9yqwvwnp202am3lqirkjxln1cj8v4wvmlyqya6hna176lj2l";
+      })
+    ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
     qtwebengine = [ ./qtwebengine-seccomp.patch ];
     qtwebkit = [ ./qtwebkit.patch ];
+    qtvirtualkeyboard = [
+      (fetchpatch {
+        name = "CVE-2018-19865-A.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtvirtualkeyboard.git;a=patch;h=c02115db1de1f3aba81e109043766d600f886522";
+        sha256 = "0ncnyl8f3ypi1kcb9z2i8j33snix111h28njrx8rb49ny01ap8x2";
+      })
+      (fetchpatch {
+        name = "CVE-2018-19865-B.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtvirtualkeyboard.git;a=patch;h=01fc537adc74d5e102c8cc93384cdf5cb08b4442";
+        sha256 = "19z8kxqf2lpjqr8189ingrpadch4niviw3p5v93zgx24v7950q27";
+      })
+      (fetchpatch {
+        name = "CVE-2018-19865-C.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtvirtualkeyboard.git;a=patch;h=993a21ba03534b172d5354405cc9d50a2a822e24";
+        sha256 = "1bipqxr9bvy8z402pv9kj2w1yzcsj1v03l09pg5jyg1xh6jbgiky";
+      })
+    ];
+    qtimageformats = [
+      (fetchpatch {
+        name = "CVE-2018-19871.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtimageformats.git;a=patch;h=9299ab07df61c56b70e047f1fe5f06b6ff541aa3";
+        sha256 = "0fd3mxdlc0s405j02bc0g72fvdfvpi31a837xfwf40m5j4jbyndr";
+      })
+    ];
+    qtsvg = [
+      (fetchpatch {
+        name = "CVE-2018-19869.patch";
+        url = "http://code.qt.io/cgit/qt/qtsvg.git/patch/?id=c5f1dd14098d1cc2cb52448fb44f53966d331443";
+        sha256 = "1kgyfsxw2f0qv5fx9y7wysjsvqikam0qc7wzhklf0406zz6rhxbl";
+      })
+    ];
   };
 
   mkDerivation =

--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -110,6 +110,7 @@ let
       /* qtwinextras = not packaged */
       qtx11extras = callPackage ../modules/qtx11extras.nix {};
       qtxmlpatterns = callPackage ../modules/qtxmlpatterns.nix {};
+      qtvirtualkeyboard = callPackage ../modules/qtvirtualkeyboard.nix {};
 
       env = callPackage ../qt-env.nix {};
       full = env "qt-full-${qtbase.version}" [

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -17,7 +17,7 @@ top-level attribute to `top-level/all-packages.nix`.
 
 {
   newScope,
-  stdenv, fetchurl, makeSetupHook,
+  stdenv, fetchurl, fetchpatch, makeSetupHook,
   bison, cups ? null, harfbuzz, libGL, perl,
   gstreamer, gst-plugins-base, gtk3, dconf,
   cf-private,
@@ -44,6 +44,25 @@ let
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
     qtwebkit = [ ./qtwebkit.patch ];
+    qtvirtualkeyboard = [
+      (fetchpatch {
+        name = "CVE-2018-19865-A.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtvirtualkeyboard.git;a=patch;h=61780a113f02b3c62fb14516fe8ea47d91f9ed9a";
+        sha256 = "0jd4nzaz9ndm9ryvrkav7kjs437l661288diklhbmgh249f8gki0";
+      })
+      (fetchpatch {
+        name = "CVE-2018-19865-B.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtvirtualkeyboard.git;a=patch;h=c0ac7a4c684e2fed60a72ceee53da89eea3f95a7";
+        sha256 = "0yvxrx5vx6845vgnq8ml3q93y61py5j0bvhqj7nqvpbmyj1wy1p3";
+
+      })
+      (fetchpatch {
+        name = "CVE-2018-19865-C.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtvirtualkeyboard.git;a=patch;h=a2e7b8412f56841e12ed20a39f4a38e32d3c1e30";
+        sha256 = "1yijysa9gy5xbxndx5ri0dkfrjqja0d1bsx52qz4mhzi4pkbib02";
+      })
+    ];
+
   };
 
   mkDerivation =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12066,7 +12066,7 @@ in
   qt56 = recurseIntoAttrs (makeOverridable
     (import ../development/libraries/qt-5/5.6) {
       inherit newScope;
-      inherit stdenv fetchurl makeSetupHook;
+      inherit stdenv fetchurl fetchpatch makeSetupHook;
       bison = bison2; # error: too few arguments to function 'int yylex(...
       inherit cups;
       harfbuzz = harfbuzzFull;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12080,7 +12080,7 @@ in
   qt59 = recurseIntoAttrs (makeOverridable
     (import ../development/libraries/qt-5/5.9) {
       inherit newScope;
-      inherit stdenv fetchurl makeSetupHook;
+      inherit stdenv fetchurl fetchpatch makeSetupHook;
       bison = bison2; # error: too few arguments to function 'int yylex(...
       inherit cups;
       harfbuzz = harfbuzzFull;


### PR DESCRIPTION
###### Motivation for this change

I recently became aware of a few things in various Qt versions that we ship that we should address:

 * CVE-2018-15518, Qt Base: “double free or corruption” in QXmlStreamReader
 * CVE-2018-19873, Qt Base: QBmpHandler segfault on malformed BMP file
 * CVE-2018-19870, Qt Base: Check for QImage allocation failure in qgifhandler
 * CVE-2018-19871, Qt Imageformats: QImage: QTgaFile CPU exhaustion
 * CVE-2018-19865, Qt Virtual Keyboard: Qt Virtual Keyboard logs all key presses
 * CVE-2018-19869, Qt Svg: Fix crash when parsing malformed url reference

More details can be obtained from the Qt annoucement [1].

[1] https://blog.qt.io/blog/2018/12/04/qt-5-11-3-released-important-security-updates


cc maintainers @qknight @ttuegel @periklis @bkchr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

