### PR TITLE
llvm: support overriding experimental targets

### DIFF
--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -15,6 +15,7 @@
 , enableManpages ? false
 # Mesa requires AMDGPU target
 , enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform "AMDGPU" ]
+, enableExperimentalTargets ? [ "WebAssembly" ]
 , enableSharedLibraries ? true
 }:
 
@@ -94,7 +95,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
     "-DLLVM_TARGETS_TO_BUILD=${llvmBackendList enableTargets}"
-    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
+    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=${llvmBackendList enableExperimentalTargets}"
     "-DLLVM_ENABLE_DUMP=ON"
   ] ++ optionals enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -16,6 +16,7 @@
 , enableSharedLibraries ? true
 # Mesa requires AMDGPU target
 , enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform "AMDGPU" ]
+, enableExperimentalTargets ? [ "WebAssembly" ]
 , enablePFM ? !stdenv.isDarwin
 }:
 
@@ -89,7 +90,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
     "-DLLVM_TARGETS_TO_BUILD=${llvmBackendList enableTargets}"
-    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
+    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=${llvmBackendList enableExperimentalTargets}"
     "-DLLVM_ENABLE_DUMP=ON"
   ] ++ optionals enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"


### PR DESCRIPTION
###### Motivation for this change
Allow building LLVM with support for experimental targets and RISC-V in particular.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

