### PR TITLE
pythonPackages.bumpversion: init at 0.5.3

### DIFF
--- a/pkgs/development/python-modules/bumpversion/default.nix
+++ b/pkgs/development/python-modules/bumpversion/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "bumpversion";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "peritus";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "08zjxa9k15jrvjy7j7qbwjkggcisbx2x4yh5rva4slnjrk3qhmx8";
+  };
+
+  # checkInputs = [ pytest mock git mercurial ];
+  # stuck at `AttributeError: module 'enum' has no attribute 'IntFlag'`
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Version-bump your software with a single command";
+    homepage = https://github.com/peritus/bumpversion;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    license = with licenses; [ mit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1064,6 +1064,8 @@ in {
 
   bumps = callPackage ../development/python-modules/bumps {};
 
+  bumpversion = callPackage ../development/python-modules/bumpversion {};
+
   cached-property = callPackage ../development/python-modules/cached-property { };
 
   caffe = pkgs.caffe.override {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

