### PR TITLE
alt-ergo: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -1,17 +1,20 @@
-{ fetchurl, stdenv, ocamlPackages }:
+{ fetchurl, stdenv, which, dune, ocamlPackages }:
 
 stdenv.mkDerivation rec {
   name = "alt-ergo-${version}";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchurl {
     url    = "https://alt-ergo.ocamlpro.com/download_manager.php?target=${name}.tar.gz";
     name   = "${name}.tar.gz";
-    sha256 = "106zfgisq6qxr7dlk8z7gi68ly7qff4frn8wab2g8z2nkkwla92w";
+    sha256 = "1ycr3ff0gacq1aqzs16n6swgfniwpim0m7rvhcam64kj0a80c6bz";
   };
 
-  buildInputs = with ocamlPackages;
-    [ ocaml findlib camlzip ocamlgraph zarith lablgtk ocplib-simplex psmt2-frontend menhir num ];
+  buildInputs = [ dune which ] ++ (with ocamlPackages; [
+    ocaml findlib camlzip lablgtk menhir num ocplib-simplex psmt2-frontend seq zarith
+  ]);
+
+  preConfigure = "patchShebangs ./configure";
 
   meta = {
     description = "High-performance theorem prover and SMT solver";

--- a/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
+++ b/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
@@ -5,14 +5,14 @@ then throw "psmt2-frontend is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "0.1";
+  version = "0.2";
   name = "ocaml${ocaml.version}-psmt2-frontend-${version}";
 
   src = fetchFromGitHub {
     owner = "Coquera";
     repo = "psmt2-frontend";
     rev = version;
-    sha256 = "0k7jlsbkdyg7hafmvynp0ik8xk7mfr00wz27vxn4ncnmp20yz4vn";
+    sha256 = "097zmbrx4gp2gnrxdmsm9lkkp5450gwi0blpxqy3833m6k5brx3n";
   };
 
   prefixKey = "-prefix ";


### PR DESCRIPTION
###### Motivation for this change

Download link  for version 2.2.0 is broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

