### PR TITLE
Freeswitch 1.8

### DIFF
--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -118,6 +118,11 @@ stdenv.mkDerivation rec {
     cp "${modulesConf}" modules.conf
   '';
 
+  postInstall = ''
+    # helper for compiling modules... not generally useful; also pulls in perl dependency
+    rm "$out"/bin/fsxs
+  '';
+
   meta = {
     description = "Cross-Platform Scalable FREE Multi-Protocol Soft Switch";
     homepage = https://freeswitch.org/;

--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -63,7 +63,7 @@ in
 
 { fetchurl, stdenv, lib, ncurses, curl, pkgconfig, gnutls, readline
 , openssl, perl, sqlite, libjpeg, speex, pcre
-, ldns, libedit, yasm, which, lua, libopus, libsndfile
+, ldns, libedit, yasm, which, lua, libopus, libsndfile, libtiff
 
 , modules ? defaultModules
 , postgresql
@@ -86,11 +86,11 @@ modulesConf = let
 in
 
 stdenv.mkDerivation rec {
-  name = "freeswitch-1.6.20";
+  name = "freeswitch-1.8.5";
 
   src = fetchurl {
     url = "https://files.freeswitch.org/freeswitch-releases/${name}.tar.bz2";
-    sha256 = "0hqz68abs5x5vzf1mndcvdi35nrhmnklzdrnrk8dyvzvz67hp2ah";
+    sha256 = "00xdrx84pw2v5pw1r5gfbb77nmvlfj275pmd48yfrc9g8c91j1sr";
   };
   postPatch = ''
     patchShebangs     libs/libvpx/build/make/rtcd.pl
@@ -100,9 +100,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    openssl ncurses curl gnutls readline perl libjpeg
-    sqlite pcre speex ldns libedit yasm which lua libopus
-    libsndfile
+    openssl ncurses gnutls readline perl libjpeg
+    sqlite pcre speex ldns libedit yasm which
+    libsndfile libtiff
   ]
   ++ lib.unique (lib.concatMap (mod: mod.inputs) enabledModules)
   ++ lib.optionals enablePostgres [ postgresql ]

--- a/pkgs/servers/sip/freeswitch/modules.nix
+++ b/pkgs/servers/sip/freeswitch/modules.nix
@@ -1,0 +1,223 @@
+{ libopus
+, lua
+, curl
+}:
+
+let
+
+mk = path: inputs: { inherit path inputs; };
+
+in
+
+# TODO: many of these are untested and missing required inputs
+{
+  applications = {
+    abstraction = mk "applications/mod_abstraction" [];
+    av = mk "applications/mod_av" [];
+    avmd = mk "applications/mod_avmd" [];
+    bert = mk "applications/mod_bert" [];
+    blacklist = mk "applications/mod_blacklist" [];
+    callcenter = mk "applications/mod_callcenter" [];
+    cidlookup = mk "applications/mod_cidlookup" [];
+    cluechoo = mk "applications/mod_cluechoo" [];
+    commands = mk "applications/mod_commands" [];
+    conference = mk "applications/mod_conference" [];
+    curl = mk "applications/mod_curl" [ curl ];
+    cv = mk "applications/mod_cv" [];
+    db = mk "applications/mod_db" [];
+    directory = mk "applications/mod_directory" [];
+    distributor = mk "applications/mod_distributor" [];
+    dptools = mk "applications/mod_dptools" [];
+    easyroute = mk "applications/mod_easyroute" [];
+    enum = mk "applications/mod_enum" [];
+    esf = mk "applications/mod_esf" [];
+    esl = mk "applications/mod_esl" [];
+    expr = mk "applications/mod_expr" [];
+    fifo = mk "applications/mod_fifo" [];
+    fsk = mk "applications/mod_fsk" [];
+    fsv = mk "applications/mod_fsv" [];
+    hash = mk "applications/mod_hash" [];
+    hiredis = mk "applications/mod_hiredis" [];
+    httapi = mk "applications/mod_httapi" [];
+    http_cache = mk "applications/mod_http_cache" [];
+    ladspa = mk "applications/mod_ladspa" [];
+    lcr = mk "applications/mod_lcr" [];
+    memcache = mk "applications/mod_memcache" [];
+    mongo = mk "applications/mod_mongo" [];
+    mp4 = mk "applications/mod_mp4" [];
+    mp4v2 = mk "applications/mod_mp4v2" [];
+    nibblebill = mk "applications/mod_nibblebill" [];
+    oreka = mk "applications/mod_oreka" [];
+    osp = mk "applications/mod_osp" [];
+    prefix = mk "applications/mod_prefix" [];
+    rad_auth = mk "applications/mod_rad_auth" [];
+    redis = mk "applications/mod_redis" [];
+    rss = mk "applications/mod_rss" [];
+    signalwire = mk "applications/mod_signalwire" [];
+    sms = mk "applications/mod_sms" [];
+    sms_flowroute = mk "applications/mod_sms_flowroute" [];
+    snapshot = mk "applications/mod_snapshot" [];
+    snom = mk "applications/mod_snom" [];
+    sonar = mk "applications/mod_sonar" [];
+    soundtouch = mk "applications/mod_soundtouch" [];
+    spandsp = mk "applications/mod_spandsp" [];
+    spy = mk "applications/mod_spy" [];
+    stress = mk "applications/mod_stress" [];
+    translate = mk "applications/mod_translate" [];
+    valet_parking = mk "applications/mod_valet_parking" [];
+    video_filter = mk "applications/mod_video_filter" [];
+    vmd = mk "applications/mod_vmd" [];
+    voicemail = mk "applications/mod_voicemail" [];
+    voicemail_ivr = mk "applications/mod_voicemail_ivr" [];
+  };
+
+  ast_tts = {
+    cepstral = mk "ast_tts/mod_cepstral" [];
+    flite = mk "ast_tts/mod_flite" [];
+    pocketsphinx = mk "ast_tts/mod_pocketsphinx" [];
+    tts_commandline = mk "ast_tts/mod_tts_commandline" [];
+    unimrcp = mk "ast_tts/mod_unimrcp" [];
+  };
+
+  codecs = {
+    amr = mk "codecs/mod_amr" [];
+    amrwb = mk "codecs/mod_amrwb" [];
+    b64 = mk "codecs/mod_b64" [];
+    bv = mk "codecs/mod_bv" [];
+    clearmode = mk "codecs/mod_clearmode" [];
+    codec2 = mk "codecs/mod_codec2" [];
+    com_g729 = mk "codecs/mod_com_g729" [];
+    dahdi_codec = mk "codecs/mod_dahdi_codec" [];
+    g723_1 = mk "codecs/mod_g723_1" [];
+    g729 = mk "codecs/mod_g729" [];
+    h26x = mk "codecs/mod_h26x" [];
+    ilbc = mk "codecs/mod_ilbc" [];
+    isac = mk "codecs/mod_isac" [];
+    mp4v = mk "codecs/mod_mp4v" [];
+    opus = mk "codecs/mod_opus" [ libopus ];
+    sangoma_codec = mk "codecs/mod_sangoma_codec" [];
+    silk = mk "codecs/mod_silk" [];
+    siren = mk "codecs/mod_siren" [];
+    theora = mk "codecs/mod_theora" [];
+  };
+
+  dialplans = {
+    asterisk = mk "dialplans/mod_dialplan_asterisk" [];
+    directory = mk "dialplans/mod_dialplan_directory" [];
+    xml = mk "dialplans/mod_dialplan_xml" [];
+  };
+
+  directories = {
+    ldap = mk "directories/mod_ldap" [];
+  };
+
+  endpoints = {
+    alsa = mk "endpoints/mod_alsa" [];
+    dingaling = mk "endpoints/mod_dingaling" [];
+    gsmopen = mk "endpoints/mod_gsmopen" [];
+    h323 = mk "endpoints/mod_h323" [];
+    khomp = mk "endpoints/mod_khomp" [];
+    loopback = mk "endpoints/mod_loopback" [];
+    opal = mk "endpoints/mod_opal" [];
+    portaudio = mk "endpoints/mod_portaudio" [];
+    rtc = mk "endpoints/mod_rtc" [];
+    rtmp = mk "endpoints/mod_rtmp" [];
+    skinny = mk "endpoints/mod_skinny" [];
+    sofia = mk "endpoints/mod_sofia" [];
+    verto = mk "endpoints/mod_verto" [];
+  };
+
+  event_handlers = {
+    amqp = mk "event_handlers/mod_amqp" [];
+    cdr_csv = mk "event_handlers/mod_cdr_csv" [];
+    cdr_mongodb = mk "event_handlers/mod_cdr_mongodb" [];
+    cdr_pg_csv = mk "event_handlers/mod_cdr_pg_csv" [];
+    cdr_sqlite = mk "event_handlers/mod_cdr_sqlite" [];
+    erlang_event = mk "event_handlers/mod_erlang_event" [];
+    event_multicast = mk "event_handlers/mod_event_multicast" [];
+    event_socket = mk "event_handlers/mod_event_socket" [];
+    fail2ban = mk "event_handlers/mod_fail2ban" [];
+    format_cdr = mk "event_handlers/mod_format_cdr" [];
+    json_cdr = mk "event_handlers/mod_json_cdr" [];
+    radius_cdr = mk "event_handlers/mod_radius_cdr" [];
+    odbc_cdr = mk "event_handlers/mod_odbc_cdr" [];
+    kazoo = mk "event_handlers/mod_kazoo" [];
+    rayo = mk "event_handlers/mod_rayo" [];
+    smpp = mk "event_handlers/mod_smpp" [];
+    snmp = mk "event_handlers/mod_snmp" [];
+    event_zmq = mk "event_handlers/mod_event_zmq" [];
+  };
+
+  formats = {
+    imagick = mk "formats/mod_imagick" [];
+    local_stream = mk "formats/mod_local_stream" [];
+    native_file = mk "formats/mod_native_file" [];
+    png = mk "formats/mod_png" [];
+    portaudio_stream = mk "formats/mod_portaudio_stream" [];
+    shell_stream = mk "formats/mod_shell_stream" [];
+    shout = mk "formats/mod_shout" [];
+    sndfile = mk "formats/mod_sndfile" [];
+    ssml = mk "formats/mod_ssml" [];
+    tone_stream = mk "formats/mod_tone_stream" [];
+    vlc = mk "formats/mod_vlc" [];
+  };
+
+  languages = {
+    basic = mk "languages/mod_basic" [];
+    java = mk "languages/mod_java" [];
+    lua = mk "languages/mod_lua" [ lua ];
+    managed = mk "languages/mod_managed" [];
+    perl = mk "languages/mod_perl" [];
+    python = mk "languages/mod_python" [];
+    v8 = mk "languages/mod_v8" [];
+    yaml = mk "languages/mod_yaml" [];
+  };
+
+  loggers = {
+    console = mk "loggers/mod_console" [];
+    graylog2 = mk "loggers/mod_graylog2" [];
+    logfile = mk "loggers/mod_logfile" [];
+    syslog = mk "loggers/mod_syslog" [];
+    raven = mk "loggers/mod_raven" [];
+  };
+
+  say = {
+    de = mk "say/mod_say_de" [];
+    en = mk "say/mod_say_en" [];
+    es = mk "say/mod_say_es" [];
+    es_ar = mk "say/mod_say_es_ar" [];
+    fa = mk "say/mod_say_fa" [];
+    fr = mk "say/mod_say_fr" [];
+    he = mk "say/mod_say_he" [];
+    hr = mk "say/mod_say_hr" [];
+    hu = mk "say/mod_say_hu" [];
+    it = mk "say/mod_say_it" [];
+    ja = mk "say/mod_say_ja" [];
+    nl = mk "say/mod_say_nl" [];
+    pl = mk "say/mod_say_pl" [];
+    pt = mk "say/mod_say_pt" [];
+    ru = mk "say/mod_say_ru" [];
+    sv = mk "say/mod_say_sv" [];
+    th = mk "say/mod_say_th" [];
+    zh = mk "say/mod_say_zh" [];
+  };
+
+  timers = {
+    posix_timer = mk "timers/mod_posix_timer" [];
+    timerfd = mk "timers/mod_timerfd" [];
+  };
+
+  xml_int = {
+    cdr = mk "xml_int/mod_xml_cdr" [];
+    curl = mk "xml_int/mod_xml_curl" [ curl ];
+    ldap = mk "xml_int/mod_xml_ldap" [];
+    radius = mk "xml_int/mod_xml_radius" [];
+    rpc = mk "xml_int/mod_xml_rpc" [];
+    scgi = mk "xml_int/mod_xml_scgi" [];
+
+    # experimental
+    odbc = mk "../../contrib/mod/xml_int/mod_xml_odbc" [];
+  };
+
+  freetdm = mk "../../libs/freetdm/mod_freetdm" [];
+}


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest FreeSWITCH; make it easier to configure which modules are built.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

