### PR TITLE
ocamlPackages.ocaml-migrate-parsetree: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, result }:
+{ stdenv, fetchFromGitHub, buildDunePackage, result, ppx_derivers }:
 
 buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
-   version = "1.1.0";
+   version = "1.2.0";
 
    src = fetchFromGitHub {
      owner = "ocaml-ppx";
      repo = pname;
      rev = "v${version}";
-     sha256 = "1d2n349d1cqm3dr09mwy5m9rfd4bkkqvri5i94wknpsrr35vnrr1";
+     sha256 = "16kas19iwm4afijv3yxd250s08absabmdcb4yj57wc8r4fmzv5dm";
    };
 
-   propagatedBuildInputs = [ result ];
+   propagatedBuildInputs = [ ppx_derivers result ];
 
    meta = {
      description = "Convert OCaml parsetrees between different major versions";


### PR DESCRIPTION
###### Motivation for this change

Maintenance update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

