### PR TITLE
qtractor: 0.6.7 -> 0.9.4

### DIFF
--- a/pkgs/applications/audio/qtractor/default.nix
+++ b/pkgs/applications/audio/qtractor/default.nix
@@ -1,21 +1,24 @@
-{ alsaLib, autoconf, automake, dssi, fetchurl, gtk2, libjack2
+{ alsaLib, autoconf, automake, dssi, fetchurl, libjack2
 , ladspaH, ladspaPlugins, liblo, libmad, libsamplerate, libsndfile
-, libtool, libvorbis, lilv, lv2, pkgconfig, qt4, rubberband, serd
+, libtool, libvorbis, lilv, lv2, pkgconfig, qttools, qtbase, rubberband, serd
 , sord, sratom, stdenv, suil }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.7";
-  name = "qtractor-${version}";
+  pname = "qtractor";
+  version = "0.9.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/qtractor/${name}.tar.gz";
-    sha256 = "0h5nblfkl4s412c9f02b40nb8c8jq8ypz67z2qn3hkvhx6i9yxsg";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "05xrzr48b19mghbpbzjqw5fy6pl9140bm5m929lrsi4rq5hp3xgg";
   };
 
+  nativeBuildInputs = [
+    autoconf automake libtool pkgconfig qttools
+  ];
   buildInputs =
-    [ alsaLib autoconf automake dssi gtk2 libjack2 ladspaH
+    [ alsaLib dssi libjack2 ladspaH
       ladspaPlugins liblo libmad libsamplerate libsndfile libtool
-      libvorbis lilv lv2 pkgconfig qt4 rubberband serd sord sratom
+      libvorbis lilv lv2 qtbase rubberband serd sord sratom
       suil
     ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19047,7 +19047,7 @@ in
 
   qtpfsgui = callPackage ../applications/graphics/qtpfsgui { };
 
-  qtractor = callPackage ../applications/audio/qtractor { };
+  qtractor = libsForQt5.callPackage ../applications/audio/qtractor { };
 
   qtscrobbler = callPackage ../applications/audio/qtscrobbler { };
 


### PR DESCRIPTION
FWIW this release is marked as a beta but so is 0.6.7
and a quick glance suggests every release is as well :).

* move to qt5
* drop gtk2
* fixup some nativeBuildInputs


###### Motivation for this change

Was looking for software to test ladspa-sdk and mlt with,
noticed "big" upgrade avail so thought I'd give a go.

Looks operational to me, although never used before :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---