### PR TITLE
Add checkPhase for neovim (disabled by default)

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -1,6 +1,7 @@
 ansicolors,
 argparse,
 dkjson
+inspect
 lrexlib-gnu,
 lrexlib-posix,
 ltermbox,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -70,6 +70,26 @@ dkjson = buildLuarocksPackage {
     };
   };
 };
+inspect = buildLuarocksPackage {
+  pname = "inspect";
+  version = "3.1.1-0";
+
+  src =  fetchurl {
+      url    = https://luarocks.org/inspect-3.1.1-0.src.rock;
+      sha256 = "0k4g9ahql83l4r2bykfs6sacf9l1wdpisav2i0z55fyfcdv387za";
+   };
+  disabled = ( luaOlder "5.1");
+  propagatedBuildInputs = [lua  ];
+  buildType="builtin";
+
+  meta = {
+    homepage = "https://github.com/kikito/inspect.lua";
+    description="Lua table visualizer, ideal for debugging";
+    license = {
+      fullName = "MIT <http://opensource.org/licenses/MIT>";
+    };
+  };
+};
 lrexlib-gnu = buildLuarocksPackage {
   pname = "lrexlib-gnu";
   version = "2.9.0-1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19810,7 +19810,7 @@ in
   wrapNeovim = callPackage ../applications/editors/neovim/wrapper.nix { };
 
   neovim-unwrapped = callPackage ../applications/editors/neovim {
-    luaPackages = luajitPackages;
+    lua = luajit;
   };
 
   neovim = wrapNeovim neovim-unwrapped { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18348,7 +18348,7 @@ in
     };
 
   mpv = callPackage ../applications/video/mpv rec {
-    inherit (luaPackages) luasocket;
+    inherit lua;
     waylandSupport     = stdenv.isLinux;
     alsaSupport        = !stdenv.isDarwin;
     pulseSupport       = !stdenv.isDarwin;

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -1105,7 +1105,7 @@ with self; {
     };
   };
 
-  vicious = stdenv.mkDerivation rec {
+  vicious = toLuaModule(stdenv.mkDerivation rec {
     name = "vicious-${version}";
     version = "2.3.1";
 
@@ -1131,7 +1131,7 @@ with self; {
       maintainers = with maintainers; [ makefu mic92 ];
       platforms   = platforms.linux;
     };
-  };
+  });
 
 });
 in (lib.extends overrides packages)

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -972,7 +972,7 @@ with self; {
     };
   };
 
-  lgi = stdenv.mkDerivation rec {
+  lgi = toLuaModule(stdenv.mkDerivation rec {
     name = "lgi-${version}";
     version = "0.9.2";
 
@@ -1007,7 +1007,7 @@ with self; {
       maintainers = with maintainers; [ lovek323 rasendubi ];
       platforms   = platforms.unix;
     };
-  };
+  });
 
   mpack = buildLuaPackage rec {
     name = "mpack-${version}";


### PR DESCRIPTION
###### Motivation for this change
and some other minor changes

The new lua infrastructure makes available the necessary lua packages to run the neovim tests. Yet some tests still fail and I don't think they are intended for distributions to run anyway so I let them disabled by default. 
They are helpful for neovim developers though !

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

