### PR TITLE
ocamlPackages.yojson: 1.4.1 -> 1.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -2,15 +2,16 @@
 let
   pname = "yojson";
   param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
-    version = "1.4.1";
-    sha256 = "0nwsfkmqpyfab4rxq76q8ff7giyanghw08094jyrp275v99zdjr9";
+  if stdenv.lib.versionAtLeast ocaml.version "4.02" then rec {
+    version = "1.6.0";
+    url = "https://github.com/ocaml-community/yojson/releases/download/${version}/yojson-${version}.tbz";
+    sha256 = "1h73zkgqs6cl9y7p2l0cgjwyqa1fzcrnzv3k6w7wyq2p1q5m84xh";
     buildInputs = [ dune ];
     extra = { inherit (dune) installPhase; };
-  } else {
+  } else rec {
     version = "1.2.3";
+    url = "https://github.com/ocaml-community/yojson/archive/v${version}.tar.gz";
     sha256 = "10dvkndgwanvw4agbjln7kgb1n9s6lii7jw82kwxczl5rd1sgmvl";
-    buildInputs = [];
     extra = {
       createFindlibDestdir = true;
 
@@ -25,11 +26,10 @@ stdenv.mkDerivation ({
   name = "ocaml${ocaml.version}-${pname}-${param.version}";
 
   src = fetchzip {
-    url = "https://github.com/mjambon/${pname}/archive/v${param.version}.tar.gz";
-    inherit (param) sha256;
+    inherit (param) url sha256;
   };
 
-  buildInputs = [ ocaml findlib ] ++ param.buildInputs;
+  buildInputs = [ ocaml findlib ] ++ (param.buildInputs or []);
 
   propagatedBuildInputs = [ cppo easy-format biniou ];
 


### PR DESCRIPTION
###### Motivation for this change

New API.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

