### PR TITLE
ocaml: init at 4.08.0+beta1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.08.nix
+++ b/pkgs/development/compilers/ocaml/4.08.nix
@@ -1,0 +1,9 @@
+import ./generic.nix {
+  major_version = "4";
+  minor_version = "08";
+  patch_version = "0+beta1";
+  sha256 = "1jgvp4pyhrg27wqpsx88kacw3ymjiz44nms9lzbh5s8pp05z5f5f";
+
+  # If the executable is stripped it does not work
+  dontStrip = true;
+}

--- a/pkgs/development/compilers/ocaml/4.08.nix
+++ b/pkgs/development/compilers/ocaml/4.08.nix
@@ -6,4 +6,7 @@ import ./generic.nix {
 
   # If the executable is stripped it does not work
   dontStrip = true;
+
+  # Breaks build with Clang
+  hardeningDisable = [ "strictoverflow" ];
 }

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -41,8 +41,10 @@ stdenv.mkDerivation (args // rec {
   };
 
   prefixKey = "-prefix ";
-  configureFlags = optionals useX11 [ "-x11lib" x11lib
-                                      "-x11include" x11inc ]
+  configureFlags = optionals useX11 (
+    if stdenv.lib.versionAtLeast version "4.08"
+    then [ "--x-libraries=${x11lib}" "--x-includes=${x11inc}"]
+    else [ "-x11lib" x11lib "-x11include" x11inc ])
   ++ optional flambdaSupport "-flambda"
   ;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1072,6 +1072,8 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_07 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.07.nix { });
 
+  ocamlPackages_4_08 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.08.nix { });
+
   ocamlPackages_latest = ocamlPackages_4_07;
 
   ocamlPackages = ocamlPackages_4_06;


### PR DESCRIPTION
###### Motivation for this change

> “The release of OCaml 4.08.0 is approaching.”
https://inbox.ocaml.org/caml-list/520BB6AA-58B7-4D31-9C64-781C2E24E000@inria.fr/T/#u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

