### PR TITLE
mumsi: Init at unstable-2018-12-12

### DIFF
--- a/pkgs/development/libraries/mumlib/default.nix
+++ b/pkgs/development/libraries/mumlib/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig
+, boost, openssl, log4cpp, libopus, protobuf }:
+with lib; stdenv.mkDerivation rec {
+  pname = "mumlib";
+  version = "unstable-2018-12-12";
+
+  src = fetchFromGitHub {
+    owner = "slomkowski";
+    repo = "mumlib";
+    rev = "f91720de264c0ab5e02bb30deafc5c4b2c245eac";
+    sha256 = "0p29z8379dp2ra0420x8xjp4d3r2mf680lj38xmlc8npdzqjqjdp";
+  };
+
+  buildInputs = [ boost openssl libopus protobuf log4cpp ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  installPhase = ''
+    install -Dm555 libmumlib.so $out/lib/libmumlib.so
+    cp -a ../include $out
+  '';
+
+  meta = {
+    description = "Fairy simple Mumble library written in C++, using boost::asio asynchronous networking framework";
+    homepage = "https://github.com/slomkowski/mumlib";
+    maintainers = with maintainers; [ das_j ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/mumsi/default.nix
+++ b/pkgs/servers/mumsi/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, boost
+, log4cpp, pjsip, openssl, alsaLib, mumlib }:
+with lib; stdenv.mkDerivation rec {
+  pname = "mumsi";
+  version = "unstable-2018-12-12";
+
+  src = fetchFromGitHub {
+    owner = "slomkowski";
+    repo = "mumsi";
+    rev = "961b75792f8da22fb5502e39edb286e32172d0b0";
+    sha256 = "0vrivl1fiiwjsz4v26nrn8ra3k9v0mcz7zjm2z319fw8hv6n1nrk";
+  };
+
+  buildInputs = [ boost log4cpp pkgconfig pjsip mumlib openssl alsaLib ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  installPhase = ''
+    install -Dm555 mumsi $out/bin/mumsi
+  '';
+
+  meta = {
+    description = "SIP to Mumble gateway/bridge using PJSUA stack";
+    homepage = "https://github.com/slomkowski/mumsi";
+    maintainers = with maintainers; [ das_j ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12404,6 +12404,8 @@ in
 
   mueval = callPackage ../development/tools/haskell/mueval { };
 
+  mumlib = callPackage ../development/libraries/mumlib { };
+
   muparser = callPackage ../development/libraries/muparser { };
 
   mygpoclient = pythonPackages.mygpoclient;
@@ -14435,6 +14437,8 @@ in
   morty = callPackage ../servers/web-apps/morty { };
 
   mullvad-vpn = callPackage ../applications/networking/mullvad-vpn { };
+
+  mumsi = callPackage ../servers/mumsi { };
 
   myserver = callPackage ../servers/http/myserver { };
 


### PR DESCRIPTION
###### Motivation for this change

I'd like to use Mumsi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

