### PR TITLE
vte-ng: 0.50.2.a -> 0.54.2.a

### DIFF
--- a/pkgs/development/libraries/vte/ng.nix
+++ b/pkgs/development/libraries/vte/ng.nix
@@ -2,13 +2,13 @@
 
 vte.overrideAttrs (oldAttrs: rec {
   name = "vte-ng-${version}";
-  version = "0.50.2.a";
+  version = "0.54.2.a";
 
   src = fetchFromGitHub {
     owner = "thestinger";
     repo = "vte-ng";
     rev = version;
-    sha256 = "0i6hfzw9sq8521kz0l7lld2km56r0bfp1hw6kxq3j1msb8z8svcf";
+    sha256 = "1r7d9m07cpdr4f7rw3yx33hmp4jmsk0dn5byq5wgksb2qjbc4ags";
   };
 
   preConfigure = oldAttrs.preConfigure + "; NOCONFIGURE=1 ./autogen.sh";


### PR DESCRIPTION
###### Motivation for this change
Made it possible to have undercurl working in my terminal (termite).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

