### PR TITLE
all-packages: Just refer to `self`, not `super`, or `res` 

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -153,9 +153,9 @@ let
     '';
   };
 
-in self: super: {
+in self: {
 
-  postgresql_9_4 = super.callPackage generic {
+  postgresql_9_4 = self.callPackage generic {
     version = "9.4.20";
     psqlSchema = "9.4";
     sha256 = "0zzqjz5jrn624hzh04drpj6axh30a9k6bgawid6rwk45nbfxicgf";
@@ -163,7 +163,7 @@ in self: super: {
     inherit self;
   };
 
-  postgresql_9_5 = super.callPackage generic {
+  postgresql_9_5 = self.callPackage generic {
     version = "9.5.15";
     psqlSchema = "9.5";
     sha256 = "0i2lylgmsmy2g1ixlvl112fryp7jmrd0i2brk8sxb7vzzpg3znnv";
@@ -171,7 +171,7 @@ in self: super: {
     inherit self;
   };
 
-  postgresql_9_6 = super.callPackage generic {
+  postgresql_9_6 = self.callPackage generic {
     version = "9.6.11";
     psqlSchema = "9.6";
     sha256 = "0c55akrkzqd6p6a8hr0338wk246hl76r9j16p4zn3s51d7f0l99q";
@@ -179,7 +179,7 @@ in self: super: {
     inherit self;
   };
 
-  postgresql_10 = super.callPackage generic {
+  postgresql_10 = self.callPackage generic {
     version = "10.6";
     psqlSchema = "10.0";
     sha256 = "0jv26y3f10svrjxzsgqxg956c86b664azyk2wppzpa5x11pjga38";
@@ -187,7 +187,7 @@ in self: super: {
     inherit self;
   };
 
-  postgresql_11 = super.callPackage generic {
+  postgresql_11 = self.callPackage generic {
     version = "11.1";
     psqlSchema = "11.1";
     sha256 = "026v0sicsh7avzi45waf8shcbhivyxmi7qgn9fd1x0vl520mx0ch";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6,25 +6,11 @@
  * Hint: ### starts category names.
  */
 { lib, noSysDirs, config}:
-res: pkgs: super:
+pkgs:
 
 with pkgs;
 
-let
-  self =
-    builtins.trace ''
-        It seems that you are using a patched Nixpkgs that references the self
-        variable in pkgs/top-level/all-packages.nix. This variable was incorrectly
-        named, so its usage needs attention. Please use pkgs for packages or super
-        for functions.
-      ''
-      res; # Do *NOT* use res in your fork. It will be removed.
-
-  # TODO: turn self into an error
-
-in
 {
-
   # Allow callPackage to fill in the pkgs argument
   inherit pkgs;
 
@@ -16218,7 +16204,7 @@ in
   };
   bitwig-studio2 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio2.nix {
     inherit (gnome3) zenity;
-    inherit (res) bitwig-studio1;
+    inherit (pkgs) bitwig-studio1;
   };
   bitwig-studio = bitwig-studio2;
 
@@ -22528,7 +22514,7 @@ in
      parameter set to the right value for your deployment target.
   */
   nixos = configuration:
-    (import (res.path + "/nixos/lib/eval-config.nix") {
+    (import (pkgs.path + "/nixos/lib/eval-config.nix") {
       inherit (pkgs.stdenv.hostPlatform) system;
       modules = [(
                   { lib, ... }: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13870,7 +13870,7 @@ in
 
   timescaledb-parallel-copy = callPackage ../development/tools/database/timescaledb-parallel-copy { };
 
-  inherit (import ../servers/sql/postgresql pkgs super)
+  inherit (import ../servers/sql/postgresql pkgs)
     postgresql_9_4
     postgresql_9_5
     postgresql_9_6

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -89,10 +89,7 @@ let
   splice = self: super: import ./splice.nix lib self (buildPackages != null);
 
   allPackages = self: super:
-    let res = import ./all-packages.nix
-      { inherit lib noSysDirs config; }
-      res self super;
-    in res;
+    import ./all-packages.nix { inherit lib noSysDirs config; } self;
 
   aliases = self: super: lib.optionalAttrs (config.allowAliases or true) (import ./aliases.nix lib self super);
 


### PR DESCRIPTION
###### Motivation for this change

Includes a change to PostgreSQL to use `self.callPackage` which is the last step needed for this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

