### PR TITLE
tetra-gtk-theme: 0.2.0 -> 201902

### DIFF
--- a/pkgs/misc/themes/tetra/default.nix
+++ b/pkgs/misc/themes/tetra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tetra-gtk-theme-${version}";
-  version = "0.2.0";
+  version = "201902";
 
   src = fetchFromGitHub {
     owner  = "hrdwrrsk";
     repo   = "tetra-gtk-theme";
     rev    = version;
-    sha256 = "1lzkmswv3ml2zj80z067j1hj1cvpdcl86jllahqx3jwnmr0a4fhd";
+    sha256 = "0xvp85mzgh5msr3s6wl9xagz2xxqmy3s9jndbmwh1cc79fycggqv";
   };
 
   preBuild = ''
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Adwaita-based gtk+ theme with design influence from elementary OS and Vertex gtk+ theme.";
+    description = "Adwaita-based gtk+ theme with design influence from elementary OS and Vertex gtk+ theme";
     homepage    = https://github.com/hrdwrrsk/tetra-gtk-theme;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ dtzWill ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [201902](https://github.com/hrdwrrsk/tetra-gtk-theme/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).