### PR TITLE
imagemagickBig: mark as broken

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
     description = "A software suite to create, edit, compose, or convert bitmap images";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.asl20;
+    broken = ghostscript != null; # https://github.com/NixOS/nixpkgs/issues/55118
     maintainers = with maintainers; [ the-kenny ];
   };
 }

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -100,6 +100,7 @@ stdenv.mkDerivation rec {
     description = "A software suite to create, edit, compose, or convert bitmap images";
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ the-kenny ];
+    broken = ghostscript != null; # https://github.com/NixOS/nixpkgs/issues/55118
     license = licenses.asl20;
   };
 }


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/55118: Reading PDFs is completely broken. 
As I don't see a quick fix for this issue, I'd recommend marking the package as broken.
