### PR TITLE
WIP: Init mayavi at 4.6.1

### DIFF
--- a/pkgs/development/python-modules/apptools/default.nix
+++ b/pkgs/development/python-modules/apptools/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, traits, traitsui, configobj
+, nose, tables, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "apptools";
+  version = "4.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dw6vvq7lqkj7mgn3s7r5hs937kl4mj5g7jf2qgvhdld9lsc5xbk";
+  };
+
+  propagatedBuildInputs = [ traits traitsui configobj ];
+
+  checkInputs = [
+    nose
+    tables
+    pandas
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Set of packages that Enthought has found useful in creating a number of applications.";
+    homepage = https://github.com/enthought/apptools;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    license = licenses.bsdOriginal;
+  };
+}

--- a/pkgs/development/python-modules/envisage/default.nix
+++ b/pkgs/development/python-modules/envisage/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, traits, apptools
+, ipykernel
+}:
+
+buildPythonPackage rec {
+  pname = "envisage";
+  version = "4.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jb5nw0w9x97jij0hd3d7kfzcj58r1cqmplmdy56bj11dyc4wyc9";
+  };
+
+  propagatedBuildInputs = [ traits apptools ];
+
+  preCheck = ''
+    export HOME=$PWD/HOME
+  '';
+
+  checkInputs = [
+    ipykernel
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Framework for building applications whose functionalities can be extended by adding 'plug-ins'";
+    homepage = https://github.com/enthought/envisage;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    license = licenses.bsdOriginal;
+  };
+}

--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, wxPython, pygments, numpy, vtk, traitsui, envisage, apptools
+, nose, mock
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "mayavi";
+  version = "4.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "tar.bz2";
+    sha256 = "02rg4j1vkny2piqn3f728kg34m54kgx396g6h5y7ykz2lk3f3h44";
+  };
+
+  # Discovery of 'vtk' in setuptools is not working properly, due to a missing
+  # .egg-info in the vtk package. It does however import and run just fine.
+  postPatch = ''
+    substituteInPlace mayavi/__init__.py --replace "'vtk'" ""
+  '';
+
+  propagatedBuildInputs = [ wxPython pygments numpy vtk traitsui envisage apptools ];
+
+  checkInputs = [ nose mock ];
+
+  disabled = isPy3k; # TODO: This would need pyqt5 instead of wxPython
+
+  doCheck = false; # Needs X server
+
+  meta = with stdenv.lib; {
+    description = "3D visualization of scientific data in Python";
+    homepage = https://github.com/enthought/mayavi;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    license = licenses.bsdOriginal;
+  };
+}

--- a/pkgs/development/python-modules/pyface/default.nix
+++ b/pkgs/development/python-modules/pyface/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, setuptools, six, traits, wxPython
+}:
+
+buildPythonPackage rec {
+  pname = "pyface";
+  version = "6.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q5rihmhcdyyp44p31f5l4a0mc9m3293rvcnma5p8w0v8j7dbrm7";
+  };
+
+  propagatedBuildInputs = [ setuptools six traits wxPython ];
+
+  doCheck = false; # Needs X server
+
+  meta = with stdenv.lib; {
+    description = "Traits-capable windowing framework";
+    homepage = https://github.com/enthought/pyface;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    license = licenses.bsdOriginal;
+  };
+}

--- a/pkgs/development/python-modules/traitsui/default.nix
+++ b/pkgs/development/python-modules/traitsui/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, traits, pyface, wxPython
+}:
+
+buildPythonPackage rec {
+  pname = "traitsui";
+  version = "6.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "080fq9hag7hvcnsd5c5fn74zjmjl6rjq40r0zwdz2bjlk9049xpi";
+  };
+
+  propagatedBuildInputs = [ traits pyface wxPython ];
+
+  doCheck = false; # Needs X server
+
+  meta = with stdenv.lib; {
+    description = "Traits-capable windowing framework";
+    homepage = https://github.com/enthought/traitsui;
+    maintainers = with stdenv.lib.maintainers; [ knedlsepp ];
+    license = licenses.bsdOriginal;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2402,6 +2402,8 @@ in {
 
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
+  envisage = callPackage ../development/python-modules/envisage { };
+
   enzyme = callPackage ../development/python-modules/enzyme {};
 
   escapism = callPackage ../development/python-modules/escapism { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4610,6 +4610,8 @@ in {
 
   pyext = callPackage ../development/python-modules/pyext { };
 
+  pyface = callPackage ../development/python-modules/pyface { };
+
   pyfantom = callPackage ../development/python-modules/pyfantom { };
 
   pyfma = callPackage ../development/python-modules/pyfma { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6337,6 +6337,11 @@ in {
 
   visitor = callPackage ../development/python-modules/visitor { };
 
+  vtk = toPythonModule (pkgs.vtk.override {
+    inherit (self) python;
+    enablePython = true;
+  });
+
   whitenoise = callPackage ../development/python-modules/whitenoise { };
 
   XlsxWriter = callPackage ../development/python-modules/XlsxWriter { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1501,6 +1501,8 @@ in {
 
   approvaltests = callPackage ../development/python-modules/approvaltests { };
 
+  apptools = callPackage ../development/python-modules/apptools {};
+
   apsw = callPackage ../development/python-modules/apsw {};
 
   astor = callPackage ../development/python-modules/astor {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5837,6 +5837,8 @@ in {
 
   tracing = callPackage ../development/python-modules/tracing { };
 
+  traitsui = callPackage ../development/python-modules/traitsui { };
+
   translationstring = callPackage ../development/python-modules/translationstring { };
 
   ttystatus = callPackage ../development/python-modules/ttystatus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3928,6 +3928,8 @@ in {
 
   maya = callPackage ../development/python-modules/maya { };
 
+  mayavi = callPackage ../development/python-modules/mayavi { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mechanize = callPackage ../development/python-modules/mechanize { };


### PR DESCRIPTION
###### Motivation for this change
This adds the mayavi package. I originally based this on a commit in June 2018 (1d1a4bfb392c7d5d2ca5e0ccd66624b7c9f3aa7e), where the mayavi GUI worked. When I rebased it onto current master, something did break, which now leads to a segmentation fault.

Help is very much appreciated.

Edit:
The segfault seems to be due to some environment impurity (QT maybe?), since it runs fine when inside a `nix-shell -I nixpkgs=$PWD -p python2Packages.mayavi --pure`,
Could probably be fixed via: #54525


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

