### PR TITLE
libcardiacarrest: 12.1-7 -> 12.2.8

### DIFF
--- a/pkgs/misc/libcardiacarrest/default.nix
+++ b/pkgs/misc/libcardiacarrest/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libcardiacarrest-${version}";
-  version = "12.1-7"; # <PA API version>-<version>
+  version = "12.2.8"; # <PA API version>.<version>
 
   src = fetchFromGitHub {
     owner = "oxij";
     repo = "libcardiacarrest";
-    rev = "d44288d9a24d6b7793fb36a4c9a548b6b55375ec";
-    sha256 = "0j3l5s6r9hgpy5y7q7kx0rkh05rk0bgfdvzbmadqps720lqjs4xm";
+    rev = "d89639f5b2d298cf74af26880f5ebf50e645166d";
+    sha256 = "0vrigwcw3g8zknqyznv6y3437ahn1w00gv3d303smmygr0p8bd94";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
# What? Why?

Update.

# `git log`

- libcardiacarrest: 12.1-7 -> 12.2.8

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (1):
    - libcardiacarrest

- On aarch64-linux: ditto
- On x86_64-darwin: ditto

# Things done

- [X] Built before rebasing onto master.
- [X] Everything still works perfectly when overriding `libpulseaudio` with this.
