### PR TITLE
sage: add compatibility for sphinx 1.8.3 (#55078)

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -91,6 +91,20 @@ stdenv.mkDerivation rec {
       rev = "cd62d45bcef93fb4f7ed62609a46135e6de07051";
       sha256 = "08l2b9w0rn1zrha6188j72f7737xs126gkgmydjd31baa6367np2";
     })
+
+    # https://trac.sagemath.org/ticket/26949
+    (fetchpatch {
+      name = "sphinx-1.8.3-dependency.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id=d305eda0fedc73fdbe0447b5d6d2b520b8d112c4";
+      sha256 = "1x3q5j8lq35vlj893gj5gq9fhzs60szm9r9rx6ri79yiy9apabph";
+    })
+    # https://trac.sagemath.org/ticket/26451
+    (fetchpatch {
+      name = "sphinx-1.8.3.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id2=0cb494282d7b4cea50aba7f4d100e7932a4c00b1&id=62b989d5ee1d9646db85ea56053cd22e9ffde5ab";
+      sha256 = "1n5c61mvhalcr2wbp66wzsynwwk59aakvx3xqa5zw9nlkx3rd0h1";
+    })
+
   ];
 
   patches = nixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sagenb.nix
+++ b/pkgs/applications/science/math/sage/sagenb.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "sagenb";
-  version = "2018-06-26"; # not 1.0.1 because of new flask syntax
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "sagemath";
     repo = "sagenb";
-    rev = "b360a0172e15501fb0163d02dce713a561fee2af";
-    sha256 = "12anydw0v9w23rbc0a94bqmjhjdir9h820c5zdhipw9ccdcc2jlf";
+    rev = version;
+    sha256 = "0bxvhr03qh2nsjdfc4pyfiqrn9jhp3vf7irsc9gqx0185jlblbxs";
   };
 
   propagatedBuildInputs = [
@@ -38,14 +38,6 @@ buildPythonPackage rec {
 
   # tests depend on sage
   doCheck = false;
-
-  patches = [
-    # work with latest flask-babel
-    (fetchpatch {
-      url = "https://github.com/sagemath/sagenb/commit/ba065eca63dd34a383e4c7ba7561430a90fcd087.patch";
-      sha256 = "1lamzsrgymdd618imrasjp6ivhw2aynh83gkybsd7pm1rzjcq4x8";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "Sage Notebook";


### PR DESCRIPTION
###### Motivation for this change

Cherry-picking https://github.com/NixOS/nixpkgs/pull/55078 into master, since the sphinx update already landed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

