### PR TITLE
groff: Remove indeterminism in manpages

### DIFF
--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = false;
 
-  patches = [ ./look-for-ar.patch ];
+  patches = [
+    ./look-for-ar.patch
+    ./mdate-determinism.patch
+  ];
 
   postPatch = stdenv.lib.optionalString (psutils != null) ''
     substituteInPlace src/preproc/html/pre-html.cpp \

--- a/pkgs/tools/text/groff/mdate-determinism.patch
+++ b/pkgs/tools/text/groff/mdate-determinism.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.comm b/Makefile.comm
+index 75efc22..b757000 100644
+--- a/Makefile.comm
++++ b/Makefile.comm
+@@ -155,7 +155,7 @@ extraclean: distclean
+ 	     -e "s|@MAN1EXT@|$(man1ext)|g" \
+ 	     -e "s|@MAN5EXT@|$(man5ext)|g" \
+ 	     -e "s|@MAN7EXT@|$(man7ext)|g" \
+-	     -e "s|@MDATE@|`$(SHELL) $(top_srcdir)/mdate.sh $<`|g" \
++	     -e "s|@MDATE@|`date +'%-d %B %Y' -r $(top_srcdir)/ChangeLog`|g" \
+ 	     -e "s|@OLDFONTDIR@|$(oldfontdir)|g" \
+ 	     -e "s|@PDFDOCDIR@|$(pdfdocdir)|g" \
+ 	     -e "s|@SYSTEMMACRODIR@|$(systemtmacdir)|g" \


### PR DESCRIPTION
It was caused by including the modification date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

