### PR TITLE
odpic: 2.4.2 -> 3.1.0

### DIFF
--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "odpic-${version}";
-  version = "2.4.2";
+  version = "3.1.0";
 
   src = fetchurl {
     url = "https://github.com/oracle/odpi/archive/v${version}.tar.gz";
-    sha256 = "0hw6b38vnh0cgm1iwpgkqa2am86baal6irp9bglacblwh8sshqdi";
+    sha256 = "0m6g7lbvfir4amf2cnap9wz9fmqrihqpihd84igrd7fp076894c0";
   };
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];


### PR DESCRIPTION
###### Motivation for this change

This bumps odpic to 3.1.0 - with the current version in unstable,
python*Packages.cx_oracle fails to compile due to some types missing in
our version of odpic:

```
gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DCXO_BUILD_VERSION=7.0.0 -I/nix/store/43lwkzvxwcymshchqhhafr2rnw2kk8ll-odpic-2.4.2/include -I/nix/store/ydk0mfpvn9smcmn72wc9i20slv1d2b79-python3-3.7.2/include/python3.7m -c src/cxoBuffer.c -o build/temp.linux-x86_64-3.7/src/cxoBuffer.o
In file included from src/cxoBuffer.c:17:0:
src/cxoModule.h:372:5: error: unknown type name 'dpiSodaColl'
     dpiSodaColl *handle;
     ^~~~~~~~~~~
src/cxoModule.h:379:5: error: unknown type name 'dpiSodaDb'
     dpiSodaDb *handle;
     ^~~~~~~~~
src/cxoModule.h:386:5: error: unknown type name 'dpiSodaDoc'
     dpiSodaDoc *handle;
     ^~~~~~~~~~
src/cxoModule.h:392:5: error: unknown type name 'dpiSodaDocCursor'
     dpiSodaDocCursor *handle;
     ^~~~~~~~~~~~~~~~
src/cxoModule.h:398:5: error: unknown type name 'dpiSodaOperOptions'
     dpiSodaOperOptions options;
     ^~~~~~~~~~~~~~~~~~
src/cxoModule.h:492:9: error: unknown type name 'dpiSodaColl'; did you mean 'dpiPool'?
         dpiSodaColl *handle);
         ^~~~~~~~~~~
         dpiPool
src/cxoModule.h:496:49: error: unknown type name 'dpiSodaDoc'; did you mean 'cxoSodaDoc'?
 cxoSodaDoc *cxoSodaDoc_new(cxoSodaDatabase *db, dpiSodaDoc *handle);
                                                 ^~~~~~~~~~
                                                 cxoSodaDoc
src/cxoModule.h:499:9: error: unknown type name 'dpiSodaDocCursor'; did you mean 'cxoSodaDocCursor'?
         dpiSodaDocCursor *handle);
         ^~~~~~~~~~~~~~~~
         cxoSodaDocCursor
```

cc @gjmoed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

