### PR TITLE
tor-browser-bundle-bin: 8.0.5 -> 8.0.6

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -89,7 +89,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "8.0.5";
+  version = "8.0.6";
 
   lang = "en-US";
 
@@ -99,7 +99,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "0afrq5vy6rxj4p2dm7kaiq3d3iv4g8ivn7nfqx0z8h1wikyaf5di";
+      sha256 = "14i32r8pw749ghigqblnbr5622jh5wp1ivnwi71vycbgp9pds4f7";
     };
 
     "i686-linux" = fetchurl {
@@ -107,7 +107,7 @@ let
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "113vn2fyw9sjxz24b2m6z4kw46rqgxglrna1lg9ji6zhkfb044vv";
+      sha256 = "0g9sd104b6xnbl2j3gbq1ga6j2h0x3jccays0gpbd235bxpjs39a";
     };
   };
 in


### PR DESCRIPTION
https://blog.torproject.org/new-release-tor-browser-806


###### Motivation for this change

May be good to backport to stable as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---