### PR TITLE
home-assistant: missing dependencies

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -592,7 +592,7 @@
     "light.lifx" = ps: with ps; [  ];
     "light.lifx_legacy" = ps: with ps; [  ];
     "light.lightwave" = ps: with ps; [  ];
-    "light.limitlessled" = ps: with ps; [  ];
+    "light.limitlessled" = ps: with ps; [ limitlessled ];
     "light.litejet" = ps: with ps; [  ];
     "light.lutron" = ps: with ps; [  ];
     "light.lutron_caseta" = ps: with ps; [  ];
@@ -799,7 +799,7 @@
     "notify.clicksend_tts" = ps: with ps; [  ];
     "notify.command_line" = ps: with ps; [  ];
     "notify.demo" = ps: with ps; [  ];
-    "notify.discord" = ps: with ps; [  ];
+    "notify.discord" = ps: with ps; [ discordpy ];
     "notify.ecobee" = ps: with ps; [  ];
     "notify.facebook" = ps: with ps; [  ];
     "notify.file" = ps: with ps; [  ];


### PR DESCRIPTION
###### Motivation for this change

```parse-requirements.py``` found some additional dependencies

Cc: @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

