### PR TITLE
icingaweb2: Init at 2.6.2

### DIFF
--- a/pkgs/servers/icingaweb2/default.nix
+++ b/pkgs/servers/icingaweb2/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, php }: with lib; stdenv.mkDerivation rec {
+  name = "icingaweb2-${version}";
+  version = "2.6.2";
+
+  src = fetchFromGitHub {
+    owner = "Icinga";
+    repo = "icingaweb2";
+    rev = "v${version}";
+    sha256 = "1gf28nm94bq6r7i8yds5y9s59559i2zvj0swzb28zll6xbyprib0";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -ra application bin etc library modules public $out
+    cp -ra doc $out/share
+
+    wrapProgram $out/bin/icingacli --prefix PATH : "${makeBinPath [ php ]}"
+  '';
+
+  meta = {
+    description = "Webinterface for Icinga 2";
+    longDescription = ''
+      A lightweight and extensible web interface to keep an eye on your environment.
+      Analyse problems and act on them.
+    '';
+    homepage = "https://www.icinga.com/products/icinga-web-2/";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13611,6 +13611,8 @@ in
 
   hydron = callPackage ../servers/hydron { };
 
+  icingaweb2 = callPackage ../servers/icingaweb2 { };
+
   ircdHybrid = callPackage ../servers/irc/ircd-hybrid { };
 
   jboss = callPackage ../servers/http/jboss { };


### PR DESCRIPTION
###### Motivation for this change

I'm currently writing a module for Icingaweb 2, and this is the first part of it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

