### PR TITLE
squirrel-sql: Add MSSQL driver.

### DIFF
--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -47,6 +47,8 @@ in stdenv.mkDerivation rec {
     makeWrapper $out/share/squirrel-sql/squirrel-sql.sh $out/bin/squirrel-sql \
       --set CLASSPATH "$cp" \
       --set JAVA_HOME "${jre}"
+    # Make sure above `CLASSPATH` gets picked up
+    substituteInPlace $out/share/squirrel-sql/squirrel-sql.sh --replace "-cp \"\$CP\"" "-cp \"\$CLASSPATH:\$CP\""
 
     mkdir -p $out/share/icons/hicolor/32x32/apps
     ln -s $out/share/squirrel-sql/icons/acorn.png \

--- a/pkgs/servers/sql/mssql/jdbc/builder.sh
+++ b/pkgs/servers/sql/mssql/jdbc/builder.sh
@@ -1,0 +1,6 @@
+source $stdenv/setup
+
+set -e
+
+mkdir -p $out/share/java
+cp $src $out/share/java/mssql-jdbc.jar

--- a/pkgs/servers/sql/mssql/jdbc/default.nix
+++ b/pkgs/servers/sql/mssql/jdbc/default.nix
@@ -1,0 +1,16 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  pname = "mssql-jdbc";
+  version = "7.2.2";
+  builder = ./builder.sh;
+
+  src = fetchurl {
+    url = "https://github.com/Microsoft/mssql-jdbc/releases/download/v${version}/${pname}-${version}.jre8.jar";
+    sha256 = "09psxjy1v3khq8lcq6h9mbgyijsgawf0z2qryk1l91ypnwl8s3pg";
+  };
+
+  meta = {
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7898,7 +7898,7 @@ in
   squeak = callPackage ../development/compilers/squeak { };
 
   squirrel-sql = callPackage ../development/tools/database/squirrel-sql {
-    drivers = [ mysql_jdbc postgresql_jdbc ];
+    drivers = [ mssql_jdbc mysql_jdbc postgresql_jdbc ];
   };
 
   stalin = callPackage ../development/compilers/stalin { };
@@ -14271,6 +14271,8 @@ in
   };
 
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };
+
+  mssql_jdbc = callPackage ../servers/sql/mssql/jdbc { };
 
   miniflux = callPackage ../servers/miniflux { };
 


### PR DESCRIPTION
###### Motivation for this change

Use squirrel-sql to talk to MSSQL databases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

