### PR TITLE
trilium: fix missing GSettings schemas

### DIFF
--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchurl, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem, gtk3, wrapGAppsHook }:
 
 let
   description = "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases.";
@@ -32,9 +32,10 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoPatchelfHook
     makeWrapper
+    wrapGAppsHook
   ];
 
-  buildInputs = atomEnv.packages;
+  buildInputs = [ atomEnv.packages gtk3 ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -48,10 +49,9 @@ in stdenv.mkDerivation rec {
     cp ${desktopItem}/share/applications/* $out/share/applications
   '';
 
-
-  # This "shouldn't" be needed, remove when possible :)
+  # LD_LIBRARY_PATH "shouldn't" be needed, remove when possible :)
   preFixup = ''
-    wrapProgram $out/bin/trilium --prefix LD_LIBRARY_PATH : "${atomEnv.libPath}"
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${atomEnv.libPath})
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

When launching Trilium via the .desktop file, such as by using `rofi`, a segfault occurs when attempting to add an image. To be more specific, when Trilium attempts to create a file chooser, it segfaults with the error:  *No GSettings schemas are installed on the system*

This error does not occur when Trilium is launched from a terminal, such as `termite`.

This change adds the GNOME and GTK gsettings schemas to the XDG_DATA_DIRS to avoid the aforementioned segfault.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~
   - [X] other Linux distributions (though .desktop file doesn't apply to other distros)
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
BEFORE:        613792592 
AFTER:        618009088
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

