### PR TITLE
NixOS: Run Docker containers as declarative systemd services

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -851,6 +851,7 @@
   ./virtualisation/container-config.nix
   ./virtualisation/containers.nix
   ./virtualisation/docker.nix
+  ./virtualisation/docker-containers.nix
   ./virtualisation/ecs-agent.nix
   ./virtualisation/libvirtd.nix
   ./virtualisation/lxc.nix

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -203,7 +203,7 @@ in {
   options.docker-containers = mkOption {
     default = {};
     type = types.attrsOf (types.submodule dockerContainer);
-    description = "Docker containers to run.";
+    description = "Docker containers to run as systemd services.";
   };
 
   config = {

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -8,21 +8,58 @@ let
     { name, config, ... }: {
 
       options = {
+
         image = mkOption {
           type = types.str;
           description = "Docker image to run.";
+          example = "library/hello-world";
         };
+
         cmd = mkOption {
           type =  with types; listOf string;
           default = [];
           description = "Commandline arguments to pass to the image's entrypoint.";
         };
+
         entrypoint = mkOption {
-          type = types.nullOr types.string;
+          type = with types; nullOr string;
           description = "Overwrite the default entrypoint of the image.";
           default = null;
         };
+
+        environment = mkOption {
+          type = with types; attrsOf string;
+          default = {};
+          description = "Environment variables to set for this container.";
+          example = {
+            DATABASE_HOST = "db.example.com";
+            DATABASE_PORT = "3306";
+          };
+        };
+
+        ports = mkOption {
+          type = with types; attrsOf string;
+          default = {};
+          description = "Network ports to forward from the host to this container.";
+          example = {
+            "8080" = "9000/tcp";
+          };
+        };
+
+        user = mkOption {
+          type = with types; nullOr string;
+          default = null;
+          description = ''
+            Override the username or UID (and optionally groupname or
+            GID) used in the container.
+          '';
+          example = "nobody:nogroup";
+        };
+
         volumes = mkOption {
+          # Note: these are "src:dst" lists so it's possible for `src`
+          # to refer to a /nix/store path, and for `dst` to include
+          # mount options.
           type = with types; listOf string;
           default = [];
           description = "List of volumes to attach to this container.";
@@ -31,6 +68,14 @@ let
             "/path/on/host:/path/inside/container"
           ];
         };
+
+        workdir = mkOption {
+          type = with types; nullOr string;
+          default = null;
+          description = "Override the default working directory for the container.";
+          example = "/var/lib/hello_world";
+        };
+
         extraDockerOptions = mkOption {
           type = with types; listOf string;
           default = [];
@@ -45,19 +90,22 @@ let
       wantedBy = [ "multi-user.target" ];
       after = [ "docker.service" "docker.socket" ];
       requires = [ "docker.service" "docker.socket" ];
-      script = lib.concatStringsSep " " ([
+      script = concatStringsSep " \\\n  " ([
         "exec ${pkgs.docker}/bin/docker run"
         "--rm"
         "--name=${containerName}"
-      ] ++ lib.optional (! isNull container.entrypoint)
-        "--entrypoint=${lib.escapeShellArg container.entrypoint}"
-        ++ (map (v: "-v ${lib.escapeShellArg v}") container.volumes)
-        ++ [
-          (lib.escapeShellArgs container.extraDockerOptions)
-          container.image
-        ]
+      ] ++ optional (! isNull container.entrypoint)
+        "--entrypoint=${escapeShellArg container.entrypoint}"
+        ++ (mapAttrsToList (k: v: "-e ${escapeShellArg k}=${escapeShellArg v}") container.environment)
+        ++ (mapAttrsToList (k: v: "-p ${escapeShellArg k}:${escapeShellArg v}") container.ports)
+        ++ optional (! isNull container.user) "-u ${escapeShellArg container.user}"
+        ++ (map (v: "-v ${escapeShellArg v}") container.volumes)
+        ++ optional (! isNull container.workdir) "-w ${escapeShellArg container.workdir}"
+        # I know escapeShellArgs exists; this results in prettier output
+        ++ map escapeShellArg container.extraDockerOptions
+        ++ [container.image]
       );
-      scriptArgs = lib.escapeShellArgs container.cmd;
+      scriptArgs = escapeShellArgs container.cmd;
       preStop = "${pkgs.docker}/bin/docker stop ${containerName}";
       reload = "${pkgs.docker}/bin/docker restart ${containerName}";
       serviceConfig = {
@@ -79,7 +127,7 @@ in {
 
   config = {
 
-    systemd.services = lib.mapAttrs' (n: v: lib.nameValuePair "docker-${n}" (mkService n v)) cfg;
+    systemd.services = mapAttrs' (n: v: nameValuePair "docker-${n}" (mkService n v)) cfg;
 
     virtualisation.docker.enable = true;
 

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -16,19 +16,19 @@ let
         };
 
         cmd = mkOption {
-          type =  with types; listOf string;
+          type =  with types; listOf str;
           default = [];
           description = "Commandline arguments to pass to the image's entrypoint.";
         };
 
         entrypoint = mkOption {
-          type = with types; nullOr string;
+          type = with types; nullOr str;
           description = "Overwrite the default entrypoint of the image.";
           default = null;
         };
 
         environment = mkOption {
-          type = with types; attrsOf string;
+          type = with types; attrsOf str;
           default = {};
           description = "Environment variables to set for this container.";
           example = {
@@ -37,8 +37,19 @@ let
           };
         };
 
+        log-driver = mkOption {
+          type = types.str;
+          default = "none";
+          description = ''
+            Logging driver for the container.  The default of "none" means that
+            the container's logs will be handled as part of the systemd unit.
+            Setting this to "journald" will result in duplicate logging, but
+            the container's logs will be visible to the `docker logs` command.
+          '';
+        };
+
         ports = mkOption {
-          type = with types; attrsOf string;
+          type = with types; attrsOf str;
           default = {};
           description = "Network ports to forward from the host to this container.";
           example = {
@@ -47,11 +58,11 @@ let
         };
 
         user = mkOption {
-          type = with types; nullOr string;
+          type = with types; nullOr str;
           default = null;
           description = ''
-            Override the username or UID (and optionally groupname or
-            GID) used in the container.
+            Override the username or UID (and optionally groupname or GID) used
+            in the container.
           '';
           example = "nobody:nogroup";
         };
@@ -60,7 +71,7 @@ let
           # Note: these are "src:dst" lists so it's possible for `src`
           # to refer to a /nix/store path, and for `dst` to include
           # mount options.
-          type = with types; listOf string;
+          type = with types; listOf str;
           default = [];
           description = "List of volumes to attach to this container.";
           example = [
@@ -70,14 +81,14 @@ let
         };
 
         workdir = mkOption {
-          type = with types; nullOr string;
+          type = with types; nullOr str;
           default = null;
           description = "Override the default working directory for the container.";
           example = "/var/lib/hello_world";
         };
 
         extraDockerOptions = mkOption {
-          type = with types; listOf string;
+          type = with types; listOf str;
           default = [];
           description = "Extra options for `docker run`.";
           example = ["--network=host"];
@@ -94,6 +105,7 @@ let
         "exec ${pkgs.docker}/bin/docker run"
         "--rm"
         "--name=${containerName}"
+        "--log-driver=${container.log-driver}"
       ] ++ optional (! isNull container.entrypoint)
         "--entrypoint=${escapeShellArg container.entrypoint}"
         ++ (mapAttrsToList (k: v: "-e ${escapeShellArg k}=${escapeShellArg v}") container.environment)

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -19,7 +19,7 @@ let
           type =  with types; listOf str;
           default = [];
           description = "Commandline arguments to pass to the image's entrypoint.";
-          literalExample = ''
+          example = literalExample ''
             ["--port=9000"]
           '';
         };
@@ -35,7 +35,7 @@ let
           type = with types; attrsOf str;
           default = {};
           description = "Environment variables to set for this container.";
-          literalExample = ''
+          example = literalExample ''
             {
               DATABASE_HOST = "db.example.com";
               DATABASE_PORT = "3306";
@@ -55,8 +55,8 @@ let
             logs</command> command.
 
             For more details and a full list of logging drivers, refer to the
-            <a href="https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver">
-            Docker engine documentation</a>
+            <link xlink:href="https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver">
+            Docker engine documentation</link>
           '';
         };
 
@@ -64,7 +64,7 @@ let
           type = with types; attrsOf str;
           default = {};
           description = "Network ports to forward from the host to this container.";
-          literalExample = ''
+          example = literalExample ''
             {
               # "port_on_host" = "port_in_container"
               "8080" = "9000/tcp";
@@ -83,9 +83,6 @@ let
         };
 
         volumes = mkOption {
-          # Note: these are "src:dst" lists so it's possible for `src`
-          # to refer to a /nix/store path, and for `dst` to include
-          # mount options.
           type = with types; listOf str;
           default = [];
           description = ''
@@ -96,10 +93,10 @@ let
             <literal>/nix/store</literal> paths, which would difficult with an
             attribute set.  There are also a variety of mount options available
             as a third field; please refer to the
-            <a href="https://docs.docker.com/engine/reference/run/#volume-shared-filesystems">
-            docker engine documentation</a> for details.
+            <link xlink:href="https://docs.docker.com/engine/reference/run/#volume-shared-filesystems">
+            docker engine documentation</link> for details.
           '';
-          literalExample = ''
+          example = literalExample ''
             [
               "volume_name:/path/inside/container"
               "/path/on/host:/path/inside/container"
@@ -118,7 +115,7 @@ let
           type = with types; listOf str;
           default = [];
           description = "Extra options for <command>docker run</command>.";
-          literalExample = ''
+          example = literalExample ''
             ["--network=host"]
           '';
         };

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -1,0 +1,84 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.docker-containers;
+
+  dockerContainer =
+    { name, config, ... }: {
+
+      options = {
+        image = mkOption {
+          type = types.str;
+          description = "Docker image to run.";
+        };
+        args = mkOption {
+          type =  with types; listOf string;
+          default = [];
+          description = "Args to pass to the image.";
+        };
+        entrypoint = mkOption {
+          type = types.nullOr types.string;
+          description = "Overwrite the default ENTRYPOINT of the image.";
+          default = null;
+        };
+        volumes = mkOption {
+          type = with types; listOf string;
+          default = [];
+          description = "List of volumes to attach to this container.";
+          example = [
+            "volume_name:/path/inside/container"
+            "/path/on/host:/path/inside/container"
+          ];
+        };
+        extraDockerOptions = mkOption {
+          type = with types; listOf string;
+          default = [];
+          description = "Extra options for `docker run`.";
+          example = ["--network=host"];
+        };
+      };
+    };
+
+  mkService = name: container:
+    let containerName = "nixos-${name}"; in {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "docker.service" "docker.socket" ];
+      requires = [ "docker.service" "docker.socket" ];
+      script = lib.concatStringsSep " " ([
+        "exec ${pkgs.docker}/bin/docker run"
+        "--rm"
+        "--name=${containerName}"
+      ] ++ lib.optional (! isNull container.entrypoint)
+        "--entrypoint=${lib.escapeShellArg container.entrypoint}"
+        ++ (map (v: "-v ${lib.escapeShellArg v}") container.volumes)
+        ++ [
+          (lib.escapeShellArgs container.extraDockerOptions)
+          container.image
+        ]
+      );
+      scriptArgs = lib.escapeShellArgs container.args;
+      preStop = "${pkgs.docker}/bin/docker stop ${containerName}";
+      reload = "${pkgs.docker}/bin/docker restart ${containerName}";
+      serviceConfig = {
+        ExecStartPre = "-${pkgs.docker}/bin/docker rm -f ${containerName}";
+        ExecStopPost = "-${pkgs.docker}/bin/docker rm -f ${containerName}";
+        TimeoutStartSec = 0;
+        TimeoutStopSec = 120;
+        Restart = "always";
+      };
+    };
+
+in {
+
+  options.docker-containers = mkOption {
+    default = {};
+    type = types.attrsOf (types.submodule dockerContainer);
+    description = "Docker containers to run.";
+  };
+
+  config = {
+    systemd.services = lib.mapAttrs' (n: v: lib.nameValuePair "docker-${n}" (mkService n v)) cfg;
+  };
+
+}

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -12,14 +12,14 @@ let
           type = types.str;
           description = "Docker image to run.";
         };
-        args = mkOption {
+        cmd = mkOption {
           type =  with types; listOf string;
           default = [];
-          description = "Args to pass to the image.";
+          description = "Commandline arguments to pass to the image's entrypoint.";
         };
         entrypoint = mkOption {
           type = types.nullOr types.string;
-          description = "Overwrite the default ENTRYPOINT of the image.";
+          description = "Overwrite the default entrypoint of the image.";
           default = null;
         };
         volumes = mkOption {
@@ -57,7 +57,7 @@ let
           container.image
         ]
       );
-      scriptArgs = lib.escapeShellArgs container.args;
+      scriptArgs = lib.escapeShellArgs container.cmd;
       preStop = "${pkgs.docker}/bin/docker stop ${containerName}";
       reload = "${pkgs.docker}/bin/docker restart ${containerName}";
       serviceConfig = {
@@ -78,7 +78,11 @@ in {
   };
 
   config = {
+
     systemd.services = lib.mapAttrs' (n: v: lib.nameValuePair "docker-${n}" (mkService n v)) cfg;
+
+    virtualisation.docker.enable = true;
+
   };
 
 }

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -19,32 +19,44 @@ let
           type =  with types; listOf str;
           default = [];
           description = "Commandline arguments to pass to the image's entrypoint.";
+          literalExample = ''
+            ["--port=9000"]
+          '';
         };
 
         entrypoint = mkOption {
           type = with types; nullOr str;
           description = "Overwrite the default entrypoint of the image.";
           default = null;
+          example = "/bin/my-app";
         };
 
         environment = mkOption {
           type = with types; attrsOf str;
           default = {};
           description = "Environment variables to set for this container.";
-          example = {
-            DATABASE_HOST = "db.example.com";
-            DATABASE_PORT = "3306";
-          };
+          literalExample = ''
+            {
+              DATABASE_HOST = "db.example.com";
+              DATABASE_PORT = "3306";
+            }
+        '';
         };
 
         log-driver = mkOption {
           type = types.str;
           default = "none";
           description = ''
-            Logging driver for the container.  The default of "none" means that
-            the container's logs will be handled as part of the systemd unit.
-            Setting this to "journald" will result in duplicate logging, but
-            the container's logs will be visible to the `docker logs` command.
+            Logging driver for the container.  The default of
+            <literal>"none"</literal> means that the container's logs will be
+            handled as part of the systemd unit.  Setting this to
+            <literal>"journald"</literal> will result in duplicate logging, but
+            the container's logs will be visible to the <command>docker
+            logs</command> command.
+
+            For more details and a full list of logging drivers, refer to the
+            <a href="https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver">
+            Docker engine documentation</a>
           '';
         };
 
@@ -52,9 +64,12 @@ let
           type = with types; attrsOf str;
           default = {};
           description = "Network ports to forward from the host to this container.";
-          example = {
-            "8080" = "9000/tcp";
-          };
+          literalExample = ''
+            {
+              # "port_on_host" = "port_in_container"
+              "8080" = "9000/tcp";
+            }
+          '';
         };
 
         user = mkOption {
@@ -73,11 +88,23 @@ let
           # mount options.
           type = with types; listOf str;
           default = [];
-          description = "List of volumes to attach to this container.";
-          example = [
-            "volume_name:/path/inside/container"
-            "/path/on/host:/path/inside/container"
-          ];
+          description = ''
+            List of volumes to attach to this container.
+
+            Note that this is a list of <literal>"src:dst"</literal> strings to
+            allow for <literal>src</literal> to refer to
+            <literal>/nix/store</literal> paths, which would difficult with an
+            attribute set.  There are also a variety of mount options available
+            as a third field; please refer to the
+            <a href="https://docs.docker.com/engine/reference/run/#volume-shared-filesystems">
+            docker engine documentation</a> for details.
+          '';
+          literalExample = ''
+            [
+              "volume_name:/path/inside/container"
+              "/path/on/host:/path/inside/container"
+            ]
+          '';
         };
 
         workdir = mkOption {
@@ -90,8 +117,10 @@ let
         extraDockerOptions = mkOption {
           type = with types; listOf str;
           default = [];
-          description = "Extra options for `docker run`.";
-          example = ["--network=host"];
+          description = "Extra options for <command>docker run</command>.";
+          literalExample = ''
+            ["--network=host"]
+          '';
         };
       };
     };

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -206,7 +206,7 @@ in {
     description = "Docker containers to run as systemd services.";
   };
 
-  config = {
+  config = mkIf (cfg != []) {
 
     systemd.services = mapAttrs' (n: v: nameValuePair "docker-${n}" (mkService n v)) cfg;
 

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -191,7 +191,23 @@ let
       ExecStartPre = "-${pkgs.docker}/bin/docker rm -f %n";
       ExecStop = "${pkgs.docker}/bin/docker stop %n";
       ExecStopPost = "-${pkgs.docker}/bin/docker rm -f %n";
-      ExecReload = "${pkgs.docker}/bin/docker restart %n";
+
+      ### There is no generalized way of supporting `reload` for docker
+      ### containers. Some containers may respond well to SIGHUP sent to their
+      ### init process, but it is not guaranteed; some apps have other reload
+      ### mechanisms, some don't have a reload signal at all, and some docker
+      ### images just have broken signal handling.  The best compromise in this
+      ### case is probably to leave ExecReload undefined, so `systemctl reload`
+      ### will at least result in an error instead of potentially undefined
+      ### behaviour.
+      ###
+      ### Advanced users can still override this part of the unit to implement
+      ### a custom reload handler, since the result of all this is a normal
+      ### systemd service from the perspective of the NixOS module system.
+      ###
+      # ExecReload = ...;
+      ###
+
       TimeoutStartSec = 0;
       TimeoutStopSec = 120;
       Restart = "always";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -57,6 +57,7 @@ in
   dhparams = handleTest ./dhparams.nix {};
   dnscrypt-proxy = handleTestOn ["x86_64-linux"] ./dnscrypt-proxy.nix {};
   docker = handleTestOn ["x86_64-linux"] ./docker.nix {};
+  docker-containers = handleTestOn ["x86_64-linux"] ./docker-containers.nix {};
   docker-edge = handleTestOn ["x86_64-linux"] ./docker-edge.nix {};
   docker-preloader = handleTestOn ["x86_64-linux"] ./docker-preloader.nix {};
   docker-registry = handleTest ./docker-registry.nix {};

--- a/nixos/tests/docker-containers.nix
+++ b/nixos/tests/docker-containers.nix
@@ -24,6 +24,6 @@ import ./make-test.nix ({ pkgs, lib, ... }: {
     startAll;
     $docker->waitForUnit("docker-nginx.service");
     $docker->waitForOpenPort(8181);
-    $docker->succeed("curl http://localhost:8181|grep Hello");
+    $docker->waitUntilSucceeds("curl http://localhost:8181|grep Hello");
   '';
 })

--- a/nixos/tests/docker-containers.nix
+++ b/nixos/tests/docker-containers.nix
@@ -1,0 +1,29 @@
+# Test Docker containers as systemd units
+
+import ./make-test.nix ({ pkgs, lib, ... }: {
+  name = "docker-containers";
+  meta = {
+    maintainers = with lib.maintainers; [ benley ];
+  };
+
+  nodes = {
+    docker = { pkgs, ... }:
+      {
+        virtualisation.docker.enable = true;
+
+        virtualisation.dockerPreloader.images = [ pkgs.dockerTools.examples.nginx ];
+
+        docker-containers.nginx = {
+          image = "nginx-container";
+          ports = ["8181:80"];
+        };
+      };
+  };
+
+  testScript = ''
+    startAll;
+    $docker->waitForUnit("docker-nginx.service");
+    $docker->waitForOpenPort(8181);
+    $docker->succeed("curl http://localhost:8181|grep Hello");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
https://discourse.nixos.org/t/deploying-docker-containers-declaratively/693

https://github.com/NixOS/nixpkgs/issues/37553 https://github.com/NixOS/nixpkgs/pull/26075

Related to https://github.com/NixOS/nixpkgs/pull/26075 but the implementation is less general; this one just offers an interface to run containers as systemd units from pre-existing Docker images.

cc @copumpkin 

TODO:

- [x] NixOS tests
- [x] Documentation
- [x] Environment vars
- [x] Publishable ports
- [x] Volume mounts
- [x] Log driver option, systemd/journald logging integration
- [x] override UID/GID, workdir, entrypoint, cmd
- [x] systemd unit generator