### PR TITLE
gtk-doc: 1.28 -> 1.29

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python, libxml2Python, libxslt, which
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python3, libxml2Python, libxslt, which
 , docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, gettext, itstool
 , withDblatex ? false, dblatex
 }:
 
 stdenv.mkDerivation rec {
   name = "gtk-doc-${version}";
-  version = "1.28";
+  version = "1.29";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk-doc/${version}/${name}.tar.xz";
-    sha256 = "05apmwibkmn1icx05l8aw241lhymcx01zvk5i499cb150bijj7li";
+    sha256 = "1cc6yl8l275qn3zpjl6f0s4fwmkczngjr9hhsdv74mln4h08wmql";
   };
 
   patches = [
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs =
-    [ pkgconfig perl python libxml2Python libxslt docbook_xml_dtd_43 docbook_xsl
+    [ pkgconfig perl python3 libxml2Python libxslt docbook_xml_dtd_43 docbook_xsl
       gnome-doc-utils gettext which itstool
     ] ++ stdenv.lib.optional withDblatex dblatex;
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   # Make six available for binaries, python.withPackages creates a wrapper
   # but scripts are not allowed in shebangs so we link it into sys.path.
   postInstall = ''
-    ln -s ${python.pkgs.six}/${python.sitePackages}/* $out/share/gtk-doc/python/
+    ln -s ${python3.pkgs.six}/${python3.sitePackages}/* $out/share/gtk-doc/python/
   '';
 
   doCheck = false; # requires a lot of stuff


### PR DESCRIPTION
###### Motivation for this change

Changes in 1.29

 o 674163 :  &ndash;  &nbsp; html-build.stamp rule broken for out-of-tree builds with absolute paths
 o 795744 : Too much escaped string - &quot;  &amp; lt;child &gt;  &quot; in description of &quot; GtkOverlay as GtkBuildable &quot; section
 o 796011 : Crash in ScanDirectory caused by overlooked use of renamed `dir` variable
 o 796012 : Several places in rebase.py incorrectly use `match.groups(1)` instead of `match.group(1)`, one causes a crash


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

