### PR TITLE
xorg.bitmap: 1.0.8 -> 1.0.9

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -32,11 +32,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   bitmap = callPackage ({ stdenv, pkgconfig, fetchurl, libX11, libXaw, xbitmaps, libXmu, xorgproto, libXt }: stdenv.mkDerivation {
-    name = "bitmap-1.0.8";
+    name = "bitmap-1.0.9";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/bitmap-1.0.8.tar.gz;
-      sha256 = "1z06a1sn3iq72rmh73f11xgb7n46bdav1fvpgczxjp6al88bsbqs";
+      url = mirror://xorg/individual/app/bitmap-1.0.9.tar.gz;
+      sha256 = "0kzbv5wh02798l77y9y8d8sjkmzm9cvsn3rjh8a86v5waj50apsb";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -11,7 +11,7 @@ https://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.9.tar.bz2
 https://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.bz2
 mirror://xorg/individual/app/appres-1.0.5.tar.bz2
 mirror://xorg/individual/app/bdftopcf-1.1.tar.bz2
-mirror://xorg/individual/app/bitmap-1.0.8.tar.gz
+mirror://xorg/individual/app/bitmap-1.0.9.tar.gz
 mirror://xorg/individual/app/editres-1.0.7.tar.bz2
 mirror://xorg/individual/app/fonttosfnt-1.0.5.tar.bz2
 mirror://xorg/individual/app/iceauth-1.0.8.tar.bz2


### PR DESCRIPTION
###### Motivation for this change

https://lists.x.org/archives/xorg-announce/2019-February/002941.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---