### PR TITLE
Security: Matomo 3.7.0 -> 3.8.1

### DIFF
--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -45,12 +45,11 @@ in {
         type = types.nullOr types.str;
         default = null;
         example = "lighttpd";
-        # TODO: piwik.php might get renamed to matomo.php in future releases
         description = ''
           Name of the web server user that forwards requests to the ${phpSocket} fastcgi socket for matomo if the nginx
           option is not used. Either this option or the nginx option is mandatory.
           If you want to use another webserver than nginx, you need to set this to that server's user
-          and pass fastcgi requests to `index.php` and `piwik.php` to this socket.
+          and pass fastcgi requests to `index.php`, `matomo.php` and `piwik.php` (legacy name) to this socket.
         '';
       };
 
@@ -215,8 +214,11 @@ in {
         locations."= /index.php".extraConfig = ''
           fastcgi_pass unix:${phpSocket};
         '';
-        # TODO: might get renamed to matomo.php in future versions
-        # allow piwik.php for tracking
+        # allow matomo.php for tracking
+        locations."= /matomo.php".extraConfig = ''
+          fastcgi_pass unix:${phpSocket};
+        '';
+        # allow piwik.php for tracking (deprecated name)
         locations."= /piwik.php".extraConfig = ''
           fastcgi_pass unix:${phpSocket};
         '';
@@ -237,8 +239,11 @@ in {
         locations."= /robots.txt".extraConfig = ''
           return 200 "User-agent: *\nDisallow: /\n";
         '';
-        # TODO: might get renamed to matomo.js in future versions
-        # let browsers cache piwik.js
+        # let browsers cache matomo.js
+        locations."= /matomo.js".extraConfig = ''
+          expires 1M;
+        '';
+        # let browsers cache piwik.js (deprecated name)
         locations."= /piwik.js".extraConfig = ''
           expires 1M;
         '';

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "matomo-${version}";
-  version = "3.7.0";
+  version = "3.8.1";
 
   src = fetchurl {
     # TODO: As soon as the tarballs are renamed as well on future releases, this should be enabled again
     # url = "https://builds.matomo.org/${name}.tar.gz";
     url = "https://builds.matomo.org/piwik-${version}.tar.gz";
-    sha256 = "17ihsmwdfrx1c1v8cp5pc3swx3h0i0l9pjrc8jyww08kavfbfly6";
+    sha256 = "0ca4fkg2jpkfg0r9hxl45ad5xzz0gxhf404i96j059bn3c41kfi0";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/web-apps/matomo/make-localhost-default-database-host.patch
+++ b/pkgs/servers/web-apps/matomo/make-localhost-default-database-host.patch
@@ -1,13 +1,13 @@
 diff --git a/plugins/Installation/FormDatabaseSetup.php b/plugins/Installation/FormDatabaseSetup.php
-index 9364f49870..2625cbb91b 100644
+index 74de2535b4..bc172ad0eb 100644
 --- a/plugins/Installation/FormDatabaseSetup.php
 +++ b/plugins/Installation/FormDatabaseSetup.php
 @@ -82,7 +82,7 @@ class FormDatabaseSetup extends QuickForm2
  
-         // default values
-         $this->addDataSource(new HTML_QuickForm2_DataSource_Array(array(
--                                                                       'host'          => '127.0.0.1',
-+                                                                       'host'          => 'localhost',
-                                                                        'type'          => $defaultDatabaseType,
-                                                                        'tables_prefix' => 'matomo_',
-                                                                   )));
+ 
+         $defaults = array(
+-            'host'          => '127.0.0.1',
++            'host'          => 'localhost',
+             'type'          => $defaultDatabaseType,
+             'tables_prefix' => 'matomo_',
+         );


### PR DESCRIPTION
###### Motivation for this change
[3.8.0](https://matomo.org/changelog/matomo-3-8-0/) was security-critical,
[3.8.1](https://matomo.org/changelog/matomo-3-8-1/) is a bugfix release for 3.8.0.

From my point of view, we should cherry-pick f0f9a118ca278a3fb66f88e10f618cd54886455a for 18.09 to fix the vulnerabilities only, while both commits should get into 19.03.
Both should neither contain breaking changes nor require no user intervention.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

