### PR TITLE
Coq: update coquelicot, interval, flocq

### DIFF
--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, which, coq, ssreflect }:
 
 stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-coquelicot-3.0.1";
+  name = "coq${coq.coq-version}-coquelicot-3.0.2";
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/37045/coquelicot-3.0.1.tar.gz";
-    sha256 = "0hsyhsy2lwqxxx2r8xgi5csmirss42lp9bkb9yy35mnya0w78c8r";
+    url = "https://gforge.inria.fr/frs/download.php/file/37523/coquelicot-3.0.2.tar.gz";
+    sha256 = "1biia7nfqf7vaqq5gmykl4rwjyvrcwss6r2jdf0in5pvp2rnrj2w";
   };
 
   nativeBuildInputs = [ which ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
   };
 
 }

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -2,9 +2,9 @@
 
 let params =
   if stdenv.lib.versionAtLeast coq.coq-version "8.7" then {
-    version = "3.0.0";
-    uid = "37477";
-    sha256 = "1h05ji5cmyqyv2i1l83xgkm7vfvcnl8r1dzvbp5yncm1jr9kf6nn";
+    version = "3.1.0";
+    uid = "37901";
+    sha256 = "02szrgz9m0ac51la1lqpiv6i2g0zbgx9gz5rp0q1g00ajldyna5c";
   } else {
     version = "2.6.1";
     uid = "37454";
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
   };
 }

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -1,12 +1,24 @@
 { stdenv, fetchurl, which, coq, coquelicot, flocq, mathcomp
 , bignums ? null }:
 
+let params =
+  if stdenv.lib.versionAtLeast coq.coq-version "8.7" then {
+    version = "3.4.0";
+    uid = "37524";
+    sha256 = "023j9sd64brqvjdidqkn5m8d7a93zd9r86ggh573z9nkjm2m7vvg";
+  } else {
+    version = "3.3.0";
+    uid = "37077";
+    sha256 = "08fdcf3hbwqphglvwprvqzgkg0qbimpyhnqsgv3gac4y1ap0f903";
+  }
+; in
+
 stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-interval-3.3.0";
+  name = "coq${coq.coq-version}-interval-${params.version}";
 
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/37077/interval-3.3.0.tar.gz";
-    sha256 = "08fdcf3hbwqphglvwprvqzgkg0qbimpyhnqsgv3gac4y1ap0f903";
+    url = "https://gforge.inria.fr/frs/download.php/file/${params.uid}/interval-${params.version}.tar.gz";
+    inherit (params) sha256;
   };
 
   nativeBuildInputs = [ which ];
@@ -26,7 +38,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq ≥ 8.8

See release notes: <https://gforge.inria.fr/frs/?view=shownotes&group_id=3599&release_id=10502>, <https://gforge.inria.fr/frs/?view=shownotes&group_id=6316&release_id=10503>.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

