### PR TITLE
gh-ost: 1.0.36 -> 1.0.47

### DIFF
--- a/pkgs/tools/misc/gh-ost/default.nix
+++ b/pkgs/tools/misc/gh-ost/default.nix
@@ -2,11 +2,11 @@
 
 let
   goPackagePath = "github.com/github/gh-ost";
-  version = "1.0.36";
-  sha256 = "0qa7k50bf87bx7sr6iwqri8l49f811gs0bj3ivslxfibcs1z5d4h";
+  version = "1.0.47";
+  sha256 = "0yyhkqis4j2cl6w2drrjxdy5j8x9zp4j89gsny6w4ql8gm5qgvvk";
 
-in {
-  gh-ost = buildGoPackage ({
+in
+buildGoPackage ({
     name = "gh-ost-${version}";
     inherit goPackagePath;
 
@@ -23,5 +23,5 @@ in {
       license = licenses.mit;
       platforms = platforms.linux;
     };
-  });
-}
+})
+


### PR DESCRIPTION
Also fixes a weirdness with the derivation where to use it, you needed
to specify `gh-ost.gh-ost`. There's nothing special about the extra
output.

###### Motivation for this change

Update version, fix weird install step.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

