### PR TITLE
libffi: enable static build

### DIFF
--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -4,6 +4,8 @@
 # libffi is used in darwin stdenv
 # we cannot run checks within it
 , doCheck ? !stdenv.isDarwin, dejagnu
+, enableStatic ? false
+, enableShared ? !enableStatic
 }:
 
 stdenv.mkDerivation rec {
@@ -49,7 +51,9 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gcc-arch=generic" # no detection of -march= or -mtune=
     "--enable-pax_emutramp"
-  ];
+  ]
+  ++ stdenv.lib.optional enableStatic "--enable-static"
+  ++ stdenv.lib.optional (!enableShared) "--disable-shared";
 
   preCheck = ''
     # The tests use -O0 which is not compatible with -D_FORTIFY_SOURCE.

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -143,6 +143,10 @@ in {
     enableShared = false;
     enableStatic = true;
   };
+  libffi = super.libffi.override {
+    enableStatic = true;
+    enableShared = false;
+  };
 
   darwin = super.darwin // {
     libiconv = super.darwin.libiconv.override {


### PR DESCRIPTION
###### Motivation for this change

Flags to have `libffi` produces static libraries.

This won't generate any rebuild because static libraries are not built by default in this case. I tried to copy what I observed for `ncurses`.

ping #43795

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

