### PR TITLE
[18.09] Keybase updates 

### DIFF
--- a/pkgs/tools/security/kbfs/default.nix
+++ b/pkgs/tools/security/kbfs/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kbfs-${version}";
-  version = "2.10.1";
+  version = "2.11.0";
 
   goPackagePath = "github.com/keybase/kbfs";
   subPackages = [ "kbfsfuse" "kbfsgit/git-remote-keybase" ];
@@ -13,7 +13,7 @@ buildGoPackage rec {
     owner = "keybase";
     repo = "kbfs";
     rev = "v${version}";
-    sha256 = "0c03jm4pxqh4cfg1d7c833hdl8l57f1sbfqxwdq16y5s2cac1yss";
+    sha256 = "1qlns7vpyj3ivm7d3vvlmx3iksl7hpcg87yh30f3n64c8jk0xc83";
   };
 
   buildFlags = [ "-tags production" ];
@@ -22,7 +22,7 @@ buildGoPackage rec {
     homepage = https://www.keybase.io;
     description = "The Keybase FS FUSE driver";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ bennofs np ];
+    maintainers = with maintainers; [ rvolosatovs bennofs np ];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -5,7 +5,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "2.13.1";
+  version = "3.0.0";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -14,7 +14,7 @@ buildGoPackage rec {
 
   src = fetchurl {
     url = "https://github.com/keybase/client/archive/v${version}.tar.gz";
-    sha256 = "0avq87y7cs3jipl444ssz1zd5jygpks20hls0fkqxxaikkpdsy4v";
+    sha256 = "1mxzihgd3qfahlmnfrpbg2kbixbjmkajrl964kaxmihrkx0fylvf";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -5,7 +5,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "2.10.1";
+  version = "2.11.0";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner  = "keybase";
     repo   = "client";
     rev    = "v${version}";
-    sha256 = "1gfxnqzs8msxmykg1zrhrrl2slmb29gl7b8s4m2g44zxaj91gfi9";
+    sha256 = "1mj78cs6j0f1f86c71j4gdphas75j3rfaqygpy87dc40kc2yj0gd";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub, cf-private
+{ stdenv, lib, buildGoPackage, fetchurl, cf-private
 , AVFoundation, AudioToolbox, ImageIO, CoreMedia
 , Foundation, CoreGraphics, MediaToolbox
 }:
@@ -12,11 +12,9 @@ buildGoPackage rec {
 
   dontRenameImports = true;
 
-  src = fetchFromGitHub {
-    owner  = "keybase";
-    repo   = "client";
-    rev    = "v${version}";
-    sha256 = "13mkbr99k3i03vp28ab5y0h5fa1pfnbfjqq2fhh4j87d5h74ld13";
+  src = fetchurl {
+    url = "https://github.com/keybase/client/archive/v${version}.tar.gz";
+    sha256 = "0avq87y7cs3jipl444ssz1zd5jygpks20hls0fkqxxaikkpdsy4v";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -5,7 +5,7 @@
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "2.11.0";
+  version = "2.13.1";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner  = "keybase";
     repo   = "client";
     rev    = "v${version}";
-    sha256 = "1mj78cs6j0f1f86c71j4gdphas75j3rfaqygpy87dc40kc2yj0gd";
+    sha256 = "13mkbr99k3i03vp28ab5y0h5fa1pfnbfjqq2fhh4j87d5h74ld13";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -3,16 +3,16 @@
 , libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook }:
 
 let
-  versionSuffix = "20190104191034.69b3ee25b7";
+  versionSuffix = "20190115203650.eec94506e4";
 in
 
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "2.13.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "2.13.1"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "5b188185dc6d594cd18876a2c955bb6481598c206f048cfd80ac2e7e8022241e";
+    sha256 = "01663jknr8s4sp51mclw9llhx07ww6yh22apawxikvpwmw9yg2qr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -3,16 +3,16 @@
 , libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook }:
 
 let
-  versionSuffix = "20181121195344.99751ac04f";
+  versionSuffix = "20190104191034.69b3ee25b7";
 in
 
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "2.11.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "2.13.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "1gh7brdw2p4xfdgc43vrmv0lvki2f3691mfh6lvksy1dv43yb8zl";
+    sha256 = "5b188185dc6d594cd18876a2c955bb6481598c206f048cfd80ac2e7e8022241e";
   };
 
   nativeBuildInputs = [
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
     homepage = https://www.keybase.io/;
     description = "The Keybase official GUI";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ puffnfresh np ];
+    maintainers = with maintainers; [ rvolosatovs puffnfresh np ];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, atk, cairo, cups, udev, hicolor-icon-theme
-, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, gnome2, gtk3, gnome3
+, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, gtk3, gnome3
 , libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook }:
 
 let
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     freetype
     gdk_pixbuf
     glib
-    gnome2.GConf
     gnome3.gsettings-desktop-schemas
     gtk3
     libnotify

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -3,16 +3,16 @@
 , libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook }:
 
 let
-  versionSuffix = "20190115203650.eec94506e4";
+  versionSuffix = "20190205202117.6394d03e6c";
 in
 
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "2.13.1"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "3.0.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "01663jknr8s4sp51mclw9llhx07ww6yh22apawxikvpwmw9yg2qr";
+    sha256 = "0nwz0v6sqx1gd7spha09pk2bjbb8lgaxbrh0r6j6p0xzgzz6birw";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Thought it would be a good idea to backport as certain users were having problems, and it seems keybase has certain restrictions with which client versions can communicate with their servers.

cc @rvolosatovs 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

