### PR TITLE
spideroak: 7.1.0 -> 7.3.0

### DIFF
--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -5,15 +5,12 @@
 
 let
   arch = if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
-    else if stdenv.hostPlatform.system == "i686-linux" then "x86"
     else throw "Spideroak client for: ${stdenv.hostPlatform.system} not supported!";
 
   interpreter = if stdenv.hostPlatform.system == "x86_64-linux" then "ld-linux-x86-64.so.2"
-    else if stdenv.hostPlatform.system == "i686-linux" then "ld-linux.so.2"
     else throw "Spideroak client for: ${stdenv.hostPlatform.system} not supported!";
 
-  sha256 = if stdenv.hostPlatform.system == "x86_64-linux" then "a88e5a8fe4a565ac500668bd53cf5784752d7c9253304ddce39ee7b01d078533"
-    else if stdenv.hostPlatform.system == "i686-linux" then "668f3b83a974a3877d16c8743c233a427ea0a44ab84b7f9aec19a2995db66c16"
+  sha256 = if stdenv.hostPlatform.system == "x86_64-linux" then "a54f2fd298a673602e9583b8f65d165b3e14b0645a27049e4a269074a00f5793"
     else throw "Spideroak client for: ${stdenv.hostPlatform.system} not supported!";
 
   ldpath = stdenv.lib.makeLibraryPath [
@@ -21,7 +18,7 @@ let
     libX11 libXext libXrender zlib
   ];
 
-  version = "7.1.0";
+  version = "7.3.0";
 
 in stdenv.mkDerivation {
   name = "spideroak-${version}";


### PR DESCRIPTION
###### Motivation for this change
A few new versions of SpiderOak have been released.

###### Things done
This bumps the version and removes 32 bit support, since it is no longer supported upstream for Linux.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
