### PR TITLE
sc2-headless: 3.17 -> 4.7.1

### DIFF
--- a/pkgs/applications/science/machine-learning/sc2-headless/default.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/default.nix
@@ -14,12 +14,12 @@ if !licenseAccepted then throw ''
 else assert licenseAccepted;
 let maps = callPackage ./maps.nix {};
 in stdenv.mkDerivation rec {
-  version = "3.17";
+  version = "4.7.1";
   name = "sc2-headless-${version}";
 
   src = fetchurl {
     url = "https://blzdistsc2-a.akamaihd.net/Linux/SC2.${version}.zip";
-    sha256 = "1biyxpf7n95hali1pw30h91rhzrj6sbwrx6s52d00mlnwdhmf2v0";
+    sha256 = "0q1ry9bd3dm8y4hvh57yfq7s05hl2k2sxi2wsl6h0r3w690v1kdd";
   };
 
   unpackCmd = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #54964

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).