### PR TITLE
excelCompare: init at 0.6.1

### DIFF
--- a/pkgs/tools/text/excelCompare/default.nix
+++ b/pkgs/tools/text/excelCompare/default.nix
@@ -1,0 +1,26 @@
+{stdenv, lib, fetchurl, makeWrapper, unzip, jre}:
+
+stdenv.mkDerivation rec {
+  name = "ExcelCompare-${version}";
+  version = "0.6.1";
+  src = fetchurl {
+    url = "https://github.com/na-ka-na/ExcelCompare/releases/download/${version}/ExcelCompare-${version}.zip";
+    sha256 = "1304qraazqm8mgjgnijzl070l0haa8jds7spnsy3xwh3vda0ka4x";
+  };
+  buildInputs = [ jre ];
+  nativeBuildInputs = [ unzip makeWrapper ];
+  sourceRoot = ".";
+
+  installPhase = ''
+    install -Dt $out/share/excel_cmp bin/dist/*
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/excel_cmp \
+      --add-flags "-ea -cp $out/share/excel_cmp/\* com.ka.spreadsheet.diff.SpreadSheetDiffer"
+  '';
+
+  meta = {
+    description = "Command line tool (and API) for diffing Excel Workbooks";
+    homepage = https://github.com/na-ka-na/ExcelCompare;
+    maintainers = stdenv.lib.maintainers.ilikeavocadoes;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2504,6 +2504,8 @@ in
 
   exa = callPackage ../tools/misc/exa { };
 
+  excelCompare = callPackage ../tools/text/excelCompare { };
+
   exempi = callPackage ../development/libraries/exempi {
     stdenv = if stdenv.isi686 then overrideCC stdenv gcc6 else stdenv;
   };


### PR DESCRIPTION
###### Motivation for this change

Add utility to produce text diff of Excel files. Couldn't build from source since it requires Java version <= 6 which is not in Nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

