### PR TITLE
openapi-generator-cli: init at 3.3.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4141,6 +4141,11 @@
     github = "shlevy";
     name = "Shea Levy";
   };
+  shou = {
+    email = "x+g@shou.io";
+    github = "Shou";
+    name = "Benedict Aas";
+  };
   siddharthist = {
     email = "langston.barrett@gmail.com";
     github = "siddharthist";

--- a/pkgs/tools/networking/openapi-generator-cli/default.nix
+++ b/pkgs/tools/networking/openapi-generator-cli/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  version = "3.3.4";
+  pname = "openapi-generator-cli";
+
+  jarfilename = "${pname}-${version}.jar";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  src = fetchurl {
+    url = "http://central.maven.org/maven2/org/openapitools/${pname}/${version}/${jarfilename}";
+    sha256 = "24cb04939110cffcdd7062d2f50c6f61159dc3e0ca3b8aecbae6ade53ad3dc8c";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    install -D "$src" "$out/share/java/${jarfilename}"
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $out/share/java/${jarfilename}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
+    homepage = https://github.com/OpenAPITools/openapi-generator;
+    license = licenses.asl20;
+    maintainers = [ maintainers.shou ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4523,6 +4523,8 @@ in
     inherit (gnome3) defaultIconTheme;
   };
 
+  openapi-generator-cli = callPackage ../tools/networking/openapi-generator-cli { };
+
   opencc = callPackage ../tools/text/opencc { };
 
   opencl-info = callPackage ../tools/system/opencl-info { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

