### PR TITLE
rocs: init at 18.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2434,7 +2434,11 @@
     name = "Karl Meakin";
     github = "Kmeakin";
   };
-
+  knairda = {
+    email = "adrian@kummerlaender.eu";
+    name = "Adrian Kummerlaender";
+    github = "KnairdA";
+  };
   knedlsepp = {
     email = "josef.kemetmueller@gmail.com";
     github = "knedlsepp";

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -166,6 +166,7 @@ let
       pim-data-exporter = callPackage ./pim-data-exporter.nix {};
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};
       print-manager = callPackage ./print-manager.nix {};
+      rocs = callPackage ./rocs.nix {};
       spectacle = callPackage ./spectacle.nix {};
       # Okteta was removed from kde applications and will now be released independently
       # Lets keep an alias for compatibility reasons

--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -1,0 +1,25 @@
+{
+  stdenv, mkDerivation, makeWrapper, lib,
+  extra-cmake-modules, boost,
+  qtbase, qtscript, qtquickcontrols, qtwebkit, qtxmlpatterns, grantlee,
+  kdoctools, karchive, kxmlgui, kcrash, kdeclarative, ktexteditor, kguiaddons
+}:
+
+mkDerivation {
+  name = "rocs";
+  nativeBuildInputs = [ extra-cmake-modules makeWrapper kdoctools ];
+  buildInputs = [
+    boost
+    qtbase qtscript qtquickcontrols qtwebkit qtxmlpatterns grantlee
+    kxmlgui kcrash kdeclarative karchive ktexteditor kguiaddons
+  ];
+  postInstall = ''
+    wrapProgram $out/bin/rocs --prefix QT_PLUGIN_PATH ":" "${qtbase.bin}/${qtbase.qtPluginPrefix}:$out/${qtbase.qtPluginPrefix}"
+  '';
+  meta = with lib; {
+    homepage = http://www.kde.org;
+    license = with licenses; [ gpl2 lgpl21 fdl12 ];
+    platforms = lib.platforms.linux;
+    maintainers = with maintainers; [ knairda ];
+  };
+}

--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, mkDerivation, makeWrapper, lib,
+  mkDerivation, lib,
   extra-cmake-modules, boost,
   qtbase, qtscript, qtquickcontrols, qtwebkit, qtxmlpatterns, grantlee,
   kdoctools, karchive, kxmlgui, kcrash, kdeclarative, ktexteditor, kguiaddons
@@ -13,9 +13,6 @@ mkDerivation {
     qtbase qtscript qtquickcontrols qtwebkit qtxmlpatterns grantlee
     kxmlgui kcrash kdeclarative karchive ktexteditor kguiaddons
   ];
-  postInstall = ''
-    wrapProgram $out/bin/rocs --prefix QT_PLUGIN_PATH ":" "${qtbase.bin}/${qtbase.qtPluginPrefix}:$out/${qtbase.qtPluginPrefix}"
-  '';
   meta = with lib; {
     homepage = http://www.kde.org;
     license = with licenses; [ gpl2 lgpl21 fdl12 ];

--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -7,16 +7,19 @@
 
 mkDerivation {
   name = "rocs";
-  nativeBuildInputs = [ extra-cmake-modules makeWrapper kdoctools ];
+
+  meta = with lib; {
+    homepage = "https://edu.kde.org/rocs/";
+    description = "A graph theory IDE.";
+    license = with licenses; [ gpl2 lgpl21 fdl12 ];
+    platforms = lib.platforms.linux;
+    maintainers = with maintainers; [ knairda ];
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     boost
     qtbase qtscript qtquickcontrols qtwebkit qtxmlpatterns grantlee
     kxmlgui kcrash kdeclarative karchive ktexteditor kguiaddons
   ];
-  meta = with lib; {
-    homepage = http://www.kde.org;
-    license = with licenses; [ gpl2 lgpl21 fdl12 ];
-    platforms = lib.platforms.linux;
-    maintainers = with maintainers; [ knairda ];
-  };
 }


### PR DESCRIPTION
###### Motivation for this change

Derivation for Rocs was missing despite the source being referenced in `pkgs/applications/kde/srcs.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

