### PR TITLE
asterisk: 15.3.0 -> 15.7.0, 13.20.0 -> 13.24.1, add 16.x

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchurl, fetchsvn,
-  jansson, libxml2, libxslt, ncurses, openssl, sqlite,
+  jansson, libedit, libxml2, libxslt, ncurses, openssl, sqlite,
   utillinux, dmidecode, libuuid, newt,
   lua, speex,
-  srtp, wget, curl, iksemel
+  srtp, wget, curl, iksemel, pkgconfig
 }:
 
 let
@@ -10,7 +10,11 @@ let
     inherit version;
     name = "asterisk-${version}";
 
-    buildInputs = [ jansson libxml2 libxslt ncurses openssl sqlite utillinux dmidecode libuuid newt lua speex srtp wget curl iksemel ];
+    buildInputs = [ jansson libedit libxml2 libxslt ncurses openssl sqlite
+                    dmidecode libuuid newt
+                    lua speex
+                    srtp wget curl iksemel ];
+    nativeBuildInputs = [ utillinux pkgconfig ];
 
     patches = [
       # We want the Makefile to install the default /var skeleton
@@ -39,8 +43,11 @@ let
     # you're likely missing an automatically downloaded dependency
     preConfigure = ''
       mkdir externals_cache
-    '' + lib.concatStringsSep "\n"
-        (lib.mapAttrsToList (dst: src: "cp -r --no-preserve=mode ${src} ${dst}") externals) + ''
+
+      ${lib.concatStringsSep "\n"
+        (lib.mapAttrsToList (dst: src: "cp -r --no-preserve=mode ${src} ${dst}") externals)}
+
+      ${lib.optionalString (externals ? "addons/mp3") "bash contrib/scripts/get_mp3_source.sh || true"}
 
       chmod -w externals_cache
     '';
@@ -53,7 +60,9 @@ let
 
     preBuild = ''
       make menuselect.makeopts
-      substituteInPlace menuselect.makeopts --replace 'format_mp3 ' ""
+      ${lib.optionalString (externals ? "addons/mp3") ''
+        substituteInPlace menuselect.makeopts --replace 'format_mp3 ' ""
+      ''}
     '';
 
     postInstall = ''
@@ -69,9 +78,14 @@ let
     };
   };
 
-  pjproject-27 = fetchurl {
+  pjproject_2_7_1 = fetchurl {
     url = http://www.pjsip.org/release/2.7.1/pjproject-2.7.1.tar.bz2;
     sha256 = "09ii5hgl5s7grx4fiimcl3s77i385h7b3kwpfa2q0arbl1ibryjr";
+  };
+
+  pjproject_2_8 = fetchurl {
+    url = http://www.pjsip.org/release/2.8/pjproject-2.8.tar.bz2;
+    sha256 = "0ybg0113rp3fk49rm2v0pcgqb28h3dv1pdy9594w2ggiz7bhngah";
   };
 
   mp3-202 = fetchsvn {
@@ -80,45 +94,62 @@ let
     sha256 = "1s9idx2miwk178sa731ig9r4fzx4gy1q8xazfqyd7q4lfd70s1cy";
   };
 
-in
-{
+in rec {
+  # Supported releases (as of 2018-11-20).
+  #
+  # Series  Type       Rel. Date   Sec. Fixes  EOL
+  # 13.x    LTS        2014-10-24  2020-10-24  2021-10-24
+  # 15.x    Standard   2017-10-03  2018-10-03  2019-10-03
+  asterisk-stable = asterisk_15;
+  # 16.x    LTS        2018-10-09  2022-10-09  2023-10-09
+  asterisk-lts = asterisk_16;
+  asterisk = asterisk_16;
 
-  asterisk-lts = common {
-    version = "13.20.0";
-    sha256 = "a3d6d953f844867ea11e0be22ee6225049cd4f5870df6ab23454623bcfbc94d5";
+  asterisk_13 = common {
+    version = "13.24.1";
+    sha256 = "1mclpk7knqjl6jr6mpvhb17wsjah4bk2xqhb3shpx1j4z19xkmm3";
     externals = {
-      "externals_cache/pjproject-2.7.1.tar.bz2" = pjproject-27;
+      "externals_cache/pjproject-2.7.1.tar.bz2" = pjproject_2_7_1;
       "addons/mp3" = mp3-202;
     };
   };
 
-  asterisk-stable = common {
-    version = "15.3.0";
-    sha256 = "f424f89f23b72f267ff9baab82d449bebbbf00c54e54fcd06b8fca13788b012c";
+  asterisk_15 = common {
+    version = "15.7.0";
+    sha256 = "1ngs73h4lz94b4f3shy1yb5laqy0z03zf451xa1nihrgp1h3ilyv";
     externals = {
-      "externals_cache/pjproject-2.7.1.tar.bz2" = pjproject-27;
+      "externals_cache/pjproject-2.8.tar.bz2" = pjproject_2_8;
       "addons/mp3" = mp3-202;
     };
   };
 
-  # asterisk-git = common {
-  #   version = "15-pre";
-  #   sha256 = "...";
-  #   externals = {
+  asterisk_16 = common {
+    version = "16.1.1";
+    sha256 = "19bfvqmxphk2608jx7jghfy7rdbj1qj5vw2fyb0fq4xjvx919wmv";
+    externals = {
+      "externals_cache/pjproject-2.8.tar.bz2" = pjproject_2_8;
+      "addons/mp3" = mp3-202;
+    };
+  };
+
+  #asterisk-git = common {
+  #  version = "15-pre";
+  #  sha256 = "...";
+  #  externals = {
   #    "externals_cache/pjproject-2.5.5.tar.bz2" = pjproject-255;
-      # Note that these sounds are included with the release tarball. They are
-      # provided here verbatim for the convenience of anyone wanting to build
-      # Asterisk from other sources. Include in externals.
-      # "sounds/asterisk-core-sounds-en-gsm-1.5.tar.gz" = fetchurl {
-      #   url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.5.tar.gz;
-      #   sha256 = "01xzbg7xy0c5zg7sixjw5025pvr4z64kfzi9zvx19im0w331h4cd";
-      # };
-      # "sounds/asterisk-moh-opsound-wav-2.03.tar.gz" = fetchurl {
-      #   url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-moh-opsound-wav-2.03.tar.gz;
-      #   sha256 = "449fb810d16502c3052fedf02f7e77b36206ac5a145f3dacf4177843a2fcb538";
-      # };
-      # TODO: Sounds for other languages could be added here
-    # }
-  # }.overrideDerivation (_: {src = fetchgit {...}})
+  #    # Note that these sounds are included with the release tarball. They are
+  #    # provided here verbatim for the convenience of anyone wanting to build
+  #    # Asterisk from other sources. Include in externals.
+  #    "sounds/asterisk-core-sounds-en-gsm-1.5.tar.gz" = fetchurl {
+  #      url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-core-sounds-en-gsm-1.5.tar.gz;
+  #      sha256 = "01xzbg7xy0c5zg7sixjw5025pvr4z64kfzi9zvx19im0w331h4cd";
+  #    };
+  #    "sounds/asterisk-moh-opsound-wav-2.03.tar.gz" = fetchurl {
+  #      url = http://downloads.asterisk.org/pub/telephony/sounds/releases/asterisk-moh-opsound-wav-2.03.tar.gz;
+  #      sha256 = "449fb810d16502c3052fedf02f7e77b36206ac5a145f3dacf4177843a2fcb538";
+  #    };
+  #    # TODO: Sounds for other languages could be added here
+  #  }
+  #}.overrideDerivation (_: {src = fetchgit {...}})
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13426,10 +13426,9 @@ in
 
   apcupsd = callPackage ../servers/apcupsd { };
 
-  asterisk = asterisk-stable;
-
   inherit (callPackages ../servers/asterisk { })
-    asterisk-stable asterisk-lts;
+    asterisk asterisk-stable asterisk-lts
+    asterisk_13 asterisk_15 asterisk_16;
 
   sabnzbd = callPackage ../servers/sabnzbd { };
 


### PR DESCRIPTION
###### Motivation for this change
Update asterisk versions and add new majorversion 16 (with LTS). This commit extends/fixes pull request #50874.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

