### PR TITLE
pivx: init at 3.2.0

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, boost165, openssl_1_1, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3, buildGo110Package }:
+{ callPackage, boost155, boost165, openssl_1_1, haskellPackages, darwin, libsForQt5, libsForQt59, miniupnpc_2, python3, buildGo110Package }:
 
 rec {
 
@@ -74,6 +74,9 @@ rec {
 
   namecoin  = callPackage ./namecoin.nix  { withGui = true; };
   namecoind = callPackage ./namecoin.nix { withGui = false; };
+
+  pivx = libsForQt59.callPackage ./pivx.nix { withGui = true; };
+  pivxd = callPackage ./pivx.nix { withGui = false; };
 
   ethabi = callPackage ./ethabi.nix { };
 

--- a/pkgs/applications/altcoins/pivx.nix
+++ b/pkgs/applications/altcoins/pivx.nix
@@ -1,0 +1,54 @@
+{ fetchFromGitHub, stdenv, pkgconfig, autoreconfHook
+, openssl, db48, boost, zlib, miniupnpc, gmp
+, qrencode, glib, protobuf, yasm, libevent
+, utillinux, qtbase ? null, qttools ? null
+, enableUpnp ? false
+, disableWallet ? false
+, disableDaemon ? false 
+, withGui ? false }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "pivx-${version}";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "PIVX-Project";
+    repo= "PIVX";
+    rev = "v${version}";
+    sha256 = "1sym6254vhq8qqpxq9qhy10m5167v7x93kqaj1gixc1vwwbxyazy";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ glib gmp openssl db48 yasm boost zlib libevent miniupnpc protobuf utillinux ]
+                  ++ optionals withGui [ qtbase qttools qrencode ];
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+                    ++ optional enableUpnp "--enable-upnp-default"
+                    ++ optional disableWallet "--disable-wallet"
+                    ++ optional disableDaemon "--disable-daemon"
+                    ++ optionals withGui [ "--with-gui=yes"
+                                           "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+                                         ];
+  
+  enableParallelBuilding = true;
+  doChecks = true;
+  postBuild = ''
+    mkdir -p $out/share/applications $out/share/icons
+    cp contrib/debian/pivx-qt.desktop $out/share/applications/
+    cp share/pixmaps/*128.png $out/share/icons/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open source crypto-currency focused on fast private transactions";
+    longDescription = ''
+      PIVX is an MIT licensed, open source, blockchain-based cryptocurrency with
+      ultra fast transactions, low fees, high network decentralization, and
+      Zero Knowledge cryptography proofs for industry-leading transaction anonymity.
+    '';
+    license = licenses.mit;
+    homepage = https://www.dash.org;
+    maintainers = with maintainers; [ wucke13 ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Having another altcoin ready for usage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

