### PR TITLE
WIP: nixos/netboot: netboot_minimal downloads the iso and extacts it

### DIFF
--- a/nixos/modules/installer/netboot/netboot-minimal.nix
+++ b/nixos/modules/installer/netboot/netboot-minimal.nix
@@ -1,10 +1,34 @@
 # This module defines a small netboot environment.
 
-{ ... }:
+{ config, ... }:
 
 {
-  imports =
-    [ ./netboot-base.nix
-      ../../profiles/minimal.nix
-    ];
+  imports = [
+    ../cd-dvd/installation-cd-base.nix
+  ];
+  boot.initrd.network.enable = true;
+  boot.devSize = "600m";
+
+  # TODO add all network modules
+  boot.initrd.kernelModules = [ "e1000" ];
+
+  # needed for dns in initrd
+  boot.initrd.extraUtilsCommands =''
+    cp ${pkgs.stdenv.cc.libc}/lib/libnss_dns.so.* $out/lib/
+  '';
+
+  boot.initrd.network.postCommands = ''
+    iso_link=https://releases.nixos.org$(wget -O- 'https://nixos.org/channels/nixos-${config.system.nixos.release}' | grep -o "/nixos/[^']*minimal[^']*x86_64-linux.iso")
+    wget "$iso_link" -O /dev/root
+  '';
+  boot.initrd.postMountCommands = ''
+    export stage2Init=$(find /mnt-root/nix/store -type f -name init | grep 'nixos-system' | sed 's@^/mnt-root@@')
+  '';
+
+  system.build.netbootIpxeScript = pkgs.writeTextDir "netboot.ipxe" ''
+    #!ipxe
+    kernel ${pkgs.stdenv.hostPlatform.platform.kernelTarget} init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+    initrd initrd
+    boot
+  '';
 }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -117,7 +117,7 @@ let
         postBuild = ''
           mkdir -p $out/nix-support
           echo "file ${kernelTarget} ${build.kernel}/${kernelTarget}" >> $out/nix-support/hydra-build-products
-          echo "file initrd ${build.netbootRamdisk}/initrd" >> $out/nix-support/hydra-build-products
+          echo "file initrd ${build.initialRamdisk}/initrd" >> $out/nix-support/hydra-build-products
           echo "file ipxe ${build.netbootIpxeScript}/netboot.ipxe" >> $out/nix-support/hydra-build-products
         '';
         preferLocalBuild = true;


### PR DESCRIPTION
###### Motivation for this change

get netboot.xyz support.
I wasn't able to test this, because I don't know how to evaluate release.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

