### PR TITLE
pythonPackages.androguard: 3.3.3 -> 3.3.4

### DIFF
--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -2,12 +2,12 @@
   asn1crypto, click, pydot, ipython, pyqt5, pyperclip }:
 
 buildPythonPackage rec {
-  version = "3.3.3";
+  version = "3.3.4";
   pname = "androguard";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zlmn3byh2whg7k2xmcd7yy43lcawhryjnzcxr9bhn54709b6iyd";
+    sha256 = "1hinfbvha7f1py1jnvxih7lx0p4z2nyaiq9bvg8v3bykwrd9jff2";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Just a regular update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

