### PR TITLE
ninja: patch to fix w/musl, see upstream issue

### DIFF
--- a/pkgs/development/tools/build-managers/ninja/default.nix
+++ b/pkgs/development/tools/build-managers/ninja/default.nix
@@ -20,6 +20,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/ninja-build/ninja/commit/9aa947471fcfc607bec6d92a1a6eed5c692edbaf.patch";
       sha256 = "0zsg46jflsh644jccrcgyfalr7fkzrv041kyi8644nyk923gcrl9";
     })
+    # https://github.com/ninja-build/ninja/issues/1510 - fix w/musl, possibly BSDs?
+    # 
+    (fetchpatch {
+      name = "fix-issue-1510.patch";
+      url = https://github.com/makepost/ninja/commit/567815df38a2ff54ad7478a90bd75c91e434236a.patch;
+      sha256 = "0zd0xyi7h2066nw1dsk76c7yf71b0f7v4p5nljda7jxi01vpdh69";
+    })
   ];
 
   nativeBuildInputs = [ python re2c ] ++ optionals buildDocs [ asciidoc docbook_xml_dtd_45 docbook_xsl libxslt.bin ];


### PR DESCRIPTION
###### Motivation for this change

Fix w/musl, possibly fix elsewhere.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---