### PR TITLE
vscode-extensions.ms-python.python: 2018.12.1 -> 2019.6.22090

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -62,7 +62,9 @@ rec {
 
   ms-vscode.cpptools = callPackage ./cpptools {};
 
-  ms-python.python = callPackage ./python {};
+  ms-python.python = callPackage ./python {
+    extractNuGet = callPackage ./python/extract-nuget.nix { };
+  };
 
   vscodevim.vim = buildVscodeMarketplaceExtension {
     mktplcRef = {

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -1,5 +1,5 @@
-{ lib, vscode-utils
-
+{ lib, stdenv, fetchurl, vscode-utils, extractNuGet
+, icu, curl, openssl, lttng-ust, autoPatchelfHook
 , pythonUseFixed ? false, python  # When `true`, the python default setting will be fixed to specified.
                                   # Use version from `PATH` for default setting otherwise.
                                   # Defaults to `false` as we expect it to be project specific most of the time.
@@ -14,15 +14,47 @@ assert ctagsUseFixed -> null != ctags;
 let
   pythonDefaultsTo = if pythonUseFixed then "${python}/bin/python" else "python";
   ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
-in
 
-vscode-utils.buildVscodeMarketplaceExtension {
+  # The arch tag comes from 'PlatformName' defined here:
+  # https://github.com/Microsoft/vscode-python/blob/master/src/client/activation/types.ts
+  arch =
+    if stdenv.isLinux && stdenv.isx86_64 then "linux-x64"
+    else if stdenv.isDarwin then "osx-x64"
+    else throw "Only x86_64 Linux and Darwin are supported.";
+
+  languageServerSha256 = {
+    "linux-x64" = "0mqjl3l1zk1zd7n0rrb2vdsrx6czhl4irdm4j5jishg9zp03gkkd";
+    "osx-x64" = "1csq8q8fszv9xk9qiabg12zybxnzn8y2jsnvjrlg4b8kvm63sz40";
+  }."${arch}";
+
+  # version is languageServerVersion in the package.json
+  languageServer = extractNuGet rec {
+    name = "Python-Language-Server";
+    version = "0.2.82";
+
+    src = fetchurl {
+      url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
+      sha256 = languageServerSha256;
+    };
+  };
+in vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2018.12.1";
-    sha256 = "1cf3yll2hfililcwq6avscgi35caccv8m8fdsvzqdfrggn5h41h4";
+    version = "2019.6.22090";
+    sha256 = "11q4ac7acp946h43myjmp2f2vh10m1c4hn1n0s5pqgjvn0i6bi3i";
   };
+
+  buildInputs = [
+    icu
+    curl
+    openssl
+    lttng-ust
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
 
   postPatch = ''
     # Patch `packages.json` so that nix's *python* is used as default value for `python.pythonPath`.
@@ -34,8 +66,14 @@ vscode-utils.buildVscodeMarketplaceExtension {
       --replace "\"default\": \"ctags\"" "\"default\": \"${ctagsDefaultsTo}\""
   '';
 
-    meta = with lib; {
-      license = licenses.mit;
-      maintainers = [ maintainers.jraygauthier ];
-    };
+  postInstall = ''
+    mkdir -p "$out/$installPrefix/languageServer.${languageServer.version}"
+    cp -R --no-preserve=ownership ${languageServer}/* "$out/$installPrefix/languageServer.${languageServer.version}"
+    chmod -R +wx "$out/$installPrefix/languageServer.${languageServer.version}"
+  '';
+
+  meta = with lib; {
+    license = licenses.mit;
+    maintainers = [ maintainers.jraygauthier ];
+  };
 }

--- a/pkgs/misc/vscode-extensions/python/extract-nuget.nix
+++ b/pkgs/misc/vscode-extensions/python/extract-nuget.nix
@@ -1,0 +1,15 @@
+{ stdenv, unzip }:
+{ name, version, src, ... }:
+
+stdenv.mkDerivation {
+  inherit name version src;
+
+  buildInputs = [ unzip ];
+  dontBuild = true;
+  unpackPhase = "unzip $src";
+  installPhase = ''
+    mkdir -p "$out"
+    chmod -R +w .
+    find . -mindepth 1 -maxdepth 1 | xargs cp -a -t "$out"
+  '';
+}

--- a/pkgs/misc/vscode-extensions/vscode-utils.nix
+++ b/pkgs/misc/vscode-extensions/vscode-utils.nix
@@ -33,11 +33,17 @@ let
     inherit vscodeExtUniqueId;
     inherit configurePhase buildPhase dontPatchELF dontStrip;
 
+    installPrefix = "share/${extendedPkgName}/extensions/${vscodeExtUniqueId}";
+
     buildInputs = [ unzip ] ++ buildInputs;
 
     installPhase = ''
-      mkdir -p "$out/share/${extendedPkgName}/extensions/${vscodeExtUniqueId}"
-      find . -mindepth 1 -maxdepth 1 | xargs -d'\n' mv -t "$out/share/${extendedPkgName}/extensions/${vscodeExtUniqueId}/"
+      runHook preInstall
+
+      mkdir -p "$out/$installPrefix"
+      find . -mindepth 1 -maxdepth 1 | xargs -d'\n' mv -t "$out/$installPrefix/"
+
+      runHook postInstall
     '';
 
   });


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

