### PR TITLE
Fix 3 warnings in nixos/tests

### DIFF
--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -45,7 +45,7 @@ with pkgs.lib;
       {
         services.gitea.enable = true;
         services.gitea.database.type = "postgres";
-        services.gitea.database.password = "secret";
+        services.gitea.database.passwordFile = pkgs.writeText "db-password" "secret";
       };
 
     testScript = ''

--- a/nixos/tests/ndppd.nix
+++ b/nixos/tests/ndppd.nix
@@ -37,8 +37,7 @@ import ./make-test.nix ({ pkgs, lib, ...} : {
       };
       services.ndppd = {
         enable = true;
-        interface = "eth1";
-        network = "fd42::/112";
+        proxies."eth1".rules."fd42::/112" = {};
       };
       containers.client = {
         autoStart = true;

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -52,8 +52,18 @@ in
     machine = {
       services.rspamd = {
         enable = true;
-        bindSocket = [ "/run/rspamd.sock mode=0600 user=root group=root" ];
-        bindUISocket = [ "/run/rspamd-worker.sock mode=0666 user=root group=root" ];
+        workers.normal.bindSockets = [{
+          socket = "/run/rspamd.sock";
+          mode = "0600";
+          owner = "root";
+          group = "root";
+        }];
+        workers.controller.bindSockets = [{
+          socket = "/run/rspamd-worker.sock";
+          mode = "0666";
+          owner = "root";
+          group = "root";
+        }];
       };
     };
 
@@ -235,7 +245,7 @@ in
       services.rspamd = {
         enable = true;
         postfix.enable = true;
-        workers.rspamd_proxy.type = "proxy";
+        workers.rspamd_proxy.type = "rspamd_proxy";
       };
     };
     testScript = ''


### PR DESCRIPTION
###### Motivation for this change

Appease the warning gods. These are some fairly trivial changes, mostly deprecations that didn't update associated tests.

The gitea warning fix bothers me a bit, I don't think this should be a warning in the first place, but I'm thoroughly uninterested in having a debate about the value of this warning given that I don't use that service. If someone does want to have this discussion and decides to drop the warning, feel free to revert my warning-fix commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

