### PR TITLE
calibre: 3.38.1 -> 3.39.1

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.39.0";
+  version = "3.39.1";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "01mlv204qjr7w1lkc6kd75d62lbf5mwbkqzs14mhls84k7sgyv5w";
+    sha256 = "08c1wsdn0giv9zfb6bis9bbrw687rci8fs26qsal8ijmjk55dfsh";
   };
 
   patches = [

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.38.1";
+  version = "3.39.0";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "07fvpnabk17sfg81xn0bsnw36k45hawwz0fcz5cmp5qydm85ncv0";
+    sha256 = "01mlv204qjr7w1lkc6kd75d62lbf5mwbkqzs14mhls84k7sgyv5w";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Changes in release 3.39.1

New features

    * Content server: Implement the "Copy to library" function. To use it click the three dots in the top right corner of a book's page and choose "Copy to library"


    *Content server: Add Next/Previous buttons to the book details page

Bug fixes

    * Content server: Fix editing metadata that affects multiple books causing all the metadata for all the books to become the sameCloses tickets: 1812781
    * Open With: Fix using .bat files as the program not working. Closes tickets: 1811045
    * ZIP Output: Fix an error when building the ToC on macOS for some books with non-ASCII ToC entries Closes tickets: 1813905
    * Edit book: Check book: Follow recent releases of epubcheck in expecting .ttf files to have the mime-type application/vnd.ms-opentype in EPUB 3 books
    * Fix font mime-types not being auto-corrected when upgrading EPUBs from 2 to 3
    * Content server: Try to detect if a book file has been edited outside of calibre and serve the updated copy
    * Fix merging books not updating author if the source book has no title
    * Content server: Fix heading for custom comments columns being duplicated in the book details page
    * Fix editing of dates not working is the date format is set to iso. Closes tickets: 1812560
    * Version 3.39.1 fixes a bug in 3.39.0 that broke copy to library for books that have saved conversion options Closes tickets: 1814279

New news sources

    * BSI News by Volker Heggemann
    * Science Advances by Jose Ortiz

Improved news sources

    * Spiegel Online
    * Il Post


Changes in release 3.39.0.

New features

    Content server: Implement the "Copy to library" function. To use it click the three dots in the top right corner of a book's page and choose "Copy to library"

    Closes tickets: 1810486
    Content server: Add Next/Previous buttons to the book details page

Bug fixes

    Content server: Fix editing metadata that affects multiple books causing all the metadata for all the books to become the same.

    Closes tickets: 1812781
    Open With: Fix using .bat files as the program not working.

    Closes tickets: 1811045
    ZIP Output: Fix an error when building the ToC on macOS for some books with non-ASCII ToC entries

    Closes tickets: 1813905
    Edit book: Check book: Follow recent releases of epubcheck in expecting .ttf files to have the mime-type application/vnd.ms-opentype in EPUB 3 books
    Fix font mime-types not being auto-corrected when upgrading EPUBs from 2 to 3
    Content server: Try to detect if a book file has been edited outside of calibre and serve the updated copy
    Fix merging books not updating author if the source book has no title
    Content server: Fix heading for custom comments columns being duplicated in the book details page
    Fix editing of dates not working is the date format is set to iso.

    Closes tickets: 1812560

New news sources

    BSI News by Volker Heggemann
    Science Advances by Jose Ortiz

Improved news sources

    Spiegel Online
    Il Post


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

