### PR TITLE
mkdocs-exclude: Init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/mkdocs-exclude/default.nix
+++ b/pkgs/development/python-modules/mkdocs-exclude/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, setuptools, mkdocs }:
+
+buildPythonPackage rec {
+  pname = "mkdocs-exclude";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12bjkgmhrd2c7hjszrvw6yp0p4b8y7sb3cadg23p0g60p598xpxp";
+  };
+  nativeBuildInputs = [ setuptools ];
+  propagatedBuildInputs = [ mkdocs ];
+
+  meta = with lib; {
+    description = "A plugin for mkdocs to exclude arbitrary paths and files";
+    homepage = https://github.com/apenwarr/mkdocs-exclude;
+    license = licenses.asl20;
+    maintainers = [ maintainers.spacefrogg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -490,6 +490,8 @@ in {
 
   matchpy = callPackage ../development/python-modules/matchpy { };
 
+  mkdocs-exclude = callPackage ../development/python-modules/mkdocs-exclude { };
+
   monty = callPackage ../development/python-modules/monty { };
 
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;


### PR DESCRIPTION
###### Motivation for this change

Adds the mkdocs-exclude plugin, a plugin for, well, mkdocs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

