### PR TITLE
python3Packages.python-jenkins: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
 , python
@@ -11,28 +11,33 @@
 , testscenarios
 , testrepository
 , kerberos
+, requests
+, unittest2
+, requests-mock
 }:
 
 buildPythonPackage rec {
   pname = "python-jenkins";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b44b3c8e0dabed371a1a8a301cc8833c635625faf003fd68c176800c71a6597c";
+    sha256 = "1h14hfcwichmppbgxf1k8njw29hchpav1kj574b4lly3j0n2vnag";
   };
 
-  patchPhase = ''
-    sed -i 's@python@${python.interpreter}@' .testr.conf
+  buildInputs = [ mock ];
+  propagatedBuildInputs = [ pbr pyyaml six multi_key_dict requests ];
+
+  checkInputs = [ unittest2 testscenarios requests-mock ];
+  checkPhase = ''
+    unit2
   '';
 
-  buildInputs = [ mock ];
-  propagatedBuildInputs = [ pbr pyyaml six multi_key_dict testtools testscenarios testrepository kerberos ];
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Python bindings for the remote Jenkins API";
     homepage = https://pypi.python.org/pypi/python-jenkins;
     license = licenses.bsd3;
+    maintainers = with maintainers; [ ma27 ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Updates to the most recent version of `python-jenkins`. It was
originally broken during the auto-update in b4588c6a0f2aba6da8cf52c2aef52a4fda6bdb89.

The tests could be run by using `unittest2` and some dependencies for
the test framwork.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

