### PR TITLE
podman: install manpages

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, pkgconfig
 , buildGoPackage, gpgme, lvm2, btrfs-progs, libseccomp
+, go-md2man
 }:
 
 buildGoPackage rec {
@@ -15,9 +16,11 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/containers/libpod";
 
+  outputs = [ "bin" "out" "man" ];
+
   # Optimizations break compilation of libseccomp c bindings
   hardeningDisable = [ "fortify" ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig go-md2man ];
 
   buildInputs = [
     btrfs-progs libseccomp gpgme lvm2
@@ -26,11 +29,12 @@ buildGoPackage rec {
   buildPhase = ''
     pushd $NIX_BUILD_TOP/go/src/${goPackagePath}
     patchShebangs .
-    make binaries
+    make binaries docs
   '';
 
   installPhase = ''
     install -Dm555 bin/podman $bin/bin/podman
+    MANDIR=$man/share/man make install.man
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Manpages were missing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

