### PR TITLE
ocamlPackages.ocsigen_server: 2.9 -> 2.11 (and related updates)

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,23 +1,22 @@
-{ stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml, camlp4,
+{ stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml, lwt_camlp4,
   lwt_react, cryptokit,
-  ipaddr, ocamlnet, lwt_ssl, ocaml_pcre,
+  ipaddr, ocamlnet, ocaml_pcre,
   opaline, ppx_tools, ppx_deriving, findlib
 , js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
 , js_of_ocaml-lwt
 , js_of_ocaml-tyxml
+, lwt_ppx
 }:
-
-assert stdenv.lib.versionAtLeast ocaml.version "4.03";
 
 stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "6.3.0";
+  version = "6.4.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "137hgdzv9fwkzf6xdksqy437lrf8xvrycf5jwc3z4cmpsigs6x7v";
+    sha256 = "1ad7ympvj0cb51d9kbp4naxkld3gv8cfp4a037a5dr55761zdhdh";
   };
 
   patches = [ ./camlp4.patch ];
@@ -27,15 +26,12 @@ stdenv.mkDerivation rec
   ];
 
   propagatedBuildInputs = [
-    camlp4
-    cryptokit
-    ipaddr
     js_of_ocaml-lwt
     js_of_ocaml-ppx
     js_of_ocaml-tyxml
+    lwt_camlp4
+    lwt_ppx
     lwt_react
-    lwt_ssl
-    ocamlnet ocaml_pcre
     ocsigen_server
     ppx_deriving
   ];

--- a/pkgs/development/ocaml-modules/lwt/camlp4.nix
+++ b/pkgs/development/ocaml-modules/lwt/camlp4.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildDunePackage, camlp4 }:
+
+buildDunePackage rec {
+  pname = "lwt_camlp4";
+  version = "git-20180325";
+
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = pname;
+    rev = "45f25a081e01071ab566924b48ba5f7553bb33ac";
+    sha256 = "1lv8z6ljfy47yvxmwf5jrvc5d3dc90r1n291x53j161sf22ddrk9";
+  };
+
+  minimumOCamlVersion = "4.02";
+
+  propagatedBuildInputs = [ camlp4 ];
+
+  meta = {
+    description = "Camlp4 syntax extension for Lwt (deprecated)";
+    license = lib.licenses.lgpl21;
+    inherit (src.meta) homepage;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}
+

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -1,42 +1,37 @@
-{ stdenv, fetchurl, ocaml, findlib, which, react, ssl
-, ocamlnet, ocaml_pcre, cryptokit, tyxml, ipaddr, zlib,
-libev, openssl, ocaml_sqlite3, tree, uutf, makeWrapper, camlp4
-, camlzip, pgocaml, lwt2, lwt_react, lwt_ssl
+{ stdenv, fetchFromGitHub, which, ocaml, findlib, lwt_react, ssl, lwt_ssl
+, lwt_log, ocamlnet, ocaml_pcre, cryptokit, tyxml, xml-light, ipaddr
+, pgocaml, camlzip, ocaml_sqlite3
+, makeWrapper
 }:
 
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "ocsigenserver is not available for OCaml ${ocaml.version}"
+else
+
 let mkpath = p: n:
-  let v = stdenv.lib.getVersion ocaml; in
-  "${p}/lib/ocaml/${v}/site-lib/${n}";
+  "${p}/lib/ocaml/${ocaml.version}/site-lib/${n}";
 in
 
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
-    version = "2.9";
-    sha256 = "0na3qa4h89f2wv31li63nfpg4151d0g8fply0bq59j3bhpyc85nd";
-    buildInputs = [ lwt_react lwt_ssl ];
-    ldpath = "";
-  } else {
-    version = "2.8";
-    sha256 = "1v44qv2ixd7i1qinyhlzzqiffawsdl7xhhh6ysd7lf93kh46d5sy";
-    buildInputs = [ lwt2 ];
-    ldpath = "${mkpath lwt2 "lwt"}";
-  }
-; in
+stdenv.mkDerivation rec {
+  version = "2.11.0";
+  name = "ocsigenserver-${version}";
 
-stdenv.mkDerivation {
-  name = "ocsigenserver-${param.version}";
-
-  src = fetchurl {
-    url = "https://github.com/ocsigen/ocsigenserver/archive/${param.version}.tar.gz";
-    inherit (param) sha256;
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = "ocsigenserver";
+    rev = version;
+    sha256 = "0y1ngki7w9s10ip7nj9qb7254bd5sp01xxz16sxyj7l7qz603hy2";
   };
 
-  buildInputs = [ocaml which findlib react ssl
-  ocamlnet ocaml_pcre cryptokit tyxml ipaddr zlib libev openssl
-  ocaml_sqlite3 tree uutf makeWrapper camlp4 pgocaml camlzip ]
-  ++ (param.buildInputs or []);
+  buildInputs = [ which makeWrapper ocaml findlib
+    lwt_react pgocaml camlzip ocaml_sqlite3
+  ];
 
-  configureFlags = [ "--root $(out) --prefix /" ];
+  propagatedBuildInputs = [ cryptokit ipaddr lwt_log lwt_ssl ocamlnet
+    ocaml_pcre tyxml xml-light
+  ];
+
+  configureFlags = [ "--root $(out)" "--prefix /" ];
 
   dontAddPrefix = true;
 
@@ -46,7 +41,7 @@ stdenv.mkDerivation {
   ''
   rm -rf $out/var/run
   wrapProgram $out/bin/ocsigenserver \
-    --prefix CAML_LD_LIBRARY_PATH : "${mkpath ssl "ssl"}:${param.ldpath}:${mkpath ocamlnet "netsys"}:${mkpath ocamlnet "netstring"}:${mkpath ocaml_pcre "pcre"}:${mkpath cryptokit "cryptokit"}:${mkpath ocaml_sqlite3 "sqlite3"}"
+    --prefix CAML_LD_LIBRARY_PATH : "${mkpath ssl "ssl"}:${mkpath ocamlnet "netsys"}:${mkpath ocamlnet "netstring"}:${mkpath ocaml_pcre "pcre"}:${mkpath cryptokit "cryptokit"}:${mkpath ocaml_sqlite3 "sqlite3"}"
   '';
 
   dontPatchShebangs = true;

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -6,7 +6,7 @@
 buildOcaml rec
 {
   name = "ocsigen-start";
-  version = "1.4.0";
+  version = "1.5.0";
 
   buildInputs = [ eliom js_of_ocaml-camlp4 ];
   propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server resource-pooling ];
@@ -21,7 +21,7 @@ buildOcaml rec
     owner = "ocsigen";
     repo = name;
     rev = version;
-    sha256 = "1kicbw5cjb9gkfmfbqf6fiwbi0rzpqgk2lzd4v6nxaiyinxm73ff";
+    sha256 = "07478hz5jhxb242hfr808516k81vdbzj4j6cycvls3b9lzbyszha";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchurl, buildOcaml, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ocsigen_deriving, ocsigen_server
+{ stdenv, fetchFromGitHub, buildOcaml, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ocsigen_deriving, ocsigen_server
 , js_of_ocaml-camlp4
+, resource-pooling
 }:
 
 buildOcaml rec
 {
   name = "ocsigen-start";
-  version = "1.1.0";
+  version = "1.2.0";
 
   buildInputs = [ eliom js_of_ocaml-camlp4 ];
-  propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server ];
+  propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server resource-pooling ];
 
   patches = [ ./templates-dir.patch ];
 
@@ -16,12 +17,12 @@ buildOcaml rec
   substituteInPlace "src/os_db.ml" --replace "citext" "text"
   '';
   
-  src = fetchurl {
-    url = "https://github.com/ocsigen/${name}/archive/${version}.tar.gz";
-    sha256 = "09cw6qzcld0m1qm66mbjg9gw8l6dynpw3fzhm3kfx5ldh0afgvjq";
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = name;
+    rev = version;
+    sha256 = "11sn673vhs08z8dq7ajnaz923kg82vvz9z5v6zq171y4zgg901zj";
   };
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = http://ocsigen.org/ocsigen-start;

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -6,7 +6,7 @@
 buildOcaml rec
 {
   name = "ocsigen-start";
-  version = "1.2.0";
+  version = "1.4.0";
 
   buildInputs = [ eliom js_of_ocaml-camlp4 ];
   propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server resource-pooling ];
@@ -21,7 +21,7 @@ buildOcaml rec
     owner = "ocsigen";
     repo = name;
     rev = version;
-    sha256 = "11sn673vhs08z8dq7ajnaz923kg82vvz9z5v6zq171y4zgg901zj";
+    sha256 = "1kicbw5cjb9gkfmfbqf6fiwbi0rzpqgk2lzd4v6nxaiyinxm73ff";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchurl, buildOcaml, ocaml, opaline
+{ stdenv, fetchFromGitHub, ocaml, findlib, opaline
 , calendar, eliom, js_of_ocaml-ppx_deriving_json
 }:
 
-buildOcaml rec
-{
- name = "ocsigen-toolkit";
- version = "1.1.0";
+stdenv.mkDerivation rec {
+ pname = "ocsigen-toolkit";
+ name = "ocaml${ocaml.version}-${pname}-${version}";
+ version = "2.0.0";
 
  propagatedBuildInputs = [ calendar eliom js_of_ocaml-ppx_deriving_json ];
- buildInputs = [ opaline ];
+ buildInputs = [ ocaml findlib opaline ];
 
  installPhase =
   ''
@@ -17,16 +17,21 @@ buildOcaml rec
     opaline -prefix $out
   '';
 
-  src = fetchurl {
-    sha256 = "1i5806gaqqllgsgjz3lf9fwlffqg3vfl49msmhy7xvq2sncbxp8a";
-    url = "https://github.com/ocsigen/${name}/archive/${version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = pname;
+    rev = version;
+    sha256 = "0gkiqw3xi31l9q9h89fnr5gfmxi9w9lg9rlv16h4ssjgrgq3y5cw";
   };
+
+  createFindlibDestdir = true;
 
   meta = {
     homepage = http://ocsigen.org/ocsigen-toolkit/;
     description = " User interface widgets for Ocsigen applications";
     license = stdenv.lib.licenses.lgpl21;
     maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+    inherit (ocaml.meta) platforms;
   };
 
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -543,10 +543,7 @@ let
 
     ocplib-simplex = callPackage ../development/ocaml-modules/ocplib-simplex { };
 
-    ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server {
-      lwt_react = lwt_react.override { lwt = lwt3; };
-      lwt_ssl = lwt_ssl.override { lwt = lwt3; };
-    };
+    ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };
 
     ocsigen-start = callPackage ../development/ocaml-modules/ocsigen-start { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -412,6 +412,8 @@ let
 
     ocaml_lwt = if lib.versionOlder "4.02" ocaml.version then lwt4 else lwt2;
 
+    lwt_camlp4 = callPackage ../development/ocaml-modules/lwt/camlp4.nix { };
+
     lwt_log = callPackage ../development/ocaml-modules/lwt_log {
       lwt = lwt4;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -231,16 +231,7 @@ let
 
     elina = callPackage ../development/ocaml-modules/elina { };
 
-    eliom = callPackage ../development/ocaml-modules/eliom {
-      js_of_ocaml-lwt = js_of_ocaml-lwt.override {
-        ocaml_lwt = lwt3;
-        lwt_log = lib.overrideDerivation
-          (lwt_log.override { lwt = lwt3; })
-          (_: { inherit (lwt3) src; });
-      };
-      lwt_react = lwt_react.override { lwt = lwt3; };
-      lwt_ssl = lwt_ssl.override { lwt = lwt3; };
-    };
+    eliom = callPackage ../development/ocaml-modules/eliom { };
 
     elpi = callPackage ../development/ocaml-modules/elpi { };
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with recent versions of OCaml and Lwt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

