### PR TITLE
zoneminder: fix build issue when using createLocally database

### DIFF
--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -205,15 +205,13 @@ in {
 
       mysql = lib.mkIf cfg.database.createLocally {
         ensureDatabases = [ cfg.database.name ];
-        ensureUsers = {
+        ensureUsers = [{
           name = cfg.database.username;
-          ensurePermissions = [
-            { "${cfg.database.name}.*" = "ALL PRIVILEGES"; }
-          ];
+          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
           initialDatabases = [
             { inherit (cfg.database) name; schema = "${pkg}/share/zoneminder/db/zm_create.sql"; }
           ];
-        };
+        }];
       };
 
       nginx = lib.mkIf useNginx {


### PR DESCRIPTION
###### Motivation for this change
In its current state, a configuration.nix enabling the zoneminder service and setting its 'database.createLocally" flag cannot be build.
It is caused by providing wrongly typed arguments to the ensureUsers and ensurePermissions built-ins.

###### Things done
Fix the types: 
  - list for ensureUsers
  - set for ensurePermissions

Note that the createLocally logic is still broken for user permission reason. I'll look into it in a following PR.

