### PR TITLE
ghc: use system `libffi`

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.3.nix
+++ b/pkgs/development/compilers/ghc/8.6.3.nix
@@ -6,6 +6,9 @@
 
 , libiconv ? null, ncurses
 
+, # GHC can be built with system libffi or a bundled one.
+  libffi ? null
+
 , useLLVM ? !stdenv.targetPlatform.isx86 || (stdenv.targetPlatform.isMusl && stdenv.hostPlatform != stdenv.targetPlatform)
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
@@ -65,6 +68,7 @@ let
 
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
+    ++ [libffi]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
@@ -149,6 +153,7 @@ stdenv.mkDerivation (rec {
   configureFlags = [
     "--datadir=$doc/share/doc/ghc"
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+  ] ++ stdenv.lib.optionals (libffi != null) ["--with-system-libffi" "--with-ffi-includes=${libffi}/include" "--with-ffi-libraries=${libffi}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && !enableIntegerSimple) [
     "--with-gmp-includes=${targetPackages.gmp.dev}/include" "--with-gmp-libraries=${targetPackages.gmp.out}/lib"
   ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [


### PR DESCRIPTION
Use the system `libffi` (`ie` nixpkgs's) instead of built-in libffi
from ghc source tree.

This will prevent library conflict when ghc dynamically links haskell
packages (linked with ghc built-in libffi) and any external library
which uses nixpkgs `libffi`.

###### Motivation for this change

In a `nix-shell` with `haskellPackages.ghcWithPackages(p :
[p.bindings-libffi])` using this pull request changes:

```
$ ghc -dynamic foo.hs  -package bindings-libffi
[1 of 1] Compiling Main             ( foo.hs, foo.o )
Linking foo ...

$ ldd ./foo | grep libffi
        libHSbindings-libffi-0.3-8zlW5dTVIDuCbNJGKO9GeK-ghc8.6.3.so => /nix/store/mblpjxlcyklsfwpa9n7bx2rsxazv2bpb-bindings-libffi-0.3/lib/ghc-8.6.3/x86_64-linux-ghc-8.6.3/libHSbindings-libffi-0.3-8zlW5dTVIDuCbNJGKO9GeK-ghc8.6.3.so (0x00007f2ca2203000)
        libffi.so.6 => /nix/store/ddgaziqy9m2jgm4z8dzkhqd3w9hzryns-libffi-3.2.1/lib/libffi.so.6 (0x00007f2ca06e6000)
```

Hovever, in a similar `nix-shell`, without this commit:

```
$ ghc -dynamic foo.hs  -package bindings-libffi
[1 of 1] Compiling Main             ( foo.hs, foo.o )
Linking foo ...
/nix/store/3xwc1ip20b0p68sxqbjjll0va4pv5hbv-binutils-2.30/bin/ld: warning: libffi.so.7, needed by /nix/store/cclv7n6jr311i5ywwkms1m3iz4lsg37j-ghc-8.6.3/lib/ghc-8.6.3/rts/libHSrts-ghc8.6.3.so, may conflict with libffi.so.6
/nix/store/3xwc1ip20b0p68sxqbjjll0va4pv5hbv-binutils-2.30/bin/ld: warning: libffi.so.7, needed by /nix/store/cclv7n6jr311i5ywwkms1m3iz4lsg37j-ghc-8.6.3/lib/ghc-8.6.3/rts/libHSrts-ghc8.6.3.so, may conflict with libffi.so.6

$ ldd ./foo | grep libffi
        libHSbindings-libffi-0.3-8zlW5dTVIDuCbNJGKO9GeK-ghc8.6.3.so => /nix/store/nbn5p1zs45ynhdjanjmc7hn8g5pvn064-bindings-libffi-0.3/lib/ghc-8.6.3/x86_64-linux-ghc-8.6.3/libHSbindings-libffi-0.3-8zlW5dTVIDuCbNJGKO9GeK-ghc8.6.3.so (0x00007eff1f4b9000)
        libffi.so.6 => /nix/store/qwmw5ddw8lk2pz4fy3irp87vj1cawvjh-libffi-3.2.1/lib/libffi.so.6 (0x00007eff1d99c000)
        libffi.so.7 => /nix/store/cclv7n6jr311i5ywwkms1m3iz4lsg37j-ghc-8.6.3/lib/ghc-8.6.3/rts/libffi.so.7 (0x00007eff1cb20000)
```

Observes the warnings during linking and the two `libffi` which appears when calling `ldd`.

# Discussion

- haskell full static build now depends on the availablility of static version of `libffi`, which is not the case in nixpkgs. This will be an issue, see https://github.com/NixOS/nixpkgs/issues/43795. Should this PR be blocked until `libffi` comes with static libraries? I've just pushed #55207 for that matter. *edit* Actually `libffi` comes with a static configuration, so this may not be a problem.
- version bump of `libffi` will triggers a mass rebuild of ghc and all haskell packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

