### PR TITLE
Nixos manual: error out on missing IDs

### DIFF
--- a/nixos/doc/manual/administration/running.xml
+++ b/nixos/doc/manual/administration/running.xml
@@ -4,7 +4,7 @@
       version="5.0"
       xml:id="ch-running">
  <title>Administration</title>
- <partintro>
+ <partintro xml:id="ch-running-intro">
   <para>
    This chapter describes various aspects of managing a running NixOS system,
    such as how to use the <command>systemd</command> service manager.

--- a/nixos/doc/manual/configuration/configuration.xml
+++ b/nixos/doc/manual/configuration/configuration.xml
@@ -4,7 +4,7 @@
       version="5.0"
       xml:id="ch-configuration">
  <title>Configuration</title>
- <partintro>
+ <partintro xml:id="ch-configuration-intro">
   <para>
    This chapter describes how to configure various aspects of a NixOS machine
    through the configuration file

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -268,7 +268,10 @@ in rec {
         --stringparam id.warnings "1" \
         --nonet --output $dst/ \
         ${docbook_xsl_ns}/xml/xsl/docbook/xhtml/chunktoc.xsl \
-        ${manual-combined}/manual-combined.xml
+        ${manual-combined}/manual-combined.xml \
+        |& tee xsltproc.out
+      grep "^ID recommended on" xsltproc.out &>/dev/null && echo "error: some IDs are missing" && false
+      rm xsltproc.out
 
       mkdir -p $dst/images/callouts
       cp ${docbook_xsl_ns}/xml/xsl/docbook/images/callouts/*.svg $dst/images/callouts/

--- a/nixos/doc/manual/development/development.xml
+++ b/nixos/doc/manual/development/development.xml
@@ -4,7 +4,7 @@
         version="5.0"
         xml:id="ch-development">
  <title>Development</title>
- <partintro>
+ <partintro xml:id="ch-development-intro">
   <para>
    This chapter describes how you can modify and extend NixOS.
   </para>

--- a/nixos/doc/manual/installation/installation.xml
+++ b/nixos/doc/manual/installation/installation.xml
@@ -4,7 +4,7 @@
       version="5.0"
       xml:id="ch-installation">
  <title>Installation</title>
- <partintro>
+ <partintro xml:id="ch-installation-intro">
   <para>
    This section describes how to obtain, install, and configure NixOS for
    first-time use.


### PR DESCRIPTION
missing ids are generated randomly by docbook, and make the manual
non-reproducible.
This force-fails the build on such cases.

See #55375 and #55396

/cc @grahamc, @samueldr, @matthewbauer




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested failure on missing IDs
- [X] Tested success when no IDs are missing
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---