### PR TITLE
pythonPackages.pyslurm: remove version check

### DIFF
--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -11,6 +11,13 @@ buildPythonPackage rec {
     sha256 = "1rymx106xa99wd4n44s7jw0w41spg39y1ji4fgn01yk7wjfrdrwg";
   };
 
+  patches = [
+    # pyslurm fails the build if the version is not within some hardcoded
+    # interval.  Because most often than not there is no real compatibility
+    # issue we are opting to disable the check.
+    ./remove_version_check.patch
+  ];
+
   buildInputs = [ cython slurm ];
   setupPyBuildFlags = [ "--slurm-lib=${slurm}/lib" "--slurm-inc=${slurm.dev}/include" ];
 

--- a/pkgs/development/python-modules/pyslurm/remove_version_check.patch
+++ b/pkgs/development/python-modules/pyslurm/remove_version_check.patch
@@ -1,0 +1,15 @@
+diff  a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -273,10 +273,9 @@ def build():
+     if (int(SLURM_INC_VER,16) < int(__min_slurm_hex_version__,16)) or \
+         (int(SLURM_INC_VER,16) > int(__max_slurm_hex_version__,16)):
+ 
+-        fatal("Build - Incorrect slurm version detected, require Slurm-%s to slurm-%s" % (
++        warn("Build - Incorrect slurm version detected, require Slurm-%s to slurm-%s" % (
+             inc_vers2str(__min_slurm_hex_version__), inc_vers2str(__max_slurm_hex_version__)
+         ))
+-        sys.exit(-1)
+ 
+     # Test for libslurm in lib64 and then lib
+     SLURM_LIB = check_libPath(SLURM_LIB)


### PR DESCRIPTION
###### Motivation for this change

`pythonPackages.pyslurm` has a check for the version of `slurm` to see if they are compatible. This prevents maintainers from bumping `slurm`.

If we look at a typical upstream version bump, it looks like:
https://github.com/PySlurm/pyslurm/commit/9477102dbcdd31d1fe674ff83b2131dccead7f9c
Nothing is changed other than the hardcoded max version. So, I think, we should take a more optimistic approach and make the check non-fatal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @markuskowa as slurm maintainer
cc @giovtorres as pyslurm upstream
this unblocks #55145