### PR TITLE
[WIP] buildEnv: accept arbitrary arguments, pass to runCommand

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -38,15 +38,14 @@ lib.makeOverridable
 
 , # Additional inputs. Handy e.g. if using makeWrapper in `postBuild`.
   buildInputs ? []
-
-, passthru ? {}
-, meta ? {}
-}:
+  # all remaining arguments are passed to runCommand { ... }
+, ...
+}@args:
 
 runCommand name
-  rec {
-    inherit manifest ignoreCollisions checkCollisionContents passthru
-            meta pathsToLink extraPrefix postBuild buildInputs;
+  (rec {
+    # inherit manifest ignoreCollisions checkCollisionContents passthru
+    #         meta pathsToLink extraPrefix postBuild buildInputs;
     pkgs = builtins.toJSON (map (drv: {
       paths =
         # First add the usual output(s): respect if user has chosen explicitly,
@@ -65,7 +64,7 @@ runCommand name
     preferLocalBuild = true;
     # XXX: The size is somewhat arbitrary
     passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else null;
-  }
+  } // removeAttrs args [ "paths" "pathsToLink" "extraOutputsToInstall" "name" ])
   ''
     ${buildPackages.perl}/bin/perl -w ${./builder.pl}
     eval "$postBuild"


### PR DESCRIPTION
###### Motivation for this change

In contrast to other places in nixpkgs, buildEnv does not pass any unknown attributes to runCommand.

With the changes of this PR, the attributes, which give more fine-grained control over the
resulting derivation, don't have to be specified explicitly in buildEnv, but are passed to runCommand
as is.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

