### PR TITLE
tuxtyping: init at 1.8.3

### DIFF
--- a/pkgs/games/t4kcommon/default.nix
+++ b/pkgs/games/t4kcommon/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, fetchurl, cmake, pkgconfig, SDL, SDL_image, SDL_mixer, SDL_net, SDL_ttf, libpng, librsvg, libxml2 }:
+
+stdenv.mkDerivation rec {
+  version = "0.1.1";
+  pname = "t4kcommon";
+
+  src = fetchFromGitHub {
+    owner = "tux4kids";
+    repo = "t4kcommon";
+    rev = "upstream/${version}";
+    sha256 = "13q02xpmps9qg8zrzzy2gzv4a6afgi28lxk4z242j780v0gphchp";
+  };
+
+  patches = [
+    # patch from debian to support libpng16 instead of libpng12
+    (fetchurl {
+      url = "https://salsa.debian.org/tux4kids-pkg-team/t4kcommon/raw/f7073fa384f5a725139f54844e59b57338b69dc7/debian/patches/libpng16.patch";
+      sha256 = "1lcpkdy5gvxgljg1vkrxych74amq0gramb1snj2831dam48is054";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ SDL SDL_image SDL_mixer SDL_net SDL_ttf libpng librsvg libxml2 ];
+
+  meta = with stdenv.lib; {
+    description = "A library of code shared between tuxmath and tuxtype.";
+    homepage = https://github.com/tux4kids/t4kcommon;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.aanderse ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/tuxtype/default.nix
+++ b/pkgs/games/tuxtype/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, pkgconfig, librsvg, SDL, SDL_image, SDL_mixer, SDL_ttf }:
+
+stdenv.mkDerivation rec {
+  version = "1.8.3";
+  name = "tuxtype-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/tux4kids/tuxtype/archive/upstream/${version}.tar.gz";
+    sha256 = "0cv935ir14cd2c8bgsxxpi6id04f61170gslakmwhxn6r3pbw0lp";
+  };
+
+  patchPhase = ''
+    patchShebangs data/scripts/sed-linux.sh
+    patchShebangs data/themes/asturian/scripts/sed-linux.sh
+    patchShebangs data/themes/greek/scripts/sed-linux.sh
+    patchShebangs data/themes/hungarian/scripts/sed-linux.sh
+
+    substituteInPlace Makefile.am \
+      --replace "\$(MKDIR_P) -m 2755 " "\$(MKDIR_P) -m 755 " \
+      --replace "chown root:games \$(DESTDIR)\$(pkglocalstatedir)/words" " "
+
+    substituteInPlace Makefile.in \
+      --replace "\$(MKDIR_P) -m 2755 " "\$(MKDIR_P) -m 755 " \
+      --replace "chown root:games \$(DESTDIR)\$(pkglocalstatedir)/words" " "
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ librsvg SDL SDL_image SDL_mixer SDL_ttf ];
+
+  configureFlags = [ "--without-sdlpango" ];
+
+  meta = with stdenv.lib; {
+    description = "An Educational Typing Tutor Game Starring Tux, the Linux Penguin";
+    homepage = https://github.com/tux4kids/tuxtype;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.aanderse ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/tuxtype/default.nix
+++ b/pkgs/games/tuxtype/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, librsvg, SDL, SDL_image, SDL_mixer, SDL_ttf }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, librsvg, libxml2, SDL, SDL_image, SDL_mixer, SDL_net, SDL_ttf, t4kcommon }:
 
 stdenv.mkDerivation rec {
   version = "1.8.3";
-  name = "tuxtype-${version}";
+  pname = "tuxtype";
 
-  src = fetchurl {
-    url = "https://github.com/tux4kids/tuxtype/archive/upstream/${version}.tar.gz";
-    sha256 = "0cv935ir14cd2c8bgsxxpi6id04f61170gslakmwhxn6r3pbw0lp";
+  src = fetchFromGitHub {
+    owner = "tux4kids";
+    repo = "tuxtype";
+    rev = "upstream/${version}";
+    sha256 = "1i33rhi9gpzfml4hd73s18h6p2s8zcr26va2vwf2pqqd9fhdwpsg";
   };
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs data/scripts/sed-linux.sh
     patchShebangs data/themes/asturian/scripts/sed-linux.sh
     patchShebangs data/themes/greek/scripts/sed-linux.sh
@@ -19,13 +21,15 @@ stdenv.mkDerivation rec {
       --replace "\$(MKDIR_P) -m 2755 " "\$(MKDIR_P) -m 755 " \
       --replace "chown root:games \$(DESTDIR)\$(pkglocalstatedir)/words" " "
 
-    substituteInPlace Makefile.in \
-      --replace "\$(MKDIR_P) -m 2755 " "\$(MKDIR_P) -m 755 " \
-      --replace "chown root:games \$(DESTDIR)\$(pkglocalstatedir)/words" " "
+    # required until the following has been merged:
+    # https://salsa.debian.org/tux4kids-pkg-team/tuxtype/merge_requests/1
+    substituteInPlace configure.ac \
+      --replace 'CFLAGS="$CFLAGS $SDL_IMAGE"' 'CFLAGS="$CFLAGS $SDL_IMAGE_CFLAGS"' \
+      --replace 'PKG_CHECK_MODULES([SDL_ttf],' 'PKG_CHECK_MODULES([SDL_TTF],'
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ librsvg SDL SDL_image SDL_mixer SDL_ttf ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ librsvg libxml2 SDL SDL_image SDL_mixer SDL_net SDL_ttf t4kcommon ];
 
   configureFlags = [ "--without-sdlpango" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21099,6 +21099,8 @@ in
 
   synthv1 = callPackage ../applications/audio/synthv1 { };
 
+  t4kcommon = callPackage ../games/t4kcommon { };
+
   tcl2048 = callPackage ../games/tcl2048 { };
 
   the-powder-toy = callPackage ../games/the-powder-toy {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21133,6 +21133,8 @@ in
 
   tuxpaint = callPackage ../games/tuxpaint { };
 
+  tuxtype = callPackage ../games/tuxtype { };
+
   speed_dreams = callPackage ../games/speed-dreams {
     # Torcs wants to make shared libraries linked with plib libraries (it provides static).
     # i686 is the only platform I know than can do that linking without plib built with -fPIC


### PR DESCRIPTION
###### Motivation for this change
I have a 5 year old. So why not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

