### PR TITLE
idrisPackages.tparsec: 2018-11-09 -> 2018-12-21

### DIFF
--- a/pkgs/development/idris-modules/tparsec.nix
+++ b/pkgs/development/idris-modules/tparsec.nix
@@ -4,15 +4,15 @@
 }:
 build-idris-package  {
   name = "tparsec";
-  version = "2018-11-09";
+  version = "2018-12-21";
 
   ipkgName = "TParsec";
 
   src = fetchFromGitHub {
     owner = "gallais";
     repo = "idris-tparsec";
-    rev = "fc5bc1e0bf21a53ec854990ed799c4c73e304b06";
-    sha256 = "0ladks6x1qhs884w4rsxnzpq8dpijyqfqbvhk55kq10xh6w1smrz";
+    rev = "6fafcaa894def6f2af86bc799e507013b56e7741";
+    sha256 = "0alnw0hqjs200gvb5f58lb16rna48j1v6wnvq4q7zbw99dcxsxwn";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

update idrisPackages.tparsec to latest rev

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

