### PR TITLE
limesuite: 18.10.0 -> 19.01.0

### DIFF
--- a/pkgs/applications/radio/limesuite/default.nix
+++ b/pkgs/applications/radio/limesuite/default.nix
@@ -4,7 +4,7 @@
 } :
 
 let
-  version = "18.10.0";
+  version = "19.01.0";
 
 in stdenv.mkDerivation {
   name = "limesuite-${version}";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation {
     owner = "myriadrf";
     repo = "LimeSuite";
     rev = "v${version}";
-    sha256 = "0nbyvcdwvfvln1wic9qwb7y221v3jv454gp5v6ms9112a41zj46h";
+    sha256 = "1r03kc1pvlhkvp19qbw7f5qzxx48z2v638f0xpawf6d1nwfky1n3";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Fresh 2019 version. 
Changelog: https://github.com/myriadrf/LimeSuite/blob/master/Changelog.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

