### PR TITLE
postgresql test: fix

### DIFF
--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -7,7 +7,7 @@ with import ../lib/testing.nix { inherit system pkgs; };
 with pkgs.lib;
 
 let
-  postgresql-versions = import ../../pkgs/servers/sql/postgresql pkgs pkgs;
+  postgresql-versions = import ../../pkgs/servers/sql/postgresql pkgs;
   test-sql = pkgs.writeText "postgresql-test" ''
     CREATE EXTENSION pgcrypto; -- just to check if lib loading works
     CREATE TABLE sth (
@@ -67,12 +67,7 @@ let
 
   };
 in
-  (mapAttrs' (name: package: { inherit name; value=make-postgresql-test name package false;}) postgresql-versions) // (
-    # just pick one version for the dump all test
-    let
-      first = head (attrNames postgresql-versions);
-      name = "${first}-backup-all";
-    in {
-      ${name} = make-postgresql-test name postgresql-versions.${first} true;
-    }
-  )
+  (mapAttrs' (name: package: { inherit name; value=make-postgresql-test name package false;}) postgresql-versions) // {
+    postgresql_11-backup-all = make-postgresql-test name postgresql-versions.postgresql_11 true;
+  }
+


### PR DESCRIPTION
Commit https://github.com/NixOS/nixpkgs/pull/55097 didn't modify all usages of postgresql/default.nix.

Also, replaced "random" pg with pg11. Random pg was always pg10.