### PR TITLE
firefoxPackages: add icecat, update tor-browser, misc cleanups

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -88,13 +88,20 @@ let
   browserVersion = if isIceCatLike then icversion
                    else if isTorBrowserLike then tbversion
                    else ffversion;
+
+  browserPatches = [
+    ./env_var_for_system_dir.patch
+  ] ++ patches;
+
 in
 
 stdenv.mkDerivation rec {
   name = "${pname}-unwrapped-${version}";
   version = browserVersion;
 
-  inherit src unpackPhase patches meta;
+  inherit src unpackPhase meta;
+
+  patches = browserPatches;
 
   # Ignore trivial whitespace changes in patches, this fixes compatibility of
   # ./env_var_for_system_dir.patch with Firefox >=65 without having to track

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,6 +1,7 @@
 { pname, ffversion, meta, updateScript ? null
 , src, unpackPhase ? null, patches ? []
 , extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? []
+, isIceCatLike ? false, icversion ? null
 , isTorBrowserLike ? false, tbversion ? null }:
 
 { lib, stdenv, pkgconfig, pango, perl, python2, zip, libIDL
@@ -25,7 +26,7 @@
 
 ## privacy-related options
 
-, privacySupport ? isTorBrowserLike
+, privacySupport ? isTorBrowserLike || isIceCatLike
 
 # WARNING: NEVER set any of the options below to `true` by default.
 # Set to `privacySupport` or `false`.
@@ -75,15 +76,23 @@ let
   default-toolkit = if stdenv.isDarwin then "cairo-cocoa"
                     else "cairo-gtk${if gtk3Support then "3" else "2"}";
 
+  binaryName = if isIceCatLike then "icecat" else "firefox";
+  binaryNameCapitalized = lib.toUpper (lib.substring 0 1 binaryName) + lib.substring 1 (-1) binaryName;
+
+  browserName = if stdenv.isDarwin then binaryNameCapitalized else binaryName;
+
   execdir = if stdenv.isDarwin
-            then "/Applications/${browserName}.app/Contents/MacOS"
+            then "/Applications/${binaryNameCapitalized}.app/Contents/MacOS"
             else "/bin";
-  browserName = if stdenv.isDarwin then "Firefox" else "firefox";
+
+  browserVersion = if isIceCatLike then icversion
+                   else if isTorBrowserLike then tbversion
+                   else ffversion;
 in
 
 stdenv.mkDerivation rec {
   name = "${pname}-unwrapped-${version}";
-  version = if !isTorBrowserLike then ffversion else tbversion;
+  version = browserVersion;
 
   inherit src unpackPhase patches meta;
 
@@ -270,22 +279,22 @@ stdenv.mkDerivation rec {
 
   installPhase = if stdenv.isDarwin then ''
     mkdir -p $out/Applications
-    cp -LR dist/Firefox.app $out/Applications
+    cp -LR dist/${binaryNameCapitalized}.app $out/Applications
   '' else null;
 
   postInstall = lib.optionalString stdenv.isLinux ''
     # Remove SDK cruft. FIXME: move to a separate output?
-    rm -rf $out/share/idl $out/include $out/lib/firefox-devel-*
+    rm -rf $out/share/idl $out/include $out/lib/${binaryName}-devel-*
 
     # Needed to find Mozilla runtime
-    gappsWrapperArgs+=(--argv0 "$out/bin/.firefox-wrapped")
+    gappsWrapperArgs+=(--argv0 "$out/bin/.${binaryName}-wrapped")
   '';
 
   postFixup = lib.optionalString stdenv.isLinux ''
     # Fix notifications. LibXUL uses dlopen for this, unfortunately; see #18712.
     patchelf --set-rpath "${lib.getLib libnotify
-      }/lib:$(patchelf --print-rpath "$out"/lib/firefox*/libxul.so)" \
-        "$out"/lib/firefox*/libxul.so
+      }/lib:$(patchelf --print-rpath "$out"/lib/${binaryName}*/libxul.so)" \
+        "$out"/lib/${binaryName}*/libxul.so
   '';
 
   doInstallCheck = true;
@@ -297,6 +306,7 @@ stdenv.mkDerivation rec {
   passthru = {
     inherit version updateScript;
     isFirefox3Like = true;
+    inherit isIceCatLike;
     inherit isTorBrowserLike;
     gtk = gtk2;
     inherit nspr;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -4,10 +4,6 @@ let
 
   common = opts: callPackage (import ./common.nix opts) {};
 
-  nixpkgsPatches = [
-    ./env_var_for_system_dir.patch
-  ];
-
 in
 
 rec {
@@ -20,7 +16,7 @@ rec {
       sha512 = "39bx76whgf53rkfqqy8gfhd44wikh89zpnqr930v4grqg3v0pfr8mbvp7xzjjlf5r7bski0wxibn9vyyy273fp99zyj1w2m5ihh9aqh";
     };
 
-    patches = nixpkgsPatches ++ [
+    patches = [
       ./no-buildconfig-ffx65.patch
     ];
 
@@ -52,7 +48,7 @@ rec {
       sha512 = "bfca42668ca78a12a9fb56368f4aae5334b1f7a71966fbba4c32b9c5e6597aac79a6e340ac3966779d2d5563eb47c054ab33cc40bfb7306172138ccbd3adb2b9";
     };
 
-    patches = nixpkgsPatches ++ [
+    patches = [
       # this one is actually an omnipresent bug
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519
       ./fix-pa-context-connect-retval.patch
@@ -77,7 +73,7 @@ rec {
       sha512 = "3n7l146gdjwhi0iq85awc0yykvi4x5m91mcylxa5mrq911bv6xgn2i92nzhgnhdilqap5218778vgvnalikzsh67irrncx1hy5f6iyx";
     };
 
-    patches = nixpkgsPatches ++ [
+    patches = [
       ./no-buildconfig-ffx65.patch
 
       # this one is actually an omnipresent bug
@@ -146,7 +142,7 @@ in rec {
       sha256 = "0icnl64nxcyf7dprpdpygxhabsvyhps8c3ixysj9bcdlj9q34ib1";
     };
 
-    patches = nixpkgsPatches ++ [
+    patches = [
       ./no-buildconfig.patch
     ];
   };
@@ -161,7 +157,7 @@ in rec {
       sha256 = "09fn54glqg1aa93hnz5zdcy07cps09dbni2b4200azh6nang630a";
     };
 
-    patches = nixpkgsPatches ++ [
+    patches = [
       # this one is actually an omnipresent bug
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519
       ./fix-pa-context-connect-retval.patch
@@ -186,8 +182,6 @@ in rec {
       # set times for xpi archives
       find . -exec touch -d'2010-01-01 00:00' {} \;
     '';
-
-    patches = nixpkgsPatches;
 
     meta = (args.meta or {}) // {
       description = "A web browser built from TorBrowser source tree";

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -218,9 +218,9 @@ in rec {
         Or just use `tor-browser-bundle` package that packs this
         `tor-browser` back into a sanely-built bundle.
       '';
-      homepage = https://www.torproject.org/projects/torbrowser.html;
-      platforms = lib.platforms.linux;
-      license = lib.licenses.bsd3;
+      homepage = "https://www.torproject.org/projects/torbrowser.html";
+      platforms = lib.platforms.unix;
+      license = with lib.licenses; [ mpl20 bsd3 ];
     };
   });
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -237,16 +237,16 @@ in rec {
   };
 
   tor-browser-8-0 = tbcommon rec {
-    ffversion = "60.3.0esr";
-    tbversion = "8.0.3";
+    ffversion = "60.4.0esr";
+    tbversion = "8.0.4";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-60.3.0esr-8.0-1-slnos"
-      rev   = "bd512ad9c40069adfc983f4f03dbd9d220cdf2f9";
-      sha256 = "1j349aqiqrf58zrx8pkqvh292w41v1vwr7x7dmd74hq4pi2iwpn8";
+      # branch "tor-browser-60.4.0esr-8.0-1-slnos"
+      rev   = "69b3852b8dfae74eec0ba2a88f7a4287d6f77446";
+      sha256 = "0v6c020lhncnhrwpm4frnpzclwaw7pvfm1z2n8xszxdy4i0dppxd";
     };
   };
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -237,16 +237,16 @@ in rec {
   };
 
   tor-browser-8-0 = tbcommon rec {
-    ffversion = "60.4.0esr";
-    tbversion = "8.0.4";
+    ffversion = "60.5.0esr";
+    tbversion = "8.0.5";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-60.4.0esr-8.0-1-slnos"
-      rev   = "69b3852b8dfae74eec0ba2a88f7a4287d6f77446";
-      sha256 = "0v6c020lhncnhrwpm4frnpzclwaw7pvfm1z2n8xszxdy4i0dppxd";
+      # branch "tor-browser-60.5.0esr-8.0-1-slnos"
+      rev   = "7f113a4ea0539bd2ea9687fe4296c880f2b006c4";
+      sha256 = "11qbhwy2q9rinfw8337b9f78x0r26lnxg25581z85vxshp2jszdq";
     };
   };
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -39,6 +39,11 @@ rec {
     };
   };
 
+  # Do not remove. This is the last version of Firefox that supports
+  # the old plugins. While this package is unsafe to use for browsing
+  # the web, there are many old useful plugins targeting offline
+  # activities (e.g. ebook readers, syncronous translation, etc) that
+  # will probably never be ported to WebExtensions API.
   firefox-esr-52 = common rec {
     pname = "firefox-esr";
     ffversion = "52.9.0esr";
@@ -146,6 +151,7 @@ in rec {
     ];
   };
 
+  # Similarly to firefox-esr-52 above.
   icecat-52 = iccommon rec {
     ffversion = "52.6.0";
     icversion = "${ffversion}-gnu1";

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -92,6 +92,80 @@ rec {
 
 } // (let
 
+  iccommon = args: common (args // {
+    pname = "icecat";
+    isIceCatLike = true;
+
+    meta = (args.meta or {}) // {
+      description = "The GNU version of the Firefox web browser";
+      longDescription = ''
+        GNUzilla is the GNU version of the Mozilla suite, and GNU
+        IceCat is the GNU version of the Firefox web browser.
+
+        Notable differences from mainline Firefox:
+
+        - entirely free software, no non-free plugins, addons,
+          artwork,
+        - no telemetry, no "studies",
+        - sane privacy and security defaults (for instance, unlike
+          Firefox, IceCat does _zero_ network requests on startup by
+          default, which means that with IceCat you won't need to
+          unplug your Ethernet cable each time you want to create a
+          new browser profile without announcing that action to a
+          bunch of data-hungry corporations),
+        - all essential privacy and security settings can be
+          configured directly from the main screen,
+        - optional first party isolation (like TorBrowser),
+        - comes with HTTPS Everywhere (like TorBrowser), Tor Browser
+          Button (like TorBrowser Bundle), LibreJS, and SpyBlock
+          plugins out of the box.
+
+        This package can be installed together with Firefox and
+        TorBrowser, it will use distinct binary names and profile
+        directories.
+      '';
+      homepage = "https://www.gnu.org/software/gnuzilla/";
+      platforms = lib.platforms.unix;
+      license = with lib.licenses; [ mpl20 gpl3Plus ];
+    };
+  });
+
+in rec {
+
+  icecat = iccommon rec {
+    ffversion = "60.3.0";
+    icversion = "${ffversion}-gnu1";
+
+    src = fetchurl {
+      url = "mirror://gnu/gnuzilla/${ffversion}/icecat-${icversion}.tar.bz2";
+      sha256 = "0icnl64nxcyf7dprpdpygxhabsvyhps8c3ixysj9bcdlj9q34ib1";
+    };
+
+    patches = nixpkgsPatches ++ [
+      ./no-buildconfig.patch
+    ];
+  };
+
+  icecat-52 = iccommon rec {
+    ffversion = "52.6.0";
+    icversion = "${ffversion}-gnu1";
+
+    src = fetchurl {
+      url = "mirror://gnu/gnuzilla/${ffversion}/icecat-${icversion}.tar.bz2";
+      sha256 = "09fn54glqg1aa93hnz5zdcy07cps09dbni2b4200azh6nang630a";
+    };
+
+    patches = nixpkgsPatches ++ [
+      # this one is actually an omnipresent bug
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519
+      ./fix-pa-context-connect-retval.patch
+    ];
+
+    meta.knownVulnerabilities = [ "Support ended in August 2018." ];
+  };
+
+}) // (let
+
   tbcommon = args: common (args // {
     pname = "tor-browser";
     isTorBrowserLike = true;
@@ -109,7 +183,7 @@ rec {
 
     patches = nixpkgsPatches;
 
-    meta = {
+    meta = (args.meta or {}) // {
       description = "A web browser built from TorBrowser source tree";
       longDescription = ''
         This is a version of TorBrowser with bundle-related patches

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17180,11 +17180,13 @@ in
   firefox-esr-52-unwrapped = firefoxPackages.firefox-esr-52;
   firefox-esr-60-unwrapped = firefoxPackages.firefox-esr-60;
   tor-browser-unwrapped = firefoxPackages.tor-browser;
+  icecat-unwrapped = firefoxPackages.icecat;
 
   firefox = wrapFirefox firefox-unwrapped { };
   firefox-esr-52 = wrapFirefox firefox-esr-52-unwrapped { };
   firefox-esr-60 = wrapFirefox firefox-esr-60-unwrapped { };
   firefox-esr = firefox-esr-60;
+  icecat = wrapFirefox icecat-unwrapped { };
 
   firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
     channel = "release";


### PR DESCRIPTION
# `git log`

- firefoxPackages.icecat: init at 60.3.0, 52.6.0

  It works, but this state is far from ideal: GNU guys update generated source
  tarballs very infrequently. Ideally, src needs to be generated by running
  makeicecat over firefox src. Will do later.

- firefoxPackages.tor-browser: 8.0.3 -> 8.0.4
- firefoxPackages.tor-browser: 8.0.4 -> 8.0.5
- firefoxPackages: add a comments explaining the purpose of older versions
- firefoxPackages.tor-browser: fix meta
- firefoxPackages: move nixpkgsPatches into common.nix

# Environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP`

- On x86_64-linux:
  New (2):
    - firefoxPackages.icecat
    - icecat
  Updated (2):
    - firefoxPackages.tor-browser
    - tor-browser-bundle

- On aarch64-linux:
  New (2):
    - firefoxPackages.icecat
    - icecat
  Updated (1):
    - firefoxPackages.tor-browser

- On x86_64-darwin:
  New (4):
    - firefoxPackages.icecat
    - firefoxPackages.tor-browser-7-5
    - firefoxPackages.tor-browser
    - icecat

# Things done

- [X] Built everything on x86_64-linux before rebasing to nixpkgs master

Note this also tries to enable `tor-browser` build on Darwin (because firefox has it enabled, so maybe it will work :]).

/cc @joachifm