### PR TITLE
rtl8821ce: init at 5.2.5_1.26055.20180108

### DIFF
--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, kernel, bc }:
+stdenv.mkDerivation rec {
+  name = "rtl8821ce-${kernel.version}-${version}";
+  version = "5.2.5_1.26055.20180108";
+
+  src = fetchFromGitHub {
+    owner = "tomaspinho";
+    repo = "rtl8821ce";
+    rev = "ab6154e150bbc7d12b0525d4cc1298ae196e45de";
+    sha256 = "1my0hidqnv4s7hi5897m81pq0sjw05np0g27hlkg9fwb83b5kzsg";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = [ bc ];
+  buildInputs = kernel.moduleBuildDependencies;
+
+  prePatch = ''
+    substituteInPlace ./Makefile \
+      --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
+      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
+      --replace /sbin/depmod \# \
+      --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  preInstall = ''
+    mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Realtek rtl8821ce driver";
+    homepage = "https://github.com/tomaspinho/rtl8821ce";
+    license = licenses.gpl2;
+    platform = platforms.linux;
+    maintainers = [ maintainers.hhm ];
+  };
+}

--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Realtek rtl8821ce driver";
     homepage = "https://github.com/tomaspinho/rtl8821ce";
     license = licenses.gpl2;
-    platform = platforms.linux;
+    platforms = platforms.linux;
     maintainers = [ maintainers.hhm ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14681,6 +14681,8 @@ in
 
     rtl8821au = callPackage ../os-specific/linux/rtl8821au { };
 
+    rtl8821ce = callPackage ../os-specific/linux/rtl8821ce { };
+
     rtlwifi_new = callPackage ../os-specific/linux/rtlwifi_new { };
 
     openafs = callPackage ../servers/openafs/1.6/module.nix { };


### PR DESCRIPTION
###### Motivation for this change
Adds driver for rtl8821ce wifi hardware, a common wireless device which is integrated in many laptops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

In order for the system to automatically use the kernel module (driver), pkgs.linuxPackages.rtl8821ce needs to be added to boot.extraModulePackages (when tested on my machine). Otherwise, and `insmod` command has to be run with the nix store path of the module as an argument, in order to load the driver. Is this normal/how it should be, or is there something else I can do in the nixpkgs package to make the driver load automatically when rtl8821ce hardware is detected, so people won't have to add the package to boot.extraModulePackages in order to use the hardware on their machine?

Thanks!