### PR TITLE
lxd: fix sh not in path

### DIFF
--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -3,6 +3,7 @@
 , squashfsTools, iproute, iptables, ebtables, libcap, dqlite
 , sqlite-replication
 , writeShellScriptBin, apparmor-profiles, apparmor-parser
+, bash
 }:
 
 buildGoPackage rec {
@@ -30,8 +31,8 @@ buildGoPackage rec {
     # binaries from test/
     rm $bin/bin/{deps,macaroon-identity}
 
-    wrapProgram $bin/bin/lxd --prefix PATH : /bin/:${stdenv.lib.makeBinPath [
-      acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute iptables ebtables
+    wrapProgram $bin/bin/lxd --prefix PATH : ${stdenv.lib.makeBinPath [
+      acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute iptables ebtables bash
       (writeShellScriptBin "apparmor_parser" ''
         exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"
       '')

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -30,7 +30,7 @@ buildGoPackage rec {
     # binaries from test/
     rm $bin/bin/{deps,macaroon-identity}
 
-    wrapProgram $bin/bin/lxd --prefix PATH ":" ${stdenv.lib.makeBinPath [
+    wrapProgram $bin/bin/lxd --prefix PATH : /bin/:${stdenv.lib.makeBinPath [
       acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute iptables ebtables
       (writeShellScriptBin "apparmor_parser" ''
         exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"


### PR DESCRIPTION
###### Motivation for this change
`lxd` networking is broken in nixos. On initial setup with `lxd init` it works because when running lxd directly `sh` is in PATH. Running `lxd network edit` afterwards fails. 
The problem is `sh` is not in `PATH` and `lxd` is not using `/bin/sh` as can be seen here https://github.com/lxc/lxd/blob/master/lxd/iptables.go#L97.


###### Things done
~In this PR I add `/bin/` to the PATH available for the `lxd` wrapper.~
Added bash to makeBinPath to provide `sh` executable t lxd.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

