### PR TITLE
WIP: pythonPackages.django-debug-toolbar: init at 1.11

### DIFF
--- a/pkgs/development/python-modules/django-debug-toolbar/default.nix
+++ b/pkgs/development/python-modules/django-debug-toolbar/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi
+, django, sqlparse }:
+
+buildPythonPackage rec {
+  pname = "django-debug-toolbar";
+  version = "1.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dipzh82lh3qs9igbb37dhw763mzbxz9g3b84kxn7csxqrh5pmw9";
+  };
+
+  # django.core.exceptions.ImproperlyConfigured (path issue with DJANGO_SETTINGS_MODULE?)
+  doCheck = false;
+
+  propagatedBuildInputs = [ django sqlparse ];
+
+  meta = with lib; {
+    description = "Configurable set of panels that display various debug information";
+    homepage = https://github.com/jazzband/django-debug-toolbar;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    # license = with licenses; [ ??? ]; # not sure what license that is
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2254,6 +2254,8 @@ in {
 
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
 
+  django-debug-toolbar = callPackage ../development/python-modules/django-debug-toolbar { };
+
   django-discover-runner = callPackage ../development/python-modules/django-discover-runner { };
 
   django_environ = callPackage ../development/python-modules/django_environ { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

