### PR TITLE
openhmd: init at 0.3.0-rc1-20181218

### DIFF
--- a/pkgs/development/libraries/openhmd/default.nix
+++ b/pkgs/development/libraries/openhmd/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchFromGitHub, pkgconfig, cmake, hidapi
+, withExamples ? true, SDL2 ? null, libGL ? null, glew ? null
+}:
+
+with lib;
+
+let onoff = if withExamples then "ON" else "OFF"; in
+
+stdenv.mkDerivation {
+  pname = "openhmd";
+  version = "0.3.0-rc1-20181218";
+
+  src = fetchFromGitHub {
+    owner = "OpenHMD";
+    repo = "OpenHMD";
+    rev = "80d51bea575a5bf71bb3a0b9683b80ac3146596a";
+    sha256 = "09011vnlsn238r5vbb1ab57x888ljaa34xibrnfbm5bl9417ii4z";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [
+    hidapi
+  ] ++ optionals withExamples [
+    SDL2 libGL glew
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_BOTH_STATIC_SHARED_LIBS=ON"
+    "-DOPENHMD_EXAMPLE_SIMPLE=${onoff}"
+    "-DOPENHMD_EXAMPLE_SDL=${onoff}"
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+  ];
+
+  postInstall = optionalString withExamples ''
+    mkdir -p $out/bin
+    install -D examples/simple/simple $out/bin/openhmd-example-simple
+    install -D examples/opengl/openglexample $out/bin/openhmd-example-opengl
+  '';
+
+  meta = {
+    homepage = "http://www.openhmd.net";
+    description = "Library API and drivers immersive technology";
+    longDescription = ''
+      OpenHMD is a very simple FLOSS C library and a set of drivers
+      for interfacing with Virtual Reality (VR) Headsets aka
+      Head-mounted Displays (HMDs), controllers and trackers like
+      Oculus Rift, HTC Vive, Windows Mixed Reality, and etc.
+    '';
+    license = licenses.boost;
+    maintainers = [ maintainers.oxij ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11914,6 +11914,8 @@ in
 
   ortp = callPackage ../development/libraries/ortp { };
 
+  openhmd = callPackage ../development/libraries/openhmd { };
+
   openrct2 = callPackage ../games/openrct2 { };
 
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };


### PR DESCRIPTION
# What? Why?

New package: a KISS library for doing VR stuff. I felt like writing an expression for it simply because it is the only one that does something VR and adheres to the KISS principle (i.e. I don't even have an HMD, made an expression purely for religious reasons :]).

# `git log`

- openhmd: init at 0.3.0-rc1-20181218

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - New (1):
    - openhmd

- On aarch64-linux: ditto
- On x86_64-darwin: ditto

# Things done

- [X] Built before rebasing on master.
- [X] Examples from the package run fine with the dummy driver.