### PR TITLE
glowing-bear: init at 0.7.1

### DIFF
--- a/pkgs/applications/networking/irc/glowing-bear/default.nix
+++ b/pkgs/applications/networking/irc/glowing-bear/default.nix
@@ -1,0 +1,27 @@
+{ fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "glowing-bear-${version}";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    rev = version;
+    owner = "glowing-bear";
+    repo = "glowing-bear";
+    sha256 = "0gwrf67l3i3nl7zy1miljz6f3vv6zzc3g9as06by548f21cizzjb";
+  };
+
+  installPhase = ''
+    mkdir $out
+    cp index.html min.js serviceworker.js webapp.manifest.json $out
+    cp -R 3rdparty assets css directives js $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A web client for Weechat";
+    homepage = https://github.com/glowing-bear/glowing-bear;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ delroth ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17398,6 +17398,8 @@ in
     inherit (darwin) IOKit;
   };
 
+  glowing-bear = callPackage ../applications/networking/irc/glowing-bear { };
+
   gmtk = callPackage ../development/libraries/gmtk { };
 
   gmu = callPackage ../applications/audio/gmu { };


### PR DESCRIPTION
###### Motivation for this change
Glowing Bear is a web frontend for the weechat relay protocol. It's a static HTML/CSS/JS app, and does not require any build (i.e. what's in the git repo can be directly copied to your webroot and ran).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

