### PR TITLE
gitAndTools.gita: init at 0.7.3

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -38,6 +38,8 @@ let
 
   git-fame = callPackage ./git-fame {};
 
+  gita = callPackage ./gita {};
+
   # The full-featured Git.
   gitFull = gitBase.override {
     svnSupport = true;

--- a/pkgs/applications/version-management/git-and-tools/gita/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gita/default.nix
@@ -1,0 +1,24 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  version = "0.7.3";
+  pname = "gita";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0ccqjf288513im7cvafiw4ypbp9s3z0avyzd4jzr13m38jrsss3r";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyyaml
+  ];
+
+  doCheck = false;  # Releases don't include tests
+
+  meta = with lib; {
+    description = "A command-line tool to manage multiple git repos";
+    homepage = https://github.com/nosarthur/gita;
+    license = licenses.mit;
+    maintainers = with maintainers; [ seqizz ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Gita is a tool for managing multiple repositories. It's helpful to me so I wanted to add it to the main repo. Please state if I did something weird because I am currently packaging bigger Python applications which kind of working so I'll fix myself before causing headache on PR step :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

