### PR TITLE
Mark merlin and flycheck-ocaml as not broken

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -83,9 +83,6 @@ self:
         packageRequires = with self; [ evil highlight ];
       });
 
-      # missing OCaml
-      flycheck-ocaml = markBroken super.flycheck-ocaml;
-
       # Expects bash to be at /bin/bash
       flycheck-rtags = markBroken super.flycheck-rtags;
 
@@ -178,9 +175,6 @@ self:
         nativeBuildInputs =
           (attrs.nativeBuildInputs or []) ++ [ external.git ];
       });
-
-      # missing OCaml
-      merlin = markBroken super.merlin;
 
       mhc = super.mhc.override {
         inherit (self.melpaPackages) calfw;


### PR DESCRIPTION
###### Motivation for this change

They seem to be working fine on `master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---