### PR TITLE
perlPackages.GeoIP2: init at 2.006001

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9267,7 +9267,7 @@ let
       url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-XS-1.000007.tar.gz;
       sha256 = "1wg1x1pqamapfhn6rbffqipncgs15k99q34agdamv76i6782ny8r";
     };
-    propagatedBuildInputs = [ MathInt128 MaxMindDBReader ];
+    propagatedBuildInputs = [ MathInt128 MaxMindDBReader pkgs.libmaxminddb ];
     buildInputs = [ NetWorks PathClass TestFatal TestNumberDelta TestRequires ];
     meta = {
       description = "Fast XS implementation of MaxMind DB reader";
@@ -9283,6 +9283,7 @@ let
     };
     propagatedBuildInputs = [ DigestSHA1 MaxMindDBReader MooseXParamsValidate MooseXStrictConstructor NetWorks SerealDecoder SerealEncoder ];
     buildInputs = [ DevelRefcount JSON TestBits TestDeep TestFatal TestHexDifferences TestRequires TestWarnings ];
+    hardeningDisable = [ "format" ];
     meta = {
       description = "Create MaxMind DB database files";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9130,6 +9130,31 @@ let
     propagatedBuildInputs = [ ClassAccessor ParamsValidate ];
   };
 
+  MathInt128 = buildPerlPackage {
+    name = "Math-Int128-0.22";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/S/SA/SALVA/Math-Int128-0.22.tar.gz;
+      sha256 = "1g0ra7ldv4fz3kqqg45dlrfavi2abfmlhf0py5ank1jk2x0clc56";
+    };
+    propagatedBuildInputs = [ MathInt64 ];
+    meta = {
+      description = "Manipulate 128 bits integers in Perl";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  MathInt64 = buildPerlPackage {
+    name = "Math-Int64-0.54";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/S/SA/SALVA/Math-Int64-0.54.tar.gz;
+      sha256 = "0lfkc0cry65lnsi28gjyz2kvdkanbhhpc0pyrswsczj3k3k53z6w";
+    };
+    meta = {
+      description = "Manipulate 64 bits integers in Perl";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   MathPlanePath = buildPerlPackage rec {
     name = "Math-PlanePath-126";
     src = fetchurl {
@@ -9219,6 +9244,20 @@ let
     buildInputs = [ PathClass TestBits TestFatal TestNumberDelta TestRequires ];
     meta = {
       description = "Read MaxMind DB files and look up IP addresses";
+      license = with stdenv.lib.licenses; [ artistic2 ];
+    };
+  };
+
+  MaxMindDBReaderXS = buildPerlModule {
+    name = "MaxMind-DB-Reader-XS-1.000007";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-XS-1.000007.tar.gz;
+      sha256 = "1wg1x1pqamapfhn6rbffqipncgs15k99q34agdamv76i6782ny8r";
+    };
+    propagatedBuildInputs = [ MathInt128 MaxMindDBReader ];
+    buildInputs = [ NetWorks PathClass TestFatal TestNumberDelta TestRequires ];
+    meta = {
+      description = "Fast XS implementation of MaxMind DB reader";
       license = with stdenv.lib.licenses; [ artistic2 ];
     };
   };
@@ -11303,6 +11342,20 @@ let
     meta = {
       homepage = https://github.com/semifor/Net-Twitter-Lite;
       description = "A perl interface to the Twitter API";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  NetWorks = buildPerlPackage {
+    name = "Net-Works-0.22";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/Net-Works-0.22.tar.gz;
+      sha256 = "1zz91vn1kdxljnlwllf4dzdsm4v6pja5694vf8l4w66azcyv5j8a";
+    };
+    propagatedBuildInputs = [ ListAllUtils MathInt128 Moo namespaceautoclean ];
+    buildInputs = [ TestFatal ];
+    meta = {
+      description = "Sane APIs for IP addresses and networks";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3266,6 +3266,19 @@ let
     };
   };
 
+  DataIEEE754 = buildPerlPackage {
+    name = "Data-IEEE754-0.02";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/Data-IEEE754-0.02.tar.gz;
+      sha256 = "07b73dlxd0qmxgkkrpa2xr61y18v3adlf1qgnl9k90kj8q9spx66";
+    };
+    buildInputs = [ TestBits ];
+    meta = {
+      description = "Pack and unpack big-endian IEEE754 floats and doubles";
+      license = with stdenv.lib.licenses; [ artistic2 ];
+    };
+  };
+
   DataInteger = buildPerlModule rec {
     name = "Data-Integer-0.006";
     src = fetchurl {
@@ -3330,6 +3343,19 @@ let
     meta = {
       homepage = https://github.com/mattp-/Data-Perl;
       description = "Base classes wrapping fundamental Perl data types";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  DataPrinter = buildPerlPackage {
+    name = "Data-Printer-0.40";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/G/GA/GARU/Data-Printer-0.40.tar.gz;
+      sha256 = "0njjh8zp5afc4602jrnmg89icj7gfsil6i955ypcqxc2gl830sb0";
+    };
+    propagatedBuildInputs = [ ClonePP FileHomeDir PackageStash SortNaturally ];
+    meta = {
+      description = "colored pretty-print of Perl data structures and objects";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
@@ -6213,6 +6239,20 @@ let
     };
     makeMakerFlags = "LIBS=-L${pkgs.geoip}/lib INC=-I${pkgs.geoip}/include";
     doCheck = false; # seems to access the network
+  };
+
+  GeoIP2 = buildPerlPackage {
+    name = "GeoIP2-2.006001";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/GeoIP2-2.006001.tar.gz;
+      sha256 = "05pb8bj2dkfcn8z56f8dcs76x65xcn05fywm7vifmfh39qgkmm62";
+    };
+    propagatedBuildInputs = [ JSONMaybeXS LWPProtocolHttps MaxMindDBReader ParamsValidate Throwable ];
+    buildInputs = [ PathClass TestFatal TestNumberDelta ];
+    meta = {
+      description = "Perl API for MaxMind's GeoIP2 web services and databases";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
   };
 
   GetoptArgvFile = buildPerlPackage rec {
@@ -9153,6 +9193,33 @@ let
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AS/ASPINELLI/Math-VecStat-0.08.tar.gz;
       sha256 = "03bdcl9pn2bc9b50c50nhnr7m9wafylnb3v21zlch98h9c78x6j0";
+    };
+  };
+
+  MaxMindDBCommon = buildPerlPackage {
+    name = "MaxMind-DB-Common-0.040001";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Common-0.040001.tar.gz;
+      sha256 = "1mqvnabskhyvi2f10f602gisfk39ws51ky55lixd0033sd5xzikb";
+    };
+    propagatedBuildInputs = [ DataDumperConcise DateTime ListAllUtils MooXStrictConstructor ];
+    meta = {
+      description = "Code shared by the MaxMind DB reader and writer modules";
+      license = with stdenv.lib.licenses; [ artistic2 ];
+    };
+  };
+
+  MaxMindDBReader = buildPerlPackage {
+    name = "MaxMind-DB-Reader-1.000013";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-1.000013.tar.gz;
+      sha256 = "0w7dmfhpibazrh75bdr7vmpji83fzldsy0zjvhg3cwadr4f35kmq";
+    };
+    propagatedBuildInputs = [ DataIEEE754 DataPrinter DataValidateIP MaxMindDBCommon ];
+    buildInputs = [ PathClass TestBits TestFatal TestNumberDelta TestRequires ];
+    meta = {
+      description = "Read MaxMind DB files and look up IP addresses";
+      license = with stdenv.lib.licenses; [ artistic2 ];
     };
   };
 
@@ -14565,6 +14632,20 @@ let
     };
     propagatedBuildInputs = [ Spiffy ];
     buildInputs = [ AlgorithmDiff TextDiff ];
+  };
+
+  TestBits = buildPerlPackage {
+    name = "Test-Bits-0.02";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Test-Bits-0.02.tar.gz;
+      sha256 = "1hqbvqlkj3k9ys4zq3f1fl1y6crni8r0ynan673f49rs91b6z0m9";
+    };
+    propagatedBuildInputs = [ ListAllUtils ];
+    buildInputs = [ TestFatal ];
+    meta = {
+      description = "Provides a bits_is() subroutine for testing binary data";
+      license = with stdenv.lib.licenses; [ artistic2 ];
+    };
   };
 
   TestCheckDeps = buildPerlPackage rec {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3938,6 +3938,19 @@ let
     };
   };
 
+  DevelRefcount = buildPerlModule {
+    name = "Devel-Refcount-0.10";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/P/PE/PEVANS/Devel-Refcount-0.10.tar.gz;
+      sha256 = "0jnaraqkigyinhwz4nqk1ndq7ssjizr98nd1dd183a6icdlx8m5n";
+    };
+    buildInputs = [ TestFatal ];
+    meta = {
+      description = "obtain the REFCNT value of a referent";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   DevelPPPort = buildPerlPackage rec {
     name = "Devel-PPPort-3.43";
     src = fetchurl {
@@ -9259,6 +9272,20 @@ let
     meta = {
       description = "Fast XS implementation of MaxMind DB reader";
       license = with stdenv.lib.licenses; [ artistic2 ];
+    };
+  };
+
+  MaxMindDBWriter = buildPerlModule {
+    name = "MaxMind-DB-Writer-0.300003";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Writer-0.300003.tar.gz;
+      sha256 = "0gpbrlmxjl45k0wg5v9ghw415hd0fns9fk8ncxzlfyjzjsxgalxs";
+    };
+    propagatedBuildInputs = [ DigestSHA1 MaxMindDBReader MooseXParamsValidate MooseXStrictConstructor NetWorks SerealDecoder SerealEncoder ];
+    buildInputs = [ DevelRefcount JSON TestBits TestDeep TestFatal TestHexDifferences TestRequires TestWarnings ];
+    meta = {
+      description = "Create MaxMind DB database files";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

Maxmind stopped distributing the ```v1```  database (https://github.com/NixOS/nixpkgs/issues/53953)
So let's start switching to ```v2```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

