### PR TITLE
Fix manual Makefile by including function doc generation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,7 +21,7 @@ fix-misc-xml:
 
 .PHONY: clean
 clean:
-	rm -f ${MD_TARGETS} .version manual-full.xml functions/library/locations.xml
+	rm -f ${MD_TARGETS} .version manual-full.xml functions/library/locations.xml functions/library/generated
 	rm -rf ./out/ ./highlightjs
 
 .PHONY: validate
@@ -71,16 +71,22 @@ highlightjs:
 	cp -r "$$HIGHLIGHTJS/loader.js" highlightjs/
 
 
-manual-full.xml: ${MD_TARGETS} .version functions/library/locations.xml *.xml **/*.xml **/**/*.xml
+manual-full.xml: ${MD_TARGETS} .version functions/library/locations.xml functions/library/generated *.xml **/*.xml **/**/*.xml
 	xmllint --nonet --xinclude --noxincludenode manual.xml --output manual-full.xml
 
 .version:
 	nix-instantiate --eval \
 		-E '(import ../lib).version' > .version
 
+function_locations := $(shell nix-build --no-out-link ./lib-function-locations.nix)
+
 functions/library/locations.xml:
-	nix-build ./lib-function-locations.nix \
-		--out-link ./functions/library/locations.xml
+	ln -s $(function_locations) ./functions/library/locations.xml
+
+functions/library/generated:
+	nix-build ./lib-function-docs.nix \
+		--arg locationsXml $(function_locations)\
+		--out-link ./functions/library/generated
 
 %.section.xml: %.section.md
 	pandoc $^ -w docbook+smart \


### PR DESCRIPTION
Since #53055 was merged the Makefile for the manual could not be run
correctly as the generated function documentation was included, but
not actually generated.

This adds the necessary generation step by first building the XML file
containing function locations and preserving its store path in a
variable, which is then used both for linking of the locations file
and as a build input for the function docs generator.

This fixes #55014

**Side note**: Recreating the derivation dependencies this way in the Makefile is a little bit awkward. Better suggestions welcome! :thinking: 

----------------

###### Motivation for this change

Manual builds were broken (as per #55014)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---

