### PR TITLE
nixos/prometheus: use append instead of insert for opening firewalls

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -119,7 +119,7 @@ let
   mkExporterConf = { name, conf, serviceOpts }:
     mkIf conf.enable {
       networking.firewall.extraCommands = mkIf conf.openFirewall (concatStrings [
-        "ip46tables -I nixos-fw ${conf.firewallFilter} "
+        "ip46tables -A nixos-fw ${conf.firewallFilter} "
         "-m comment --comment ${name}-exporter -j nixos-fw-accept"
       ]);
       systemd.services."prometheus-${name}-exporter" = mkMerge ([{


### PR DESCRIPTION
Inserting with `-I` causes the rules to placed before `ctstate`
tracking, while `-A` places them alongside all other allow rules.

###### Motivation for this change

 Before

```
Chain nixos-fw (1 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 nixos-fw-accept  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:9100 /* node-exporter */
3832K  749M nixos-fw-accept  all  --  lo     *       0.0.0.0/0            0.0.0.0/0
1066K 4080M nixos-fw-accept  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    1    64 nixos-fw-accept  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:22
    0     0 nixos-fw-accept  icmp --  *      *       0.0.0.0/0            0.0.0.0/0            icmptype 8
 110K   29M nixos-fw-log-refuse  all  --  *      *       0.0.0.0/0            0.0.0.0/0
```

After
```
Chain nixos-fw (1 references)
 pkts bytes target     prot opt in     out     source               destination
  414 75214 nixos-fw-accept  all  --  lo     *       0.0.0.0/0            0.0.0.0/0
   36  7770 nixos-fw-accept  all  --  *      *       0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
    0     0 nixos-fw-accept  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:22
    0     0 nixos-fw-accept  icmp --  *      *       0.0.0.0/0            0.0.0.0/0            icmptype 8
    0     0 nixos-fw-accept  tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:9100 /* node-exporter */
    7  1621 nixos-fw-log-refuse  all  --  *      *       0.0.0.0/0            0.0.0.0/0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

