### PR TITLE
rhash: 1.3.6 -> 1.3.8

### DIFF
--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, which }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.6";
+  version = "1.3.8";
   name = "rhash-${version}";
 
   src = fetchFromGitHub {
     owner = "rhash";
     repo = "RHash";
     rev = "v${version}";
-    sha256 = "1c8gngjj34ylx1f56hjbvml22bif0bx1b88dx2cyxbix8praxqh7";
+    sha256 = "0i00wl63hn80g0s9gdi772gchbghwgkvn4nbb5227y2wwy30yyi2";
   };
 
   nativeBuildInputs = [ which ];
@@ -16,10 +16,9 @@ stdenv.mkDerivation rec {
   # configure script is not autotools-based, doesn't support these options
   configurePlatforms = [ ];
 
-  doCheck = false; # fails
+  doCheck = true;
 
-  installTargets = [ "install" "install-lib-shared" "install-lib-so-link" ];
-  postInstall = "make -C librhash install-headers";
+  installTargets = [ "install" "install-lib-shared" "install-lib-so-link" "install-lib-headers" ];
 
   meta = with stdenv.lib; {
     homepage = http://rhash.anz.ru;

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  checkTarget = "test-full";
+
   installTargets = [ "install" "install-lib-shared" "install-lib-so-link" "install-lib-headers" ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

 https://github.com/rhash/RHash/releases/tag/v1.3.8 
 https://github.com/rhash/RHash/releases/tag/v1.3.7

Staging because cmake depends on it, so likely many rebuilds :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---