### PR TITLE
pkgs/misc/cups/drivers: add brother mfcl3770cdw

### DIFF
--- a/pkgs/misc/cups/drivers/brother/mfcl3770cdw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/mfcl3770cdw/default.nix
@@ -1,0 +1,88 @@
+{ pkgsi686Linux
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, ghostscript
+, gnugrep
+, gnused
+, which
+, perl
+, lib
+}:
+
+let
+  model = "mfcl3770cdw";
+  version = "1.0.2-0";
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103935/${model}pdrv-${version}.i386.deb";
+    sha256 = "09fhbzhpjymhkwxqyxzv24b06ybmajr6872yp7pri39595mhrvay";
+  };
+  reldir = "opt/brother/Printers/${model}/";
+
+in rec {
+  driver = pkgsi686Linux.stdenv.mkDerivation rec {
+    inherit src version;
+    name = "${model}drv-${version}";
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      dir="$out/${reldir}"
+      substituteInPlace $dir/lpd/filter_${model} \
+        --replace /usr/bin/perl ${perl}/bin/perl \
+        --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+      wrapProgram $dir/lpd/filter_${model} \
+        --prefix PATH : ${stdenv.lib.makeBinPath [
+          coreutils ghostscript gnugrep gnused which
+        ]}
+    # need to use i686 glibc here, these are 32bit proprietary binaries
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $dir/lpd/brmfcl3770cdwfilter
+    '';
+
+    meta = {
+      description = "Brother ${lib.strings.toUpper model} driver";
+      homepage = http://www.brother.com/;
+      license = stdenv.lib.licenses.unfree;
+      platforms = [ "x86_64-linux" "i686-linux" ];
+      maintainers = [ stdenv.lib.maintainers.steveej ];
+    };
+  };
+
+  cupswrapper = stdenv.mkDerivation rec {
+    inherit version src;
+    name = "${model}cupswrapper-${version}";
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      basedir=${driver}/${reldir}
+      dir=$out/${reldir}
+      substituteInPlace $dir/cupswrapper/brother_lpdwrapper_${model} \
+        --replace /usr/bin/perl ${perl}/bin/perl \
+        --replace "basedir =~" "basedir = \"$basedir\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+      wrapProgram $dir/cupswrapper/brother_lpdwrapper_${model} \
+        --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnugrep gnused ]}
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+      ln $dir/cupswrapper/brother_lpdwrapper_${model} $out/lib/cups/filter
+      ln $dir/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model
+    '';
+
+    meta = {
+      description = "Brother ${lib.strings.toUpper model} CUPS wrapper driver";
+      homepage = http://www.brother.com/;
+      license = stdenv.lib.licenses.gpl2;
+      platforms = [ "x86_64-linux" "i686-linux" ];
+      maintainers = [ stdenv.lib.maintainers.steveej ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25155,6 +25155,10 @@ in
   mfcl2740dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2740dwcupswrapper { };
   mfcl2740dwlpr = callPackage ../misc/cups/drivers/mfcl2740dwlpr { };
 
+  # This driver is only available as a 32 bit proprietary binary driver
+  mfcl3770cdwlpr = (callPackage ../misc/cups/drivers/brother/mfcl3770cdw/default.nix { }).driver;
+  mfcl3770cdwcupswrapper = (callPackage ../misc/cups/drivers/brother/mfcl3770cdw/default.nix { }).cupswrapper;
+
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 


### PR DESCRIPTION
This adds the printer driver for the Brother MFCL3770CDW.
It combines the cups-wrapper and the driver in one file which allows
sharing common variables and making it less error-prone than the other
Brother drivers in repository.

I volunteer for maintaining this one as long as I've got the model
around.

###### Motivation for this change
New driver for new hardware. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

