### PR TITLE
nixos/php: init new php module for command line usage

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -113,6 +113,7 @@
   ./programs/nm-applet.nix
   ./programs/npm.nix
   ./programs/oblogout.nix
+  ./programs/php.nix
   ./programs/plotinus.nix
   ./programs/qt5ct.nix
   ./programs/screen.nix

--- a/nixos/modules/programs/php.nix
+++ b/nixos/modules/programs/php.nix
@@ -1,0 +1,70 @@
+{ config, pkgs, lib, ... }:
+
+let
+
+  cfg = config.programs.php;
+
+  phpIni = pkgs.runCommand "php.ini" {
+    inherit (cfg) phpPackage phpOptions;
+    nixDefaults =
+      ''
+        ; Needed for PHP's mail() function.
+        sendmail_path = sendmail -t -i
+      '' + lib.optionalString (!isNull config.time.timeZone) ''
+        ; Apparently PHP doesn't use $TZ.
+        date.timezone = "${config.time.timeZone}"
+      '';
+    passAsFile = [ "nixDefaults" "phpOptions" ];
+  } ''
+    cat $phpPackage/etc/php.ini $nixDefaultsPath $phpOptionsPath > $out
+  '';
+
+  phpWrapper = pkgs.symlinkJoin {
+    name = "php";
+    paths = [ cfg.phpPackage ];
+    buildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/php --set PHPRC ${phpIni}
+    '';
+  };
+
+in
+{
+
+  # interface
+
+  options = {
+
+    programs.php = {
+
+      enable = lib.mkEnableOption "Enable PHP for the command line.";
+
+      phpPackage = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.php;
+        defaultText = "pkgs.php";
+        description = "Overridable attribute of the PHP package to use.";
+      };
+
+      phpOptions = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = ''
+          date.timezone = "CET";
+        '';
+        description = "Options appended to the PHP configuration file <filename>php.ini</filename>.";
+      };
+
+    };
+
+  };
+
+  # implementation
+
+  config = lib.mkIf cfg.enable {
+
+    environment.systemPackages = [ phpWrapper ];
+
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change
Currently no convenient way to set php.ini system wide while invoking php from the command line.

Example usage:
  programs.php.enable = true;
  programs.php.phpPackage = pkgs.php71;
  programs.php.phpOptions = ''
    extension=${pkgs.php71Packages.mailparse}/lib/php/extensions/mailparse.so
  '';

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

