### PR TITLE
home-assistant: add lifx component dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3228,6 +3228,11 @@
     github = "nequissimus";
     name = "Tim Steinbach";
   };
+  netixx = {
+    email = "dev.espinetfrancois@gmail.com";
+    github = "netixx";
+    name = "François Espinet";
+  };
   nikitavoloboev = {
     email = "nikita.voloboev@gmail.com";
     github = "nikitavoloboev";

--- a/pkgs/development/python-modules/aiolifx-effects/default.nix
+++ b/pkgs/development/python-modules/aiolifx-effects/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, isPy3k
+, aiolifx
+}:
+
+buildPythonPackage rec {
+  pname = "aiolifx-effects";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "aiolifx_effects";
+    sha256 = "cb4ac52deeb220783fc6449251cf40833fcffa28648270be64b1b3e83e06b503";
+  };
+
+  # tests are not implemented
+  doCheck = false;
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [ aiolifx ];
+
+  meta = with lib; {
+    homepage = https://github.com/amelchio/aiolifx_effects;
+    license = licenses.mit;
+    description = "Light effects (pulse, colorloop ...) for LIFX lights running on aiolifx";
+    maintainers = with maintainers; [ netixx ];
+  };
+}

--- a/pkgs/development/python-modules/aiolifx/default.nix
+++ b/pkgs/development/python-modules/aiolifx/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, isPy3k
+, ifaddr
+, bitstring
+}:
+
+buildPythonPackage rec {
+  pname = "aiolifx";
+  version = "0.6.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cf53c9faea6eee25a466e73eef1753b82a75c7497648149c19c15342df2678f2";
+  };
+
+  # tests are not implemented
+  doCheck = false;
+
+  disabled = !isPy3k;
+
+  propagatedBuildInputs = [ bitstring ifaddr ];
+
+  meta = with lib; {
+    homepage = http://github.com/frawau/aiolifx;
+    license = licenses.mit;
+    description = "API for local communication with LIFX devices over a LAN with asyncio";
+    maintainers = with maintainers; [ netixx ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -559,7 +559,7 @@
     "konnected" = ps: with ps; [ aiohttp-cors ];
     "lametric" = ps: with ps; [  ];
     "lcn" = ps: with ps; [  ];
-    "lifx" = ps: with ps; [  ];
+    "lifx" = ps: with ps; [ aiolifx ];
     "light" = ps: with ps; [  ];
     "light.abode" = ps: with ps; [  ];
     "light.ads" = ps: with ps; [  ];
@@ -589,7 +589,7 @@
     "light.isy994" = ps: with ps; [  ];
     "light.knx" = ps: with ps; [  ];
     "light.lcn" = ps: with ps; [  ];
-    "light.lifx" = ps: with ps; [  ];
+    "light.lifx" = ps: with ps; [ aiolifx aiolifx-effects ];
     "light.lifx_legacy" = ps: with ps; [  ];
     "light.lightwave" = ps: with ps; [  ];
     "light.limitlessled" = ps: with ps; [ limitlessled ];
@@ -1144,7 +1144,7 @@
     "sensor.serial" = ps: with ps; [  ];
     "sensor.serial_pm" = ps: with ps; [  ];
     "sensor.seventeentrack" = ps: with ps; [  ];
-    "sensor.shodan" = ps: with ps; [  ];
+    "sensor.shodan" = ps: with ps; [ shodan ];
     "sensor.sht31" = ps: with ps; [  ];
     "sensor.sigfox" = ps: with ps; [  ];
     "sensor.simulated" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -170,6 +170,8 @@ in {
 
   aiolifx = callPackage ../development/python-modules/aiolifx { };
 
+  aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };
+
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -168,6 +168,8 @@ in {
 
   aioimaplib = callPackage ../development/python-modules/aioimaplib { };
 
+  aiolifx = callPackage ../development/python-modules/aiolifx { };
+
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };


### PR DESCRIPTION
###### Motivation for this change
This commit solves https://github.com/NixOS/nixpkgs/issues/55527 by adding required
python packages and binding them in the component-packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
