### PR TITLE
broot: init at 0.6.0

### DIFF
--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  name = "broot-${version}";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Canop";
+    repo = "broot";
+    rev = "v${version}";
+    sha256 = "192qqlqym8lpskh6f7sf5fanybjwhdqs1cgl6mqm35763fa5jrdj";
+  };
+
+  cargoSha256 = "059iylnkjb7lxxs9v2b6h05nidwgcj6kqyhcq58lalkhb63srb1q";
+
+  meta = with stdenv.lib; {
+    description = "An interactive tree view, a fuzzy search, a balanced BFS descent and customizable commands";
+    homepage = "https://github.com/Canop/broot";
+    maintainers = with maintainers; [ magnetophon ];
+    license = with licenses; [ mit ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1004,6 +1004,8 @@ in
   };
   bro = callPackage ../applications/networking/ids/bro { };
 
+  broot = callPackage ../tools/misc/broot { };
+
   bruteforce-luks = callPackage ../tools/security/bruteforce-luks { };
 
   breakpointHook = assert stdenv.isLinux;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

