### PR TITLE
yanone-kaffeesatz: init at 2004

### DIFF
--- a/pkgs/data/fonts/yanone-kaffeesatz/default.nix
+++ b/pkgs/data/fonts/yanone-kaffeesatz/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchzip}:
+
+fetchzip {
+  name = "yanone-kaffeesatz-2004";
+
+  url = https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip;
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "190c4wx7avy3kp98lsyml7kc0jw7csf5n79af2ypbkhsadfsy8di";
+
+  meta = {
+    description = "The free font classic";
+    maintainers = with stdenv.lib.maintainers; [ mt-caret ];
+    platforms = with stdenv.lib.platforms; all;
+    homepage = https://yanone.de/fonts/kaffeesatz/;
+    license = stdenv.lib.licenses.ofl;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16006,6 +16006,8 @@ in
 
   xorg-rgb = callPackage ../data/misc/xorg-rgb {};
 
+  yanone-kaffeesatz = callPackage ../data/fonts/yanone-kaffeesatz {};
+
   zafiro-icons = callPackage ../data/icons/zafiro-icons { };
 
   zeal = libsForQt5.callPackage ../data/documentation/zeal { };


### PR DESCRIPTION
###### Motivation for this change

Add a font.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

