### PR TITLE
coqPackages.mathcomp-analysis: init at 0.1.0

### DIFF
--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, coq, mathcomp-bigenough, mathcomp-finmap }:
+
+stdenv.mkDerivation rec {
+  version = "0.1.0";
+  name = "coq${coq.coq-version}-mathcomp-analysis-${version}";
+
+  src = fetchFromGitHub {
+    owner = "math-comp";
+    repo = "analysis";
+    rev = version;
+    sha256 = "0hwkr2wzy710pcyh274fcarzdx8sv8myp16pv0vq5978nmih46al";
+  };
+
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ mathcomp-bigenough mathcomp-finmap ];
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  meta = {
+    description = "Analysis library compatible with Mathematical Components";
+    inherit (src.meta) homepage;
+    inherit (coq.meta) platforms;
+    license = stdenv.lib.licenses.cecill-c;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.8" ];
+  };
+}

--- a/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, coq, mathcomp }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.0";
+  name = "coq${coq.coq-version}-mathcomp-bigenough-${version}";
+
+  src = fetchFromGitHub {
+    owner = "math-comp";
+    repo = "bigenough";
+    rev = version;
+    sha256 = "10g0gp3hk7wri7lijkrqna263346wwf6a3hbd4qr9gn8hmsx70wg";
+  };
+
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ mathcomp ];
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  meta = {
+    description = "A small library to do epsilon - N reasonning";
+    inherit (src.meta) homepage;
+    inherit (mathcomp.meta) platforms license;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
+  };
+}

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, coq, mathcomp }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.0";
+  name = "coq${coq.coq-version}-mathcomp-finmap-${version}";
+
+  src = fetchFromGitHub {
+    owner = "math-comp";
+    repo = "finmap";
+    rev = version;
+    sha256 = "05df59v3na8jhpsfp7hq3niam6asgcaipg2wngnzxzqnl86srp2a";
+  };
+
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ mathcomp ];
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  meta = {
+    description = "A finset and finmap library";
+    inherit (src.meta) homepage;
+    inherit (mathcomp.meta) platforms license;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -33,6 +33,7 @@ let
       iris = callPackage ../development/coq-modules/iris {};
       math-classes = callPackage ../development/coq-modules/math-classes { };
       mathcomp = callPackage ../development/coq-modules/mathcomp { };
+      mathcomp-bigenough = callPackage ../development/coq-modules/mathcomp-bigenough { };
       metalib = callPackage ../development/coq-modules/metalib { };
       multinomials = callPackage ../development/coq-modules/multinomials {};
       paco = callPackage ../development/coq-modules/paco {};

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -33,6 +33,7 @@ let
       iris = callPackage ../development/coq-modules/iris {};
       math-classes = callPackage ../development/coq-modules/math-classes { };
       mathcomp = callPackage ../development/coq-modules/mathcomp { };
+      mathcomp-analysis = callPackage ../development/coq-modules/mathcomp-analysis { };
       mathcomp-bigenough = callPackage ../development/coq-modules/mathcomp-bigenough { };
       mathcomp-finmap = callPackage ../development/coq-modules/mathcomp-finmap { };
       metalib = callPackage ../development/coq-modules/metalib { };

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -34,6 +34,7 @@ let
       math-classes = callPackage ../development/coq-modules/math-classes { };
       mathcomp = callPackage ../development/coq-modules/mathcomp { };
       mathcomp-bigenough = callPackage ../development/coq-modules/mathcomp-bigenough { };
+      mathcomp-finmap = callPackage ../development/coq-modules/mathcomp-finmap { };
       metalib = callPackage ../development/coq-modules/metalib { };
       multinomials = callPackage ../development/coq-modules/multinomials {};
       paco = callPackage ../development/coq-modules/paco {};


### PR DESCRIPTION
###### Motivation for this change

Add a library and its dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

