### PR TITLE
petsc: 3.8.4 -> 3.10.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2050,6 +2050,11 @@
     github = "jammerful";
     name = "jammerful";
   };
+  jamtrott = {
+    email = "james@simula.no";
+    github = "jamtrott";
+    name = "James D. Trotter";
+  };
   jansol = {
     email = "jan.solanti@paivola.fi";
     github = "jansol";

--- a/pkgs/applications/science/math/scotch/default.nix
+++ b/pkgs/applications/science/math/scotch/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchurl, bison, openmpi, flex, zlib}:
+{ stdenv, fetchurl, bison, openmpi, flex, zlib, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   version = "6.0.4";
   name = "scotch-${version}";
   src_name = "scotch_${version}";
 
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [ bison openmpi flex zlib ];
 
   src = fetchurl {
@@ -15,22 +16,33 @@ stdenv.mkDerivation rec {
   sourceRoot = "${src_name}/src";
 
   preConfigure = ''
-    ln -s Make.inc/Makefile.inc.x86-64_pc_linux2 Makefile.inc
+    substituteInPlace Makefile \
+      --replace '-$(CP) -f ../include/*scotch*.h $(includedir)' '-$(CP) -f ../include/*.h $(includedir)' \
+      --replace '-$(CP) -f ../lib/*scotch*$(LIB) $(libdir)' '-$(CP) -f ../lib/*$(LIB) $(libdir)'
+
+    ln -s Make.inc/Makefile.inc.x86-64_pc_linux2.shlib Makefile.inc
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile.inc \
+      --replace gcc mpicc \
+      --replace "-DSCOTCH_PTHREAD " "" \
+      --replace "-DCOMMON_PTHREAD" "-DCOMMON_PTHREAD -DCOMMON_PTHREAD_BARRIER" \
+      --replace "-lrt" "" \
+      --replace "-shared" "-dynamiclib -undefined dynamic_lookup" \
+      --replace ".so" ".dylib"
   '';
 
-  buildFlags = [ "scotch ptscotch" ];
-  installFlags = [ "prefix=\${out}" ];
+  buildFlags = [ "scotch ptscotch esmumps ptesmumps" ];
+  installFlags = [ "prefix=\${out} scotch ptscotch esmumps ptesmumps" ];
 
   meta = {
     description = "Graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering";
     longDescription = ''
-      Scotch is a software package for graph and mesh/hypergraph partitioning, graph clustering, 
+      Scotch is a software package for graph and mesh/hypergraph partitioning, graph clustering,
       and sparse matrix ordering.
     '';
     homepage = http://www.labri.fr/perso/pelegrin/scotch;
     license = stdenv.lib.licenses.cecill-c;
     maintainers = [ stdenv.lib.maintainers.bzizou ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }
-

--- a/pkgs/development/libraries/science/math/hypre/default.nix
+++ b/pkgs/development/libraries/science/math/hypre/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, gfortran, cmake, openmpi }:
+
+stdenv.mkDerivation rec {
+  name = "hypre";
+  version = "2.14.0";
+
+  src = fetchurl {
+    url = "https://github.com/LLNL/hypre/archive/v${version}.tar.gz";
+    sha256 = "0v515i73bvaz378h5465b1dy9v2gf924zy2q94cpq4qqarawvkqh";
+  };
+
+  sourceRoot = "${name}-${version}/src";
+
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DHYPRE_INSTALL_PREFIX=$out -DHYPRE_SHARED=ON -DCMAKE_SHARED_LINKER_FLAGS=\"-lmpi\""
+  '';
+
+  buildInputs = [ cmake gfortran openmpi ];
+
+  meta = {
+    description = "Scalable linear solvers and multigrid methods";
+    homepage = https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods;
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ jamtrott ];
+  };
+}

--- a/pkgs/development/libraries/science/math/mumps/default.nix
+++ b/pkgs/development/libraries/science/math/mumps/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, gfortran, blas, liblapack, metis, openmpi, scalapack, scotch }:
+
+stdenv.mkDerivation rec {
+  name = "mumps";
+  version = "5.1.2-p2";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/petsc/pkg-mumps/get/v${version}.tar.gz";
+    sha256 = "0211njml8pxhj69pj5p2vjwvwz94wxzd8knd9yq69z8w7qrs5b4a";
+  };
+
+  patchPhase = ''
+    ln -s Make.inc/Makefile.debian.PAR Makefile.inc
+    substituteInPlace Makefile.inc \
+      --replace "LSCOTCHDIR = /usr/lib" "LSCOTCHDIR = ${scotch}/lib" \
+      --replace "ISCOTCH   = -I/usr/include/scotch" "ISCOTCH   = -I${scotch}/include" \
+      --replace "LMETISDIR = /usr/lib" "LMETISDIR = ${metis}/lib" \
+      --replace "IMETIS    = -I/usr/include/metis" "IMETIS    = -I${metis}/include" \
+      --replace "INCPAR = -I/usr/lib/openmpi/include" "INCPAR = -I${openmpi}/include" \
+      --replace 'LIBPAR = $(SCALAP) $(LAPACK)  -lmpi -lmpi_f77' 'LIBPAR = $(SCALAP) $(LAPACK) -lmpi -lmpi_mpifh' \
+      --replace "SCALAP  = -lscalapack-openmpi -lblacs-openmpi  -lblacsF77init-openmpi -lblacsCinit-openmpi" "SCALAP  = -lscalapack"
+  '';
+
+  buildFlags = [ "all" ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -R include $out
+    cp lib/*.a $out/lib
+  '';
+
+  buildInputs = [ gfortran blas liblapack metis openmpi scalapack scotch ];
+
+  meta = {
+    description = "A parallel sparse direct solver";
+    homepage = http://mumps-solver.org/;
+    license = stdenv.lib.licenses.cecill-c;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ jamtrott ];
+  };
+}

--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -1,50 +1,89 @@
 { stdenv
 , fetchurl
-, blas
 , gfortran
+, pkgconfig
+, python2
+, blas
+, hdf5
+, hypre
 , liblapack
-, python }:
+, metis
+, mumps
+, openmpi
+, openssh
+, scalapack
+, scotch
+, spai
+, suitesparse
+, superlu
+, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
+  version = "3.10.3";
   name = "petsc-${version}";
-  version = "3.8.4";
 
   src = fetchurl {
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-${version}.tar.gz";
-    sha256 = "1iy49gagxncx09d88kxnwkj876p35683mpfk33x37165si6xqy4z";
+    sha256 = "1r4dvkrmsx2sxzm7krwvji4c1pl4girmihj0xr7n14g0pamnn46d";
   };
 
-  nativeBuildInputs = [ blas gfortran.cc.lib liblapack python ];
+  nativeBuildInputs = [
+    gfortran
+    pkgconfig
+    python2
+  ] ++ stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];
+
+  buildInputs = [
+    blas
+    hdf5
+    hypre
+    liblapack
+    metis
+    mumps
+    openmpi
+    openssh
+    scalapack
+    scotch
+    spai
+    suitesparse
+    superlu
+  ];
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace config/install.py \
       --replace /usr/bin/install_name_tool install_name_tool
+    substituteInPlace config/BuildSystem/config/packages/MUMPS.py \
+      --replace "'libmpiseq.a'" ""
   '';
 
   preConfigure = ''
     patchShebangs .
-    configureFlagsArray=(
-      $configureFlagsArray
-      "--CC=$CC"
-      "--with-cxx=0"
-      "--with-fc=0"
-      "--with-mpi=0"
-      "--with-blas-lib=[${blas}/lib/libblas.a,${gfortran.cc.lib}/lib/libgfortran.a]"
-      "--with-lapack-lib=[${liblapack}/lib/liblapack.a,${gfortran.cc.lib}/lib/libgfortran.a]"
-    )
   '';
 
-  postInstall = ''
-    rm $out/bin/petscmpiexec
-    rm $out/bin/popup
-    rm $out/bin/uncrustify.cfg
-    rm -rf $out/bin/win32fe
-  '';
+  configureFlags = [
+    "--COPTFLAGS=\"-g -O2\""
+    "--CXXOPTFLAGS=\"-g -O2\""
+    "--with-debugging=yes"
+    "--with-fortran-bindings=no"
+    "--with-hdf5-dir=${hdf5}"
+    "--with-hypre-dir=${hypre}"
+    "--with-metis-dir=${metis}"
+    "--with-mumps-dir=${mumps}"
+    "--with-scalapack-dir=${scalapack}"
+    "--with-ptscotch-dir=${scotch}"
+    "--with-spai-dir=${spai}"
+    "--with-suitesparse-dir=${suitesparse}"
+    "--with-superlu-dir=${superlu}"
+  ];
+
+  doCheck = true;
+  checkTarget = "test";
 
   meta = {
     description = "Library of linear algebra algorithms for solving partial differential equations";
     homepage = https://www.mcs.anl.gov/petsc/index.html;
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.bsd2;
+    maintainers = with stdenv.lib.maintainers; [ jamtrott ];
   };
 }

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -35,14 +35,15 @@ stdenv.mkDerivation rec {
     export OMP_NUM_THREADS=1
 
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:`pwd`/lib
   '';
 
   meta = with stdenv.lib; {
     homepage = http://www.netlib.org/scalapack/;
     description = "Library of high-performance linear algebra routines for parallel distributed memory machines";
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.costrouc ];
   };
-
 }

--- a/pkgs/development/libraries/science/math/spai/default.nix
+++ b/pkgs/development/libraries/science/math/spai/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "spai";
+  version = "3.0-p1";
+
+  src = fetchurl {
+    url = "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/spai-${version}.tar.gz";
+    sha256 = "13nadflrkanmw9v86z12kwwx63wys4k8s6iyaamx6apl8frxb708";
+  };
+
+  configurePhase = ''
+    substituteInPlace lib/Makefile \
+      --replace "include Makefile.in" ""
+  '';
+
+  buildPhase = ''
+    make -C lib
+  '';
+
+  installPhase = ''
+    mkdir -p $out/include
+    cp lib/*.h $out/include
+    mkdir -p $out/lib
+    cp lib/libspai.a $out/lib
+  '';
+
+  meta = {
+    description = "Sparse approximate inverse preconditioner";
+    homepage = https://bitbucket.org/petsc/pkg-spai;
+    platforms = stdenv.lib.platforms.all;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ jamtrott ];
+  };
+}

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, fetchpatch, python, buildPythonPackage, mpi, openssh }:
+{ stdenv, fetchPypi, fetchpatch, python, buildPythonPackage, cython, mpi, openssh }:
 
 buildPythonPackage rec {
   pname = "mpi4py";
@@ -46,14 +46,18 @@ buildPythonPackage rec {
     export OMPI_MCA_rmaps_base_oversubscribe=yes
   '';
 
-  setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
+  # The "build_src --force" flag is used to re-build the package's cython code.
+  # This prevents issues when using multiple cython-based packages
+  # together (for example, mpi4py and petsc4py) due to code that has been
+  # generated with incompatible cython versions.
+  setupPyBuildFlags = [ "--mpicc=${mpi}/bin/mpicc" "build_src --force" ];
 
-  buildInputs = [ mpi openssh ];
+  buildInputs = [ cython mpi openssh ];
 
   meta = {
     description =
       "Python bindings for the Message Passing Interface standard";
-    homepage = http://code.google.com/p/mpi4py/;
+    homepage = https://bitbucket.org/mpi4py/mpi4py/;
     license = stdenv.lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -52,7 +52,8 @@ buildPythonPackage rec {
   # generated with incompatible cython versions.
   setupPyBuildFlags = [ "--mpicc=${mpi}/bin/mpicc" "build_src --force" ];
 
-  buildInputs = [ cython mpi openssh ];
+  nativeBuildInputs = [ cython ];
+  buildInputs = [ mpi openssh ];
 
   meta = {
     description =

--- a/pkgs/development/python-modules/petsc4py/default.nix
+++ b/pkgs/development/python-modules/petsc4py/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchPypi
+, python
+, buildPythonPackage
+, cython
+, numpy
+, petsc
+, openmpi
+, openssh
+, mpi4py
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "petsc4py";
+  version = "3.10.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "094hcnran0r2z1wlvmjswsz3ski1m9kqrl5l0ax8jjhnk55x0flh";
+  };
+
+  PETSC_DIR = "${petsc}";
+
+  setupPyBuildFlags = [ "build_src --force" ];
+
+  buildInputs = [
+    cython
+    numpy
+    openssh
+    mpi4py
+  ];
+
+  propagatedBuildInputs = [
+    petsc
+    openmpi
+  ];
+
+  checkInputs = [ pytest ];
+
+  meta = {
+    description = "Python bindings for PETSc, the Portable, Extensible Toolkit for Scientific Computation";
+    homepage = https://bitbucket.org/petsc/petsc4py;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jamtrott ];
+  };
+}

--- a/pkgs/development/python-modules/petsc4py/default.nix
+++ b/pkgs/development/python-modules/petsc4py/default.nix
@@ -4,10 +4,9 @@
 , buildPythonPackage
 , cython
 , numpy
-, petsc
 , openmpi
 , openssh
-, mpi4py
+, petsc
 , pytest }:
 
 buildPythonPackage rec {
@@ -21,20 +20,14 @@ buildPythonPackage rec {
 
   PETSC_DIR = "${petsc}";
 
+  # The "build_src --force" flag is used to re-build the package's cython code.
+  # This prevents issues when using multiple cython-based packages
+  # together (for example, mpi4py and petsc4py) due to code that has been
+  # generated with incompatible cython versions.
   setupPyBuildFlags = [ "build_src --force" ];
 
-  buildInputs = [
-    cython
-    numpy
-    openssh
-    mpi4py
-  ];
-
-  propagatedBuildInputs = [
-    petsc
-    openmpi
-  ];
-
+  nativeBuildInputs = [ cython openmpi openssh ];
+  propagatedBuildInputs = [ numpy ];
   checkInputs = [ pytest ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11704,6 +11704,10 @@ in
 
   mueval = callPackage ../development/tools/haskell/mueval { };
 
+  mumps = callPackage ../development/libraries/science/math/mumps {
+    blas = openblas;
+  };
+
   muparser = callPackage ../development/libraries/muparser { };
 
   mygpoclient = pythonPackages.mygpoclient;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12582,6 +12582,8 @@ in
 
   soundtouch = callPackage ../development/libraries/soundtouch {};
 
+  spai = callPackage ../development/libraries/science/math/spai { };
+
   spandsp = callPackage ../development/libraries/spandsp {};
 
   spaceship-prompt = callPackage ../shells/zsh/spaceship-prompt {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21675,7 +21675,10 @@ in
 
   rubiks = callPackage ../development/libraries/science/math/rubiks { };
 
-  petsc = callPackage ../development/libraries/science/math/petsc { };
+  petsc = callPackage ../development/libraries/science/math/petsc {
+    blas = openblas;
+    hdf5 = hdf5-mpi;
+  };
 
   parmetis = callPackage ../development/libraries/science/math/parmetis {
     mpi = openmpi;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10328,6 +10328,8 @@ in
 
   hyperscan = callPackage ../development/libraries/hyperscan { };
 
+  hypre = callPackage ../development/libraries/science/math/hypre { };
+
   icu58 = callPackage (import ../development/libraries/icu/58.nix fetchurl) ({
     nativeBuildRoot = buildPackages.icu58.override { buildRootOnly = true; };
   } //

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -532,6 +532,8 @@ in {
 
   perf = callPackage ../development/python-modules/perf { };
 
+  petsc4py = callPackage ../development/python-modules/petsc4py { };
+
   phonopy = callPackage ../development/python-modules/phonopy { };
 
   pims = callPackage ../development/python-modules/pims { };


### PR DESCRIPTION
These changes upgrade PETSc to the most recent release and add several useful linear solver backends, including HYPRE, MUMPS, scalapack, and SPAI.  In addition, the Python wrapper package petsc4py is built.

This has been tested on Mac OS X 10.13.6 (High Sierra).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

