### PR TITLE
cdimgtools,perlPackages.DataHexdumper: init at 0.3, init at 3.001

### DIFF
--- a/pkgs/tools/cd-dvd/cdimgtools/default.nix
+++ b/pkgs/tools/cd-dvd/cdimgtools/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromRepoOrCz, autoreconfHook, makeWrapper, libdvdcss, libdvdread, perl, perlPackages, asciidoc, xmlto, sourceHighlight, docbook_xsl, docbook_xml_dtd_45 }:
+
+stdenv.mkDerivation rec {
+  name = "cdimgtools-${version}";
+  version = "0.3";
+
+  src = fetchFromRepoOrCz {
+    repo = "cdimgtools";
+    rev = "version/0.3";
+    sha256 = "1hxg3glxj26fh9xnv184sfdc2wi4cnzvn7chz47wcqdsd0d5fn8w";
+  };
+
+  nativeBuildInputs = [ autoreconfHook makeWrapper asciidoc perlPackages.PodPerldoc xmlto sourceHighlight docbook_xsl docbook_xml_dtd_45 ];
+
+  buildInputs = [ perl perlPackages.StringEscape perlPackages.DataHexdumper libdvdcss libdvdread ];
+
+  patches = [ ./nrgtool_fix_my.patch ./removed_dvdcss_interface_2.patch];
+
+  postFixup = ''
+    for cmd in raw96cdconv nrgtool; do
+      wrapProgram "$out/bin/$cmd" --prefix PERL5LIB : "$PERL5LIB"
+    done
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  installTargets = [ "install" "install-doc" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://repo.or.cz/cdimgtools.git/blob_plain/refs/heads/release:/README.html;
+    description = "Tools to inspect and manipulate CD/DVD optical disc images";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ hhm ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/tools/cd-dvd/cdimgtools/nrgtool_fix_my.patch
+++ b/pkgs/tools/cd-dvd/cdimgtools/nrgtool_fix_my.patch
@@ -1,0 +1,12 @@
+Fixes an error in nrgtool.
+--- a/nrgtool
++++ b/nrgtool
+@@ -162,7 +162,7 @@ sub process_file {
+ 	}
+ 	seek $nrg, 0, SEEK_SET if ($iff_only);
+ 	seek $nrg, $offset, SEEK_SET unless ($iff_only);
+-	while (my $_ = read_chunk($nrg, $iff)) {
++	while ($_ = read_chunk($nrg, $iff)) {
+ 		if ($_ < -1) {
+ 			warn  "ERROR while reading an IFF chunk; aborting\n";
+ 			return;

--- a/pkgs/tools/cd-dvd/cdimgtools/removed_dvdcss_interface_2.patch
+++ b/pkgs/tools/cd-dvd/cdimgtools/removed_dvdcss_interface_2.patch
@@ -1,0 +1,53 @@
+Removes the deprecated and removed `dvdcss_interface_2` libdvdcss function.
+
+This does not change any functionality; it only modifies the printing of software version information.
+--- a/cssdec.c
++++ b/cssdec.c
+@@ -102,8 +102,8 @@ int main( int argc, char *argv[] )
+ 			b_keyonly = 1;
+ 			break;
+ 		case 'V':
+-			printf( "%s version %s (libdvdcss version %s)\n",
+-			  progname, progversion, dvdcss_interface_2 );
++			printf( "%s version %s\n",
++			  progname, progversion );
+ 			exit( EX_SUCCESS );
+ 			break;
+ 		case '?':
+@@ -126,8 +126,8 @@ int main( int argc, char *argv[] )
+ 	if( argc >= 3 ) end = (int)strtol( argv[2], (char **)NULL, 0 );
+ 
+ 	/* Initialize libdvdcss */
+-	printe( 2, "%s version %s (libdvdcss version %s)",
+-	  progname, progversion, dvdcss_interface_2 );
++	printe( 2, "%s version %s",
++	  progname, progversion );
+ 	dvdcss = dvdcss_open( (char *)dvdfile );
+ 	if( dvdcss == NULL )
+ 	{
+diff --git a/dvdimgdecss.c b/dvdimgdecss.c
+index 0b7006d..b7d251a 100644
+--- a/dvdimgdecss.c
++++ b/dvdimgdecss.c
+@@ -157,8 +157,8 @@ int main( int argc, char *argv[] )
+ 			dvdread_decrypt = 1;
+ 			break;
+ 		case 'V':
+-			printf( "%s version %s (libdvdcss version %s)\n",
+-			  progname, progversion, dvdcss_interface_2 );
++			printf( "%s version %s\n",
++			  progname, progversion );
+ 			exit( EX_SUCCESS );
+ 			break;
+ 		case '?':
+@@ -180,8 +180,8 @@ int main( int argc, char *argv[] )
+ 	if( !imgfile ) verbosity++;
+ 
+ 	/* Open the DVD */
+-	printe( 2, "%s: version %s (libdvdcss version %s)\n",
+-	  progname, progversion, dvdcss_interface_2 );
++	printe( 2, "%s: version %s\n",
++	  progname, progversion );
+ 	dvdcss = dvdcss_open( dvdfile );
+ 	if( dvdcss == NULL ) {
+ 		printe( 1, "opening of the DVD (%s) with libdvdcss failed\n", dvdfile );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1871,6 +1871,8 @@ in
 
   cdi2iso = callPackage ../tools/cd-dvd/cdi2iso { };
 
+  cdimgtools = callPackage ../tools/cd-dvd/cdimgtools { };
+
   cdrdao = callPackage ../tools/cd-dvd/cdrdao { };
 
   cdrkit = callPackage ../tools/cd-dvd/cdrkit { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3256,6 +3256,18 @@ let
     };
   };
 
+  DataHexdumper = buildPerlPackage rec {
+    name = "Data-Hexdumper-3.0001";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/${name}.tar.gz";
+      sha256 = "f9243cbe8affed5045fe4df505726a7a7289471e30c51ac065b3ed6ce0d1a604";
+    };
+    meta = {
+      description = "Make binary data human-readable";
+      license = with stdenv.lib.licenses; [ artistic1 gpl2 ];
+    };
+  };
+
   DataHierarchy = buildPerlPackage {
     name = "Data-Hierarchy-0.34";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Adds the `CD|imgtools` package, which is useful for certain operations on CD images.

Also adds its dependencies which were not already present.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

