### PR TITLE
pythonPackages.contextvars: relax constraint on immutables version

### DIFF
--- a/pkgs/development/python-modules/contextvars/default.nix
+++ b/pkgs/development/python-modules/contextvars/default.nix
@@ -10,6 +10,8 @@ buildPythonPackage rec {
     sha256 = "09fnni8cyxm070bfv9ay030qbyk0dfds5nq77s0p38h33hp08h93";
   };
 
+  # pull request for this patch is https://github.com/MagicStack/contextvars/pull/9
+  patches = [ ./immutables_version.patch ];
   propagatedBuildInputs = [ immutables ];
 
   meta = {

--- a/pkgs/development/python-modules/contextvars/immutables_version.patch
+++ b/pkgs/development/python-modules/contextvars/immutables_version.patch
@@ -1,0 +1,11 @@
+--- ./setup.py	2018-07-30 15:40:14.000000000 +0000
++++ ./setup.py	2019-02-12 18:33:24.984430303 +0000
+@@ -17,7 +17,7 @@
+     packages=['contextvars'],
+     provides=['contextvars'],
+     install_requires=[
+-        'immutables==0.6',
++        'immutables>=0.6',
+     ],
+     license='Apache License, Version 2.0',
+     classifiers=[


### PR DESCRIPTION
The build was broken before since we have immutables 0.9

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

