### PR TITLE
kio-extras: enable man protocol

### DIFF
--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -156,6 +156,7 @@ in
       environment.systemPackages = [ pkgs.man-db ];
       environment.pathsToLink = [ "/share/man" ];
       environment.extraOutputsToInstall = [ "man" ] ++ optional cfg.dev.enable "devman";
+      environment.etc."man.conf".source = "${pkgs.man-db}/etc/man_db.conf";
     })
 
     (mkIf cfg.info.enable {

--- a/pkgs/applications/kde/kio-extras.nix
+++ b/pkgs/applications/kde/kio-extras.nix
@@ -3,7 +3,7 @@
   exiv2, kactivities, karchive, kbookmarks, kconfig, kconfigwidgets,
   kcoreaddons, kdbusaddons, kguiaddons, kdnssd, kiconthemes, ki18n, kio, khtml,
   kdelibs4support, kpty, libmtp, libssh, openexr, ilmbase, openslp, phonon,
-  qtsvg, samba, solid
+  qtsvg, samba, solid, gperf
 }:
 
 mkDerivation {
@@ -16,7 +16,7 @@ mkDerivation {
   buildInputs = [
     exiv2 kactivities karchive kbookmarks kconfig kconfigwidgets kcoreaddons
     kdbusaddons kguiaddons kdnssd kiconthemes ki18n kio khtml kdelibs4support
-    kpty libmtp libssh openexr openslp phonon qtsvg samba solid
+    kpty libmtp libssh openexr openslp phonon qtsvg samba solid gperf
   ];
   CXXFLAGS = [ "-I${ilmbase.dev}/include/OpenEXR" ];
 }


### PR DESCRIPTION
###### Motivation for this change
This installs the kio "man:" protocol handler, which fixes the UNIX manual
section in the KDE Help Center.

Note that kde currently parses "/etc/man.conf" manually, if `$MANPATH` is not
set, to build its man page index. (if https://bugs.kde.org/show_bug.cgi?id=404022
is addressed, the "/etc/man.conf" symlink should not be necessary anymore)

###### Things done

Verified that KDE Help Center displays man pages locally on a 18.09 system.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

