### PR TITLE
Fix electron crash when using file chooser dialog

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,5 +1,4 @@
 { stdenv, newScope, makeWrapper
-, wrapGAppsHook, gnome3, glib
 , electron, xdg_utils, makeDesktopItem
 , auth0ClientID ? "0spuNKfIGeLAQ_Iki9t3fGxbfJl3k8SU"
 , auth0Domain ? "nixpkgs.auth0.com" }:
@@ -28,9 +27,8 @@ with self;
 stdenv.mkDerivation {
   name = "rambox-${rambox-bare.version}";
 
-  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ glib gnome3.gsettings_desktop_schemas ];
   unpackPhase = ":";
 
   dontWrapGApps = true; # we only want $gappsWrapperArgs here
@@ -45,7 +43,6 @@ stdenv.mkDerivation {
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/rambox \
       --add-flags "${rambox-bare} --without-update" \
-      "''${gappsWrapperArgs[@]}" \
       --prefix PATH : ${xdg_utils}/bin
   '';
 

--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,6 +1,6 @@
 { stdenv, newScope, makeWrapper
 , wrapGAppsHook, gnome3, glib
-, electron_3, xdg_utils, makeDesktopItem
+, electron, xdg_utils, makeDesktopItem
 , auth0ClientID ? "0spuNKfIGeLAQ_Iki9t3fGxbfJl3k8SU"
 , auth0Domain ? "nixpkgs.auth0.com" }:
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
   '';
 
   postFixup = ''
-    makeWrapper ${electron_3}/bin/electron $out/bin/rambox \
+    makeWrapper ${electron}/bin/electron $out/bin/rambox \
       --add-flags "${rambox-bare} --without-update" \
       "''${gappsWrapperArgs[@]}" \
       --prefix PATH : ${xdg_utils}/bin

--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, libXScrnSaver, makeWrapper, fetchurl, unzip, atomEnv, libuuid, at-spi2-atk }:
+{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, gtk3, unzip, atomEnv, libuuid, at-spi2-atk }:
 
 let
   version = "4.0.0";
@@ -36,7 +36,15 @@ let
       };
     }.${stdenv.hostPlatform.system} or throwSystem;
 
-    buildInputs = [ unzip makeWrapper ];
+    buildInputs = [ gtk3 ];
+
+    nativeBuildInputs = [
+      unzip
+      makeWrapper
+      wrapGAppsHook
+    ];
+
+    dontWrapGApps = true; # electron is in lib, we need to wrap it manually
 
     buildCommand = ''
       mkdir -p $out/lib/electron $out/bin
@@ -51,7 +59,8 @@ let
         $out/lib/electron/electron
 
       wrapProgram $out/lib/electron/electron \
-        --prefix LD_PRELOAD : ${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1
+        --prefix LD_PRELOAD : ${stdenv.lib.makeLibraryPath [ libXScrnSaver ]}/libXss.so.1 \
+        "''${gappsWrapperArgs[@]}"
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change

#50985 

Thanks @jtojnar for the solution!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

