### PR TITLE
WIP: social-auth-app-django: init at 3.1.0

### DIFF
--- a/pkgs/development/python-modules/social-auth-app-django/default.nix
+++ b/pkgs/development/python-modules/social-auth-app-django/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, buildPythonPackage, isPyPy, fetchFromGitHub
+, six, social-auth-core }:
+
+buildPythonPackage rec {
+  pname = "social-auth-app-django";
+  version = "3.1.0";
+
+  disabled = isPyPy;
+
+  src = fetchFromGitHub {
+    owner = "python-social-auth";
+    repo = "social-app-django";
+    rev = version;
+    sha256 = "1h0hc83pfjm1wn6ylypkfcrwn4rf530nsyjnwgv4h5n80n8vkyha";
+  };
+
+  # checkInputs = [ mock django ];
+
+  propagatedBuildInputs = [ six social-auth-core ];
+
+  # manage.py failed to setup DJANGO_SETTINGS_MODULE (i guess path issue?)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "social authentication/registration mechanism with support for several frameworks and auth providers";
+    homepage = https://github.com/python-social-auth/social-app-django;
+    maintainers= with maintainers; [ peterromfeldhk ];
+    # license = with licenses; [ ??? ]; no idea what license this is
+  };
+}

--- a/pkgs/development/python-modules/social-auth-core/default.nix
+++ b/pkgs/development/python-modules/social-auth-core/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, buildPythonPackage, isPyPy, fetchFromGitHub
+, six, requests_oauthlib, python3-openid }:
+
+buildPythonPackage rec {
+  pname = "social-auth-core";
+  version = "3.0.0";
+
+
+  src = fetchFromGitHub {
+    owner = "python-social-auth";
+    repo = "social-core";
+    rev = version;
+    sha256 = "0kf6swarf0pipx6mxxww7iqfj02agpm8c3c0qm59h71xawl93syk";
+  };
+
+  # checkInputs = [ xmlsec pkgconfig libxml2 ];
+
+  propagatedBuildInputs = [ six requests_oauthlib python3-openid ];
+
+  # im stuck with `Could not find xmlsec1 config. Are libxmlsec1-dev and pkg-config installed?`
+  doCheck = false;
+
+  meta = with lib; {
+    description = "social authentication/registration mechanism with support for several frameworks and auth providers";
+    homepage = https://github.com/python-social-auth/social-core;
+    maintainers= with maintainers; [ peterromfeldhk ];
+    # license = with licenses; [ ??? ]; no idea what license this is
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4023,6 +4023,10 @@ in {
 
   snuggs = callPackage ../development/python-modules/snuggs { };
 
+  social-auth-app-django = callPackage ../development/python-modules/social-auth-app-django { };
+
+  social-auth-core = callPackage ../development/python-modules/social-auth-core { };
+
   spake2 = callPackage ../development/python-modules/spake2 { };
 
   sphfile = callPackage ../development/python-modules/sphfile { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

