### PR TITLE
pythonPackages.testpath: build from src instead of pre-built binary

### DIFF
--- a/pkgs/development/python-modules/testpath/default.nix
+++ b/pkgs/development/python-modules/testpath/default.nix
@@ -1,17 +1,21 @@
 { stdenv
+, lib
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
+, pathlib2
 }:
 
 buildPythonPackage rec {
   pname = "testpath";
   version = "0.4.2";
-  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
-    sha256 = "46c89ebb683f473ffe2aab0ed9f12581d4d078308a3cb3765d79c6b2317b0109";
+    inherit pname version;
+    sha256 = "b694b3d9288dbd81685c5d2e7140b81365d46c29f5db4bc659de5aa6b98780f8";
   };
+
+  propagatedBuildInputs = lib.optional (pythonOlder "3.4") pathlib2;
 
   meta = with stdenv.lib; {
     description = "Test utilities for code working with files and commands";


### PR DESCRIPTION
In older releases of testpath, pypi only had a pre-compiled binary wheel;
however, newer releases have a tar.gz src file that we can use to build and test
this ourselves.

###### Motivation for this change
Improve general hygiene and purity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

