### PR TITLE
libvdpau: pull a few upstream commits

### DIFF
--- a/pkgs/development/libraries/libvdpau/default.nix
+++ b/pkgs/development/libraries/libvdpau/default.nix
@@ -1,17 +1,30 @@
-{ stdenv, fetchurl, pkgconfig, xorg, libGL_driver }:
+{ stdenv, fetchurl, pkgconfig, xorg, libGL_driver
+, fetchFromGitLab, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
   name = "libvdpau-${version}";
-  version = "1.1.1";
+  version = "1.1.1.p1";
 
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "vdpau";
+    repo = "libvdpau";
+    # The only "more substatial" change atop 1.1.1 is
+    # https://gitlab.freedesktop.org/vdpau/libvdpau/commit/53eeb07f
+    rev = "52a6ea26";
+    sha256 = "02bz5w789vyzrfs3hvl698faa8ayy8ads7j6l418dalhfwz3q550";
+  };
+  /*
   src = fetchurl {
     url = "https://people.freedesktop.org/~aplattner/vdpau/${name}.tar.bz2";
-    sha256 = "857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736";
+    sha256 = "857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736"; # 1.1.1
   };
+  */
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = with xorg; [ xorgproto libXext ];
 
   propagatedBuildInputs = [ xorg.libX11 ];


### PR DESCRIPTION
###### Motivation for this change

- :-1:  I mainly wanted to try if it fixes the [Darwin failure](https://hydra.nixos.org/build/87621696) by accident.
- [ ] Also, I've been getting a line from `vlc`:
  `postproc filter error: Unsupported input chroma (VDV0)`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after; no difference)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

