### PR TITLE
pythonPackages.typing-extensions: 3.6.6 -> 3.7.2

### DIFF
--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -4,11 +4,11 @@ let
 
 in buildPythonPackage rec {
   pname = "typing_extensions";
-  version = "3.6.6";
+  version = "3.7.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "07vhddjnd3mhdijyc3s0mwi9jgfjp3rr056nxqiavydbvkrvgrsi";
+    sha256 = "0wfsv71pvkyf2na938l579jh0v3kzl6g744ijgnahcwd4d9x0b7v";
   };
 
   checkInputs = lib.optional (pythonOlder "3.5") typing;


### PR DESCRIPTION
###### Motivation for this change

Just a regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

