### PR TITLE
perlPackages.IOTty: fix darwin sandbox build

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7682,6 +7682,7 @@ let
       url = "mirror://cpan/authors/id/T/TO/TODDR/${name}.tar.gz";
       sha256 = "0399anjy3bc0w8xzsc3qx5vcyqryc9gc52lc7wh7i49hsdq8gvx2";
     };
+    doCheck = !stdenv.isDarwin;  # openpty fails in the sandbox
   };
 
   IPCountry = buildPerlPackage rec {


### PR DESCRIPTION
2 of the tests fail when sandboxing is enabled, we might want to allow
this case in the profile if there are more cases but for now just
disable the tests on darwin.

    warning: TIOCSCTTY failed, slave might not be set as controlling terminal: Operation not permitted at /private/tmp/nix-build-perl5.28.1-IO-Tty-1.12.drv-0/IO-Tty-1.12/blib/lib/IO/Pty.pm line 121.
    Error: could not connect pty as controlling terminal!
    no controlling terminal at t/test.t line 68.
    sysread() failed:  at t/test.t line 91.
    # Looks like your test exited with 255 just after 2.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

