### PR TITLE
llvm7: replace patch with official upstream commit

### DIFF
--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -49,9 +49,10 @@ in stdenv.mkDerivation (rec {
 
   patches = [
     # https://bugs.llvm.org/show_bug.cgi?id=39427
+    # https://github.com/NixOS/nixpkgs/issues/54370
     (fetchpatch {
-      url = "https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/raw/5a7d283d4e00bc4822c7b0226e593c344c8f6050/debian/patches/pr39427-misscompile.diff";
-      sha256 = "03mpydsaw0xvcp7kb4sgjzcl5v22620r5z78kv3mz5wp7sn76fg5";
+      url = "https://github.com/llvm-mirror/llvm/commit/57567def148f387153a8149fb590bd39b1b006a1.patch";
+      sha256 = "1w1xg5pxpc6cals1nf5j5k4p6qi8lcrpvn0paxc86m415i79xmcg";
     })
     # backport, fix building rust crates with lto
     (fetchpatch {


### PR DESCRIPTION
Hopefully this also addresses any problems enountered
with the patch used previously.

###### Motivation for this change

cc #54370
(although this may not fix everything, should fix Optional error)

Same goal as #54122, but uses upstream commit instead of patch from
Debian (which I believe matches upstream's first attempt to fix this as
well).

Basically this was tricky to get right on all compilers,
thankfully it seems to have been sorted out.

Fingers crossed :).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---