### PR TITLE
pythonPackages.django-webpack-loader: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/django-webpack-loader/default.nix
+++ b/pkgs/development/python-modules/django-webpack-loader/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "django-webpack-loader";
+  version = "0.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bwpgmkh32d7a5dgppin9m0mnh8a33ccl5ksnpw5vjp4lal3xq73";
+  };
+
+  # django.core.exceptions.ImproperlyConfigured (path issue with DJANGO_SETTINGS_MODULE?)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Use webpack to generate your static bundles";
+    homepage = https://github.com/owais/django-webpack-loader;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2284,6 +2284,8 @@ in {
 
   django-sr = callPackage ../development/python-modules/django-sr { };
 
+  django-webpack-loader = callPackage ../development/python-modules/django-webpack-loader { };
+
   django_tagging = callPackage ../development/python-modules/django_tagging { };
 
   django_tagging_0_4_3 = if


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

