### PR TITLE
oxipng: 2.1.8 -> 2.2.0

### DIFF
--- a/pkgs/tools/graphics/oxipng/default.nix
+++ b/pkgs/tools/graphics/oxipng/default.nix
@@ -1,17 +1,20 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  version = "2.1.8";
+  version = "2.2.0";
   name = "oxipng-${version}";
 
   src = fetchFromGitHub {
     owner = "shssoichiro";
     repo = "oxipng";
     rev = "v${version}";
-    sha256 = "18ld65vm58s6x918g6bhfkrg7lw2lca8daidv88ff14wm5khjvik";
+    sha256 = "00ys1dy8r1g84j04w50qcjas0qnfw4vphazvbfasd9q2b1p5z69l";
   };
 
-  cargoSha256 = "034i8hgi0zgv085bimlja1hl3nd096rqpi167pw6rda5aj18c625";
+  cargoSha256 = "125r3jmgwcq8qddm8hjpyzaam96kkifaxixksyaw2iqk9xq0nrpm";
+
+  # https://crates.io/crates/cloudflare-zlib#arm-vs-nightly-rust
+  cargoBuildFlags = [ "--features=cloudflare-zlib/arm-always" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/shssoichiro/oxipng;
@@ -19,8 +22,5 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
-
-    # Needs newer/unstable rust: error[E0658]: macro is_arm_feature_detected! is unstable
-    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
[changelog](https://github.com/shssoichiro/oxipng/blob/master/CHANGELOG.md#version-220)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

