### PR TITLE
gcalcli: 4.0.0a4 -> 4.0.3

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -4,15 +4,21 @@
 with python3.pkgs;
 
 buildPythonApplication rec {
-  version = "4.0.0a4";
-  name = "gcalcli-${version}";
+  pname = "gcalcli";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner  = "insanum";
-    repo   = "gcalcli";
+    repo   = pname;
     rev    = "v${version}";
-    sha256 = "00giq5cdigidzv5bz4wgzi1yp6xlf2rdcy6ynmsc6bcf0cl5x64d";
+    sha256 = "15hpm7b09p5qnha0hpp0mgdl2pgsyq2sjcqihk3fsv7arngdbr5q";
   };
+
+  postPatch = lib.optionalString stdenv.isLinux ''
+    substituteInPlace gcalcli/argparsers.py --replace \
+      "command = 'notify-send -u critical" \
+      "command = '${libnotify}/bin/notify-send -u critical"
+  '';
 
   propagatedBuildInputs = [
     dateutil gflags httplib2 parsedatetime six vobject


### PR DESCRIPTION
###### Motivation for this change

Pretty sure build-tested and tested resulting utility
(it complained about some flags in my ~/.gcalclirc were deprecated)
but don't have that build handy so just in case let's check again :).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---