### PR TITLE
thunderbird: clean up, make flags closer to default, official branding

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -1,28 +1,40 @@
-{ lib, stdenv, fetchurl, pkgconfig, gtk2, pango, perl, python, zip, fetchpatch
-, libIDL, libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
-, freetype, fontconfig, file, nspr, nss, libnotify
-, yasm, libGLU_combined, sqlite, unzip
-, hunspell, libevent, libstartup_notification
-, icu, libpng, jemalloc
-, autoconf213, which, m4
-, writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
-, cargo, rustc, llvmPackages
-, enableGTK3 ? false, gtk3, gnome3, wrapGAppsHook, makeWrapper
-, enableCalendar ? true
-, debugBuild ? false
-, # If you want the resulting program to call itself "Thunderbird" instead
-  # of "Earlybird" or whatever, enable this option.  However, those
-  # binaries may not be distributed without permission from the
-  # Mozilla Foundation, see
-  # http://www.mozilla.org/foundation/trademarks/.
-  enableOfficialBranding ? false
-, makeDesktopItem
-}:
+{ stdenv, fetchurl, fetchpatch, callPackage, makeDesktopItem, autoconf213
+, cargo, m4, perl, pkgconfig, python2, rustc, unzip, which, wrapGAppsHook, yasm
+, dbus, dbus-glib, gtk2, gtk3, hunspell, icu, jemalloc, libevent, libjpeg
+, libnotify, libpng, libpulseaudio, libstartup_notification, pango, sqlite
+, xorg, zip, zlib, gcc, llvmPackages, debugBuild ? false
+, enableCalendar ? true, enableOfficialBranding ? true }:
+
+with stdenv.lib;
 
 let
-  wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
-  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
-in stdenv.mkDerivation rec {
+  desktopItem = makeDesktopItem {
+    categories = concatStringsSep ";" [
+      "Application"
+      "Network"
+    ];
+    desktopName = "Thunderbird";
+    genericName = "Mail Reader";
+    name = "thunderbird";
+    exec = "thunderbird %U";
+    icon = "$out/lib/thunderbird/chrome/icons/default/default256.png";
+    mimeType = concatStringsSep ";" [
+      # Email
+      "x-scheme-handler/mailto"
+      "message/rfc822"
+      # Feeds
+      "x-scheme-handler/feed"
+      "application/rss+xml"
+      "application/x-extension-rss"
+      # Newsgroups
+      "x-scheme-handler/news"
+      "x-scheme-handler/snews"
+      "x-scheme-handler/nntp"
+    ];
+  };
+in
+
+stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
   version = "60.5.0";
 
@@ -31,168 +43,133 @@ in stdenv.mkDerivation rec {
     sha512 = "39biv0yk08l4kkfrsiqgsdsvpa7ih992jmakjnf2wqzrnbk4pfsrck6bnl038bihs1v25ia8c2vs25sm4wzbxzjr0z82fn31qysv2xi";
   };
 
-  # from firefox, but without sound libraries
-  buildInputs =
-    [ gtk2 zip libIDL libjpeg zlib bzip2
-      dbus dbus-glib pango freetype fontconfig xorg.libXi
-      xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
-      nspr nss libnotify xorg.pixman yasm libGLU_combined
-      xorg.libXScrnSaver xorg.xorgproto
-      xorg.libXext sqlite unzip
-      hunspell libevent libstartup_notification /* cairo */
-      icu libpng jemalloc
-    ]
-    ++ lib.optionals enableGTK3 [ gtk3 gnome3.defaultIconTheme ];
-
-  # from firefox + m4 + wrapperTool
-  nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python wrapperTool cargo rustc ];
-
-  patches = [
-    # Remove buildconfig.html to prevent a dependency on clang etc.
-    ./no-buildconfig.patch
+  nativeBuildInputs = [
+    autoconf213
+    cargo
+    m4
+    perl
+    pkgconfig
+    python2
+    rustc
+    unzip
+    which
+    wrapGAppsHook
+    yasm
   ];
 
-  configureFlags =
-    [ # from firefox, but without sound libraries (alsa, libvpx, pulseaudio)
-      "--enable-application=comm/mail"
-      "--disable-alsa"
-      "--disable-pulseaudio"
+  buildInputs = [
+    dbus
+    dbus-glib
+    gtk2
+    gtk3
+    hunspell
+    icu
+    jemalloc
+    libevent
+    libjpeg
+    libnotify
+    libpng
+    libpulseaudio
+    libstartup_notification
+    pango
+    sqlite
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXext
+    xorg.libXft
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXt
+    xorg.pixman
+    zip
+    zlib
+  ];
 
-      "--with-system-jpeg"
-      "--with-system-zlib"
-      "--with-system-bz2"
-      "--with-system-nspr"
-      "--with-system-nss"
-      "--with-system-libevent"
-      "--with-system-png" # needs APNG support
-      "--with-system-icu"
-      "--enable-rust-simd"
-      "--enable-system-ffi"
-      "--enable-system-hunspell"
-      "--enable-system-pixman"
-      "--enable-system-sqlite"
-      #"--enable-system-cairo"
-      "--enable-startup-notification"
-      "--disable-crashreporter"
-      "--disable-tests"
-      "--disable-necko-wifi" # maybe we want to enable this at some point
-      "--disable-updater"
-      "--enable-jemalloc"
-      "--disable-gconf"
-      "--enable-default-toolkit=cairo-gtk${if enableGTK3 then "3" else "2"}"
-      "--enable-js-shell"
-    ]
-      ++ lib.optional enableCalendar "--enable-calendar"
-      ++ (if debugBuild then [ "--enable-debug" "--enable-profiling"]
-                        else [ "--disable-debug" "--enable-release"
-                               "--disable-debug-symbols"
-                               "--enable-optimize" "--enable-strip" ])
-      ++ lib.optional enableOfficialBranding "--enable-official-branding"
-      ++ lib.optionals (lib.versionAtLeast version "56" && !stdenv.hostPlatform.isi686) [
-        # on i686-linux: --with-libclang-path is not available in this configuration
-        "--with-libclang-path=${llvmPackages.libclang}/lib"
-        "--with-clang-path=${llvmPackages.clang}/bin/clang"
-      ];
+  patches = [
+    # Remove buildconfig.html to prevent a dependency on clang:
+    ./no-buildconfig.diff
+  ];
+
+  configureFlags = [
+    "--enable-application=comm/mail"
+    "--enable-default-toolkit=cairo-gtk3"
+    "--enable-jemalloc"
+    "--enable-js-shell"
+    "--enable-rust-simd"
+    "--enable-startup-notification"
+
+    "--disable-alsa"
+    "--disable-crashreporter"
+    "--disable-gconf"
+    "--disable-tests" # tests require network access
+    "--disable-updater"
+
+    "--enable-system-ffi"
+    "--enable-system-hunspell"
+    "--enable-system-pixman"
+    "--enable-system-sqlite"
+    "--with-system-bz2"
+    "--with-system-icu"
+    "--with-system-jpeg"
+    "--with-system-libevent"
+    "--with-system-png"
+    "--with-system-zlib"
+
+    "--with-clang-path=${llvmPackages.clang}/bin/clang"
+    "--with-libclang-path=${llvmPackages.libclang}/lib"
+  ] ++ optional enableCalendar "--enable-calendar"
+    ++ optional enableOfficialBranding "--enable-official-branding"
+    ++ (if debugBuild then [ "--enable-debug"
+                             "--enable-profiling"]
+                      else [ "--disable-debug"
+                             "--enable-release"
+                             "--disable-debug-symbols"
+                             "--enable-optimize"
+                             "--enable-strip" ]);
 
   enableParallelBuilding = true;
 
-  preConfigure =
-    ''
-      cxxLib=$( echo -n ${gcc}/include/c++/* )
-      archLib=$cxxLib/$( ${gcc}/bin/gcc -dumpmachine )
+  preConfigure = ''
+    export BINDGEN_SYSTEM_FLAGS="-cxx-isystem ${gcc}/lib/c++/${getVersion gcc} -isystem $(cc -dumpmachine)"
+    configureScript=$PWD/configure
 
-      test -f layout/style/ServoBindings.toml && sed -i -e '/"-DRUST_BINDGEN"/ a , "-cxx-isystem", "'$cxxLib'", "-isystem", "'$archLib'"' layout/style/ServoBindings.toml
+    mkdir ../target
+    cd ../target
+  '';
 
-      configureScript="$(realpath ./configure)"
-      mkdir ../objdir
-      cd ../objdir
-    '';
+  postInstall = ''
+    ${desktopItem.buildCommand}
+  '';
 
-  dontWrapGApps = true; # we do it ourselves
-  postInstall =
-    ''
-      # TODO: Move to a dev output?
-      rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
-
-      # $binary is a symlink to $target.
-      # We wrap $target by replacing the $binary symlink.
-      local target="$out/lib/thunderbird/thunderbird"
-      local binary="$out/bin/thunderbird"
-
-      # Wrap correctly, this is needed to
-      # 1) find Mozilla runtime, because argv0 must be the real thing,
-      #    or a symlink thereto. It cannot be the wrapper itself
-      # 2) detect itself as the default mailreader across builds
-      gappsWrapperArgs+=(
-        --argv0 "$target"
-        --set MOZ_APP_LAUNCHER thunderbird
-      )
-      ${
-        # We wrap manually because wrapGAppsHook does not detect the symlink
-        # To mimic wrapGAppsHook, we run it with dontWrapGApps, so
-        # gappsWrapperArgs gets defined correctly
-        lib.optionalString enableGTK3 "wrapGAppsHook"
-      }
-
-      # "$binary" is a symlink, replace it by the wrapper
-      rm "$binary"
-      makeWrapper "$target" "$binary" "''${gappsWrapperArgs[@]}"
-
-      ${ let desktopItem = makeDesktopItem {
-          name = "thunderbird";
-          exec = "thunderbird %U";
-          desktopName = "Thunderbird";
-          icon = "$out/lib/thunderbird/chrome/icons/default/default256.png";
-          genericName = "Mail Reader";
-          categories = "Application;Network";
-          mimeType = stdenv.lib.concatStringsSep ";" [
-            # Email
-            "x-scheme-handler/mailto"
-            "message/rfc822"
-            # Newsgroup
-            "x-scheme-handler/news"
-            "x-scheme-handler/snews"
-            "x-scheme-handler/nntp"
-            # Feed
-            "x-scheme-handler/feed"
-            "application/rss+xml"
-            "application/x-extension-rss"
-          ];
-        }; in desktopItem.buildCommand
-      }
-    '';
-
-  postFixup =
-    # Fix notifications. LibXUL uses dlopen for this, unfortunately; see #18712.
-    ''
-      patchelf --set-rpath "${lib.getLib libnotify
-        }/lib:$(patchelf --print-rpath "$out"/lib/thunderbird*/libxul.so)" \
-          "$out"/lib/thunderbird*/libxul.so
-    '';
+  postFixup = ''
+    # libXUL dlopens libinotify, see:
+    # https://github.com/NixOS/nixpkgs/issues/18712
+    local xul=$out/lib/thunderbird/libxul.so
+    patchelf --set-rpath "${libnotify}/lib:$(patchelf --print-rpath $xul)" $xul
+  '';
 
   doInstallCheck = true;
-  installCheckPhase =
-    ''
-      # Some basic testing
-      "$out/bin/thunderbird" --version
-    '';
+
+  installCheckPhase = ''
+    $out/bin/thunderbird --version
+  '';
 
   disallowedRequisites = [ stdenv.cc ];
 
   meta = with stdenv.lib; {
     description = "A full-featured e-mail client";
     homepage = http://www.mozilla.org/thunderbird/;
-    license =
-      # Official branding implies thunderbird name and logo cannot be reuse,
-      # see http://www.mozilla.org/foundation/licensing.html
-      if enableOfficialBranding then licenses.proprietary else licenses.mpl11;
-    maintainers = [ maintainers.pierron maintainers.eelco ];
+    license = licenses.mpl20;
+    maintainers = with maintainers; [
+      eelco
+      pierron
+      yegortimoshenko
+    ];
     platforms = platforms.linux;
   };
 
-  passthru.updateScript = import ./../../browsers/firefox/update.nix {
+  passthru.updateScript = callPackage ../../browsers/firefox/update.nix {
     attrPath = "thunderbird";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
-    inherit stdenv writeScript lib common-updater-scripts xidel coreutils gnused gnugrep curl;
   };
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig.diff
+++ b/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig.diff
@@ -1,6 +1,6 @@
-diff -ru -x '*~' a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
---- a/docshell/base/nsAboutRedirector.cpp	2017-07-31 18:20:51.000000000 +0200
-+++ b/docshell/base/nsAboutRedirector.cpp	2017-09-26 22:02:00.814151731 +0200
+diff -ru a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
+--- a/docshell/base/nsAboutRedirector.cpp	2019-01-22 22:43:50.000000000 +0300
++++ b/docshell/base/nsAboutRedirector.cpp	2019-02-01 05:35:04.621505861 +0300
 @@ -32,8 +32,6 @@
      {"about", "chrome://global/content/aboutAbout.xhtml", 0},
      {"addons", "chrome://mozapps/content/extensions/extensions.xul",
@@ -10,9 +10,9 @@ diff -ru -x '*~' a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRe
      {"checkerboard", "chrome://global/content/aboutCheckerboard.xhtml",
       nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
           nsIAboutModule::ALLOW_SCRIPT},
-diff -ru -x '*~' a/toolkit/content/jar.mn b/toolkit/content/jar.mn
---- a/toolkit/content/jar.mn	2017-07-31 18:20:52.000000000 +0200
-+++ b/toolkit/content/jar.mn	2017-09-26 22:01:42.383350314 +0200
+diff -ru a/toolkit/content/jar.mn b/toolkit/content/jar.mn
+--- a/toolkit/content/jar.mn	2019-01-22 22:44:03.000000000 +0300
++++ b/toolkit/content/jar.mn	2019-02-01 05:34:44.358479332 +0300
 @@ -39,7 +39,6 @@
     content/global/plugins.css
     content/global/browser-child.js

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19598,9 +19598,7 @@ in
   thonny = callPackage ../applications/editors/thonny { };
 
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
-    inherit (gnome2) libIDL;
     libpng = libpng_apng;
-    enableGTK3 = true;
   };
 
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};


### PR DESCRIPTION
###### Motivation for this change

Clean up derivation, strip away flags that upstream is not happy with (such as `--disable-alsa`), enable official Thunderbird branding.

Superset of #38943, #36449.

cc @jerith666 @vcunat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

