### PR TITLE
gnome-documents: 3.30.0 -> 3.30.1

### DIFF
--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, meson, ninja, gettext, fetchurl, fetchpatch, evince, gjs
+{ stdenv, meson, ninja, gettext, fetchurl, evince, gjs
 , pkgconfig, gtk3, glib, tracker, tracker-miners
 , itstool, libxslt, webkitgtk, libgdata
 , gnome-desktop, libzapojit, libgepub
@@ -29,14 +29,6 @@ stdenv.mkDerivation rec {
     libsoup webkitgtk gjs gobject-introspection
     tracker tracker-miners libgdata
     gnome-desktop libzapojit libgepub
-  ];
-
-  patches = [
-    # fix RPATH to libgd
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-documents/commit/d18a92e0a940073ac766f609937539e4fc6cdbb7.patch";
-      sha256 = "0s3mk8vrl1gzk93yvgqbnz44i27qw1d9yvvmnck3fv23phrxkzk9";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-documents-${version}";
-  version = "3.30.0";
+  version = "3.30.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-documents/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0zchkjpc9algmxrpj0f9i2lc4h1yp8z0h76vn32xa9jr46x4lsh6";
+    sha256 = "1z8gkfi2wyyd3bbv73rcdzi1gzaaaskabyscmbj51prayiw106b6";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -7,17 +7,20 @@
 , desktop-file-utils, wrapGAppsHook, python3 }:
 
 stdenv.mkDerivation rec {
-  name = "gnome-documents-${version}";
+  pname = "gnome-documents";
   version = "3.30.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-documents/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/gnome-documents/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1z8gkfi2wyyd3bbv73rcdzi1gzaaaskabyscmbj51prayiw106b6";
   };
 
   doCheck = true;
 
-  mesonFlags = [ "-Dgetting-started=true" ];
+  mesonFlags = [
+    "-Dgetting_started=true"
+    "-Dno_network=true"
+  ];
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext itstool libxslt desktop-file-utils docbook_xsl docbook_xml_dtd_42 wrapGAppsHook python3
@@ -29,6 +32,11 @@ stdenv.mkDerivation rec {
     libsoup webkitgtk gjs gobject-introspection
     tracker tracker-miners libgdata
     gnome-desktop libzapojit libgepub
+  ];
+
+  # Don't try to keep git submodules in sync for build
+  patches = [
+    ./no-network-option.patch
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/no-network-option.patch
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/no-network-option.patch
@@ -1,0 +1,21 @@
+diff --git a/meson.build b/meson.build
+index 55e12065..895f59d1 100644
+--- a/meson.build
++++ b/meson.build
+@@ -30,7 +30,7 @@ documents_pkglibdir = join_paths(documents_libdir, meson.project_name())
+
+ documents_schemadir = join_paths(documents_datadir, 'glib-2.0', 'schemas')
+
+-if not get_option('buildtype').contains('plain')
++if not get_option('no_network')
+   run_command('git', '-C', meson.source_root(), 'submodule', 'update', '--init', '--recursive')
+ endif
+
+diff --git a/meson_options.txt b/meson_options.txt
+index aa4f389f..55705447 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,2 +1,3 @@
+ option('documentation', type: 'boolean', value: true, description: 'build documentation')
+ option('getting_started', type: 'boolean', value: false, description: 'build getting started PDFs')
++option('no_network', type: 'boolean', value: false, description: 'build without networking')


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---