### PR TITLE
fff: 2.0 -> 2.1

### DIFF
--- a/pkgs/applications/misc/fff/default.nix
+++ b/pkgs/applications/misc/fff/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, fetchFromGitHub, makeWrapper, xdg_utils, file, coreutils }:
+{ stdenv, fetchFromGitHub, makeWrapper, bashInteractive, xdg_utils, file, coreutils, w3m, xdotool }:
 
 stdenv.mkDerivation rec {
   pname = "fff";
-  version = "2.0";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "dylanaraps";
     repo = pname;
     rev = version;
-    sha256 = "0pqxqg1gnl3kgqma5vb0wcy4n9xbm0dp7g7dxl60cwcyqvd4vm3i";
+    sha256 = "0s5gi5ghwax5gc886pvbpcmsbmzhxzywajwzjsdxwjyd1v1iynwh";
   };
 
-  pathAdd = stdenv.lib.makeSearchPath "bin" [ xdg_utils file coreutils ];
-  buildInputs = [ makeWrapper ];
+  pathAdd = stdenv.lib.makeSearchPath "bin" ([ xdg_utils file coreutils w3m xdotool ]);
 
-  installPhase = ''
-    install -D fff "$out/bin/fff"
-    install -D README.md "$out/share/doc/fff/README.md"
-    install -D fff.1 "$out/share/man/man1/fff.1"
-    wrapProgram $out/bin/fff --prefix PATH : ${pathAdd}
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bashInteractive ];
+  dontBuild = true;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/fff" --prefix PATH : $pathAdd
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Version bump.

- This package previously used `bash` instead of `bashInteractive`, which made tab completion not work.
- `installPhase` removed because of an upstream Makefile addition
- New dependencies and optional feature added

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

