### PR TITLE
prosody: update communityModules

### DIFF
--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -25,7 +25,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "0.11.2";
+  version = "0.11.2"; # also update communityModules
   name = "prosody-${version}";
 
   src = fetchurl {
@@ -33,10 +33,13 @@ stdenv.mkDerivation rec {
     sha256 = "0ca8ivqb4hxqka08pwnaqi1bqxrdl8zw47g6z7nw9q5r57fgc4c9";
   };
 
+  # A note to all those merging automated updates: Please also update this
+  # attribute as some modules might not be compatible with a newer prosody
+  # version.
   communityModules = fetchhg {
     url = "https://hg.prosody.im/prosody-modules";
-    rev = "150a7bd59043";
-    sha256 = "0nfx3lngcy88nd81gb7v4kh3nz1bzsm67bxgpd2lprk54diqcrz1";
+    rev = "b54e98d5c4a1";
+    sha256 = "0bzn92j48krb2zhp9gn5bbn5sg0qv15j5lpxfszwqdln3lpmrvzg";
   };
 
   buildInputs = [ lua5 makeWrapper libidn openssl ]


### PR DESCRIPTION
###### Motivation for this change
After the latest automatic updates of the prosody package the community
modules were partially incompatible. The worst effect I suffered was a
very high timeout (hours) on reconnects due to the stanza module throwing a
runtime error on the server.

We should probably try harder to keep them in sync.

I have been running this change on my own prosody instance for a bit now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc maintainers @fpletz @globin 

---

