### PR TITLE
flannel: 0.6.2 -> 0.11.0

### DIFF
--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -4,7 +4,7 @@ with lib;
 
 buildGoPackage rec {
   name = "flannel-${version}";
-  version = "0.6.2";
+  version = "0.11.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/coreos/flannel";
@@ -15,7 +15,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "coreos";
     repo = "flannel";
-    sha256 = "03l0zyv9ajda70zw7jgwlmilw26h849jbb9f4slbycphhvbmpvb9";
+    sha256 = "0akxlrrsm2w51g0qd7dnsdy0hdajx98sdhxw4iknjr2kn7j3gph9";
   };
 
   meta = {

--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
     description = "Network fabric for containers, designed for Kubernetes";
     license = licenses.asl20;
     homepage = https://github.com/coreos/flannel;
-    maintainers = with maintainers; [offline];
+    maintainers = with maintainers; [johanot offline];
     platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The Flannel package current version (0.6.2) is from 2016. Since it is used as default CNI implementation in Kubernetes, it seems a bit scary to use such an old version.

Added myself as maintainer on the package.

Ran both the kubernetes RBAC and DNS test cases, and they both work fine with flannel 0.11.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

