### PR TITLE
xfce4-13.tumbler: 0.2.1 -> 0.2.3

### DIFF
--- a/pkgs/desktops/xfce4-13/tumbler/default.nix
+++ b/pkgs/desktops/xfce4-13/tumbler/default.nix
@@ -6,9 +6,9 @@
 mkXfceDerivation rec {
   category = "xfce";
   pname = "tumbler";
-  version = "0.2.1";
+  version = "0.2.3";
 
-  sha256 = "0vgk3s6jnsrs8bawrfc11s8nwsm4jvcl3aidbaznk52g97xiyxz0";
+  sha256 = "1gb4dav6q9bn64c2ayi4896cr79lb8k63ja2sm3lwsjxgg1r4hw9";
 
   buildInputs = [ gdk_pixbuf ffmpegthumbnailer libgsf poppler ];
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

