### PR TITLE
rink: init at 0.4.4

### DIFF
--- a/pkgs/applications/science/misc/rink/cargo-lock.patch
+++ b/pkgs/applications/science/misc/rink/cargo-lock.patch
@@ -1,0 +1,1725 @@
+diff --git a/Cargo.lock b/Cargo.lock
+new file mode 100644
+index 0000000..c67e9ed
+--- /dev/null
++++ b/Cargo.lock
+@@ -0,0 +1,1719 @@
++[[package]]
++name = "MacTypes-sys"
++version = "2.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "aho-corasick"
++version = "0.6.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "antidote"
++version = "1.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "autocfg"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "base64"
++version = "0.9.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "bincode"
++version = "0.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "bitflags"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bitflags"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bitflags"
++version = "1.0.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bodyparser"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "buf_redux"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "byteorder"
++version = "1.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bytes"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "cc"
++version = "1.0.28"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "cfg-if"
++version = "0.1.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "chrono"
++version = "0.2.25"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "chrono"
++version = "0.4.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "chrono-humanize"
++version = "0.0.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "chrono-tz"
++version = "0.2.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
++ "parse-zoneinfo 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "cloudabi"
++version = "0.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "conduit-mime-types"
++version = "0.7.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "core-foundation"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "core-foundation-sys"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "dtoa"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "encoding"
++version = "0.2.33"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "encoding-index-japanese"
++version = "1.20141219.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "encoding-index-korean"
++version = "1.20141219.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "encoding-index-simpchinese"
++version = "1.20141219.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "encoding-index-singlebyte"
++version = "1.20141219.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "encoding-index-tradchinese"
++version = "1.20141219.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "encoding_index_tests"
++version = "0.1.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "error"
++version = "0.1.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "filetime"
++version = "0.1.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "foreign-types"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "foreign-types-shared"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "fsevent"
++version = "0.2.17"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "fsevent-sys"
++version = "0.1.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "fuchsia-cprng"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "glob"
++version = "0.2.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "handlebars"
++version = "0.25.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "handlebars-iron"
++version = "0.23.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "handlebars 0.25.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "notify 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "httparse"
++version = "1.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "hyper"
++version = "0.10.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "hyper-native-tls"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "idna"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "inotify"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "ipc-channel"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bincode 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "irc"
++version = "0.11.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "iron"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "itoa"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "json"
++version = "0.10.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "kernel32-sys"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "language-tags"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "lazy_static"
++version = "0.2.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "lazy_static"
++version = "1.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "libc"
++version = "0.2.48"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "limiter"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "linefeed"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "log"
++version = "0.3.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "log"
++version = "0.4.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "logger"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "matches"
++version = "0.1.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "memchr"
++version = "0.1.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "memchr"
++version = "2.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "mime"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "mime_guess"
++version = "1.8.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "mio"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "miow"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "modifier"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "mount"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "sequence_trie 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "multipart"
++version = "0.8.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "buf_redux 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime_guess 1.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "native-tls"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
++ "security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "net2"
++version = "0.2.33"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "nix"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "nix"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
++ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "notify"
++version = "3.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fsevent 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "inotify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num"
++version = "0.1.42"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-bigint"
++version = "0.1.44"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-complex"
++version = "0.1.43"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-integer"
++version = "0.1.39"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-iter"
++version = "0.1.37"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-rational"
++version = "0.1.42"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-traits"
++version = "0.1.43"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-traits"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "num_cpus"
++version = "1.9.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "ole32-sys"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "openssl"
++version = "0.10.16"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "openssl-probe"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "openssl-sys"
++version = "0.9.40"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
++ "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "params"
++version = "0.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bodyparser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "multipart 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "urlencoded 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "parse-zoneinfo"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "percent-encoding"
++version = "1.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "persistent"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "pest"
++version = "0.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "phf"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "phf_codegen"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "phf_generator"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "phf_shared"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "pkg-config"
++version = "0.3.14"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "plugin"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "quick-error"
++version = "1.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "quote"
++version = "0.3.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "rand"
++version = "0.3.23"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand"
++version = "0.4.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand"
++version = "0.6.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_jitter 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_chacha"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_core"
++version = "0.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_core"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "rand_hc"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_isaac"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_jitter"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_os"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_pcg"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_xorshift"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rdrand"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "redox_syscall"
++version = "0.1.51"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "regex"
++version = "0.2.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "regex-syntax"
++version = "0.5.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "remove_dir_all"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rink"
++version = "0.4.4"
++dependencies = [
++ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
++ "chrono-humanize 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "chrono-tz 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "json 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "linefeed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rink-irc"
++version = "0.4.0"
++dependencies = [
++ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "irc 0.11.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rink 0.4.4",
++]
++
++[[package]]
++name = "rink-web"
++version = "0.4.0"
++dependencies = [
++ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "handlebars 0.25.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "handlebars-iron 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "limiter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rink 0.4.4",
++ "router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "route-recognizer"
++version = "0.1.12"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "router"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rust-gmp"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rustc-serialize"
++version = "0.3.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "rustc_version"
++version = "0.1.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rustc_version"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "safemem"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "same-file"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "schannel"
++version = "0.1.14"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "security-framework"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "security-framework-sys"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "semver"
++version = "0.1.20"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "semver"
++version = "0.9.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "semver-parser"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "sequence_trie"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "serde"
++version = "0.8.23"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "serde"
++version = "1.0.85"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "serde_codegen"
++version = "0.8.23"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_codegen_internals 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "serde_codegen_internals"
++version = "0.11.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "serde_derive"
++version = "0.8.23"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "serde_codegen 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "serde_json"
++version = "0.8.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "shell32-sys"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "siphasher"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "slab"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "smallvec"
++version = "0.6.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "staticfile"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "strsim"
++version = "0.5.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "syn"
++version = "0.10.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "tempdir"
++version = "0.3.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "tempfile"
++version = "3.0.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
++ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "thread_local"
++version = "0.3.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "time"
++version = "0.1.42"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "toml"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "traitobject"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "typeable"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "typemap"
++version = "0.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "ucd-util"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "unicase"
++version = "1.4.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicode-bidi"
++version = "0.3.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicode-normalization"
++version = "0.1.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicode-width"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "unicode-xid"
++version = "0.0.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "unreachable"
++version = "1.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unsafe-any"
++version = "0.4.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "url"
++version = "1.7.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "urlencoded"
++version = "0.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bodyparser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "utf8-ranges"
++version = "1.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "uuid"
++version = "0.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "vcpkg"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "version_check"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "void"
++version = "1.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "walkdir"
++version = "0.1.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "walkdir"
++version = "1.0.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "winapi"
++version = "0.2.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "winapi"
++version = "0.3.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "winapi-build"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "winapi-i686-pc-windows-gnu"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "winapi-x86_64-pc-windows-gnu"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "ws2_32-sys"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "xml-rs"
++version = "0.3.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[metadata]
++"checksum MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f"
++"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
++"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
++"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
++"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
++"checksum bincode 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55eb0b7fd108527b0c77860f75eca70214e11a8b4c6ef05148c54c05a25d48ad"
++"checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
++"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
++"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
++"checksum bodyparser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6928e817538b74a73d1dd6e9a942a2a35c632a597b6bb14fd009480f859a6bf5"
++"checksum buf_redux 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "861b9d19b9f5cb40647242d10d0cb0a13de0a96d5ff8c8a01ea324fa3956eb7d"
++"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
++"checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
++"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
++"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
++"checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
++"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
++"checksum chrono-humanize 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92afb1436280b0e4ed573c747ad30a1469cd945c201265b4d01e72cfa598da4f"
++"checksum chrono-tz 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "45438695f3f154032951a341ecca7ed200714bea615096885c9e86ca9fa3d66b"
++"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
++"checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
++"checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
++"checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
++"checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
++"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
++"checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
++"checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
++"checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
++"checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
++"checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
++"checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
++"checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
++"checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
++"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
++"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
++"checksum fsevent 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c4bbbf71584aeed076100b5665ac14e3d85eeb31fdbb45fbd41ef9a682b5ec05"
++"checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
++"checksum fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81f7f8eb465745ea9b02e2704612a9946a59fa40572086c6fd49d6ddcf30bf31"
++"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
++"checksum handlebars 0.25.3 (registry+https://github.com/rust-lang/crates.io-index)" = "15bdf598fc3c2de40c6b340213028301c0d225eea55a2294e6cc148074e557a1"
++"checksum handlebars-iron 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f86cf6ff931aa78e61415ad40c48a9af101b9a888eeed6ecf4f48dc52e80b76"
++"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
++"checksum hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c"
++"checksum hyper-native-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d375598f442742b0e66208ee12501391f1c7ac0bafb90b4fe53018f81f06068"
++"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
++"checksum inotify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8458c07bdbdaf309c80e2c3304d14c3db64e7465d4f07cf589ccb83fd0ff31a"
++"checksum ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "675587430ede6756dd03fdfdf9888f22f83855fd131c8451d842a710b059e571"
++"checksum irc 0.11.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6a45f7136bbfeec4377afc6363b38440ce153d8a61777d56da0c6b1176cf135a"
++"checksum iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2440ae846e7a8c7f9b401db8f6e31b4ea5e7d3688b91761337da7e054520c75b"
++"checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
++"checksum json 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f3fb4510c0dbc38f7f43bdbe8b53defae0cd338b81ef416462a0ef69d600165c"
++"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
++"checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
++"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
++"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
++"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
++"checksum limiter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc5d8bf63416df5331084dd9883b9598582f0d7ad5e42d53e55b05366931676"
++"checksum linefeed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1301a570e4e7d2d0f324b7a3fa73eac85b05c81b656a0983b16ebc8c504e53b6"
++"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
++"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
++"checksum logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92ff59f9a797ff30f711fe6b8489ad424953cee17c206de77d3c5957a9182ba7"
++"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
++"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
++"checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
++"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
++"checksum mime_guess 1.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2d4c0961143b8efdcfa29c3ae63281601b446a4a668165454b6c90f8024954c5"
++"checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
++"checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
++"checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
++"checksum mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32245731923cd096899502fc4c4317cfd09f121e80e73f7f576cf3777a824256"
++"checksum multipart 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b16d6498fe5b0c2f6d973fd9753da099948834f96584d628e44a75f0d2955b03"
++"checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
++"checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
++"checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
++"checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
++"checksum notify 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13fdd4a6894329b193f38f03a88823ce721275fdfdb29820c44a30515033524e"
++"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
++"checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
++"checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
++"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
++"checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
++"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
++"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
++"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
++"checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
++"checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
++"checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
++"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
++"checksum openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)" = "1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6"
++"checksum params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "421e9f2c30e80365c9672709be664bfc84f73b088720d1cc1f4e99675814bb37"
++"checksum parse-zoneinfo 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ee19a3656dadae35a33467f9714f1228dd34766dbe49e10e656b5296867aea"
++"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
++"checksum persistent 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c9c94f2ef72dc272c6bcc8157ccf2bc7da14f4c58c69059ac2fc48492d6916"
++"checksum pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
++"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
++"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
++"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
++"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
++"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
++"checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
++"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
++"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
++"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
++"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
++"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
++"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
++"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
++"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
++"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
++"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
++"checksum rand_jitter 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "080723c6145e37503a2224f801f252e14ac5531cb450f4502698542d188cb3c0"
++"checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
++"checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
++"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
++"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
++"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
++"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
++"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
++"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
++"checksum route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3255338088df8146ba63d60a9b8e3556f1146ce2973bc05a75181a42ce2256"
++"checksum router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9b1797ff166029cb632237bb5542696e54961b4cf75a324c6f05c9cf0584e4e"
++"checksum rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ddf28998d5730b96a9fe188557953de503d77ff403ae175ad1417921e5d906"
++"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
++"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
++"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
++"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
++"checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
++"checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
++"checksum security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfab8dda0e7a327c696d893df9ffa19cadc4bd195797997f5223cf5831beaf05"
++"checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
++"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
++"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
++"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
++"checksum sequence_trie 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c915714ca833b1d4d6b8f6a9d72a3ff632fe45b40a8d184ef79c81bec6327eed"
++"checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
++"checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
++"checksum serde_codegen 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c5d8a33087d8984f9535daa62a6498a08f6476050b00ab9339dd847e4c25cc"
++"checksum serde_codegen_internals 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "afad7924a009f859f380e4a2e3a509a845c2ac66435fcead74a4d983b21ae806"
++"checksum serde_derive 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "ce44e5f4264b39e9d29c875357b7cc3ebdfb967bb9e22bfb5e44ffa400af5306"
++"checksum serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "67f7d2e9edc3523a9c8ec8cd6ec481b3a27810aafee3e625d311febd3e656b4c"
++"checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
++"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
++"checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
++"checksum smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15"
++"checksum staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31493480e073d52522a94cdf56269dd8eb05f99549effd1826b0271690608878"
++"checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
++"checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
++"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
++"checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
++"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
++"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
++"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
++"checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
++"checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
++"checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
++"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
++"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
++"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
++"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
++"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
++"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
++"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
++"checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
++"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
++"checksum urlencoded 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c28708636d6f7298a53b1cdb6af40f1ab523209a7cb83cf4d41b3ebc671d319"
++"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
++"checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
++"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
++"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
++"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
++"checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
++"checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
++"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
++"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
++"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
++"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
++"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
++"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
++"checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"

--- a/pkgs/applications/science/misc/rink/default.nix
+++ b/pkgs/applications/science/misc/rink/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform, openssl, pkgconfig, gmp, ncurses }:
+
+rustPlatform.buildRustPackage rec {
+  version = "0.4.4";
+  name = "rink-${version}";
+
+  src = fetchFromGitHub {
+    owner = "tiffany352";
+    repo = "rink-rs";
+    rev = "v${version}";
+    sha256 = "0rvck5ahg7s51fdlr2ch698cwnyc6qp84zhfgs3wkszj9r5j470k";
+  };
+  cargoPatches = [ ./cargo-lock.patch ];
+
+  cargoSha256 = "0xmmxm7zwmq7w0pspx17glg4mjgh9l61w0h2k7n97x6p35i198d1";
+
+  buildInputs = [ pkgconfig ];
+  propagatedBuildInputs = [ openssl gmp ncurses ];
+
+  # Some tests fail and/or attempt to use internet servers.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Unit-aware calculator";
+    homepage = http://rink.tiffnix.com;
+    license = with licenses; [ mpl20 gpl3 ];
+    maintainers = [ maintainers.sb0 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22107,6 +22107,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   });
 
+  rink = callPackage ../applications/science/misc/rink { };
+
   simgrid = callPackage ../applications/science/misc/simgrid { };
 
   spyder = callPackage ../applications/science/spyder { };


### PR DESCRIPTION
###### Motivation for this change
Add the Rink unit-aware calculator (https://rink.tiffnix.com/)

###### Things done

- [X] Tested using sandboxing
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
