### PR TITLE
pythonPackages.assimulo: init at 3.0 [WIP] [Help needed]

### DIFF
--- a/pkgs/development/python-modules/assimulo/default.nix
+++ b/pkgs/development/python-modules/assimulo/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, buildPythonPackage, fetchsvn, fetchurl, gcc, gfortran, numpy, scipy,
+ matplotlib, cython, blas, liblapack, sundials, nose, python, lib }:
+
+# For the official installation instructions, see:
+# https://jmodelica.org/assimulo/installation.html
+
+let
+
+  # Assimulo requires Sundials 2.5/2.6
+  sundials26 = sundials.overrideDerivation (
+    attrs: rec {
+      name = "${attrs.pname}-${version}";
+      version = "2.6.2";
+      src = fetchurl {
+        url = "https://computation.llnl.gov/projects/${attrs.pname}/download/${attrs.pname}-${version}.tar.gz";
+        sha256 = "0bsdmal7sq90ih5hihqg6isa35cbbwbs865k2zrv1llxa18h3vfq";
+      };
+    }
+  );
+
+in buildPythonPackage rec {
+
+  pname = "assimulo";
+  version = "3.0";
+
+  # NOTE: PyPI source tarball is missing some files, so use SVN. See:
+  # https://stackoverflow.com/a/54567317/2184571
+  src = fetchsvn {
+    url = "https://svn.jmodelica.org/assimulo/tags/Assimulo-${version}/";
+    rev = "875";
+    sha256 = "0n9560qbsrrhs1xvppsrvgi7s2ki3a8751p9qq31dsly23d5mv97";
+  };
+
+  buildInputs = [ gfortran gcc ];
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ cython numpy scipy matplotlib ];
+
+  # NOTE: Requires static versions of BLAS and LAPACK.
+  #
+  # TODO: Not sure how to make use of SuperLU. Probably Sundials in nixpkgs
+  # should be compiled with SuperLU support? Now there's a debug message: "Could
+  # not detect SuperLU support with Sundials, disabling support for SuperLU."
+  setupPyBuildFlags = [
+    "--blas-home=${blas}/lib"
+    "--blas-name=blas"
+    "--lapack-home=${liblapack}/lib"
+    "--sundials-home=${sundials26}"
+  ];
+
+  # I have no idea why dist directory ends up under build, but that's where it
+  # is so let's move it. Otherwise the install phase fails on "pushd dist" as
+  # dist is not found..
+  postBuild = ''
+    mv build/dist ./
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    pushd tests
+    nosetests
+    popd
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://jmodelica.org/assimulo/;
+    description = "Simulation package for solving ordinary differential equations";
+    # NOTE: The license was specified as LGPL without a version, so I'm assuming
+    # any LGPL version is ok.
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -182,6 +182,8 @@ in {
 
   aspy-yaml = callPackage ../development/python-modules/aspy.yaml { };
 
+  assimulo = callPackage ../development/python-modules/assimulo { };
+
   astral = callPackage ../development/python-modules/astral { };
 
   astropy = callPackage ../development/python-modules/astropy { };


### PR DESCRIPTION
###### Motivation for this change

Add Assimulo package: https://jmodelica.org/assimulo/

**EDIT: Ready for review!**

~~This is still work in progress.~~ ~~The build fails at the very end:~~ ~~**EDIT: fixed this error, now tests failing**~~

```
...
removing build/bdist.linux-x86_64/wheel
sortvarnames: failed to compute dependencies because of cyclic dependencies between am, n
sortvarnames: failed to compute dependencies because of cyclic dependencies between am, n
installing
/nix/store/yax21ms90cwr2l4rygd60wfbpfwg5hip-stdenv-linux/setup: line 1307: pushd: dist: No such file or directory
note: keeping build directory '/tmp/nix-build-python3.7-assimulo-3.0.drv-5'
builder for '/nix/store/3jj55c5kdgnsnd4lj4rpmfpkq19gh6cw-python3.7-assimulo-3.0.drv' failed with exit code 1
error: build of '/nix/store/3jj55c5kdgnsnd4lj4rpmfpkq19gh6cw-python3.7-assimulo-3.0.drv' failed
```

~~So apparently `dist` directory is missing for some reason. The build phase doesn't create it as it should, I suppose. Any help would be great!~~

~~Full log: [assimulo.log](https://github.com/NixOS/nixpkgs/files/2842081/assimulo.log)~~


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

