### PR TITLE
tmsu: install manpage properly into man1 subdirectory

### DIFF
--- a/pkgs/tools/filesystems/tmsu/default.nix
+++ b/pkgs/tools/filesystems/tmsu/default.nix
@@ -44,11 +44,11 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/sbin
-    mkdir -p $out/share/man
+    mkdir -p $out/share/man/man1
     mkdir -p $out/share/zsh/site-functions
     make install INSTALL_DIR=$out/bin \
                  MOUNT_INSTALL_DIR=$out/sbin \
-                 MAN_INSTALL_DIR=$out/share/man \
+                 MAN_INSTALL_DIR=$out/share/man/man1 \
                  ZSH_COMP_INSTALL_DIR=$out/share/zsh/site-functions
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Without this change and MANPATH="$HOME/.nix-profile/share/man:", man
does not find tmsu manpage, which is installed as share/man/tmsu.1, not
share/man/man1/tmsu.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [+] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [+] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [+] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [+] Assured whether relevant documentation is up to date
- [+] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---