### PR TITLE
desktop-files-utils: add setupHook to remove mimeinfo.cache

### DIFF
--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -49,10 +49,6 @@ stdenv.mkDerivation rec {
     patchShebangs meson_post_install.py
   '';
 
-  postInstall = ''
-    rm $out/share/applications/mimeinfo.cache
-  '';
-
   meta = {
     homepage = https://fontmanager.github.io/;
     description = "Simple font management for GTK+ desktop environments";

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -46,10 +46,6 @@ in stdenv.mkDerivation rec {
     "-Dsystemdunitdir=lib/systemd/system"
   ];
 
-  postInstall = ''
-    rm $out/share/applications/mimeinfo.cache
-  '';
-
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;

--- a/pkgs/tools/misc/desktop-file-utils/default.nix
+++ b/pkgs/tools/misc/desktop-file-utils/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib libintl ];
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     homepage = http://www.freedesktop.org/wiki/Software/desktop-file-utils;
     description = "Command line utilities for working with .desktop files";

--- a/pkgs/tools/misc/desktop-file-utils/setup-hook.sh
+++ b/pkgs/tools/misc/desktop-file-utils/setup-hook.sh
@@ -1,0 +1,6 @@
+# Remove mimeinfo cache
+mimeinfoPreFixupPhase() {
+    rm -f $out/share/applications/mimeinfo.cache
+}
+
+preFixupPhases="$preFixupPhases mimeinfoPreFixupPhase"


### PR DESCRIPTION
Post-Installation scripts are running `update-desktop-database -q`
creating these files which obviously results in a lot of collisions.

Much better solution than eventually noticing their existence and
removing them in `postInstall`.

###### Motivation for this change

Probably been mentioned more than a few times that we should just
go ahead and do this.

Closes https://github.com/NixOS/nixpkgs/issues/48295


###### Things done

Built `file-roller` and the `mimeinfo.cache` doesn't exist anymore.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

