### PR TITLE
odpic: 2.4.2 -> 3.1.0

### DIFF
--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "odpic-${version}";
-  version = "2.4.2";
+  version = "3.1.0";
 
   src = fetchurl {
     url = "https://github.com/oracle/odpi/archive/v${version}.tar.gz";
-    sha256 = "0hw6b38vnh0cgm1iwpgkqa2am86baal6irp9bglacblwh8sshqdi";
+    sha256 = "0m6g7lbvfir4amf2cnap9wz9fmqrihqpihd84igrd7fp076894c0";
   };
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];


### PR DESCRIPTION
###### Motivation for this change
Upgrade to 3.1.0 as pythonPackages.cx_oracle now depends on 3.1.0 and fails to compile with 2.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

