### PR TITLE
pythonPackages.pyogg: 0.6.2a1 -> 0.6.6a1

### DIFF
--- a/pkgs/development/python-modules/pyogg/default.nix
+++ b/pkgs/development/python-modules/pyogg/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
     pname = "PyOgg";
-    version = "0.6.2a1";
+    version = "0.6.6a1";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1mjh5zx7mfy246lya1qc42j4q4pz6v5zbd8blnfib9ncswcb1v6l";
+      sha256 = "1ihzgl8p0rc3yjsp27zdrrs2r4qar5yf5l4v8wg0lilvan78h0rs";
     };
 
     buildInputs = [ libvorbis flac libogg libopus ];


### PR DESCRIPTION
###### Motivation for this change

Just a regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

