### PR TITLE
ocropus: 20170811 -> 1.3.3

### DIFF
--- a/pkgs/applications/misc/ocropus/default.nix
+++ b/pkgs/applications/misc/ocropus/default.nix
@@ -18,12 +18,12 @@ let
 
 in
 pythonPackages.buildPythonApplication rec {
-  name = "ocropus-${version}";
-  version = "20170811";
+  pname = "ocropus";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
-    sha256 = "0qx0d8yj0w66qglkrmfavp5dh1sky72njfaqii7bnrpv5n4j3q39";
-    rev = "ae84a8edaf0b76135f749ba66fc30c272d0726d0";
+    sha256 = "02p1334mic5cfhvpfphfrbim4036yfd8s2zzpwm0xmm829z71nr7";
+    rev = "v${version}";
     repo = "ocropy";
     owner = "tmbdev";
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @domenkozar 