### PR TITLE
pythonPackages.aplpy: init at 2.0.3

### DIFF
--- a/pkgs/development/python-modules/aplpy/default.nix
+++ b/pkgs/development/python-modules/aplpy/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, astropy
+, astropy-helpers
+, matplotlib
+, reproject
+, pyavm
+, pyregion
+, pillow
+, scikitimage
+, shapely
+}:
+
+buildPythonPackage rec {
+  pname = "aplpy";
+  version = "2.0.3";
+
+  doCheck = false; # tests require pytest-astropy
+
+  src = fetchPypi {
+    pname = "APLpy";
+    inherit version;
+    sha256 = "239f3d83635ca4251536aeb577df7c60df77fc4d658097b92094719739aec3f3";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    astropy
+    astropy-helpers
+    matplotlib
+    reproject
+    pyavm
+    pyregion
+    pillow
+    scikitimage
+    shapely
+  ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  meta = with lib; {
+    description = "The Astronomical Plotting Library in Python";
+    homepage = http://aplpy.github.io;
+    license = licenses.mit;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/development/python-modules/astropy-healpix/default.nix
+++ b/pkgs/development/python-modules/astropy-healpix/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, astropy
+, astropy-helpers
+}:
+
+buildPythonPackage rec {
+  pname = "astropy-healpix";
+  version = "0.4";
+
+  doCheck = false; # tests require pytest-astropy
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8c9709ac923759c92eca6d2e623e734d0f417eed40ba835b77d99dec09e51aa2";
+  };
+
+  propagatedBuildInputs = [ numpy astropy astropy-helpers ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  meta = with lib; {
+    description = "BSD-licensed HEALPix for Astropy";
+    homepage = https://github.com/astropy/astropy-healpix;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/development/python-modules/astropy-helpers/default.nix
+++ b/pkgs/development/python-modules/astropy-helpers/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "astropy-helpers";
+  version = "3.1";
+
+  disabled = !isPy3k;
+
+  doCheck = false; # tests requires sphinx-astropy
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "37caf1f21bfdf653f7bb9f5b070dc1bb59cd70c0e09f9c5742401f57400a6e52";
+  };
+
+  meta = with lib; {
+    description = "Utilities for building and installing Astropy, Astropy affiliated packages, and their respective documentation";
+    homepage = https://github.com/astropy/astropy-helpers;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/development/python-modules/pyavm/default.nix
+++ b/pkgs/development/python-modules/pyavm/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, astropy
+, astropy-helpers
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "pyavm";
+  version = "0.9.4";
+
+  src = fetchPypi {
+    pname = "PyAVM";
+    inherit version;
+    sha256 = "f298b864e5bc101ecbb0e46252e95e18a180ac28ba6ec362e63c12a7e914e386";
+  };
+
+  propagatedBuildInputs = [ astropy-helpers ];
+
+  checkInputs = [ pytest astropy pillow ];
+
+  checkPhase = "pytest";
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  meta = with lib; {
+    description = "Simple pure-python AVM meta-data handling";
+    homepage = http://astrofrog.github.io/pyavm/;
+    license = licenses.mit;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/development/python-modules/pyregion/default.nix
+++ b/pkgs/development/python-modules/pyregion/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyparsing
+, numpy
+, cython
+, astropy
+}:
+
+buildPythonPackage rec {
+  pname = "pyregion";
+  version = "2.0";
+
+  doCheck = false; # tests require pytest-astropy
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a8ac5f764b53ec332f6bc43f6f2193ca13e8b7d5a3fb2e20ced6b2ea42a9d094";
+  };
+
+  propagatedBuildInputs = [
+    pyparsing
+    numpy
+    cython
+    astropy
+  ];
+
+  meta = with lib; {
+    description = "Python parser for ds9 region files";
+    homepage = https://github.com/astropy/pyregion;
+    license = licenses.mit;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/development/python-modules/reproject/default.nix
+++ b/pkgs/development/python-modules/reproject/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, astropy
+, astropy-healpix
+, astropy-helpers
+, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "reproject";
+  version = "0.4";
+
+  doCheck = false; # tests require pytest-astropy
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "dbbb18a8b211292c7ce61121b8538fc279540337be1c05cabc7570c5aca6d734";
+  };
+
+  propagatedBuildInputs = [ numpy astropy astropy-healpix astropy-helpers scipy ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  meta = with lib; {
+    description = "Reproject astronomical images";
+    homepage = https://reproject.readthedocs.io;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.smaret ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -178,6 +178,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  aplpy = callPackage ../development/python-modules/aplpy { };
+
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
   asana = callPackage ../development/python-modules/asana { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -798,6 +798,8 @@ in {
 
   relatorio = callPackage ../development/python-modules/relatorio { };
 
+  reproject = callPackage ../development/python-modules/reproject { };
+
   remotecv = callPackage ../development/python-modules/remotecv { };
 
   pyzufall = callPackage ../development/python-modules/pyzufall { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4965,6 +4965,8 @@ in {
 
   potr = callPackage ../development/python-modules/potr {};
 
+  pyregion = callPackage ../development/python-modules/pyregion {};
+
   python-u2flib-host = callPackage ../development/python-modules/python-u2flib-host { };
 
   pluggy = callPackage ../development/python-modules/pluggy {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -196,6 +196,8 @@ in {
 
   astropy-helpers = callPackage ../development/python-modules/astropy-helpers { };
 
+  astropy-healpix = callPackage ../development/python-modules/astropy-healpix { };
+
   astroquery = callPackage ../development/python-modules/astroquery { };
 
   asttokens = callPackage ../development/python-modules/asttokens { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -194,6 +194,8 @@ in {
 
   astropy = callPackage ../development/python-modules/astropy { };
 
+  astropy-helpers = callPackage ../development/python-modules/astropy-helpers { };
+
   astroquery = callPackage ../development/python-modules/astroquery { };
 
   asttokens = callPackage ../development/python-modules/asttokens { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1526,6 +1526,8 @@ in {
 
   cffi = callPackage ../development/python-modules/cffi { };
 
+  pyavm = callPackage ../development/python-modules/pyavm { };
+
   pycollada = callPackage ../development/python-modules/pycollada { };
 
   pycontracts = callPackage ../development/python-modules/pycontracts { };


### PR DESCRIPTION
###### Motivation for this change

Add a Nix expression for the [Aplpy](http://aplpy.github.io) Python package and its dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

