### PR TITLE
smlnj: 110.84 -> 110.85

### DIFF
--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -1,32 +1,32 @@
 { stdenv, fetchurl, darwin }:
 let
-  version = "110.84";
+  version = "110.85";
   baseurl = "http://smlnj.cs.uchicago.edu/dist/working/${version}";
 
   sources = map fetchurl [
-    { url = "${baseurl}/config.tgz";              sha256 = "0cpqrvixqwf64fa94wzwf59p0lnnmwxgkwm3qwhf28l2fv5d640q"; }
-    { url = "${baseurl}/cm.tgz";                  sha256 = "0qq6kdi8xqi3w1rsmi4rgjdbjr9m4crizb1ma5xg51x8h42ccmbh"; }
-    { url = "${baseurl}/compiler.tgz";            sha256 = "11zfdwr7a10ylzvap2j0c1py11zi500hfnmhd5lvy9spwzray8vd"; }
-    { url = "${baseurl}/runtime.tgz";             sha256 = "0v2dv0hh0gxnzzxz8vzqn5avxh7mynaj4g9kkbv4gcnxxaylpksz"; }
-    { url = "${baseurl}/system.tgz";              sha256 = "0612a6qls202l6wbckcd6dklh7nb75fk4c4qmbs9h2h0j3kisszl"; }
-    { url = "${baseurl}/MLRISC.tgz";              sha256 = "0wnhvy677p2f7pxlk8mmk3gi605nawy1zzn2cf4619wg04v54g6s"; }
-    { url = "${baseurl}/smlnj-lib.tgz";           sha256 = "1pg9y0lcp18fc91y45yb2lysnrzml00xdhcilkc1cx17am394mik"; }
-    { url = "${baseurl}/old-basis.tgz";           sha256 = "14zdkzfri4a7mj7zck2c43aqkg0y7kppp2nkbihg069g4ifgw5fg"; }
-    { url = "${baseurl}/ckit.tgz";                sha256 = "0dlccmnchs38www0a3ibrjxipf8xi03d7pgriynjqdyjjgik89by"; }
-    { url = "${baseurl}/nlffi.tgz";               sha256 = "0c9z2fq8d7ln4flzc5pkfym9rkjhjymjm60v1avh1c337lmai5lb"; }
-    { url = "${baseurl}/cml.tgz";                 sha256 = "16jn5fn8khxnjj0kwjzavx2ms3kv16zy35wamh8k51nv8v3i0qam"; }
-    { url = "${baseurl}/eXene.tgz";               sha256 = "1701l155aiprzxh5p5whb9qbg368cqq0bzdwkwsxgrrllfhwdq9z"; }
-    { url = "${baseurl}/ml-lpt.tgz";              sha256 = "19dk9yqq6f5ayqlf7p95aakc4swj6x1j8m0ka2slzzb9g93f2q1g"; }
-    { url = "${baseurl}/ml-lex.tgz";              sha256 = "0w20w17rd67n6zgxzwq89k9ywc78l3ydxcax0pniwzv6m5d08znc"; }
-    { url = "${baseurl}/ml-yacc.tgz";             sha256 = "1fdxhy4f2dgs19p20vg7yysi9gxp6hc1ggs97k4zq448y2ssxsyg"; }
-    { url = "${baseurl}/ml-burg.tgz";             sha256 = "066r0zy5rc60y8kzh2c06hy1b217lh6qffvxlwz8w1w86yqkgsk2"; }
-    { url = "${baseurl}/pgraph.tgz";              sha256 = "1jy1g9xiv14jj9svb5wgbdm520qbdhamfmxlf31xnh552gg18bxa"; }
-    { url = "${baseurl}/trace-debug-profile.tgz"; sha256 = "0nkawi2mdmsw24a1pkwp2brixrvxyqgxzsylp7w7ak35p20l5igc"; }
-    { url = "${baseurl}/heap2asm.tgz";            sha256 = "159y8c8xnim7p4pyynjirqhwi73lkrq0fksk8wnpcdh5clmwacrx"; }
-    { url = "${baseurl}/smlnj-c.tgz";             sha256 = "1sgfdnvkqa6wmwg027wg8lvg7zxq36p83bkymy8qkjdlxhxm2nhl"; }
-    { url = "${baseurl}/doc.tgz";                 sha256 = "083h5h937gkhfq3xk982vmng903c83d98yh5fps53f62wib99mhf"; }
-    { url = "${baseurl}/boot.x86-unix.tgz";       sha256 = "10nf79jzmv64ag8c11fxd9ggw21a9kdn9shqkiz1kni3lq63p7m2"; }
-    { url = "${baseurl}/asdl.tgz";                sha256 = "13jvdgv63h4s8p9q563hyisbz464y88y2flvwyxvi1n11lh15rwb"; }
+    { url = "${baseurl}/config.tgz";              sha256 = "1qlir3q0vi7f1wyz2jyaiqy3z72d0xngsa122ks5g0b7b0hcdgm1"; }
+    { url = "${baseurl}/cm.tgz";                  sha256 = "0330jkmaxgy085hsgajqikm242gms650rks24mfxhgk11r4ks105"; }
+    { url = "${baseurl}/compiler.tgz";            sha256 = "1zrqqvi9332g3clrh01z19sl06g3zlnp6zzz5z8rvsfwbiqp929m"; }
+    { url = "${baseurl}/runtime.tgz";             sha256 = "1n9hd99s2i834yihx4n59gl1cnh7hiiz8im735bmifmv50vzfdf4"; }
+    { url = "${baseurl}/system.tgz";              sha256 = "17samia4lzcz3mk73i330bspap2ks937arx35n9dr7bws0appfm8"; }
+    { url = "${baseurl}/MLRISC.tgz";              sha256 = "039g6dwxy96bkvw1z19vwn8q150h7s8jlcmsg851bgz3j3h6vs18"; }
+    { url = "${baseurl}/smlnj-lib.tgz";           sha256 = "1wk4w1npipm6qqgwis2xrbdjamwmiwv6ci4y40nzryhb37yxfj6d"; }
+    { url = "${baseurl}/old-basis.tgz";           sha256 = "0lkhbkkglz7lk1c93hc1y1di5dx20fgfhybvsqjp1bcwz8jsd70y"; }
+    { url = "${baseurl}/ckit.tgz";                sha256 = "14qxgw2vhq4dfiv5zl2gdhvjp75s10dqw97mqxffmh3vayyad1fi"; }
+    { url = "${baseurl}/nlffi.tgz";               sha256 = "16l8iszkyh34dqdbplsxycipvbw61yjamgxllcq8axiq4h7spy7w"; }
+    { url = "${baseurl}/cml.tgz";                 sha256 = "05dlqz4r3qa3rpqgjlx91fsfx7j6gk3dkw28zcgg5g32irmd1la3"; }
+    { url = "${baseurl}/eXene.tgz";               sha256 = "07mahzxns26hkfax9gc8cq4s8sfzj531wwnm47b8qkhd72d3ncn2"; }
+    { url = "${baseurl}/ml-lpt.tgz";              sha256 = "0073hfn98l61ryshhqw9855fb49vs9qcz9nplbg2pa2f7manqbk0"; }
+    { url = "${baseurl}/ml-lex.tgz";              sha256 = "106km17f4wyvhzkx62cfq2gp4ihya8l234550laqb50zf8vxyklq"; }
+    { url = "${baseurl}/ml-yacc.tgz";             sha256 = "1r0k7lz8xnir271pykbs4agadysbs35kkmg1p816kzfyz5bsrrq9"; }
+    { url = "${baseurl}/ml-burg.tgz";             sha256 = "10jqasplbxp50ryq74aazbnyaz8l492rhdij5mr1kzyfj79fysh9"; }
+    { url = "${baseurl}/pgraph.tgz";              sha256 = "1pxqddbrb7y9kp89gz8v8vfjmw4wajfy6757gb8c6x499jarxa60"; }
+    { url = "${baseurl}/trace-debug-profile.tgz"; sha256 = "0fkalpdzdrm1gmafn33ck4dw8s92p9iwm4fav4m9jcqyha9az3g7"; }
+    { url = "${baseurl}/heap2asm.tgz";            sha256 = "056gkmrylyrf0q0r3cpx76zx8mc62033jkn1bnjn0f8r31yhbipc"; }
+    { url = "${baseurl}/smlnj-c.tgz";             sha256 = "04c4jnylj5dnd4sjywzwnqlv9g7dkrilq6d4cy543dw03yhjdykw"; }
+    { url = "${baseurl}/doc.tgz";                 sha256 = "1rpk9g1nhjpc2b4pmzmj8v80knrhljn17ghiwznnljv53hka7jzx"; }
+    { url = "${baseurl}/boot.x86-unix.tgz";       sha256 = "05rh1y74jvp6zs96mb7nkwbgwwbss0zy2iw4gicdkyf6in0nk4la"; }
+    { url = "${baseurl}/asdl.tgz";                sha256 = "1d465bncgy92ni6430dbq6isvnysfhvykjrxm98dz82iih7a6vqb"; }
   ];
 in stdenv.mkDerivation {
   name = "smlnj-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

