### PR TITLE
opencascade-occt: init at 7.3.0p2

### DIFF
--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -12,7 +12,6 @@
 }:
 
 let version = "7.3.0p2";
-    patch = "p2";
     commit = "V7_3_0p2";
 
 in stdenv.mkDerivation {

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -12,7 +12,7 @@
 }:
 
 let version = "7.3.0p2";
-    commit = "V7_3_0p2";
+    commit = "V${builtins.replaceStrings ["."] ["_"] version}";
 
 in stdenv.mkDerivation {
 

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -17,7 +17,7 @@ let version = "7.3.0";
 
 in stdenv.mkDerivation {
 
-  name = "opencascade-${version}${patch}";
+  name = "opencascade-occt-${version}";
 
   src = fetchurl {
     name = "occt-${commit}.tar.gz";

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -11,7 +11,7 @@
 , doxygen
 }:
 
-let version = "7.3.0";
+let version = "7.3.0p2";
     patch = "p2";
     commit = "V7_3_0p2";
 

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -24,7 +24,8 @@ in stdenv.mkDerivation {
     sha256 = "0nc9k1nqpj0n99pr7qkva79irmqhh007dffwghiyzs031zhd7i6w";
   };
 
-  buildInputs = [ cmake tcl tk vtk mesa_glu libXext libXmu libXi doxygen ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ tcl tk vtk mesa_glu libXext libXmu libXi doxygen ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchurl
+, cmake
+, tcl
+, tk
+, vtk
+, mesa_glu
+, libXext
+, libXmu
+, libXi
+, doxygen
+}:
+
+let version = "7.3.0";
+    patch = "p2";
+    commit = "V7_3_0p2";
+
+in stdenv.mkDerivation {
+
+  name = "opencascade-${version}${patch}";
+
+  src = fetchurl {
+    name = "occt-${commit}.tar.gz";
+    url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
+    sha256 = "0nc9k1nqpj0n99pr7qkva79irmqhh007dffwghiyzs031zhd7i6w";
+  };
+
+  buildInputs = [ cmake tcl tk vtk mesa_glu libXext libXmu libXi doxygen ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
+    homepage = "https://www.opencascade.org/";
+    license = licenses.lgpl21;  # essentially...
+    # The special exception defined in the file OCCT_LGPL_EXCEPTION.txt
+    # are basically about making the license a little less share-alike.
+    maintainers = with maintainers; [ amiloradovsky ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11832,7 +11832,7 @@ in
   openbabel = callPackage ../development/libraries/openbabel { };
 
   opencascade = callPackage ../development/libraries/opencascade { };
-  opencascade_occt = callPackage ../development/libraries/opencascade-occt { };
+  opencascade-occt = callPackage ../development/libraries/opencascade-occt { };
 
   opencl-headersGen = v: callPackage ../development/libraries/opencl-headers { version = v; };
   opencl-headers_1_2 = opencl-headersGen "12";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11832,6 +11832,7 @@ in
   openbabel = callPackage ../development/libraries/openbabel { };
 
   opencascade = callPackage ../development/libraries/opencascade { };
+  opencascade_occt = callPackage ../development/libraries/opencascade-occt { };
 
   opencl-headersGen = v: callPackage ../development/libraries/opencl-headers { version = v; };
   opencl-headers_1_2 = opencl-headersGen "12";


### PR DESCRIPTION
Just a package of the official OpenCASCADE OCCT (not OCE).

###### Motivation for this change

I was playing a bit with the library, and wanted to store/publish the Nix-expression I wrote along the way somewhere… Later it may be possible to let building FreeCAD, KiCAD, and OpenSceneGraph with either of these distributions (OCCT or OCE). But for now this is just it.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

