### PR TITLE
haskellPackages.insert-ordered-containers: fix test phase

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1186,6 +1186,7 @@ self: super: {
   # Jailbreak tasty < 1.2: https://github.com/phadej/tdigest/issues/30
   tdigest = doJailbreak super.tdigest; # until tdigest > 0.2.1
   these = doJailbreak super.these; # until these >= 0.7.6
+  insert-ordered-containers = appendPatch super.insert-ordered-containers ./patches/insert-ordered-containers-fix-test.patch;
 
   # These patches contain fixes for 8.6 that should be safe for
   # earlier versions, but we need the relaxed version bounds in GHC

--- a/pkgs/development/haskell-modules/patches/insert-ordered-containers-fix-test.patch
+++ b/pkgs/development/haskell-modules/patches/insert-ordered-containers-fix-test.patch
@@ -1,0 +1,25 @@
+diff --git a/insert-ordered-containers.cabal b/insert-ordered-containers.cabal
+index 0e8923a..bfbbec4 100644
+--- a/insert-ordered-containers.cabal
++++ b/insert-ordered-containers.cabal
+@@ -21,8 +21,8 @@ tested-with:
+   GHC==7.10.3,
+   GHC==8.0.1,
+   GHC==8.2.2,
+-  GHC==8.4.3,
+-  GHC==8.6.1
++  GHC==8.4.4,
++  GHC==8.6.3
+ 
+ extra-source-files:
+     CHANGELOG.md
+@@ -70,7 +70,7 @@ test-suite ins-ord-containers-tests
+     , unordered-containers
+     , base
+     , insert-ordered-containers
+-    , tasty             >= 0.10.1.2 && <1.2
++    , tasty             >= 0.10.1.2 && <1.3
+     , tasty-quickcheck  >= 0.8.3.2  && <0.11
+     , QuickCheck        >=2.7.6     && <2.13
+   default-language: Haskell2010
+


### PR DESCRIPTION
###### Motivation for this change
Fix build package haskellPackages.insert-ordered-containers
Used this commit https://github.com/phadej/insert-ordered-containers/commit/73fdf9c7a41ea7a02ee336cb01cb54f0ebc248f8
Fix issue https://github.com/NixOS/nixpkgs/issues/53067

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

