### PR TITLE
pythonPackages.django-proxy: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/django-proxy/default.nix
+++ b/pkgs/development/python-modules/django-proxy/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi
+, requests }:
+
+buildPythonPackage rec {
+  pname = "django-proxy";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04mvrs2q620vwz1hvcpnbw5gkiv44arb3ygwd6rlmwjawyx6nfiv";
+  };
+
+  # django.core.exceptions.ImproperlyConfigured (path issue with DJANGO_SETTINGS_MODULE?)
+  doCheck = false;
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = with lib; {
+    description = "Simple HTTP proxy service as a Django app";
+    homepage = https://github.com/mjumbewu/django-proxy;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = with licenses; [ unfree ]; # no license
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2276,6 +2276,8 @@ in {
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-proxy = callPackage ../development/python-modules/django-proxy { };
+
   django-rest-auth = callPackage ../development/python-modules/django-rest-auth { };
 
   django-sampledatahelper = callPackage ../development/python-modules/django-sampledatahelper { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

