### PR TITLE
swift: 4.2.1 -> 4.2.2

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -34,7 +34,7 @@
 }:
 
 let
-  v_base = "4.2.1";
+  v_base = "4.2.2";
   version = "${v_base}-RELEASE";
   version_friendly = "${v_base}";
 
@@ -84,7 +84,7 @@ let
     };
     foundation = fetch {
       repo = "swift-corelibs-foundation";
-      sha256 = "1bfnkj8s3v327cy0czkngz0ryzmz7amjzkkxbsg2zyrhf9a9f0f7";
+      sha256 = "1ki9vc723r13zgm6bcmif43aypavb2hz299gbhp93qkndz8hqkx5";
     };
     libdispatch = fetch {
       repo = "swift-corelibs-libdispatch";
@@ -93,7 +93,7 @@ let
     };
     swift = fetch {
       repo = "swift";
-      sha256 = "0y277wi0m6zp1yph9s14mmc65m21q5fm6lgzkn2rkrbaz25fdzak";
+      sha256 = "1hwi6hi9ss1kj1s65v5q8v8d872c0914qfy1018xijd029lwq694";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Not all hashes changed, which isn't impossible but maybe worth checking
by someone not using the same caches I am :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---