### PR TITLE
Security updates, parity: 2.2.8 -> 2.2.9

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.3.1";
-  sha256      = "13y3gczqb0rb6v17j63j1zp11cnykbv9c674hrk1i6jb3y4am4lv";
+  version     = "2.3.2";
+  sha256      = "1063n7lkcfkywi0a06pxkw0wkq3qyq4lr53fv584mlbnh2hj8gpm";
   cargoSha256 = "1pj5hzy7k1l9bbw1qpz80vvk89qz4qz4rnnkcvn2rkbmq382gxwy";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.2.8";
-  sha256      = "1l2bxra4fkbh8gnph9wnc24ddmzfdclsgcjbx8q6fflhcg6r9hf1";
+  version     = "2.2.9";
+  sha256      = "0n9zk25ni4asfdqc4xh0gqp2446vxacqz7qcrmsngf8swvayvi16";
   cargoSha256 = "10lg0vzikzlj927hpn59x1dz9dvhcaqsl8nz14vj2iz42vfkcm7p";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/paritytech/parity-ethereum/releases/tag/v2.2.9
* https://github.com/paritytech/parity-ethereum/releases/tag/v2.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

