### PR TITLE
pythonPackages.dask-mpi: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/dask-mpi/default.nix
+++ b/pkgs/development/python-modules/dask-mpi/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, dask
+, distributed
+, mpi4py
+, pytest
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "1.0.2";
+  pname = "dask-mpi";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1apzzh90gl9jx43z0gjmgpniplhvqziafi2l8688a0g01vw7ibjv";
+  };
+
+  checkInputs = [ pytest requests ];
+  propagatedBuildInputs = [ dask distributed mpi4py ];
+
+  checkPhase = ''
+    py.test dask_mpi
+  '';
+
+  # hardcoded mpirun path in tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dask/dask-mpi;
+    description = "Deploy Dask using mpi4py";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -299,7 +299,7 @@ in {
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
   cfn-flip = callPackage ../development/python-modules/cfn-flip { };
- 
+
   chalice = callPackage ../development/python-modules/chalice { };
 
   cleo = callPackage ../development/python-modules/cleo { };
@@ -1573,6 +1573,8 @@ in {
   dask-jobqueue = callPackage ../development/python-modules/dask-jobqueue { };
 
   dask-ml = callPackage ../development/python-modules/dask-ml { };
+
+  dask-mpi = callPackage ../development/python-modules/dask-mpi { };
 
   dask-xgboost = callPackage ../development/python-modules/dask-xgboost { };
 


### PR DESCRIPTION
Address issue with PR #55212

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

