### PR TITLE
 buildEnv, substituteAll: disable binary cache lookups

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -196,4 +196,5 @@ in stdenv.mkDerivation {
     ${if isMultiBuild then extraBuildCommandsMulti else ""}
   '';
   preferLocalBuild = true;
+  allowSubstitutes = false;
 }

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -63,6 +63,7 @@ runCommand name
       priority = drv.meta.priority or 5;
     }) paths);
     preferLocalBuild = true;
+    allowSubstitutes = false;
     # XXX: The size is somewhat arbitrary
     passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else null;
   }

--- a/pkgs/build-support/substitute-files/substitute-all-files.nix
+++ b/pkgs/build-support/substitute-files/substitute-all-files.nix
@@ -22,4 +22,5 @@ stdenv.mkDerivation ({
     eval "$postInstall"
   '';
   preferLocalBuild = true;
+  allowSubstitutes = false;
 } // args)

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -8,4 +8,5 @@ stdenvNoCC.mkDerivation ({
   builder = ./substitute-all.sh;
   inherit (args) src;
   preferLocalBuild = true;
+  allowSubstitutes = false;
 } // args)

--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -4,6 +4,7 @@ runCommand "fc-cache"
   rec {
     buildInputs = [ fontconfig.bin ];
     preferLocalBuild = true;
+    allowSubstitutes = false;
     passAsFile = [ "fontDirs" ];
     fontDirs = ''
       <!-- Font directories -->


### PR DESCRIPTION
###### Motivation for this change

Building of every closure (even after minor changes in configuration.nix) requires Internet access (and get stuck in case of internet problems):

```
checking substituter 'http://cache.nixos.org' for path '/nix/store/1s9ihmx0sphd1p6hsyd39kscr2cgxn3c-stage-2-init.sh'
checking substituter 'http://cache.nixos.org' for path '/nix/store/cj7mj8g5ndm268gn0y1k0b8nzgackwf8-system-path'
querying info about '/nix/store/1s9ihmx0sphd1p6hsyd39kscr2cgxn3c-stage-2-init.sh' on 'http://cache.nixos.org'...
querying info about '/nix/store/cj7mj8g5ndm268gn0y1k0b8nzgackwf8-system-path' on 'http://cache.nixos.org'...
```

So, let's make ```buildEnv``` and ```substituteAll``` not to lookup in the binary caches as it is already done with many of the trivial builders.
Even if there is no problems with the Internet speed/latency, they are so small so it is faster to build them locally than to download. i also suspect their hit ratio is close to zero, so those lookups are pure waste.