### PR TITLE
keybase: on Linux, symlink kbfsfuse, git-remote-keybase into main package

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildGoPackage, fetchurl, cf-private
 , AVFoundation, AudioToolbox, ImageIO, CoreMedia
-, Foundation, CoreGraphics, MediaToolbox
+, Foundation, CoreGraphics, MediaToolbox, kbfs
 }:
 
 buildGoPackage rec {
@@ -23,6 +23,11 @@ buildGoPackage rec {
     cf-private
   ];
   buildFlags = [ "-tags production" ];
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    ln -s ${kbfs}/bin/kbfsfuse           $bin/bin/kbfsfuse
+    ln -s ${kbfs}/bin/git-remote-keybase $bin/bin/git-remote-keybase
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://www.keybase.io/;


### PR DESCRIPTION
###### Motivation for this change

This fixes some innocuous errors when keybase tries to detect the version kbfs, which it does by default now to warn of upgrade compatibility.  Furthermore including git-remote-keybase seems rather sensible, considering I (at least) expected the 'keybase' application to simply include these things

This does have the downside of bloating the closure of `keybase` by about ~100mb on x86_64 Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---