### PR TITLE
cairo: 1.16.0 -> 1.17.2

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -10,14 +10,14 @@
 assert glSupport -> libGL != null;
 
 let
-  version = "1.16.0";
+  version = "1.17.2";
   inherit (stdenv.lib) optional optionals;
 in stdenv.mkDerivation rec {
   name = "cairo-${version}";
 
   src = fetchurl {
     url = "https://cairographics.org/${if stdenv.lib.mod (builtins.fromJSON (stdenv.lib.versions.minor version)) 2 == 0 then "releases" else "snapshots"}/${name}.tar.xz";
-    sha256 = "0c930mk5xr2bshbdljv005j3j8zr47gqmkry3q6qgvqky6rjjysy";
+    sha256 = "1pq1i10fkcijbcjzg8589bd6wx5s555nyrhw20ms4irabrjx8w3b";
   };
 
   outputs = [ "out" "dev" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change


> This snapshot provides the new support for writing floating point
> formats as 16 bpc PNGs, with support for RGBA128F and RGB96F formats.
> This new feature increases Cairo's pixman version requirement to 0.36.0.

Also contains upstream fixes (I think?) for #54805


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Still build-testing but looks pretty safe (~20 commits total).