### PR TITLE
greybird: 3.22.9 -> 3.22.10

### DIFF
--- a/pkgs/data/themes/greybird/default.nix
+++ b/pkgs/data/themes/greybird/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook, which, sassc, glib, libxml2, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "greybird";
-  version = "3.22.9";
+  version = "3.22.10";
 
   src = fetchFromGitHub {
     owner = "shimmerproject";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0mixs47v0jvqpmfsv0k0d0l24y4w35krah8mgnwamr0b8spmazz3";
+    sha256 = "1g1mnzxqwlbymq8npd2j294f8dzf9fw9nicd4pajmscg2vk71da9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15592,6 +15592,8 @@ in
 
   go-font = callPackage ../data/fonts/go-font { };
 
+  greybird = callPackage ../data/themes/greybird { };
+
   gyre-fonts = callPackage ../data/fonts/gyre {};
 
   hack-font = callPackage ../data/fonts/hack { };
@@ -22452,8 +22454,6 @@ in
     gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
     binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
   };
-
-  greybird = callPackage ../misc/themes/greybird { };
 
   guetzli = callPackage ../applications/graphics/guetzli { };
 


### PR DESCRIPTION
###### Motivation for this change

Update to version [3.22.10](https://github.com/shimmerproject/Greybird/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).