### PR TITLE
New package for `yubikey-manager-qt`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -788,6 +788,11 @@
     github = "caugner";
     name = "Claas Augner";
   };
+  cbley = {
+    email = "claudio.bley@gmail.com";
+    github = "avdv";
+    name = "Claudio Bley";
+  };
   cdepillabout = {
     email = "cdep.illabout@gmail.com";
     github = "cdepillabout";

--- a/pkgs/tools/misc/yubikey-manager-qt/default.nix
+++ b/pkgs/tools/misc/yubikey-manager-qt/default.nix
@@ -1,0 +1,81 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+, pyotherside
+, pythonPackages
+, python3
+, qmake
+, qt5
+, yubikey-manager
+, yubikey-personalization
+}:
+
+with import <nixpkgs> {};
+
+let
+  qmlPath = qmlLib: "${qmlLib}/${qt5.qtbase.qtQmlPrefix}";
+
+  qml2ImportPath = lib.concatMapStringsSep ";" qmlPath [
+    qt5.qtbase.bin qt5.qtdeclarative.bin pyotherside qt5.qtquickcontrols qt5.qtquickcontrols2.bin qt5.qtgraphicaleffects
+  ];
+
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "yubikey-manager-qt";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-${version}.tar.gz";
+    sha256 = "8049a233a8cca07543d745a9f619c0fc3afb324f5d0030b93f037b34ac1c5e66";
+  };
+
+  nativeBuildInputs = [ makeWrapper python3.pkgs.wrapPython qmake ];
+
+  sourceRoot = ".";
+
+  postPatch = ''
+    substituteInPlace ykman-gui/deployment.pri --replace '/usr/bin' "$out/bin"
+  '';
+
+  buildInputs = [ pythonPackages.python stdenv qt5.qtbase qt5.qtgraphicaleffects qt5.qtquickcontrols qt5.qtquickcontrols2 pyotherside ];
+
+  buildPhase = ''
+    qmake
+    make
+  '';
+
+  enableParallelBuilding = true;
+
+  pythonPath = [ yubikey-manager ];
+
+  # Need LD_PRELOAD for libykpers as the Nix cpython disables ctypes.cdll.LoadLibrary
+  # support that the yubicommon library uses to load libykpers
+  postInstall = ''
+    buildPythonPath "$pythonPath"
+
+    wrapProgram $out/bin/ykman-gui \
+      --prefix PYTHONPATH : "$program_PYTHONPATH" \
+      --prefix LD_PRELOAD : "${yubikey-personalization}/lib/libykpers-1.so" \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib pcsclite}/lib:${yubikey-personalization}/lib" \
+      --set QML2_IMPORT_PATH "${qml2ImportPath}" \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms \
+      --prefix QT_PLUGIN_PATH : "${qt5.qtsvg.bin}/${qt5.qtbase.qtPluginPrefix}"
+
+      mkdir -p $out/share/applications
+      cp resources/ykman-gui.desktop $out/share/applications/ykman-gui.desktop
+      mkdir -p $out/share/ykman-gui/icons
+      cp resources/icons/*.{icns,ico,png,xpm} $out/share/ykman-gui/icons
+      substituteInPlace $out/share/applications/ykman-gui.desktop \
+        --replace 'Exec=ykman-gui' "Exec=$out/bin/ykman-gui" \
+  '';
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = ''Cross-platform application for configuring any YubiKey over all USB interfaces.'';
+    homepage = https://developers.yubico.com/yubikey-manager-qt/;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.cbley ];
+    platforms = platforms.linux;
+    homepage = "https://github.com/Yubico";
+  };
+}

--- a/pkgs/tools/misc/yubikey-manager-qt/default.nix
+++ b/pkgs/tools/misc/yubikey-manager-qt/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl
 , makeWrapper
+, pcsclite
 , pyotherside
 , pythonPackages
 , python3
@@ -10,22 +11,21 @@
 , yubikey-personalization
 }:
 
-with import <nixpkgs> {};
+with stdenv;
 
 let
   qmlPath = qmlLib: "${qmlLib}/${qt5.qtbase.qtQmlPrefix}";
 
-  qml2ImportPath = lib.concatMapStringsSep ";" qmlPath [
+  qml2ImportPath = lib.concatMapStringsSep ":" qmlPath [
     qt5.qtbase.bin qt5.qtdeclarative.bin pyotherside qt5.qtquickcontrols qt5.qtquickcontrols2.bin qt5.qtgraphicaleffects
   ];
 
 in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "yubikey-manager-qt";
   version = "1.1.0";
 
   src = fetchurl {
-    url = "https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-${version}.tar.gz";
+    url = "https://developers.yubico.com/yubikey-manager-qt/Releases/${pname}-${version}.tar.gz";
     sha256 = "8049a233a8cca07543d745a9f619c0fc3afb324f5d0030b93f037b34ac1c5e66";
   };
 
@@ -37,12 +37,7 @@ in stdenv.mkDerivation rec {
     substituteInPlace ykman-gui/deployment.pri --replace '/usr/bin' "$out/bin"
   '';
 
-  buildInputs = [ pythonPackages.python stdenv qt5.qtbase qt5.qtgraphicaleffects qt5.qtquickcontrols qt5.qtquickcontrols2 pyotherside ];
-
-  buildPhase = ''
-    qmake
-    make
-  '';
+  buildInputs = [ pythonPackages.python qt5.qtbase qt5.qtgraphicaleffects qt5.qtquickcontrols qt5.qtquickcontrols2 pyotherside ];
 
   enableParallelBuilding = true;
 
@@ -71,11 +66,10 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     inherit version;
-    description = ''Cross-platform application for configuring any YubiKey over all USB interfaces.'';
+    description = "Cross-platform application for configuring any YubiKey over all USB interfaces.";
     homepage = https://developers.yubico.com/yubikey-manager-qt/;
     license = licenses.bsd2;
     maintainers = [ maintainers.cbley ];
     platforms = platforms.linux;
-    homepage = "https://github.com/Yubico";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13099,6 +13099,10 @@ in
 
   yubikey-manager = callPackage ../tools/misc/yubikey-manager { };
 
+  yubikey-manager-qt = libsForQt5.callPackage ../tools/misc/yubikey-manager-qt {
+    pythonPackages = python3Packages;
+  };
+
   yubikey-neo-manager = callPackage ../tools/misc/yubikey-neo-manager { };
 
   yubikey-personalization = callPackage ../tools/misc/yubikey-personalization {


### PR DESCRIPTION
###### Motivation for this change

I own a few Yubikeys, USB keys for FIDO2 U2F auth. There is a new graphical  manager appliation based on Qt5 (similar to yubikey-manager-neo) from Yubico.

This is my first try writing a Nix expression for a new package, a probably made some mistakes. Please advice.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

