### PR TITLE
hepmc3: init at 3.1.0

### DIFF
--- a/pkgs/development/libraries/physics/hepmc3/default.nix
+++ b/pkgs/development/libraries/physics/hepmc3/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, cmake, coreutils, root }:
+
+stdenv.mkDerivation rec {
+  name = "hepmc3-${version}";
+  version = "3.1.0";
+
+  src = fetchurl {
+    url = "http://hepmc.web.cern.ch/hepmc/releases/HepMC3-${version}.tar.gz";
+    sha256 = "12kzdqdbq7md0nn58jvilhh00yddfir65f0q2026k0ym37bfwdyd";
+  };
+
+  buildInputs = [ cmake root ];
+
+  postInstall = ''
+    substituteInPlace "$out"/bin/HepMC3-config \
+      --replace 'greadlink' '${coreutils}/bin/readlink'
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "The HepMC package is an object oriented, C++ event record for High Energy Physics Monte Carlo generators and simulation";
+    license     = licenses.gpl3;
+    homepage    = http://hepmc.web.cern.ch/hepmc/;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22204,6 +22204,8 @@ in
 
   hepmc = callPackage ../development/libraries/physics/hepmc { };
 
+  hepmc3 = callPackage ../development/libraries/physics/hepmc3 { };
+
   herwig = callPackage ../development/libraries/physics/herwig { };
 
   lhapdf = callPackage ../development/libraries/physics/lhapdf { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

