### PR TITLE
taffybar: Remove strictDeps and restore overrideAttrs

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -153,9 +153,6 @@ self: super: builtins.intersectAttrs super {
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
   gtk-traymanager = addPkgconfigDepend super.gtk-traymanager pkgs.gtk3;
 
-  # Add necessary reference to gtk3 package, plus specify needed dbus version, plus turn on strictDeps to fix build
-  taffybar = ((addPkgconfigDepend super.taffybar pkgs.gtk3).overrideDerivation (drv: { strictDeps = true; }));
-
   # Add necessary reference to gtk3 package
   gi-dbusmenugtk3 = addPkgconfigDepend super.gi-dbusmenugtk3 pkgs.gtk3;
 


### PR DESCRIPTION
###### Motivation for this change
Get rid of now-unnecessary overrides for strictDeps and pkgconfig gtk3, restoring overrideAttrs.

taffybar still does not compile because the current Hackage release does not support `gi-gdkpixbuf > 0.16` but should be fine with the next release, eg. this overlay builds, or one that downgrades gi-gdkpixbuf:

```
  haskellPackages = with self.haskell.lib; super.haskellPackages.extend (hself: hsuper: {
    # Supports gi-gdkpixbuf 2.0.18
    taffybar = if !(hsuper.taffybar.version == "3.1.1")
    then "taffybar overlay out of date"
    else (
      hsuper.taffybar.overrideAttrs (oa : {
        src = self.fetchFromGitHub {
          owner = "taffybar";
          repo = "taffybar";
          rev = "e382599358bb06383ba4b08d469fc093c11f5915";
          sha256 = "0qncwpfz0v2b6nbdf7qgzl93kb30yxznkfk49awrz8ms3pq6vq6g";
        };
      })
    );
  });
```

cc @puffnfresh so you can confirm that it's safe to get rid of strictDeps now. :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

