### PR TITLE
gitkraken: 4.2.1 -> 4.2.2 & fix missing gsettings schemas

### DIFF
--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -1,8 +1,8 @@
 { stdenv, libXcomposite, libgnome-keyring, makeWrapper, udev, curl, alsaLib
-, libXfixes, atk, gtk3, libXrender, pango, gnome2, cairo, freetype, fontconfig
+, libXfixes, atk, gtk3, libXrender, pango, gnome2, gnome3, cairo, freetype, fontconfig
 , libX11, libXi, libxcb, libXext, libXcursor, glib, libXScrnSaver, libxkbfile, libXtst
 , nss, nspr, cups, fetchurl, expat, gdk_pixbuf, libXdamage, libXrandr, dbus
-, dpkg, makeDesktopItem, openssl
+, dpkg, makeDesktopItem, openssl, wrapGAppsHook, hicolor-icon-theme
 }:
 
 with stdenv.lib;
@@ -65,8 +65,8 @@ stdenv.mkDerivation rec {
     comment = "Graphical Git client from Axosoft";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ dpkg gtk3];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  buildInputs = [ dpkg gtk3 gnome3.defaultIconTheme hicolor-icon-theme ];
 
   unpackCmd = ''
     mkdir out
@@ -86,11 +86,13 @@ stdenv.mkDerivation rec {
     cp -av share bin $out/
     popd
 
-    makeWrapper $out/share/gitkraken/gitkraken $out/bin/gitkraken \
-      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH
+    ln -s $out/share/gitkraken/gitkraken $out/bin/gitkraken
+    # makeWrapper $out/share/gitkraken/gitkraken $out/bin/gitkraken \
+    #   --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH
   '';
 
   postFixup = ''
+    wrapGAppsHook
     pushd $out/share/gitkraken
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" gitkraken
 

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ dpkg ];
+  buildInputs = [ dpkg gtk3];
 
   unpackCmd = ''
     mkdir out
@@ -85,7 +85,9 @@ stdenv.mkDerivation rec {
     rm -rf bin/gitkraken share/lintian
     cp -av share bin $out/
     popd
-    ln -s $out/share/gitkraken/gitkraken $out/bin/gitkraken
+
+    makeWrapper $out/share/gitkraken/gitkraken $out/bin/gitkraken \
+      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH
   '';
 
   postFixup = ''

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -12,11 +12,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gitkraken-${version}";
-  version = "4.2.1";
+  version = "4.2.2";
 
   src = fetchurl {
     url = "https://release.axocdn.com/linux/GitKraken-v${version}.deb";
-    sha256 = "07f9h3276bs7m22vwpxrxmlwnq7l5inr2l67nmpiaz1569yabwsg";
+    sha256 = "0zbnw2x15688hjdj10kpp2ipka3j7b2p945a4mzwlsc8a245ljgb";
   };
 
   libPath = makeLibraryPath [

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
-  buildInputs = [ dpkg gtk3 gnome3.defaultIconTheme hicolor-icon-theme ];
+  buildInputs = [ dpkg gtk3 gnome3.adwaita-icon-theme hicolor-icon-theme ];
 
   unpackCmd = ''
     mkdir out
@@ -87,12 +87,9 @@ stdenv.mkDerivation rec {
     popd
 
     ln -s $out/share/gitkraken/gitkraken $out/bin/gitkraken
-    # makeWrapper $out/share/gitkraken/gitkraken $out/bin/gitkraken \
-    #   --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH
   '';
 
   postFixup = ''
-    wrapGAppsHook
     pushd $out/share/gitkraken
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" gitkraken
 


### PR DESCRIPTION
###### Motivation for this change
Update gitkraken 4.2.1 to 4.2.2
Fix gitkraken missing GSettings schemas

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

