### PR TITLE
Add myself as maintainer to several packages

### DIFF
--- a/pkgs/applications/editors/texmaker/default.nix
+++ b/pkgs/applications/editors/texmaker/default.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.xm1math.net/texmaker/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ cfouche ];
+    maintainers = with maintainers; [ cfouche markuskowa ];
   };
 }

--- a/pkgs/applications/misc/welle-io/default.nix
+++ b/pkgs/applications/misc/welle-io/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "A DAB/DAB+ Software Radio";
     homepage = https://www.welle.io/;
-    maintainers = with maintainers; [ ck3d ];
+    maintainers = with maintainers; [ ck3d markuskowa ];
     license = licenses.gpl2;
     platforms = with platforms; [ "x86_64-linux" "i686-linux" ] ++ darwin;
   };

--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     homepage = http://libre.tibirna.org/projects/qgit/wiki/QGit;
     description = "Graphical front-end to Git";
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg markuskowa ];
     inherit (qtbase.meta) platforms;
   };
 }

--- a/pkgs/tools/misc/snapper/default.nix
+++ b/pkgs/tools/misc/snapper/default.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation rec {
     homepage = http://snapper.io;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ tstrobel ];
+    maintainers = with maintainers; [ tstrobel markuskowa ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Those are programs I use regularly and I want get notified by r-ryantm when a new update comes in (also nice to keep an overview on repology).

###### Things done

* snapper
* qgit
* texmaker
* welle-io

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @ck3d @peterhoeg @cfouche @tstrobel
---

