### PR TITLE
corretto8: init at 8.202.08.2

### DIFF
--- a/pkgs/development/compilers/openjdk/corretto.nix
+++ b/pkgs/development/compilers/openjdk/corretto.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, bash
+, openjdk8
+
+, ...
+}:
+
+let
+  version = "8.212.04.2";
+  src = fetchFromGitHub {
+    owner  = "corretto";
+    repo   = "corretto-8";
+    rev    = "709b72ea0c99171cc284e220b844dc333d9e6880";
+    sha256 = "0p16vp959q9wyrj74jqdg0708mljbbjra87vjkm10bnd40wg1ia2";
+  };
+
+  name = "corretto-${version}";
+
+  # In the form: $MAJOR.$UPDATE.$BUILD.$REVISION
+  tokens = lib.splitString "." version;
+
+  majorVersion     = builtins.elemAt tokens 0;
+  updateVersion    = builtins.elemAt tokens 1;
+  buildNumber      = builtins.elemAt tokens 2;
+  correttoRevision = builtins.elemAt tokens 3;
+
+  corretto = openjdk8.overrideAttrs (oldAttrs: rec {
+    inherit name version src;
+
+    # Override upstream sources and directory auto-detection; Corretto includes
+    # everything in the same repository.
+    srcs = null;
+    sourceRoot = null;
+
+    # OpenJDK sources in the repo are stored under './src'
+    postUnpack = ''
+      sourceRoot+=/src
+    '' + (oldAttrs.postUnpack or "");
+
+    # Don't need the 'move everything to the same directory' steps that the main
+    # recipe does.
+    prePatch = null;
+
+    patches = oldAttrs.patches ++ [
+      # Suppress an error from -Wformat
+      (fetchpatch {
+        url = "http://icedtea.classpath.org/hg/icedtea8/raw-file/cea1a48810dd/patches/pr3597.patch";
+        sha256 = "1dy79l5jq8npdx35i9aq9xai5lz9k35db65phkvham69ch4564g7";
+      })
+    ];
+
+    # The configure script isn't marked as executable, so we need to run it
+    # directly with Bash.
+    configureScript = "${bash}/bin/bash ./configure";
+
+    # Pass correct build versions
+    configureFlags = oldAttrs.configureFlags ++[
+      "--with-update-version=${updateVersion}"
+      "--with-build-number=b${buildNumber}"
+      "--with-corretto-revision=${correttoRevision}"
+      "--disable-zip-debug-info"
+    ];
+
+    # Needed because otherwise we get a warning about _FORTIFY_SOURCE
+    NIX_CFLAGS_COMPILE = "-O1";
+
+    meta = with stdenv.lib; {
+      homepage = https://aws.amazon.com/corretto/;
+      license = licenses.gpl2Classpath;
+      description = "No-cost, multiplatform, production-ready distribution of OpenJDK";
+      maintainers = with maintainers; [ andrew-d ];
+      platforms = platforms.linux;
+    };
+
+    passthru = {
+      inherit (openjdk8) architecture;
+      home = "${corretto}/lib/openjdk";
+    };
+  });
+
+in corretto

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7493,6 +7493,11 @@ in
         inherit installjdk pluginSupport;
       });
 
+  corretto8 = callPackage ../development/compilers/openjdk/corretto.nix {
+    bootjdk = bootjdk.override { version = "8"; };
+    inherit (gnome2) GConf gnome_vfs;
+  };
+
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 
   jikes = callPackage ../development/compilers/jikes { };


### PR DESCRIPTION
###### Motivation for this change
[AWS Corretto](https://aws.amazon.com/corretto/) is a distribution of OpenJDK that comes with additional performance and security patches, and long-term support until at least June 2023.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

As maintainers of the existing OpenJDK 8 package:
r? @edwtjo @NeQuissimus 

I'd be interested to hear what you folks think about this "override `openjdk8`" approach; it saves a ton of code duplication and refactoring compared to writing an entirely new derivation.