### PR TITLE
compiler-rt-7.0.1: Fix build on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/7/compiler-rt-clock_gettime.patch
+++ b/pkgs/development/compilers/llvm/7/compiler-rt-clock_gettime.patch
@@ -1,0 +1,74 @@
+commit f00c7bccf7955b7dfbb4859fd9019e9eb3349f2d
+Author: Tobias Mayer <tobim@fastmail.fm>
+Date:   Wed Feb 13 12:44:17 2019 +0100
+
+    Provide clock_gettime for xray on macos < 10.12
+
+diff --git a/lib/xray/xray_basic_logging.cc b/lib/xray/xray_basic_logging.cc
+index a46c151af..38aea6932 100644
+--- a/lib/xray/xray_basic_logging.cc
++++ b/lib/xray/xray_basic_logging.cc
+@@ -36,6 +36,29 @@
+ #include "xray_tsc.h"
+ #include "xray_utils.h"
+ 
++#if __MACH__
++#include <mach/clock.h>
++#include <mach/mach.h>
++enum clockid_t {
++    CLOCK_MONOTONIC = REALTIME_CLOCK,
++    CLOCK_REALTIME = REALTIME_CLOCK
++};
++
++int clock_gettime(clockid_t clock_id, struct timespec *ts) {
++  if (ts != NULL) {
++      clock_serv_t cclock;
++      mach_timespec_t mts;
++      host_get_clock_service(mach_host_self(), clock_id, &cclock);
++      clock_get_time(cclock, &mts);
++      mach_port_deallocate(mach_task_self(), cclock);
++      ts->tv_sec = mts.tv_sec;
++      ts->tv_nsec = mts.tv_nsec;
++      return 0;
++  }
++  return -1;
++}
++#endif
++
+ namespace __xray {
+ 
+ SpinMutex LogMutex;
+diff --git a/lib/xray/xray_fdr_logging.cc b/lib/xray/xray_fdr_logging.cc
+index 4b308b27f..1d044c8fd 100644
+--- a/lib/xray/xray_fdr_logging.cc
++++ b/lib/xray/xray_fdr_logging.cc
+@@ -38,6 +38,29 @@
+ #include "xray_tsc.h"
+ #include "xray_utils.h"
+ 
++#if __MACH__
++#include <mach/clock.h>
++#include <mach/mach.h>
++enum clockid_t {
++    CLOCK_MONOTONIC = REALTIME_CLOCK,
++    CLOCK_REALTIME = REALTIME_CLOCK
++};
++
++int clock_gettime(clockid_t clock_id, struct timespec *ts) {
++  if (ts != NULL) {
++      clock_serv_t cclock;
++      mach_timespec_t mts;
++      host_get_clock_service(mach_host_self(), clock_id, &cclock);
++      clock_get_time(cclock, &mts);
++      mach_port_deallocate(mach_task_self(), cclock);
++      ts->tv_sec = mts.tv_sec;
++      ts->tv_nsec = mts.tv_nsec;
++      return 0;
++  }
++  return -1;
++}
++#endif
++
+ namespace __xray {
+ 
+ atomic_sint32_t LoggingStatus = {XRayLogInitStatus::XRAY_LOG_UNINITIALIZED};

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -1,5 +1,4 @@
 { stdenv, version, fetch, cmake, python, llvm, libcxxabi }:
-with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "compiler-rt-${version}";
   inherit version;
@@ -16,7 +15,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
-  ] ++ optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
+  ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin ./compiler-rt-clock_gettime.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra


### PR DESCRIPTION
###### Motivation for this change
compiler-rt-7.0.1 does not compile on darwin because nixpkgs' current libSystem does not provide `clock_gettime()`.

###### Things done
Implemented workaround.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

