### PR TITLE
roundcube: add support for third-party plugins

### DIFF
--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -10,6 +10,8 @@ import ./make-test.nix ({ pkgs, ...} : {
         enable = true;
         hostName = "roundcube";
         database.password = "notproduction";
+        package = pkgs.roundcube.withPlugins (plugins: [ plugins.persistent_login ]);
+        plugins = [ "persistent_login" ];
       };
       services.nginx.virtualHosts.roundcube = {
         forceSSL = false;
@@ -23,6 +25,6 @@ import ./make-test.nix ({ pkgs, ...} : {
     $roundcube->waitForUnit("postgresql.service");
     $roundcube->waitForUnit("phpfpm-roundcube.service");
     $roundcube->waitForUnit("nginx.service");
-    $roundcube->succeed("curl -sSfL http://roundcube/");
+    $roundcube->succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'");
   '';
 })

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip }:
+{ lib, stdenv, fetchzip, buildEnv, roundcube, roundcubePlugins }:
 let
   version = "1.3.8";
 in
@@ -13,6 +13,11 @@ fetchzip rec {
     rm -rf $out/installer
   '';
 
+  passthru.withPlugins = f: buildEnv {
+    name = "${roundcube.name}-with-plugins";
+    paths = (f roundcubePlugins) ++ [ roundcube ];
+  };
+
   meta = {
     description = "Open Source Webmail Software";
     maintainers = with stdenv.lib.maintainers; [ vskilet ];
@@ -20,4 +25,3 @@ fetchzip rec {
     platforms = stdenv.lib.platforms.all;
   };
 }
-

--- a/pkgs/servers/roundcube/plugins/default.nix
+++ b/pkgs/servers/roundcube/plugins/default.nix
@@ -1,0 +1,11 @@
+{ newScope, pkgs }:
+
+let
+
+  callPackage = newScope (pkgs // plugins);
+
+  plugins = import ./plugins.nix { inherit callPackage; };
+
+in
+
+  plugins

--- a/pkgs/servers/roundcube/plugins/persistent_login/default.nix
+++ b/pkgs/servers/roundcube/plugins/persistent_login/default.nix
@@ -1,0 +1,13 @@
+{ roundcubePlugin, fetchFromGitHub }:
+
+roundcubePlugin rec {
+  pname = "persistent_login";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mfreiholz";
+    repo = pname;
+    rev = "version-${version}";
+    sha256 = "1k2jgbshwig8q5l440y59pgwbfbc0pdrjbpihba834a4pm0y6anl";
+  };
+}

--- a/pkgs/servers/roundcube/plugins/plugins.nix
+++ b/pkgs/servers/roundcube/plugins/plugins.nix
@@ -1,0 +1,9 @@
+{ callPackage }:
+
+{
+  inherit callPackage;
+
+  roundcubePlugin = callPackage ./roundcube-plugin.nix { };
+
+  persistent_login = callPackage ./persistent_login { };
+}

--- a/pkgs/servers/roundcube/plugins/roundcube-plugin.nix
+++ b/pkgs/servers/roundcube/plugins/roundcube-plugin.nix
@@ -1,0 +1,7 @@
+{ runCommand }:
+{ pname, version, src }:
+
+runCommand "roundcube-plugin-${pname}-${version}" { } ''
+  mkdir -p $out/plugins/
+  cp -r ${src} $out/plugins/${pname}
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1613,6 +1613,8 @@ in
 
   roundcube = callPackage ../servers/roundcube { };
 
+  roundcubePlugins = callPackage ../servers/roundcube/plugins { };
+
   rsbep = callPackage ../tools/backup/rsbep { };
 
   rsyslog = callPackage ../tools/system/rsyslog {


### PR DESCRIPTION
###### Motivation for this change

This aims to support roundcube with third-party plugins. Those plugins should be listed in the meta-package `roundcubePlugins` and can be added to the roundcube using `roundcube.withPlugins`.

I also packaged the `persistent_login` plugin to support a remember me checkbox in roundcube.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

