### PR TITLE
intel-media-driver: 18.3.0 -> 18.4.0

### DIFF
--- a/pkgs/development/libraries/intel-media-driver/default.nix
+++ b/pkgs/development/libraries/intel-media-driver/default.nix
@@ -5,20 +5,19 @@
 
 stdenv.mkDerivation rec {
   name = "intel-media-driver-${version}";
-  version = "18.3.0";
+  version = "18.4.0";
 
   src = fetchFromGitHub {
     owner  = "intel";
     repo   = "media-driver";
     rev    = "intel-media-${version}";
-    sha256 = "15kcyg9ss2v1bbw6yvxqb833h1vs0h659n8ix0x5x03cfm1wsi57";
+    sha256 = "0mvb1dq2014gc60lz22dag230flqw859dcqi08hdmmci30qgw88x";
   };
 
-  cmakeFlags = [ "-DINSTALL_DRIVER_SYSCONF=OFF" ];
-
-  preConfigure = ''
-    cmakeFlags="$cmakeFlags -DLIBVA_DRIVERS_PATH=$out/lib/dri"
-  '';
+  cmakeFlags = [
+    "-DINSTALL_DRIVER_SYSCONF=OFF"
+    "-DLIBVA_DRIVERS_PATH=${placeholder "out"}/lib/dri"
+  ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 

--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, libdrm, libva
+{ stdenv, fetchFromGitHub, pkgconfig
+, libdrm, libva, libX11, libXext, libXfixes, wayland, meson, ninja
 }:
 
 stdenv.mkDerivation rec {
@@ -13,9 +13,15 @@ stdenv.mkDerivation rec {
     sha256 = "1yk9bg1wg4nqva3l01s6bghcvc3hb02gp62p1sy5qk0r9mn5kpik";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig ];
 
-  buildInputs = [ libdrm libva ];
+  buildInputs = [ libdrm libva libX11 libXext libXfixes wayland ];
+
+  mesonFlags = [
+    "-Ddrm=true"
+    "-Dx11=true"
+    "-Dwayland=true"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libva-utils/default.nix
+++ b/pkgs/development/libraries/libva-utils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner  = "01org";
     repo   = "libva-utils";
     rev    = version;
-    sha256 = "0k5v72prcq462x780j9vpqf4ckrpqf536z6say81wpna0l0qbd98";
+    sha256 = "1yk9bg1wg4nqva3l01s6bghcvc3hb02gp62p1sy5qk0r9mn5kpik";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/development/libraries/libva/default.nix
+++ b/pkgs/development/libraries/libva/default.nix
@@ -6,14 +6,14 @@
 
 stdenv.mkDerivation rec {
   name = "libva-${lib.optionalString minimal "minimal-"}${version}";
-  version = "2.3.0";
+  version = "2.4.0";
 
   # update libva-utils and vaapiIntel as well
   src = fetchFromGitHub {
     owner  = "01org";
     repo   = "libva";
     rev    = version;
-    sha256 = "0zip22b5qwyjygsmrmjq62hdpl9z77d84h5hni8cn6xz5cmbw29z";
+    sha256 = "1b58n6rjfsfjfw1s5kdfa0jpfiqs83g2w14s7sfp1qkckkz3988l";
   };
 
   outputs = [ "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change

Maybe it's time to make a NixOS flag for setting `LIBVA_DRIVER_NAME`?
(for now I set it to `iHD` as a sessionVariable)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---