### PR TITLE
rtl-sdr: Move udev rules

### DIFF
--- a/pkgs/applications/radio/rtl-sdr/default.nix
+++ b/pkgs/applications/radio/rtl-sdr/default.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
   #   rules manually.
   # * Propagate libusb-1.0 dependency in pkg-config file.
   postInstall = stdenv.lib.optionalString stdenv.isLinux ''
-    mkdir -p "$out/etc/udev/rules.d/"
-    cp ../rtl-sdr.rules "$out/etc/udev/rules.d/99-rtl-sdr.rules"
+    install -Dm=644 ../rtl-sdr.rules $out/lib/udev/rules.d/99-rtl-sdr.rules
 
     pcfile="$out"/lib/pkgconfig/librtlsdr.pc
     grep -q "Requires:" "$pcfile" && { echo "Upstream has added 'Requires:' in $(basename "$pcfile"); update nix expression."; exit 1; }


### PR DESCRIPTION
###### Motivation for this change
This should fix #55552.

And to get the udev rules installed one needs to do the following:
```nix
services.udev.packages = [ pkgs.rtl-sdr ];
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jparris @bjornfor 