### PR TITLE
pro-office-calculator: 1.0.6 -> 1.0.13

### DIFF
--- a/pkgs/games/pro-office-calculator/default.nix
+++ b/pkgs/games/pro-office-calculator/default.nix
@@ -1,22 +1,16 @@
 { stdenv, fetchFromGitHub, tinyxml-2, cmake, qtbase, qtmultimedia, fetchpatch }:
 stdenv.mkDerivation rec {
-  version = "1.0.6";
+  version = "1.0.13";
   name = "pro-office-calculator-${version}";
 
   src = fetchFromGitHub {
     owner  = "RobJinman";
     repo   = "pro_office_calc";
     rev    = "v${version}";
-    sha256 = "1irgch6cbc2f8il1zh8qf98m43h41hma80dxzz9c7xvbvl99lybd";
+    sha256 = "1v75cysargmp4fk7px5zgib1p6h5ya4w39rndbzk614fcnv0iipd";
   };
 
   buildInputs = [ qtbase qtmultimedia tinyxml-2 ];
-
-  # This fixes a bug resulting in "illegal instruction"
-  patches = [(fetchpatch {
-    url = https://github.com/RobJinman/pro_office_calc/commit/806180d69d4af6b3183873f471c57bfdaf529560.patch;
-    sha256 = "1rcdjy233yf3kv4v18c82jyg08dykj2qspvg08n5b3bir870sbxz";
-  })];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
###### Motivation for this change

Just a regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

