### PR TITLE
vcs_query: init at 0.4.0

### DIFF
--- a/pkgs/tools/misc/vcs_query/default.nix
+++ b/pkgs/tools/misc/vcs_query/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, python3, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "vcs_query";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "mageta";
+    repo = "vcs_query";
+    rev = "v${version}";
+    sha256 = "05va0na9yxkpqhm9v0x3k58148qcf2bbcv5bnmj7vn9r7fwyjrlx";
+  };
+
+  nativeBuildInputs = [ python3 python3.pkgs.wrapPython ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm0755 vcs_query.py $out/bin/vcs_query
+    patchShebangs $out/bin
+    buildPythonPath ${python3.pkgs.vobject};
+    patchPythonScript $out/bin/vcs_query
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mageta/vcs_query;
+    description = "eMail query-command to use vCards in mutt and Vim";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5973,6 +5973,8 @@ in
 
   vcsh = callPackage ../applications/version-management/vcsh { };
 
+  vcs_query = callPackage ../tools/misc/vcs_query { };
+
   vcstool = callPackage ../development/tools/vcstool { };
 
   verilator = callPackage ../applications/science/electronics/verilator {};


### PR DESCRIPTION
###### Motivation for this change

This is a simple, python-based CLI utility that queries vCard files for
a certain pattern. It's fairly easy to integrate with e.g. NeoMutt to
look for contacts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

