### PR TITLE
zeitgeist: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/libraries/zeitgeist/default.nix
+++ b/pkgs/development/libraries/zeitgeist/default.nix
@@ -5,22 +5,22 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.1";
-  name = "zeitgeist-${version}";
+  pname = "zeitgeist";
+  version = "1.0.2";
 
   outputs = [ "out" "lib" "dev" "man" ] ++ stdenv.lib.optional pythonSupport "py";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = "zeitgeist";
-    repo = "zeitgeist";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1lgqcqr5h9ba751b7ajp7h2w1bb5qza2w3k1f95j3ab15p7q0q44";
+    sha256 = "0ig3d3j1n0ghaxsgfww6g2hhcdwx8cljwwfmp9jk1nrvkxd6rnmv";
   };
 
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
-  configureFlags = [ "--with-session-bus-services-dir=$(out)/share/dbus-1/services" ];
+  configureFlags = [ "--with-session-bus-services-dir=${placeholder ''out''}/share/dbus-1/services" ];
 
   nativeBuildInputs = [
     autoconf automake libtool pkgconfig gettext gobject-introspection vala python2Packages.python
@@ -42,8 +42,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A service which logs the users's activities and events";
-    homepage = http://zeitgeist.freedesktop.org/;
-    maintainers = with maintainers; [ lethalman ];
+    homepage = https://zeitgeist.freedesktop.org/;
+    maintainers = with maintainers; [ lethalman worldofpeace ];
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
https://cgit.freedesktop.org/zeitgeist/zeitgeist/commit/?id=f6394278664b19210823d27e9c04d363f38bd33d

Mostly stuff so it can play nice with newer valac.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

