### PR TITLE
Reverts kernel bump + patch

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -58,14 +58,11 @@ rec {
     };
   };
 
-  # Reverts a change related to the overlayfs overhaul in 4.19
-  # https://github.com/NixOS/nixpkgs/issues/48828#issuecomment-445208626
-  revert-vfs-dont-open-real = rec {
-    name = "revert-vfs-dont-open-real";
+  raspberry_pi_wifi_fix = rec {
+    name = "raspberry-pi-wifi-fix";
     patch = fetchpatch {
-      name = name + ".patch";
-      url = https://github.com/samueldr/linux/commit/ee23fa215caaa8102f4ab411d39fcad5858147f2.patch;
-      sha256 = "0bp4jryihg1y2sl8zlj6w7vvnxj0kmb6xdy42hpvdv43kb6ngiaq";
+      url = https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/730522ae76aa57b89fa317c5084613d3d50cf3b8/core/linux-aarch64/0005-mmc-sdhci-iproc-handle-mmc_of_parse-errors-during-pr.patch;
+      sha256 = "0gbfycky28vbdjgys1z71wl5q073dmbrkvbnr6693jsda3qhp6za";
     };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14742,7 +14742,7 @@ in
   });
 
   # The current default kernel / kernel modules.
-  linuxPackages = linuxPackages_4_19;
+  linuxPackages = linuxPackages_4_14;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14556,7 +14556,6 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
-        kernelPatches.revert-vfs-dont-open-real
       ];
   };
 
@@ -14564,7 +14563,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
-        kernelPatches.revert-vfs-dont-open-real
+        kernelPatches.raspberry_pi_wifi_fix
       ];
   };
 


### PR DESCRIPTION
This affected users of the unstable branch in an "untenable" way. #54508, once merged, will allow us to catch similar regressions.

See

 * #48828
 * #54509 

Hopefully we can have a resolution for the issues before the 19.03 release.

cc @peti @bachp

We don't have "unstable" release notes, but if we had some, we'd include something along the line:

> The default kernel has been downgraded back to the 4.14 LTS. This will affect all the default images built by the project, especially notable the sd_card image for aarch64 has never previously been built with the 4.14 kernel. End-users of either new hardware or fussy hardware might want to verify which kernel they are using before rebuilding and rebooting to keep track of potential regressions after boot.
>
> Please note that the `new_kernel` variants, which would help with this issue for users needing an installation media with a new kernel, haven't been build since the addition of ZFS to the default build for the installers. cc @grahamc / PR #51090
>
> ```
> in job ‘nixos.***_new_kernel.***-linux’:
> Linux v4.20.6 is not yet supported by zfsonlinux v0.7.12.
> Try zfsUnstable or set the NixOS option boot.zfs.enableUnstable.
> ```

* * *
 * ✔️ Fits CONTRIBUTING.md