### PR TITLE
zsh: 5.7 -> 5.7.1

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ncurses, pcre, fetchpatch }:
 
 let
-  version = "5.7";
+  version = "5.7.1";
 
   documentation = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}-doc.tar.xz";
-    sha256 = "0pgisyi82pg5mycx1k7vfx9hwzl6zq00r5s9v91lg4gqisvlvagh";
+    sha256 = "1d1r88n1gfdavx4zy3svl1gljrvzim17jb2r834hafg2a016flrh";
   };
 
 in
@@ -15,17 +15,8 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}.tar.xz";
-    sha256 = "04ynid3ggvy6i5c26bk52mq6x5vyrdwgryid9hggmnb1nf8b41vq";
+    sha256 = "1s3yww0mzgvpc48kp0x868mm3gbna42sbgzya0nknj0x5hn2jq3j";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "vcs_info.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/vcs_info.patch?h=packages/zsh&id=1b7537ff5343819b3110a76bbdd2a1bf9ef80c4a";
-      sha256 = "0rc63cdc0qzhmj2dp5jnmxgyl5c47w857s8379fq36z8g0bi3rwq";
-      excludes = [ "ChangeLog" ];
-    })
-  ];
 
   buildInputs = [ ncurses pcre ];
 


### PR DESCRIPTION
###### Motivation for this change

Some fixes include one we were patching to fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---