### PR TITLE
cbfstool: 4.7 -> 4.9

### DIFF
--- a/pkgs/applications/virtualization/cbfstool/default.nix
+++ b/pkgs/applications/virtualization/cbfstool/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchgit, iasl, flex, bison }:
+{ stdenv, fetchurl, iasl, flex, bison }:
 
 stdenv.mkDerivation rec {
   name = "cbfstool-${version}";
-  version = "4.7";
+  version = "4.9";
 
-  src = fetchgit {
-    url = "http://review.coreboot.org/p/coreboot";
-    rev = "refs/tags/${version}";
-    sha256 = "02k63013vf7wgsilslj68fs1x81clvqpn91dydaqhv5aymh73zpi";
+  src = fetchurl {
+    url = "https://coreboot.org/releases/coreboot-${version}.tar.xz";
+    sha256 = "0xkai65d3z9fivwscbkm7ndcw2p9g794xz8fwdv979w77n5qsdij";
   };
 
   nativeBuildInputs = [ flex bison ];


### PR DESCRIPTION
also fix source, followup of #55066

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

