### PR TITLE
terraform-providers.libvirt: 0.4 -> 0.5.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -19,7 +19,7 @@
 
 buildGoPackage rec {
   name = "terraform-provider-libvirt-${version}";
-  version = "0.4";
+  version = "0.5.1";
 
   goPackagePath = "github.com/dmacvicar/terraform-provider-libvirt";
 
@@ -27,7 +27,7 @@ buildGoPackage rec {
     owner = "dmacvicar";
     repo = "terraform-provider-libvirt";
     rev = "v${version}";
-    sha256 = "05jkjp1kis4ncryv34pkb9cz2yhzbwg62x9qmlqsqlxwz9hqny3r";
+    sha256 = "0shnj5byqj3qzyqniiy1dcygd8xw1h2bx9z6mgcydw8k64fkm4bw";
   };
 
   buildInputs = [ libvirt pkgconfig makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Updating terraform libvirt provider to latest tag

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

