### PR TITLE
pythonPackages.requests: update base16 hash to more conventional base32 hash

### DIFF
--- a/pkgs/development/python-modules/requests-kerberos/default.nix
+++ b/pkgs/development/python-modules/requests-kerberos/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "An authentication handler for using Kerberos with Python Requests.";
-    homepage    = "https://github.com/requests/requests-kerberos";
+    homepage    = https://github.com/requests/requests-kerberos;
     license     = licenses.isc;
     maintainers = with maintainers; [ catern ];
   };

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263";
+    sha256 = "0qzj6cgv3k9wyj7wlxgz7xq0cfg4jbbkfm24pp8dnhczwl31527a";
   };
 
   nativeBuildInputs = [ pytest ];


### PR DESCRIPTION
nix-hash --type sha256 --to-base32 ea881... converts to this shorter hash, which
is what is printed on prefetch-url validations as well. This does not cause a
package rebuild or hash change.

###### Motivation for this change
Just doing some standardization and cleanup. Also removed unnecessary quotes on a homepage url.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

