### PR TITLE
pythonPackages.django-sql-explorer: init at 1.1.2

### DIFF
--- a/pkgs/development/python-modules/django-sql-explorer/default.nix
+++ b/pkgs/development/python-modules/django-sql-explorer/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, isPyPy, fetchPypi
+, six, django, sqlparse, unicodecsv }:
+
+buildPythonPackage rec {
+  pname = "django-sql-explorer";
+  version = "1.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kpaz4ch3m4i9jmqwkjcinjlqypqab02sh97vvig8dqhlmrbkrv5";
+  };
+
+  propagatedBuildInputs = [ six django sqlparse unicodecsv ];
+
+  # django.core.exceptions.ImproperlyConfigured (path issue with DJANGO_SETTINGS_MODULE?)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Quickly write and share SQL queries in a simple, usable SQL editor";
+    homepage = https://github.com/groveco/django-sql-explorer;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2282,6 +2282,8 @@ in {
 
   django-sites = callPackage ../development/python-modules/django-sites { };
 
+  django-sql-explorer = callPackage ../development/python-modules/django-sql-explorer { };
+
   django-sr = callPackage ../development/python-modules/django-sr { };
 
   django_tagging = callPackage ../development/python-modules/django_tagging { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

