### PR TITLE
dirvish: init at 1.2.1 

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -541,6 +541,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "OpenSSL License";
   };
 
+  osl2 = spdx {
+    spdxId = "OSL-2.0";
+    fullName = "Open Software License 2.0";
+  };
+
   osl21 = spdx {
     spdxId = "OSL-2.1";
     fullName = "Open Software License 2.1";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4703,6 +4703,11 @@
     email = "windenntw@gmail.com";
     name = "Antonio Vargas Gonzalez";
   };
+  winpat = {
+    email = "patrickwinter@posteo.ch";
+    github = "winpat";
+    name = "Patrick Winter";
+  };
   wizeman = {
     email = "rcorreia@wizy.org";
     github = "wizeman";

--- a/pkgs/tools/backup/dirvish/default.nix
+++ b/pkgs/tools/backup/dirvish/default.nix
@@ -1,0 +1,61 @@
+{ fetchurl, stdenv, makeWrapper, perl, rsync, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "dirvish-1.2.1";
+  src = fetchurl {
+    url = "http://dirvish.org/${name}.tgz";
+    sha256 = "6b7f29c3541448db3d317607bda3eb9bac9fb3c51f970611ffe27e9d63507dcd";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ perl ] ++ (with perlPackages; [ GetoptLong TimeParseDate TimePeriod ]);
+
+  executables = [ "dirvish" "dirvish-runall" "dirvish-expire" "dirvish-locate" ];
+  manpages = [ "dirvish.8" "dirvish-runall.8" "dirvish-expire.8" "dirvish-locate.8" "dirvish.conf.5" ];
+
+  buildPhase = ''
+    HEADER="#!${perl}/bin/perl
+
+    \$CONFDIR = \"/etc/dirvish\";
+
+    "
+
+    for executable in $executables; do
+      (
+        echo "$HEADER"
+        cat $executable.pl loadconfig.pl
+      ) > $executable
+      chmod +x $executable
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp --target-directory=$out/bin $executables
+
+    for manpage in $manpages; do
+      if [[ $manpage =~ \.([[:digit:]]+)$ ]]; then
+        section=''${BASH_REMATCH[1]}
+        mkdir -p $out/man/man$section
+        cp --target-directory=$out/man/man$section $manpage
+      else
+        echo "Couldn't determine man page section by filename"
+        exit 1
+      fi
+    done
+  '';
+
+  postFixup = ''
+    for executable in $executables; do
+      wrapProgram $out/bin/$executable \
+        --set PERL5LIB "$PERL5LIB"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Dirvish is a fast, disk based, rotating network backup system";
+    homepage = http://dirvish.org/;
+    license = stdenv.lib.licenses.osl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/backup/dirvish/default.nix
+++ b/pkgs/tools/backup/dirvish/default.nix
@@ -57,5 +57,6 @@ stdenv.mkDerivation rec {
     homepage = http://dirvish.org/;
     license = stdenv.lib.licenses.osl2;
     platforms = platforms.linux;
+    maintainers = [ maintainers.winpat ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2276,6 +2276,8 @@ with pkgs;
 
   dirmngr = callPackage ../tools/security/dirmngr { };
 
+  dirvish  = callPackage ../tools/backup/dirvish { };
+
   disper = callPackage ../tools/misc/disper { };
 
   dleyna-connector-dbus = callPackage ../development/libraries/dleyna-connector-dbus { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16847,6 +16847,7 @@ let
     meta = {
       description = "A Perl module to deal with time periods";
       license = stdenv.lib.licenses.gpl1;
+      maintainers = [ maintainers.winpat ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16838,6 +16838,18 @@ let
     };
   };
 
+  TimePeriod = buildPerlPackage {
+    name = "Time-Period-1.25";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PB/PBOYD/Time-Period-1.25.tar.gz";
+      sha256 = "d07fa580529beac6a9c8274c6bf220b4c3aade685df65c1669d53339bf6ef1e8";
+    };
+    meta = {
+      description = "A Perl module to deal with time periods";
+      license = stdenv.lib.licenses.gpl1;
+    };
+  };
+
   Tk = buildPerlPackage rec {
     name = "Tk-804.034";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Dirvish is a battle proof wrapper around rsync.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

