### PR TITLE
multimc: unstable-2018-06-04 -> 0.6.4

### DIFF
--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -4,14 +4,12 @@ let
   libpath = with xorg; stdenv.lib.makeLibraryPath [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio ];
 in stdenv.mkDerivation rec {
   name = "multimc-${version}";
-  # Current release as of 2018-06-23 (v0.6.2) breaks under Qt 5.11—see
-  # https://github.com/NixOS/nixpkgs/issues/42387
-  version = "unstable-2018-06-04";
+  version = "0.6.4";
   src = fetchFromGitHub {
     owner = "MultiMC";
     repo = "MultiMC5";
-    rev = "19bb50b872da2702b8e0b65f3f7b6b54c1c5b071";
-    sha256 = "01frkk2klm1axr7ywnj23ikxn5pkgj8q6w8vqbslsvmh8bni8rk0";
+    rev = "0.6.4";
+    sha256 = "0z9mhvfsq9m2cmi0dbrjjc51642r6ppdbb8932236gar5j7w3bc2";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ cmake file makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
0.6.4 is the latest beta version of MultiMC. We are currently using an unstable commit, so I consider this an improvement. This closes #55699 via the second option listed there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ N/A
- [x] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~ N/A
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

