### PR TITLE
Diffoscope: update, add guestfs when bloated

### DIFF
--- a/pkgs/development/python-modules/guestfs/default.nix
+++ b/pkgs/development/python-modules/guestfs/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchurl, libguestfs, qemu }:
+
+buildPythonPackage rec {
+  pname = "guestfs";
+  version = "1.40.1";
+
+  src = fetchurl {
+    url = "http://download.libguestfs.org/python/guestfs-${version}.tar.gz";
+    sha256 = "06a4b5xf1rkhnzfvck91n0z9mlkrgy90s9na5a8da2g4p776lhkf";
+  };
+
+  propagatedBuildInputs = [ libguestfs qemu ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://libguestfs.org/guestfs-python.3.html";
+    description = "Use libguestfs from Python";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ grahamc ];
+  };
+}

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -43,6 +43,7 @@ python3Packages.buildPythonApplication rec {
     ] ++ lib.optionals enableBloat [
       apktool cbfstool colord fpc ghc ghostscriptX giflib gnupg1 gnumeric imagemagick
       llvm jdk mono openssh pdftk poppler_utils tcpdump unoconv
+      python3Packages.guestfs
     ];
 
   doCheck = false; # Calls 'mknod' in squashfs tests, which needs root

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -9,12 +9,12 @@
 # Note: when upgrading this package, please run the list-missing-tools.sh script as described below!
 python3Packages.buildPythonApplication rec {
   name = "diffoscope-${version}";
-  version = "99";
+  version = "110";
 
   src = fetchgit {
     url    = "https://anonscm.debian.org/git/reproducible/diffoscope.git";
     rev    = "refs/tags/${version}";
-    sha256 = "04a2sqv43g002b7s0crk9gnpdvf90j8j8p01b6shinxh6an8prs2";
+    sha256 = "0rhjxigwxbqbqk7xv7n4m4rh693rg3cbp4x565jv68iy423mf2fb";
   };
 
   patches = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -406,6 +406,8 @@ in {
 
   gssapi = callPackage ../development/python-modules/gssapi { };
 
+  guestfs = callPackage ../development/python-modules/guestfs { };
+
   h5py = callPackage ../development/python-modules/h5py {
     hdf5 = pkgs.hdf5;
   };


### PR DESCRIPTION
###### Motivation for this change

Before, diffoscope would emit a binary diff:

![image](https://user-images.githubusercontent.com/76716/52386254-374dab80-2a53-11e9-8109-494b0a153f8f.png)

Now, diffoscpe emits a nice diff:

![image](https://user-images.githubusercontent.com/76716/52386274-4a607b80-2a53-11e9-90b3-1ead5bd6dac7.png)
 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

