### PR TITLE
ipe: 7.2.9 -> 7.2.10

### DIFF
--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -3,26 +3,16 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ipe-7.2.9";
+  name = "ipe-7.2.10";
 
   src = fetchurl {
     url = "https://dl.bintray.com/otfried/generic/ipe/7.2/${name}-src.tar.gz";
-    sha256 = "1i0h0q32xvbb0d3y2ff76jxnaw05hjf2z5gzww886z8arxwar1xn";
+    sha256 = "0rm31kvyg30452bz12yi49bkhdmi4bjdx6zann5cdlbi0pvmx7xh";
   };
 
-  # changes taken from Gentoo portage
-  preConfigure = ''
-    cd src
-    sed -i \
-      -e 's/fpic/fPIC/' \
-      -e 's/moc-qt4/moc/' \
-      config.mak || die
-    sed -i -e 's/install -s/install/' common.mak || die
-  '';
+  sourceRoot = "${name}/src";
 
-  NIX_CFLAGS_COMPILE = [ "-std=c++11" ]; # build with Qt 5.7
-
-  IPEPREFIX="$$out";
+  IPEPREFIX="${placeholder "out"}";
   URWFONTDIR="${texlive}/texmf-dist/fonts/type1/urw/";
   LUA_PACKAGE = "lua";
 
@@ -37,6 +27,8 @@ stdenv.mkDerivation rec {
       wrapProgram "$prog" --prefix PATH : "${texlive}/bin"
     done
   '';
+
+  enableParallelBuilding = true;
 
   #TODO: make .desktop entry
 


### PR DESCRIPTION
https://mailman.science.uu.nl/pipermail/ipe-announce/2019-February/000077.html

Cleanup a bit while visiting :).


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---