### PR TITLE
python.pkgs.pytest-mock: 1.10.0 -> 1.10.1

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -1,14 +1,14 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k
 , cheroot, contextlib2, portend, routes, six
-, setuptools_scm, zc_lockfile
+, setuptools_scm, zc_lockfile, more-itertools
 , backports_unittest-mock, objgraph, pathpy, pytest, pytestcov
-, backports_functools_lru_cache, requests_toolbelt
+, backports_functools_lru_cache, requests_toolbelt, pytest-services
 }:
 
 let
   srcInfo = if isPy3k then {
-    version = "18.0.1";
-    sha256 = "3002fc47b982c3df4d08dbe5996b093fd73f85b650ab8df19e8b9b95f5c00520";
+    version = "18.1.0";
+    sha256 = "4dd2f59b5af93bd9ca85f1ed0bb8295cd0f5a8ee2b84d476374d4e070aa5c615";
   } else {
     version = "17.4.1";
     sha256 = "1kl17anzz535jgkn9qcy0c2m0zlafph0iv7ph3bb9mfrs2bgvagv";
@@ -22,14 +22,26 @@ in buildPythonPackage rec {
     inherit (srcInfo) version sha256;
   };
 
-  propagatedBuildInputs = [ cheroot contextlib2 portend routes six zc_lockfile ];
+  propagatedBuildInputs = if isPy3k then [
+    # required
+    cheroot portend more-itertools zc_lockfile
+    # optional
+    routes
+  ] else [
+    cheroot contextlib2 portend routes six zc_lockfile
+  ];
 
   buildInputs = [ setuptools_scm ];
 
-  checkInputs = [ backports_unittest-mock objgraph pathpy pytest pytestcov backports_functools_lru_cache requests_toolbelt ];
+  checkInputs = if isPy3k then [
+    objgraph pytest pytestcov pathpy requests_toolbelt pytest-services
+  ] else [
+    backports_unittest-mock objgraph pathpy pytest pytestcov backports_functools_lru_cache requests_toolbelt
+  ];
 
   checkPhase = ''
-    LANG=en_US.UTF-8 pytest
+    # 3 out of 5 SignalHandlingTests need network access
+    LANG=en_US.UTF-8 pytest -k "not SignalHandlingTests and not test_4_Autoreload"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-services/default.nix
+++ b/pkgs/development/python-modules/pytest-services/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, requests
+, psutil
+, pytest
+, subprocess32
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-services";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "035bc9ce8addb33f7c2ec95a9c0c88926d213a6c2e12b2c57da31a4ec0765f2c";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    psutil
+    pytest
+  ] ++ lib.optional (!isPy3k) subprocess32;
+
+  # no tests in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Services plugin for pytest testing framework";
+    homepage = https://github.com/pytest-dev/pytest-services;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1566,6 +1566,8 @@ in {
 
   pytest-server-fixtures = callPackage ../development/python-modules/pytest-server-fixtures { };
 
+  pytest-services = callPackage ../development/python-modules/pytest-services { };
+
   pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
   pytestcov = callPackage ../development/python-modules/pytest-cov { };


### PR DESCRIPTION
###### Motivation for this change
The upgrade seems to have led to test failures at CherryPy's side. I'm not sure if the remaining ones are really related to network access or if that is in fact mocked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

