### PR TITLE
pythonPackages.pkgconfig: use same setupHook as pkgconfig

### DIFF
--- a/pkgs/development/python-modules/pkgconfig/default.nix
+++ b/pkgs/development/python-modules/pkgconfig/default.nix
@@ -4,6 +4,8 @@ buildPythonPackage rec {
   pname = "pkgconfig";
   version = "1.4.0";
 
+  setupHook = pkgconfig.setupHook;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "048c3b457da7b6f686b647ab10bf09e2250e4c50acfe6f215398a8b5e6fcdb52";


### PR DESCRIPTION
This setupHook is necessary for actually using pkgconfig. Without this
setupHook, you need to put both pythonPackages.pkgconfig and pkgconfig
into your buildInputs, just to get the setuphook of the latter.

Previously, pythonPackages.pkgconfig depended on pkgconfig as a
propagatedBuildInput, so this setupHook was propagated down to
dependents. That was changed to a regular nativeBuildInput, so now
this setupHook change is necessary for packages to only depend on
pythonPackages.pkgconfig.

A possible alternative is extracting out a common pkgconfigHook
package and having both pythonPackages.pkgconfig and pkgconfig depend
on that with propagatedBuildInputs. That might be necessary to avoid
the buildHook running twice?

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

