### PR TITLE
libgxps: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/development/libraries/libgxps/default.nix
+++ b/pkgs/development/libraries/libgxps/default.nix
@@ -1,28 +1,15 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobject-introspection, cairo
-, libarchive, freetype, libjpeg, libtiff, gnome3, fetchpatch
+, libarchive, freetype, libjpeg, libtiff, gnome3
 }:
 
 stdenv.mkDerivation rec {
   pname = "libgxps";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "412b1343bd31fee41f7204c47514d34c563ae34dafa4cc710897366bd6cd0fae";
+    sha256 = "157s4c9gjjss6yd7qp7n4q6s72gz1k4ilsx4xjvp357azk49z4qs";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2018-10733-1.patch";
-      url = https://gitlab.gnome.org/GNOME/libgxps/commit/b458226e162fe1ffe7acb4230c114a52ada5131b.patch;
-      sha256 = "0pqg9iwkg69qknj7vkgn26c32fndy55byxivd4km0vjfhfyx69hd";
-    })
-    (fetchpatch {
-      name = "CVE-2018-10733-2.patch";
-      url = https://gitlab.gnome.org/GNOME/libgxps/commit/133fe2a96e020d4ca65c6f64fb28a404050ebbfd.patch;
-      sha256 = "19n01x8zs05wf801mkz4mypvapph7h941md3hr3rj0ry6r88pkir";
-    })
-  ];
 
   nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
   buildInputs = [ glib cairo freetype libjpeg libtiff ];

--- a/pkgs/development/libraries/libgxps/default.nix
+++ b/pkgs/development/libraries/libgxps/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobject-introspection, cairo
-, libarchive, freetype, libjpeg, libtiff, gnome3
+, libarchive, freetype, libjpeg, libtiff, gnome3, lcms2
 }:
 
 stdenv.mkDerivation rec {
@@ -12,12 +12,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
-  buildInputs = [ glib cairo freetype libjpeg libtiff ];
+  buildInputs = [ glib cairo freetype libjpeg libtiff lcms2 ];
   propagatedBuildInputs = [ libarchive ];
 
   mesonFlags = [
     "-Denable-test=false"
-    "-Dwith-liblcms2=false"
   ];
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---