### PR TITLE
apvlv: fix build with poppler 0.73.0

### DIFF
--- a/pkgs/applications/misc/apvlv/default.nix
+++ b/pkgs/applications/misc/apvlv/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/naihe2010/apvlv/commit/a3a895772a27d76dab0c37643f0f4c73f9970e62.patch";
       sha256 = "1fpc7wr1ajilvwi5gjsy5g9jcx4bl03gp5dmajg90ljqbhwz2bfi";
     })
+    ./fix-build-with-poppler-0.73.0.patch
   ];
 
   installPhase = ''

--- a/pkgs/applications/misc/apvlv/fix-build-with-poppler-0.73.0.patch
+++ b/pkgs/applications/misc/apvlv/fix-build-with-poppler-0.73.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ApvlvPdf.cc b/src/ApvlvPdf.cc
+index 765b112..83d133f 100644
+--- a/src/ApvlvPdf.cc
++++ b/src/ApvlvPdf.cc
+@@ -29,7 +29,7 @@
+ #include "ApvlvPdf.h"
+
+ #ifndef POPPLER_WITH_GDK
+-#include <goo/gtypes.h>
++#include <goo/gfile.h>
+
+ static void
+ copy_cairo_surface_to_pixbuf (cairo_surface_t *surface,


### PR DESCRIPTION
###### Motivation for this change

closes https://github.com/NixOS/nixpkgs/issues/54021

###### Things done

Took @worldofpeace's commit and provided some more info in the commit message. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

