### PR TITLE
apvlv: fix build for poppler 0.73.0

### DIFF
--- a/pkgs/applications/misc/apvlv/default.nix
+++ b/pkgs/applications/misc/apvlv/default.nix
@@ -43,6 +43,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # poppler 0.73.0 moved functionality from gtypes.h into gfile.h
+  postPatch = ''
+    grep -rlF '#include "goo/gtypes.h"' | xargs sed -i 's|#include "goo/gtypes.h"|#include "goo/gfile.h"|g'
+    grep -rlF '#include <goo/gtypes.h>' | xargs sed -i 's|#include <goo/gtypes.h>|#include <goo/gfile.h>|g'
+  '';
+
   installPhase = ''
     # binary
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

`apvlv` doesn't build on master.

Pinging maintainer @ardumont

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

