### PR TITLE
coqPackages.paramcoq: init at 1.1.1

### DIFF
--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, coq }:
+
+let params =
+  {
+    "8.7" = {
+      version = "1.1.1+coq8.7";
+      sha256 = "1i7b5pkx46zf9il2xikbp3rhpnh3wdfbhw5yxcf9yk28ky9s0a0l";
+    };
+    "8.8" = {
+      version = "1.1.1";
+      sha256 = "0b07zvgm9cx6j2d9631zmqjs6sf30kiqg6k15xk3km7n80d53wfh";
+    };
+    "8.9" = {
+      version = "1.1.1+coq8.9";
+      sha256 = "002xabhjlph394vydw3dx8ipv5ry2nq3py4440bk9a18ljx0w6ll";
+    };
+  };
+  param = params."${coq.coq-version}";
+in
+
+stdenv.mkDerivation rec {
+  inherit (param) version;
+  name = "coq${coq.coq-version}-paramcoq-${version}";
+  src = fetchFromGitHub {
+    owner = "coq-community";
+    repo = "paramcoq";
+    rev = "v${version}";
+    inherit (param) sha256;
+  };
+
+  buildInputs = [ coq ]
+  ++ (with coq.ocamlPackages; [ ocaml findlib camlp5 ])
+  ;
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v params;
+  };
+
+  meta = {
+    description = "Coq plugin for parametricity";
+    inherit (src.meta) homepage;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (coq.meta) platforms;
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -39,6 +39,7 @@ let
       metalib = callPackage ../development/coq-modules/metalib { };
       multinomials = callPackage ../development/coq-modules/multinomials {};
       paco = callPackage ../development/coq-modules/paco {};
+      paramcoq = callPackage ../development/coq-modules/paramcoq {};
       QuickChick = callPackage ../development/coq-modules/QuickChick {};
       simple-io = callPackage ../development/coq-modules/simple-io { };
       ssreflect = callPackage ../development/coq-modules/ssreflect { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

