### PR TITLE
backport changes to autoPatchelfHook

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -155,8 +155,10 @@ autoPatchelf() {
     # outside of this function.
     while IFS= read -r -d $'\0' file; do
       isELF "$file" || continue
-      # dynamically linked?
-      readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+      if isExecutable "$file"; then
+          # Skip if the executable is statically linked.
+          readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+      fi
       autoPatchelfFile "$file"
     done < <(find "$prefix" -type f -print0)
 }

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -7,7 +7,7 @@ gatherLibraries() {
 addEnvHooks "$targetOffset" gatherLibraries
 
 isExecutable() {
-    readelf -h "$1" | grep -q '^ *Type: *EXEC\>'
+    readelf -h "$1" 2> /dev/null | grep -q '^ *Type: *EXEC\>'
 }
 
 # We cache dependencies so that we don't need to search through all of them on

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -7,21 +7,7 @@ gatherLibraries() {
 addEnvHooks "$targetOffset" gatherLibraries
 
 isExecutable() {
-    [ "$(file -b -N --mime-type "$1")" = application/x-executable ]
-}
-
-findElfs() {
-    find "$1" -type f -exec "$SHELL" -c '
-        while [ -n "$1" ]; do
-            mimeType="$(file -b -N --mime-type "$1")"
-            if [ "$mimeType" = application/x-executable \
-              -o "$mimeType" = application/x-pie-executable \
-              -o "$mimeType" = application/x-sharedlib ]; then
-                echo "$1"
-            fi
-            shift
-        done
-    ' -- {} +
+    readelf -h "$1" | grep -q '^ *Type: *EXEC\>'
 }
 
 # We cache dependencies so that we don't need to search through all of them on
@@ -167,9 +153,12 @@ autoPatchelf() {
     # findDependency outside of this, the dependency cache needs to be rebuilt
     # from scratch, so keep this in mind if you want to run findDependency
     # outside of this function.
-    findElfs "$prefix" | while read -r elffile; do
-        autoPatchelfFile "$elffile"
-    done
+    while IFS= read -r -d $'\0' file; do
+      isELF "$file" || continue
+      # dynamically linked?
+      readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+      autoPatchelfFile "$file"
+    done < <(find "$prefix" -type f -print0)
 }
 
 # XXX: This should ultimately use fixupOutputHooks but we currently don't have

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -173,7 +173,7 @@ addAutoPatchelfSearchPath() {
 }
 
 autoPatchelf() {
-    local -a norecurse=
+    local norecurse=
 
     while [ $# -gt 0 ]; do
         case "$1" in

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -205,9 +205,12 @@ autoPatchelf() {
     # outside of this function.
     while IFS= read -r -d $'\0' file; do
       isELF "$file" || continue
+      segmentHeaders="$(LANG=C readelf -l "$file")"
+      # Skip if the ELF file doesn't have segment headers (eg. object files).
+      echo "$segmentHeaders" | grep -q '^Program Headers:' || continue
       if isExecutable "$file"; then
           # Skip if the executable is statically linked.
-          LANG=C readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+          echo "$segmentHeaders" | grep -q "^ *INTERP\\>" || continue
       fi
       autoPatchelfFile "$file"
     done < <(find "$@" ${norecurse:+-maxdepth 1} -type f -print0)

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -180,6 +180,11 @@ autoPatchelf() {
 # So what we do here is basically run in postFixup and emulate the same
 # behaviour as fixupOutputHooks because the setup hook for patchelf is run in
 # fixupOutput and the postFixup hook runs later.
-postFixupHooks+=(
-    'autoPatchelf $(for output in $outputs; do echo "${!output}"; done)'
-)
+postFixupHooks+=('
+    if [ -z "$dontAutoPatchelf" ]; then
+        autoPatchelf $(for output in $outputs; do
+            [ -e "${!output}" ] || continue
+            echo "${!output}"
+        done)
+    fi
+')

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -153,7 +153,7 @@ autoPatchelf() {
     # Add all shared objects of the current output path to the start of
     # cachedDependencies so that it's choosen first in findDependency.
     cachedDependencies+=(
-        $(find "$prefix" \! -type d \( -name '*.so' -o -name '*.so.*' \))
+        $(find "$@" \! -type d \( -name '*.so' -o -name '*.so.*' \))
     )
     local elffile
 
@@ -169,7 +169,7 @@ autoPatchelf() {
           LANG=C readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
       fi
       autoPatchelfFile "$file"
-    done < <(find "$prefix" -type f -print0)
+    done < <(find "$@" -type f -print0)
 }
 
 # XXX: This should ultimately use fixupOutputHooks but we currently don't have
@@ -181,5 +181,5 @@ autoPatchelf() {
 # behaviour as fixupOutputHooks because the setup hook for patchelf is run in
 # fixupOutput and the postFixup hook runs later.
 postFixupHooks+=(
-    'for output in $outputs; do prefix="${!output}" autoPatchelf; done'
+    'autoPatchelf $(for output in $outputs; do echo "${!output}"; done)'
 )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -81,8 +81,7 @@ with pkgs;
     { deps = [ autoconf264 automake111x gettext libtool ]; }
     ../build-support/setup-hooks/autoreconf.sh;
 
-  autoPatchelfHook = makeSetupHook
-    { name = "auto-patchelf-hook"; deps = [ file ]; }
+  autoPatchelfHook = makeSetupHook { name = "auto-patchelf-hook"; }
     ../build-support/setup-hooks/auto-patchelf.sh;
 
   ensureNewerSourcesHook = { year }: makeSetupHook {}


### PR DESCRIPTION
###### Motivation for this change
For whatever reason the version of `autoPatchelfHook` on `18.09` seems to break for https://github.com/NixOS/nixpkgs/pull/55429 and https://github.com/NixOS/nixpkgs/pull/55535.

Simply backporting the changes on master seems to have resolved it.

cc @Mic92 @aszlig 

###### Things done

I've built and executed the programs fine from the aforementioned pull requests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

