### PR TITLE
getmail: 5.8 -> 5.10

### DIFF
--- a/pkgs/tools/networking/getmail/default.nix
+++ b/pkgs/tools/networking/getmail/default.nix
@@ -2,11 +2,11 @@
 
 python2Packages.buildPythonApplication rec {
   pname = "getmail";
-  version = "5.8";
+  version = "5.10";
 
   src = fetchurl {
     url = "http://pyropus.ca/software/getmail/old-versions/${pname}-${version}.tar.gz";
-    sha256 = "0vl4cc733pd9d21y4pr4jc1ly657d0akxj1bdh1xfjggx33l3541";
+    sha256 = "0qc4gp66mhaxyjj7pfz9v69kxnw76my4zw07hvc4f3kj3balkygx";
   };
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

