### PR TITLE
python.pkgs.dateparser: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "dateparser";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "940828183c937bcec530753211b70f673c0a9aab831e43273489b310538dff86";
+    sha256 = "42d51be54e74a8e80a4d76d1fa6e4edd997098fce24ad2d94a2eab5ef247193e";
   };
 
   checkInputs = [ nose mock parameterized six glibcLocales ];

--- a/pkgs/servers/home-assistant/cli.nix
+++ b/pkgs/servers/home-assistant/cli.nix
@@ -1,11 +1,10 @@
-# dateparser tests fail on pyton37: https://github.com/NixOS/nixpkgs/issues/52766
-{ lib, python36, glibcLocales }:
+{ lib, python3, glibcLocales }:
 
-python36.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "homeassistant-cli";
   version = "0.5.0";
 
-  src = python36.pkgs.fetchPypi {
+  src = python3.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "4ad137d336508ab74840a34b3cc488ad884cc75285f5d7842544df1c3adacf8d";
   };
@@ -19,7 +18,7 @@ python36.pkgs.buildPythonApplication rec {
     glibcLocales
   ];
 
-  propagatedBuildInputs = with python36.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     requests netdisco click click-log tabulate jsonpath_rw jinja2 dateparser regex ruamel_yaml aiohttp
   ];
 
@@ -31,7 +30,7 @@ python36.pkgs.buildPythonApplication rec {
     $out/bin/hass-cli completion zsh > "$out/share/zsh/site-functions/_hass-cli"
   '';
 
-  checkInputs = with python36.pkgs; [
+  checkInputs = with python3.pkgs; [
     pytest requests-mock
   ];
 

--- a/pkgs/tools/misc/papis/default.nix
+++ b/pkgs/tools/misc/papis/default.nix
@@ -1,8 +1,8 @@
 { lib, fetchFromGitHub, fetchpatch
-, python36, xdg_utils
+, python3, xdg_utils
 }:
 
-python36.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "papis";
   version = "0.7.5";
 
@@ -20,7 +20,7 @@ python36.pkgs.buildPythonApplication rec {
     sha256 = "0cmagfdaaml1pxhnxggifpb47z5g1p231qywnvnqpd3dm93382w1";
   };
 
-  propagatedBuildInputs = with python36.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     click requests filetype pyparsing configparser
     arxiv2bib pyyaml chardet beautifulsoup4 prompt_toolkit
     bibtexparser python-slugify pyparser pylibgen
@@ -33,7 +33,7 @@ python36.pkgs.buildPythonApplication rec {
     install -Dt "$out/etc/bash_completion.d" scripts/shell_completion/build/bash/papis
   '';
 
-  checkInputs = (with python36.pkgs; [
+  checkInputs = (with python3.pkgs; [
     pytest
   ]) ++ [
     xdg_utils

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1791,9 +1791,7 @@ in
 
   burp = callPackage ../tools/backup/burp { };
 
-  buku = callPackage ../applications/misc/buku {
-    python3 = python36; # due to #52766
-  };
+  buku = callPackage ../applications/misc/buku { };
 
   byzanz = callPackage ../applications/video/byzanz {};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

