### PR TITLE
keyutils: patch out unreproducibility

### DIFF
--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -9,6 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "05bi5ja6f3h3kdi7p9dihlqlfrsmi1wh1r2bdgxc0180xh6g5bnk";
   };
 
+  patches = [
+    (fetchurl {
+      # improve reproducibility
+      url = "https://salsa.debian.org/debian/keyutils/raw/4cecffcb8e2a2aa4ef41777ed40e4e4bcfb2e5bf/debian/patches/Make-build-reproducible.patch";
+      sha256 = "0wnvbjfrbk7rghd032z684l7vk7mhy3bd41zvhkrhgp3cd5id0bm";
+    })
+  ];
+
+  BUILDDATE = "1970-01-01";
   outputs = [ "out" "lib" "dev" ];
 
   installFlags = [


### PR DESCRIPTION
###### Motivation for this change

https://r13y.com/diff/wy095xndvc5px8j6x5rzyn4qmwi041yr-keyutils-1.6.drv.html#lib---libkeyutils.so.-.-

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

