### PR TITLE
rdma-core: 22 -> 22.1

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "22";
+  version = "22.1";
 
 in stdenv.mkDerivation {
   name = "rdma-core-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "linux-rdma";
     repo = "rdma-core";
     rev = "v${version}";
-    sha256 = "1xkd51bz6p85gahsw18knrvirn404ca98lqmp1assyn4irs7khx8";
+    sha256 = "04772rsn5a0gr4yss63fk35zfl05hz2l27q9yva922i8qq38f90a";
   };
 
   nativeBuildInputs = [ cmake pkgconfig pandoc ];


### PR DESCRIPTION
###### Motivation for this change
regular upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

