### PR TITLE
Office Code Pro: init at 1.004

### DIFF
--- a/pkgs/data/fonts/office-code-pro/default.nix
+++ b/pkgs/data/fonts/office-code-pro/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "office-code-pro";
+  version = "1.004";
+
+  src = fetchFromGitHub {
+    owner = "nathco";
+    repo = "Office-Code-Pro";
+    rev = version;
+    sha256 = "0znmjjyn5q83chiafy252bhsmw49r2nx2ls2cmhjp4ihidfr6cmb";
+  };
+
+  installPhase = ''
+    fontDir=$out/share/fonts/opentype
+    docDir=$out/share/doc/${pname}-${version}
+    mkdir -p $fontDir $docDir
+    install -Dm644 README.md $docDir
+    install -t $fontDir -m644 'Fonts/Office Code Pro/OTF/'*.otf
+    install -t $fontDir -m644 'Fonts/Office Code Pro D/OTF/'*.otf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A customized version of Source Code Pro";
+    longDescription = ''
+      Office Code Pro is a customized version of Source Code Pro, the monospaced
+      sans serif originally created by Paul D. Hunt for Adobe Systems
+      Incorporated. The customizations were made specifically for text editors
+      and coding environments, but are still very usable in other applications.
+    '';
+    homepage = https://github.com/nathco/Office-Code-Pro;
+    license = licenses.ofl;
+    maintainers = [ maintainers.AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15716,6 +15716,8 @@ in
 
   numix-cursor-theme = callPackage ../data/icons/numix-cursor-theme { };
 
+  office-code-pro = callPackage ../data/fonts/office-code-pro { };
+
   oldstandard = callPackage ../data/fonts/oldstandard { };
 
   oldsindhi = callPackage ../data/fonts/oldsindhi { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

