### PR TITLE
agave: 008 -> 009

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -1,20 +1,21 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "agave-${version}";
-  version = "008";
+  pname = "agave";
+  version = "009";
 
   src = fetchurl {
-    url = "https://github.com/agarick/agave/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "0g50mqpffn4dq761vibaf8dwfkbcl5da1cc89qz6pq35ircipbns";
+    url = "https://github.com/agarick/agave/releases/download/v${version}/agave-r.ttf";
+    sha256 = "05766gp2glm1p2vknk1nncxigq28hg8s58kjwsbn8zpwy8ivywpk";
   };
 
   sourceRoot = ".";
 
+  unpackPhase = ":";
   dontBuild = true;
   installPhase = ''
     mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
+    cp $src $out/share/fonts/truetype/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Touchups.

Packaging changed a bit since only ships
a single ttf now.

https://github.com/agarick/agave/compare/v008...v009

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---