### PR TITLE
soapy[bladerf,remote,uhd]:  0.4.0 -> 0.4.1, 0.5.0 -> 0.5.1, 0.3.4 -> 0.3.5

### DIFF
--- a/pkgs/applications/radio/soapybladerf/default.nix
+++ b/pkgs/applications/radio/soapybladerf/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "0.4.0";
+  version = "0.4.1";
 
 in stdenv.mkDerivation {
   name = "soapybladerf-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "pothosware";
     repo = "SoapyBladeRF";
     rev = "soapy-bladerf-${version}";
-    sha256 = "1gf1azfydw033nlg2bgs9cbsbp9npjdrgjwlsffn0d9x0qbgxjqp";
+    sha256 = "02wh09850vinqg248fw4lxmx7y857cqmnnb8jm9zhyrsggal0hki";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/applications/radio/soapyremote/default.nix
+++ b/pkgs/applications/radio/soapyremote/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, soapysdr, avahi }:
 
 let
-  version = "0.5.0";
+  version = "0.5.1";
 
 in stdenv.mkDerivation {
   name = "soapyremote-${version}";
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
     owner = "pothosware";
     repo = "SoapyRemote";
     rev = "soapy-remote-${version}";
-    sha256 = "1lyjhf934zap61ky7rbk46bp8s8sjk8sgdyszhryfyf571jv9b2i";
+    sha256 = "1qlpjg8mh564q26mni8g6bb8w9nj7hgcq86278fszxpwpnk3jsvk";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/radio/soapyuhd/default.nix
+++ b/pkgs/applications/radio/soapyuhd/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "0.3.4";
+  version = "0.3.5";
 
 in stdenv.mkDerivation {
   name = "soapyuhd-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "pothosware";
     repo = "SoapyUHD";
     rev = "soapy-uhd-${version}";
-    sha256 = "1da7cjcvfdqhgznm7x14s1h7lwz5lan1b48akw445ah1vxwvh4hl";
+    sha256 = "07cr4zk42d0l5g03wm7dzl5lmqr104hmzp1fdjqa1z7xq4v9c9b1";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Regular updates of some soapy plugins. Changelogs:
* https://github.com/pothosware/SoapyBladeRF/blob/master/Changelog.txt
* https://github.com/pothosware/SoapyRemote/blob/master/Changelog.txt
* https://github.com/pothosware/SoapyUHD/blob/master/Changelog.txt
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

