### PR TITLE
rdedup: 3.0.1 -> 3.1.1

### DIFF
--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -3,16 +3,20 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rdedup-${version}";
-  version = "3.0.1";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "dpc";
     repo = "rdedup";
-    rev = "e0f26f379a434f76d238c7a5fa6ddd8ae8b32f19";
-    sha256 = "1nhf8ap0w99aa1h0l599cx90lcvfvjaj67nw9flq9bmmzpn53kp9";
+    rev = "rdedup-v${version}";
+    sha256 = "0y34a3mpghdmcb2rx4z62q0s351bfmy1287d75mm07ryfgglgsd7";
   };
 
-  cargoSha256 = "1x6wchlcxb1frww6y04gfx4idxv9h0g9qfxrhgb6g5qy3bqhqq3p";
+  cargoSha256 = "0p19qcz2ph6axfccjwc6z72hrlb48l7sf1n0hc1gfq8hj2s3k2s1";
+
+  patches = [
+    ./v3.1.1-fix-Cargo.lock.patch
+  ];
 
   nativeBuildInputs = [ pkgconfig llvmPackages.libclang clang_39 ];
   buildInputs = [ openssl libsodium lzma ];

--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl libsodium lzma ]
     ++ (stdenv.lib.optional stdenv.isDarwin Security);
 
+  broken = stdenv.isDarwin;
+
   configurePhase = ''
     export LIBCLANG_PATH="${llvmPackages.libclang}/lib"
   '';

--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, libsodium
-, llvmPackages, clang_39, lzma }:
+, llvmPackages, clang_39, lzma
+, Security }:
 
 rustPlatform.buildRustPackage rec {
   name = "rdedup-${version}";
@@ -19,7 +20,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   nativeBuildInputs = [ pkgconfig llvmPackages.libclang clang_39 ];
-  buildInputs = [ openssl libsodium lzma ];
+  buildInputs = [ openssl libsodium lzma ]
+    ++ (stdenv.lib.optional stdenv.isDarwin Security);
 
   configurePhase = ''
     export LIBCLANG_PATH="${llvmPackages.libclang}/lib"

--- a/pkgs/tools/backup/rdedup/v3.1.1-fix-Cargo.lock.patch
+++ b/pkgs/tools/backup/rdedup/v3.1.1-fix-Cargo.lock.patch
@@ -1,0 +1,28 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 96be83a..fe07471 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -880,12 +880,12 @@ dependencies = [
+ 
+ [[package]]
+ name = "rdedup"
+-version = "3.1.0"
++version = "3.1.1"
+ dependencies = [
+  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "rdedup-lib 3.0.0",
++ "rdedup-lib 3.1.0",
+  "rpassword 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "slog 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -900,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "rdedup-lib"
+-version = "3.0.0"
++version = "3.1.0"
+ dependencies = [
+  "backblaze-b2 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19139,7 +19139,9 @@ in
 
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };
 
-  rdedup = callPackage ../tools/backup/rdedup { };
+  rdedup = callPackage ../tools/backup/rdedup {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   rdup = callPackage ../tools/backup/rdup { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

