### PR TITLE
tinycdb: init at 0.7.8

### DIFF
--- a/pkgs/development/libraries/tinycdb/default.nix
+++ b/pkgs/development/libraries/tinycdb/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "tinycdb";
+  version = "0.78";
+  outputs = [ "out" "dev" "lib" "man" ];
+  separateDebugInfo = true;
+  makeFlags = [ "prefix=$(out)" "staticlib" "sharedlib" "cdb-shared" ];
+  postInstall = ''
+    mkdir -p $lib/lib $dev/lib $out/bin
+    cp libcdb.so* $lib/lib
+    cp cdb-shared $out/bin/cdb
+    mv $out/lib/libcdb.a $dev/lib
+    rmdir $out/lib
+  '';
+
+  src = fetchurl {
+    url = "http://www.corpit.ru/mjt/tinycdb/${pname}-${version}.tar.gz";
+    sha256 = "0g6n1rr3lvyqc85g6z44lw9ih58f2k1i3v18yxlqvnla5m1qyrsh";
+  };
+
+  meta = with lib; {
+
+    description = "utility to manipulate constant databases (cdb)";
+
+    longDescription = ''
+      tinycdb is a small, fast and reliable utility and subroutine
+      library for creating and reading constant databases. The database
+      structure is tuned for fast reading.
+      '';
+
+    homepage = https://www.corpit.ru/mjt/tinycdb.html;
+    license = licenses.publicDomain;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14542,6 +14542,8 @@ in
 
   tidyp = callPackage ../development/libraries/tidyp { };
 
+  tinycdb = callPackage ../development/libraries/tinycdb { };
+
   tinyxml = tinyxml2;
 
   tinyxml2 = callPackage ../development/libraries/tinyxml/2.6.2.nix { };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [+] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [+] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [+] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---