### PR TITLE
llvm-polly,clang-polly: Add llvm/clang variants w/polly support

### DIFF
--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
 , fixDarwinDylibNames
 , enableManpages ? false
+, enablePolly ? false # TODO: get this info from llvm (passthru?)
 }:
 
 let
@@ -30,6 +31,9 @@ let
       "-DSPHINX_OUTPUT_MAN=ON"
       "-DSPHINX_OUTPUT_HTML=OFF"
       "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+    ] ++ stdenv.lib.optionals enablePolly [
+      "-DWITH_POLLY=ON"
+      "-DLINK_POLLY_INTO_TOOLS=ON"
     ];
 
     patches = [ ./purity.patch ];

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -29,9 +29,15 @@ let
   in {
 
     llvm = callPackage ./llvm.nix { };
+    llvm-polly = callPackage ./llvm.nix { enablePolly = true; };
 
     clang-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
+    };
+    clang-polly-unwrapped = callPackage ./clang {
+      inherit clang-tools-extra_src;
+      llvm = tools.llvm-polly;
+      enablePolly = true;
     };
 
     llvm-manpages = lowPrio (tools.llvm.override {

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -17,12 +17,14 @@
 # Mesa requires AMDGPU target
 , enableTargets ? [ stdenv.hostPlatform stdenv.targetPlatform "AMDGPU" ]
 , enablePFM ? !stdenv.isDarwin
+, enablePolly ? false
 }:
 
 let
   inherit (stdenv.lib) optional optionals optionalString;
 
   src = fetch "llvm" "16s196wqzdw4pmri15hadzqgdi926zln3an2viwyq0kini6zr3d3";
+  polly_src = fetch "polly" "0wgvayfilgb530bq51l7szxfb13l24nnrmyji2f6ncq95a24dw8v";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
@@ -38,6 +40,9 @@ in stdenv.mkDerivation (rec {
     unpackFile ${src}
     mv llvm-${version}* llvm
     sourceRoot=$PWD/llvm
+  '' + optionalString enablePolly ''
+    unpackFile ${polly_src}
+    mv polly-* $sourceRoot/tools/polly
   '';
 
   outputs = [ "out" "python" ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6620,6 +6620,8 @@ in
       useMacosReexportHack = true;
     };
   };
+  llvm-polly = llvmPackages_7.llvm-polly;
+  clang-polly = clang_7.override { cc = llvmPackages_7.clang-polly-unwrapped; };
 
   clang_7  = llvmPackages_7.clang;
   clang_6  = llvmPackages_6.clang;


### PR DESCRIPTION
###### Motivation for this change

Polly is much easier to use when linked into llvm and friends.

Related: #20941.

We may want to enable it by default, unsure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---