### PR TITLE
WIP: pythonPackages.django-jsonfield: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/django-jsonfield/default.nix
+++ b/pkgs/development/python-modules/django-jsonfield/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, buildPythonPackage, isPyPy, fetchPypi
+, django, sqlite }:
+
+buildPythonPackage rec {
+  pname = "django-jsonfield";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gna25jizsk46d367ygzh9ba9hvcjv7qbql6bnsnb4vkaiazs2kc";
+  };
+
+  preCheck = ''
+    export DB_ENGINE=sqlite3
+    export DB_NAME=tests
+  '';
+
+  checkInputs = [ django sqlite ];
+
+  # one test is failing :(
+  doCheck = false;
+
+  meta = with lib; {
+    description = "JSON field for django models";
+    homepage = http://bitbucket.org/schinckel/django-jsonfield/;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    # license = with licenses; [ ??? ]; # not sure what license that is
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2270,6 +2270,8 @@ in {
 
   django-jinja = callPackage ../development/python-modules/django-jinja2 { };
 
+  django-jsonfield = callPackage ../development/python-modules/django-jsonfield { };
+
   django-pglocks = callPackage ../development/python-modules/django-pglocks { };
 
   django-picklefield = callPackage ../development/python-modules/django-picklefield { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

