### PR TITLE
python3Packages.sly: init at 0.3

### DIFF
--- a/pkgs/development/python-modules/sly/default.nix
+++ b/pkgs/development/python-modules/sly/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "sly";
+  version = "0.3";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "be6a3825b042a9e1b6f5730fc747e6d983c917f0f002d798d0b9f86ca5c05ad9";
+  };
+
+  checkInputs = [ pytest ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An improved PLY implementation of lex and yacc for Python 3";
+    homepage = https://github.com/dabeaz/sly;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -778,6 +778,8 @@ in {
 
   slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };
 
+  sly = callPackage ../development/python-modules/sly { };
+
   snapcast = callPackage ../development/python-modules/snapcast { };
 
   spglib = callPackage ../development/python-modules/spglib { };


### PR DESCRIPTION
tests will be included with the next release
https://github.com/dabeaz/sly/pull/25
this is why I have not disabled tests (currently they pass with 0
tests run).

###### Motivation for this change

Saw a great talk on this package. Looking to toy around with an LALR parser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

