### PR TITLE
all-packages.nix: move defaults to package files

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -121,7 +121,7 @@ rec {
       auto = builtins.intersectAttrs (lib.functionArgs f) autoArgs;
       origArgs = auto // args;
       pkgs = f origArgs;
-      mkAttrOverridable = name: pkg: makeOverridable (newArgs: (f newArgs).${name}) origArgs;
+      mkAttrOverridable = name: _: makeOverridable (newArgs: (f newArgs).${name}) origArgs;
     in lib.mapAttrs mkAttrOverridable pkgs;
 
 

--- a/pkgs/applications/misc/evilvte/default.nix
+++ b/pkgs/applications/misc/evilvte/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, makeWrapper, pkgconfig,
   gnome2, glib, pango, cairo, gdk_pixbuf, atk, freetype, xorg,
-  configH
+  configH ? ""
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, makeDesktopItem, perlSupport, libX11, libXt, libXft,
+{ stdenv, fetchurl, makeDesktopItem, perlSupport ? true, libX11, libXt, libXft,
   ncurses, perl, fontconfig, freetype, pkgconfig, libXrender,
-  gdkPixbufSupport, gdk_pixbuf, unicode3Support }:
+  gdkPixbufSupport ? true, gdk_pixbuf, unicode3Support ? true }:
 
 let
   pname = "rxvt-unicode";

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch
 , ncurses, boehmgc, gettext, zlib
 , sslSupport ? true, openssl ? null
-, graphicsSupport ? true, imlib2 ? null
+, graphicsSupport ? !stdenv.isDarwin, imlib2 ? null
 , x11Support ? graphicsSupport, libX11 ? null
 , mouseSupport ? !stdenv.isDarwin, gpm-ncurses ? null
 , perl, man, pkgconfig, buildPackages, w3m

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -2,9 +2,9 @@
 , glibcLocales, expect, ncurses, libotr, curl, readline, libuuid
 , cmocka, libmicrohttpd, stabber, expat, libmesode
 
-, autoAwaySupport ? false,       libXScrnSaver ? null, libX11 ? null
-, notifySupport ? false,         libnotify ? null, gdk_pixbuf ? null
-, traySupport ? false,           gnome2 ? null
+, autoAwaySupport ? true,       libXScrnSaver ? null, libX11 ? null
+, notifySupport ? true,         libnotify ? null, gdk_pixbuf ? null
+, traySupport ? true,           gnome2 ? null
 , pgpSupport ? true,            gpgme ? null
 , pythonPluginSupport ? true,   python ? null
 }:

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -1,14 +1,14 @@
 { monolithic ? true # build monolithic Quassel
 , daemon ? false # build Quassel daemon
 , client ? false # build Quassel client
-, tag ? "" # tag added to the package name
+, tag ? "-kf5" # tag added to the package name
 , static ? false # link statically
 
 , stdenv, fetchFromGitHub, cmake, makeWrapper, dconf
 , qtbase, qtscript
 , phonon, libdbusmenu, qca-qt5
 
-, withKDE ? stdenv.isLinux # enable KDE integration
+, withKDE ? true # enable KDE integration
 , extra-cmake-modules
 , kconfigwidgets
 , kcoreaddons

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -2,7 +2,7 @@
 , gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, python, libcap, glib
 , libssh, zlib, cmake, extra-cmake-modules, fetchpatch, makeWrapper
 , withGtk ? false, gtk3 ? null, librsvg ? null, gsettings-desktop-schemas ? null, wrapGAppsHook ? null
-, withQt ? false, qt5 ? null
+, withQt ? true, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 }:
 

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, libiconv, zlib, popt
-, enableACLs ? true, acl ? null
+, enableACLs ? !(stdenv.isDarwin || stdenv.isSunOS || stdenv.isFreeBSD), acl ? null
 , enableCopyDevicesPatch ? false
 }:
 

--- a/pkgs/applications/science/math/cplex/default.nix
+++ b/pkgs/applications/science/math/cplex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, openjdk, gtk2, xorg, glibcLocales, releasePath }:
+{ stdenv, makeWrapper, openjdk, gtk2, xorg, glibcLocales, releasePath ? null }:
 
 # To use this package, you need to download your own cplex installer from IBM
 # and override the releasePath attribute to point to the location of the file.  

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -2,13 +2,13 @@
 , ncurses
 , withXaw3d ? false
 #, withPVMlib ? false
-, tcl, tk, withTk ? false
+, tcl, tk, withTk ? true
 , gtk2, withGtk ? false # working ?
 #, withF2c ? false
-, ocaml, withOCaml ? false
+, ocaml, withOCaml ? true
 #, withJava ? false
 #, atlasMath, withAtlas ? false
-, xlibsWrapper, withX ? false
+, xlibsWrapper, withX ? true
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -1,6 +1,6 @@
-{ bdbSupport ? false # build support for Berkeley DB repositories
+{ bdbSupport ? true # build support for Berkeley DB repositories
 , httpServer ? false # build Apache DAV module
-, httpSupport ? false # client must support http
+, httpSupport ? true # client must support http
 , pythonBindings ? false
 , perlBindings ? false
 , javahlBindings ? false

--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -5,21 +5,21 @@ let
 in
 stdenv.mkDerivation {
   inherit name;
- 
+
   src = fetchurl {
     url = "https://dl.suckless.org/dwm/${name}.tar.gz";
     sha256 = "1zkmwb6df6m254shx06ly90c0q4jl70skk1pvkixpb7hcxhwbxn2";
   };
- 
+
   buildInputs = [ libX11 libXinerama libXft ];
- 
+
   prePatch = ''sed -i "s@/usr/local@$out@" config.mk'';
 
   # Allow users set their own list of patches
   inherit patches;
 
   buildPhase = " make ";
- 
+
   meta = {
     homepage = https://suckless.org/;
     description = "Dynamic window manager for X";

--- a/pkgs/build-support/fetchsvnssh/default.nix
+++ b/pkgs/build-support/fetchsvnssh/default.nix
@@ -1,4 +1,4 @@
-{stdenvNoCC, subversion, sshSupport ? false, openssh ? null, expect}: 
+{stdenvNoCC, subversion, sshSupport ? true, openssh ? null, expect}:
 {username, password, url, rev ? "HEAD", md5 ? "", sha256 ? ""}:
 
 

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeWrapper, apr, expat, gnused
 , sslSupport ? true, openssl
-, bdbSupport ? false, db
+, bdbSupport ? true, db
 , ldapSupport ? !stdenv.isCygwin, openldap
 , libiconv
 , cyrus_sasl, autoreconfHook

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -1,7 +1,7 @@
 {stdenv, lib, fetchurl, gettext, perlPackages, intltool, pkgconfig, glib,
   libxml2, sqlite, zlib, sg3_utils, gdk_pixbuf, taglib,
   libimobiledevice, pythonPackages, mutagen,
-  monoSupport ? true, mono, gtk-sharp-2_0
+  monoSupport ? false, mono, gtk-sharp-2_0
 }:
 
 let

--- a/pkgs/development/libraries/libspotify/default.nix
+++ b/pkgs/development/libraries/libspotify/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libspotify, alsaLib, readline, pkgconfig, apiKey, unzip, gnused }:
+{ stdenv, fetchurl, libspotify, alsaLib, readline, pkgconfig, apiKey ? null, unzip, gnused }:
 
 let
   version = "12.1.51";

--- a/pkgs/games/residualvm/default.nix
+++ b/pkgs/games/residualvm/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, SDL, zlib, libmpeg2, libmad, libogg, libvorbis, flac, alsaLib
-, openglSupport ? false, libGLU_combined ? null
+, libGLSupported
+, openglSupport ? libGLSupported, libGLU_combined ? null
 }:
 
 assert openglSupport -> libGLU_combined != null;

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, lib, fetchurl, pkgconfig, zlib, expat, openssl, autoconf
+{ config, stdenv, lib, fetchurl, pkgconfig, zlib, expat, openssl, autoconf
 , libjpeg, libpng, libtiff, freetype, fontconfig, libpaper, jbig2dec
 , libiconv, ijs
-, x11Support ? false, xlibsWrapper ? null
-, cupsSupport ? false, cups ? null
+, cupsSupport ? config.ghostscript.cups or (!stdenv.isDarwin), cups ? null
+, x11Support ? cupsSupport, xlibsWrapper ? null # with CUPS, X11 only adds very little
 }:
 
 assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
+
 let
   version = "9.${ver_min}";
   ver_min = "26";

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchurl, pkgconfig, jansson, pcre
 # plugins: list of strings, eg. [ "python2" "python3" ]
-, plugins
-, pam, withPAM ? false
-, systemd, withSystemd ? false
+, plugins ? []
+, pam, withPAM ? stdenv.isLinux
+, systemd, withSystemd ? stdenv.isLinux
 , python2, python3, ncurses
 , ruby, php-embed, mysql
 }:

--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -1,5 +1,5 @@
 { stdenv, runCommand, makeWrapper, lndir
-, dconf, hicolor-icon-theme, ibus, librsvg, plugins
+, dconf, hicolor-icon-theme, ibus, librsvg, plugins ? []
 }:
 
 let

--- a/pkgs/tools/misc/gams/default.nix
+++ b/pkgs/tools/misc/gams/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, file, licenseFile, optgamsFile}:
+{ stdenv, fetchurl, unzip, file, licenseFile ? null, optgamsFile ? null}:
 
 assert licenseFile != null;
 

--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -1,10 +1,10 @@
 { stdenv, autoconf, automake, pkgconfig, gettext, libtool, bison
 , flex, which, subversion, fetchsvn, makeWrapper, libftdi, libusb, readline
 , python3
-, svfSupport ? false
-, bsdlSupport ? false
-, staplSupport ? false
-, jedecSupport ? false
+, svfSupport ? true
+, bsdlSupport ? true
+, staplSupport ? true
+, jedecSupport ? true
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/networking/ssmtp/default.nix
+++ b/pkgs/tools/networking/ssmtp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, tlsSupport ? false, openssl ? null}:
+{stdenv, fetchurl, tlsSupport ? true, openssl ? null}:
 
 assert tlsSupport -> openssl != null;
 

--- a/pkgs/tools/package-management/disnix/dysnomia/default.nix
+++ b/pkgs/tools/package-management/disnix/dysnomia/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   };
 
   preConfigure = if enableEjabberdDump then "export PATH=$PATH:${ejabberd}/sbin" else "";
-  
+
   configureFlags = [
      (if enableApacheWebApplication then "--with-apache" else "--without-apache")
      (if enableAxis2WebService then "--with-axis2" else "--without-axis2")
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
      (if enableMongoDatabase then "--with-mongodb" else "--without-mongodb")
      "--with-job-template=${jobTemplate}"
    ];
-  
+
   buildInputs = [ getopt ]
     ++ stdenv.lib.optional enableEjabberdDump ejabberd
     ++ stdenv.lib.optional enableMySQLDatabase mysql.out

--- a/pkgs/tools/video/mjpegtools/default.nix
+++ b/pkgs/tools/video/mjpegtools/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, gtk2, libdv, libjpeg, libpng, libX11, pkgconfig, SDL, SDL_gfx
-, withMinimal ? false
+, withMinimal ? true
 }:
 
 # TODO:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4181,9 +4181,7 @@ in
 
   mitmproxy = callPackage ../tools/networking/mitmproxy { };
 
-  mjpegtools = callPackage ../tools/video/mjpegtools {
-    withMinimal = true;
-  };
+  mjpegtools = callPackage ../tools/video/mjpegtools { };
 
   mjpegtoolsFull = mjpegtools.override {
     withMinimal = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19117,10 +19117,7 @@ in
     llvmPackages = llvmPackages_7;
   };
 
-  rsync = callPackage ../applications/networking/sync/rsync {
-    enableACLs = !(stdenv.isDarwin || stdenv.isSunOS || stdenv.isFreeBSD);
-    enableCopyDevicesPatch = (config.rsync.enableCopyDevicesPatch or false);
-  };
+  rsync = callPackage ../applications/networking/sync/rsync (config.rsync or {});
   rrsync = callPackage ../applications/networking/sync/rsync/rrsync.nix {};
 
   rtl_433 = callPackage ../applications/misc/rtl_433 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19411,16 +19411,7 @@ in
 
   sublime3-dev = sublime3Packages.sublime3-dev;
 
-  inherit (callPackages ../applications/version-management/subversion {
-      bdbSupport = true;
-      httpServer = false;
-      httpSupport = true;
-      pythonBindings = false;
-      perlBindings = false;
-      javahlBindings = false;
-      saslSupport = false;
-      sasl = cyrus_sasl;
-    })
+  inherit (callPackages ../applications/version-management/subversion { sasl = cyrus_sasl; })
     subversion18 subversion19 subversion_1_10 subversion_1_11;
 
   subversion = subversion_1_11;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18865,12 +18865,9 @@ in
   # And I don't want to rewrite all rules
   procmail = callPackage ../applications/misc/procmail { };
 
-  profanity = callPackage ../applications/networking/instant-messengers/profanity {
-    notifySupport   = config.profanity.notifySupport   or true;
-    traySupport     = config.profanity.traySupport     or true;
-    autoAwaySupport = config.profanity.autoAwaySupport or true;
+  profanity = callPackage ../applications/networking/instant-messengers/profanity ({
     python = python3;
-  };
+  } // (config.profanity or {}));
 
   protonmail-bridge = libsForQt5.callPackage ../applications/networking/protonmail-bridge { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -822,9 +822,7 @@ in
 
   autorandr = callPackage ../tools/misc/autorandr {};
 
-  avahi = callPackage ../development/libraries/avahi {
-    qt4Support = config.avahi.qt4Support or false;
-  };
+  avahi = callPackage ../development/libraries/avahi (config.avahi or {});
 
   avro-c = callPackage ../development/libraries/avro-c { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3066,10 +3066,9 @@ in
 
   grpcurl = callPackage ../tools/networking/grpcurl { };
 
-  grub = pkgsi686Linux.callPackage ../tools/misc/grub {
-    buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
+  grub = pkgsi686Linux.callPackage ../tools/misc/grub ({
     stdenv = overrideCC stdenv pkgsi686Linux.gcc6;
-  };
+  } // (config.grub or {}));
 
   trustedGrub = pkgsi686Linux.callPackage ../tools/misc/grub/trusted.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17236,13 +17236,9 @@ in
 
   flameshot = libsForQt5.callPackage ../tools/misc/flameshot { };
 
-  flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer {
-    debug = config.flashplayer.debug or false;
-  };
+  flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer (config.flashplayer or {});
 
-  flashplayer-standalone = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix {
-    debug = config.flashplayer.debug or false;
-  };
+  flashplayer-standalone = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer/standalone.nix (config.flashplayer or {});
 
   flashplayer-standalone-debugger = flashplayer-standalone.override {
     debug = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -230,9 +230,7 @@ in
 
   fetchsvnrevision = import ../build-support/fetchsvnrevision runCommand subversion;
 
-  fetchsvnssh = callPackage ../build-support/fetchsvnssh {
-    sshSupport = true;
-  };
+  fetchsvnssh = callPackage ../build-support/fetchsvnssh { };
 
   fetchhg = callPackage ../build-support/fetchhg { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18932,12 +18932,7 @@ in
   quantomatic = callPackage ../applications/science/physics/quantomatic { };
 
   quassel = libsForQt5.callPackage ../applications/networking/irc/quassel {
-    monolithic = true;
-    daemon = false;
-    client = false;
-    withKDE = true;
-    dconf = gnome3.dconf;
-    tag = "-kf5";
+    inherit (gnome3) dconf;
   };
 
   quasselClient = quassel.override {
@@ -18949,8 +18944,8 @@ in
   quasselDaemon = quassel.override {
     monolithic = false;
     daemon = true;
-    tag = "-daemon-qt5";
     withKDE = false;
+    tag = "-daemon-qt5";
   };
 
   quirc = callPackage ../tools/graphics/quirc {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19896,9 +19896,7 @@ in
 
   vym = qt5.callPackage ../applications/misc/vym { };
 
-  w3m = callPackage ../applications/networking/browsers/w3m {
-    graphicsSupport = !stdenv.isDarwin;
-  };
+  w3m = callPackage ../applications/networking/browsers/w3m { };
 
   # Should always be the version with the most features
   w3m-full = w3m;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10895,7 +10895,6 @@ in
 
   libgpod = callPackage ../development/libraries/libgpod {
     inherit (pkgs.pythonPackages) mutagen;
-    monoSupport = false;
   };
 
   libgssglue = callPackage ../development/libraries/libgssglue { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9272,7 +9272,6 @@ in
   apr = callPackage ../development/libraries/apr { };
 
   aprutil = callPackage ../development/libraries/apr-util {
-    bdbSupport = true;
     db = if stdenv.isFreeBSD then db4 else db;
     # XXX: only the db_185 interface was available through
     #      apr with db58 on freebsd (nov 2015), for unknown reasons

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22347,10 +22347,7 @@ in
 
   gensgs = pkgsi686Linux.callPackage ../misc/emulators/gens-gs { };
 
-  ghostscript = callPackage ../misc/ghostscript rec {
-    cupsSupport = config.ghostscript.cups or (!stdenv.isDarwin);
-    x11Support = cupsSupport; # with CUPS, X11 only adds very little
-  };
+  ghostscript = callPackage ../misc/ghostscript { };
 
   ghostscriptX = appendToName "with-X" (ghostscript.override {
     cupsSupport = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -500,10 +500,7 @@ in
 
   arduino = arduino-core.override { withGui = true; };
 
-  arduino-core = callPackage ../development/arduino/arduino-core {
-    jdk = jdk;
-    withGui = false;
-  };
+  arduino-core = callPackage ../development/arduino/arduino-core { };
 
   apitrace = libsForQt5.callPackage ../applications/graphics/apitrace {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21969,13 +21969,7 @@ in
 
   singular = callPackage ../applications/science/math/singular { };
 
-  scilab = callPackage ../applications/science/math/scilab {
-    withXaw3d = false;
-    withTk = true;
-    withGtk = false;
-    withOCaml = true;
-    withX = true;
-  };
+  scilab = callPackage ../applications/science/math/scilab { };
 
   scilab-bin = callPackage ../applications/science/math/scilab-bin {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17107,9 +17107,7 @@ in
   welle-io = libsForQt5.callPackage ../applications/misc/welle-io { };
 
   wireshark = callPackage ../applications/networking/sniffers/wireshark {
-    withQt = true;
     qt5 = qt59;
-    withGtk = false;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices SystemConfiguration;
   };
   wireshark-qt = wireshark;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -674,10 +674,7 @@ in
 
   gamecube-tools = callPackage ../development/tools/gamecube-tools { };
 
-  gams = callPackage ../tools/misc/gams {
-    licenseFile = config.gams.licenseFile or null;
-    optgamsFile = config.gams.optgamsFile or null;
-  };
+  gams = callPackage ../tools/misc/gams (config.gams or {});
 
   git-fire = callPackage ../tools/misc/git-fire { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5916,11 +5916,7 @@ in
 
   usync = callPackage ../applications/misc/usync { };
 
-  uwsgi = callPackage ../servers/uwsgi {
-    plugins = [];
-    withPAM = stdenv.isLinux;
-    withSystemd = stdenv.isLinux;
-  };
+  uwsgi = callPackage ../servers/uwsgi { };
 
   vacuum = callPackage ../applications/networking/instant-messengers/vacuum {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22780,15 +22780,9 @@ in
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
   samsung-unified-linux-driver = res.samsung-unified-linux-driver_4_01_17;
 
-  sane-backends = callPackage ../applications/graphics/sane/backends {
-    gt68xxFirmware = config.sane.gt68xxFirmware or null;
-    snapscanFirmware = config.sane.snapscanFirmware or null;
-  };
+  sane-backends = callPackage ../applications/graphics/sane/backends (config.sane or {});
 
-  sane-backends-git = callPackage ../applications/graphics/sane/backends/git.nix {
-    gt68xxFirmware = config.sane.gt68xxFirmware or null;
-    snapscanFirmware = config.sane.snapscanFirmware or null;
-  };
+  sane-backends-git = callPackage ../applications/graphics/sane/backends/git.nix (config.sane or {});
 
   brlaser = callPackage ../misc/cups/drivers/brlaser { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18128,7 +18128,6 @@ in
 
   mercurial = callPackage ../applications/version-management/mercurial {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
-    guiSupport = false; # use mercurialFull to get hgk GUI
   };
 
   mercurialFull = appendToName "full" (pkgs.mercurial.override { guiSupport = true; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1156,7 +1156,7 @@ in
 
   coprthr = callPackage ../development/libraries/coprthr { };
 
-  cplex = callPackage ../applications/science/math/cplex { releasePath = config.cplex.releasePath or null; };
+  cplex = callPackage ../applications/science/math/cplex (config.cplex or {});
 
   cpulimit = callPackage ../tools/misc/cpulimit { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6197,12 +6197,7 @@ in
 
   uptimed = callPackage ../tools/system/uptimed { };
 
-  urjtag = callPackage ../tools/misc/urjtag {
-    svfSupport = true;
-    bsdlSupport = true;
-    staplSupport = true;
-    jedecSupport = true;
-  };
+  urjtag = callPackage ../tools/misc/urjtag { };
 
   urlwatch = callPackage ../tools/networking/urlwatch { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19395,9 +19395,7 @@ in
     };
   };
 
-  libspotify = callPackage ../development/libraries/libspotify {
-    apiKey = config.libspotify.apiKey or null;
-  };
+  libspotify = callPackage ../development/libraries/libspotify (config.libspotify or {});
 
   sourcetrail = callPackage ../development/tools/sourcetrail { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20851,9 +20851,7 @@ in
 
   racer = callPackage ../games/racer { };
 
-  residualvm = callPackage ../games/residualvm {
-    openglSupport = libGLSupported;
-  };
+  residualvm = callPackage ../games/residualvm { };
 
   rftg = callPackage ../games/rftg { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19108,11 +19108,7 @@ in
   rxvt = callPackage ../applications/misc/rxvt { };
 
   # urxvt
-  rxvt_unicode = callPackage ../applications/misc/rxvt_unicode {
-    perlSupport = true;
-    gdkPixbufSupport = true;
-    unicode3Support = true;
-  };
+  rxvt_unicode = callPackage ../applications/misc/rxvt_unicode { };
 
   rxvt_unicode-with-plugins = callPackage ../applications/misc/rxvt_unicode/wrapper.nix {
     plugins = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5551,9 +5551,7 @@ in
 
   sslmate = callPackage ../development/tools/sslmate { };
 
-  ssmtp = callPackage ../tools/networking/ssmtp {
-    tlsSupport = true;
-  };
+  ssmtp = callPackage ../tools/networking/ssmtp { };
 
   ssocr = callPackage ../applications/misc/ssocr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13734,13 +13734,11 @@ in
     bluetoothSupport = true;
     remoteControlSupport = true;
     zeroconfSupport = true;
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
 
   # libpulse implementations
   libpulseaudio-vanilla = pulseaudio.override {
     libOnly = true;
-    inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
 
   apulse = callPackage ../misc/apulse { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2006,7 +2006,6 @@ in
 
   ibus-with-plugins = callPackage ../tools/inputmethods/ibus/wrapper.nix {
     inherit (gnome3) dconf;
-    plugins = [ ];
   };
 
   interception-tools = callPackage ../tools/inputmethods/interception-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19627,14 +19627,11 @@ in
 
   toggldesktop = libsForQt5.callPackage ../applications/misc/toggldesktop { };
 
-  tomahawk = callPackage ../applications/audio/tomahawk {
+  tomahawk = callPackage ../applications/audio/tomahawk ({
     taglib = taglib_1_9;
-    enableXMPP      = config.tomahawk.enableXMPP      or true;
-    enableKDE       = config.tomahawk.enableKDE       or false;
-    enableTelepathy = config.tomahawk.enableTelepathy or false;
     quazip = quazip_qt4;
     boost = boost155;
-  };
+  } // (config.tomahawk or {}));
 
   topydo = callPackage ../applications/misc/topydo {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22638,15 +22638,7 @@ in
 
   disnix = callPackage ../tools/package-management/disnix { };
 
-  dysnomia = callPackage ../tools/package-management/disnix/dysnomia {
-    enableApacheWebApplication = config.disnix.enableApacheWebApplication or false;
-    enableAxis2WebService = config.disnix.enableAxis2WebService or false;
-    enableEjabberdDump = config.disnix.enableEjabberdDump or false;
-    enableMySQLDatabase = config.disnix.enableMySQLDatabase or false;
-    enablePostgreSQLDatabase = config.disnix.enablePostgreSQLDatabase or false;
-    enableSubversionRepository = config.disnix.enableSubversionRepository or false;
-    enableTomcatWebApplication = config.disnix.enableTomcatWebApplication or false;
-  };
+  dysnomia = callPackage ../tools/package-management/disnix/dysnomia (config.disnix or {});
 
   disnixos = callPackage ../tools/package-management/disnix/disnixos { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16920,9 +16920,7 @@ in
 
   etherape = callPackage ../applications/networking/sniffers/etherape { };
 
-  evilvte = callPackage ../applications/misc/evilvte {
-    configH = config.evilvte.config or "";
-  };
+  evilvte = callPackage ../applications/misc/evilvte (config.evilvte or {});
 
   evopedia = callPackage ../applications/misc/evopedia { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5557,9 +5557,7 @@ in
 
   stress-ng = callPackage ../tools/system/stress-ng { };
 
-  stoken = callPackage ../tools/security/stoken {
-    withGTK3 = config.stoken.withGTK3 or true;
-  };
+  stoken = callPackage ../tools/security/stoken (config.stoken or {});
 
   storeBackup = callPackage ../tools/backup/store-backup { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13601,13 +13601,7 @@ in
   mod_python = pkgs.apacheHttpdPackages.mod_python;
   mod_wsgi = pkgs.apacheHttpdPackages.mod_wsgi;
 
-  mpd = callPackage ../servers/mpd {
-    aacSupport    = config.mpd.aacSupport or true;
-    clientSupport = config.mpd.clientSupport or true;
-    ffmpegSupport = config.mpd.ffmpegSupport or true;
-    opusSupport   = config.mpd.opusSupport or true;
-
-  };
+  mpd = callPackage ../servers/mpd (config.mpd or {});
 
   mpd_clientlib = callPackage ../servers/mpd/clientlib.nix { };
 

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -73,7 +73,7 @@ in let
   # whatever arguments it doesn't explicitly provide. This way,
   # `all-packages.nix` doesn't know more than it needs too.
   #
-  # It's OK that `args` doesn't include default arguemtns from this file:
+  # It's OK that `args` doesn't include default arguments from this file:
   # they'll be deterministically inferred. In fact we must *not* include them,
   # because it's important that if some parameter which affects the default is
   # substituted with a different argument, the default is re-inferred.

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -52,22 +52,22 @@ in
           map (n: import (path + ("/" + n)))
             (builtins.filter (n: builtins.match ".*\\.nix" n != null || pathExists (path + ("/" + n + "/default.nix")))
               (attrNames content))
-        else 
+        else
           # it's a file, so the result is the contents of the file itself
           import path;
     in
       if pathOverlays != "" && pathExists pathOverlays then overlays pathOverlays
-      else if pathExists homeOverlaysFile && pathExists homeOverlaysDir then 
+      else if pathExists homeOverlaysFile && pathExists homeOverlaysDir then
         throw ''
           Nixpkgs overlays can be specified with ${homeOverlaysFile} or ${homeOverlaysDir}, but not both.
           Please remove one of them and try again.
         ''
-      else if pathExists homeOverlaysFile then 
-        if isDir homeOverlaysFile then 
+      else if pathExists homeOverlaysFile then
+        if isDir homeOverlaysFile then
           throw (homeOverlaysFile + " should be a file")
         else overlays homeOverlaysFile
       else if pathExists homeOverlaysDir then
-        if !(isDir homeOverlaysDir) then 
+        if !(isDir homeOverlaysDir) then
           throw (homeOverlaysDir + " should be a directory")
         else overlays homeOverlaysDir
       else []


### PR DESCRIPTION
# What?

A bit of noop cleanups followed by a first patchset in a series that moves package option defaults (like `whateverSupport = false`) from `all-packages.nix` to the package expressions themselves.

I take specific care not to rename or drop any `config` options here (I do add some as a side-effect, though).

# Why?

Because definitions in `all-packages.nix` and package expression frequently conflict. It also makes #50643 (which itself is motivated by a proper implementation of #12877) much easier to do.

# `git log`

- dwm: cleanup whitespace
- dysnomia: cleanup whitespace
- pulseaudioFull, libpulseaudio-vanilla: cleanup

  These are already inherited in the parent derivation.
- top-level: fix a typo
- top-level: cleanup whitespace
- lib: tiny cleanup
- *: move defaults to the package file

A bunch of these.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @matthewbauer @7c6f434c, I guess
