### PR TITLE
osquery: fix build

### DIFF
--- a/pkgs/tools/networking/lldpd/default.nix
+++ b/pkgs/tools/networking/lldpd/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchurl, pkgconfig, removeReferencesTo
-, libevent, readline, net_snmp }:
+, libevent, readline, net_snmp, openssl
+}:
 
 stdenv.mkDerivation rec {
   name = "lldpd-${version}";
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkgconfig removeReferencesTo ];
-  buildInputs = [ libevent readline net_snmp ];
+  buildInputs = [ libevent readline net_snmp openssl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -4,7 +4,7 @@
 , beecrypt, augeas, libxml2, sleuthkit, yara, lldpd, google-gflags
 , thrift, boost, rocksdb_lite, glog, gbenchmark, snappy
 , openssl, file, doxygen
-, gtest, sqlite, fpm, zstd, rdkafka, rapidjson, fetchgit
+, gtest, sqlite, fpm, zstd, rdkafka, rapidjson, fetchgit, fetchurl
 }:
 
 let
@@ -61,6 +61,16 @@ stdenv.mkDerivation rec {
         sha256 = "1ny3srcsxd6kj59zq1cman5myj8kzw010wbyc6mrpk4kp823r5nx";
       };
     });
+
+    # dpkg 1.19.2 dropped api in `<dpkg/dpkg-db.h>` which breaks compilation.
+    dpkg' = dpkg.overrideAttrs (old: rec {
+      name = "dpkg-${version}";
+      version = "1.19.0.5";
+      src = fetchurl {
+        url = "mirror://debian/pool/main/d/dpkg/dpkg_${version}.tar.xz";
+        sha256 = "1dc5kp3fqy1k66fly6jfxkkg7w6d0jy8szddpfyc2xvzga94d041";
+      };
+    });
   in [
     udev audit
 
@@ -69,7 +79,7 @@ stdenv.mkDerivation rec {
       customMemoryManagement = false;
     })
 
-    lvm2' libgcrypt libarchive libgpgerror libuuid iptables dpkg
+    lvm2' libgcrypt libarchive libgpgerror libuuid iptables dpkg'
     lzma bzip2 rpm beecrypt augeas libxml2 sleuthkit
     yara lldpd gflags' thrift boost
     glog gbenchmark snappy openssl


### PR DESCRIPTION
###### Motivation for this change

Fixing osquery required the following changes:

* fix `lldpd` (missing `openssl`, see also https://hydra.nixos.org/build/88562937)
* downgrade `dpkg` for `osquery` (1.19.2 had some api changes, the problem is reported at https://github.com/facebook/osquery/issues/5435)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

