### PR TITLE
trilium: 0.27.4 -> 0.28.3

### DIFF
--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, p7zip, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchurl, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem }:
 
 let
   description = "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases.";
@@ -10,18 +10,26 @@ let
     desktopName = "Trilium Notes";
     categories = "Office";
   };
+  version = "0.28.3";
+
+  # Fetch from source repo, no longer included in release.
+  # (they did special-case icon.png but we want the scalable svg)
+  # Use the version here to ensure we get any changes.
+  trilium_svg = fetchurl {
+    url = "https://raw.githubusercontent.com/zadam/trilium/v${version}/src/public/images/trilium.svg";
+    sha256 = "1rgj7pza20yndfp8n12k93jyprym02hqah36fkk2b3if3kcmwnfg";
+  };
 
 in stdenv.mkDerivation rec {
   name = "trilium-${version}";
-  version = "0.27.4";
+  inherit version;
 
   src = fetchurl {
-    url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.7z";
-    sha256 = "1qb11axaifw5xjycrc6qsyd8h36rgjd7rjql8895v8agckf3g2c1";
+    url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
+    sha256 = "0bg7fzb0drw6692hcskiwwd4d9s9547cqp3m1s4qj0y7ca3wrx8r";
   };
 
   nativeBuildInputs = [
-    p7zip /* for unpacking */
     autoPatchelfHook
     makeWrapper
   ];
@@ -36,7 +44,7 @@ in stdenv.mkDerivation rec {
     cp -r ./* $out/share/trilium
     ln -s $out/share/trilium/trilium $out/bin/trilium
 
-    ln -s $out/share/trilium/resources/app/src/public/images/trilium.svg $out/share/icons/hicolor/scalable/apps/trilium.svg
+    ln -s ${trilium_svg} $out/share/icons/hicolor/scalable/apps/trilium.svg
     cp ${desktopItem}/share/applications/* $out/share/applications
   '';
 

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -10,7 +10,15 @@ let
     desktopName = "Trilium Notes";
     categories = "Office";
   };
+
+in stdenv.mkDerivation rec {
+  name = "trilium-${version}";
   version = "0.28.3";
+
+  src = fetchurl {
+    url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
+    sha256 = "0bg7fzb0drw6692hcskiwwd4d9s9547cqp3m1s4qj0y7ca3wrx8r";
+  };
 
   # Fetch from source repo, no longer included in release.
   # (they did special-case icon.png but we want the scalable svg)
@@ -20,14 +28,6 @@ let
     sha256 = "1rgj7pza20yndfp8n12k93jyprym02hqah36fkk2b3if3kcmwnfg";
   };
 
-in stdenv.mkDerivation rec {
-  name = "trilium-${version}";
-  inherit version;
-
-  src = fetchurl {
-    url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-    sha256 = "0bg7fzb0drw6692hcskiwwd4d9s9547cqp3m1s4qj0y7ca3wrx8r";
-  };
 
   nativeBuildInputs = [
     autoPatchelfHook


### PR DESCRIPTION
* Fetch svg icon since no longer included.
* Move to xz so don't need p7zip


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---