### PR TITLE
tt-rss-plugin-auth-ldap: Use the correct license

### DIFF
--- a/pkgs/servers/tt-rss/plugin-auth-ldap/default.nix
+++ b/pkgs/servers/tt-rss/plugin-auth-ldap/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Plugin for TT-RSS to authenticate users via ldap";
-    license = licenses.gpl3;
+    license = licenses.asl20;
     homepage = https://github.com/hydrian/TTRSS-Auth-LDAP;
     maintainers = with maintainers; [ mic92 ];
     platforms = platforms.all;


### PR DESCRIPTION
The repo now has a license file which contains the Apache 2 license.

###### Motivation for this change

The license was wrong

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

