### PR TITLE
mkDerivation: cleaner handling of the `name` argument

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -28,7 +28,7 @@ let params =
       propagatedBuildInputs = [ coq-ext-lib simple-io ];
     };
   };
-  param = params."${coq.coq-version}" or params."8.8";
+  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/Velisarios/default.nix
+++ b/pkgs/development/coq-modules/Velisarios/default.nix
@@ -20,7 +20,7 @@ let params =
       sha256 = "0l9885nxy0n955fj1gnijlxl55lyxiv9yjfmz8hmfrn9hl8vv1m2";
     };
   };
-  param = params."${coq.coq-version}" or params."8.8";
+  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -18,7 +18,7 @@ let
     "8.7" = v20180709;
     "8.8" = v20181016;
   };
-  param = params."${coq.coq-version}" or params."8.8";
+  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -26,7 +26,7 @@ let params =
       sha256 = "09dq1vvshhlhgjccrhqgbhnq2hrys15xryfszqq11rzpgvl2zgdv";
     };
   };
-  param = params."${coq.coq-version}" or params."8.8";
+  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -14,7 +14,7 @@ let params =
     "8.8" = v_8_8;
     "8.9" = v_8_8;
     };
-  param = params."${coq.coq-version}" or params."8.9"
+  param = params."${coq.coq-version}"
 ; in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -22,7 +22,7 @@ let params = {
     sha256 = "0qvar8gfbrcs9fmvkph5asqz4l5fi63caykx3bsn8zf0xllkwv0n";
   };
 };
-param = params."${coq.coq-version}" or params."8.8";
+param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation {

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -26,7 +26,7 @@ let
       sha256 = "1sj7vyarmvp1w5kvbhgpgap1yd0yrj4n1jrla0wv70k0jrq5hhpz";
     };
   };
-  param = params."${coq.coq-version}" or params."8.8";
+  param = params."${coq.coq-version}";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -12,7 +12,7 @@ rec {
   # * https://nixos.org/nix/manual/#ssec-derivation
   #   Explanation about derivations in general
   mkDerivation =
-    { name ? ""
+    {
 
     # These types of dependencies are all exhaustively documented in
     # the "Specifying Dependencies" section of the "Standard
@@ -21,7 +21,7 @@ rec {
     # TODO(@Ericson2314): Stop using legacy dep attribute names
 
     #                           host offset -> target offset
-    , depsBuildBuild              ? [] # -1 -> -1
+      depsBuildBuild              ? [] # -1 -> -1
     , depsBuildBuildPropagated    ? [] # -1 -> -1
     , nativeBuildInputs           ? [] # -1 ->  0  N.B. Legacy name
     , propagatedNativeBuildInputs ? [] # -1 ->  0  N.B. Legacy name
@@ -177,14 +177,14 @@ rec {
            "checkInputs" "installCheckInputs"
            "__impureHostDeps" "__propagatedImpureHostDeps"
            "sandboxProfile" "propagatedSandboxProfile"])
-        // (lib.optionalAttrs (name == "")) {
+        // (lib.optionalAttrs (!(attrs ? name))) {
           name = "${attrs.pname}-${attrs.version}";
         } // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)) {
           # Fixed-output derivations like source tarballs shouldn't get a host
           # suffix. But we have some weird ones with run-time deps that are
           # just used for their side-affects. Those might as well since the
           # hash can't be the same. See #32986.
-          name = "${if name != "" then name else "${attrs.pname}-${attrs.version}"}-${stdenv.hostPlatform.config}";
+          name = "${attrs.name or "${attrs.pname}-${attrs.version}"}-${stdenv.hostPlatform.config}";
         } // {
           builder = attrs.realBuilder or stdenv.shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
@@ -274,7 +274,7 @@ rec {
       meta = {
           # `name` above includes cross-compilation cruft (and is under assert),
           # lets have a clean always accessible version here.
-          name = if name != "" then name else "${attrs.pname}-${attrs.version}";
+          name = attrs.name or "${attrs.pname}-${attrs.version}";
 
           # If the packager hasn't specified `outputsToInstall`, choose a default,
           # which is the name of `p.bin or p.out or p`;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -177,9 +177,9 @@ rec {
            "checkInputs" "installCheckInputs"
            "__impureHostDeps" "__propagatedImpureHostDeps"
            "sandboxProfile" "propagatedSandboxProfile"])
-        // (lib.optionalAttrs (!(attrs ? name))) {
+        // (lib.optionalAttrs (!(attrs ? name) && attrs ? pname && attrs ? version)) {
           name = "${attrs.pname}-${attrs.version}";
-        } // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix)) {
+        } // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix && (attrs ? name || (attrs ? pname && attrs ? version)))) {
           # Fixed-output derivations like source tarballs shouldn't get a host
           # suffix. But we have some weird ones with run-time deps that are
           # just used for their side-affects. Those might as well since the


### PR DESCRIPTION
The logic in `mkDerivation` for checking whether the `name ` argument is given or not is wrong.

It gets a default value, and then to detect if `name` was present, its *value* is compared to the default one.

This in wrong in that: 1. it is too convoluted; and 2. it forces the evaluation of the value of the `name` attribute when we only care about it being here or not.

In this PR, we directly use standard constructs of the Nix language to detect whether attributes are present (`attrs ? name` and `attrs.name or …`).

Consequently, we can revert e20b65156cee92d30b43f8e339bd686bd83538cb, that was wrongly motivated.

Running `nix-review` yields: “Nothing changed”.

cc/ @matthewbauer.