### PR TITLE
rrdtool: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -2,20 +2,12 @@
 , tcl-8_5, darwin }:
 
 stdenv.mkDerivation rec {
-  name = "rrdtool-1.7.0";
+  name = "rrdtool-1.7.1";
 
   src = fetchurl {
     url = "https://oss.oetiker.ch/rrdtool/pub/${name}.tar.gz";
-    sha256 = "0ssjqpa0dwwzbylc0drmlbq922qcw8crffc0rpr805xr6n4k8zgr";
+    sha256 = "1bhsg119j94xwykp2sbp01hhxcg78gzblfn7j98slrv9va77g6wq";
   };
-
-  patches = [
-    # fix regression https://github.com/oetiker/rrdtool-1.x/issues/794
-    (fetchpatch {
-      url = "https://github.com/oetiker/rrdtool-1.x/compare/0f28f99...f1edd12.patch";
-      sha256 = "10g56zy0rdjpv3kvvmf6vvaysmla05wi8byy3l0xrz2x8m02ylqq";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change

Update to latest release.

Bugfixes

    about 38949 assorted fixes for the windows build of rrdtool <Wolfgang Stöggl>
    fix many compile time warnings <Wolfgang Stöggl>
    Re-enable 0-width lines
    Include rrd_pdpcalc.pod in Makefile.am also <Peter Valdemar Mørch>
    Lots of spelling fixes for rrdtool source and documentation <Peter Valdemar Mørch>, <Jean-Michel Vourgère>, ,
    fix off by one issue in rrdtool xport output
    fix lua extension build
    fix python bindings , , , <Christian Kröger>
    fix multiple static variable issues in conflict with MT
    make translations actually work
    Fixed configure --enable / --disable options <Jaroslav Škarvada>
    rrd_daemon stability fixes
    fix tcl bindings
    do not call umask ever (not MT safe)

Features

    Multiline Titles , ,
    French translation <Jean-Michel Vourgère>
    Added support for --allow-shrink with --rigid flag (#843)
    Added SUSPEND/RESUME/SUSPENDALL/RESUMEALL commands for rrd_cached <
    include the daemon name in the error message



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

