### PR TITLE
textadept: 9.3 -> 10.2

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -1,139 +1,29 @@
-{ stdenv, fetchhg, fetchurl, fetchzip, gtk2, glib, pkgconfig, unzip, ncurses, zip }:
-let
-  # Textadept requires a whole bunch of external dependencies.
-  # The build system expects to be able to download them with wget.
-  # This expression gets Nix to fetch them instead.
-
-
-  cached_url = url: sha256: fetchurl {
-    inherit sha256 url;
-  };
-
-  get_url = url: sha256: let
-    store_path = cached_url url sha256;
-  in ''
-    local_path=$(basename ${store_path} | sed -e 's@^[0-9a-z]\+-@@')
-
-    # Copy the file from the Nix store and remove the hash part.
-    cp ${store_path} $local_path
-
-    # Update its access and modified times.
-    touch $local_path
-  '';
-
-  cached_url_zip = url: sha256: fetchzip {
-    inherit sha256 url;
-  };
-
-  get_url_zip = url: sha256: let
-    store_path = cached_url_zip url sha256;
-  in ''
-    (
-      build_dir=$PWD
-      cd $TMPDIR
-
-      local_path=$(basename ${url} .zip)
-
-      cp -r ${store_path} $local_path
-      chmod u+rwX -R $local_path
-      zip -r $build_dir/$local_path.zip $local_path
-      touch $local_path
-    )
-  '';
-
-
-  # These lists are taken from the Makefile.
-  scintilla_tgz  = "scintilla373.tgz";
-  tre_zip        = "cdce45e8dd7a3b36954022b4a4d3570e1ac5a4f8.zip";
-  scinterm_zip   = "scinterm_1.8.zip";
-  scintillua_zip = "33298b6cbce3.zip";
-  lua_tgz        = "lua-5.3.4.tar.gz";
-  lpeg_tgz       = "lpeg-1.0.0.tar.gz";
-  lfs_zip        = "v_1_6_3.zip";
-  lspawn_zip     = "lspawn_1.5.zip";
-  luajit_tgz     = "LuaJIT-2.0.3.tar.gz";
-  libluajit_tgz  = "libluajit_2.0.3.x86_64.tgz";
-  gtdialog_zip   = "gtdialog_1.3.zip";
-  cdk_tgz        = "cdk-5.0-20150928.tgz";
-  termkey_tgz    = "libtermkey-0.17.tar.gz";
-
-  scinterm_url   = "http://foicica.com/scinterm/download/" + scinterm_zip;
-  tre_url        = "https://github.com/laurikari/tre/archive/" + tre_zip;
-  #scintillua_url = "http://foicica.com/scintillua/download/" + scintillua_zip;
-  scintillua_url = "http://foicica.com/hg/scintillua/archive/" + scintillua_zip;
-  gtdialog_url   = "http://foicica.com/gtdialog/download/" + gtdialog_zip;
-  lspawn_url     = "http://foicica.com/lspawn/download/" + lspawn_zip;
-
-  scintilla_url  = "mirror://sourceforge/scintilla/" + scintilla_tgz;
-  lua_url        = "http://www.lua.org/ftp/" + lua_tgz;
-  lpeg_url       = "http://www.inf.puc-rio.br/~roberto/lpeg/" + lpeg_tgz;
-  lfs_url        = "https://github.com/keplerproject/luafilesystem/archive/" + lfs_zip;
-  luajit_url     = "http://luajit.org/download/" + luajit_tgz;
-  libluajit_url  = "http://foicica.com/textadept/download/" + libluajit_tgz;
-  cdk_url        = "http://invisible-mirror.net/archives/cdk/" + cdk_tgz;
-  bombay_url     = "http://foicica.com/hg/bombay/archive/tip.zip";
-  termkey_url    = "http://www.leonerd.org.uk/code/libtermkey/" + termkey_tgz;
-
-
-  get_scintilla   = get_url scintilla_url   "0rkczxzj6bqxks4jcbxbyrarjhfjh95nwxxiqprfid1kaamgkfm2";
-  get_tre         = get_url tre_url         "0mw8npwk5nnhc33352j4akannhpx77kqvfam8jdq1n4yf8js1gi7";
-  get_scinterm    = get_url scinterm_url    "02ax6cjpxylfz7iqp1cjmsl323in066a38yklmsyzdl3w7761nxi";
-  get_scintillua  = get_url scintillua_url  "1kx113dpjby1p9jcsqlnlzwj01z94f9szw4b38077qav3bj4lk6g";
-  get_lua         = get_url lua_url         "0320a8dg3aci4hxla380dx1ifkw8gj4gbw5c4dz41g1kh98sm0gn";
-  get_lpeg        = get_url lpeg_url        "13mz18s359wlkwm9d9iqlyyrrwjc6iqfpa99ai0icam2b3khl68h";
-  get_lfs         = get_url_zip lfs_url     "1hxcnqj53540ysyw8fzax7f09pl98b8f55s712gsglcdxp2g2pri";
-  get_lspawn      = get_url lspawn_url      "09c6v9irblay2kv1n7i59pyj9g4xb43c6rfa7ba5m353lymcwwqi";
-  get_luajit      = get_url luajit_url      "0ydxpqkmsn2c341j4r2v6r5r0ig3kbwv3i9jran3iv81s6r6rgjm";
-  get_libluajit   = get_url libluajit_url   "1nhvcdjpqrhd5qbihdm3bxpw84irfvnw2vmfqnsy253ay3dxzrgy";
-  get_gtdialog    = get_url gtdialog_url    "0nvcldyhj8abr8jny9pbyfjwg8qfp9f2h508vjmrvr5c5fqdbbm0";
-  get_cdk         = get_url cdk_url         "0j74l874y33i26y5kjg3pf1vswyjif8k93pqhi0iqykpbxfsg382";
-  get_bombay      = get_url_zip bombay_url  "0illabngrrxidkprgz268wgjqknrds34nhm6hav95xc1nmsdr6jj"
-    + "mv tip.zip bombay.zip\n";
-  get_termkey     = get_url termkey_url     "12gkrv1ldwk945qbpprnyawh0jz7rmqh18fyndbxiajyxmj97538";
-
-
-  get_deps = get_scintilla
-    + get_tre
-    + get_scinterm
-    + get_scintillua
-    + get_lua
-    + get_lpeg
-    + get_lfs
-    + get_lspawn
-    + get_luajit
-    + get_libluajit
-    + get_gtdialog
-    + get_cdk
-    + get_bombay
-    + get_termkey;
-in
+{ lib, stdenv, fetchhg, fetchurl, gtk2, glib, pkgconfig, unzip, ncurses, zip }:
 stdenv.mkDerivation rec {
-  version = "9.3";
+  version = "10.2";
   name = "textadept-${version}";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    gtk2 glib unzip ncurses zip
+    gtk2 ncurses glib unzip zip
   ];
 
   src = fetchhg {
     url = http://foicica.com/hg/textadept;
     rev = "textadept_${version}";
-    sha256 = "18x79pazm86agn1khdxfnf87la6kli3xasi7dcjx7l6yyz19y14d";
+    sha256 = "0fai8xqddkkprmbf0cf8wwgv7ccfdb1iyim30nppm2m16whkc8fl";
   };
 
-  preConfigure = ''
+  preConfigure =
+    lib.concatStringsSep "\n" (lib.mapAttrsToList (name: params:
+      "ln -s ${fetchurl params} $PWD/src/${name}"
+    ) (import ./deps.nix)) + ''
+
+    # work around trying to download stuff in `make deps`
+    function wget() { true; }
+    export -f wget
+
     cd src
-
-    # Make a dummy wget.
-    mkdir wget
-    echo '#! ${stdenv.shell}' > wget/wget
-    chmod a+x wget/wget
-    export PATH="$PATH:$PWD/wget"
-
-    ${get_deps}
-
-    # Let the build system do whatever setup it needs to do with these files.
     make deps
   '';
 

--- a/pkgs/applications/editors/textadept/deps.nix
+++ b/pkgs/applications/editors/textadept/deps.nix
@@ -1,0 +1,42 @@
+{
+    "542782a4df7d.zip" = {
+      url = "http://foicica.com/hg/scintilla/archive/542782a4df7d.zip";
+      sha256 = "1qwxxcj86z9y7ij05j60lcp1awy2c9ck0vnn9z6c732sqjza0zx5";
+    };
+    "lua-5.3.5.tar.gz" = {
+      url = "http://www.lua.org/ftp/lua-5.3.5.tar.gz";
+      sha256 = "1b2qn2rv96nmbm6zab4l877bd4zq7wpwm8drwjiy2ih4jqzysbhc";
+    };
+    "lpeg-1.0.0.tar.gz" = {
+      url = "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.0.tar.gz";
+      sha256 = "13mz18s359wlkwm9d9iqlyyrrwjc6iqfpa99ai0icam2b3khl68h";
+    };
+    "v_1_6_3.zip" = {
+      url = "https://github.com/keplerproject/luafilesystem/archive/v_1_6_3.zip";
+      sha256 = "044s125im2irb4i42nnc5shvjj25fp4vsdbzd6b0va5igj0f6h4y";
+    };
+    "6435a42450c7.zip" = {
+      url = "http://foicica.com/hg/gtdialog/archive/6435a42450c7.zip";
+      sha256 = "1vxn89sif3qccksb6x5iprysqhjg69g7nyxlgrg31q397dmsg1ym";
+    };
+    "cdk-5.0-20150928.tgz" = {
+      url = "http://invisible-mirror.net/archives/cdk/cdk-5.0-20150928.tgz";
+      sha256 = "0j74l874y33i26y5kjg3pf1vswyjif8k93pqhi0iqykpbxfsg382";
+    };
+    "libtermkey-0.20.tar.gz" = {
+      url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.20.tar.gz";
+      sha256 = "1xfj6lchhfljmbcl6dz8dpakppyy13nbl4ykxiv5x4dr9b4qf3bc";
+    };
+    "pdcurs36.zip" = {
+      url = "http://prdownloads.sourceforge.net/pdcurses/pdcurs36.zip";
+      sha256 = "0y91zpygrxms7d1l5ksrz42bkvq8jd2xqlj5j7wgyxcl58chcw9b";
+    };
+    "bombay.zip" = {
+      url = "http://foicica.com/hg/bombay/archive/b25520cc76bb.zip";
+      sha256 = "07spq7jmkfyq20gv67yffara3ln3ns2xi0k02m2mxdms3xm1q36h";
+    };
+    "cloc-1.60.pl" = {
+      url = "http://prdownloads.sourceforge.net/cloc/cloc-1.60.pl";
+      sha256 = "0p504bi19va3dh274v7lb7giqrydwa5yyry60f7jpz84y6z71a2a";
+    };
+}


### PR DESCRIPTION
###### Motivation for this change
Package was out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

