### PR TITLE
chirp: 20181018 -> 20190201

### DIFF
--- a/pkgs/applications/misc/chirp/default.nix
+++ b/pkgs/applications/misc/chirp/default.nix
@@ -2,12 +2,12 @@
 , pyserial, pygtk }:
 
 stdenv.mkDerivation rec {
-  name = "chirp-daily-${version}";
-  version = "20181018";
+  pname = "chirp-daily";
+  version = "20190201";
 
   src = fetchurl {
-    url = "https://trac.chirp.danplanet.com/chirp_daily/daily-${version}/${name}.tar.gz";
-    sha256 = "0jd7xi6q09b3djn1k7pj1sbqvw24kn7dcp9r6abvxily4pc1xhdr";
+    url = "https://trac.chirp.danplanet.com/chirp_daily/daily-${version}/${pname}-${version}.tar.gz";
+    sha256 = "1ag3qzdq39zhpagviq9gpwk4y3h11z0j40nccsnhlq8h8bxpvwlf";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

