### PR TITLE
hydra: 2018-08-07 -> 2019-02-01

### DIFF
--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -1,77 +1,91 @@
-import ../make-test.nix ({ pkgs, ...} :
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../../.. { inherit system config; }
+}:
 
 let
-   trivialJob = pkgs.writeTextDir "trivial.nix" ''
-     { trivial = builtins.derivation {
-         name = "trivial";
-         system = "x86_64-linux";
-         builder = "/bin/sh";
-         args = ["-c" "echo success > $out; exit 0"];
-       };
-     }
-   '';
 
-    createTrivialProject = pkgs.stdenv.mkDerivation {
-      name = "create-trivial-project";
-      unpackPhase = ":";
-      buildInputs = [ pkgs.makeWrapper ];
-      installPhase = "install -m755 -D ${./create-trivial-project.sh} $out/bin/create-trivial-project.sh";
-      postFixup = ''
-        wrapProgram "$out/bin/create-trivial-project.sh" --prefix PATH ":" ${pkgs.stdenv.lib.makeBinPath [ pkgs.curl ]} --set EXPR_PATH ${trivialJob}
-      '';
-    };
+  trivialJob = pkgs.writeTextDir "trivial.nix" ''
+   { trivial = builtins.derivation {
+       name = "trivial";
+       system = "x86_64-linux";
+       builder = "/bin/sh";
+       args = ["-c" "echo success > $out; exit 0"];
+     };
+   }
+  '';
 
-in {
-  name = "hydra-init-localdb";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ pstn lewo ma27 ];
+  createTrivialProject = pkgs.stdenv.mkDerivation {
+    name = "create-trivial-project";
+    unpackPhase = ":";
+    buildInputs = [ pkgs.makeWrapper ];
+    installPhase = "install -m755 -D ${./create-trivial-project.sh} $out/bin/create-trivial-project.sh";
+    postFixup = ''
+      wrapProgram "$out/bin/create-trivial-project.sh" --prefix PATH ":" ${pkgs.stdenv.lib.makeBinPath [ pkgs.curl ]} --set EXPR_PATH ${trivialJob}
+    '';
   };
 
-  machine =
-    { pkgs, ... }:
+  callTest = f: f { inherit system pkgs; };
 
-    {
-      virtualisation.memorySize = 1024;
-      time.timeZone = "UTC";
+  hydraPkgs = {
+    inherit (pkgs) nixStable nixUnstable;
+  };
 
-      environment.systemPackages = [ createTrivialProject pkgs.jq ];
-      services.hydra = {
-        enable = true;
+  tests = pkgs.lib.flip pkgs.lib.mapAttrs hydraPkgs (name: nix:
+    callTest (import ../make-test.nix ({ pkgs, lib, ... }:
+      {
+        name = "hydra-with-${name}";
+        meta = with pkgs.stdenv.lib.maintainers; {
+          maintainers = [ pstn lewo ma27 ];
+        };
 
-        #Hydra needs those settings to start up, so we add something not harmfull.
-        hydraURL = "example.com";
-        notificationSender = "example@example.com";
-      };
-      nix = {
-        buildMachines = [{
-          hostName = "localhost";
-          systems = [ "x86_64-linux" ];
-        }];
+        machine = { pkgs, ... }:
+          {
+            virtualisation.memorySize = 1024;
+            time.timeZone = "UTC";
 
-        binaryCaches = [];
-      };
-    };
+            environment.systemPackages = [ createTrivialProject pkgs.jq ];
+            services.hydra = {
+              enable = true;
 
-  testScript =
-    ''
-      # let the system boot up
-      $machine->waitForUnit("multi-user.target");
-      # test whether the database is running
-      $machine->succeed("systemctl status postgresql.service");
-      # test whether the actual hydra daemons are running
-      $machine->succeed("systemctl status hydra-queue-runner.service");
-      $machine->succeed("systemctl status hydra-init.service");
-      $machine->succeed("systemctl status hydra-evaluator.service");
-      $machine->succeed("systemctl status hydra-send-stats.service");
+              #Hydra needs those settings to start up, so we add something not harmfull.
+              hydraURL = "example.com";
+              notificationSender = "example@example.com";
 
-      $machine->succeed("hydra-create-user admin --role admin --password admin");
+              package = pkgs.hydra.override { inherit nix; };
+            };
+            nix = {
+              buildMachines = [{
+                hostName = "localhost";
+                systems = [ "x86_64-linux" ];
+              }];
 
-      # create a project with a trivial job
-      $machine->waitForOpenPort(3000);
+              binaryCaches = [];
+            };
+          };
 
-      # make sure the build as been successfully built
-      $machine->succeed("create-trivial-project.sh");
+        testScript = ''
+          # let the system boot up
+          $machine->waitForUnit("multi-user.target");
+          # test whether the database is running
+          $machine->succeed("systemctl status postgresql.service");
+          # test whether the actual hydra daemons are running
+          $machine->succeed("systemctl status hydra-queue-runner.service");
+          $machine->succeed("systemctl status hydra-init.service");
+          $machine->succeed("systemctl status hydra-evaluator.service");
+          $machine->succeed("systemctl status hydra-send-stats.service");
 
-      $machine->waitUntilSucceeds('curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq');
-    '';
-})
+          $machine->succeed("hydra-create-user admin --role admin --password admin");
+
+          # create a project with a trivial job
+          $machine->waitForOpenPort(3000);
+
+          # make sure the build as been successfully built
+          $machine->succeed("create-trivial-project.sh");
+
+          $machine->waitUntilSucceeds('curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq');
+        '';
+      })));
+
+in
+  tests

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -1,7 +1,7 @@
 { stdenv, nix, perlPackages, buildEnv, releaseTools, fetchFromGitHub
 , makeWrapper, autoconf, automake, libtool, unzip, pkgconfig, sqlite, libpqxx
 , gitAndTools, mercurial, darcs, subversion, bazaar, openssl, bzip2, libxslt
-, guile, perl, postgresql, nukeReferences, git, boehmgc
+, guile, perl, postgresql, nukeReferences, git, boehmgc, nlohmann_json
 , docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
 , rpm, dpkg, cdrkit, pixz, lib, fetchpatch, boost, autoreconfHook
 }:
@@ -34,8 +34,8 @@ let
         CatalystViewDownload
         CatalystViewJSON
         CatalystViewTT
-        CatalystXRoleApplicator
         CatalystXScriptServerStarman
+        CatalystXRoleApplicator
         CryptRandPasswd
         DBDPg
         DBDSQLite
@@ -71,15 +71,15 @@ let
   };
 in releaseTools.nixBuild rec {
   name = "hydra-${version}";
-  version = "2018-08-07";
+  version = "2019-02-01";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "4dca8fe14d3f782bdf927f37efce722acefffff3";
-    sha256 = "1yas4psmvfp7lhcp81ia2sy93b78j9hiw9a6n3q2m1a616hwpm25";
+    rev = "8b5948f4cf12424c04df67a6eb136c9846fb2cfd";
+    sha256 = "0ldk3li394vykl9c4v9bs8pir05pmad24s0rx9bzqgz569zfj2iv";
   };
 
   buildInputs =
@@ -88,6 +88,7 @@ in releaseTools.nixBuild rec {
       guile # optional, for Guile + Guix support
       perlDeps perl nix
       postgresql # for running the tests
+      nlohmann_json
     ] ++ lib.optionals isGreaterNix20 [ boost ];
 
   hydraPath = lib.makeBinPath (

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -8,6 +8,10 @@
 
 with stdenv;
 
+if lib.versions.major nix.version == "1"
+  then throw "This Hydra version doesn't support Nix 1.x"
+else
+
 let
   isGreaterNix20 = with lib.versions;
     let


### PR DESCRIPTION
###### Motivation for this change

The version of Hydra currently in nixpkgs does not build because it is incompatible with the latest version of Nix.

###### Things done

Updates Hydra to the latest revision. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

