### PR TITLE
lguf-brightness: unstable-2019-02-07 -> unstable-2019-02-11

### DIFF
--- a/pkgs/misc/lguf-brightness/default.nix
+++ b/pkgs/misc/lguf-brightness/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   pname = "lguf-brightness";
 
-  version = "unstable-2018-02-07";
+  version = "unstable-2018-02-11";
 
   src = fetchFromGitHub  {
     owner = "periklis";
     repo = pname;
-    rev = "d194272b7a0374b27f036cbc1a9be7f231d40cbb";
-    sha256 = "0zj81bqchms9m7rik1jxp6zylh9dxqzr7krlj9947v0phr4qgah4";
+    rev = "fcb2bc1738d55c83b6395c24edc27267a520a725";
+    sha256 = "0cf7cn2kpmlvz00qxqj1m5zxmh7i2x75djbj4wqk7if7a0nlrd5m";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

