### PR TITLE
[18.09] buildbot: fix CVE-2019-7313

### DIFF
--- a/pkgs/development/tools/build-managers/buildbot/default.nix
+++ b/pkgs/development/tools/build-managers/buildbot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, openssh, buildbot-worker, buildbot-pkg, pythonPackages, runCommand, makeWrapper }:
+{ stdenv, fetchpatch, openssh, buildbot-worker, buildbot-pkg, pythonPackages, runCommand, makeWrapper }:
 
 let
   withPlugins = plugins: runCommand "wrapped-${package.name}" {
@@ -74,6 +74,15 @@ let
       # This patch disables the test that tries to read /etc/os-release which
       # is not accessible in sandboxed builds.
       ./skip_test_linux_distro.patch
+
+      # CVE-2019-7313
+      # https://github.com/buildbot/buildbot/wiki/CRLF-injection-in-Buildbot-login-and-logout-redirect-code
+      # https://github.com/buildbot/buildbot/compare/v1.8.0...v1.8.1
+      (fetchpatch {
+        url = "https://github.com/buildbot/buildbot/commit/bdae9fea4e8978b19e12425776b2d083febd91a6.diff";
+        sha256 = "18fbcbqphs8jjmfvjjcbcnv5wj87mj6jv9lmx17lfhpi5hg2axph";
+        stripLen = 1;
+      })
     ];
 
     # TimeoutErrors on slow machines -> aarch64


### PR DESCRIPTION
###### Motivation for this change

https://github.com/buildbot/buildbot/wiki/CRLF-injection-in-Buildbot-login-and-logout-redirect-code
Fix for master comes as bump to 1.8.1 #52536

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

