### PR TITLE
lkl: install liblkl.so and liblkl-hijack.so

### DIFF
--- a/pkgs/applications/virtualization/lkl/default.nix
+++ b/pkgs/applications/virtualization/lkl/default.nix
@@ -30,7 +30,9 @@ stdenv.mkDerivation rec {
     cp tools/lkl/{cptofs,fs2tar,lklfuse} $out/bin
     ln -s cptofs $out/bin/cpfromfs
     cp -r tools/lkl/include $dev/
-    cp tools/lkl/liblkl*.{a,so} $lib/lib
+    cp tools/lkl/liblkl.a \
+       tools/lkl/lib/liblkl.so \
+       tools/lkl/lib/hijack/liblkl-hijack.so $lib/lib
   '';
 
   # We turn off format and fortify because of these errors (fortify implies -O2, which breaks the jitter entropy code):


### PR DESCRIPTION
###### Motivation for this change

The `lkl` package currently does not contain `liblkl-hijack.so`, which prevents the `lkl-hijack.sh` script from working. I also noticed that `liblkl.so` is not being installed. It appears that the locations of the libraries in the source tree changed since a previous version.

###### Things done

Install all the necessary libraries.

cc @copumpkin

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

