### PR TITLE
nix1: fix `perl-bindings` build

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -13,7 +13,7 @@ let
 
   sh = busybox-sandbox-shell;
 
-  common = { name, suffix ? "", src, fromGit ? false }:
+  common = { name, suffix ? "", src, includesPerl ? false, fromGit ? false }:
     let nix = stdenv.mkDerivation rec {
       inherit name src;
       version = lib.getVersion name;
@@ -113,7 +113,7 @@ let
       passthru = {
         inherit fromGit;
 
-        perl-bindings = stdenv.mkDerivation {
+        perl-bindings = if includesPerl then nix else stdenv.mkDerivation {
           name = "nix-perl-${version}";
 
           inherit src;
@@ -150,6 +150,9 @@ in rec {
       url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
       sha256 = "0ca5782fc37d62238d13a620a7b4bff6a200bab1bd63003709249a776162357c";
     };
+
+    # Nix1 has the perl bindings by default, so no need to build the manually.
+    includesPerl = true;
   };
 
   nixStable = common rec {


### PR DESCRIPTION
###### Motivation for this change

Nix 1.11 builds perl-bindings by default, `nix1.perl-bindings` fails
with the following error:

```
building
no Makefile, doing nothing
installing
install flags: install
make: *** No rule to make target 'install'.  Stop.
```

This is probably due to #47316. Previously the `perl-bindings` were
referenced to `nix1` instead of the `perl-bindings` function as Nix 1.11
built those during its build process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

