### PR TITLE
mailman-rss: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/mailman-rss/default.nix
+++ b/pkgs/development/python-modules/mailman-rss/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, python3Packages, withTwitter ? false}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mailman-rss";
+  version = "0.2.4";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1brrik70jyagxa9l0cfmlxvqpilwj1q655bphxnvjxyganxf4c00";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ dateutil future requests beautifulsoup4 ]
+    ++ stdenv.lib.optional withTwitter python3Packages.twitter
+  ;
+
+  # No tests in Pypi Tarball
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Mailman archive -> rss converter";
+    homepage = https://github.com/kyamagu/mailman-rss;
+    license = licenses.mit;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13621,6 +13621,8 @@ in
 
   mailman = callPackage ../servers/mail/mailman { };
 
+  mailman-rss = callPackage ../development/python-modules/mailman-rss { };
+
   mattermost = callPackage ../servers/mattermost { };
   matterircd = callPackage ../servers/mattermost/matterircd.nix { };
   matterbridge = callPackage ../servers/matterbridge { };


### PR DESCRIPTION
###### Motivation for this change

Might be useful to a couple maintainers here; to keep track of mailing lists in an RSS reader instead of dealing with e-mails.

First python ecosystem contribution, don't hold back with the nitpicks.

Verified it built and worked with both python 2 and python 3.

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

