### PR TITLE
thinkfan: add option for libatasmart support

### DIFF
--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -47,6 +47,8 @@ let
     ${cfg.levels}
   '';
 
+  thinkfan = pkgs.thinkfan.override { smartSupport = cfg.smartSupport; };
+
 in {
 
   options = {
@@ -58,6 +60,15 @@ in {
         default = false;
         description = ''
           Whether to enable thinkfan, fan controller for IBM/Lenovo ThinkPads.
+        '';
+      };
+
+      smartSupport = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to build thinkfan with SMART support to read temperatures 
+          directly from hard disks.
         '';
       };
 
@@ -77,7 +88,7 @@ in {
               Which may be provided by any hwmon drivers (keyword
               hwmon)
 
-            S.M.A.R.T. (since 0.9 and requires the USE_ATASMART compilation flag)
+            S.M.A.R.T. (requires smartSupport to be enabled)
               Which reads the temperature directly from the hard
               disk using libatasmart (keyword atasmart)
 
@@ -125,18 +136,17 @@ in {
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [ pkgs.thinkfan ];
+    environment.systemPackages = [ thinkfan ];
 
     systemd.services.thinkfan = {
       description = "Thinkfan";
       after = [ "basic.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.thinkfan ];
-      serviceConfig.ExecStart = "${pkgs.thinkfan}/bin/thinkfan -n -c ${configFile}";
+      path = [ thinkfan ];
+      serviceConfig.ExecStart = "${thinkfan}/bin/thinkfan -n -c ${configFile}";
     };
 
     boot.extraModprobeConfig = "options thinkpad_acpi experimental=1 fan_control=1";
 
   };
-
 }

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, cmake }:
+{ stdenv, fetchurl, cmake
+, smartSupport ? false, libatasmart }:
 
 stdenv.mkDerivation rec {
   name = "thinkfan-${version}";
@@ -10,6 +11,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  buildInputs = stdenv.lib.optional smartSupport libatasmart;
+
+  cmakeFlags = stdenv.lib.optional smartSupport "-DUSE_ATASMART=ON";
 
   installPhase = ''
     install -Dm755 {.,$out/bin}/thinkfan


### PR DESCRIPTION
###### Motivation for this change

This patch allows you to build thinkfan with SMART support.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).