### PR TITLE
singularity: rewrite path to cp in bootstrap script

### DIFF
--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     sed -i 's/-static//g' src/Makefile.am
     patchShebangs .
+    substituteInPlace libexec/bootstrap-scripts/deffile-sections.sh \
+      --replace /bin/cp ${coreutils}/bin/cp
   '';
 
   configureFlags = [ "--localstatedir=/var" ];


### PR DESCRIPTION
###### Motivation for this change

If you use the %files section in the Singularity file, `/bin/cp` is invoked under the hood when copying. This is not working on NixOS. With this patch, it seems to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

