### PR TITLE
hetzner-kube: 0.3.1 -> 0.3.2rc1

### DIFF
--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -1,18 +1,20 @@
 { lib, buildGoPackage, fetchFromGitHub, ... }:
 
-let version = "0.3.1"; in
-
-buildGoPackage {
-  name = "hetzner-kube-${version}";
+buildGoPackage rec {
+  name = "${pname}-${version}";
+  pname = "hetzner-kube";
+  version = "0.3.2-rc1";
 
   src = fetchFromGitHub {
     owner = "xetys";
     repo = "hetzner-kube";
-    rev = "${version}";
-    sha256 = "1xldh1ca8ym8cg3w5cxizmhqxwi5kmiin28f320mxdr28fzljc2w";
+    rev = version;
+    sha256 = "16pzcpcr98rcrv5k57fa7h9a82wiv4p2ckhkmisynkr7f1xk60mw";
   };
 
   goPackagePath = "github.com/xetys/hetzner-kube";
+  subPackages = ["."];
+  goDeps = ./deps.nix;
 
   meta = {
     description = "A CLI tool for provisioning Kubernetes clusters on Hetzner Cloud";

--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -1,7 +1,6 @@
 { lib, buildGoPackage, fetchFromGitHub, ... }:
 
 buildGoPackage rec {
-  name = "${pname}-${version}";
   pname = "hetzner-kube";
   version = "0.3.2-rc1";
 

--- a/pkgs/applications/networking/cluster/hetzner-kube/deps.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/deps.nix
@@ -1,0 +1,255 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/Pallinder/go-randomdata";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Pallinder/go-randomdata";
+      rev =  "15df0648130a623e418886f81b2aaecd0a00547b";
+      sha256 = "1kdrchnhp71spz6amcbxr5m0pdksbqx8jjydvxb82pw43rrbx6s7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/andreyvit/diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/andreyvit/diff";
+      rev =  "c7f18ee00883bfd3b00e0a2bf7607827e0148ad4";
+      sha256 = "1s4qjkxig5yqahpzfl4xqh4kzi9mymdpkzq6kj3f4dr5dl3hlynr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-kit/kit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-kit/kit";
+      rev =  "ca4112baa34cb55091301bdc13b1420a122b1b9e";
+      sha256 = "0vsqmjnd3zj3qxg455kz27fjd9zh2vx5x17hfgzjv2pqsg3jas13";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-logfmt/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-logfmt/logfmt";
+      rev =  "390ab7935ee28ec6b286364bba9b4dd6410cb3d5";
+      sha256 = "1gkgh3k5w1xwb2qbjq52p6azq3h1c1rr6pfwjlwj1zrijpzn2xb9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-stack/stack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-stack/stack";
+      rev =  "259ab82a6cad3992b4e21ff5cac294ccb06474bc";
+      sha256 = "0irkqifyj84cbnq4n66ax2r591id2285diw5hzcz2k3bga8d8lqr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gosuri/uilive";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gosuri/uilive";
+      rev =  "ac356e6e42cd31fcef8e6aec13ae9ed6fe87713e";
+      sha256 = "1k28zbc14p1yqzhamp9rcagjdw6wsdb55m08nx758jwlr31az6jy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gosuri/uiprogress";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gosuri/uiprogress";
+      rev =  "d0567a9d84a1c40dd7568115ea66f4887bf57b33";
+      sha256 = "1m7rxf71mn8w2yysc8wmf2703avhci6f4nkiijjl1f2cx4kzykck";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev =  "ef8a98b0bbce4a65b5aa4c368430a80ddc533168";
+      sha256 = "1qalfsc31fra7hcw2lc3s20aj7al62fq3j5fn5kga3mg99b82nyr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hetznercloud/hcloud-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hetznercloud/hcloud-go";
+      rev =  "400c6f026bf3c8d5fead3df7806e6981a16bb6b8";
+      sha256 = "0y6y7glnzbrzmly2j139vj8279w3c8bm1zc2mzljwyjpa6pvp7di";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kr/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/logfmt";
+      rev =  "b84e30acd515aadc4b783ad4ff83aff3299bdfe0";
+      sha256 = "02ldzxgznrfdzvghfraslhgp19la1fczcbzh7wm2zdc6lmpd1qq9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev =  "c2353362d570a7bfa228149c62842019201cfb71";
+      sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "0360b2af4f38e8d38c7fce2a9f4e702702d73a39";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev =  "58046073cbffe2f25d425fe1331102f55cf719de";
+      sha256 = "0kwflrwsjdsy8vbhyzicc4c2vdi7lhdvn4rarfr18x1qsrb7n1bx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev =  "f15292f7a699fcc1a38a80977f80a046874ba8ac";
+      sha256 = "0zm3nhdvmj3f8q0vg2sjfw1sm3pwsw0ggz501awz95w99664a8al";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev =  "c01d1270ff3e442a8a57cddc1c92dc1138598194";
+      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev =  "1744e2970ca51c86172c8190fadad617561ed6e7";
+      sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev =  "787d034dfe70e44075ccc060d346146ef53270ad";
+      sha256 = "0138rjiacl71h7kvhzinviwvy6qa2m6rflpv9lgqv15hnjvhwvg1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev =  "8965335b8c7107321228e3e3702cab9832751bac";
+      sha256 = "177bk7lq40jbgv9p9r80aydpaccfk8ja3a7jjhfwiwk9r1pa4rr2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "ef82de70bb3f60c65fb8eebacbb2d122ef517385";
+      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev =  "14d3d4c518341bea657dd8a226f5121c0ff8c9f2";
+      sha256 = "1f9154lijbz0kkgqwmbphykwl4adv4fvkx6n1p7fdq3x5j9g8i17";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "9a97c102cda95a86cec2345a6f09f55a939babf5";
+      sha256 = "005598piihl3l83a71ahj10cpq9pbhjck4xishx1b4dzc02r9xr2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev =  "907c19d40d9a6c9bb55f040ff4ae45271a4754b9";
+      sha256 = "177ziws6mwxdlvicmgpv7w7zy5ri2wgnw2f2v3789b5skv9d6a6b";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "de0752318171da717af4ce24d0a2e8626afaeb11";
+      sha256 = "1ps1dl2a5lwr3vbwcy8n4i1v73m567y024sk961fk281phrzp13i";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "1c9583448a9c3aa0f9a6a5241bf73c0bd8aafded";
+      sha256 = "0g0nc549pmdmvja4mdqh0kgvznnw6wliqmx5wrnj02l3a23vizmi";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+]


### PR DESCRIPTION
hetzner-kube: 0.3.1 -> 0.3.2rc1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---