### PR TITLE
sonar-scanner-bin: init at 3.3.0.1492

### DIFF
--- a/pkgs/tools/security/sonar-scanner-bin/default.nix
+++ b/pkgs/tools/security/sonar-scanner-bin/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchurl, unzip, jre }:
+
+let
+
+  version = "3.3.0.1492";
+
+  sonarScannerArchPackage = {
+    "x86_64-linux" = {
+      url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-linux.zip";
+      sha256 = "1vn22d1i14440wlym0kxzbmjlxd9x9b0wc2ifm8fwig1xvnwpjwd";
+    };
+    "x86_64-darwin" = {
+      url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-macosx.zip";
+      sha256 = "1m7cplak63m2rmad7f2s1iksi1qn43m2h1jm0qh3m219xcpl632i";
+    };
+  };
+
+in stdenv.mkDerivation rec {
+  inherit version;
+  name = "sonar-scanner-bin-${version}";
+
+  src = fetchurl sonarScannerArchPackage.${stdenv.hostPlatform.system};
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -r lib/* $out/lib/
+    mkdir -p $out/bin
+    cp bin/* $out/bin/
+    mkdir -p $out/conf
+    cp conf/* $out/conf/
+  '';
+
+  fixupPhase = ''
+    substituteInPlace $out/bin/sonar-scanner \
+      --replace "\$sonar_scanner_home/jre" "${lib.getBin jre}"
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/SonarSource/sonar-scanner-cli;
+    description = "SonarQube Scanner used to start code analysis";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ peterromfeldhk ];
+    platforms = builtins.attrNames sonarScannerArchPackage;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5493,6 +5493,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  sonar-scanner-bin = callPackage ../tools/security/sonar-scanner-bin { };
+
   solr = callPackage ../servers/search/solr { };
 
   solvespace = callPackage ../applications/graphics/solvespace { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

