### PR TITLE
toybox: init at 0.8.0

### DIFF
--- a/pkgs/tools/misc/toybox/default.nix
+++ b/pkgs/tools/misc/toybox/default.nix
@@ -1,0 +1,62 @@
+{
+  stdenv, lib, fetchFromGitHub, buildPackages,
+  enableStatic ? false,
+  enableMinimal ? false,
+  extraConfig ? ""
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "toybox";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "landley";
+    repo = pname;
+    rev = version;
+    sha256 = "00q6vlc06xbhcjcyqkyp66d1pv7qgwhs00gk4vyixhjqh80giwzl";
+  };
+
+  buildInputs = lib.optionals enableStatic [ stdenv.cc.libc stdenv.cc.libc.static ];
+
+  postPatch = "patchShebangs scripts";
+
+  inherit extraConfig;
+  passAsFile = [ "extraConfig" ];
+
+  configurePhase = ''
+    make ${if enableMinimal then
+      "allnoconfig"
+    else
+      if stdenv.isFreeBSD then
+        "freebsd_defconfig"
+      else
+        if stdenv.isDarwin then
+          "macos_defconfig"
+        else
+          "defconfig"
+    }
+
+    cat $extraConfigPath .config > .config-
+    mv .config- .config
+
+    make oldconfig
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ] ++ lib.optional enableStatic "LDFLAGS=--static";
+
+  # tests currently (as of 0.8.0) get stuck in an infinite loop...
+  # ...this is fixed in latest git, so doCheck can likely be enabled for next release
+  # see https://github.com/landley/toybox/commit/b928ec480cd73fd83511c0f5ca786d1b9f3167c3
+  #doCheck = true;
+  checkTarget = "tests";
+
+  meta = with stdenv.lib; {
+    description = "Lightweight implementation of some Unix command line utilities";
+    homepage = https://landley.net/toybox/;
+    license = licenses.bsd0;
+    platforms = with platforms; linux ++ darwin ++ freebsd;
+    maintainers = with maintainers; [ hhm ];
+    priority = 10;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5862,6 +5862,8 @@ in
 
   toxvpn = callPackage ../tools/networking/toxvpn { };
 
+  toybox = callPackage ../tools/misc/toybox { };
+
   tpmmanager = callPackage ../applications/misc/tpmmanager { };
 
   tpm-quote-tools = callPackage ../tools/security/tpm-quote-tools { };


### PR DESCRIPTION
B"H

[`toybox`](https://landley.net/toybox/) package, supporting static building via `enableStatic` parameter, and custom configuration via `extraConfig` and `enableMinimal` parameters
`parseconfig` shell function, and misc other parts, are based on the `busybox` package derivation.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

