### PR TITLE
compton-git: 5 -> 5.1-rc2, fix crashes and other regressions

### DIFF
--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -63,7 +63,7 @@ let
 
   gitSource = rec {
     pname = "compton-git";
-    version = "5";
+    version = "5.1-rc2";
 
     COMPTON_VERSION = "v${version}";
 
@@ -73,7 +73,7 @@ let
       owner  = "yshui";
       repo   = "compton";
       rev    = COMPTON_VERSION;
-      sha256 = "1x5r2dch023imgdqhgf1zxi05cc742s7xr7jzpymvl9ldqly8ppa";
+      sha256 = "1qpy76kkhz8gfby842ry7lanvxkjxh4ckclkcjk4xi2wsmbhyp08";
     };
 
     buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

cc #54914


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---