### PR TITLE
percona-server56: 5.6.35-80.0 -> 5.6.43-84.3

### DIFF
--- a/pkgs/servers/sql/percona/5.6.x.nix
+++ b/pkgs/servers/sql/percona/5.6.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "percona-server-${version}";
-  version = "5.6.35-80.0";
+  version = "5.6.43-84.3";
 
   src = fetchurl {
     url = "https://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-${version}/source/tarball/percona-server-${version}.tar.gz";
-    sha256 = "0szjywx902da09pg8yqj8l2acplmh69hn5smrk45i291qsi5m6r5";
+    sha256 = "1cc0lfmpq4pw90bcsszsygw06vd4j4bh3ph5x0yn3z7wddvmjlpw";
   };
 
   buildInputs = [ cmake bison ncurses openssl zlib libaio perl ];
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
     rm -r $out/mysql-test $out/sql-bench $out/data "$out"/lib/*.a
-    rm $out/share/man/man1/mysql-test-run.pl.1
   '';
 
   passthru.mysqlVersion = "5.6";
@@ -57,6 +56,5 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2;
     maintainers = with maintainers; [ grahamc ];
-    broken = true; # 2018-04-11
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update and unbreak package. Tested by setting `services.mysql.package = pkgs.percona-server56` in `nixos/tests/mysql.nix` (and increasing `virtualisation.memorySize`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

