### PR TITLE
lguf-brightness: Init at 2018-02-07

### DIFF
--- a/pkgs/misc/lguf-brightness/default.nix
+++ b/pkgs/misc/lguf-brightness/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, libusb1, ncurses5 }:
+
+stdenv.mkDerivation rec {
+  pname = "lguf-brightness";
+
+  version = "unstable-2018-02-07";
+
+  src = fetchFromGitHub  {
+    owner = "periklis";
+    repo = pname;
+    rev = "d194272b7a0374b27f036cbc1a9be7f231d40cbb";
+    sha256 = "0zj81bqchms9m7rik1jxp6zylh9dxqzr7krlj9947v0phr4qgah4";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libusb1 ncurses5 ];
+
+  installPhase = ''
+    install -D lguf_brightness $out/bin/lguf_brightness
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Adjust brightness for LG UltraFine 4K display (cross platform)";
+    homepage = https://github.com/periklis/lguf-brightness;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ periklis ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22474,6 +22474,8 @@ in
 
   kops = callPackage ../applications/networking/cluster/kops { };
 
+  lguf-brightness = callPackage ../misc/lguf-brightness { };
+
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };
   lilypond-unstable = callPackage ../misc/lilypond/unstable.nix { };
   lilypond-with-fonts = callPackage ../misc/lilypond/with-fonts.nix {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

