### PR TITLE
nixos/bamf: generate bamf-2.index

### DIFF
--- a/nixos/modules/services/desktops/bamf.nix
+++ b/nixos/modules/services/desktops/bamf.nix
@@ -19,5 +19,12 @@ with lib;
     services.dbus.packages = [ pkgs.bamf ];
 
     systemd.packages = [ pkgs.bamf ];
+
+    environment.extraSetup = ''
+      if [ -w $out/share/applications ]; then
+          echo "Rebuilding bamf-2.index..."
+          ${pkgs.bamf.update-index} $out/share/applications > $out/share/applications/bamf-2.index
+      fi
+    '';
   };
 }

--- a/pkgs/development/libraries/bamf/bamf-index.patch
+++ b/pkgs/development/libraries/bamf/bamf-index.patch
@@ -1,0 +1,13 @@
+diff --git a/src/bamf-matcher.c b/src/bamf-matcher.c
+index 52dbd3a..b7167a4 100644
+--- a/src/bamf-matcher.c
++++ b/src/bamf-matcher.c
+@@ -1405,7 +1405,7 @@ fill_desktop_file_table (BamfMatcher * self,
+ 
+       bamf_matcher_add_new_monitored_directory (self, directory);
+ 
+-      bamf_file = g_build_filename (directory, BAMF_INDEX_NAME, NULL);
++      bamf_file = g_build_filename ("/run/current-system/sw/share/applications", BAMF_INDEX_NAME, NULL);
+ 
+       if (g_file_test (bamf_file, G_FILE_TEST_EXISTS))
+         {

--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -52,6 +52,11 @@ stdenv.mkDerivation rec {
 
   passthru.update-index = update-bamf-index;
 
+  patches = [
+    # Hardcode path to index as it will never be it XDG_DATA_DIRS
+    ./bamf-index.patch
+  ];
+
   # Fix hard-coded path
   # https://bugs.launchpad.net/bamf/+bug/1780557
   postPatch = ''

--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -1,6 +1,16 @@
 { stdenv, autoconf, automake, libtool, gnome3, which, fetchgit, libgtop, libwnck3, glib, vala, pkgconfig
 , libstartup_notification, gobject-introspection, gtk-doc, docbook_xsl
-, xorgserver, dbus, python2 }:
+, xorgserver, dbus, python2, perl, substituteAll }:
+
+let
+
+  update-bamf-index = substituteAll {
+    src = ./update-bamf-index.pl;
+    inherit perl;
+    isExecutable = true;
+  };
+
+in
 
 stdenv.mkDerivation rec {
   name = "bamf-${version}";
@@ -39,6 +49,8 @@ stdenv.mkDerivation rec {
     libstartup_notification
     libwnck3
   ];
+
+  passthru.update-index = update-bamf-index;
 
   # Fix hard-coded path
   # https://bugs.launchpad.net/bamf/+bug/1780557

--- a/pkgs/development/libraries/bamf/update-bamf-index.pl
+++ b/pkgs/development/libraries/bamf/update-bamf-index.pl
@@ -1,0 +1,85 @@
+#!@perl@/bin/perl
+
+# Taken from ubuntu packaging
+# See: https://git.launchpad.net/bamf/tree/debian/bamfdaemon.postinst
+#
+# Take note that this certainly isn't a robust solution.
+#
+# However the elementary project will eventually remove
+# its depdenence on libbamf and libwnck and migrate to
+# becoming compatable with Wayland.
+#
+# See:
+#
+# - https://github.com/elementary/gala/issues/68
+# - https://github.com/elementary/gala/issues/70
+# - https://github.com/elementary/gala/issues/297
+
+use File::Find;
+my $dir_name;
+
+sub strip_exec
+{
+    my $f = $_;
+    return unless $f =~ /\.desktop$/;
+    return unless ("$File::Find::dir" eq "$dir_name");
+    my @lines;
+    open F, $f;
+    @lines = <F>;
+    close F;
+    my $in_desktop_entry = 0;
+    my $exec = "";
+    my $class = "";
+    my $no_display = "false";
+    my $only_show_in = "";
+
+    foreach (@lines)
+    {
+        if (/^\[\s*(.+)\s*\]/)
+        {
+            $was_in_desktop = $in_desktop_entry;
+            $in_desktop_entry = ($1 eq "Desktop Entry");
+
+            if ($was_in_desktop and !$in_desktop_entry)
+            {
+                last;
+            }
+        }
+
+        if ($in_desktop_entry)
+        {
+            if (/^Exec=(.+)$/)
+            {
+                $exec = $1;
+                $exec =~ s/^\s+|\s+$//g;
+            }
+
+            if (/^NoDisplay=(.+)$/)
+            {
+                $no_display = $1;
+                $no_display =~ s/^\s+|\s+$//g;
+            }
+
+            if (/^OnlyShowIn=(.+)$/)
+            {
+                $only_show_in = $1;
+                $only_show_in =~ s/^\s+|\s+$//g;
+            }
+
+            if (/^StartupWMClass=(.+)$/)
+            {
+                $class = $1;
+                $class =~ s/^\s+|\s+$//g;
+            }
+        }
+    }
+
+    if ($exec ne "")
+    {
+        print "$f\t$exec\t$class\t$only_show_in\t$no_display\n";
+    }
+};
+
+$dir_name = $ARGV[-1];
+$dir_name = $1 if($dir_name=~/(.*)\/$/);
+find(\&strip_exec, $dir_name);


### PR DESCRIPTION
Bamf wants this index of certain desktop file keys
so it can match application windows to desktop files.

I'm guessing it's obviously faster than enumerating all
the directories for them.

See:  https://git.launchpad.net/bamf/tree/src/bamf-matcher.c

###### Motivation for this change
Recalled that I probably should be doing this.
~However I think that the index won't have any data
from programs installed with `nix-env`.~

~Not sure what I'd need to do to fix this (activation script?).~


###### Things done

- [x] Built Pantheon in a vm and checked that the system result had the index

###### I probably need to check if bamfdaemon is actually using the index and this isn't naive.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

