### PR TITLE
Revert "rustfmt: 1.0.0 -> 1.0.1"

### DIFF
--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "1.0.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustfmt";
     rev = "${version}";
-    sha256 = "1l18ycbq3125sq8v3wgma630wd6kclarlf8f51cmi9blk322jg9p";
+    sha256 = "17ady2zq4jcbgawgpfszrkp6kxabb2f261g82y2az7nfax1h1pwy";
   };
 
-  cargoSha256 = "1557783icdzlwn02c5zl4362yl85r5zj4nkjv80p6896yli9hk9h";
+  cargoSha256 = "0v8iq50h9368kai3m710br5cxc3p6mpbwz1v6gaf5802n48liqs8";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 


### PR DESCRIPTION

###### Motivation for this change
This reverts commit 7fff567ee99c1f343ecdd82fef2e35fb6f50e423. It depends
on the rustc update I reverted in #55379. It should be re-introduced
after that rustc update has gone through staging.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

