### PR TITLE
hunspell-dicts: add support for Hungarian dictionary

### DIFF
--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -250,6 +250,35 @@ let
       };
     };
 
+  mkDictFromLibreOffice =
+    { shortName
+    , shortDescription
+    , dictFileName
+    , license
+    , readmeFile ? "README_${dictFileName}.txt"
+    , sourceRoot ? dictFileName }:
+    mkDict rec {
+      name = "hunspell-dict-${shortName}-libreoffice-${version}";
+      version = "6.2.0.3";
+      inherit dictFileName readmeFile;
+      src = fetchFromGitHub {
+        owner = "LibreOffice";
+        repo = "dictionaries";
+        rev = "libreoffice-${version}";
+        sha256 = "0rw9ahhynia5wsgyd67lrhinqqn1s1rizgiykb3palbyk0lv72xj";
+      };
+      buildPhase = ''
+        cp -a ${sourceRoot}/* .
+      '';
+      meta = with stdenv.lib; {
+        homepage = https://wiki.documentfoundation.org/Development/Dictionaries;
+        description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
+        license = license;
+        maintainers = with maintainers; [ vlaci ];
+        platforms = platforms.all;
+      };
+    };
+
 in {
 
   /* ENGLISH */
@@ -508,6 +537,15 @@ in {
         sha256 = "0lw193jr7ldvln5x5z9p21rz1by46h0say9whfcw2kxs9vprd5b3";
       })
     ];
+  };
+
+  /* HUNGARIAN */
+
+  hu-hu = mkDictFromLibreOffice {
+    shortName = "hu-hu";
+    dictFileName = "hu_HU";
+    shortDescription = "Hungarian (Hungary)";
+    license = with stdenv.lib.licenses; [ mpl20 lgpl3 ];
   };
 
   /* SWEDISH */


### PR DESCRIPTION
###### Motivation for this change

LibreOffice has a comprehensive collection of Hunspell dictionaries.
`mkDictFromLibreOffice` helper is introduced to make it easy to add new
dictionaries from this repository. `license` is parametrized because
each dictionary has its own license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

