### PR TITLE
nix-script: init at 2015-09-22

### DIFF
--- a/pkgs/tools/nix/nix-script/default.nix
+++ b/pkgs/tools/nix/nix-script/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, haskellPackages, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nix-script-${version}";
+  version = "2015-09-22";
+
+  src  = fetchFromGitHub {
+    owner  = "bennofs";
+    repo   = "nix-script";
+    rev    = "83064dc557b642f6748d4f2372b2c88b2a82c4e7";
+    sha256 = "0iwclyd2zz8lv012yghfr4696kdnsq6xvc91wv00jpwk2c09xl7a";
+  };
+
+  buildInputs  = [
+    (haskellPackages.ghcWithPackages (hs: with hs; [ posix-escape ]))
+  ];
+
+  phases = [ "buildPhase" "installPhase" "fixupPhase" ];
+  buildPhase = ''
+    mkdir -p $out/bin
+    ghc -O2 $src/nix-script.hs -o $out/bin/nix-script -odir . -hidir .
+  '';
+  installPhase = ''
+    ln -s $out/bin/nix-script $out/bin/nix-scripti
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A shebang for running inside nix-shell.";
+    homepage    = https://github.com/bennofs/nix-script;
+    license     = licenses.bsd3;
+    maintainers = with maintainers; [ bennofs rnhmjoj ];
+    platforms   = haskellPackages.ghc.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22699,6 +22699,8 @@ in
 
   nix-update-source = callPackage ../tools/package-management/nix-update-source {};
 
+  nix-script = callPackage ../tools/nix/nix-script {};
+
   nix-template-rpm = callPackage ../build-support/templaterpm { inherit (pythonPackages) python toposort; };
 
   nix-top = callPackage ../tools/package-management/nix-top { };


### PR DESCRIPTION
###### Motivation for this change
Figured it was time to move this into nixpkgs

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

