### PR TITLE
kube-router: 0.2.3 -> 0.2.5

### DIFF
--- a/pkgs/applications/networking/cluster/kube-router/default.nix
+++ b/pkgs/applications/networking/cluster/kube-router/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kube-router-${version}";
-  version = "0.2.3";
+  version = "0.2.5";
   rev = "v${version}";
 
   goPackagePath = "github.com/cloudnativelabs/kube-router";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "cloudnativelabs";
     repo = "kube-router";
-    sha256 = "1dsr76dq6sycwgh75glrcb4scv52lrrd0aivskhc7mwq30plafcj";
+    sha256 = "1j6q6kg4qj75v2mdy9ivvwq8mx9fpdf0w08959l8imrp5byd56wv";
   };
 
   buildFlagsArray = ''


### PR DESCRIPTION
###### Motivation for this change
Contains various bugfixes and improvements. Among them, a critical fix for an issue that causes kube-router to crash when declaring network policies without port numbers.

Manually tested with positive results on our kubernetes cluster.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---
