### PR TITLE
nixos-build-vms: pass `--option` to `nix-build`

### DIFF
--- a/nixos/doc/manual/man-nixos-build-vms.xml
+++ b/nixos/doc/manual/man-nixos-build-vms.xml
@@ -24,8 +24,14 @@
     
    <arg>
     <option>--help</option>
-   </arg>
-    
+  </arg>
+
+  <arg>
+    <option>--option</option>
+    <replaceable>name</replaceable>
+    <replaceable>value</replaceable>
+  </arg>
+
    <arg choice="plain">
     <replaceable>network.nix</replaceable>
    </arg>
@@ -112,6 +118,18 @@
     <listitem>
      <para>
       Shows the usage of this command to the user.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--option</option> <replaceable>name</replaceable> <replaceable>value</replaceable>
+    </term>
+    <listitem>
+     <para>Set the Nix configuration option
+      <replaceable>name</replaceable> to <replaceable>value</replaceable>.
+      This overrides settings in the Nix configuration file (see
+      <citerefentry><refentrytitle>nix.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>).
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/modules/installer/tools/nixos-build-vms/nixos-build-vms.sh
+++ b/nixos/modules/installer/tools/nixos-build-vms/nixos-build-vms.sh
@@ -9,49 +9,44 @@ showUsage() {
 
 # Parse valid argument options
 
-PARAMS=`getopt -n $0 -o h -l no-out-link,show-trace,help -- "$@"`
+nixBuildArgs=()
+networkExpr=
 
-if [ $? != 0 ]
-then
-    showUsage
-    exit 1
-fi
-
-eval set -- "$PARAMS"
-
-# Evaluate valid options
-
-while [ "$1" != "--" ]
-do
+while [ $# -gt 0 ]; do
     case "$1" in
-	--no-out-link)
-	    noOutLinkArg="--no-out-link"
-	    ;;
-	--show-trace)
-	    showTraceArg="--show-trace"
-	    ;;
-	-h|--help)
-	    showUsage
-	    exit 0
-	    ;;
+      --no-out-link)
+        nixBuildArgs+=("--no-out-link")
+        ;;
+      --show-trace)
+        nixBuildArgs+=("--show-trace")
+        ;;
+      -h|--help)
+        showUsage
+        exit 0
+        ;;
+      --option)
+        shift
+        nixBuildArgs+=("--option" "$1" "$2"); shift
+        ;;
+      *)
+        if [ ! -z "$networkExpr" ]; then
+          echo "Network expression already set!"
+          showUsage
+          exit 1
+        fi
+        networkExpr="$(readlink -f $1)"
+        ;;
     esac
-    
+
     shift
 done
 
-shift
-
-# Validate the given options
-
-if [ "$1" = "" ]
+if [ -z "$networkExpr" ]
 then
     echo "ERROR: A network expression must be specified!" >&2
     exit 1
-else
-    networkExpr=$(readlink -f $1)
 fi
 
 # Build a network of VMs
-
 nix-build '<nixpkgs/nixos/modules/installer/tools/nixos-build-vms/build-vms.nix>' \
-    --argstr networkExpr $networkExpr $noOutLinkArg $showTraceArg
+    --argstr networkExpr $networkExpr "${nixBuildArgs[@]}"


### PR DESCRIPTION
###### Motivation for this change

Also simplified the argument parsing to write all currently supported
CLI options into a bash array and pass this to `nix-build`.

Also documented `--option` usage in the corresponding manpage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

