### PR TITLE
pythonPackages.grammalecte: 0.6.1 -> 0.6.5

### DIFF
--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -7,25 +7,22 @@
 
 buildPythonPackage rec {
   pname = "grammalecte";
-  version = "0.6.1";
+  version = "0.6.5";
 
   src = fetchurl {
     url = "http://www.dicollecte.org/grammalecte/zip/Grammalecte-fr-v${version}.zip";
-    sha256 = "0y2ck6pkd2p3cbjlxxvz3x5rnbg3ghfx97n13302rnab66cy4zkh";
+    sha256 = "11byjs3ggdhia5f4vyfqfvbbczsfqimll98h98g7hlsrm7vrifb0";
   };
 
   propagatedBuildInputs = [ bottle ];
 
   preBuild = "cd ..";
-  postInstall = ''
-    rm $out/bin/bottle.py
-  '';
 
   disabled = !isPy3k;
 
   meta = {
     description = "Grammalecte is an open source grammar checker for the French language";
-    homepage = https://dicollecte.org/grammalecte/;
+    homepage = https://grammalecte.net;
     license = with lib.licenses; [ gpl3 ];
     maintainers = with lib.maintainers; [ apeyroux ];
   };


### PR DESCRIPTION
###### Motivation for this change

up grammalecte to 0.6.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

