### PR TITLE
 pythonPackages.notedown: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4806,6 +4806,11 @@
     github = "vbmithr";
     name = "Vincent Bernardoff";
   };
+  vcanadi = {
+    email = "vito.canadi@gmail.com";
+    github = "vcanadi";
+    name = "Vitomir Čanadi";
+  };
   vcunat = {
     email = "vcunat@gmail.com";
     github = "vcunat";

--- a/pkgs/development/python-modules/notedown/default.nix
+++ b/pkgs/development/python-modules/notedown/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, nbconvert
+, nbformat
+, notebook
+, pandoc-attributes
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "notedown";
+  version = "1.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "36e033ebbbe5aca0fab031ffaf3611d5bc5c50237df68ff81bb95f8be353a1ee";
+  };
+
+  propagatedBuildInputs = [
+    notebook
+    nbconvert
+    nbformat
+    pandoc-attributes
+    six
+  ];
+
+  # No tests in pypi source
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/aaren/notedown;
+    description = "Convert IPython Notebooks to markdown (and back)";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ vcanadi ];
+  };
+}

--- a/pkgs/development/python-modules/pandoc-attributes/default.nix
+++ b/pkgs/development/python-modules/pandoc-attributes/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, pandocfilters
+}:
+
+buildPythonPackage rec {
+  pname = "pandoc-attributes";
+  version = "0.1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "69221502dac74f5df1317011ce62c85a83eef5da3b71c63b1908e98224304a8c";
+  };
+
+  propagatedBuildInputs = [
+    pandocfilters
+  ];
+
+  # No tests in pypi source
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/aaren/pandoc-attributes;
+    description = "An Attribute class to be used with pandocfilters";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ vcanadi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4902,6 +4902,8 @@ in {
 
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };
 
+  pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
+
   htmltreediff = callPackage ../development/python-modules/htmltreediff { };
 
   repeated_test = callPackage ../development/python-modules/repeated_test { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3252,6 +3252,8 @@ in {
 
   notebook = callPackage ../development/python-modules/notebook { };
 
+  notedown = callPackage ../development/python-modules/notedown { };
+
   notify = callPackage ../development/python-modules/notify { };
 
   notify2 = callPackage ../development/python-modules/notify2 {};


### PR DESCRIPTION
###### Motivation for this change
Add notedown to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

