### PR TITLE
ladspa-sdk: 1.13 -> 1.15

### DIFF
--- a/pkgs/applications/audio/ladspa-sdk/default.nix
+++ b/pkgs/applications/audio/ladspa-sdk/default.nix
@@ -1,16 +1,15 @@
 { stdenv, fetchurl }:
 stdenv.mkDerivation rec {
-  name = "ladspa-sdk-${version}";
-  version = "1.13";
+  pname = "ladspa-sdk";
+  version = "1.15";
   src = fetchurl {
     url = "https://www.ladspa.org/download/ladspa_sdk_${version}.tgz";
-    sha256 = "0srh5n2l63354bc0srcrv58rzjkn4gv8qjqzg8dnq3rs4m7kzvdm";
+    sha256 = "1vgx54cgsnc3ncl9qbgjbmq12c444xjafjkgr348h36j16draaa2";
   };
 
   patchPhase = ''
     cd src
-    sed -i 's@/usr/@$(out)/@g'  makefile
-    sed -i 's@-mkdirhier@mkdir -p@g'  makefile
+    substituteInPlace Makefile --replace /usr/ "$out/"
   '';
 
   meta = {

--- a/pkgs/applications/audio/ladspa-sdk/ladspah.nix
+++ b/pkgs/applications/audio/ladspa-sdk/ladspah.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl }:
 stdenv.mkDerivation rec {
-  name = "ladspa.h-${version}";
-  version = "1.13";
+  pname = "ladspa-sdk";
+  version = "1.15";
   src = fetchurl {
     url = "https://www.ladspa.org/download/ladspa_sdk_${version}.tgz";
-    sha256 = "0srh5n2l63354bc0srcrv58rzjkn4gv8qjqzg8dnq3rs4m7kzvdm";
+    sha256 = "1vgx54cgsnc3ncl9qbgjbmq12c444xjafjkgr348h36j16draaa2";
   };
 
   installPhase = ''


### PR DESCRIPTION
Bump header-only variant as well.

http://www.ladspa.org/ladspa_sdk/changes.html

also modernize, drop mkdirhier touchup as upstream dropped it


###### Motivation for this change

poking around packages while updating and testing mlt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---