### PR TITLE
cron: fix error when running crontab as sudo (issue #54827)

### DIFF
--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, sendmailPath ? "/usr/sbin/sendmail"}:
+{stdenv, fetchurl, vim, sendmailPath ? "/usr/sbin/sendmail"}:
 
 stdenv.mkDerivation {
   name = "cron-4.1";
@@ -24,6 +24,9 @@ stdenv.mkDerivation {
     cat >> pathnames.h <<__EOT__
     #undef _PATH_SENDMAIL
     #define _PATH_SENDMAIL "${sendmailPath}"
+
+    #undef _PATH_VI
+    #define _PATH_VI "${vim}/bin/vim"
 
     #undef _PATH_DEFPATH
     #define _PATH_DEFPATH "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/bin:/bin"


### PR DESCRIPTION
###### Motivation for this change
Issue #54827
Please backport this to 18.09 as well as it is breaking some workflow.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

