### PR TITLE
Revert "rustc: 1.31.0 -> 1.32.0"

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.31.0";
+  version = "1.30.1";
 
-  # fetch hashes by running `print-hashes.sh 1.31.0`
+  # fetch hashes by running `print-hashes.sh 1.30.0`
   hashes = {
-    i686-unknown-linux-gnu = "46333e8feec55bc1f99fd03028370f6163ef1e33e483da0389a9c424ec9634ed";
-    x86_64-unknown-linux-gnu = "c8a2016109ffdc12a488660edc5f30c1643729efc15abe311ebb187437e506bf";
-    armv7-unknown-linux-gnueabihf = "60bb75649b457ad971e94dd14c666b59deeee2176b14ae0f98e2fa435c172c1e";
-    aarch64-unknown-linux-gnu = "4e68c70aba58004d9e86c2b4463e88466affee51242349a038b456cf6f4be5c9";
-    i686-apple-darwin = "ec8d08eeea97d78d37430e9b32511e87854aad502f4e3e77e806788246b36e6f";
-    x86_64-apple-darwin = "5d4035e3cecb7df13e728bcff125b52b43b126e91f8311c66b143f353362606f";
+    i686-unknown-linux-gnu = "c61655977fb16decf0ceb76043b9ae2190927aa9cc24f013d444384dcab99bbf";
+    x86_64-unknown-linux-gnu = "a01a493ed8946fc1c15f63e74fc53299b26ebf705938b4d04a388a746dfdbf9e";
+    armv7-unknown-linux-gnueabihf = "9b3b6df02a2a92757e4993a7357fdd02e07b60101a748b4618e6ae1b90bc1b6b";
+    aarch64-unknown-linux-gnu = "6d87d81561285abd6c1987e07b60b2d723936f037c4b46eedcc12e8566fd3874";
+    i686-apple-darwin = "a7c14b18e96406d9f43d69d0f984b2fa6f92cc7b7b37e2bb7b70b6f44b02b083";
+    x86_64-apple-darwin = "3ba1704a7defe3d9a6f0c1f68792c084da83bcba85e936d597bac0c019914b94";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -10,8 +10,8 @@ rustPlatform.buildRustPackage rec {
   inherit version src patches;
 
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again
-  cargoVendorDir = "vendor";
-  preBuild = "pushd src/tools/cargo";
+  cargoVendorDir = "src/vendor";
+  preBuild = "cd src; pushd tools/cargo";
   postBuild = "popd";
 
   passthru.rustc = rustc;
@@ -23,10 +23,10 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ cacert file curl python openssl cmake zlib makeWrapper libgit2 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
 
-  LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+  LIBGIT2_SYS_USE_PKG_CONFIG=1;
 
   # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
-  RUSTC_BOOTSTRAP = 1;
+  RUSTC_BOOTSTRAP=1;
 
   # FIXME: Use impure version of CoreFoundation because of missing symbols.
   # CFURLSetResourcePropertyForKey is defined in the headers but there's no

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -7,11 +7,11 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
-  version = "1.32.0";
-  cargoVersion = "1.32.0";
+  version = "1.31.0";
+  cargoVersion = "1.31.0";
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "0ji2l9xv53y27xy72qagggvq47gayr5lcv2jwvmfirx029vlqnac";
+    sha256 = "01pg2619bwjnhjbphryrbkwaz0lw8cfffm4xlz35znzipb04vmcs";
   };
 in rec {
   rustc = callPackage ./rustc.nix {
@@ -22,6 +22,11 @@ in rec {
 
       # Re-evaluate if this we need to disable this one
       #./patches/stdsimd-disable-doctest.patch
+
+      # Fails on hydra - not locally; the exact reason is unknown.
+      # Comments in the test suggest that some non-reproducible environment
+      # variables such $RANDOM can make it fail.
+      ./patches/disable-test-inherit-env.patch
     ];
 
     withBundledLLVM = false;

--- a/pkgs/development/compilers/rust/patches/disable-test-inherit-env.patch
+++ b/pkgs/development/compilers/rust/patches/disable-test-inherit-env.patch
@@ -1,0 +1,10 @@
+--- rustc-1.26.2-src.org/src/libstd/process.rs	2018-06-01 21:40:11.000000000 +0100
++++ rustc-1.26.2-src/src/libstd/process.rs	2018-06-08 07:50:23.023828658 +0100
+@@ -1745,6 +1745,7 @@
+     }
+ 
+     #[test]
++    #[ignore]
+     fn test_inherit_env() {
+         use env;
+ 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,6 +1,6 @@
 { stdenv, targetPackages, removeReferencesTo
 , fetchurl, fetchgit, fetchzip, file, python2, tzdata, ps
-, llvm, ncurses, darwin, rustPlatform, git, cmake, curl
+, llvm, jemalloc, ncurses, darwin, rustPlatform, git, cmake, curl
 , which, libffi, gdb
 , version
 , withBundledLLVM ? false
@@ -19,6 +19,8 @@ let
   inherit (darwin.apple_sdk.frameworks) Security;
 
   llvmShared = llvm.override { enableSharedLibraries = true; };
+
+  prefixedJemalloc = jemalloc.override { stripPrefix = false; };
 
   target = builtins.replaceStrings [" "] [","] (builtins.toString targets);
 in
@@ -60,6 +62,7 @@ stdenv.mkDerivation {
   configureFlags = configureFlags
                 ++ [ "--enable-local-rust" "--local-rust-root=${rustPlatform.rust.rustc}" "--enable-rpath"
                      "--enable-vendor"
+                     "--jemalloc-root=${prefixedJemalloc}/lib"
                      "--default-linker=${targetPackages.stdenv.cc}/bin/cc" ]
                 ++ optional (!withBundledLLVM) [ "--enable-llvm-link-shared" "--llvm-root=${llvmShared}" ]
                 ++ optional (targets != []) "--target=${target}";
@@ -82,6 +85,7 @@ stdenv.mkDerivation {
     patchShebangs src/etc
 
     ${optionalString (!withBundledLLVM) ''rm -rf src/llvm''}
+    rm -rf src/jemalloc
 
     # Fix the configure script to not require curl as we won't use it
     sed -i configure \
@@ -93,7 +97,7 @@ stdenv.mkDerivation {
     # https://github.com/rust-lang/rust/issues/39522
     echo removing gdb-version-sensitive tests...
     find src/test/debuginfo -type f -execdir grep -q ignore-gdb-version '{}' \; -print -delete
-    rm src/test/debuginfo/{borrowed-c-style-enum.rs,c-style-enum-in-composite.rs,generic-enum-with-different-disr-sizes.rs}
+    rm src/test/debuginfo/{borrowed-c-style-enum.rs,c-style-enum-in-composite.rs,gdb-pretty-struct-and-enums-pre-gdb-7-7.rs,generic-enum-with-different-disr-sizes.rs}
 
     # Useful debugging parameter
     # export VERBOSE=1


### PR DESCRIPTION

###### Motivation for this change

This reverts commit 56dba36eb5bc783c314d0fa627585cab42cebe7a. It breaks some packages and a version of the update with fixes applied (https://github.com/NixOS/nixpkgs/pull/54323) is already in staging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

