### PR TITLE
tlf: Init at 1.3.2

### DIFF
--- a/pkgs/applications/radio/tlf/default.nix
+++ b/pkgs/applications/radio/tlf/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, autoconf, automake, pkgconfig, glib
+, perl, ncurses, hamlib, xmlrpc_c }:
+
+stdenv.mkDerivation rec {
+  pname = "tlf";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0gniysjm8aq5anq0a0az31vd6h1vyg56bifc7rpf53lsh9hkzmgc";
+  };
+
+  nativeBuildInputs = [ autoreconfHook autoconf automake pkgconfig perl ];
+  buildInputs = [ glib ncurses hamlib xmlrpc_c ];
+
+  configureFlags = [ "--enable-hamlib" "--enable-fldigi-xmlrpc" ];
+
+  postInstall = ''
+    mkdir -p $out/lib
+
+    # Hack around lack of libtinfo in NixOS
+    ln -s ${ncurses.out}/lib/libncursesw.so.6 $out/lib/libtinfo.so.5
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Advanced ham radio logging and contest program";
+    longDescription = ''
+      TLF is a curses based console mode general logging and contest program for
+      amateur radio.
+
+      It supports the CQWW, the WPX, the ARRL-DX, the ARRL-FD, the PACC and the
+      EU SPRINT shortwave contests (single operator) as well as a LOT MORE basic
+      contests, general QSO and DXpedition mode.
+    '';
+    homepage = https://tlf.github.io/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19684,6 +19684,8 @@ in
 
   tla = callPackage ../applications/version-management/arch { };
 
+  tlf = callPackage ../applications/radio/tlf { };
+
   tlp = callPackage ../tools/misc/tlp {
     inherit (linuxPackages) x86_energy_perf_policy;
   };


### PR DESCRIPTION
###### Motivation for this change
Advanced ham radio logging and contest program

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

