### PR TITLE
nixos/tasks/encrypted-devices: fix regression from #54637

### DIFF
--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -19,21 +19,21 @@ let
         description = "The block device is backed by an encrypted one, adds this device as a initrd luks entry.";
       };
 
-      options.blkDev = mkOption {
+      blkDev = mkOption {
         default = null;
         example = "/dev/sda1";
         type = types.nullOr types.str;
         description = "Location of the backing encrypted device.";
       };
 
-      options.label = mkOption {
+      label = mkOption {
         default = null;
         example = "rootfs";
         type = types.nullOr types.str;
         description = "Label of the unlocked encrypted device. Set <literal>fileSystems.&lt;name?&gt;.device</literal> to <literal>/dev/mapper/&lt;label&gt;</literal> to mount the unlocked device.";
       };
 
-      options.keyFile = mkOption {
+      keyFile = mkOption {
         default = null;
         example = "/mnt-root/root/.swapkey";
         type = types.nullOr types.str;


### PR DESCRIPTION
27982b408e465554b8831f492362bc87ed0ec02a introduced a bug when
refactoring the encrypted-devices module, causing some encrypted
filesystem options to not be recognized anymore.

See e.g. https://hydra.nixos.org/build/88145490

FYI @danbst 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

