### PR TITLE
iosevka-bin: 2.0.2 -> 2.1.0

### DIFF
--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "2.0.2";
+  version = "2.1.0";
 in fetchzip rec {
   name = "iosevka-bin-${version}";
 
@@ -12,7 +12,7 @@ in fetchzip rec {
     unzip -j $downloadedFile \*.ttc -d $out/share/fonts/iosevka
   '';
 
-  sha256 = "0jr9d02dk4zbq3kyhpfs6gyynwss60210pc1dfxn0qbw3j9ch2l4";
+  sha256 = "0hx91pdkiw0qvkkl7qnl78p5afldcmn18l5m1iclldnvrghrxizz";
 
   meta = with stdenv.lib; {
     homepage = https://be5invis.github.io/Iosevka/;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/be5invis/Iosevka/releases/tag/v2.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---