### PR TITLE
bazel: set BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 on Darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -256,7 +256,12 @@ stdenv.mkDerivation rec {
     cp scripts/packages/bazel.sh $out/bin/bazel
     mv output/bazel $out/bin/bazel-real
 
-    wrapProgram "$out/bin/bazel" --add-flags --server_javabase="${runJdk}"
+    # Wrap bazel and set BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 which is necessary on
+    # Darwin to disable Bazel's Xcode toolchain detection which would configure
+    # compilers and linkers from Xcode instead of from PATH. This flag is no-op
+    # on Linux machines.
+    wrapProgram "$out/bin/bazel" --add-flags --server_javabase="${runJdk}" \
+      --set BAZEL_USE_CPP_ONLY_TOOLCHAIN 1
 
     # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions


### PR DESCRIPTION
###### Motivation for this change

This change fixes Bazel on Darwin machines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

