### PR TITLE
python.pkgs.matplotlib: add numpy 1.6 compat patch

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -105,6 +105,12 @@ stdenv.mkDerivation rec {
       sha256 = "1n5c61mvhalcr2wbp66wzsynwwk59aakvx3xqa5zw9nlkx3rd0h1";
     })
 
+    # https://trac.sagemath.org/ticket/27061
+    (fetchpatch {
+      name = "numpy-1.16-inline-fortran.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id=a05b6b038e1571ab15464e98f76d1927c0c3fd12";
+      sha256 = "05yq97pq84xi60wb1p9skrad5h5x770gq98ll4frr7hvvmlwsf58";
+    })
   ];
 
   patches = nixPatches ++ packageUpgradePatches;

--- a/pkgs/development/python-modules/matplotlib/2.nix
+++ b/pkgs/development/python-modules/matplotlib/2.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchPypi, python, buildPythonPackage, pycairo, backports_functools_lru_cache
 , which, cycler, dateutil, nose, numpy, pyparsing, sphinx, tornado, kiwisolver
 , freetype, libpng, pkgconfig, mock, pytz, pygobject3, functools32, subprocess32
+, fetchpatch
 , enableGhostscript ? false, ghostscript ? null, gtk3
 , enableGtk2 ? false, pygtk ? null, gobject-introspection
 , enableGtk3 ? false, cairo
@@ -47,9 +48,16 @@ buildPythonPackage rec {
     ++ stdenv.lib.optionals enableQt [ pyqt4 ]
     ++ stdenv.lib.optionals python.isPy2 [ functools32 subprocess32 ];
 
-  patches =
-    [ ./basedirlist.patch ] ++
-    stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv-2.2.3.patch ];
+  patches = [
+    ./basedirlist.patch
+
+    # https://github.com/matplotlib/matplotlib/pull/12478
+    (fetchpatch {
+      name = "numpy-1.16-compat.patch";
+      url = "https://github.com/matplotlib/matplotlib/commit/2980184d092382a40ab21f95b79582ffae6e19d6.patch";
+      sha256 = "1c0wj28zy8s5h6qiavx9zzbhlmhjwpzbc3fyyw9039mbnqk0spg2";
+    })
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ ./darwin-stdenv-2.2.3.patch ];
 
   # Matplotlib tries to find Tcl/Tk by opening a Tk window and asking the
   # corresponding interpreter object for its library paths. This fails if


### PR DESCRIPTION
###### Motivation for this change

Numpy deprecated asscalar in 1.16. This will be fixed in the next
matplotlib version, but to avoid deprecation warnings (and because they
are breaking the sage testsuite), it can't hurt to backport the fix
already.

Upstream: https://github.com/matplotlib/matplotlib/pull/12478

The patch is already included in 3.x and will be in the next 2.x release.



Also adds a small sage patch needed for numpy 1.6 compatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

