### PR TITLE
Add optional ceph support for libvirt and qemu

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -14,6 +14,7 @@
 , spiceSupport ? !stdenv.isDarwin, spice, spice-protocol
 , usbredirSupport ? spiceSupport, usbredir
 , xenSupport ? false, xen
+, cephSupport ? false, ceph
 , openGLSupport ? sdlSupport, mesa_noglu, epoxy, libdrm
 , virglSupport ? openGLSupport, virglrenderer
 , smbdSupport ? false, samba
@@ -63,6 +64,7 @@ stdenv.mkDerivation rec {
     ++ optionals usbredirSupport [ usbredir ]
     ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
     ++ optionals xenSupport [ xen ]
+    ++ optionals cephSupport [ ceph ]
     ++ optionals openGLSupport [ mesa_noglu epoxy libdrm ]
     ++ optionals virglSupport [ virglrenderer ]
     ++ optionals smbdSupport [ samba ];
@@ -117,6 +119,7 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isLinux "--enable-linux-aio"
     ++ optional gtkSupport "--enable-gtk"
     ++ optional xenSupport "--enable-xen"
+    ++ optional cephSupport "--enable-rbd"
     ++ optional openGLSupport "--enable-opengl"
     ++ optional virglSupport "--enable-virglrenderer"
     ++ optional smbdSupport "--smbd=${samba}/bin/smbd";

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -7,6 +7,7 @@
 , curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
+, enableCeph ? false, ceph
 }:
 
 with stdenv.lib;
@@ -45,6 +46,8 @@ in stdenv.mkDerivation rec {
     xen
   ] ++ optionals enableIscsi [
     openiscsi
+  ] ++ optionals enableCeph [
+    ceph
   ] ++ optionals stdenv.isDarwin [
     libiconv gmp
   ];
@@ -85,6 +88,8 @@ in stdenv.mkDerivation rec {
     "--with-storage-zfs"
   ] ++ optionals enableIscsi [
     "--with-storage-iscsi"
+  ] ++ optionals enableCeph [
+    "--with-storage-rbd"
   ] ++ optionals stdenv.isDarwin [
     "--with-init-script=none"
   ];


### PR DESCRIPTION
###### Motivation for this change
Both libvirtd and qemu can use the rbd protocol to interface with a ceph cluster for block devices, however this support has to be enabled at compile time.

The changes are straightforward and only adds an optional argument to enable ceph support for qemu and libvirt packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

