### PR TITLE
fortune: 1.99.1 -> 2.6.2

### DIFF
--- a/pkgs/tools/misc/fortune/default.nix
+++ b/pkgs/tools/misc/fortune/default.nix
@@ -1,17 +1,31 @@
-{ stdenv, fetchurl, recode }:
+{ stdenv, fetchurl, cmake, recode, perl }:
 
+let srcs = {
+      fortune = fetchurl {
+        url = https://github.com/shlomif/fortune-mod/archive/fortune-mod-2.6.2.tar.gz;
+        sha256 = "89223bb649ea62b030527f181539182d6a17a1a43b0cc499a52732b839f7b691";
+      };
+      shlomifCommon = fetchurl {
+        url = https://bitbucket.org/shlomif/shlomif-cmake-modules/raw/default/shlomif-cmake-modules/Shlomif_Common.cmake;
+        sha256 = "62f188a9f1b7ab0e757eb0bc6540d9c0026d75edc7acc1c3cdf7438871d0a94f";
+      };
+    };
+in
 stdenv.mkDerivation {
-  name = "fortune-mod-1.99.1";
+  name = "fortune-mod-2.6.2";
 
-  src = fetchurl {
-    url = http://ftp.de.debian.org/debian/pool/main/f/fortune-mod/fortune-mod_1.99.1.orig.tar.gz;
-    sha256 = "1kpa2hgbglj5dbfasvl9wc1q3xpl91mqn3sfby46r4rwyzhswlgw";
-  };
+  src = srcs.fortune;
 
-  buildInputs = [ recode ];
+  sourceRoot = "fortune-mod-fortune-mod-2.6.2/fortune-mod";
+
+  buildInputs = [ cmake recode perl ];
 
   preConfigure = ''
-    sed -i "s|/usr/|$out/|" Makefile
+    cp ${srcs.shlomifCommon} cmake/Shlomif_Common.cmake
+  '';
+
+  configureScript = ''
+    cmake -DCMAKE_INSTALL_PREFIX=$out .
   '';
 
   preBuild = ''
@@ -19,8 +33,7 @@ stdenv.mkDerivation {
   '';
 
   postInstall = ''
-    mv $out/games/fortune $out/bin/fortune
-    rmdir $out/games
+    cp $out/games/fortune $out/bin/fortune
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/fortune/default.nix
+++ b/pkgs/tools/misc/fortune/default.nix
@@ -2,7 +2,7 @@
 
 let srcs = {
       fortune = fetchurl {
-        url = https://github.com/shlomif/fortune-mod/archive/fortune-mod-2.6.2.tar.gz;
+        url = "https://github.com/shlomif/fortune-mod/archive/fortune-mod-${version}.tar.gz";
         sha256 = "89223bb649ea62b030527f181539182d6a17a1a43b0cc499a52732b839f7b691";
       };
       shlomifCommon = fetchurl {
@@ -25,10 +25,6 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     cp ${srcs.shlomifCommon} cmake/Shlomif_Common.cmake
-  '';
-
-  preBuild = ''
-    makeFlagsArray=("CC=$CC" "REGEXDEFS=-DHAVE_REGEX_H -DPOSIX_REGEX" "LDFLAGS=")
   '';
 
   postInstall = ''

--- a/pkgs/tools/misc/fortune/default.nix
+++ b/pkgs/tools/misc/fortune/default.nix
@@ -10,22 +10,21 @@ let srcs = {
         sha256 = "62f188a9f1b7ab0e757eb0bc6540d9c0026d75edc7acc1c3cdf7438871d0a94f";
       };
     };
+    version = "2.6.2";
 in
 stdenv.mkDerivation {
-  name = "fortune-mod-2.6.2";
+  name = "fortune-mod-${version}";
 
   src = srcs.fortune;
 
-  sourceRoot = "fortune-mod-fortune-mod-2.6.2/fortune-mod";
+  sourceRoot = "fortune-mod-fortune-mod-${version}/fortune-mod";
 
-  buildInputs = [ cmake recode perl ];
+  nativeBuildInputs = [ cmake perl ];
+
+  buildInputs = [ recode ];
 
   preConfigure = ''
     cp ${srcs.shlomifCommon} cmake/Shlomif_Common.cmake
-  '';
-
-  configureScript = ''
-    cmake -DCMAKE_INSTALL_PREFIX=$out .
   '';
 
   preBuild = ''
@@ -33,7 +32,8 @@ stdenv.mkDerivation {
   '';
 
   postInstall = ''
-    cp $out/games/fortune $out/bin/fortune
+    mv $out/games/fortune $out/bin/fortune
+    rm -r $out/games
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update fortune from 1.99.1 to 2.6.2.

Fix: #55107 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

