### PR TITLE
zuki-themes: 3.28-3 -> 3.30-1

### DIFF
--- a/pkgs/data/themes/zuki/default.nix
+++ b/pkgs/data/themes/zuki/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  name = "zuki-themes-${version}";
-  version = "3.28-3";
+  pname = "zuki-themes";
+  version = "3.30-1";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
-    repo = "zuki-themes";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0sgp41fpd8lyyb0v82y41v3hmb0ayv3zqqrv0m3ln0dzkr7ym9g7";
+    sha256 = "0d7i0jhjiarqnwkc1k505bw8r9bvbwk3x8yzqmc3vnwcd7mr3m9x";
   };
 
   buildInputs = [ gdk_pixbuf librsvg ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16004,6 +16004,8 @@ in
 
   zilla-slab = callPackage ../data/fonts/zilla-slab { };
 
+  zuki-themes = callPackage ../data/themes/zuki { };
+
 
   ### APPLICATIONS
 
@@ -23274,8 +23276,6 @@ in
   wtf = callPackage ../applications/misc/wtf { };
 
   zk-shell = callPackage ../applications/misc/zk-shell { };
-
-  zuki-themes = callPackage ../misc/themes/zuki { };
 
   tora = libsForQt5.callPackage ../development/tools/tora {};
 


### PR DESCRIPTION
###### Motivation for this change

Update to version [3.30-1](https://github.com/lassekongo83/zuki-themes/releases/tag/v3.30-1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).