### PR TITLE
pythonPackages.cassandra-driver: 3.15.1 -> 3.16.0 - fix build

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -20,14 +20,26 @@
 
 buildPythonPackage rec {
   pname = "cassandra-driver";
-  version = "3.15.1";
+  version = "3.16.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1xcirbvlj00id8269akhk8gy2sv0mlnbgy3nagi32648jwsrcadg";
+    sha256 = "1gjs2lqy0ba6zhh13a1dhirk59i7lc4zcbl7h50619hdm5kv3g22";
   };
 
-  buildInputs = [ pkgs.libev cython ];
+  buildInputs = [
+    pkgs.libev
+    # NOTE: next version will work with cython 0.29
+    # Requires 'Cython!=0.25,<0.29,>=0.20'
+    (cython.overridePythonAttrs(old: rec {
+      pname = "Cython";
+      version = "0.28.3";
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526";
+      };
+    }))
+  ];
 
   propagatedBuildInputs = [ six ]
     ++ stdenv.lib.optionals (pythonOlder "3.4") [ futures ];


### PR DESCRIPTION
cassandra-driver requires an older version of cython than the one
present in nixpkgs.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

