### PR TITLE
slic3r-prusa3d: 1.41.2 -> 1.41.3

### DIFF
--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -33,7 +33,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "slic3r-prusa-edition-${version}";
-  version = "1.41.2";
+  version = "1.41.3";
 
   enableParallelBuilding = true;
 
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "Slic3r";
-    sha256 = "046ircwc0wr586v7106ys557ypslmyq9p4qgi34ads1d6bgxhlyy";
+    sha256 = "0mxgxq968d6vrpc92iymw42hcjkbf2v87l4h8x7fadi1jqm4ccwy";
     rev = "version_${version}";
   };
 


### PR DESCRIPTION
###### Motivation for this change

New update on the stable branch. https://github.com/prusa3d/Slic3r/releases/tag/version_1.41.3

1.42.0 is still in development, so https://github.com/NixOS/nixpkgs/pull/55475 has to wait.

cc @thorstenweber83 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

