### PR TITLE
xastir: 2.0.8 -> 2.1.0

### DIFF
--- a/pkgs/applications/misc/xastir/default.nix
+++ b/pkgs/applications/misc/xastir/default.nix
@@ -5,14 +5,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "xastir-${version}";
-  version = "208";
+  pname = "xastir";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
-    owner = "Xastir";
-    repo = "Xastir";
-    rev = "707f3aa8c7ca3e3fecd32d5a4af3f742437e5dce";
-    sha256 = "1mm22vn3hws7dmg9wpaj4s0zkzb77i3aqa2ay3q6kqjkdhv25brl";
+    owner = pname;
+    repo = pname;
+    rev = "Release-${version}";
+    sha256 = "16zsgy3589snawr8f1fa22ymvpnjy6njvxmsck7q8p2xmmz2ry7r";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

