### PR TITLE
elasticsearch: add example on how to use plugins

### DIFF
--- a/nixos/modules/services/search/elasticsearch.nix
+++ b/nixos/modules/services/search/elasticsearch.nix
@@ -131,6 +131,7 @@ in {
       description = "Extra elasticsearch plugins";
       default = [];
       type = types.listOf types.package;
+      example = lib.literalExample "[ pkgs.elasticsearchPlugins.discovery-ec2 ]";
     };
 
   };


### PR DESCRIPTION
See https://discourse.nixos.org/t/elastic-search-plugins/1997

However, I'm not keen to merge this, as I can't build any ES plugin. I'm trying it in declarative container:
```
  containers.elastic = {
    autoStart = true;
    config = { pkgs, ...}: {
      nixpkgs.config.allowUnfree = true;
      services.elasticsearch.enable = true;
      services.elasticsearch.package = pkgs.elasticsearch6;
      services.elasticsearch.plugins = [ pkgs.elasticsearchPlugins.discovery-ec2 ];
    };
  };
```
```
builder for '/nix/store/a1dxizvfp549arl4waq54jq8l8bskf24-elasticsearch-discovery-ec2-6.5.1.drv' failed with exit code 1; last 8 log lines:
  unpacking sources
  patching sources
  configuring
  no configure script, doing nothing
  building
  no Makefile, doing nothing
  installing
  Error: Could not find or load main class org.elasticsearch.tools.java_version_checker.JavaVersionChecker
```
cc @Mic92 @basvandijk

Also, don't know how to make sure plugin from example won't be removed in future. Or example will be updated when plugin is removed.

nixpkgs 11cf7d6